### PR TITLE
fix(api_server): report real partial/interrupted state on the SSE stream

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3544,13 +3544,22 @@ class APIServerAdapter(BasePlatformAdapter):
                         else ""
                     ),
                 )
+                # Report the turn the way the agent actually ended it. Pinning
+                # these to False told an SSE client that a truncated
+                # (output-cap / context-pressure) or user-interrupted turn was
+                # a clean, whole answer; the non-streaming session surfaces
+                # already derive both from the run result.
+                _is_partial = bool(result.get("partial")) if isinstance(result, dict) else False
+                _is_interrupted = (
+                    bool(result.get("interrupted")) if isinstance(result, dict) else False
+                )
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
                     "content": final_response,
                     "completed": True,
-                    "partial": False,
-                    "interrupted": False,
+                    "partial": _is_partial,
+                    "interrupted": _is_interrupted,
                     "runtime": effective_runtime,
                 }))
                 await queue.put(_event_payload("run.completed", {

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1198,3 +1198,104 @@ async def test_capabilities_advertises_session_model_lock(adapter):
         "method": "POST",
         "path": "/api/sessions/{session_id}/model",
     }
+
+
+def _sse_event_payload(body: str, event_name: str) -> dict:
+    """Return the JSON payload of the first ``event_name`` frame in an SSE body."""
+    import json as _json
+
+    current = None
+    for line in body.splitlines():
+        if line.startswith("event: "):
+            current = line[len("event: "):].strip()
+        elif line.startswith("data: ") and current == event_name:
+            return _json.loads(line[len("data: "):])
+    raise AssertionError(f"no {event_name} event in SSE body: {body[:400]}")
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_reports_partial_completion(adapter, session_db):
+    """A truncated turn must not be streamed as a complete one.
+
+    Every non-streaming session surface derives the flag from the run result
+    (``bool(result.get("partial"))``); the SSE ``assistant.completed`` event
+    hardcoded ``False``, so an SSE client renders a cut-off answer as if the
+    agent had finished.
+    """
+    session_id = session_db.create_session("partial-stream-session", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("Half an ans")
+        return (
+            {
+                "final_response": "Half an ans",
+                "session_id": session_id,
+                "partial": True,
+            },
+            {"total_tokens": 3},
+        )
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "long question"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    assert _sse_event_payload(body, "assistant.completed")["partial"] is True
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_reports_interrupted_completion(adapter, session_db):
+    """A user-interrupted turn must be flagged as interrupted, not clean."""
+    session_id = session_db.create_session("interrupted-stream-session", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("Working on i")
+        return (
+            {
+                "final_response": "Working on i",
+                "session_id": session_id,
+                "interrupted": True,
+            },
+            {"total_tokens": 3},
+        )
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "do a thing"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    assert _sse_event_payload(body, "assistant.completed")["interrupted"] is True
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_reports_clean_completion(adapter, session_db):
+    """A normal turn still reports neither flag."""
+    session_id = session_db.create_session("clean-stream-session", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("All done.")
+        return ({"final_response": "All done.", "session_id": session_id}, {"total_tokens": 2})
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "hi"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    payload = _sse_event_payload(body, "assistant.completed")
+    assert payload["partial"] is False
+    assert payload["interrupted"] is False


### PR DESCRIPTION
## What does this PR do?

The session SSE lane pins both completion flags to `False`:

```python
await queue.put(_event_payload("assistant.completed", {
    ...
    "completed": True,
    "partial": False,        # <- hardcoded
    "interrupted": False,    # <- hardcoded
```

Every **non-streaming** session surface in the same file already derives the flag from the run result (`is_partial = bool(result.get("partial"))`, used for the JSON chat responses), and the agent genuinely produces both keys: `partial` on the output-cap / context-pressure truncation paths in `agent/conversation_loop.py` and `agent/codex_runtime.py`, `interrupted` on user interrupts.

So a turn the agent ended early is announced to a streaming client as a clean, whole answer. The client has no way to tell a cut-off response from a finished one — no truncation affordance, no "continue" offer, and a UI that lays out partial turns differently renders the fragment as final. This is the second half of #72316 (the reporter hit it with the Hermes WebUI); the first half — the `ollama.com` false-positive in the local-Ollama stop heuristic — is already covered by #60996, so this PR deliberately does not touch it.

Reproduced against `main` (`136f8dab6`) by returning a run result with the flag set and reading the emitted event:

```
FAILED test_session_chat_stream_reports_partial_completion
FAILED test_session_chat_stream_reports_interrupted_completion
E   assert False is True
```

Both now pass, and a normal turn still reports `partial: false, interrupted: false` (pinned by a third test).

## Related Issue

Second half of #72316. The first half is #60996.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py` (`_handle_session_chat_stream`): derive `partial` and `interrupted` for the `assistant.completed` event from the run result, using the same `isinstance(result, dict)` guard shape as the sibling non-streaming lanes. `result` was already in scope (the same block reads `final_response`, `session_id` and `runtime` off it).
- `tests/gateway/test_session_api.py`: a small SSE frame parser plus three tests — a truncated turn streams `partial: true`, an interrupted turn streams `interrupted: true`, and a normal turn still streams both `false`.

## How to Test

1. Drive `POST /api/sessions/{id}/chat/stream` for a turn that ends truncated (output cap) or that the user interrupts.
2. Read the `assistant.completed` SSE frame: before this change it always says `"partial": false, "interrupted": false`; after, it matches the run result — same values the non-streaming endpoints already return for that turn.
3. `pytest tests/gateway/test_session_api.py -q` -> 36 passed (3 new). The two flag tests fail on `main` without the code change (`assert False is True`).
4. Wider run: `pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_active_work_drain.py -q` -> 269 passed, 1 skipped. `pytest tests/gateway/ -q -k "api_server or session_api or stream"` -> 883 passed, 2 failed; those 2 (`test_post_stream_media_delivery`, `test_update_streaming`) are pre-existing on `main` — verified by re-running them with this change stashed.
5. Tested on Ubuntu 24.04.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate — #60996 covers the other half of #72316 (`run_agent.py` heuristic); no open PR touches the SSE completion event
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and they pass (see step 4 for the pre-existing, unrelated failures)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (the event already documents these fields; this makes them truthful)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific behaviour)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schemas touched; the SSE event shape is unchanged, only its values)
