### PR TITLE
fix(gateway): preserve media dedup after streamed replies (salvage #72321)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14600,7 +14600,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _media_adapter:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
-                            history_media_paths=_history_media_paths,
+                            history_media_paths=_collect_history_media_paths(history),
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -212,6 +212,54 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
     )
 
 
+# ── Post-stream MEDIA delivery keeps prior-turn deduplication ──────────
+
+
+@pytest.mark.asyncio
+async def test_streamed_response_receives_prior_turn_media_paths(
+    monkeypatch, tmp_path
+):
+    """An ordinary streamed reply completes the post-stream delivery branch.
+
+    The history-derived dedup set is part of that branch's contract, rather
+    than an optional best-effort hint: passing an undefined local crashes the
+    entire reply, while passing an empty set reintroduces duplicate MEDIA
+    attachments on later streamed responses.
+    """
+    runner = _bootstrap(monkeypatch, tmp_path)
+    prior_path = "/tmp/already-delivered.png"
+    runner.session_store.load_transcript.return_value = [
+        {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+    ]
+    runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    runner._deliver_media_from_response = AsyncMock()
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "the streamed reply completed normally",
+            "messages": [
+                {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+                {"role": "user", "content": "what is my status?"},
+                {"role": "assistant", "content": "the streamed reply completed normally"},
+            ],
+            "tools": [],
+            "history_offset": 1,
+            "last_prompt_tokens": 0,
+            "already_sent": True,
+            "failed": False,
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response is None
+    runner._deliver_media_from_response.assert_awaited_once()
+    assert runner._deliver_media_from_response.await_args.kwargs[
+        "history_media_paths"
+    ] == {prior_path}
+
+
 # ── Test 4: normal path (new_messages found) uses skip_db=True ────────
 
 


### PR DESCRIPTION
## Summary

Salvages PR #72321 by @TheEpTic: every streamed gateway reply crashed with `NameError: name '_history_media_paths' is not defined` after the model request already succeeded — the post-stream MEDIA-delivery branch in `_handle_message_with_agent` referenced a local that only exists inside `_run_agent_inner` (introduced in 83bba799e2). Users got the generic platform error on ordinary text replies as well as MEDIA-bearing ones.

Root cause: cross-function scope leak — the dedup set was bound in a different function's scope than the call site reading it (AST-verified: zero direct-scope assignments of `_history_media_paths` in `_handle_message_with_agent`).

## Changes

- `gateway/run.py`: derive the dedup set from the handler's own loaded transcript via `_collect_history_media_paths(history)` — same semantics as the original dedup contract, no empty-set fallback.
- `tests/gateway/test_42039_duplicate_user_message.py`: regression test exercising the real `already_sent` branch, asserting prior-turn MEDIA paths reach `_deliver_media_from_response`.

## Validation

| | Before (main) | After |
|---|---|---|
| Streamed reply, `already_sent=True` | `NameError`, generic platform error | delivered normally |
| Regression test (sabotage run against main's line) | FAILED with the exact `NameError` | passes |
| `scripts/run_tests.sh tests/gateway/test_42039_duplicate_user_message.py` | 4 passed / 1 failed | 5 passed |

Two independent production confirmations on the original PR thread (Fedora + macOS Telegram gateways) verified both the crash on current main and this fix.

Duplicate cluster: #72228 (@Ieqzya, earliest report — empty-set fallback drops dedup + unrelated desktop files), #72317 (@jorgeblanc9, same one-liner, no test), #72326 (@kylesteele-sudo, valid alternative placement + test). This salvage uses #72321's implementation; @TheEpTic's authorship preserved via cherry-pick.

## Infographic

![fix(gateway): preserve media dedup after streamed replies](https://v3b.fal.media/files/b/0aa3ddf5/UayS2zukQTZdaovOLm_kK_dSZgtei5.png)
