### PR TITLE
docs(portal): describe per-model routing accurately — not everything goes through OpenRouter

### DIFF
--- a/website/docs/guides/run-hermes-with-nous-portal.md
+++ b/website/docs/guides/run-hermes-with-nous-portal.md
@@ -228,7 +228,7 @@ The quarantine clears automatically on successful re-login.
 
 ### Model I want isn't in the `/model` picker
 
-The Portal catalog mirrors OpenRouter's model list (300+). If a model is missing, try typing the OpenRouter-style slug directly:
+The Portal catalog draws on OpenRouter's model list (300+) plus models served through proprietary or secondary providers. If a model is missing, try typing the OpenRouter-style slug directly:
 
 ```bash
 /model anthropic/claude-opus-4.6

--- a/website/docs/integrations/nous-portal.md
+++ b/website/docs/integrations/nous-portal.md
@@ -42,7 +42,11 @@ The Portal proxies a curated catalog of agentic models from across the ecosystem
 | **Hermes** | Hermes-4-70B, Hermes-4-405B (chat, see [note below](#a-note-on-hermes-4)) |
 | **+ everything else** | 280+ additional models — the full agentic frontier |
 
-Routing happens through OpenRouter under the hood, so model availability and failover behavior matches what you'd get with an OpenRouter key — just billed against your Nous subscription instead. Switch between Claude Sonnet 4.6 for code and Gemini 3 Pro for long context with `/model` mid-session — no new credentials, no top-ups, no surprise zero-balance errors.
+Under the hood, the Portal routes each model to the backend best suited for it — some models go through OpenRouter, others through proprietary or secondary providers, and the routing for a given model can change over time. Everything is billed against your Nous subscription either way. Switch between Claude Sonnet 4.6 for code and Gemini 3 Pro for long context with `/model` mid-session — no new credentials, no top-ups, no surprise zero-balance errors.
+
+:::note
+Because routing is per-model and not always through OpenRouter, OpenRouter-specific request extensions (such as `provider` routing preferences, `session_id` sticky routing, or top-level `cache_control`) are not part of the Portal's API contract and may be ignored depending on which backend serves the model.
+:::
 
 ### The Nous Tool Gateway
 
@@ -251,7 +255,7 @@ Your Portal refresh token was invalidated (password change, manual revoke, or se
 
 ### Want to use a specific provider model that the Portal doesn't expose
 
-The Portal proxies through OpenRouter, so any model that OpenRouter supports is generally available. If a specific model isn't appearing in `/model`, try the OpenRouter-style slug directly:
+The Portal routes each model to a suitable backend — some through OpenRouter, others through proprietary or secondary providers — so most models OpenRouter supports are generally available. If a specific model isn't appearing in `/model`, try the OpenRouter-style slug directly:
 
 ```bash
 /model anthropic/claude-opus-4.6

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/run-hermes-with-nous-portal.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/run-hermes-with-nous-portal.md
@@ -225,7 +225,7 @@ hermes auth add nous
 
 ### 我想要的模型不在 `/model` 选择器中
 
-Portal 目录镜像了 OpenRouter 的模型列表（300+ 个）。如果某个模型缺失，尝试直接输入 OpenRouter 风格的 slug：
+Portal 目录基于 OpenRouter 的模型列表（300+ 个），并补充了通过专有或备用提供商提供的模型。如果某个模型缺失，尝试直接输入 OpenRouter 风格的 slug：
 
 ```bash
 /model anthropic/claude-opus-4.6

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/nous-portal.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/nous-portal.md
@@ -38,7 +38,11 @@ Portal 代理了来自整个生态系统的精选 agentic 模型目录——统�
 | **Hermes** | Hermes-4-70B、Hermes-4-405B（对话，见[下方说明](#a-note-on-hermes-4)） |
 | **+ 其他所有模型** | 240+ 额外模型——完整的 agentic 前沿生态 |
 
-底层路由通过 OpenRouter 实现，因此模型可用性和故障转移行为与使用 OpenRouter 密钥一致——只是计费走你的 Nous 订阅。在会话中途用 `/model` 即可在 Claude Sonnet 4.6（适合代码）和 Gemini 2.5 Pro（适合长上下文）之间切换——无需新凭证，无需充值，不会遇到余额为零的意外报错。
+底层上，Portal 会为每个模型选择最合适的后端——部分模型通过 OpenRouter 路由，其他模型则通过专有或备用提供商，且某个模型的路由方式可能随时间调整。所有用量都统一计入你的 Nous 订阅。在会话中途用 `/model` 即可在 Claude Sonnet 4.6（适合代码）和 Gemini 2.5 Pro（适合长上下文）之间切换——无需新凭证，无需充值，不会遇到余额为零的意外报错。
+
+:::note
+由于路由是按模型进行的，并非总是经过 OpenRouter，OpenRouter 专有的请求扩展（如 `provider` 路由偏好、`session_id` 粘性路由或顶层 `cache_control`）不属于 Portal 的 API 契约，可能会被忽略，具体取决于该模型由哪个后端提供服务。
+:::
 
 ### Nous Tool Gateway
 
@@ -246,7 +250,7 @@ hermes portal
 
 ### 想使用 Portal 未暴露的特定提供商模型
 
-Portal 通过 OpenRouter 代理，因此 OpenRouter 支持的所有模型通常都可用。如果某个模型未出现在 `/model` 中，可直接尝试 OpenRouter 风格的 slug：
+Portal 会为每个模型选择合适的后端——部分模型通过 OpenRouter 路由，其他模型则通过专有或备用提供商——因此 OpenRouter 支持的大多数模型通常都可用。如果某个模型未出现在 `/model` 中，可直接尝试 OpenRouter 风格的 slug：
 
 ```bash
 /model anthropic/claude-opus-4.6


### PR DESCRIPTION
## Summary

The Nous Portal docs no longer claim all routing goes through OpenRouter — they now say some models route through OpenRouter and others through proprietary or secondary providers, with per-model routing subject to change.

The old wording ("Routing happens through OpenRouter under the hood, so ... failover behavior matches what you'd get with an OpenRouter key", "The Portal catalog mirrors OpenRouter's model list", "The Portal proxies through OpenRouter") licensed users to expect OpenRouter-proprietary request extensions — top-level `cache_control`, `session_id` / `x-session-id` sticky routing, `prompt_cache_key` — to work through the Portal. That expectation produced misfiled bug reports (#71576 measured OpenRouter's sticky-routing feature against the Portal and reported the delta as a P0).

## Changes

- `website/docs/integrations/nous-portal.md`: reword the routing paragraph (some models via OpenRouter, others via proprietary/secondary providers); add a `:::note` stating OpenRouter-specific request extensions are not part of the Portal API contract; fix the FAQ "proxies through OpenRouter" line.
- `website/docs/guides/run-hermes-with-nous-portal.md`: "mirrors OpenRouter's model list" → "draws on OpenRouter's model list plus models served through proprietary or secondary providers".
- zh-Hans mirrors of both pages: same three edits.

## Validation

| | Before | After |
|---|---|---|
| Routing claim | "happens through OpenRouter under the hood" | per-model: OpenRouter / proprietary / secondary providers |
| OR extensions (`session_id`, top-level `cache_control`) | implied supported | explicitly out of contract |
| en/zh parity | — | both locales updated |

Docs-only; no code paths touched.

## Infographic

![Nous Portal docs per-model routing](https://v3b.fal.media/files/b/0aa3ddf5/z842u4ypeoW4ePRGGAFQZ_6PyoplR0.png)
