### PR TITLE
fix(agent): skip project context in non-coding sessions

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2018,6 +2018,7 @@ def build_context_files_prompt(
     skip_soul: bool = False,
     context_length: Optional[int] = None,
     allow_install_tree_fallback: bool = False,
+    skip_project_context: bool = False,
 ) -> str:
     """Discover and load context files for the system prompt.
 
@@ -2036,6 +2037,9 @@ def build_context_files_prompt(
 
     When *skip_soul* is True, SOUL.md is not included here (it was already
     loaded via ``load_soul_md()`` for the identity slot).
+
+    When *skip_project_context* is True, project instructions are omitted but
+    SOUL.md handling is unchanged.
     """
     if cwd is None:
         cwd = os.getcwd()
@@ -2056,7 +2060,9 @@ def build_context_files_prompt(
     # their launch dir IS the user's shell cwd (developing Hermes in-tree).
     from agent.runtime_cwd import _is_install_tree
 
-    if (
+    if skip_project_context:
+        project_context = ""
+    elif (
         cwd_is_fallback
         and not allow_install_tree_fallback
         and _is_install_tree(cwd_path)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -180,6 +180,21 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         if isinstance(_cc_len, int) and _cc_len > 0:
             _ctx_len = _cc_len
 
+    # The coding/general posture governs every coding-specific prompt concern,
+    # including whether project instruction files belong in this session.
+    # Resolve it once so those decisions cannot disagree within a cached prompt.
+    _context_cwd = resolve_context_cwd()
+    _runtime_mode = None
+    try:
+        from agent.coding_context import resolve_runtime_mode
+
+        _runtime_mode = resolve_runtime_mode(
+            platform=agent.platform, cwd=_context_cwd, model=agent.model
+        )
+    except Exception:
+        # Coding-context probing must never block prompt build.
+        pass
+
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
@@ -307,14 +322,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # reach everything, and every name stays visible for recall). The
         # default coding posture leaves the index untouched.
         _compact_cats = frozenset()
-        try:
-            from agent.coding_context import coding_compact_skill_categories
-
-            _compact_cats = coding_compact_skill_categories(
-                platform=agent.platform, cwd=resolve_context_cwd()
-            )
-        except Exception:
-            _compact_cats = frozenset()
+        if _runtime_mode is not None:
+            try:
+                _compact_cats = _runtime_mode.compact_skill_categories()
+            except Exception:
+                pass
         skills_prompt = _r.build_skills_system_prompt(
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
@@ -353,14 +365,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # stay in their historical position after the workspace snapshot.
     coding_workspace_parts: List[str] = []
     coding_trailing_parts: List[str] = []
-    if agent.valid_tool_names:
+    if agent.valid_tool_names and _runtime_mode is not None:
         try:
-            from agent.coding_context import coding_system_prompt_parts
-
-            coding_prefix_parts, coding_workspace_parts, coding_trailing_parts = coding_system_prompt_parts(
-                platform=agent.platform,
-                cwd=resolve_context_cwd(),
-                model=agent.model,
+            coding_prefix_parts, coding_workspace_parts, coding_trailing_parts = (
+                _runtime_mode.system_prompt_parts()
             )
             stable_parts.extend(coding_prefix_parts)
         except Exception:
@@ -488,9 +496,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # gateway daemons) self-spawns into the install tree, where the
         # fallback would inject this repo's contributor AGENTS.md (#64590).
         context_files_prompt = _r.build_context_files_prompt(
-            cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
+            cwd=_context_cwd, skip_soul=_soul_loaded,
             context_length=_ctx_len,
-            allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+            allow_install_tree_fallback=agent.platform in ("cli", "tui"),
+            skip_project_context=(
+                _runtime_mode is not None and not _runtime_mode.is_coding
+            ),
+        )
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -718,6 +718,20 @@ class TestBuildContextFilesPrompt:
         assert "Ruff for linting" in result
         assert "Project Context" in result
 
+    def test_skips_project_context_but_keeps_soul(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (tmp_path / "AGENTS.md").write_text("Project instructions.")
+        (hermes_home / "SOUL.md").write_text("Identity instructions.")
+
+        result = build_context_files_prompt(
+            cwd=str(tmp_path), skip_project_context=True
+        )
+
+        assert "Project instructions." not in result
+        assert "Identity instructions." in result
+
     def test_skips_agents_md_in_install_tree_on_fallback(self, monkeypatch, tmp_path):
         # A backend that FALLS BACK into the install tree (cwd=None → getcwd,
         # the desktop default) must not load that tree's contributor AGENTS.md
@@ -1723,5 +1737,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -104,6 +104,28 @@ class TestContextFileCwd:
         assert options["skip_project_context"] is False
 
 
+def test_real_prompt_build_skips_chat_project_context_but_keeps_soul(
+    monkeypatch, tmp_path
+):
+    project_dir = tmp_path / "project"
+    hermes_home = tmp_path / "hermes-home"
+    project_dir.mkdir()
+    hermes_home.mkdir()
+    (project_dir / "AGENTS.md").write_text(
+        "E2E_PROJECT_CONTEXT_SENTINEL", encoding="utf-8"
+    )
+    (hermes_home / "SOUL.md").write_text("E2E_SOUL_IDENTITY_SENTINEL", encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(project_dir))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    prompt = build_system_prompt(
+        _make_agent(platform="telegram", load_soul_identity=True)
+    )
+
+    assert "E2E_SOUL_IDENTITY_SENTINEL" in prompt
+    assert "E2E_PROJECT_CONTEXT_SENTINEL" not in prompt
+
+
 def _stable_prompt(agent):
     with (
         patch("run_agent.load_soul_md", return_value=""),

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from agent.system_prompt import build_system_prompt, build_system_prompt_parts
 
@@ -29,15 +29,17 @@ def _make_agent(**overrides):
     return SimpleNamespace(**base)
 
 
-def _captured_context_cwd(agent):
-    """The cwd build_system_prompt_parts hands to build_context_files_prompt."""
+def _captured_context_file_options(agent):
+    """The options build_system_prompt_parts hands to context-file discovery."""
     captured = {}
 
     def fake_context_files(
         cwd=None, skip_soul=False, context_length=None,
         allow_install_tree_fallback=False,
+        skip_project_context=False,
     ):
         captured["cwd"] = cwd
+        captured["skip_project_context"] = skip_project_context
         return ""
 
     with (
@@ -47,7 +49,11 @@ def _captured_context_cwd(agent):
         patch("run_agent.build_context_files_prompt", side_effect=fake_context_files),
     ):
         build_system_prompt_parts(agent)
-    return captured["cwd"]
+    return captured
+
+
+def _captured_context_cwd(agent):
+    return _captured_context_file_options(agent)["cwd"]
 
 
 class TestContextFileCwd:
@@ -60,6 +66,42 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+    def test_skips_project_context_for_chat_platform(self, monkeypatch, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("Project instructions.")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+        options = _captured_context_file_options(_make_agent(platform="telegram"))
+
+        assert options["skip_project_context"] is True
+
+    def test_skips_project_context_when_coding_context_is_off(self, monkeypatch, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("Project instructions.")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+        with patch("agent.coding_context._coding_mode", return_value="off"):
+            options = _captured_context_file_options(_make_agent(platform="cli"))
+
+        assert options["skip_project_context"] is True
+
+    def test_explicit_coding_context_keeps_project_context_for_chat_platform(
+        self, monkeypatch, tmp_path
+    ):
+        (tmp_path / "AGENTS.md").write_text("Project instructions.")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+        with patch("agent.coding_context._coding_mode", return_value="on"):
+            options = _captured_context_file_options(_make_agent(platform="telegram"))
+
+        assert options["skip_project_context"] is False
+
+    def test_keeps_project_context_for_coding_cli(self, monkeypatch, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("Project instructions.")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+        options = _captured_context_file_options(_make_agent(platform="cli"))
+
+        assert options["skip_project_context"] is False
 
 
 def _stable_prompt(agent):
@@ -163,18 +205,25 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
         "Conversation started: Friday, January 02, 2026",
     ))
 
+    runtime_mode = Mock(
+        is_coding=True,
+        system_prompt_parts=Mock(
+            return_value=(
+                ["CODING_STABLE"],
+                ["WORKSPACE"],
+                ["Operator instructions (from config):\nOPERATOR"],
+            )
+        ),
+        compact_skill_categories=Mock(return_value=frozenset()),
+    )
+
     with (
         patch("run_agent.load_soul_md", return_value=""),
         patch("run_agent.build_nous_subscription_prompt", return_value=""),
         patch("run_agent.build_environment_hints", return_value=""),
         patch("run_agent.build_context_files_prompt", return_value="CONTEXT_FILES"),
         patch(
-            "agent.coding_context.coding_system_prompt_parts",
-            return_value=(
-                ["CODING_STABLE"],
-                ["WORKSPACE"],
-                ["Operator instructions (from config):\nOPERATOR"],
-            ),
+            "agent.coding_context.resolve_runtime_mode", return_value=runtime_mode
         ),
         patch("agent.file_safety._resolve_active_profile_name", return_value="default"),
         patch("hermes_time.now", return_value=datetime(2026, 1, 2)),

--- a/website/docs/user-guide/features/context-files.md
+++ b/website/docs/user-guide/features/context-files.md
@@ -1,26 +1,26 @@
 ---
 sidebar_position: 8
 title: "Context Files"
-description: "Project context files — .hermes.md, AGENTS.md, CLAUDE.md, global SOUL.md, and .cursorrules — automatically injected into every conversation"
+description: "Project context files for coding sessions, plus the global SOUL.md identity loaded independently in every posture"
 ---
 
 # Context Files
 
-Hermes Agent automatically discovers and loads context files that shape how it behaves. Some are project-local and discovered from your working directory. `SOUL.md` is now global to the Hermes instance and is loaded from `HERMES_HOME` only.
+Hermes Agent automatically discovers context files that shape how it behaves. Project-local files are loaded into the startup system prompt only when the session resolves to the coding posture. `SOUL.md` is global to the Hermes instance, loaded from `HERMES_HOME` only, and remains available in both coding and general postures.
 
 ## Supported Context Files
 
 | File | Purpose | Discovery |
 |------|---------|-----------| 
 | **.hermes.md** / **HERMES.md** | Project instructions (highest priority) | Walks to git root |
-| **AGENTS.md** | Project instructions, conventions, architecture | CWD at startup + subdirectories progressively |
+| **AGENTS.md** | Project instructions, conventions, architecture | CWD at startup in coding posture + subdirectories progressively |
 | **CLAUDE.md** | Claude Code context files (also detected) | CWD at startup + subdirectories progressively |
 | **SOUL.md** | Global personality and tone customization for this Hermes instance | `HERMES_HOME/SOUL.md` only |
 | **.cursorrules** | Cursor IDE coding conventions | CWD only |
 | **.cursor/rules/*.mdc** | Cursor IDE rule modules | CWD only |
 
 :::info Priority system
-Only **one** project context type is loaded per session (first match wins): `.hermes.md` → `AGENTS.md` → `CLAUDE.md` → `.cursorrules`. **SOUL.md** is always loaded independently as the agent identity (slot #1).
+When startup project context is enabled, only **one** project context type is loaded per session (first match wins): `.hermes.md` → `AGENTS.md` → `CLAUDE.md` → `.cursorrules`. **SOUL.md** is always loaded independently as the agent identity (slot #1).
 :::
 
 ## AGENTS.md
@@ -29,7 +29,7 @@ Only **one** project context type is loaded per session (first match wins): `.he
 
 ### Progressive Subdirectory Discovery
 
-At session start, Hermes loads the `AGENTS.md` from your working directory into the system prompt. As the agent navigates into subdirectories during the session (via `read_file`, `terminal`, `search_files`, etc.), it **progressively discovers** context files in those directories and injects them into the conversation at the moment they become relevant.
+At session start, Hermes loads the `AGENTS.md` from your working directory into the system prompt when the session is in the coding posture. As the agent navigates into subdirectories during the session (via `read_file`, `terminal`, `search_files`, etc.), it **progressively discovers** context files in those directories and injects them into the conversation at the moment they become relevant.
 
 ```
 my-project/
@@ -106,7 +106,9 @@ This means your existing Cursor conventions automatically apply when using Herme
 
 Context files are loaded by `build_context_files_prompt()` in `agent/prompt_builder.py`:
 
-1. **Scan working directory** — checks for `.hermes.md` → `AGENTS.md` → `CLAUDE.md` → `.cursorrules` (first match wins)
+Before scanning project files, Hermes resolves the session's coding posture. Messaging platforms default to the general posture, and `agent.coding_context: off` forces it, so those sessions skip startup project-context discovery. `agent.coding_context: on` explicitly enables the coding posture. `SOUL.md` is handled independently and remains loaded in either posture.
+
+1. **Scan working directory in coding posture** — checks for `.hermes.md` → `AGENTS.md` → `CLAUDE.md` → `.cursorrules` (first match wins); general-posture sessions skip this project scan
 2. **Content is read** — each file is read as UTF-8 text
 3. **Security scan** — content is checked for prompt injection patterns
 4. **Truncation** — files exceeding `context_file_max_chars` characters (default 20,000) are head/tail truncated (70% head, 20% tail, with a marker in the middle)


### PR DESCRIPTION
## What does this PR do?

Stops project instruction files from consuming prompt context in chat-platform sessions and whenever `agent.coding_context` is `off`. Previously, system-prompt assembly always loaded project context even after the coding posture had resolved to general.

The fix resolves the runtime posture once per system-prompt build and uses it consistently for coding guidance, skill compaction, and project-context discovery. `SOUL.md` remains available as the agent identity.

## Related Issue

Fixes #72268

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add a project-context-only skip option to the context-file prompt builder.
- Skip `HERMES.md`, `AGENTS.md`, `CLAUDE.md`, and Cursor rules when the resolved posture is general.
- Reuse one resolved runtime mode throughout system-prompt construction.
- Cover Telegram, explicit `coding_context: off`, CLI coding workspaces, explicit `on`, and SOUL preservation.

## How to Test

1. Set `terminal.cwd` to a project with `AGENTS.md`.
2. Use Telegram or set `agent.coding_context: off`; the resulting system prompt excludes the project instructions.
3. Use a CLI coding workspace, or explicitly set `coding_context: on`; project instructions remain available.

Validated with:

```text
.venv/bin/python -m pytest -q -o addopts='' tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py tests/agent/test_coding_context.py
236 passed, 1 skipped

.venv/bin/python scripts/check-windows-footguns.py --all
No Windows footguns found
```

A direct temporary-`HERMES_HOME` prompt-build probe also confirmed that Telegram excludes a project-context sentinel while CLI includes it.

## Compatibility Notes

Explicit `coding_context: on` continues to override the chat-platform default, matching the existing coding-context contract.