### PR TITLE
Fix/post stream history media paths nameerror

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14598,6 +14598,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if response:
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
+                        # Compute here — the non-streaming path builds this
+                        # set later in `_process_message_background`, which is
+                        # skipped when already_sent short-circuits. Referencing
+                        # that out-of-scope name raised NameError after every
+                        # successful streamed turn (commonly after /compress).
+                        _history_media_paths = _collect_history_media_paths(
+                            history or []
+                        )
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                             history_media_paths=_history_media_paths,

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -19,7 +19,7 @@ import pytest
 
 from gateway.config import Platform
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
-from gateway.run import GatewayRunner
+from gateway.run import GatewayRunner, _collect_history_media_paths
 from gateway.session import SessionSource
 
 
@@ -144,3 +144,57 @@ async def test_explicit_media_document_still_delivers_post_stream(tmp_path, monk
         file_path=str(media_file),
         metadata={},
     )
+
+
+@pytest.mark.asyncio
+async def test_post_stream_skips_media_already_in_history(tmp_path, monkeypatch):
+    """Streaming already_sent path must build history_media_paths locally.
+
+    The non-streaming set lives in ``_process_message_background`` and is out
+    of scope when ``already_sent`` short-circuits. Referencing that unbound
+    name used to raise NameError after every successful streamed turn
+    (commonly the first message after ``/compress``).
+    """
+    old = _allowed_media_path(tmp_path, monkeypatch, "old.png")
+    new = _allowed_media_path(tmp_path, monkeypatch, "new.png")
+    adapter = _adapter()
+    history = [
+        {"role": "assistant", "content": f"Earlier chart MEDIA:{old}"},
+    ]
+    # Same construction as the already_sent block in _handle_message_with_agent.
+    history_media_paths = _collect_history_media_paths(history or [])
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}),
+        f"Echo MEDIA:{old}\nFresh MEDIA:{new}",
+        _event(),
+        adapter,
+        history_media_paths=history_media_paths,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    images_kwargs = adapter.send_multiple_images.await_args.kwargs
+    delivered = [path for path, _caption in images_kwargs["images"]]
+    assert any(str(new) in path for path in delivered)
+    assert not any(str(old) in path for path in delivered)
+
+
+@pytest.mark.asyncio
+async def test_post_stream_history_media_paths_empty_history_still_delivers(
+    tmp_path, monkeypatch
+):
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "solo.png")
+    adapter = _adapter()
+    history_media_paths = _collect_history_media_paths([])
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}),
+        f"Here MEDIA:{media_file}",
+        _event(),
+        adapter,
+        history_media_paths=history_media_paths,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    images_kwargs = adapter.send_multiple_images.await_args.kwargs
+    assert str(media_file) in images_kwargs["images"][0][0]


### PR DESCRIPTION
## What does this PR do?

After a successful streamed reply, the gateway’s `already_sent` path tried to deliver `MEDIA:` attachments using `_history_media_paths` from the non-streaming code path. That name is out of scope there, so every successful streamed turn could crash with:

NameError: name '_history_media_paths' is not defined

Users then saw the generic “Sorry, I encountered an unexpected error” — commonly right after `/compress`, even though the model reply already went out.

This PR builds the history media path set locally in that `already_sent` block before calling `_deliver_media_from_response`, matching the non-streaming dedupe behavior without depending on an out-of-scope variable.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — in `_handle_message_with_agent`, compute `_history_media_paths = _collect_history_media_paths(history or [])` on the streaming `already_sent` path before post-stream MEDIA delivery
- `tests/gateway/test_post_stream_media_delivery.py` — cover history-path dedupe and empty-history delivery for the post-stream path

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_post_stream_media_delivery.py -q`
2. Telegram (or any gateway platform) with streaming on: grow a long session, run `/compress`, then send another message — reply should complete without the unexpected-error footer
3. Confirm a fresh `MEDIA:` in the new reply still attaches; a path already present in prior history is not re-sent

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reporter dump (sanitized):

ERROR gateway.run: Agent error in session agent:main:telegram:dm:...
Traceback (most recent call last):
  File ".../gateway/run.py", line 14575, in _handle_message_with_agent
    history_media_paths=_history_media_paths,
NameError: name '_history_media_paths' is not defined

Context: `/compress` succeeded (`851 → 281` messages), next streamed turn answered (~1085 chars), then this crash surfaced as the unexpected-error message.
