### PR TITLE
fix(file_operations): use native Windows path for rg/linter calls

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -975,6 +975,23 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _rg_path_arg(self, path: str) -> str:
+        """Shell-quote a filesystem *path* for ripgrep on Windows.
+
+        ripgrep (``rg.exe``) is a NATIVE Windows binary on this host. The
+        standard ``_escape_shell_arg`` runs paths through ``_bash_safe_path``,
+        which rewrites ``C:/Users/x`` to the MSYS ``/c/Users/x`` spelling so
+        bash builtins (cat/sed/find) resolve them. But rg.exe cannot parse
+        ``/c/...`` and fails with ``os error 2/3``. Convert the path back to
+        native ``C:/...`` form and quote WITHOUT the MSYS rewrite so the
+        absolute-path search_files case works. No-op off Windows.
+        """
+        import sys
+        if sys.platform == "win32":
+            from tools.environments.local import _msys_to_windows_path
+            path = _msys_to_windows_path(path)
+        return "'" + path.replace("'", "'\"'\"'") + "'"
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -1767,8 +1784,11 @@ class ShellFileOperations(FileOperations):
         if not self._has_command(base_cmd):
             return LintResult(skipped=True, message=f"{base_cmd} not available")
 
-        # Run linter
-        cmd = linter_cmd.replace("{file}", self._escape_shell_arg(path))
+        # Run linter. Use the native-Windows path form (C:/...) for the
+        # file argument: linters like node/go/rustfmt are NATIVE Windows
+        # binaries that reject the MSYS /c/... spelling (_bash_safe_path
+        # would produce), while python/npx (MSYS) also accept C:/...
+        cmd = linter_cmd.replace("{file}", self._rg_path_arg(path))
         result = self._exec(cmd, timeout=30)
 
         if result.exit_code != 0 and _looks_like_linter_unusable(base_cmd, result.stdout):
@@ -2218,7 +2238,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._rg_path_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2229,7 +2249,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._rg_path_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2285,8 +2305,8 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
-        
+        cmd_parts.append(self._rg_path_arg(path))
+
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,
         # so we grab generously and filter in Python.


### PR DESCRIPTION
TITLE:
fix(file_operations): use native Windows path for rg/linter calls

BODY:
## Summary

On Windows, `search_files` with an **absolute Windows path** fails for content and file searches, and the shell linter fails for `.js`/`.go`/`.rs` files — all on absolute paths.

- `search_files` `target='content'` → `rg: /c/Users/...: O sistema não pode encontrar o caminho especificado. (os error 3)`
- `search_files` `target='files'` → `total_count: 0` (silent false negative)
- shell linter (`.js`→`node --check`, `.go`→`go vet`, `.rs`→`rustfmt --check`) → `Cannot find module 'C:\c\Users\...'`

Relative paths (`.`) work, which masked the bug.

## Root cause

`tools/file_operations.py` — `_escape_shell_arg` (line ~961) routes every
argument through `_bash_safe_path`, which rewrites `C:/Users/x` to the MSYS
`/c/Users/x` spelling. That is correct for bash builtins (`cat`, `sed`, `find`,
`grep`) and MSYS binaries (`python`, `npx`), which understand `/c/...`.

But `rg.exe` (ripgrep) and the native linters (`node`, `go`, `rustfmt`) are
**native Windows binaries** that cannot parse `/c/...` and interpret it
literally as `C:\c\...`, failing with `os error 2/3`.

The bug class is any shell command that passes an absolute Windows path to a
native binary through `_escape_shell_arg`. The fix addresses every affected
call site, not just the one reported.

## Fix

Add `ShellFileOperations._rg_path_arg(path)` that, on `win32`, converts the
path back to native `C:/...` form via `_msys_to_windows_path` before
shell-quoting (without the MSYS rewrite), and use it at the `rg` and linter
call sites:

- `_search_with_rg` (content search) — path argument
- `_search_files_rg` (file search, 2 call sites) — path argument
- shell linter (`LINTERS` table: node/go/rustfmt) — `{file}` argument

`grep`/`find` call sites keep `_escape_shell_arg` (they are MSYS binaries and
accept `/c/...`), so no regression there. The new method is a no-op off Windows.

## Test plan

Validated with a fresh interpreter (no stale module cache) on Windows 11 / ripgrep 14.1.1:

1. `search_files` content, absolute `C:\...` path → was `os error 3`, now returns real matches.
2. `search_files` files, absolute `C:\...` path → was `total_count: 0`, now lists real files.
3. shell linter `node --check` on absolute `C:\...` → was `Cannot find module`, now `rc 0`.
4. absolute path **with a space** → quoting holds, match found (no regression).
5. relative path `.` → still works (no regression).
6. Control: `rg C:/...` succeeds, `rg /c/...` fails (confirms root cause in isolation).

Reapplication script + detector (`grep -q '_rg_path_arg(self, path: str) -> str:'`) included for post-`hermes update` recovery, since `hermes update` runs `git reset --hard origin/main` and discards local core edits.

## Files changed

- `tools/file_operations.py` (+26 / -6)

(cherry-picked from a local fix; authorship preserved)
