### PR TITLE
fix(pet): scope pet.generate/pet.hatch to the active profile

### DIFF
--- a/apps/desktop/src/store/pet-gallery.ts
+++ b/apps/desktop/src/store/pet-gallery.ts
@@ -59,9 +59,15 @@ export type GatewayRequest = <T>(
 
 /** Profile-scoped pet RPC. Pets are per-profile, so every call carries the active
  *  profile (the gateway no-ops it for the launch profile). One chokepoint so no
- *  call site can forget it. */
-const petRpc = <T>(request: GatewayRequest, method: string, params: Record<string, unknown> = {}): Promise<T> =>
-  request<T>(method, { ...params, profile: petProfile() })
+ *  call site can forget it — forwards timeoutMs/signal so long-running calls
+ *  (pet-generate's drafting/hatching) can use it too. */
+export const petRpc = <T>(
+  request: GatewayRequest,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs?: number,
+  signal?: AbortSignal
+): Promise<T> => request<T>(method, { ...params, profile: petProfile() }, timeoutMs, signal)
 
 /** A JSON-RPC "method not found" — the backend predates the pet RPCs. */
 function isMissingMethod(error: unknown): boolean {

--- a/apps/desktop/src/store/pet-generate.test.ts
+++ b/apps/desktop/src/store/pet-generate.test.ts
@@ -1,0 +1,83 @@
+import { atom } from 'nanostores'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GatewayRequest } from './pet-gallery'
+
+// Keep the heavy, side-effecting import chains inert for a unit test — only
+// pet.ts / profile.ts / pet-gallery.ts / pet-generate.ts run for real, so
+// petProfile()'s actual resolution (the thing this test exists to check) is
+// genuinely exercised rather than mocked away.
+const $gateway = atom<unknown>({ id: 'live-socket', on: vi.fn(() => () => undefined) })
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  ensureGatewayForProfile: vi.fn(async () => undefined),
+  openGatewayForProfile: vi.fn(async () => undefined)
+}))
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  setApiRequestProfile: vi.fn(),
+  STARTUP_REQUEST_TIMEOUT_MS: 5000
+}))
+vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
+vi.mock('@/store/starmap', () => ({ resetStarmapGraph: vi.fn() }))
+vi.mock('@/store/native-notifications', () => ({ dispatchNativeNotification: vi.fn() }))
+
+const { checkPetGenAvailable, generateDrafts, discardHatched } = await import('./pet-generate')
+const { $activeGatewayProfile } = await import('./profile')
+
+/** Every pet.* RPC must resolve against the desktop's active (possibly
+ *  non-launch) profile — see pet.ts's petProfile() docstring. Regression
+ *  coverage for the pet-generate.ts call sites that used to call the bare
+ *  `request()` passed into them, silently dropping `profile` and always
+ *  hitting the launch profile's HERMES_HOME regardless of which profile the
+ *  desktop UI was actually showing. */
+describe('pet-generate.ts RPC calls carry the active profile', () => {
+  beforeEach(() => {
+    $activeGatewayProfile.set('beta')
+  })
+
+  it('pet.generate.status carries profile', async () => {
+    const request = vi.fn(async () => ({ available: false, providers: [] })) as unknown as GatewayRequest
+
+    await checkPetGenAvailable(request)
+
+    expect(request).toHaveBeenCalledWith(
+      'pet.generate.status',
+      expect.objectContaining({ profile: 'beta' }),
+      undefined,
+      undefined
+    )
+  })
+
+  it('pet.generate carries profile alongside its long timeout + abort signal', async () => {
+    const request = vi.fn(async () => ({
+      ok: true,
+      token: 'tok1',
+      drafts: [{ index: 0, dataUri: 'data:x' }]
+    })) as unknown as GatewayRequest
+
+    await generateDrafts(request, { prompt: 'a fox' })
+
+    expect(request).toHaveBeenCalledWith(
+      'pet.generate',
+      expect.objectContaining({ profile: 'beta', prompt: 'a fox' }),
+      expect.any(Number),
+      expect.any(AbortSignal)
+    )
+  })
+
+  it('pet.remove (discard) carries profile', async () => {
+    const request = vi.fn(async () => ({ ok: true })) as unknown as GatewayRequest
+    const { $petGenPreview } = await import('./pet-generate')
+    $petGenPreview.set({ slug: 'stray-pet', displayName: 'Stray', enabled: false })
+
+    await discardHatched(request)
+
+    expect(request).toHaveBeenCalledWith(
+      'pet.remove',
+      expect.objectContaining({ profile: 'beta', slug: 'stray-pet' }),
+      undefined,
+      undefined
+    )
+  })
+})

--- a/apps/desktop/src/store/pet-generate.ts
+++ b/apps/desktop/src/store/pet-generate.ts
@@ -6,7 +6,7 @@ import { $gateway } from '@/store/gateway'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { notify } from '@/store/notifications'
 import { type PetInfo } from '@/store/pet'
-import { applyAdoptedPet, type GatewayRequest } from '@/store/pet-gallery'
+import { applyAdoptedPet, type GatewayRequest, petRpc } from '@/store/pet-gallery'
 /**
  * Feature store for the "generate a pet" flow (Cmd-K → Pets → Generate).
  *
@@ -132,7 +132,7 @@ export function markRemixConfirmed(): void {
 /** Probe whether generation is possible (a reference-capable backend exists). */
 export async function checkPetGenAvailable(request: GatewayRequest): Promise<void> {
   try {
-    const res = await request<{ available: boolean; providers?: PetGenProvider[] }>('pet.generate.status')
+    const res = await petRpc<{ available: boolean; providers?: PetGenProvider[] }>(request, 'pet.generate.status')
     $petGenAvailable.set(Boolean(res?.available))
     const providers = res?.providers ?? []
     $petGenProviders.set(providers)
@@ -212,7 +212,7 @@ export function cleanupPetGenOnClose(request: GatewayRequest): void {
   const preview = $petGenPreview.get()
 
   if ((status === 'preview' || status === 'adopting') && preview?.slug) {
-    void request('pet.remove', { slug: preview.slug }).catch(() => {})
+    void petRpc(request, 'pet.remove', { slug: preview.slug }).catch(() => {})
     resetPetGen()
   }
 }
@@ -354,7 +354,7 @@ export async function generateDrafts(request: GatewayRequest, options: GenerateO
   const preview = $petGenPreview.get()
 
   if (preview?.slug) {
-    await request('pet.remove', { slug: preview.slug }).catch(() => {})
+    await petRpc(request, 'pet.remove', { slug: preview.slug }).catch(() => {})
   }
 
   $petGenStatus.set('generating')
@@ -403,7 +403,8 @@ export async function generateDrafts(request: GatewayRequest, options: GenerateO
     }) ?? (() => {})
 
   try {
-    const result = await request<{ ok: boolean; token: string; drafts: PetDraft[] }>(
+    const result = await petRpc<{ ok: boolean; token: string; drafts: PetDraft[] }>(
+      request,
       'pet.generate',
       {
         prompt,
@@ -519,7 +520,8 @@ export async function hatchSelected(request: GatewayRequest, options: HatchOptio
       }) ?? (() => {})
 
   try {
-    const result = await request<{ ok: boolean; slug: string; displayName: string; pet?: PetInfo }>(
+    const result = await petRpc<{ ok: boolean; slug: string; displayName: string; pet?: PetInfo }>(
+      request,
       'pet.hatch',
       {
         token,
@@ -538,7 +540,7 @@ export async function hatchSelected(request: GatewayRequest, options: HatchOptio
     // Stopped mid-hatch: the server created the pet anyway, so delete it.
     if (!hatch.isCurrent(hatchRunId)) {
       if (result?.slug) {
-        void request('pet.remove', { slug: result.slug }).catch(() => {})
+        void petRpc(request, 'pet.remove', { slug: result.slug }).catch(() => {})
       }
 
       return false
@@ -603,7 +605,7 @@ export async function adoptHatched(request: GatewayRequest, name?: string): Prom
     let adoptSlug = preview.slug
 
     if (finalName && finalName !== preview.displayName) {
-      const renamed = await request<{ ok: boolean; slug: string }>('pet.rename', {
+      const renamed = await petRpc<{ ok: boolean; slug: string }>(request, 'pet.rename', {
         slug: preview.slug,
         name: finalName
       }).catch(() => null)
@@ -613,7 +615,7 @@ export async function adoptHatched(request: GatewayRequest, name?: string): Prom
       }
     }
 
-    const result = await request<{ ok: boolean; slug: string; displayName: string }>('pet.select', {
+    const result = await petRpc<{ ok: boolean; slug: string; displayName: string }>(request, 'pet.select', {
       slug: adoptSlug
     })
 
@@ -643,7 +645,7 @@ export async function discardHatched(request: GatewayRequest): Promise<void> {
   const preview = $petGenPreview.get()
 
   if (preview?.slug) {
-    await request('pet.remove', { slug: preview.slug }).catch(() => {})
+    await petRpc(request, 'pet.remove', { slug: preview.slug }).catch(() => {})
   }
 
   $petGenPreview.set(null)

--- a/tests/tui_gateway/test_pet_generate_rpc.py
+++ b/tests/tui_gateway/test_pet_generate_rpc.py
@@ -62,3 +62,93 @@ def _fake_hatch_factory(captured):
     return fake_hatch
 
 
+def test_pet_generate_status_scoped_to_active_profile(monkeypatch, tmp_path):
+    """pet.generate.status must resolve credentials under the selected profile.
+
+    Every other pet.* RPC (pet.select, pet.info, ...) carries ``@_profile_scoped``
+    so a desktop session "switched" to profile X reads/writes X's HERMES_HOME.
+    pet.generate.status resolved the image-gen provider from the launch
+    profile's config instead, so the generate overlay could report "available"
+    (or the wrong provider list) for a profile that never configured one.
+    """
+    from hermes_constants import get_hermes_home
+
+    profile_home = tmp_path / "profiles" / "beta"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
+    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "beta" else None)
+
+    seen = []
+
+    def fake_resolve_provider(*, require_references=True, prefer=None):
+        from agent.pet.generate.imagegen import GenerationError
+
+        seen.append(str(get_hermes_home()))
+        raise GenerationError("no provider")
+
+    monkeypatch.setattr("agent.pet.generate.imagegen.resolve_provider", fake_resolve_provider)
+    monkeypatch.setattr("agent.pet.generate.imagegen.list_sprite_providers", lambda: (seen.append(str(get_hermes_home())) or []))
+
+    server._methods["pet.generate.status"]("r1", {"profile": "beta"})
+
+    assert seen == [str(profile_home), str(profile_home)]
+
+
+def test_pet_generate_stages_drafts_under_active_profile_home(monkeypatch, tmp_path):
+    """pet.generate must stage drafts under the selected profile's cache dir.
+
+    ``_pet_gen_root()``'s own docstring says its staging dir is profile-scoped,
+    but the handler lacked ``@_profile_scoped`` so it always resolved to the
+    launch profile's HERMES_HOME regardless of the caller's active profile.
+    """
+    import agent.pet.generate as gen
+
+    profile_home = tmp_path / "profiles" / "beta"
+    profile_home.mkdir(parents=True)
+    launch_home = tmp_path / "default"
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "beta" else None)
+    monkeypatch.setattr(gen, "generate_base_drafts", _fake_drafts_factory(tmp_path))
+
+    resp = server._methods["pet.generate"]("r1", {"prompt": "a fox", "profile": "beta"})
+    result = resp["result"]
+    assert result["ok"]
+
+    staged = profile_home / "cache" / "pet-gen" / result["token"] / "draft-0.png"
+    assert staged.is_file()
+    assert not (launch_home / "cache" / "pet-gen" / result["token"]).exists()
+
+
+def test_pet_hatch_installs_pet_under_active_profile_home(monkeypatch, tmp_path):
+    """pet.hatch must install the new pet under the selected profile's pets dir.
+
+    Without ``@_profile_scoped``, a pet hatched while a secondary profile is
+    active landed in the LAUNCH profile's ``pets/`` directory. The subsequent
+    (correctly profile-scoped) ``pet.select`` then can't find the slug in the
+    active profile's store — the "just created" pet is unadoptable.
+    """
+    import agent.pet.generate as gen
+
+    profile_home = tmp_path / "profiles" / "beta"
+    profile_home.mkdir(parents=True)
+    launch_home = tmp_path / "default"
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "beta" else None)
+
+    captured = {}
+    monkeypatch.setattr(gen, "generate_base_drafts", _fake_drafts_factory(tmp_path))
+    monkeypatch.setattr(gen, "hatch_pet", _fake_hatch_factory(captured))
+
+    token = server._methods["pet.generate"](
+        "r1", {"prompt": "a fox", "profile": "beta"}
+    )["result"]["token"]
+
+    resp = server._methods["pet.hatch"](
+        "r2",
+        {"token": token, "index": 0, "name": "Beta Fox", "profile": "beta"},
+    )
+    result = resp["result"]
+    assert result["ok"]
+
+    assert (profile_home / "pets" / "beta-fox").is_dir()
+    assert not (launch_home / "pets" / "beta-fox").exists()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1854,6 +1854,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("pet.generate.status")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Whether pet generation is possible right now.
 
@@ -1885,6 +1886,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("pet.generate")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Generate candidate base looks for a new pet (the draft/variant step).
 
@@ -1998,6 +2000,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("pet.hatch")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Turn a chosen base draft into a full pet — installed but NOT yet active.
 


### PR DESCRIPTION
## Summary

`pet.generate`, `pet.generate.status`, and `pet.hatch` were the only `pet.*` RPC handlers in `tui_gateway/server.py` missing the `@_profile_scoped` decorator, even though:

- `_pet_gen_root()`'s own docstring: *"Profile-scoped staging dir for in-progress generation drafts."*
- `agent/pet/store.py`'s own docstring: *"Pets live under `get_hermes_home()/pets/<slug>/` so every profile gets its own."*

Every other `pet.*` handler already carries the decorator: `pet.select`, `pet.info`, `pet.info.meta`, `pet.cells`, `pet.gallery`, `pet.remove`, `pet.export`, `pet.rename`, `pet.thumb`, `pet.disable`, `pet.scale`.

**Impact:** In desktop app-global-remote mode (one backend serving several profiles), generating/hatching a pet while a secondary profile is active writes the staged drafts and the newly-installed pet under the *launch* profile's `HERMES_HOME` instead of the active one, and resolves image-gen credentials from the launch profile's config. The subsequent (correctly profile-scoped) `pet.select` then can't find the slug in the active profile's store — the pet the user just "created" is unadoptable.

**Client-side mirror bug:** `pet-gallery.ts`'s `petRpc()` is the one chokepoint that stamps every pet RPC with the active profile (*"One chokepoint so no call site can forget it"*). `pet-generate.ts`'s calls — `pet.generate.status`, `pet.generate`, `pet.hatch`, and its own `pet.remove`/`pet.rename`/`pet.select` calls in the adopt/discard flow — all bypassed it via a bare `request()`, so `profile` was silently dropped even with the server-side fix alone. Fixed all of them to go through `petRpc()`, which gained optional `timeoutMs`/`signal` passthrough so the long-running generate/hatch calls (which need custom timeouts + an `AbortSignal`) can use it too.

## What changed

- `tui_gateway/server.py`: add `@_profile_scoped` to `pet.generate.status`, `pet.generate`, `pet.hatch`.
- `apps/desktop/src/store/pet-gallery.ts`: extend `petRpc()` to forward `timeoutMs`/`signal`, and export it.
- `apps/desktop/src/store/pet-generate.ts`: route all profile-scoped RPC calls (`pet.generate.status`, `pet.generate`, `pet.hatch`, `pet.remove` x3, `pet.rename`, `pet.select`) through `petRpc()`. `pet.cancel` intentionally left as a bare call — it's an in-memory token, not profile-scoped state.

## Testing

- `tests/tui_gateway/test_pet_generate_rpc.py`: 3 new tests proving `pet.generate.status`/`pet.generate`/`pet.hatch` resolve credentials and stage/install files under the *selected* profile's home, not the launch profile's. Mutation-verified (fail against pre-fix `server.py`).
- `apps/desktop/src/store/pet-generate.test.ts` (new): 3 tests proving the fixed client call sites include `profile` in their RPC params. Mutation-verified (fail against pre-fix `pet-generate.ts`/`pet-gallery.ts`).
- Full neighboring suites green: `tests/test_tui_gateway_server.py`, `tests/test_tui_gateway_ws.py`, `tests/tui_gateway/`, `tests/hermes_cli/test_pet_toggle.py`, `tests/agent/test_pet_engine.py`, `tests/agent/test_pet_generate.py`, `tests/cli/test_cli_pet_pane.py` (1 unrelated pre-existing failure confirmed independent of this change via stash-and-rerun — a test-order-pollution issue reproducible without this diff), and `apps/desktop`'s full `src/store/` suite (464 tests).
- `ruff check`, `eslint`, `prettier --check`, and `tsc --noEmit` all clean on the changed files.

## Checklist

- [x] Root-caused via direct code reading, not pattern-matching (server docstrings + client `petRpc` chokepoint both confirm the fix's premise)
- [x] Regression tests added on both sides (server + client), mutation-verified against pre-fix code
- [x] No behavior change for single-profile / launch-profile usage (`_profile_scoped` and `petRpc` both no-op for the launch profile)