### PR TITLE
fix(agent): keep system cache breakpoints across provider failover (salvage of #72099 by @necoweb3)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -774,6 +774,41 @@ def _compression_deferred_result(
     }
 
 
+def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool:
+    """Rewrite a cache-decorated system message in place, keeping its blocks.
+
+    ``apply_anthropic_cache_control`` runs once per call block, *before* the
+    retry loop, and splits the system prompt into ``[static prefix, volatile
+    tail]`` text blocks carrying the cache_control breakpoints. Assigning a bare
+    string over that list drops both breakpoints, so the failover retry ships
+    the whole system prompt uncached and re-bills it in full.
+
+    ``rewrite_prompt_model_identity`` only touches the LAST ``Model:`` /
+    ``Provider:`` lines, and those live in the volatile tail — so the static
+    prefix stays byte-identical and its cache entry keeps matching. Returns
+    False when the shape is not one we can safely patch, so the caller falls
+    back to the plain-string assignment.
+    """
+    content = system_message.get("content")
+    if not isinstance(content, list) or not content:
+        return False
+    if not all(
+        isinstance(part, dict) and part.get("type") == "text" for part in content
+    ):
+        return False
+    if len(content) == 1:
+        content[0]["text"] = effective
+        return True
+    if len(content) == 2:
+        head = content[0].get("text") or ""
+        if head and effective.startswith(head):
+            tail = effective[len(head):]
+            if tail:
+                content[1]["text"] = tail
+                return True
+    return False
+
+
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     """Refresh the in-flight system message after a provider failover.
 
@@ -796,7 +831,8 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
         effective = sp
         if agent.ephemeral_system_prompt:
             effective = (effective + "\n\n" + agent.ephemeral_system_prompt).strip()
-        api_messages[0]["content"] = effective
+        if not _rewrite_system_content_blocks(api_messages[0], effective):
+            api_messages[0]["content"] = effective
     return sp
 
 

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 from agent.chat_completion_helpers import rewrite_prompt_model_identity
 from agent.conversation_loop import _sync_failover_system_message
+from agent.prompt_caching import apply_anthropic_cache_control
 
 
 _PROMPT = (
@@ -102,3 +103,89 @@ class TestSyncFailoverSystemMessage:
         assert api_messages == [{"role": "user", "content": "hi"}]
         # Still returns the cached prompt for subsequent call-block rebuilds.
         assert result == agent._cached_system_prompt
+
+
+class TestSyncFailoverPreservesCacheDecoration:
+    """The sync must not flatten a cache-decorated system message.
+
+    ``apply_anthropic_cache_control`` runs once per call block, before the retry
+    loop, splitting the system prompt into ``[static prefix, volatile tail]``
+    blocks that carry the cache_control breakpoints. A failover fires *inside*
+    that retry loop, so overwriting the list with a bare string drops both
+    breakpoints and the retried request re-bills the whole system prompt.
+    """
+
+    _STATIC = "You are a helpful assistant.\n\nStable brief.\n"
+
+    def _decorated(self, prompt):
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "what model are you?"},
+        ]
+        return apply_anthropic_cache_control(
+            messages,
+            cache_ttl=None,
+            native_anthropic=True,
+            static_system_prefix=self._STATIC,
+        )
+
+    def test_keeps_breakpoints_and_static_prefix(self):
+        prompt = self._STATIC + "Model: gpt-5.4-mini\nProvider: openai-codex"
+        agent = _agent(prompt=prompt)
+        api_messages = self._decorated(prompt)
+        assert isinstance(api_messages[0]["content"], list)
+
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        _sync_failover_system_message(agent, api_messages, prompt)
+
+        content = api_messages[0]["content"]
+        assert isinstance(content, list), "cache decoration was flattened to a string"
+        assert len(content) == 2
+        assert all(part.get("cache_control") for part in content), (
+            "the failover retry would ship zero system cache breakpoints"
+        )
+        # The static prefix must stay byte-identical or its cache entry misses.
+        assert content[0]["text"] == self._STATIC
+        # The identity refresh still lands, in the volatile tail.
+        assert "Model: gemma4:e2b-mlx" in content[1]["text"]
+        assert "Provider: custom" in content[1]["text"]
+
+    def test_keeps_single_block_shape(self):
+        prompt = "Model: gpt-5.4-mini\nProvider: openai-codex"
+        agent = _agent(prompt=prompt)
+        # No static prefix match -> the single-block fallback layout.
+        api_messages = apply_anthropic_cache_control(
+            [{"role": "system", "content": prompt}],
+            cache_ttl=None,
+            native_anthropic=True,
+            static_system_prefix=None,
+        )
+        assert isinstance(api_messages[0]["content"], list)
+        assert len(api_messages[0]["content"]) == 1
+
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        _sync_failover_system_message(agent, api_messages, prompt)
+
+        content = api_messages[0]["content"]
+        assert isinstance(content, list) and len(content) == 1
+        assert content[0].get("cache_control")
+        assert "Model: gemma4:e2b-mlx" in content[0]["text"]
+
+    def test_ephemeral_prompt_lands_in_the_volatile_tail(self):
+        prompt = self._STATIC + "Model: gpt-5.4-mini\nProvider: openai-codex"
+        agent = _agent(prompt=prompt, ephemeral="Stay terse.")
+        api_messages = self._decorated(prompt)
+
+        _sync_failover_system_message(agent, api_messages, prompt)
+
+        content = api_messages[0]["content"]
+        assert content[0]["text"] == self._STATIC
+        assert content[1]["text"].endswith("Stay terse.")
+
+    def test_unknown_block_shape_falls_back_to_string(self):
+        agent = _agent()
+        api_messages = [
+            {"role": "system", "content": [{"type": "image", "source": {}}]},
+        ]
+        _sync_failover_system_message(agent, api_messages, _PROMPT)
+        assert api_messages[0]["content"] == agent._cached_system_prompt


### PR DESCRIPTION
## Summary
System-prompt cache breakpoints now survive a provider failover instead of being stripped on every failover-recovered call.

Root cause: `_sync_failover_system_message` refreshed the `Model:`/`Provider:` identity lines by assigning a plain string over `api_messages[0]["content"]`. Under caching that content is a 2-block decorated list, so the assignment flattened it and dropped both system breakpoints — every failover-recovered call (and every gateway turn while a primary is degraded) shipped a 10–30K-token system prompt uncached at full write price.

## Changes
- `agent/conversation_loop.py`: `_rewrite_system_content_blocks` rewrites the decorated blocks in place — the static prefix stays byte-identical (cache entry survives), only the volatile tail's text is replaced; falls back to string assignment on unknown shapes.
- `tests/agent/test_failover_identity.py`: 13 tests.

## Validation
| | Before | After |
|---|---|---|
| after failover | str, 0 breakpoints | list, 2 breakpoints, static prefix byte-identical |

Mirrors the existing `_reapply_reasoning_echo_for_provider` precedent. Preserves the prompt-caching invariant (the `startswith(head)` guard falls back safely when the prefix itself changed).

Salvage of #72099 — @necoweb3's commit cherry-picked with authorship preserved.

## Infographic

![Failover cache fix](https://v3b.fal.media/files/b/0aa3de74/Yyamm8BmsWtAj3oHTYy4A_iiPBjsIS.png)
