### PR TITLE
fix(environments): stop multiline session env from becoming shell via snapshot (salvage of #71306 by @HexLab98)

### DIFF
--- a/tests/tools/test_snapshot_multiline_session_env_injection.py
+++ b/tests/tools/test_snapshot_multiline_session_env_injection.py
@@ -1,0 +1,99 @@
+"""Newline in bridged session env must not become shell code via the snapshot.
+
+Regression for issue #71296: bash 3.2 ``export -p`` prints a value containing
+a newline as a multi-line ``declare -x NAME="…`` block. The old line-based
+``grep -vE`` filter removed only the opener; continuation lines (e.g.
+``curl … | bash #`` smuggled into a Matrix room/display name) persisted into
+the shared terminal snapshot and executed on the next ``source``, with stdout
+discarded by the wrapper.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.environments.base import _export_dump_excluding_session_vars
+
+
+def _bash() -> str:
+    return "/bin/bash" if os.path.exists("/bin/bash") else "bash"
+
+
+def _run_dump_and_source(
+    *,
+    tmp_path: Path,
+    env_name: str,
+    env_value: str,
+    marker: Path,
+) -> subprocess.CompletedProcess:
+    snap = tmp_path / "snap"
+    dump = _export_dump_excluding_session_vars(shlex.quote(str(snap)))
+    q_snap = shlex.quote(str(snap))
+    q_marker = shlex.quote(str(marker))
+    script = f"""
+set -e
+export {env_name}
+{dump}
+if grep -qE 'pwned|touch |{env_name}' {q_snap}; then
+  echo "LEAKED_INTO_SNAPSHOT" >&2
+  exit 2
+fi
+bash -c 'source {q_snap} >/dev/null 2>&1 || true'
+if [ -e {q_marker} ]; then
+  echo "PAYLOAD_EXECUTED" >&2
+  exit 3
+fi
+if ! grep -qE '^declare -x PATH=' {q_snap}; then
+  echo "PATH_MISSING" >&2
+  exit 4
+fi
+"""
+    env = os.environ.copy()
+    env[env_name] = env_value
+    return subprocess.run(
+        [_bash(), "-c", script],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_multiline_session_chat_name_not_executed_via_snapshot(tmp_path: Path):
+    """Continuation lines of HERMES_SESSION_CHAT_NAME must not run on source."""
+    marker = tmp_path / "pwned"
+    chat_name = f"demo\ntouch {marker} #"
+    proc = _run_dump_and_source(
+        tmp_path=tmp_path,
+        env_name="HERMES_SESSION_CHAT_NAME",
+        env_value=chat_name,
+        marker=marker,
+    )
+    assert proc.returncode == 0, (
+        f"rc={proc.returncode}\nstdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+    )
+    assert not marker.exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_multiline_session_user_name_not_executed_via_snapshot(tmp_path: Path):
+    """Same hole via HERMES_SESSION_USER_NAME (display-name path)."""
+    marker = tmp_path / "pwned_user"
+    user_name = f"alice\ntouch {marker} #"
+    proc = _run_dump_and_source(
+        tmp_path=tmp_path,
+        env_name="HERMES_SESSION_USER_NAME",
+        env_value=user_name,
+        marker=marker,
+    )
+    assert proc.returncode == 0, (
+        f"rc={proc.returncode}\nstdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+    )
+    assert not marker.exists()

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -56,13 +56,19 @@ def test_regex_preserves_user_env():
 def test_export_snippet_shape():
     snippet = _export_dump_excluding_session_vars("/tmp/snap.tmp.$BASHPID")
     assert "export -p" in snippet
-    assert "grep -vE" in snippet
+    # Unset-by-name (not line-grep): multi-line declare values must not leave
+    # continuation lines in the snapshot (issue #71296).
+    assert "unset" in snippet
+    assert "${!HERMES_SESSION_*}" in snippet
+    assert "${!HERMES_CRON_AUTO_DELIVER_*}" in snippet
+    assert "HERMES_UI_SESSION_ID" in snippet
+    assert "grep -vE" not in snippet
     assert "/tmp/snap.tmp.$BASHPID" in snippet
-    # The redirection must be attached to a brace group wrapping the pipeline,
-    # NOT to the grep segment: a redirect on grep expands $BASHPID inside
-    # grep's pipeline subshell (a different PID than the parent shell that
-    # expands the follow-up ``mv`` operand), silently orphaning the dump and
-    # breaking snapshot env persistence entirely.
+    # The redirection must be attached to a brace group wrapping the dump,
+    # NOT to a pipeline segment: a redirect on a pipeline segment expands
+    # $BASHPID inside that segment's subshell (a different PID than the parent
+    # that expands the follow-up ``mv`` operand), silently orphaning the dump
+    # and breaking snapshot env persistence entirely.
     assert snippet.lstrip().startswith("{ ")
     assert "|| true; }" in snippet
     assert snippet.rstrip().endswith("> /tmp/snap.tmp.$BASHPID")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -397,7 +397,9 @@ def _cwd_marker(session_id: str) -> str:
 # set), not Hermes' per-turn session identity.
 #
 # Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
-# with one of these prefixes.
+# with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
+# as the Python-side contract for the exclusion set; the dump path unsets by
+# name/prefix instead of grepping declare lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
     "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_)"
 )
@@ -407,24 +409,31 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
     """Return a shell snippet that dumps ``export -p`` to *tmp_path* minus the
     per-session bridged vars (see ``_SNAPSHOT_EXCLUDED_ENV_REGEX``).
 
-    ``export -p`` emits one ``declare -x NAME="value"`` line per exported var.
-    We drop the HERMES_SESSION_* / UI / CRON_AUTO_DELIVER lines so they never
-    persist across sessions in the shared snapshot. ``grep -vE`` returns exit 1
-    when it filters everything, so ``|| true`` keeps the pipeline's success
-    contract intact for the callers that chain on it.
+    Unset the bridged vars in a subshell *before* ``export -p``. A line-based
+    ``grep -vE`` filter is unsafe: bash 3.2 prints a value containing a newline
+    as a multi-line ``declare -x NAME="…`` block, so only the opener matches the
+    regex and continuation lines (e.g. ``curl … | bash #`` smuggled into a
+    Matrix room/display name via ``HERMES_SESSION_CHAT_NAME``) land in the
+    snapshot and execute on the next ``source`` (issue #71296). Unsetting first
+    means ``export -p`` never emits those vars — including any continuation
+    lines. ``|| true`` keeps the success contract for callers that chain on it.
 
-    The pipeline MUST be wrapped in a brace group with the redirection applied
-    to the group, not to the last pipeline segment. *tmp_path* typically embeds
-    ``$BASHPID`` for concurrency-safe temp names; a redirection attached
-    directly to ``grep`` is expanded inside grep's own pipeline subshell, where
-    ``$BASHPID`` resolves to the grep subshell's PID — while the caller's
-    follow-up ``mv $tmp`` expands in the parent shell to a DIFFERENT PID. The
-    dump then lands in an orphaned temp file and the snapshot silently never
-    updates (all exported-env persistence breaks). The brace-group redirect is
-    expanded in the current shell, keeping both expansions consistent.
+    The dump MUST be wrapped in a brace group with the redirection applied to
+    the group. *tmp_path* typically embeds ``$BASHPID`` for concurrency-safe
+    temp names; a redirection attached to a pipeline segment would expand
+    ``$BASHPID`` inside that segment's subshell (a different PID than the
+    parent that expands the follow-up ``mv``), silently orphaning the dump.
+    The brace-group redirect is expanded in the current shell, keeping both
+    expansions consistent.
     """
+    # ${!PREFIX*} is bash 3.2+ name-prefix expansion; empty matches are fine
+    # because ``unset`` with only missing names is ignored under 2>/dev/null.
     return (
-        f"{{ export -p | grep -vE '{_SNAPSHOT_EXCLUDED_ENV_REGEX}' || true; }} "
+        "{ ( "
+        "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
+        "HERMES_UI_SESSION_ID 2>/dev/null; "
+        "export -p; "
+        ") || true; } "
         f"> {tmp_path}"
     )
 
@@ -689,11 +698,11 @@ class BaseEnvironment(ABC):
         # Chain mv on the export succeeding so a failed/partial dump never
         # replaces a good snapshot; drop the temp on failure so it isn't
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
-        # NOTE: the redirection must be attached to a brace group, not to the
-        # grep pipeline segment — ``_snap_tmp`` embeds ``$BASHPID``, and a
-        # redirect on grep is expanded inside grep's pipeline subshell (a
-        # different PID than the parent shell that expands the ``mv`` operand),
-        # silently orphaning the dump. See _export_dump_excluding_session_vars.
+        # NOTE: the redirection must be attached to a brace group — ``_snap_tmp``
+        # embeds ``$BASHPID``, and a redirect on a pipeline segment expands
+        # inside that segment's subshell (a different PID than the parent that
+        # expands the ``mv`` operand), silently orphaning the dump. See
+        # _export_dump_excluding_session_vars.
         if self._snapshot_ready:
             parts.append(
                 f"{{ {_export_dump_excluding_session_vars(_snap_tmp)} "


### PR DESCRIPTION
## Summary
A newline in a platform-derived value (e.g. a Matrix room or display name, bridged as `HERMES_SESSION_CHAT_NAME` / `HERMES_SESSION_USER_NAME`) can no longer inject shell commands into the terminal environment snapshot (RCE on the gateway host, fixes #71296).

Root cause: on bash 3.2 (stock macOS `/bin/bash`), `export -p` prints a value containing a newline as a multi-line `declare -x` block. The old line-based `grep -vE` filter removed only the opener line; continuation lines (e.g. `curl … | bash #` smuggled into a room name) persisted into the shared snapshot and executed on the next `source`.

## Changes
- `tools/environments/base.py`: unset the bridged session vars in a subshell **before** `export -p`, so they never appear in the dump — including continuation lines. Both snapshot call sites route through the one `_export_dump_excluding_session_vars` helper, so this covers the whole class.
- Two regression test files.

## Validation
Reproduced the RCE against the bash-3.2 rendering: **before** the payload executes on `source`; **after** it does not, while legitimate user env and `PATH` still persist and session vars are still stripped. 6 tests passed.

Salvage of #71306 — @HexLab98's commits cherry-picked with authorship preserved.

## Infographic

![Multiline env injection fix](https://v3b.fal.media/files/b/0aa3de71/QBRSPJ-4BsIy4yOfRNwKL_d4tSrWG1.png)
