### PR TITLE
fix(lazy_deps): anchor-gated activation stops phantom backend refreshes

### DIFF
--- a/contributors/emails/viteballoons@gmail.com
+++ b/contributors/emails/viteballoons@gmail.com
@@ -1,0 +1,1 @@
+paralegalia

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -227,16 +227,70 @@ def test_nemo_relay_extra_uses_supported_official_distribution_range():
 
 def _uv_lock_version(package: str) -> str:
     """Resolved version of ``package`` in uv.lock, or fail loudly."""
+    versions = _uv_lock_versions(package)
+    assert versions, f"{package} not found in uv.lock"
+    assert len(versions) == 1, f"{package} resolves to multiple versions in uv.lock: {versions}"
+    return next(iter(versions))
+
+
+def _uv_lock_versions(package: str) -> set[str]:
+    """All resolved versions of ``package`` in uv.lock (normally 0 or 1)."""
     import re
 
     lock_path = Path(__file__).resolve().parents[1] / "uv.lock"
     lock = lock_path.read_text(encoding="utf-8")
-    m = re.search(
-        rf'\[\[package\]\]\nname = "{re.escape(package)}"\nversion = "([^"]+)"',
-        lock,
+    return {
+        m.group(1)
+        for m in re.finditer(
+            rf'\[\[package\]\]\nname = "{re.escape(package)}"\nversion = "([^"]+)"',
+            lock,
+        )
+    }
+
+
+def test_every_lazy_deps_exact_pin_matches_uv_lock():
+    """Class invariant for #60783/#60685: one version per package, everywhere.
+
+    Any package that is BOTH exact-pinned in ``tools/lazy_deps.py`` AND
+    resolved in the committed uv.lock is a *shared* package: the core
+    install ships the locked version, and the ``hermes update`` lazy-refresh
+    pass re-asserts the LAZY_DEPS pin whenever the package is present
+    (``active_features()``). If the two disagree, every update churns the
+    package — and when the lazy pin is older, it force-DOWNGRADES a version
+    another consumer needs (huggingface-hub==1.2.3 vs transformers'
+    >=1.5.0 broke Hindsight local embeddings; stale aiohttp pins reopened
+    patched CVEs in #31817). Contract: for every such package, pin ==
+    locked version. When bumping a pin, regenerate the lock in the same
+    commit (`uv lock --upgrade-package <name>`), and vice versa.
+    """
+    from tools.lazy_deps import LAZY_DEPS
+
+    drift = {}
+    seen = set()
+    for feature, specs in LAZY_DEPS.items():
+        for package, pin in _exact_pins(specs).items():
+            if (package, pin) in seen:
+                continue
+            seen.add((package, pin))
+            locked = _uv_lock_versions(package)
+            if not locked:
+                # Lazy-only package never resolved by the core lock — no
+                # shared-version hazard.
+                continue
+            if pin not in locked:
+                drift.setdefault(package, {})[feature] = {
+                    "lazy_pin": pin,
+                    "uv_lock": sorted(locked),
+                }
+
+    assert not drift, (
+        "LAZY_DEPS exact pins must match the uv.lock resolved version for "
+        "every package the core lock also ships — otherwise `hermes update` "
+        "churns/downgrades the shared package out from under its other "
+        "consumers (#60783, #31817). Bump the pin AND run "
+        "`uv lock --upgrade-package <name>` in the same commit. Drift: "
+        f"{drift}"
     )
-    assert m, f"{package} not found in uv.lock"
-    return m.group(1)
 
 
 def test_huggingface_hub_lazy_pin_matches_uv_lock():

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -320,7 +320,7 @@ class TestActiveFeatures:
         monkeypatch.setattr(ld, "_is_present", lambda spec: False)
         assert ld.active_features() == []
 
-    def test_finds_features_with_at_least_one_package_installed(self, monkeypatch):
+    def test_finds_features_with_anchor_package_installed(self, monkeypatch):
         # Pretend only honcho-ai is installed; nothing else.
         monkeypatch.setattr(
             ld, "_is_present",
@@ -332,15 +332,23 @@ class TestActiveFeatures:
         assert "memory.hindsight" not in active
         assert "platform.slack" not in active
 
-    def test_multi_package_feature_active_if_any_present(self, monkeypatch):
-        # platform.slack has 3 packages; only one needs to be present
-        # for the feature to count as active (user activated it before,
-        # one transitive may have been uninstalled separately).
+    def test_multi_package_feature_active_if_anchor_present(self, monkeypatch):
+        # platform.slack has multiple packages; the first spec is its anchor.
         monkeypatch.setattr(
             ld, "_is_present",
             lambda spec: ld._pkg_name_from_spec(spec) == "slack-bolt",
         )
         assert "platform.slack" in ld.active_features()
+
+    def test_shared_dependency_does_not_activate_feature(self, monkeypatch):
+        # asyncpg is a generic dependency that may be installed for unrelated
+        # reasons. It must not make hermes update try to refresh Matrix unless
+        # the Matrix anchor package (mautrix) is present.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "asyncpg",
+        )
+        assert "platform.matrix" not in ld.active_features()
 
 
 class TestRefreshActiveFeatures:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -877,8 +877,12 @@ def feature_install_command(feature: str) -> Optional[str]:
 def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 
-    A feature counts as "active" if at least one of its declared packages
-    is currently installed in the venv (presence check, ignoring version).
+    A feature counts as "active" if its anchor package (the first declared
+    spec) is currently installed in the venv (presence check, ignoring
+    version). We intentionally do NOT treat shared helper packages as proof
+    that a backend was enabled: for example ``platform.matrix`` depends on
+    generic packages like ``asyncpg``/``aiosqlite`` that can be installed for
+    unrelated reasons, while the actual Matrix adapter anchor is ``mautrix``.
     Features the user has never enabled stay quiet.
 
     Used by ``hermes update`` to figure out which lazy backends need a
@@ -886,7 +890,7 @@ def active_features() -> list[str]:
     """
     active = []
     for feature, specs in LAZY_DEPS.items():
-        if any(_is_present(s) for s in specs):
+        if specs and _is_present(specs[0]):
             active.append(feature)
     return active
 


### PR DESCRIPTION
## Summary
`hermes update` no longer refreshes (and potentially downgrades) lazy backends the user never enabled — a feature now counts as active only when its **anchor package** (first declared spec) is installed, and a new class invariant keeps every shared LAZY_DEPS pin in lockstep with `uv.lock` (fixes #44404).

Root cause: `active_features()` marked a feature active if ANY of its declared packages was present. Shared transitives (aiohttp via any HTTP consumer, asyncpg, numpy, qrcode) false-activated `platform.slack` / `platform.matrix` / `platform.discord` etc., and the refresh pass then reinstalled their pins — pointless churn at best, a shared-package downgrade at worst (the #60783 mechanism), and on Windows a locked-.pyd install failure.

## Changes
- `tools/lazy_deps.py`: `active_features()` keys on `specs[0]` (the anchor — always the feature's distinctive SDK: slack-bolt, mautrix, discord.py, ...) instead of any-present. Salvaged from #27878 by @paralegalia (earliest of a 6-PR cluster), authorship preserved via cherry-pick.
- `tests/test_project_metadata.py`: **class invariant** generalizing the huggingface-hub lockstep test from #72320 — every package exact-pinned in LAZY_DEPS that the core `uv.lock` also resolves must pin the SAME version. Any future stale pin (the #60783 / #31817 mechanism) fails CI with bump instructions.
- `tests/tools/test_lazy_deps.py`: anchor-gating regression tests (shared dep present → NOT active; anchor present → active).

Anchor audit: all 34 features. 30 anchors are distinctive SDKs. The 4 whose anchor is also core-shipped (`tool.dashboard`/fastapi, `tool.vision`/Pillow, `tool.computer_use`/mcp, `tool.trace_upload`/huggingface-hub) still activate on core installs — by design, these ARE core-usable features — and their pins now provably match uv.lock, so their refresh is always a no-op ("current", zero pip calls).

## Validation
| | Before | After |
|---|---|---|
| aiohttp/asyncpg present, no Slack/Matrix ever enabled | slack+matrix+discord+teams "active", refresh reinstalls pins (matrix even tries the python-olm build) | not active, no churn |
| slack-bolt installed | active | active (unchanged) |
| shared pin drifts from lock | silent downgrade on update | CI fails with lockstep instructions |

- `scripts/run_tests.sh tests/tools/test_lazy_deps.py tests/test_project_metadata.py` — 78/78 green
- E2E (real imports, temp HERMES_HOME, faked installed-set): only shared transitives present → `active_features()` excludes all messaging platforms; adding `slack-bolt` activates `platform.slack`

## Credit
Salvages #27878 by @paralegalia (earliest submitter). Same-cluster PRs reaching the same conclusion independently: #44416 (@liuhao1024, version-aware variant), #54178 (@spiky02plateau), #58652 (@tianma-if), #67930 (@nrmjeremy), #70590 (@merlinrabens).

Fixes #44404.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa3de87/S4uSuXXHlUXquwEfYKhyD_RfsAZkbR.png)
