### PR TITLE
fix(update): heal active memory provider deps after venv rebuild

### DIFF
--- a/contributors/emails/155588579+spiky02plateau@users.noreply.github.com
+++ b/contributors/emails/155588579+spiky02plateau@users.noreply.github.com
@@ -1,0 +1,1 @@
+spiky02plateau

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7713,6 +7713,11 @@ def _update_via_zip(args):
             )
         _install_python_dependencies_with_optional_fallback(pip_cmd)
 
+    # ZIP path parity: heal the active memory provider's bridge packages
+    # after the dependency reinstall, same as the git-pull path (#53272,
+    # #70636).
+    _refresh_active_memory_provider_dependencies()
+
     node_failures = _update_node_dependencies()
     _build_web_ui(PROJECT_ROOT / "web")
 
@@ -9539,6 +9544,55 @@ def _refresh_active_lazy_features(
             "  ⚠ Leaving `.lazy-refresh-incomplete` until import probes can confirm health."
         )
     return False
+
+
+def _refresh_active_memory_provider_dependencies() -> None:
+    """Refresh pip dependencies for the configured external memory provider.
+
+    Memory-provider bridge packages are declared in each provider's
+    ``plugin.yaml`` (plus mode-dependent extras like Hindsight's
+    ``hindsight-all``), NOT in Hermes' editable-install extras or
+    ``LAZY_DEPS`` alone — so the core dependency reinstall above can strip
+    or downgrade them (#53272 mem0ai, #70636 hindsight-embed). Re-run the
+    provider's declared install for the ACTIVE provider only, after the
+    core install and lazy refresh, so the last write to any shared package
+    is the one the active provider needs.
+
+    Never raises. A failure here must not block the rest of the update.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception as exc:
+        logger.debug("Memory provider refresh skipped (config load failed): %s", exc)
+        return
+
+    provider = ""
+    if isinstance(cfg, dict):
+        memory_cfg = cfg.get("memory")
+        if isinstance(memory_cfg, dict):
+            if memory_cfg.get("enabled") is False:
+                return
+            provider = str(memory_cfg.get("provider") or "").strip()
+
+    # "default" / empty is the built-in file-backed store — no pip deps.
+    if not provider or provider in {"default", "builtin", "none"}:
+        return
+
+    try:
+        from hermes_cli.memory_setup import _install_dependencies
+    except Exception as exc:
+        logger.debug("Memory provider refresh skipped (import failed): %s", exc)
+        return
+
+    print()
+    print(f"→ Refreshing active memory provider dependencies ({provider})...")
+
+    try:
+        _install_dependencies(provider, force=True)
+    except Exception as exc:
+        print(f"  ⚠ {provider} dependencies failed to refresh: {exc}")
 
 
 def _install_python_dependencies_with_optional_fallback(
@@ -12198,6 +12252,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 "  ⚠ Lazy-refresh recovery incomplete — run `hermes` again "
                 "to finish import-based venv repair."
             )
+
+        # Heal the active memory provider's bridge packages last — the core
+        # reinstall + lazy refresh above may have stripped or downgraded
+        # plugin.yaml-declared deps that aren't in extras (#53272, #70636).
+        _refresh_active_memory_provider_dependencies()
 
         node_failures = _update_node_dependencies()
         _build_web_ui(PROJECT_ROOT / "web")

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -8,6 +8,7 @@ the provider's config schema. Writes config to config.yaml + .env.
 from __future__ import annotations
 
 import os
+import re
 import sys
 import shlex
 from pathlib import Path
@@ -16,6 +17,32 @@ from hermes_constants import get_hermes_home
 from hermes_cli.secret_prompt import masked_secret_prompt
 
 _CANCELLED = -1
+
+
+def _provider_pip_dependencies(provider_name: str, declared: list) -> list:
+    """Return the pip deps a provider actually needs on THIS install.
+
+    ``plugin.yaml`` declares the provider's baseline bridge packages, but
+    some providers install mode-dependent extras at setup time that the
+    manifest can't express. Hindsight's ``local_embedded`` mode installs
+    ``hindsight-all`` (daemon + embedder + client) during
+    ``hermes memory setup`` — if the update-time refresh only reinstalled
+    the declared ``hindsight-client``, the embedded daemon would stay
+    broken after a venv rebuild stripped ``hindsight-embed`` (#70636).
+    """
+    deps = list(declared or [])
+    if provider_name == "hindsight":
+        try:
+            import json
+            cfg_path = get_hermes_home() / "hindsight" / "config.json"
+            cfg = json.loads(cfg_path.read_text(encoding="utf-8")) if cfg_path.exists() else {}
+            mode = cfg.get("mode", "")
+            # "local" is a legacy alias for "local_embedded"
+            if mode in {"local", "local_embedded"}:
+                deps.append("hindsight-all")
+        except Exception:
+            pass
+    return deps
 
 
 # ---------------------------------------------------------------------------
@@ -77,8 +104,16 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # Provider discovery
 # ---------------------------------------------------------------------------
 
-def _install_dependencies(provider_name: str) -> None:
-    """Install pip dependencies declared in plugin.yaml."""
+def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
+    """Install pip dependencies declared in ``plugin.yaml``.
+
+    When ``force`` is true, every declared dependency is handed to the
+    installer even if its import currently succeeds — the resolver then
+    reinstalls anything missing or version-drifted and no-ops on satisfied
+    ranges. This is how ``hermes update`` heals the active memory provider
+    after a venv rebuild/sync removed or downgraded its bridge packages
+    (#53272, #70636).
+    """
     import subprocess
     from plugins.memory import find_provider_dir
 
@@ -96,7 +131,7 @@ def _install_dependencies(provider_name: str) -> None:
     except Exception:
         return
 
-    pip_deps = meta.get("pip_dependencies", [])
+    pip_deps = _provider_pip_dependencies(provider_name, meta.get("pip_dependencies", []))
     if not pip_deps:
         return
 
@@ -108,10 +143,15 @@ def _install_dependencies(provider_name: str) -> None:
         "hindsight-all": "hindsight",
     }
 
-    # Check which packages are missing
+    # Check which packages need installation.
     missing = []
     for dep in pip_deps:
-        import_name = _IMPORT_NAMES.get(dep, dep.replace("-", "_").split("[")[0])
+        if force:
+            missing.append(dep)
+            continue
+        dep_name = re.match(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*", dep)
+        base = dep_name.group(0) if dep_name else dep
+        import_name = _IMPORT_NAMES.get(base, base.replace("-", "_").split("[")[0])
         try:
             __import__(import_name)
         except ImportError:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -131,10 +131,19 @@ def _check_local_runtime() -> tuple[bool, str | None]:
     error from NumPy before the daemon starts. Treat that as "unavailable"
     so Hermes can degrade gracefully instead of repeatedly trying to start
     a broken local memory backend.
+
+    The embedded daemon computes embeddings via ``sentence_transformers``
+    (transformers + huggingface-hub). Importing ``hindsight`` /
+    ``hindsight_embed`` alone succeeds even when that stack is broken, so
+    without importing it here the probe would falsely report the backend
+    healthy and ``hermes memory status`` would stay green while the daemon
+    aborts at startup on every retain/recall. Import it too so the probe (and
+    status) reports the real ImportError.
     """
     try:
         importlib.import_module("hindsight")
         importlib.import_module("hindsight_embed.daemon_embed_manager")
+        importlib.import_module("sentence_transformers")
         return True, None
     except Exception as exc:
         return False, str(exc)

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -230,3 +230,76 @@ def test_write_env_vars_plain_value_roundtrips(tmp_path):
     env_path = tmp_path / ".env"
     memory_setup._write_env_vars(env_path, {"PROVIDER_API_KEY": "sk-plain-1234"})
     assert env_path.read_text(encoding="utf-8") == "PROVIDER_API_KEY=sk-plain-1234\n"
+
+
+# ---------------------------------------------------------------------------
+# _provider_pip_dependencies — mode-aware dep expansion (#70636)
+# ---------------------------------------------------------------------------
+
+def test_provider_pip_dependencies_passthrough_for_non_hindsight():
+    deps = memory_setup._provider_pip_dependencies("mem0", ["mem0ai>=2.0.10,<3"])
+    assert deps == ["mem0ai>=2.0.10,<3"]
+
+
+def test_provider_pip_dependencies_adds_hindsight_all_for_local_embedded(tmp_path, monkeypatch):
+    """local_embedded Hindsight needs hindsight-all (daemon + embedder), not
+    just the declared hindsight-client — a venv rebuild that stripped
+    hindsight-embed must be healed by the update-time refresh (#70636)."""
+    import json
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    (tmp_path / "hindsight").mkdir()
+    (tmp_path / "hindsight" / "config.json").write_text(
+        json.dumps({"mode": "local_embedded"}), encoding="utf-8"
+    )
+    deps = memory_setup._provider_pip_dependencies("hindsight", ["hindsight-client>=0.6.1"])
+    assert deps == ["hindsight-client>=0.6.1", "hindsight-all"]
+
+
+def test_provider_pip_dependencies_legacy_local_alias(tmp_path, monkeypatch):
+    import json
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    (tmp_path / "hindsight").mkdir()
+    (tmp_path / "hindsight" / "config.json").write_text(
+        json.dumps({"mode": "local"}), encoding="utf-8"
+    )
+    deps = memory_setup._provider_pip_dependencies("hindsight", ["hindsight-client>=0.6.1"])
+    assert "hindsight-all" in deps
+
+
+def test_provider_pip_dependencies_cloud_hindsight_unchanged(tmp_path, monkeypatch):
+    import json
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
+    (tmp_path / "hindsight").mkdir()
+    (tmp_path / "hindsight" / "config.json").write_text(
+        json.dumps({"mode": "cloud"}), encoding="utf-8"
+    )
+    deps = memory_setup._provider_pip_dependencies("hindsight", ["hindsight-client>=0.6.1"])
+    assert deps == ["hindsight-client>=0.6.1"]
+
+
+def test_install_dependencies_force_reinstalls_versioned_specs(tmp_path, monkeypatch):
+    """force=True hands every declared spec (version ranges intact) to pip,
+    so a downgraded/stripped bridge package is restored on hermes update."""
+    import yaml as _yaml
+
+    plugin_dir = tmp_path / "mem0"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        _yaml.safe_dump({"pip_dependencies": ["mem0ai>=2.0.10,<3"]}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "plugins.memory.find_provider_dir", lambda name: plugin_dir
+    )
+
+    installed = []
+
+    def fake_pip_install(args, timeout=120):
+        installed.append(args)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr("hermes_cli.tools_config._pip_install", fake_pip_install)
+
+    memory_setup._install_dependencies("mem0", force=True)
+
+    assert installed, "force=True must reach the pip install step"
+    assert any("mem0ai>=2.0.10,<3" in args for args in installed)

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -480,6 +480,94 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     assert ".[all]" in install_cmds[0]
 
 
+def test_refresh_active_memory_provider_dependencies_reinstalls_active_provider(monkeypatch):
+    """#53272/#70636: update must re-run the active provider's dep install."""
+    recorded = []
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": "mem0"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.memory_setup._install_dependencies",
+        lambda provider_name, force=False: recorded.append((provider_name, force)),
+    )
+
+    hermes_main._refresh_active_memory_provider_dependencies()
+
+    assert recorded == [("mem0", True)]
+
+
+@pytest.mark.parametrize(
+    "memory_cfg",
+    [
+        {},                                          # no provider configured
+        {"provider": ""},                            # empty provider
+        {"provider": "default"},                     # built-in store
+        {"provider": "mem0", "enabled": False},      # memory disabled
+    ],
+)
+def test_refresh_active_memory_provider_dependencies_skips_inactive(monkeypatch, memory_cfg):
+    recorded = []
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": memory_cfg},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.memory_setup._install_dependencies",
+        lambda provider_name, force=False: recorded.append((provider_name, force)),
+    )
+
+    hermes_main._refresh_active_memory_provider_dependencies()
+
+    assert recorded == []
+
+
+def test_refresh_active_memory_provider_dependencies_never_raises(monkeypatch):
+    """A provider install failure must not block the rest of the update."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": "hindsight"}},
+    )
+
+    def boom(provider_name, force=False):
+        raise RuntimeError("pip exploded")
+
+    monkeypatch.setattr("hermes_cli.memory_setup._install_dependencies", boom)
+
+    hermes_main._refresh_active_memory_provider_dependencies()  # must not raise
+
+
+def test_cmd_update_refreshes_active_memory_provider_dependencies(monkeypatch, tmp_path):
+    """The git-pull update path must invoke the memory-provider refresh."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
+
+    refresh_calls = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_refresh_active_memory_provider_dependencies",
+        lambda: refresh_calls.append(True),
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
+            return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
+            return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert refresh_calls == [True]
+
+
 def test_install_with_optional_fallback_honors_custom_group(monkeypatch):
     """Termux update path should target .[termux-all] when requested."""
     calls = []


### PR DESCRIPTION
## Summary
`hermes update` now heals the active memory provider's pip dependencies after the core reinstall — Mem0 OSS and local Hindsight (including the embedded daemon stack) survive every update instead of silently breaking until a manual reinstall (fixes #53272, fixes the hindsight-embed half of #70636).

Root cause: memory-provider bridge packages are declared in each provider's `plugin.yaml` (installed by `hermes memory setup`), NOT in Hermes' extras or LAZY_DEPS — so the update flow's `.[all]` reinstall + lazy refresh could strip or downgrade them and nothing ever put them back. Hindsight `local_embedded` is worse: setup installs `hindsight-all` (daemon + embedder + client), which even the manifest doesn't declare, so `hindsight-embed` was invisible to every refresh path.

## Changes
- `hermes_cli/main.py`: `_refresh_active_memory_provider_dependencies()` — re-runs the ACTIVE provider's declared dep install after the core install + lazy refresh, wired into **both** the git-pull and ZIP update paths. Skips builtin/none/disabled. Never raises.
- `hermes_cli/memory_setup.py`: `_install_dependencies(force=True)` hands every declared spec to the resolver (restores missing AND version-drifted packages; no-op when satisfied). Spec-aware import probing so version ranges (`mem0ai>=2.0.10,<3`) map to import names correctly.
- `hermes_cli/memory_setup.py`: `_provider_pip_dependencies()` — mode-aware expansion: Hindsight in `local`/`local_embedded` mode adds `hindsight-all`, matching what setup actually installs (#70636's missing piece).
- `plugins/memory/hindsight/__init__.py`: availability probe now imports `sentence_transformers` too (salvaged from #68009 by @spiky02plateau) — `hermes memory status` / `is_available()` report the real ImportError instead of staying green while the daemon aborts at startup.
- 9 new tests (update wiring, skip guards, never-raise, mode expansion, force path, probe coverage).

## Validation
| | Before | After |
|---|---|---|
| `hermes update` with mem0 OSS active | `mem0ai` gone → "No module named 'mem0'" | reinstalled every update |
| update with Hindsight local_embedded | `hindsight-embed` stripped, daemon dead, status green | `hindsight-client` + `hindsight-all` healed; probe reports embedding-stack breakage honestly |
| provider install fails mid-update | — | warning printed, update continues (never-raise) |

- `scripts/run_tests.sh tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_memory_setup.py tests/plugins/memory/test_hindsight_provider.py` — 184/184 green
- Sabotage run: removing the cmd_update wiring fails `test_cmd_update_refreshes_active_memory_provider_dependencies`
- E2E (real imports, temp HERMES_HOME, real config.yaml + hindsight config.json in local_embedded mode): refresh installs exactly `['hindsight-client>=0.6.1', 'hindsight-all']`

## Credit
Salvages #53505 by @LeonSGP43 (update-path refresh — surgical reapply, stale base) and #68009 by @spiky02plateau (embedding-stack probe), authorship preserved. #40341 (@GodsBoy discussion) and #53298 identified the same mechanism earlier for the plugin.yaml route.

Fixes #53272. Fixes the package-healing half of #70636 (the hermes.env overwrite half is #70606, separate).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa3de93/Ztbnx55Y0f2Fp3S5ZFYzu_d9SwBPWQ.png)
