### PR TITLE
fix(kanban): carry chat_type through the dashboard home-channel subscription

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -481,7 +481,14 @@ class HomeChannel:
     # authorization boundary and resolves them against its authoritative stores.
     user_id: Optional[str] = None
     scope_id: Optional[str] = None
-    
+    # The SessionSource.chat_type ("dm", "group", "channel", "thread") observed
+    # when /sethome ran. build_session_key() keys DMs on a wholly different
+    # shape from group/thread, so a consumer that wakes a session against this
+    # home channel (e.g. the kanban dashboard's home-channel subscribe) needs
+    # this to route to the SAME session /sethome was run in, instead of
+    # defaulting to "group" and building the wrong key (#56580).
+    chat_type: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "platform": self.platform.value,
@@ -494,8 +501,10 @@ class HomeChannel:
             result["user_id"] = self.user_id
         if self.scope_id:
             result["scope_id"] = self.scope_id
+        if self.chat_type:
+            result["chat_type"] = self.chat_type
         return result
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "HomeChannel":
         return cls(
@@ -505,6 +514,7 @@ class HomeChannel:
             thread_id=str(data["thread_id"]) if data.get("thread_id") else None,
             user_id=str(data["user_id"]) if data.get("user_id") else None,
             scope_id=str(data["scope_id"]) if data.get("scope_id") else None,
+            chat_type=str(data["chat_type"]) if data.get("chat_type") else None,
         )
 
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3036,6 +3036,11 @@ class GatewaySlashCommandsMixin:
                 if getattr(source, "scope_id", None)
                 else None
             ),
+            chat_type=(
+                str(source.chat_type)
+                if getattr(source, "chat_type", None)
+                else None
+            ),
         )
 
         # config.yaml is canonical because it can persist the authenticated

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2060,6 +2060,7 @@ def _configured_home_channels() -> list[dict]:
             "chat_id": hc.chat_id,
             "thread_id": hc.thread_id or "",
             "name": hc.name or "Home",
+            "chat_type": hc.chat_type or "",
         })
     # Stable order for deterministic UI — platform name alphabetical.
     result.sort(key=lambda r: r["platform"])
@@ -2145,6 +2146,7 @@ def subscribe_home(task_id: str, platform: str, board: Optional[str] = Query(Non
             task_id=task_id,
             platform=platform,
             chat_id=home["chat_id"],
+            chat_type=home["chat_type"] or None,
             thread_id=home["thread_id"] or None,
             notifier_profile=_active_profile_name(),
         )

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -35,6 +35,7 @@ class TestHomeChannelRoundtrip:
             name="general",
             user_id="user-123",
             scope_id="guild-456",
+            chat_type="dm",
         )
         d = hc.to_dict()
         restored = HomeChannel.from_dict(d)
@@ -44,6 +45,15 @@ class TestHomeChannelRoundtrip:
         assert restored.name == "general"
         assert restored.user_id == "user-123"
         assert restored.scope_id == "guild-456"
+        assert restored.chat_type == "dm"
+
+    def test_to_dict_omits_chat_type_when_unset(self):
+        """Legacy/env-var-sourced homes have no chat_type — the key must be
+        absent (not null), matching thread_id/user_id/scope_id's convention."""
+        hc = HomeChannel(platform=Platform.DISCORD, chat_id="999", name="general")
+
+        assert "chat_type" not in hc.to_dict()
+        assert HomeChannel.from_dict(hc.to_dict()).chat_type is None
 
 
 class TestPlatformConfigRoundtrip:

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -132,6 +132,37 @@ async def test_sethome_updates_running_config_for_same_process_restart(tmp_path,
 
 
 @pytest.mark.asyncio
+async def test_sethome_captures_source_chat_type(tmp_path, monkeypatch):
+    """/sethome must persist the source's chat_type onto the HomeChannel.
+
+    build_session_key() keys DMs on a wholly different shape from
+    group/thread, so a consumer that later wakes a session against this home
+    channel (the kanban dashboard's home-subscribe endpoint) needs to know
+    whether /sethome ran in a DM to route to the SAME session, instead of
+    defaulting to "group" and building the wrong key (#56580).
+    """
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
+    monkeypatch.setattr("gateway.slash_commands.persist_home_channel", lambda home, **kwargs: None)
+
+    runner, _adapter = make_restart_runner()
+    source = make_restart_source(chat_id="dm-home-1", chat_type="dm")
+    source.chat_name = "Ops DM"
+    event = MessageEvent(
+        text="/sethome",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m-home-dm",
+    )
+
+    await runner._handle_set_home_command(event)
+
+    home = runner.config.get_home_channel(Platform.TELEGRAM)
+    assert home is not None
+    assert home.chat_type == "dm"
+
+
+@pytest.mark.asyncio
 async def test_sethome_preserves_thread_target_for_same_process_restart(tmp_path, monkeypatch):
     """/sethome from a topic/thread stores the thread-aware home target."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -778,6 +778,43 @@ def test_home_channels_lists_only_platforms_with_home(client, with_home_channels
         assert h["subscribed"] is False
 
 
+def test_home_subscribe_carries_chat_type_from_sethome(client, kanban_home, monkeypatch):
+    """A home channel set via /sethome in a DM carries its chat_type into the
+    notify_sub row, so the gateway notifier's wake path builds the DM-shaped
+    session key instead of defaulting to "group" (#56580 follow-up: the
+    dashboard's home-subscribe endpoint was the one add_notify_sub call site
+    that never threaded chat_type through, because HomeChannel itself never
+    persisted it)."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "abc:fake")
+    (kanban_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  telegram:\n"
+        "    enabled: true\n"
+        "    home_channel:\n"
+        "      platform: telegram\n"
+        "      chat_id: '555'\n"
+        "      name: Ops DM\n"
+        "      chat_type: dm\n",
+        encoding="utf-8",
+    )
+
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
+    r = client.post(f"/api/plugins/kanban/tasks/{t['id']}/home-subscribe/telegram")
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, t["id"])
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["chat_id"] == "555"
+    assert subs[0]["chat_type"] == "dm"
+
+
 # ---------------------------------------------------------------------------
 # Recovery endpoints (reclaim + reassign) and warnings field
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`#56580`'s fix threaded `SessionSource.chat_type` into `add_notify_sub`'s call sites — the auto-subscribe path (`tools/kanban_tools.py`) and the `/kanban create` slash command (`gateway/slash_commands.py`) — but its own follow-up commit (`c03a06b8d`) explicitly noted a remaining gap:

> The dashboard plugin API (`plugins/kanban/dashboard/plugin_api.py`) still has the gap because the `home_channel` config schema doesn't carry `chat_type` — that's a follow-up that needs a config schema change.

This PR is that follow-up.

**Impact:** Without `chat_type`, subscribing a task to a home channel via the dashboard always created a `kanban_notify_subs` row with `chat_type=NULL`. The gateway notifier's wake path (`gateway/kanban_watchers.py`) defaults an unset `chat_type` to `"group"`, but `build_session_key()` keys DMs on a wholly different shape (`":dm:<chat_id>"`) than group/thread. So a task-completion notification routed to a home channel that's actually a DM built the wrong-shaped session key and opened a **fresh session** instead of resuming the DM conversation the user actually has with the bot — silently losing context on every notification.

## What changed

- **`gateway/config.py`**: `HomeChannel` gains an optional `chat_type` field. Round-trips through `to_dict()`/`from_dict()`; omitted from the dict when unset, matching `thread_id`/`user_id`/`scope_id`'s existing convention — no behavior change for env-var-sourced homes (`TELEGRAM_HOME_CHANNEL` etc.), which have no `chat_type` to carry and keep defaulting to `"group"` as before.
- **`gateway/slash_commands.py`**: `/sethome` now captures `source.chat_type` onto the persisted `HomeChannel`.
- **`plugins/kanban/dashboard/plugin_api.py`**: `_configured_home_channels()` surfaces `chat_type`, and `subscribe_home()` threads it into `add_notify_sub()` — the third and last call site `#56580` set out to cover.

## Testing

- `tests/gateway/test_config.py::TestHomeChannelRoundtrip`: round-trip coverage for the new field, plus a test asserting it's omitted (not `null`) when unset.
- `tests/gateway/test_restart_notification.py::test_sethome_captures_source_chat_type`: `/sethome` from a DM persists `chat_type="dm"` onto the running config.
- `tests/plugins/test_kanban_dashboard_plugin.py::test_home_subscribe_carries_chat_type_from_sethome`: subscribing via the dashboard endpoint to a config.yaml-sourced DM home channel produces a `notify_sub` row with `chat_type="dm"`.
- All 4 new/changed assertions mutation-verified (fail against the pre-fix code).
- Full neighboring suites green: `tests/gateway/test_config.py`, `test_restart_notification.py`, `test_slack_relay_parent_command.py`, `test_home_target_env_var.py`, `test_matrix.py`, `test_status_command.py`, `test_delivery.py`, `test_session.py`, `test_weixin.py`, `test_setup_feishu.py`, `test_restart_drain.py`, `test_gateway_shutdown.py`, `test_restart_resume_pending.py`, `test_teams.py`, `test_telegram_topic_mode.py`, `test_prompt_tail_freeze.py`, `test_pii_redaction.py`, `tests/cron/test_scheduler.py`, `test_kanban_notifier.py`, `tests/hermes_cli/test_kanban_db.py`, `tests/plugins/test_kanban_dashboard_plugin.py` (1631 tests total).
- `ruff check` clean on all changed files.

## Checklist

- [x] Root-caused from a maintainer-acknowledged gap in a merged commit, verified live in code (not assumed from the commit message alone)
- [x] Regression tests added, mutation-verified against pre-fix code
- [x] No behavior change for existing env-var-configured home channels