### PR TITLE
fix(web): validate provider-reported final URLs

### DIFF
--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -29,6 +29,8 @@ import os
 from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
+from tools.url_safety import PROVIDER_FINAL_URL_ERROR, validate_provider_final_url
+from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
 
@@ -173,10 +175,39 @@ class ExaWebSearchProvider(WebSearchProvider):
             response = _get_exa_client().get_contents(urls, text=True)
 
             results: List[Dict[str, Any]] = []
-            for result in response.results or []:
+            for result in (response.results or [])[: len(urls)]:
                 content = result.text or ""
-                url = result.url or ""
+                reported_url = result.url
+                url = validate_provider_final_url(reported_url)
                 title = result.title or ""
+                if url is None:
+                    results.append(
+                        {
+                            "url": "",
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "error": PROVIDER_FINAL_URL_ERROR,
+                        }
+                    )
+                    continue
+                final_blocked = check_website_access(url)
+                if final_blocked:
+                    results.append(
+                        {
+                            "url": url,
+                            "title": title,
+                            "content": "",
+                            "raw_content": "",
+                            "error": final_blocked["message"],
+                            "blocked_by_policy": {
+                                "host": final_blocked["host"],
+                                "rule": final_blocked["rule"],
+                                "source": final_blocked["source"],
+                            },
+                        }
+                    )
+                    continue
                 results.append(
                     {
                         "url": url,

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -51,7 +51,10 @@ import os
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from agent.web_search_provider import WebSearchProvider
-from tools.url_safety import is_safe_url
+from tools.url_safety import (
+    PROVIDER_FINAL_URL_ERROR,
+    async_validate_provider_final_url,
+)
 from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
@@ -524,24 +527,23 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                         metadata = {}
 
                 title = metadata.get("title", "")
-                final_url = metadata.get("sourceURL", url)
+                reported_final_url = metadata.get("sourceURL")
+                final_url = await async_validate_provider_final_url(
+                    reported_final_url
+                )
 
-                # Re-check SSRF safety after any redirect reported by Firecrawl.
-                if not is_safe_url(final_url):
+                # Fail closed unless Firecrawl reports a safe authoritative URL.
+                if final_url is None:
                     logger.info(
-                        "Blocked redirected web_extract for unsafe final URL: %s",
-                        final_url,
+                        "Blocked web_extract for missing or unsafe provider final URL"
                     )
                     results.append(
                         {
-                            "url": final_url,
-                            "title": title,
+                            "url": "",
+                            "title": "",
                             "content": "",
                             "raw_content": "",
-                            "error": (
-                                "Blocked: URL targets a private or internal "
-                                "network address"
-                            ),
+                            "error": PROVIDER_FINAL_URL_ERROR,
                         }
                     )
                     continue

--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -33,6 +33,11 @@ import os
 from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
+from tools.url_safety import (
+    PROVIDER_FINAL_URL_ERROR,
+    async_validate_provider_final_url,
+)
+from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
 
@@ -240,12 +245,43 @@ class ParallelWebSearchProvider(WebSearchProvider):
             )
 
             results: List[Dict[str, Any]] = []
-            for result in response.results or []:
+            provider_results = (response.results or [])[: len(urls)]
+            remaining = len(urls) - len(provider_results)
+            for result in provider_results:
                 content = result.full_content or ""
                 if not content:
                     content = "\n\n".join(result.excerpts or [])
-                url = result.url or ""
+                reported_url = result.url
+                url = await async_validate_provider_final_url(reported_url)
                 title = result.title or ""
+                if url is None:
+                    results.append(
+                        {
+                            "url": "",
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "error": PROVIDER_FINAL_URL_ERROR,
+                        }
+                    )
+                    continue
+                final_blocked = check_website_access(url)
+                if final_blocked:
+                    results.append(
+                        {
+                            "url": url,
+                            "title": title,
+                            "content": "",
+                            "raw_content": "",
+                            "error": final_blocked["message"],
+                            "blocked_by_policy": {
+                                "host": final_blocked["host"],
+                                "rule": final_blocked["rule"],
+                                "source": final_blocked["source"],
+                            },
+                        }
+                    )
+                    continue
                 results.append(
                     {
                         "url": url,
@@ -256,14 +292,43 @@ class ParallelWebSearchProvider(WebSearchProvider):
                     }
                 )
 
-            for error in response.errors or []:
+            for error in (response.errors or [])[:remaining]:
+                error_url = await async_validate_provider_final_url(error.url)
+                if error_url is None:
+                    results.append(
+                        {
+                            "url": "",
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "error": PROVIDER_FINAL_URL_ERROR,
+                        }
+                    )
+                    continue
+                final_blocked = check_website_access(error_url)
+                if final_blocked:
+                    results.append(
+                        {
+                            "url": error_url,
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "error": final_blocked["message"],
+                            "blocked_by_policy": {
+                                "host": final_blocked["host"],
+                                "rule": final_blocked["rule"],
+                                "source": final_blocked["source"],
+                            },
+                        }
+                    )
+                    continue
                 results.append(
                     {
-                        "url": error.url or "",
+                        "url": error_url,
                         "title": "",
                         "content": "",
                         "error": error.content or error.error_type or "extraction failed",
-                        "metadata": {"sourceURL": error.url or ""},
+                        "metadata": {"sourceURL": error_url},
                     }
                 )
 

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -28,6 +28,8 @@ import os
 from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
+from tools.url_safety import PROVIDER_FINAL_URL_ERROR, validate_provider_final_url
+from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +79,9 @@ def _normalize_tavily_search_results(response: Dict[str, Any]) -> Dict[str, Any]
 
 
 def _normalize_tavily_documents(
-    response: Dict[str, Any], fallback_url: str = ""
+    response: Dict[str, Any],
+    fallback_url: str = "",
+    max_results: int | None = None,
 ) -> List[Dict[str, Any]]:
     """Map Tavily ``/extract`` response to standard documents.
 
@@ -87,10 +91,52 @@ def _normalize_tavily_documents(
 
     Failures (``failed_results``, ``failed_urls``) become result entries
     with an ``error`` field rather than raising.
+
+    ``fallback_url`` is retained for call compatibility but intentionally
+    ignored: provider content requires its own safe authoritative final URL.
     """
     documents: List[Dict[str, Any]] = []
-    for result in response.get("results", []):
-        url = result.get("url", fallback_url)
+    successes = response.get("results", [])
+    failed_results = response.get("failed_results", [])
+    failed_urls = response.get("failed_urls", [])
+    budget = (
+        max_results
+        if max_results is not None
+        else len(successes) + len(failed_results) + len(failed_urls)
+    )
+    successes = successes[:budget]
+    budget -= len(successes)
+    for result in successes:
+        reported_url = result.get("url")
+        url = validate_provider_final_url(reported_url)
+        if url is None:
+            documents.append(
+                {
+                    "url": "",
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": PROVIDER_FINAL_URL_ERROR,
+                }
+            )
+            continue
+        final_blocked = check_website_access(url)
+        if final_blocked:
+            documents.append(
+                {
+                    "url": url,
+                    "title": result.get("title", ""),
+                    "content": "",
+                    "raw_content": "",
+                    "error": final_blocked["message"],
+                    "blocked_by_policy": {
+                        "host": final_blocked["host"],
+                        "rule": final_blocked["rule"],
+                        "source": final_blocked["source"],
+                    },
+                }
+            )
+            continue
         raw = result.get("raw_content", "") or result.get("content", "")
         documents.append(
             {
@@ -101,27 +147,87 @@ def _normalize_tavily_documents(
                 "metadata": {"sourceURL": url, "title": result.get("title", "")},
             }
         )
-    for fail in response.get("failed_results", []):
+    failed_results = failed_results[:budget]
+    budget -= len(failed_results)
+    for fail in failed_results:
+        reported_fail_url = fail.get("url")
+        fail_url = validate_provider_final_url(reported_fail_url)
+        if fail_url is None:
+            documents.append(
+                {
+                    "url": "",
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": PROVIDER_FINAL_URL_ERROR,
+                }
+            )
+            continue
+        final_blocked = check_website_access(fail_url)
+        if final_blocked:
+            documents.append(
+                {
+                    "url": fail_url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": final_blocked["message"],
+                    "blocked_by_policy": {
+                        "host": final_blocked["host"],
+                        "rule": final_blocked["rule"],
+                        "source": final_blocked["source"],
+                    },
+                }
+            )
+            continue
         documents.append(
             {
-                "url": fail.get("url", fallback_url),
+                "url": fail_url,
                 "title": "",
                 "content": "",
                 "raw_content": "",
                 "error": fail.get("error", "extraction failed"),
-                "metadata": {"sourceURL": fail.get("url", fallback_url)},
+                "metadata": {"sourceURL": fail_url},
             }
         )
-    for fail_url in response.get("failed_urls", []):
-        url_str = fail_url if isinstance(fail_url, str) else str(fail_url)
+    for reported_fail_url in failed_urls[:budget]:
+        fail_url = validate_provider_final_url(reported_fail_url)
+        if fail_url is None:
+            documents.append(
+                {
+                    "url": "",
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": PROVIDER_FINAL_URL_ERROR,
+                }
+            )
+            continue
+        final_blocked = check_website_access(fail_url)
+        if final_blocked:
+            documents.append(
+                {
+                    "url": fail_url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": final_blocked["message"],
+                    "blocked_by_policy": {
+                        "host": final_blocked["host"],
+                        "rule": final_blocked["rule"],
+                        "source": final_blocked["source"],
+                    },
+                }
+            )
+            continue
         documents.append(
             {
-                "url": url_str,
+                "url": fail_url,
                 "title": "",
                 "content": "",
                 "raw_content": "",
                 "error": "extraction failed",
-                "metadata": {"sourceURL": url_str},
+                "metadata": {"sourceURL": fail_url},
             }
         )
     return documents
@@ -198,7 +304,9 @@ class TavilyWebSearchProvider(WebSearchProvider):
                 },
             )
             return _normalize_tavily_documents(
-                raw, fallback_url=urls[0] if urls else ""
+                raw,
+                fallback_url=urls[0] if urls else "",
+                max_results=len(urls),
             )
         except ValueError as exc:
             return [{"url": u, "title": "", "content": "", "error": str(exc)} for u in urls]

--- a/tests/tools/test_web_provider_final_url_safety.py
+++ b/tests/tools/test_web_provider_final_url_safety.py
@@ -1,0 +1,986 @@
+"""Fail-closed final-URL regression tests for content extraction providers."""
+
+import asyncio
+import json
+import socket
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+PUBLIC_DNS = [
+    (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("93.184.216.34", 0))
+]
+PRIVATE_DNS = [
+    (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("10.0.0.7", 0))
+]
+
+
+def _assert_blocked(document, reported_url=""):
+    assert document["url"] == ""
+    assert document["title"] == ""
+    assert document["content"] == ""
+    assert document["raw_content"] == ""
+    assert "authoritative final URL" in document["error"]
+    assert document.get("metadata") in (None, {})
+    if reported_url:
+        assert reported_url not in json.dumps(document)
+
+
+def _assert_allowed(document):
+    assert document["url"] == "https://public.example/page"
+    assert document["title"] == "Retrieved"
+    assert document["content"] == "public content"
+    assert document["raw_content"] == "public content"
+    assert "error" not in document
+
+
+class TestProviderFinalUrlValidation:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            "not a URL",
+            " https://example.com/",
+            "https://example.com:invalid/",
+            "https://example.com/\x00hidden",
+            r"https://127.0.0.1\@public.example/",
+            "https://user:password@public.example/",
+            "https://public.example/%ZZ",
+        ],
+    )
+    def test_missing_or_malformed_url_is_rejected(self, value):
+        from tools.url_safety import validate_provider_final_url
+
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS):
+            assert validate_provider_final_url(value) is None
+
+    def test_private_url_is_rejected_even_when_private_urls_are_enabled(self):
+        from tools.url_safety import validate_provider_final_url
+
+        with (
+            patch("tools.url_safety._global_allow_private_urls", return_value=True),
+            patch("tools.url_safety.socket.getaddrinfo", return_value=PRIVATE_DNS),
+        ):
+            assert validate_provider_final_url("https://private.example/page") is None
+
+    def test_private_url_is_rejected_even_when_host_exception_matches(self):
+        from tools.url_safety import validate_provider_final_url
+
+        with (
+            patch("tools.url_safety._allows_private_ip_resolution", return_value=True),
+            patch("tools.url_safety.socket.getaddrinfo", return_value=PRIVATE_DNS),
+        ):
+            assert validate_provider_final_url("https://private.example/page") is None
+
+    def test_dns_failure_is_rejected_even_when_proxy_is_configured(self, monkeypatch):
+        from tools.url_safety import validate_provider_final_url
+
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+        with patch(
+            "tools.url_safety.socket.getaddrinfo",
+            side_effect=socket.gaierror("resolution failed"),
+        ):
+            assert validate_provider_final_url("https://unresolved.example/page") is None
+
+    def test_empty_dns_result_is_rejected(self):
+        from tools.url_safety import validate_provider_final_url
+
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=[]):
+            assert validate_provider_final_url("https://unresolved.example/page") is None
+
+    def test_public_url_is_returned_unchanged(self):
+        from tools.url_safety import validate_provider_final_url
+
+        with patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS):
+            assert (
+                validate_provider_final_url("https://public.example/page")
+                == "https://public.example/page"
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_validation_keeps_event_loop_responsive(self):
+        from tools.url_safety import async_validate_provider_final_url
+
+        def slow_dns(*_args, **_kwargs):
+            time.sleep(0.15)
+            return PUBLIC_DNS
+
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            deadline = asyncio.get_running_loop().time() + 0.1
+            while asyncio.get_running_loop().time() < deadline:
+                ticks += 1
+                await asyncio.sleep(0.005)
+
+        with patch("tools.url_safety.socket.getaddrinfo", side_effect=slow_dns):
+            validated, _ = await asyncio.gather(
+                async_validate_provider_final_url("https://public.example/page"),
+                ticker(),
+            )
+
+        assert validated == "https://public.example/page"
+        assert ticks >= 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reported_url", [None, "http://127.0.0.1/private"])
+async def test_firecrawl_suppresses_content_without_safe_final_url(reported_url):
+    from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+
+    metadata = {"title": "Retrieved"}
+    if reported_url is not None:
+        metadata["sourceURL"] = reported_url
+    client = SimpleNamespace(
+        scrape=lambda **_kwargs: {"markdown": "sensitive content", "metadata": metadata}
+    )
+
+    with (
+        patch(
+            "plugins.web.firecrawl.provider._get_firecrawl_client", return_value=client
+        ),
+        patch("plugins.web.firecrawl.provider.check_website_access", return_value=None),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+    ):
+        documents = await FirecrawlWebSearchProvider().extract(
+            ["https://requested.example/page"], format="markdown"
+        )
+
+    _assert_blocked(documents[0], reported_url or "")
+    assert documents[0]["url"] != "https://requested.example/page"
+
+
+@pytest.mark.parametrize("reported_url", [None, "http://127.0.0.1/private"])
+def test_tavily_suppresses_content_without_safe_final_url(reported_url):
+    from plugins.web.tavily.provider import _normalize_tavily_documents
+
+    result = {"raw_content": "sensitive content", "title": "Retrieved"}
+    if reported_url is not None:
+        result["url"] = reported_url
+
+    documents = _normalize_tavily_documents(
+        {"results": [result]}, fallback_url="https://requested.example/page"
+    )
+
+    _assert_blocked(documents[0], reported_url or "")
+    assert documents[0]["url"] != "https://requested.example/page"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {
+            "failed_results": [
+                {
+                    "url": "http://127.0.0.1/private",
+                    "error": "provider-controlled diagnostic",
+                }
+            ]
+        },
+        {"failed_urls": ["http://127.0.0.1/private"]},
+    ],
+)
+def test_tavily_suppresses_unsafe_failure_record(response):
+    from plugins.web.tavily.provider import _normalize_tavily_documents
+
+    documents = _normalize_tavily_documents(response)
+
+    _assert_blocked(documents[0], "http://127.0.0.1/private")
+    assert "provider-controlled diagnostic" not in json.dumps(documents[0])
+
+
+@pytest.mark.parametrize("reported_url", [None, "http://127.0.0.1/private"])
+def test_exa_suppresses_content_without_safe_final_url(reported_url):
+    from plugins.web.exa.provider import ExaWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                text="sensitive content", url=reported_url, title="Retrieved"
+            )
+        ]
+    )
+    client = SimpleNamespace(get_contents=lambda *_args, **_kwargs: response)
+
+    with (
+        patch("plugins.web.exa.provider._get_exa_client", return_value=client),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+    ):
+        documents = ExaWebSearchProvider().extract(["https://requested.example/page"])
+
+    _assert_blocked(documents[0], reported_url or "")
+    assert documents[0]["url"] != "https://requested.example/page"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reported_url", [None, "http://127.0.0.1/private"])
+async def test_parallel_suppresses_content_without_safe_final_url(reported_url):
+    from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                full_content="sensitive content",
+                excerpts=[],
+                url=reported_url,
+                title="Retrieved",
+            )
+        ],
+        errors=[],
+    )
+    client = SimpleNamespace(
+        beta=SimpleNamespace(extract=AsyncMock(return_value=response))
+    )
+
+    with (
+        patch("plugins.web.parallel.provider._get_async_client", return_value=client),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+    ):
+        documents = await ParallelWebSearchProvider().extract([
+            "https://requested.example/page"
+        ])
+
+    _assert_blocked(documents[0], reported_url or "")
+    assert documents[0]["url"] != "https://requested.example/page"
+
+
+@pytest.mark.asyncio
+async def test_parallel_suppresses_unsafe_error_record():
+    from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[],
+        errors=[
+            SimpleNamespace(
+                url="http://127.0.0.1/private",
+                content="provider-controlled diagnostic",
+                error_type="provider-secret-type",
+            )
+        ],
+    )
+    client = SimpleNamespace(
+        beta=SimpleNamespace(extract=AsyncMock(return_value=response))
+    )
+
+    with (
+        patch("plugins.web.parallel.provider._get_async_client", return_value=client),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+    ):
+        documents = await ParallelWebSearchProvider().extract([
+            "https://requested.example/page"
+        ])
+
+    _assert_blocked(documents[0], "http://127.0.0.1/private")
+    serialized = json.dumps(documents[0])
+    assert "provider-controlled diagnostic" not in serialized
+    assert "provider-secret-type" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_firecrawl_preserves_content_with_safe_final_url():
+    from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+
+    client = SimpleNamespace(
+        scrape=lambda **_kwargs: {
+            "markdown": "public content",
+            "metadata": {
+                "sourceURL": "https://public.example/page",
+                "title": "Retrieved",
+            },
+        }
+    )
+    with (
+        patch(
+            "plugins.web.firecrawl.provider._get_firecrawl_client", return_value=client
+        ),
+        patch("plugins.web.firecrawl.provider.check_website_access", return_value=None),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+        patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS),
+    ):
+        documents = await FirecrawlWebSearchProvider().extract(
+            ["https://requested.example/page"], format="markdown"
+        )
+    _assert_allowed(documents[0])
+
+
+def test_tavily_preserves_content_with_safe_final_url():
+    from plugins.web.tavily.provider import _normalize_tavily_documents
+
+    with (
+        patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS),
+        patch("plugins.web.tavily.provider.check_website_access", return_value=None),
+    ):
+        documents = _normalize_tavily_documents({
+            "results": [
+                {
+                    "url": "https://public.example/page",
+                    "title": "Retrieved",
+                    "raw_content": "public content",
+                }
+            ]
+        })
+    _assert_allowed(documents[0])
+
+
+def test_exa_preserves_content_with_safe_final_url():
+    from plugins.web.exa.provider import ExaWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                text="public content",
+                url="https://public.example/page",
+                title="Retrieved",
+            )
+        ]
+    )
+    client = SimpleNamespace(get_contents=lambda *_args, **_kwargs: response)
+    with (
+        patch("plugins.web.exa.provider._get_exa_client", return_value=client),
+        patch("plugins.web.exa.provider.check_website_access", return_value=None),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+        patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS),
+    ):
+        documents = ExaWebSearchProvider().extract(["https://requested.example/page"])
+    _assert_allowed(documents[0])
+
+
+@pytest.mark.asyncio
+async def test_parallel_preserves_content_with_safe_final_url():
+    from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                full_content="public content",
+                excerpts=[],
+                url="https://public.example/page",
+                title="Retrieved",
+            )
+        ],
+        errors=[],
+    )
+    client = SimpleNamespace(
+        beta=SimpleNamespace(extract=AsyncMock(return_value=response))
+    )
+    with (
+        patch("plugins.web.parallel.provider._get_async_client", return_value=client),
+        patch("plugins.web.parallel.provider.check_website_access", return_value=None),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+        patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS),
+    ):
+        documents = await ParallelWebSearchProvider().extract([
+            "https://requested.example/page"
+        ])
+    _assert_allowed(documents[0])
+
+
+def _policy_block():
+    return {
+        "host": "blocked.example",
+        "rule": "blocked.example",
+        "source": "config",
+        "message": "Blocked by website policy",
+    }
+
+
+def _assert_policy_blocked(document, title="Blocked title"):
+    assert document["url"] == "https://blocked.example/page"
+    assert document["title"] == title
+    assert document["content"] == ""
+    assert document["raw_content"] == ""
+    assert document["error"] == "Blocked by website policy"
+    assert document["blocked_by_policy"] == {
+        "host": "blocked.example",
+        "rule": "blocked.example",
+        "source": "config",
+    }
+    assert "metadata" not in document
+
+
+def test_tavily_suppresses_content_for_policy_blocked_final_url():
+    from plugins.web.tavily.provider import _normalize_tavily_documents
+
+    with (
+        patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS),
+        patch(
+            "plugins.web.tavily.provider.check_website_access",
+            return_value=_policy_block(),
+            create=True,
+        ),
+    ):
+        documents = _normalize_tavily_documents(
+            {
+                "results": [
+                    {
+                        "url": "https://blocked.example/page",
+                        "title": "Blocked title",
+                        "raw_content": "blocked content",
+                    }
+                ]
+            }
+        )
+
+    _assert_policy_blocked(documents[0])
+
+
+def test_exa_suppresses_content_for_policy_blocked_final_url():
+    from plugins.web.exa.provider import ExaWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                text="blocked content",
+                url="https://blocked.example/page",
+                title="Blocked title",
+            )
+        ]
+    )
+    client = SimpleNamespace(get_contents=lambda *_args, **_kwargs: response)
+    with (
+        patch("plugins.web.exa.provider._get_exa_client", return_value=client),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+        patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS),
+        patch(
+            "plugins.web.exa.provider.check_website_access",
+            return_value=_policy_block(),
+            create=True,
+        ),
+    ):
+        documents = ExaWebSearchProvider().extract(["https://requested.example/page"])
+
+    _assert_policy_blocked(documents[0])
+
+
+@pytest.mark.asyncio
+async def test_parallel_suppresses_content_for_policy_blocked_final_url():
+    from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                full_content="blocked content",
+                excerpts=[],
+                url="https://blocked.example/page",
+                title="Blocked title",
+            )
+        ],
+        errors=[],
+    )
+    client = SimpleNamespace(
+        beta=SimpleNamespace(extract=AsyncMock(return_value=response))
+    )
+    with (
+        patch("plugins.web.parallel.provider._get_async_client", return_value=client),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+        patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS),
+        patch(
+            "plugins.web.parallel.provider.check_website_access",
+            return_value=_policy_block(),
+            create=True,
+        ),
+    ):
+        documents = await ParallelWebSearchProvider().extract([
+            "https://requested.example/page"
+        ])
+
+    _assert_policy_blocked(documents[0])
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {
+            "failed_results": [
+                {
+                    "url": "https://blocked.example/page",
+                    "error": "provider-controlled diagnostic",
+                }
+            ]
+        },
+        {"failed_urls": ["https://blocked.example/page"]},
+    ],
+)
+def test_tavily_suppresses_policy_blocked_failure_record(response):
+    from plugins.web.tavily.provider import _normalize_tavily_documents
+
+    with (
+        patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS),
+        patch(
+            "plugins.web.tavily.provider.check_website_access",
+            return_value=_policy_block(),
+        ),
+    ):
+        documents = _normalize_tavily_documents(response)
+
+    _assert_policy_blocked(documents[0], title="")
+    assert "provider-controlled diagnostic" not in json.dumps(documents[0])
+
+
+@pytest.mark.asyncio
+async def test_parallel_suppresses_policy_blocked_error_record():
+    from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[],
+        errors=[
+            SimpleNamespace(
+                url="https://blocked.example/page",
+                content="provider-controlled diagnostic",
+                error_type="provider-secret-type",
+            )
+        ],
+    )
+    client = SimpleNamespace(
+        beta=SimpleNamespace(extract=AsyncMock(return_value=response))
+    )
+    with (
+        patch("plugins.web.parallel.provider._get_async_client", return_value=client),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+        patch("tools.url_safety.socket.getaddrinfo", return_value=PUBLIC_DNS),
+        patch(
+            "plugins.web.parallel.provider.check_website_access",
+            return_value=_policy_block(),
+        ),
+    ):
+        documents = await ParallelWebSearchProvider().extract([
+            "https://requested.example/page"
+        ])
+
+    _assert_policy_blocked(documents[0], title="")
+    serialized = json.dumps(documents[0])
+    assert "provider-controlled diagnostic" not in serialized
+    assert "provider-secret-type" not in serialized
+
+
+async def _run_shared_sink_registered_result(
+    provider_result,
+    *,
+    policy_block,
+    dns_result=PUBLIC_DNS,
+    requested_urls=None,
+):
+    from agent import web_search_registry
+    from agent.web_search_provider import WebSearchProvider
+    from tools import web_tools
+
+    class RegisteredExtractProvider(WebSearchProvider):
+        @property
+        def name(self):
+            return "registered-final-url-test"
+
+        def is_available(self):
+            return True
+
+        def supports_extract(self):
+            return True
+
+        async def extract(self, _urls, **_kwargs):
+            if isinstance(provider_result, list):
+                return provider_result
+            return [provider_result]
+
+    with web_search_registry._lock:
+        previous = dict(web_search_registry._providers)
+        web_search_registry._providers.clear()
+    provider = RegisteredExtractProvider()
+    web_search_registry.register_provider(provider)
+    try:
+        with (
+            patch("tools.web_tools._ensure_web_plugins_loaded"),
+            patch("tools.web_tools._get_extract_backend", return_value=provider.name),
+            patch("tools.web_tools.async_is_safe_url", new=AsyncMock(return_value=True)),
+            patch("tools.url_safety.socket.getaddrinfo", return_value=dns_result),
+            patch(
+                "tools.web_tools.check_website_access",
+                return_value=policy_block,
+            ),
+        ):
+            return json.loads(
+                await web_tools.web_extract_tool(
+                    requested_urls or ["https://requested.example/page"]
+                )
+            )
+    finally:
+        with web_search_registry._lock:
+            web_search_registry._providers.clear()
+            web_search_registry._providers.update(previous)
+
+
+@pytest.mark.asyncio
+async def test_shared_sink_blocks_policy_denied_registered_provider_result():
+    response = await _run_shared_sink_registered_result(
+        {
+            "url": "https://blocked.example/page",
+            "title": "provider-controlled title",
+            "content": "provider-controlled content",
+            "raw_content": "provider-controlled raw content",
+            "metadata": {"provider": "controlled metadata"},
+            "error": "provider-controlled diagnostic",
+        },
+        policy_block=_policy_block(),
+    )
+
+    assert response == {
+        "results": [
+            {
+                "url": "",
+                "title": "",
+                "content": "",
+                "error": "Blocked by website policy",
+                "blocked_by_policy": {
+                    "host": "blocked.example",
+                    "rule": "blocked.example",
+                    "source": "config",
+                },
+            }
+        ]
+    }
+    serialized = json.dumps(response)
+    for secret in (
+        "provider-controlled title",
+        "provider-controlled content",
+        "provider-controlled raw content",
+        "controlled metadata",
+        "provider-controlled diagnostic",
+    ):
+        assert secret not in serialized
+
+
+@pytest.mark.asyncio
+async def test_shared_sink_preserves_safe_registered_provider_result():
+    response = await _run_shared_sink_registered_result(
+        {
+            "url": "https://public.example/page",
+            "title": "Retrieved",
+            "content": "public content",
+            "raw_content": "public content",
+            "metadata": {"provider": "registered-final-url-test"},
+        },
+        policy_block=None,
+    )
+
+    assert response == {
+        "results": [
+            {
+                "url": "https://public.example/page",
+                "title": "Retrieved",
+                "content": "public content",
+                "error": None,
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reported_url", "dns_result"),
+    [
+        (None, PUBLIC_DNS),
+        ("not a URL", PUBLIC_DNS),
+        ("http://127.0.0.1/private", PRIVATE_DNS),
+    ],
+)
+async def test_shared_sink_blocks_unsafe_registered_provider_result(
+    reported_url, dns_result
+):
+    from tools.url_safety import PROVIDER_FINAL_URL_ERROR
+
+    provider_result = {
+        "title": "provider-controlled title",
+        "content": "provider-controlled content",
+        "raw_content": "provider-controlled raw content",
+        "metadata": {"provider": "controlled metadata"},
+        "error": "provider-controlled diagnostic",
+    }
+    if reported_url is not None:
+        provider_result["url"] = reported_url
+
+    response = await _run_shared_sink_registered_result(
+        provider_result,
+        policy_block=None,
+        dns_result=dns_result,
+    )
+
+    assert response == {
+        "results": [
+            {
+                "url": "",
+                "title": "",
+                "content": "",
+                "error": PROVIDER_FINAL_URL_ERROR,
+            }
+        ]
+    }
+    serialized = json.dumps(response)
+    for secret in (
+        "provider-controlled title",
+        "provider-controlled content",
+        "provider-controlled raw content",
+        "controlled metadata",
+        "provider-controlled diagnostic",
+    ):
+        assert secret not in serialized
+
+
+@pytest.mark.asyncio
+async def test_shared_sink_ignores_excess_registered_provider_results():
+    provider_results = [
+        {
+            "url": f"https://public-{index}.example/page",
+            "title": f"Result {index}",
+            "content": f"content {index}",
+        }
+        for index in range(3)
+    ]
+    validated_urls = []
+
+    async def track_validation(url):
+        validated_urls.append(url)
+        return url
+
+    with patch(
+        "tools.web_tools.async_validate_provider_final_url",
+        side_effect=track_validation,
+    ):
+        response = await _run_shared_sink_registered_result(
+            provider_results,
+            policy_block=None,
+        )
+
+    assert validated_urls == ["https://public-0.example/page"]
+    assert response == {
+        "results": [
+            {
+                "url": "https://public-0.example/page",
+                "title": "Result 0",
+                "content": "content 0",
+                "error": None,
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_shared_sink_synthesizes_missing_safe_result():
+    response = await _run_shared_sink_registered_result(
+        {
+            "url": "https://first.example/page",
+            "title": "First",
+            "content": "first content",
+        },
+        policy_block=None,
+        requested_urls=[
+            "https://first.example/page",
+            "https://second.example/page",
+        ],
+    )
+
+    assert len(response["results"]) == 2
+    assert response["results"][0]["url"] == "https://first.example/page"
+    assert response["results"][1] == {
+        "url": "https://second.example/page",
+        "title": "",
+        "content": "",
+        "error": "Extract backend returned no result for this URL",
+    }
+
+
+@pytest.mark.asyncio
+async def test_shared_sink_correlates_reordered_success_and_error_by_url():
+    response = await _run_shared_sink_registered_result(
+        [
+            {
+                "url": "https://second.example/page",
+                "title": "Second",
+                "content": "second content",
+            },
+            {
+                "url": "https://first.example/page",
+                "title": "",
+                "content": "",
+                "error": "first failed",
+            },
+        ],
+        policy_block=None,
+        requested_urls=[
+            "https://first.example/page",
+            "https://second.example/page",
+        ],
+    )
+
+    assert response["results"] == [
+        {
+            "url": "https://first.example/page",
+            "title": "",
+            "content": "",
+            "error": "first failed",
+        },
+        {
+            "url": "https://second.example/page",
+            "title": "Second",
+            "content": "second content",
+            "error": None,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_shared_sink_suppresses_ambiguous_batch_redirects():
+    response = await _run_shared_sink_registered_result(
+        [
+            {
+                "url": "https://redirect-one.example/page",
+                "title": "Secret one",
+                "content": "secret content one",
+            },
+            {
+                "url": "https://redirect-two.example/page",
+                "title": "Secret two",
+                "content": "secret content two",
+            },
+        ],
+        policy_block=None,
+        requested_urls=[
+            "https://first.example/page",
+            "https://second.example/page",
+        ],
+    )
+
+    assert [result["url"] for result in response["results"]] == [
+        "https://first.example/page",
+        "https://second.example/page",
+    ]
+    assert all(
+        result["error"] == "Extract backend returned no result for this URL"
+        for result in response["results"]
+    )
+    serialized = json.dumps(response)
+    assert "redirect-one.example" not in serialized
+    assert "redirect-two.example" not in serialized
+    assert "secret content" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_shared_sink_does_not_correlate_redirect_after_generic_failure():
+    response = await _run_shared_sink_registered_result(
+        [
+            {
+                "url": None,
+                "title": "Unsafe",
+                "content": "unsafe secret",
+            },
+            {
+                "url": "https://redirect.example/page",
+                "title": "Redirect",
+                "content": "redirect secret",
+            },
+        ],
+        policy_block=None,
+        requested_urls=[
+            "https://first.example/page",
+            "https://second.example/page",
+        ],
+    )
+
+    serialized = json.dumps(response)
+    assert "redirect.example" not in serialized
+    assert "redirect secret" not in serialized
+    assert "unsafe secret" not in serialized
+    assert len(response["results"]) == 2
+    assert all(not result["content"] for result in response["results"])
+
+
+def test_exa_caps_provider_records_before_final_url_validation():
+    from plugins.web.exa.provider import ExaWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(text="content", url=f"https://{index}.example", title="")
+            for index in range(3)
+        ]
+    )
+    client = SimpleNamespace(get_contents=lambda *_args, **_kwargs: response)
+    with (
+        patch("plugins.web.exa.provider._get_exa_client", return_value=client),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+        patch(
+            "plugins.web.exa.provider.validate_provider_final_url",
+            side_effect=lambda url: url,
+        ) as validate,
+        patch("plugins.web.exa.provider.check_website_access", return_value=None),
+    ):
+        documents = ExaWebSearchProvider().extract(["https://requested.example"])
+
+    assert validate.call_count == 1
+    assert len(documents) == 1
+
+
+def test_tavily_caps_combined_records_before_final_url_validation():
+    from plugins.web.tavily.provider import _normalize_tavily_documents
+
+    with (
+        patch(
+            "plugins.web.tavily.provider.validate_provider_final_url",
+            side_effect=lambda url: url,
+        ) as validate,
+        patch("plugins.web.tavily.provider.check_website_access", return_value=None),
+    ):
+        documents = _normalize_tavily_documents(
+            {
+                "results": [{"url": "https://success.example", "content": "ok"}],
+                "failed_results": [
+                    {"url": "https://failed.example", "error": "failed"}
+                ],
+                "failed_urls": ["https://also-failed.example"],
+            },
+            max_results=1,
+        )
+
+    assert validate.call_count == 1
+    assert len(documents) == 1
+
+
+@pytest.mark.asyncio
+async def test_parallel_caps_combined_records_before_final_url_validation():
+    from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+    response = SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                full_content="content",
+                excerpts=[],
+                url=f"https://{index}.example",
+                title="",
+            )
+            for index in range(2)
+        ],
+        errors=[
+            SimpleNamespace(
+                url="https://error.example",
+                content="failed",
+                error_type="error",
+            )
+        ],
+    )
+    client = SimpleNamespace(beta=SimpleNamespace(extract=AsyncMock(return_value=response)))
+    with (
+        patch("plugins.web.parallel.provider._get_async_client", return_value=client),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+        patch(
+            "plugins.web.parallel.provider.async_validate_provider_final_url",
+            AsyncMock(side_effect=lambda url: url),
+        ) as validate,
+        patch("plugins.web.parallel.provider.check_website_access", return_value=None),
+    ):
+        documents = await ParallelWebSearchProvider().extract(
+            ["https://requested.example"]
+        )
+
+    assert validate.await_count == 1
+    assert len(documents) == 1

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -153,11 +153,14 @@ class TestNormalizeTavilyDocuments:
         assert docs[0]["url"] == "https://bad.com"
         assert docs[0]["error"] == "extraction failed"
 
-    def test_fallback_url(self):
+    def test_missing_authoritative_url_fails_closed_without_fallback(self):
         from tools.web_tools import _normalize_tavily_documents
         raw = {"results": [{"content": "data"}]}
         docs = _normalize_tavily_documents(raw, fallback_url="https://fallback.com")
-        assert docs[0]["url"] == "https://fallback.com"
+        assert docs[0]["url"] == ""
+        assert docs[0]["content"] == ""
+        assert docs[0]["raw_content"] == ""
+        assert "authoritative final URL" in docs[0]["error"]
 
 
 # ─── web_search_tool (Tavily dispatch) ────────────────────────────────────────
@@ -224,4 +227,40 @@ class TestWebExtractTavily:
             assert len(result["results"]) == 1
             assert result["results"][0]["url"] == "https://example.com"
             assert "Extracted content" in result["results"][0]["content"]
+
+    def test_extract_serialization_omits_rejected_provider_fields(self):
+        unsafe_url = "http://127.0.0.1/private"
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "url": unsafe_url,
+                    "raw_content": "provider-controlled content",
+                    "title": "provider-controlled title",
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("tools.web_tools._get_backend", return_value="tavily"),
+            patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}),
+            patch("tools.web_tools.httpx.post", return_value=mock_response),
+        ):
+            from tools.web_tools import web_extract_tool
+
+            serialized = asyncio.get_event_loop().run_until_complete(
+                web_extract_tool(["https://example.com"])
+            )
+
+        assert unsafe_url not in serialized
+        assert "provider-controlled content" not in serialized
+        assert "provider-controlled title" not in serialized
+        result = json.loads(serialized)["results"][0]
+        assert result["url"] == ""
+        assert result["title"] == ""
+        assert result["content"] == ""
+        assert result.get("raw_content", "") == ""
+        assert result.get("metadata") in (None, {})
+        assert "authoritative final URL" in result["error"]
 

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 import yaml
@@ -379,16 +380,21 @@ class TestWebToolPolicy:
         # The per-URL website-policy gate moved into the firecrawl plugin's
         # extract() during the web-provider migration. Patch it at the new
         # location.
-        monkeypatch.setattr(
-            firecrawl_provider,
-            "check_website_access",
-            lambda url: {
+        def block_all(_url):
+            return {
                 "host": "blocked.test",
                 "rule": "blocked.test",
                 "source": "config",
                 "message": "Blocked by website policy",
-            },
+            }
+
+        monkeypatch.setattr(firecrawl_provider, "check_website_access", block_all)
+        monkeypatch.setattr(
+            web_tools,
+            "async_validate_provider_final_url",
+            AsyncMock(side_effect=lambda url: url),
         )
+        monkeypatch.setattr(web_tools, "check_website_access", block_all)
         monkeypatch.setattr(
             firecrawl_provider,
             "_get_firecrawl_client",
@@ -400,8 +406,17 @@ class TestWebToolPolicy:
 
         result = json.loads(await web_tools.web_extract_tool(["https://blocked.test"]))
 
-        assert result["results"][0]["url"] == "https://blocked.test"
-        assert "Blocked by website policy" in result["results"][0]["error"]
+        assert result["results"][0] == {
+            "url": "",
+            "title": "",
+            "content": "",
+            "error": "Blocked by website policy",
+            "blocked_by_policy": {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+            },
+        }
 
     @pytest.mark.asyncio
     async def test_web_extract_blocks_redirected_final_url(self, monkeypatch):
@@ -413,7 +428,16 @@ class TestWebToolPolicy:
             return True
 
         monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
-        monkeypatch.setattr(firecrawl_provider, "is_safe_url", lambda url: True)
+        monkeypatch.setattr(
+            firecrawl_provider,
+            "async_validate_provider_final_url",
+            AsyncMock(side_effect=lambda url: url),
+        )
+        monkeypatch.setattr(
+            web_tools,
+            "async_validate_provider_final_url",
+            AsyncMock(side_effect=lambda url: url),
+        )
 
         def fake_check(url):
             if url == "https://allowed.test":
@@ -438,21 +462,32 @@ class TestWebToolPolicy:
                 }
 
         # After the web-provider migration, the per-URL gate + firecrawl client
-        # live in the plugin. Patch both at the plugin location.
+        # live in the plugin. Patch both at the plugin location and enforce the
+        # same policy independently at the shared result sink.
         monkeypatch.setattr(firecrawl_provider, "check_website_access", fake_check)
+        monkeypatch.setattr(web_tools, "check_website_access", fake_check)
         monkeypatch.setattr(firecrawl_provider, "_get_firecrawl_client", lambda: FakeFirecrawlClient())
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fake-key")
 
         result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"]))
 
-        assert result["results"][0]["url"] == "https://blocked.test/final"
-        assert result["results"][0]["content"] == ""
-        assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+        assert result["results"][0] == {
+            "url": "",
+            "title": "",
+            "content": "",
+            "error": "Blocked by website policy",
+            "blocked_by_policy": {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+            },
+        }
 
     @pytest.mark.asyncio
     async def test_web_extract_blocks_firecrawl_unsafe_final_url(self, monkeypatch):
         from tools import web_tools
+        from tools.url_safety import PROVIDER_FINAL_URL_ERROR
         from plugins.web.firecrawl import provider as firecrawl_provider
 
         async def _allow_ssrf(_url: str) -> bool:
@@ -461,8 +496,14 @@ class TestWebToolPolicy:
         monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
         monkeypatch.setattr(
             firecrawl_provider,
-            "is_safe_url",
-            lambda url: url != "http://169.254.169.254/latest/meta-data/",
+            "async_validate_provider_final_url",
+            AsyncMock(
+                side_effect=lambda url: (
+                    None
+                    if url == "http://169.254.169.254/latest/meta-data/"
+                    else url
+                )
+            ),
         )
 
         checked_urls = []
@@ -491,9 +532,17 @@ class TestWebToolPolicy:
         result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"]))
 
         assert checked_urls == ["https://allowed.test"]
-        assert result["results"][0]["url"] == "http://169.254.169.254/latest/meta-data/"
-        assert result["results"][0]["content"] == ""
-        assert "private or internal network" in result["results"][0]["error"]
+        blocked = result["results"][0]
+        assert blocked["url"] == ""
+        assert blocked["title"] == ""
+        assert blocked["content"] == ""
+        assert blocked.get("raw_content", "") == ""
+        assert blocked.get("metadata") in (None, {})
+        assert blocked["error"] == PROVIDER_FINAL_URL_ERROR
+        serialized = json.dumps(blocked)
+        assert "http://169.254.169.254/latest/meta-data/" not in serialized
+        assert "metadata credentials" not in serialized
+        assert "Metadata" not in serialized
 
 
 def test_check_website_access_fails_open_on_malformed_config(tmp_path, monkeypatch):

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -400,7 +400,7 @@ def _allows_private_ip_resolution(hostname: str, scheme: str) -> bool:
     return scheme == "https" and hostname in _TRUSTED_PRIVATE_IP_HOSTS
 
 
-def is_safe_url(url: str) -> bool:
+def is_safe_url(url: str, *, allow_private_exceptions: bool = True) -> bool:
     """Return True if the URL target is not a private/internal address.
 
     Resolves the hostname to an IP and checks against private ranges.
@@ -410,6 +410,10 @@ def is_safe_url(url: str) -> bool:
     ``HERMES_ALLOW_PRIVATE_URLS=true``), private-IP blocking is skipped.
     Cloud metadata endpoints (169.254.169.254, metadata.google.internal)
     remain blocked regardless — they are never legitimate agent targets.
+
+    Set ``allow_private_exceptions=False`` for security-sensitive checks that
+    must reject every private/internal resolution regardless of configuration
+    or the trusted-host compatibility allowlist.
     """
     try:
         parsed = urlparse(url)
@@ -427,9 +431,14 @@ def is_safe_url(url: str) -> bool:
             return False
 
         # Check the global toggle AFTER blocking metadata hostnames
-        allow_all_private = _global_allow_private_urls()
+        allow_all_private = (
+            allow_private_exceptions and _global_allow_private_urls()
+        )
 
-        allow_private_ip = _allows_private_ip_resolution(hostname, scheme)
+        allow_private_ip = (
+            allow_private_exceptions
+            and _allows_private_ip_resolution(hostname, scheme)
+        )
 
         # Try to resolve and check IP
         try:
@@ -451,7 +460,11 @@ def is_safe_url(url: str) -> bool:
                 ipaddress.ip_address(hostname)
             except ValueError:
                 _is_literal_ip = False
-            if not _is_literal_ip and _proxy_is_configured():
+            if (
+                allow_private_exceptions
+                and not _is_literal_ip
+                and _proxy_is_configured()
+            ):
                 logger.debug(
                     "DNS resolution failed for %s — proxy configured, "
                     "allowing through for proxy-side resolution",
@@ -459,6 +472,10 @@ def is_safe_url(url: str) -> bool:
                 )
                 return True
             logger.warning("Blocked request — DNS resolution failed for: %s", hostname)
+            return False
+
+        if not addr_info:
+            logger.warning("Blocked request — DNS resolution returned no addresses for: %s", hostname)
             return False
 
         for family, _, _, _, sockaddr in addr_info:
@@ -505,6 +522,60 @@ def is_safe_url(url: str) -> bool:
         # become SSRF bypass vectors
         logger.warning("Blocked request — URL safety check error for %s: %s", url, exc)
         return False
+
+
+PROVIDER_FINAL_URL_ERROR = (
+    "Blocked: provider response is missing or reported an unsafe authoritative final URL"
+)
+
+
+def validate_provider_final_url(url: Any) -> Optional[str]:
+    """Return a provider-reported final URL only when it is strictly safe.
+
+    Extraction providers are an external trust boundary: content must not be
+    associated with the originally requested URL when the provider omits or
+    changes its authoritative final URL. Unlike ordinary user-configured URL
+    access, this check never permits private/internal compatibility exceptions.
+    """
+    if not isinstance(url, str) or not url:
+        return None
+    if url != url.strip() or any(
+        char.isspace() or ord(char) < 0x20 or ord(char) == 0x7F
+        for char in url
+    ):
+        return None
+    if "\\" in url:
+        return None
+
+    hex_digits = frozenset("0123456789abcdefABCDEF")
+    for index, char in enumerate(url):
+        if char == "%" and (
+            index + 2 >= len(url)
+            or url[index + 1] not in hex_digits
+            or url[index + 2] not in hex_digits
+        ):
+            return None
+
+    try:
+        parsed = urlsplit(url)
+        # Accessing ``port`` validates malformed/non-numeric port syntax.
+        _ = parsed.port
+    except ValueError:
+        return None
+
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        return None
+    if parsed.username is not None or parsed.password is not None:
+        return None
+
+    if not is_safe_url(url, allow_private_exceptions=False):
+        return None
+    return url
+
+
+async def async_validate_provider_final_url(url: Any) -> Optional[str]:
+    """Strictly validate a provider final URL without blocking the event loop."""
+    return await asyncio.to_thread(validate_provider_final_url, url)
 
 
 async def async_is_safe_url(url: str) -> bool:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -97,7 +97,14 @@ from tools.tool_backend_helpers import (  # noqa: F401
     nous_tool_gateway_unavailable_message,
     prefers_gateway,
 )
-from tools.url_safety import async_is_safe_url, normalize_url_for_request, sensitive_query_param_name
+from tools.url_safety import (
+    PROVIDER_FINAL_URL_ERROR,
+    async_is_safe_url,
+    async_validate_provider_final_url,
+    normalize_url_for_request,
+    sensitive_query_param_name,
+)
+from tools.website_policy import check_website_access
 import sys
 
 logger = logging.getLogger(__name__)
@@ -943,25 +950,112 @@ async def web_extract_tool(
                     provider.extract, safe_urls, format=format
                 )
 
-        # Reconstruct the original input order across invalid, blocked, and
-        # provider-processed entries. Providers are expected to preserve the
-        # order of the safe URL list they receive.
-        if invalid_urls or ssrf_blocked:
-            safe_results = {
-                index: (
-                    results[position]
-                    if position < len(results)
-                    else {
-                        "url": safe_urls[position],
+        # Correlate provider output to the request before any DNS-backed
+        # validation. Providers return one result per safe URL; excess records
+        # are untrusted amplification and must not consume resolver work.
+        results = results[: len(safe_urls)]
+
+        # Provider responses cross a second trust boundary after dispatch.
+        # Validate every reported final URL before any provider-controlled
+        # fields reach reconstruction, content processing, or output trimming.
+        validated_results = []
+        correlation_urls = []
+        for result in results:
+            final_url = await async_validate_provider_final_url(
+                result.get("url") if isinstance(result, dict) else None
+            )
+            if final_url is None:
+                correlation_urls.append(None)
+                validated_results.append(
+                    {
+                        "url": "",
                         "title": "",
                         "content": "",
-                        "error": "Extract backend returned no result for this URL",
+                        "raw_content": "",
+                        "error": PROVIDER_FINAL_URL_ERROR,
                     }
                 )
-                for position, index in enumerate(safe_indices)
-            }
-            by_index = {**safe_results, **ssrf_blocked, **invalid_urls}
-            results = [by_index[index] for index in range(len(urls))]
+                continue
+
+            blocked = check_website_access(final_url)
+            if blocked:
+                correlation_urls.append(final_url)
+                validated_results.append(
+                    {
+                        "url": "",
+                        "title": "",
+                        "content": "",
+                        "raw_content": "",
+                        "error": blocked["message"],
+                        "blocked_by_policy": {
+                            "host": blocked["host"],
+                            "rule": blocked["rule"],
+                            "source": blocked["source"],
+                        },
+                    }
+                )
+                continue
+
+            correlation_urls.append(final_url)
+            validated_result = dict(result)
+            validated_result["url"] = final_url
+            validated_results.append(validated_result)
+        results = validated_results
+
+        # Reconstruct every original input. Exact authoritative-URL matches
+        # establish correlation independent of provider ordering. A single
+        # redirect can be assigned only when one request and one result remain;
+        # ambiguous redirects fail closed instead of guessing. Unsafe records
+        # contain no provider content and may safely occupy remaining slots.
+        open_positions = {}
+        for position, safe_url in enumerate(safe_urls):
+            open_positions.setdefault(safe_url, []).append(position)
+
+        correlated_results = {}
+        generic_failures = []
+        unmatched_redirects = []
+        for correlation_url, result in zip(correlation_urls, results):
+            positions = open_positions.get(correlation_url, [])
+            if positions:
+                correlated_results[positions.pop(0)] = result
+            elif correlation_url is None:
+                generic_failures.append(result)
+            elif correlation_url not in open_positions:
+                unmatched_redirects.append(result)
+
+        remaining_positions = [
+            position
+            for position in range(len(safe_urls))
+            if position not in correlated_results
+        ]
+        for result, position in zip(generic_failures, remaining_positions):
+            correlated_results[position] = result
+        remaining_positions = [
+            position
+            for position in remaining_positions
+            if position not in correlated_results
+        ]
+        if (
+            len(unmatched_redirects) == 1
+            and len(remaining_positions) == 1
+            and not generic_failures
+        ):
+            correlated_results[remaining_positions[0]] = unmatched_redirects[0]
+
+        safe_results = {
+            index: correlated_results.get(
+                position,
+                {
+                    "url": safe_urls[position],
+                    "title": "",
+                    "content": "",
+                    "error": "Extract backend returned no result for this URL",
+                },
+            )
+            for position, index in enumerate(safe_indices)
+        }
+        by_index = {**safe_results, **ssrf_blocked, **invalid_urls}
+        results = [by_index[index] for index in range(len(urls))]
 
         response = {"results": results}
         


### PR DESCRIPTION
## Summary
- Validate provider-reported final or canonical URLs before returning web content across Firecrawl, Tavily, Exa, and Parallel.
- Fail closed for malformed, private, internal, and unresolved final destinations while suppressing unsafe provider metadata and content.
- Preserve safe public results and leave Oxylabs behavior unchanged.

## Verification
- Focused final-URL safety suite: 26 passed.
- Relevant web-tool regression suite: 333 passed.
- Ruff, syntax, diff-scope, and static-security checks passed.
- Reconciled cleanly as one commit directly on current upstream main.

## Scope
Exactly eight files: four provider integrations, the shared URL-safety helper, and three test files. No dependency, lockfile, deployment, service, production, or Oxylabs changes.