### PR TITLE
fix(weixin): tighten TCPConnector keepalive to drain CLOSE_WAIT sockets (partial salvage of #70939 by @webtecnica)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -124,6 +124,12 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     When ``certifi`` is installed, use its Mozilla CA bundle to guarantee
     verification. Otherwise fall back to aiohttp's default (which honors
     ``SSL_CERT_FILE`` env var via ``trust_env=True``).
+
+    Uses a tight ``keepalive_timeout=2`` (default aiohttp: 30s) so idle
+    connections drain promptly behind proxies like Cloudflare Warp that
+    leave peer-initiated FIN in ``CLOSE_WAIT`` (same class as #18451).
+    ``enable_cleanup_closed=True`` helps the connector clean up sockets
+    that the remote side has already closed.
     """
     try:
         import ssl
@@ -133,7 +139,12 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     if not AIOHTTP_AVAILABLE:
         return None
     ssl_ctx = ssl.create_default_context(cafile=certifi.where())
-    return aiohttp.TCPConnector(ssl=ssl_ctx)
+    return aiohttp.TCPConnector(
+        ssl=ssl_ctx,
+        # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451, #69089).
+        keepalive_timeout=2,
+        enable_cleanup_closed=True,
+    )
 
 ITEM_TEXT = 1
 ITEM_IMAGE = 2


### PR DESCRIPTION
## Summary
The WeiXin SSL connector now drains idle `CLOSE_WAIT` sockets promptly instead of letting them accumulate behind proxies that leave peer-initiated FINs half-closed (Cloudflare Warp and similar).

`aiohttp`'s default `keepalive_timeout` is 30s, so idle connections lingered; this sets `keepalive_timeout=2` + `enable_cleanup_closed=True` on the weixin connector (same socket-leak class as #18451, related to #69089).

## Changes
- `gateway/platforms/weixin.py`: `_make_ssl_connector()` builds the `TCPConnector` with `keepalive_timeout=2` and `enable_cleanup_closed=True`.

## Partial salvage of #70939
Only the weixin connector hardening survives. The PR's other half — an event-loop-freeze watchdog (heartbeat-file staleness → `os._exit`) — is **superseded** by the loop-liveness watchdog already merged on main (selector floor + thread-based schedule-and-verify probe, config-gated via `gateway.loop_watchdog`, with shutdown-race hardening). Merging the PR's watchdog would arm a second, cruder freeze-killer (wall-clock file staleness, hard exit, no config gate). #69089 is already closed by that landed work.

@webtecnica's connector change is preserved with authorship. The original PR should be closed as partially-superseded, crediting this salvage for the surviving hunk.

## Infographic

![WeiXin connector CLOSE_WAIT drain](https://v3b.fal.media/files/b/0aa3dec7/NgXUA0tIjZE_UIrCj9omE_MsxjZeLT.png)
