### PR TITLE
fix: add usedforsecurity=False to hashlib.sha1 in tui_gateway/server.py

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14850,7 +14850,7 @@ def _compute_mcp_rev() -> str:
             sort_keys=True,
             default=str,
         )
-        return hashlib.sha1(rev_src.encode()).hexdigest()[:12]
+        return hashlib.sha1(rev_src.encode(), usedforsecurity=False).hexdigest()[:12]
     except Exception:
         return ""
 


### PR DESCRIPTION
## Summary

`hashlib.sha1()` at `tui_gateway/server.py:14853` is called without `usedforsecurity=False`. On FIPS-enabled systems (RHEL 8/9 FIPS mode), this crashes with `ValueError: EVP_DigestInit_ex disabled for FIPS`.

## Root Cause

The function `_mcp_config_rev()` uses `hashlib.sha1()` to compute a short cache key from MCP config JSON. This is a non-security use (cache key generation), but without `usedforsecurity=False`, FIPS systems reject the call entirely.

## Fix

Added `usedforsecurity=False` to the `hashlib.sha1()` call. This is a zero-functional-change fix - the hash output is identical, but FIPS systems will now allow it.

## Changes

- `tui_gateway/server.py:14853`: `hashlib.sha1(...)` -> `hashlib.sha1(..., usedforsecurity=False)`

## Test Plan

- [ ] Syntax check passes
- [ ] No behavioral change - cache key generation works identically
