### PR TITLE
fix(gateway): resolve NameError for _history_media_paths

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13208,6 +13208,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Load conversation history from transcript
         history = await self.async_session_store.load_transcript(session_entry.session_id)
+        _history_media_paths = _collect_history_media_paths(history)
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts


### PR DESCRIPTION
## Summary
This PR fixes a `NameError` in the gateway's message handler. 

### The Problem
In `gateway/run.py`, the variable `_history_media_paths` was being passed to `_deliver_media_from_response` but was never defined within the `_handle_message_with_agent` function. This caused the gateway to crash with a `NameError` whenever the agent attempted to deliver media (images/audio) via the streaming delivery path or when processing messages with `MEDIA:` tags.

### The Fix
The `_history_media_paths` variable is now correctly initialized by calling `_collect_history_media_paths(history)` after loading the transcript, matching the pattern used in other parts of the gateway.

### Verification
- Verified the fix locally: the `NameError` no longer occurs when sending media.
- Verified that media deduplication (the purpose of this variable) functions correctly with this initialization.