### PR TITLE
fix(agent): parse "exceeds maximum output tokens" error for retry (#72281)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1338,6 +1338,11 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # The input itself fits — this is purely an output-cap error, so reduce
         # max_tokens and retry; do NOT compress.
         "range of max_tokens should be" in error_lower
+    ) or (
+        # OpenAI-compatible relays (e.g. DeepSeek, Novita):
+        #   "max_tokens (98304) exceeds model's maximum output tokens (65536)"
+        "exceeds" in error_lower
+        and "maximum output tokens" in error_lower
     )
     if not is_output_cap_error:
         return None
@@ -1350,6 +1355,18 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     )
     if _m_range:
         _cap = int(_m_range.group(1))
+        if _cap >= 1:
+            return _cap
+
+    # OpenAI-compatible relay form: "max_tokens (98304) exceeds model's
+    # maximum output tokens (65536)".  The parenthesised value after
+    # "maximum output tokens" is the provider's real output cap.
+    _m_exceeds = re.search(
+        r'maximum\s+output\s+tokens\s*\(\s*(\d+)\s*\)',
+        error_lower,
+    )
+    if _m_exceeds:
+        _cap = int(_m_exceeds.group(1))
         if _cap >= 1:
             return _cap
 

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -85,6 +85,25 @@ class TestParseDashScopeOutputCap:
         assert parse_available_output_tokens_from_error(msg) == 32768
 
 
+class TestParseOpenAICompatibleRelayOutputCap:
+    """OpenAI-compatible relays (e.g. DeepSeek, Novita) reject oversized
+    max_tokens with: 'max_tokens (N) exceeds model's maximum output tokens (M)'."""
+
+    def test_deepseek_exceeds_format(self):
+        msg = ("API call failed after 3 retries: [400]: max_tokens (98304) "
+               "exceeds model's maximum output tokens (65536) for model "
+               "deepseek-v4-flash")
+        assert parse_available_output_tokens_from_error(msg) == 65536
+
+    def test_exceeds_format_case_insensitive(self):
+        msg = "Max_Tokens (100000) EXCEEDS Model's Maximum Output Tokens (32768)"
+        assert parse_available_output_tokens_from_error(msg) == 32768
+
+    def test_exceeds_format_small_cap(self):
+        msg = "max_tokens (9999) exceeds model's maximum output tokens (4096)"
+        assert parse_available_output_tokens_from_error(msg) == 4096
+
+
 class TestIsOutputCapError:
     """`is_output_cap_error` is the broader yes/no gate that keeps an
     output-cap 400 out of the compression death-loop even when we can't parse


### PR DESCRIPTION
## Summary

Fixes #72281. OpenAI-compatible relays (e.g. DeepSeek, Novita) return a 400 error when `max_tokens` exceeds the model's output cap with the phrasing:

```
max_tokens (98304) exceeds model's maximum output tokens (65536)
```

This was not recognized by `parse_available_output_tokens_from_error()`, so the error was treated as a generic failure instead of triggering the output-cap retry path that lowers `max_tokens` and retries.

## Changes

- **agent/model_metadata.py**: Added `"exceeds" + "maximum output tokens"` detection to `is_output_cap_error` gate, and a regex to extract the provider-reported cap from parenthesised form `(65536)`.
- **tests/test_output_cap_parsing.py**: Added `TestParseOpenAICompatibleRelayOutputCap` with 3 test cases covering the DeepSeek/Novita error format.

## Testing

```
pytest tests/test_output_cap_parsing.py -x --timeout=30 -q
# 23 passed (20 existing + 3 new)
```
