### PR TITLE
fix(cron): anchor kill branch so `SKILL=` is not a gateway lifecycle command

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -60,9 +60,13 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # Branch C: systemctl ops on a hermes-gateway unit.
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both
-    # token orders because real reproductions show both.
-    r"|(?:p?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
-    r"|(?:p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    # token orders because real reproductions show both. The leading `\b`
+    # anchors the command identifier so `kill` cannot match as a substring
+    # inside an unrelated word — without it, a shell variable named
+    # `SKILL="hermes-gateway-recovery"` matches (the `KILL` in `SKILL`) and
+    # a script containing no lifecycle command at all is wrongly blocked.
+    r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
+    r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
 )
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -50,6 +50,13 @@ class TestGatewayLifecyclePattern:
         "kill hermes gateway process",
         "pkill -f hermes.*gateway",
         "pkill -f gateway.*hermes",          # inverse token order
+        # The leading `\b` added to branch D must not weaken real detection:
+        # a kill command is still caught at line start, after leading
+        # whitespace, after a shell operator, and when uppercased.
+        "  kill -TERM $(pgrep -f hermes-gateway)",
+        "x=1 && pkill -9 -f hermes.*gateway",
+        "sudo pkill -f hermes-gateway",
+        "PKILL -F HERMES.*GATEWAY",
     ])
     def test_kill_commands(self, text):
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
@@ -84,6 +91,15 @@ class TestGatewayLifecyclePattern:
         "Monitor the gateway and tell me if a restart is recommended",
         "research how the OpenAI API gateway handles restart after rate limiting",
         "compare AWS API Gateway vs Cloudflare on restart latency",
+        # Regression: `kill` must not match as a *substring* of an unrelated
+        # word. Branch D previously lacked a leading `\b`, so the `KILL` inside
+        # `SKILL` matched and any script assigning a gateway-related skill name
+        # was blocked despite containing no lifecycle command at all.
+        'SKILL="hermes-gateway-launchd-recovery"',
+        'SKILL="hermes gateway notes"',
+        "MYSKILL=hermes-gateway-docs; echo $MYSKILL",
+        'echo "follow the hermes-gateway-launchd-recovery skill"',
+        "# upskill on hermes gateway internals",
     ])
     def test_safe_commands(self, text):
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"


### PR DESCRIPTION
## Problem

The gateway-lifecycle guard's branch D matches `p?kill\b...` with **no leading word boundary**, so `kill` can match as a *substring* of an unrelated word.

A cron script containing nothing but:

```bash
SKILL="hermes-gateway-launchd-recovery"
```

is rejected with:

> Blocked: cron job contains a gateway lifecycle command (restart/stop/kill).

The regex matches the `KILL` inside `SKILL`, then finds the `hermes` and `gateway` tokens that follow. There is no command in the file at all.

## Why it matters

This blocks a natural case: a cron script that references a gateway-related skill or runbook **by name**. I hit it while scheduling a detection-only gateway health watchdog — its only offence was naming the recovery skill in a shell variable. The failure is also confusing to debug, because the error insists there's a lifecycle command in a file that plainly has none.

Reproduce on `main`:

```python
from cron.lifecycle_guard import contains_gateway_lifecycle_command as f
assert f('SKILL="hermes-gateway-launchd-recovery"') is False  # fails on main
```

## Fix

Add a leading `\b` to both token orders of branch D. This anchors the command identifier rather than narrowing what it matches, so real detection is unchanged.

The guard is shared — `cron.jobs.create_job` (both the `hermes cron create` CLI and the agent's `cronjob` tool) and `tools/terminal_tool.py` all route through `contains_gateway_lifecycle_command` — so the one-line fix covers every enforcement path.

## Tests

Added to the existing parametrized cases in `TestGatewayLifecyclePattern`:

**Must stay blocked** (proves `\b` doesn't weaken detection) — kill at line start, after leading whitespace, after a shell operator (`&&`), with `sudo`, and uppercased.

**Must be allowed** (the regression) — `SKILL="hermes-gateway-launchd-recovery"`, `SKILL="hermes gateway notes"`, `MYSKILL=hermes-gateway-docs; echo $MYSKILL`, `echo "follow the hermes-gateway-launchd-recovery skill"`, `# upskill on hermes gateway internals`.

Verification:

- The 4 new safe-command cases **fail on the unpatched regex** and pass with the fix (confirmed by reverting just the `\b` and re-running — red/green, not vacuous).
- `819 passed` across `tests/hermes_cli/test_gateway_restart_loop.py` + `tests/cron`.
- Unrelated pre-existing failures elsewhere in `tests/hermes_cli/` were confirmed byte-identical with and without this change.

This follows the same intent as the earlier #30728 follow-up that stopped the guard firing on English prose: only concrete command shapes should trigger the block.
