### PR TITLE
fix(honcho): stop background workers before exit

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1141,6 +1141,29 @@ class MemoryManager:
                     provider.name, e,
                 )
 
+    def shutdown_timeout_seconds(self) -> float:
+        """Return a conservative watchdog hint for provider teardown."""
+        total = _SYNC_DRAIN_TIMEOUT_S
+        for provider in self._providers:
+            hint = getattr(provider, "shutdown_timeout_seconds", None)
+            if not callable(hint):
+                continue
+            try:
+                value = hint()
+                if not isinstance(value, (int, float, str)):
+                    raise TypeError("shutdown timeout must be numeric")
+                provider_timeout = max(0.0, float(value))
+                if getattr(provider, "shutdown_retryable", False):
+                    provider_timeout *= 2.0
+                total += provider_timeout
+            except Exception:
+                logger.debug(
+                    "Memory provider '%s' returned an invalid shutdown timeout",
+                    provider.name,
+                    exc_info=True,
+                )
+        return total
+
     def shutdown_all(self) -> None:
         """Shut down all providers (reverse order for clean teardown).
 
@@ -1159,6 +1182,16 @@ class MemoryManager:
                     "Memory provider '%s' shutdown failed: %s",
                     provider.name, e,
                 )
+                if not getattr(provider, "shutdown_retryable", False):
+                    continue
+                try:
+                    provider.shutdown()
+                except Exception as retry_error:
+                    logger.warning(
+                        "Memory provider '%s' shutdown retry failed: %s",
+                        provider.name,
+                        retry_error,
+                    )
 
     @property
     def shutdown_drain_state(self) -> Dict[str, Any]:

--- a/cli.py
+++ b/cli.py
@@ -1115,6 +1115,28 @@ def _arm_exit_watchdog(timeout_s: float | None = None) -> None:
         pass  # best-effort — never block shutdown on watchdog setup
 
 
+def _cleanup_watchdog_timeout_seconds() -> float:
+    """Return the operator override or a provider-aware cleanup deadline."""
+    configured = os.getenv("HERMES_EXIT_WATCHDOG_S")
+    if configured is not None:
+        try:
+            return float(configured)
+        except (TypeError, ValueError):
+            return 30.0
+
+    timeout_s = 30.0
+    memory_manager = getattr(_active_agent_ref, "_memory_manager", None)
+    hint = getattr(memory_manager, "shutdown_timeout_seconds", None)
+    if callable(hint):
+        try:
+            # Leave headroom for transcript finalization and the other bounded
+            # cleanup stages that run before memory-provider teardown.
+            timeout_s = max(timeout_s, float(hint()) + 15.0)
+        except Exception:
+            pass
+    return timeout_s
+
+
 _signal_watchdog_armed = False
 
 
@@ -1147,10 +1169,7 @@ def _arm_exit_watchdog_on_shutdown_signal() -> None:
     if _signal_watchdog_armed:
         return
     _signal_watchdog_armed = True
-    try:
-        base = float(os.getenv("HERMES_EXIT_WATCHDOG_S", "30"))
-    except (TypeError, ValueError):
-        base = 30.0
+    base = _cleanup_watchdog_timeout_seconds()
     if base <= 0:
         return  # explicitly disabled
     try:
@@ -1169,7 +1188,7 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     # Bound total shutdown time: if cleanup (or the interpreter's
     # thread-join teardown after it) wedges, force-exit instead of
     # leaving a zombie CLI holding the terminal for minutes.
-    _arm_exit_watchdog()
+    _arm_exit_watchdog(timeout_s=_cleanup_watchdog_timeout_seconds())
 
     # Reset terminal input modes first, before the slower resource teardown
     # below (MCP / browser / memory shutdown can take seconds). On Ctrl+C the

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -237,6 +237,8 @@ ALL_TOOL_SCHEMAS = [PROFILE_SCHEMA, SEARCH_SCHEMA, REASONING_SCHEMA, CONTEXT_SCH
 class HonchoMemoryProvider(MemoryProvider):
     """Honcho AI-native memory with dialectic Q&A and persistent user modeling."""
 
+    shutdown_retryable = True
+
     def backup_paths(self) -> List[str]:
         """Honcho keeps its peer/session config under ~/.honcho when no
         profile-local honcho.json exists (see client.resolve_config_path)."""
@@ -252,6 +254,9 @@ class HonchoMemoryProvider(MemoryProvider):
 
     def __init__(self, query_rewriter: Optional[Callable[[str], str]] = None):
         self._manager = None   # HonchoSessionManager
+        self._initializing_manager = None  # HonchoSessionManager
+        self._manager_lock = threading.Lock()
+        self._owned_managers: set[Any] = set()
         self._config = None    # HonchoClientConfig
         self._session_key = ""
         self._query_rewriter = query_rewriter
@@ -259,6 +264,9 @@ class HonchoMemoryProvider(MemoryProvider):
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
         self._sync_thread: Optional[threading.Thread] = None
+        self._background_threads: set[threading.Thread] = set()
+        self._background_threads_lock = threading.Lock()
+        self._shutdown_event = threading.Event()
 
         self._recall_mode = "hybrid"  # "context", "tools", or "hybrid"
 
@@ -294,6 +302,61 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # Cron and flush contexts disable the plugin entirely.
         self._cron_skipped = False
+
+    def _join_timeout_seconds(self) -> float:
+        """Return a shutdown window that outlives one configured HTTP call."""
+        timeout = getattr(self._config, "timeout", None)
+        try:
+            request_timeout = float(timeout) if timeout is not None else 30.0
+        except (TypeError, ValueError):
+            request_timeout = 30.0
+        # Dialectic depth can issue several sequential HTTP calls in one worker.
+        depth = max(1, int(getattr(self, "_dialectic_depth", 1)))
+        return max(5.0, request_timeout * depth + 2.0)
+
+    def shutdown_timeout_seconds(self) -> float:
+        """Return a watchdog hint covering flush, managers, and retries."""
+        timeout = getattr(self._config, "timeout", None)
+        try:
+            request_timeout = float(timeout) if timeout is not None else 30.0
+        except (TypeError, ValueError):
+            request_timeout = 30.0
+        manager_attempt = max(5.0, request_timeout * 2.0 + 4.0)
+        with self._manager_lock:
+            managers = set(self._owned_managers)
+            managers.update(
+                manager
+                for manager in (self._manager, self._initializing_manager)
+                if manager is not None
+            )
+        manager_count = max(1, len(managers))
+        # on_session_end() may spend one manager window at its writer barrier;
+        # shutdown then gives every retained manager two attempts.
+        return self._join_timeout_seconds() + manager_attempt * (
+            1 + manager_count * 2
+        )
+
+    def _start_background_thread(
+        self, *, target: Callable[[], None], name: str
+    ) -> Optional[threading.Thread]:
+        """Start and track a worker unless provider shutdown has begun."""
+        thread: Optional[threading.Thread] = None
+
+        def _wrapped() -> None:
+            try:
+                target()
+            finally:
+                if thread is not None:
+                    with self._background_threads_lock:
+                        self._background_threads.discard(thread)
+
+        with self._background_threads_lock:
+            if self._shutdown_event.is_set():
+                return None
+            thread = threading.Thread(target=_wrapped, daemon=True, name=name)
+            self._background_threads.add(thread)
+            thread.start()
+        return thread
 
     @property
     def name(self) -> str:
@@ -427,13 +490,13 @@ class HonchoMemoryProvider(MemoryProvider):
         assembly. ``wait_timeout`` lets fast/mock initializations finish before
         returning while still failing open for slow backends.
         """
-        if self._cron_skipped or self._session_initialized:
+        if self._shutdown_event.is_set() or self._cron_skipped or self._session_initialized:
             return
         if not self._config or self._lazy_init_kwargs is None:
             return
 
         with self._init_lock:
-            if self._cron_skipped or self._session_initialized:
+            if self._shutdown_event.is_set() or self._cron_skipped or self._session_initialized:
                 return
             if self._init_thread and self._init_thread.is_alive():
                 return
@@ -452,17 +515,29 @@ class HonchoMemoryProvider(MemoryProvider):
                     self._init_error = ""
                 except Exception as e:
                     self._init_error = str(e)
+                    with self._manager_lock:
+                        manager = self._initializing_manager
+                    if manager is not None:
+                        try:
+                            manager.shutdown()
+                        except Exception:
+                            logger.warning("Honcho failed-init cleanup failed", exc_info=True)
+                        else:
+                            with self._manager_lock:
+                                self._owned_managers.discard(manager)
+                                if self._initializing_manager is manager:
+                                    self._initializing_manager = None
                     self._manager = None
                     logger.warning("Honcho background session init failed: %s", e)
 
-            self._init_thread = threading.Thread(
+            self._init_thread = self._start_background_thread(
                 target=_run,
-                daemon=True,
                 name="honcho-session-init",
             )
-            self._init_thread.start()
             if wait_timeout > 0:
-                self._init_thread.join(timeout=wait_timeout)
+                init_thread = self._init_thread
+                if init_thread is not None:
+                    init_thread.join(timeout=wait_timeout)
 
     def _do_session_init(self, cfg, session_id: str, **kwargs) -> None:
         """Shared session initialization logic for both eager and lazy paths."""
@@ -470,13 +545,25 @@ class HonchoMemoryProvider(MemoryProvider):
         from plugins.memory.honcho.session import HonchoSessionManager
 
         client = get_honcho_client(cfg)
-        self._manager = HonchoSessionManager(
+        manager = HonchoSessionManager(
             honcho=client,
             config=cfg,
             context_tokens=cfg.context_tokens,
             runtime_user_peer_name=kwargs.get("user_id") or None,
             runtime_user_peer_name_alt=kwargs.get("user_id_alt") or None,
         )
+
+        with self._manager_lock:
+            self._owned_managers.add(manager)
+            self._initializing_manager = manager
+            shutdown_started = self._shutdown_event.is_set()
+        if shutdown_started:
+            manager.shutdown()
+            with self._manager_lock:
+                self._owned_managers.discard(manager)
+                if self._initializing_manager is manager:
+                    self._initializing_manager = None
+            return
 
         self._session_key = self._resolve_session_key(cfg, session_id, **kwargs)
         logger.debug("Honcho session key resolved: %s", self._session_key)
@@ -486,7 +573,7 @@ class HonchoMemoryProvider(MemoryProvider):
         # synchronous setup has finished; background startup sets _manager before
         # get_or_create()/migration/prewarm are complete, and lifecycle hooks must
         # not treat that partially initialized state as usable.
-        session = self._manager.get_or_create(self._session_key)
+        session = manager.get_or_create(self._session_key)
 
         # Skip under per-session strategy: every Hermes run creates a fresh
         # Honcho session by design, so uploading MEMORY.md/USER.md/SOUL.md to
@@ -496,7 +583,7 @@ class HonchoMemoryProvider(MemoryProvider):
             if not session.messages and cfg.session_strategy != "per-session":
                 from hermes_constants import get_hermes_home
                 mem_dir = str(get_hermes_home() / "memories")
-                self._manager.migrate_memory_files(self._session_key, mem_dir)
+                manager.migrate_memory_files(self._session_key, mem_dir)
                 logger.debug("Honcho memory file migration attempted for new session: %s", self._session_key)
             elif cfg.session_strategy == "per-session":
                 logger.debug(
@@ -505,6 +592,23 @@ class HonchoMemoryProvider(MemoryProvider):
                 )
         except Exception as e:
             logger.debug("Honcho memory file migration skipped: %s", e)
+
+        with self._manager_lock:
+            if self._shutdown_event.is_set():
+                shutdown_started = True
+            else:
+                self._manager = manager
+                self._session_initialized = True
+                shutdown_started = False
+            if not shutdown_started and self._initializing_manager is manager:
+                self._initializing_manager = None
+        if shutdown_started:
+            manager.shutdown()
+            with self._manager_lock:
+                self._owned_managers.discard(manager)
+                if self._initializing_manager is manager:
+                    self._initializing_manager = None
+            return
 
         # Query-aware base retrieval starts with the first substantive message.
         # Generic dialectic prewarm is incompatible with latest-message rewriting.
@@ -534,12 +638,10 @@ class HonchoMemoryProvider(MemoryProvider):
                         self._dialectic_empty_streak += 1
 
                 self._prefetch_thread_started_at = time.monotonic()
-                prewarm_thread = threading.Thread(
+                prewarm_thread = self._start_background_thread(
                     target=_prewarm_dialectic,
-                    daemon=True,
                     name="honcho-prewarm-dialectic",
                 )
-                prewarm_thread.start()
                 self._prefetch_thread = prewarm_thread
                 logger.debug("Honcho dialectic prewarm started for session: %s", self._session_key)
             else:
@@ -547,46 +649,56 @@ class HonchoMemoryProvider(MemoryProvider):
                     "Honcho generic dialectic prewarm skipped: awaiting first user message"
                 )
 
-        self._session_initialized = True
-
     def _ensure_session(self) -> bool:
         """Lazily initialize the Honcho session (for tools-only mode).
 
         Returns True if the manager is ready, False otherwise.
         """
-        if self._manager and self._session_initialized:
-            return True
-        if self._cron_skipped:
-            return False
-        if self._init_thread and self._init_thread.is_alive():
-            return False
-        if not self._config or self._lazy_init_kwargs is None:
-            return False
+        with self._init_lock:
+            if self._manager and self._session_initialized:
+                return True
+            if self._shutdown_event.is_set() or self._cron_skipped:
+                return False
+            if self._init_thread and self._init_thread.is_alive():
+                return False
+            if not self._config or self._lazy_init_kwargs is None:
+                return False
 
-        try:
-            self._do_session_init(
-                self._config,
-                self._lazy_init_session_id or "hermes-default",
-                **self._lazy_init_kwargs,
-            )
-            # Clear lazy refs
-            self._lazy_init_kwargs = None
-            self._lazy_init_session_id = None
-            return self._manager is not None
-        except Exception as e:
-            self._manager = None
-            self._session_initialized = False
-            logger.warning("Honcho lazy session init failed: %s", e)
-            return False
+            try:
+                self._do_session_init(
+                    self._config,
+                    self._lazy_init_session_id or "hermes-default",
+                    **self._lazy_init_kwargs,
+                )
+                # Clear lazy refs
+                self._lazy_init_kwargs = None
+                self._lazy_init_session_id = None
+                return self._manager is not None
+            except Exception as e:
+                with self._manager_lock:
+                    manager = self._initializing_manager
+                if manager is not None:
+                    try:
+                        manager.shutdown()
+                    except Exception:
+                        logger.warning("Honcho failed-init cleanup failed", exc_info=True)
+                    else:
+                        with self._manager_lock:
+                            self._owned_managers.discard(manager)
+                            if self._initializing_manager is manager:
+                                self._initializing_manager = None
+                self._manager = None
+                self._session_initialized = False
+                logger.warning("Honcho lazy session init failed: %s", e)
+                return False
 
     def _session_ready(self) -> bool:
         """Return whether a manager/session key can be used safely.
 
-        Background initialization sets ``_manager`` before the blocking
-        get-or-create call completes, so ``_session_initialized`` guards real
-        async startup. Tests and legacy direct construction may inject a ready
-        manager/session key without setting that flag; allow that only when no
-        init thread is currently in flight.
+        Background initialization publishes ``_manager`` only after blocking
+        remote setup succeeds. Tests and legacy direct construction may inject
+        a ready manager/session key without setting that flag; allow that only
+        when no init thread is currently in flight.
         """
         if not self._manager or not self._session_key:
             return False
@@ -676,7 +788,7 @@ class HonchoMemoryProvider(MemoryProvider):
         Returns empty in tools-only mode and respects the configured injection
         frequency and context budget.
         """
-        if self._cron_skipped:
+        if self._shutdown_event.is_set() or self._cron_skipped:
             return ""
 
         # Tools-only mode has no automatic injection.
@@ -740,10 +852,12 @@ class HonchoMemoryProvider(MemoryProvider):
                     except Exception as e:
                         logger.debug("Honcho first-turn base context failed: %s", e)
 
-                _bt = threading.Thread(
-                    target=_fetch_base, daemon=True, name="honcho-base-first"
+                _bt = self._start_background_thread(
+                    target=_fetch_base,
+                    name="honcho-base-first",
                 )
-                _bt.start()
+                if _bt is None:
+                    return ""
                 _base_wait = (
                     max(0.0, first_turn_base_deadline - time.monotonic())
                     if first_turn_base_deadline is not None
@@ -817,12 +931,13 @@ class HonchoMemoryProvider(MemoryProvider):
                         self._dialectic_empty_streak += 1
 
                 self._prefetch_thread_started_at = time.monotonic()
-                first_turn_thread = threading.Thread(
-                    target=_run_first_turn, daemon=True, name="honcho-prefetch-first"
+                first_turn_thread = self._start_background_thread(
+                    target=_run_first_turn,
+                    name="honcho-prefetch-first",
                 )
-                first_turn_thread.start()
                 self._prefetch_thread = first_turn_thread
-                self._prefetch_thread.join(timeout=_first_turn_timeout)
+                if first_turn_thread is not None:
+                    first_turn_thread.join(timeout=_first_turn_timeout)
             if self._prefetch_thread and self._prefetch_thread.is_alive():
                 logger.debug(
                     "Honcho first-turn dialectic still running after %.1fs — "
@@ -886,7 +1001,7 @@ class HonchoMemoryProvider(MemoryProvider):
 
         Context and dialectic refreshes have independent cadence controls.
         """
-        if self._cron_skipped:
+        if self._shutdown_event.is_set() or self._cron_skipped:
             return
         # Tools-only mode has no automatic prefetch.
         if self._recall_mode == "tools":
@@ -953,10 +1068,10 @@ class HonchoMemoryProvider(MemoryProvider):
                 self._dialectic_empty_streak += 1
 
         self._prefetch_thread_started_at = time.monotonic()
-        prefetch_thread = threading.Thread(
-            target=_run, daemon=True, name="honcho-prefetch"
+        prefetch_thread = self._start_background_thread(
+            target=_run,
+            name="honcho-prefetch",
         )
-        prefetch_thread.start()
         self._prefetch_thread = prefetch_thread
 
     # ----- Dialectic depth: multi-pass .chat() with cold/warm prompts -----
@@ -1331,7 +1446,7 @@ class HonchoMemoryProvider(MemoryProvider):
         Messages exceeding the Honcho API limit (default 25k chars) are
         split into multiple messages with continuation markers.
         """
-        if self._cron_skipped:
+        if self._shutdown_event.is_set() or self._cron_skipped:
             return
         if self._recall_mode == "tools" and not self._session_ready():
             return
@@ -1356,10 +1471,10 @@ class HonchoMemoryProvider(MemoryProvider):
 
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=5.0)
-        self._sync_thread = threading.Thread(
-            target=_sync, daemon=True, name="honcho-sync"
+        self._sync_thread = self._start_background_thread(
+            target=_sync,
+            name="honcho-sync",
         )
-        self._sync_thread.start()
 
     def on_memory_write(
         self,
@@ -1377,7 +1492,7 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if action != "add" or target != "user" or not content:
             return
-        if self._cron_skipped:
+        if self._shutdown_event.is_set() or self._cron_skipped:
             return
         if self._recall_mode == "tools" and not self._session_ready():
             return
@@ -1391,8 +1506,7 @@ class HonchoMemoryProvider(MemoryProvider):
             except Exception as e:
                 logger.debug("Honcho memory mirror failed: %s", e)
 
-        t = threading.Thread(target=_write, daemon=True, name="honcho-memwrite")
-        t.start()
+        self._start_background_thread(target=_write, name="honcho-memwrite")
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
@@ -1402,13 +1516,10 @@ class HonchoMemoryProvider(MemoryProvider):
             return
         if not self._session_initialized and self._init_thread and self._init_thread.is_alive():
             return
-        # Wait for pending sync
-        if self._sync_thread and self._sync_thread.is_alive():
-            self._sync_thread.join(timeout=10.0)
         try:
             self._manager.flush_all()
         except Exception as e:
-            logger.debug("Honcho session-end flush failed: %s", e)
+            logger.warning("Honcho session-end flush failed: %s", e)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return tool schemas, respecting recall_mode.
@@ -1537,15 +1648,63 @@ class HonchoMemoryProvider(MemoryProvider):
             return tool_error(f"Honcho {tool_name} failed: {e}")
 
     def shutdown(self) -> None:
-        for t in (self._prefetch_thread, self._sync_thread):
-            if t and t.is_alive():
-                t.join(timeout=5.0)
-        # Flush any remaining messages
-        if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
-            try:
-                self._manager.flush_all()
-            except Exception:
-                pass
+        self._shutdown_event.set()
+        deadline = time.monotonic() + self._join_timeout_seconds()
+
+        with self._background_threads_lock:
+            workers = list(self._background_threads)
+        for thread in workers:
+            if thread.is_alive():
+                thread.join(timeout=max(0.0, deadline - time.monotonic()))
+
+        # Initialization publishes its manager under _manager_lock, so shutdown
+        # cannot miss a manager created concurrently after teardown begins.
+        with self._manager_lock:
+            managers = list(self._owned_managers)
+            managers.extend((self._manager, self._initializing_manager))
+        seen: set[int] = set()
+        manager_errors: list[Exception] = []
+        for manager in managers:
+            if manager is None or id(manager) in seen:
+                continue
+            seen.add(id(manager))
+            shutdown_error: Exception | None = None
+            for attempt in range(2):
+                try:
+                    manager.shutdown()
+                except Exception as exc:
+                    shutdown_error = exc
+                    logger.warning(
+                        "Honcho manager shutdown attempt %d failed",
+                        attempt + 1,
+                        exc_info=True,
+                    )
+                else:
+                    shutdown_error = None
+                    break
+            if shutdown_error is None:
+                with self._manager_lock:
+                    self._owned_managers.discard(manager)
+                    if self._manager is manager:
+                        self._manager = None
+                    if self._initializing_manager is manager:
+                        self._initializing_manager = None
+            else:
+                manager_errors.append(shutdown_error)
+
+        with self._background_threads_lock:
+            live_workers = [
+                thread.name for thread in self._background_threads if thread.is_alive()
+            ]
+        if live_workers:
+            raise RuntimeError(
+                "Honcho workers did not stop before shutdown deadline: "
+                + ", ".join(sorted(live_workers))
+            )
+        if manager_errors:
+            raise RuntimeError(
+                f"{len(manager_errors)} Honcho manager(s) failed to shut down"
+            ) from manager_errors[0]
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -7,9 +7,10 @@ import queue
 import re
 import logging
 import threading
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING
 
 from plugins.memory.honcho.client import get_honcho_client
 
@@ -143,6 +144,11 @@ class HonchoSessionManager:
         # Async write queue — started lazily on first enqueue
         self._async_queue: queue.Queue | None = None
         self._async_thread: threading.Thread | None = None
+        self._shutdown_event = threading.Event()
+        self._shutdown_lock = threading.Lock()
+        self._shutdown_complete = False
+        self._background_threads: set[threading.Thread] = set()
+        self._background_threads_lock = threading.Lock()
         if write_frequency == "async":
             self._async_queue = queue.Queue()
             self._async_thread = threading.Thread(
@@ -151,6 +157,39 @@ class HonchoSessionManager:
                 daemon=True,
             )
             self._async_thread.start()
+
+    def _join_timeout_seconds(self) -> float:
+        """Return a shutdown window that outlives one configured HTTP call."""
+        timeout = getattr(self._config, "timeout", None)
+        try:
+            request_timeout = float(timeout) if timeout is not None else 30.0
+        except (TypeError, ValueError):
+            request_timeout = 30.0
+        # The async writer retries once after a short backoff, so shutdown must
+        # outlive both bounded requests rather than just the first one.
+        return max(5.0, request_timeout * 2.0 + 4.0)
+
+    def _start_background_thread(
+        self, *, name: str, target: Callable[[], None]
+    ) -> threading.Thread | None:
+        """Start and track a worker unless manager shutdown has begun."""
+        thread: threading.Thread | None = None
+
+        def _wrapped() -> None:
+            try:
+                target()
+            finally:
+                if thread is not None:
+                    with self._background_threads_lock:
+                        self._background_threads.discard(thread)
+
+        with self._background_threads_lock:
+            if self._shutdown_event.is_set():
+                return None
+            thread = threading.Thread(target=_wrapped, name=name, daemon=True)
+            self._background_threads.add(thread)
+            thread.start()
+        return thread
 
     @property
     def honcho(self) -> Honcho:
@@ -465,6 +504,12 @@ class HonchoSessionManager:
                 item = self._async_queue.get(timeout=5)
                 if item is _ASYNC_SHUTDOWN:
                     break
+                if isinstance(item, threading.Event):
+                    try:
+                        self._flush_all_sync()
+                    finally:
+                        item.set()
+                    continue
 
                 first_error: Exception | None = None
                 try:
@@ -506,20 +551,26 @@ class HonchoSessionManager:
           "session" — defer until flush_session() is called explicitly
           N (int)   — flush every N turns
         """
-        self._turn_counter += 1
-        wf = self._write_frequency
+        # Admission and async enqueue are one lifecycle operation. Otherwise a
+        # save can pass the shutdown check and enqueue behind the consumed
+        # sentinel, stranding data after the writer exits.
+        with self._shutdown_lock:
+            if self._shutdown_event.is_set():
+                return
+            self._turn_counter += 1
+            wf = self._write_frequency
 
-        if wf == "async":
-            if self._async_queue is not None:
-                self._async_queue.put(session)
-        elif wf == "turn":
-            self._flush_session(session)
-        elif wf == "session":
-            # Accumulate; caller must call flush_all() at session end
-            pass
-        elif isinstance(wf, int) and wf > 0:
-            if self._turn_counter % wf == 0:
+            if wf == "async":
+                if self._async_queue is not None:
+                    self._async_queue.put(session)
+            elif wf == "turn":
                 self._flush_session(session)
+            elif wf == "session":
+                # Accumulate; caller must call flush_all() at session end
+                pass
+            elif isinstance(wf, int) and wf > 0:
+                if self._turn_counter % wf == 0:
+                    self._flush_session(session)
 
     def flush_all(self) -> None:
         """Flush all pending unsynced messages for all cached sessions.
@@ -527,6 +578,21 @@ class HonchoSessionManager:
         Called at session end for "session" write_frequency, or to force
         a sync before process exit regardless of mode.
         """
+        with self._shutdown_lock:
+            if (
+                self._async_queue is not None
+                and self._async_thread is not None
+                and self._async_thread.is_alive()
+            ):
+                barrier = threading.Event()
+                self._async_queue.put(barrier)
+                if not barrier.wait(timeout=self._join_timeout_seconds()):
+                    raise RuntimeError("Honcho async flush did not complete before deadline")
+                return
+            self._flush_all_sync()
+
+    def _flush_all_sync(self) -> None:
+        """Flush cached sessions when no other thread owns async delivery."""
         with self._cache_lock:
             sessions = list(self._cache.values())
         for session in sessions:
@@ -535,22 +601,41 @@ class HonchoSessionManager:
             except Exception as e:
                 logger.error("Honcho flush_all error for %s: %s", session.key, e)
 
-        # Drain async queue synchronously if it exists
-        if self._async_queue is not None:
-            while not self._async_queue.empty():
-                try:
-                    item = self._async_queue.get_nowait()
-                    if item is not _ASYNC_SHUTDOWN:
-                        self._flush_session(item)
-                except queue.Empty:
-                    break
-
     def shutdown(self) -> None:
-        """Gracefully shut down the async writer thread."""
-        if self._async_queue is not None and self._async_thread is not None:
-            self.flush_all()
-            self._async_queue.put(_ASYNC_SHUTDOWN)
-            self._async_thread.join(timeout=10)
+        """Gracefully stop all manager-owned Honcho worker threads."""
+        with self._shutdown_lock:
+            if self._shutdown_complete:
+                return
+
+            self._shutdown_event.set()
+            deadline = time.monotonic() + self._join_timeout_seconds()
+
+            with self._background_threads_lock:
+                workers = list(self._background_threads)
+            for thread in workers:
+                if thread.is_alive():
+                    thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            live_workers = [thread.name for thread in workers if thread.is_alive()]
+            if live_workers:
+                raise RuntimeError(
+                    "Honcho manager workers did not stop before shutdown deadline: "
+                    + ", ".join(sorted(live_workers))
+                )
+
+            # Stop admission first, then let the single async writer drain all
+            # queued work through the FIFO sentinel. Do not synchronously drain
+            # the same queue while the writer owns it: that races _synced state
+            # and can duplicate remote messages.
+            if self._async_queue is not None and self._async_thread is not None:
+                self._async_queue.put(_ASYNC_SHUTDOWN)
+                self._async_thread.join(timeout=max(0.0, deadline - time.monotonic()))
+                if self._async_thread.is_alive():
+                    raise RuntimeError("Honcho async writer did not stop before shutdown deadline")
+
+            # Preserve provider shutdown's historical final-flush guarantee for
+            # session and integer write modes, after background ownership ends.
+            self._flush_all_sync()
+            self._shutdown_complete = True
 
     def delete(self, key: str) -> bool:
         """Delete a session from local cache."""
@@ -684,8 +769,7 @@ class HonchoSessionManager:
             if result:
                 self.set_context_result(session_key, result)
 
-        t = threading.Thread(target=_run, name="honcho-context-prefetch", daemon=True)
-        t.start()
+        self._start_background_thread(name="honcho-context-prefetch", target=_run)
 
     def set_context_result(self, session_key: str, result: dict[str, str]) -> None:
         """Store a prefetched context result in a thread-safe way."""

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -389,6 +389,41 @@ class TestMemoryManager:
         mgr.shutdown_all()
         assert order == ["external", "builtin"]  # reverse order
 
+    def test_shutdown_timeout_includes_provider_hints(self):
+        class HintProvider(FakeMemoryProvider):
+            def shutdown_timeout_seconds(self):
+                return 7.0
+
+        mgr = MemoryManager()
+        provider = HintProvider("external")
+        mgr.add_provider(provider)
+
+        assert mgr.shutdown_timeout_seconds() == 12.0
+
+    def test_shutdown_retries_opted_in_provider_and_budgets_retry(self):
+        class RetryProvider(FakeMemoryProvider):
+            shutdown_retryable = True
+
+            def __init__(self):
+                super().__init__("external")
+                self.shutdown_calls = 0
+
+            def shutdown_timeout_seconds(self):
+                return 7.0
+
+            def shutdown(self):
+                self.shutdown_calls += 1
+                if self.shutdown_calls == 1:
+                    raise RuntimeError("still draining")
+
+        mgr = MemoryManager()
+        provider = RetryProvider()
+        mgr.add_provider(provider)
+
+        assert mgr.shutdown_timeout_seconds() == 19.0
+        mgr.shutdown_all()
+        assert provider.shutdown_calls == 2
+
     def test_initialize_all(self):
         mgr = MemoryManager()
         p1 = FakeMemoryProvider("builtin")

--- a/tests/cli/test_cli_shutdown_memory_messages.py
+++ b/tests/cli/test_cli_shutdown_memory_messages.py
@@ -22,6 +22,26 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 
+def test_cleanup_watchdog_accounts_for_memory_shutdown(monkeypatch):
+    import cli as cli_mod
+
+    monkeypatch.delenv("HERMES_EXIT_WATCHDOG_S", raising=False)
+    agent = MagicMock()
+    agent._memory_manager.shutdown_timeout_seconds.return_value = 40.0
+    cli_mod._active_agent_ref = agent
+    try:
+        assert cli_mod._cleanup_watchdog_timeout_seconds() == 55.0
+    finally:
+        cli_mod._active_agent_ref = None
+
+
+def test_cleanup_watchdog_preserves_operator_override(monkeypatch):
+    import cli as cli_mod
+
+    monkeypatch.setenv("HERMES_EXIT_WATCHDOG_S", "12")
+    assert cli_mod._cleanup_watchdog_timeout_seconds() == 12.0
+
+
 @patch("hermes_cli.plugins.invoke_hook")
 def test_cleanup_forwards_session_messages(mock_invoke_hook):
     """_run_cleanup forwards a populated ``_session_messages`` list."""

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -13,8 +13,10 @@ import json
 import threading
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho import HonchoMemoryProvider
 from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
@@ -327,12 +329,308 @@ class TestAsyncWriterThread:
         assert len(flushed) == 1
         assert flushed[0] is sess
 
+    def test_flush_all_uses_writer_barrier_without_duplicate_write(self):
+        mgr = _make_manager(write_frequency="async")
+        sess = _make_session()
+        sess.add_message("user", "pending")
+        mgr._cache[sess.key] = sess
+        entered = threading.Event()
+        release = threading.Event()
+        remote_writes = []
+
+        def controlled_flush(session):
+            unsynced = [msg for msg in session.messages if not msg.get("_synced")]
+            if not unsynced:
+                return True
+            entered.set()
+            release.wait(timeout=2)
+            remote_writes.append(list(unsynced))
+            for msg in unsynced:
+                msg["_synced"] = True
+            return True
+
+        mgr._flush_session = controlled_flush
+        assert mgr._async_queue is not None
+        mgr._async_queue.put(sess)
+        assert entered.wait(timeout=1)
+        flush_thread = threading.Thread(target=mgr.flush_all)
+        flush_thread.start()
+        release.set()
+        flush_thread.join(timeout=2)
+        mgr.shutdown()
+
+        assert not flush_thread.is_alive()
+        assert len(remote_writes) == 1
+
     def test_shutdown_sentinel_stops_loop(self):
         mgr = _make_manager(write_frequency="async")
         thread = mgr._async_thread
         mgr.shutdown()
         thread.join(timeout=10)
         assert not thread.is_alive()
+
+    def test_shutdown_flushes_session_mode(self):
+        """Manager shutdown preserves the provider's final-flush contract."""
+        mgr = _make_manager(write_frequency="session")
+        sess = _make_session()
+        sess.add_message("user", "pending")
+        mgr._cache[sess.key] = sess
+
+        with patch.object(mgr, "_flush_session", return_value=True) as flush:
+            mgr.shutdown()
+
+        flush.assert_called_once_with(sess)
+
+    def test_shutdown_joins_manager_prefetch_worker(self):
+        mgr = _make_manager(write_frequency="turn")
+        entered = threading.Event()
+        release = threading.Event()
+
+        def slow_context(*_args, **_kwargs):
+            entered.set()
+            release.wait(timeout=2)
+            return {"representation": "ready"}
+
+        mgr.get_prefetch_context = slow_context
+        mgr.prefetch_context("cli:test", "hello")
+        assert entered.wait(timeout=1)
+        timer = threading.Timer(0.05, release.set)
+        timer.start()
+        try:
+            mgr.shutdown()
+        finally:
+            release.set()
+            timer.join(timeout=1)
+
+        with mgr._background_threads_lock:
+            assert not any(thread.is_alive() for thread in mgr._background_threads)
+
+    def test_shutdown_waits_for_in_flight_async_write(self):
+        mgr = _make_manager(write_frequency="async")
+        assert mgr._config is not None
+        mgr._config.timeout = 0.01
+        sess = _make_session()
+        sess.add_message("user", "pending")
+        entered = threading.Event()
+        release = threading.Event()
+
+        def blocked_flush(session):
+            assert session is sess
+            entered.set()
+            release.wait(timeout=2)
+            return True
+
+        mgr._flush_session = blocked_flush
+        assert mgr._async_queue is not None
+        mgr._async_queue.put(sess)
+        assert entered.wait(timeout=1)
+        timer = threading.Timer(0.05, release.set)
+        timer.start()
+        try:
+            mgr.shutdown()
+        finally:
+            release.set()
+            timer.join(timeout=1)
+
+        assert mgr._async_thread is not None
+        assert not mgr._async_thread.is_alive()
+
+    def test_save_enqueue_is_atomic_with_shutdown_sentinel(self):
+        mgr = _make_manager(write_frequency="async")
+        sess = _make_session()
+        sess.add_message("user", "pending")
+        entered = threading.Event()
+        release = threading.Event()
+        flushed = threading.Event()
+        assert mgr._async_queue is not None
+        original_put = mgr._async_queue.put
+
+        def controlled_put(item, *args, **kwargs):
+            if item is sess:
+                entered.set()
+                release.wait(timeout=2)
+            return original_put(item, *args, **kwargs)
+
+        mgr._async_queue.put = controlled_put
+        mgr._flush_session = lambda session: flushed.set() or session is sess
+        save_thread = threading.Thread(target=mgr.save, args=(sess,))
+        save_thread.start()
+        assert entered.wait(timeout=1)
+        shutdown_thread = threading.Thread(target=mgr.shutdown)
+        shutdown_thread.start()
+        release.set()
+        save_thread.join(timeout=1)
+        shutdown_thread.join(timeout=2)
+
+        assert not save_thread.is_alive()
+        assert not shutdown_thread.is_alive()
+        assert flushed.is_set()
+        assert mgr._async_thread is not None
+        assert not mgr._async_thread.is_alive()
+
+    def test_manager_shutdown_timeout_is_retryable(self):
+        mgr = _make_manager(write_frequency="turn")
+        release = threading.Event()
+
+        def blocked_worker() -> None:
+            release.wait(timeout=2)
+
+        worker = mgr._start_background_thread(
+            name="blocked-prefetch",
+            target=blocked_worker,
+        )
+        assert worker is not None
+        mgr._join_timeout_seconds = lambda: 0.01
+
+        with pytest.raises(RuntimeError, match="blocked-prefetch"):
+            mgr.shutdown()
+
+        assert not mgr._shutdown_complete
+        release.set()
+        worker.join(timeout=1)
+        mgr.shutdown()
+        assert mgr._shutdown_complete
+
+    def test_shutdown_rejects_new_manager_workers(self):
+        mgr = _make_manager(write_frequency="turn")
+        mgr.shutdown()
+
+        assert mgr._start_background_thread(name="late", target=lambda: None) is None
+
+    def test_provider_shutdown_stops_async_writer(self):
+        """The provider owns the manager and must stop its daemon writer."""
+        mgr = _make_manager(write_frequency="async")
+        provider = HonchoMemoryProvider()
+        provider._manager = mgr
+        provider._session_initialized = True
+        thread = mgr._async_thread
+        assert thread is not None
+
+        try:
+            provider.shutdown()
+            assert not thread.is_alive()
+        finally:
+            # Keep the RED case from leaking its daemon into the test process.
+            mgr.shutdown()
+
+    def test_provider_shutdown_stops_manager_published_during_init(self):
+        provider = HonchoMemoryProvider()
+        provider._config = MagicMock(timeout=0.01)
+        manager = MagicMock()
+        provider._initializing_manager = manager
+        entered = threading.Event()
+        release = threading.Event()
+
+        def blocked_init():
+            entered.set()
+            release.wait(timeout=2)
+
+        provider._init_thread = provider._start_background_thread(
+            target=blocked_init,
+            name="honcho-session-init",
+        )
+        assert entered.wait(timeout=1)
+        timer = threading.Timer(0.05, release.set)
+        timer.start()
+        try:
+            provider.shutdown()
+        finally:
+            release.set()
+            timer.join(timeout=1)
+
+        manager.shutdown.assert_called_once_with()
+        assert provider._init_thread is not None
+        assert not provider._init_thread.is_alive()
+
+    def test_init_created_after_shutdown_is_stopped_before_publication(self):
+        provider = HonchoMemoryProvider()
+        provider._shutdown_event.set()
+        cfg = MagicMock(context_tokens=1000)
+        manager = MagicMock()
+
+        with (
+            patch(
+                "plugins.memory.honcho.client.get_honcho_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "plugins.memory.honcho.session.HonchoSessionManager",
+                return_value=manager,
+            ),
+        ):
+            provider._do_session_init(cfg, "test-session")
+
+        manager.shutdown.assert_called_once_with()
+        assert provider._manager is None
+        assert provider._initializing_manager is None
+
+    def test_provider_shutdown_rejects_new_workers(self):
+        provider = HonchoMemoryProvider()
+        provider.shutdown()
+
+        assert provider._start_background_thread(target=lambda: None, name="late") is None
+
+    def test_provider_retains_and_reports_failed_manager_shutdown(self):
+        provider = HonchoMemoryProvider()
+        manager = MagicMock()
+        manager.shutdown.side_effect = [
+            RuntimeError("blocked once"),
+            RuntimeError("blocked twice"),
+            None,
+        ]
+        provider._manager = manager
+        provider._owned_managers.add(manager)
+
+        with pytest.raises(RuntimeError, match="1 Honcho manager"):
+            provider.shutdown()
+
+        assert manager in provider._owned_managers
+        assert provider._manager is manager
+        provider.shutdown()
+        assert manager not in provider._owned_managers
+        assert provider._manager is None
+
+    def test_provider_shutdown_timeout_covers_internal_retry(self):
+        provider = HonchoMemoryProvider()
+        provider._config = MagicMock(timeout=2.0)
+        provider._dialectic_depth = 1
+
+        # Provider workers: 5s. Manager: one flush plus two 8s attempts.
+        assert provider.shutdown_timeout_seconds() == 29.0
+
+        provider._owned_managers.update((MagicMock(), MagicMock()))
+        # One flush plus two attempts for each of two retained managers.
+        assert provider.shutdown_timeout_seconds() == 45.0
+
+    def test_lazy_initialization_is_serialized(self):
+        provider = HonchoMemoryProvider()
+        provider._config = MagicMock()
+        provider._lazy_init_kwargs = {}
+        provider._lazy_init_session_id = "test"
+        entered = threading.Event()
+        release = threading.Event()
+        calls = []
+
+        def initialize_once(*_args, **_kwargs):
+            calls.append(1)
+            entered.set()
+            release.wait(timeout=2)
+            provider._manager = MagicMock()
+            provider._session_initialized = True
+
+        provider._do_session_init = initialize_once
+        first = threading.Thread(target=provider._ensure_session)
+        second = threading.Thread(target=provider._ensure_session)
+        first.start()
+        assert entered.wait(timeout=1)
+        second.start()
+        release.set()
+        first.join(timeout=1)
+        second.join(timeout=1)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert len(calls) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix intermittent Python exit 134 after a successful Honcho-backed CLI response by making the provider own and stop every background worker before interpreter finalization.

- track provider- and session-manager-owned workers
- reject new background work once shutdown begins
- publish the session manager atomically after remote initialization
- serialize save admission with shutdown and use a writer-owned FIFO flush barrier
- preserve final flushing for `session` and `exit` write modes
- retry failed manager cleanup while retaining ownership until it succeeds
- derive CLI exit-watchdog bounds from provider shutdown budgets while preserving explicit operator overrides
- add deterministic coverage for initialization/shutdown races, blocked writes, prefetch workers, late admission, timeout/retry, and watchdog integration

## Root cause

`HonchoMemoryProvider.shutdown()` called `flush_all()` but never stopped `HonchoSessionManager`'s daemon `honcho-async-writer`. Provider-owned initialization, prefetch, sync, and memory-write threads were also not comprehensively tracked. During fast fallback exits, Python could begin finalization while a daemon thread was still in Honcho/httpx/native TLS code, producing SIGABRT after the model response had already been printed.

The narrow `manager.shutdown()` fix was not enough: shutdown could race with session initialization and miss a manager published afterward; save admission could race the writer sentinel; synchronous flushing could race a live writer; and the fixed 30-second CLI exit watchdog could expire before timeout-aware Honcho cleanup completed. This change introduces terminal admission gates, atomic manager publication, writer-owned flush ordering, retained/retryable manager ownership, and provider-aware watchdog timing.

## Reproduction and verification

Before this fix, the isolated memory-disabled fallback profile returned the expected response but aborted with exit 134 in 3 of 5 runs.

After the lifecycle fix:

- 24 of 24 equivalent fallback runs returned the expected marker and exited 0
- `uv run --extra honcho --extra dev pytest -q tests/honcho_plugin`
  - 450 passed; 4 cache-busting singleton/order failures outside the changed code
  - a clean `origin/main` worktree reproduced 3 failures from the same cache-busting test class (437 passed)
- `uv run --extra honcho --extra dev pytest -q tests/honcho_plugin/test_async_memory.py tests/honcho_plugin/test_session.py tests/agent/test_memory_provider.py tests/cli/test_cli_shutdown_memory_messages.py`
  - 323 passed
- Ruff checks over all changed Python files passed
- `git diff --check` passed

The original provider-shutdown regression was verified RED before the fix and GREEN afterward.

## Related work

This addresses the same shutdown/finalization family discussed in #60616, #37632, and #33485 and overlaps with ideas in #7627, #31664, #37635, and #58292. The distinguishing scope here is complete ownership across the async writer, manager prefetch workers, provider initialization, context/dialectic prefetch, sync, and explicit memory-write paths, including manager-publication and production-watchdog integration.
