### PR TITLE
fix(gateway): expand ${VAR} env refs in load_gateway_config (#72096)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -16,7 +16,7 @@ from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
-from hermes_cli.config import get_hermes_home
+from hermes_cli.config import get_hermes_home, _expand_env_vars
 from agent.secret_scope import current_secret_scope, get_secret as _get_secret
 from utils import is_truthy_value
 
@@ -1288,6 +1288,7 @@ def load_gateway_config() -> GatewayConfig:
             # the messaging gateway. Fail-open via the shared helper.
             from hermes_cli import managed_scope
             yaml_cfg = managed_scope.apply_managed_overlay(yaml_cfg)
+            yaml_cfg = _expand_env_vars(yaml_cfg)
 
             # Shared nested-fallback source: settings meant to be top-level
             # keys are also accepted when a user nests them under `gateway:`


### PR DESCRIPTION
## Summary

Fixes #72096. `gateway/config.py::load_gateway_config()` reads `config.yaml` with `yaml.safe_load()` but never calls `_expand_env_vars()`, unlike the CLI config loader (`hermes_cli.config.load_config`). Values under `platforms.<name>.extra` therefore keep literal `${VAR}` text.

For slash-command access control this silently inverts the intended behaviour: an unresolved `${TELEGRAM_ADMIN_ID}` becomes a non-empty set `{"${TELEGRAM_ADMIN_ID}"}` that can never match any real user id, so admin-only commands are permanently gated off with no error or warning.

## Changes

- **gateway/config.py**: Import `_expand_env_vars` from `hermes_cli.config` and call it on `yaml_cfg` after managed scope overlay, matching the CLI config loader's expansion pass.

## Testing

- Syntax check: `python3 -m py_compile gateway/config.py` — OK
- Lint: `ruff check gateway/config.py` — All checks passed
- Existing tests: `pytest tests/test_gateway_streaming_nested_config.py` — 16 passed
