### PR TITLE
fix(plugins): attribute task-routed LLM calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4862,6 +4862,14 @@ def _resolve_single_provider(
     )
     return client
 
+
+def _mark_client_route_provider(client: Any, provider: str) -> Any:
+    """Remember the concrete provider selected behind an ``auto`` route."""
+    if client is not None:
+        object.__setattr__(client, "_hermes_route_provider", _route_provider_name(provider))
+    return client
+
+
 def _resolve_auto(
     main_runtime: Optional[Dict[str, Any]] = None,
     task: Optional[str] = None,
@@ -5003,6 +5011,7 @@ def _resolve_auto(
             if client is not None:
                 logger.info("Auxiliary auto-detect: using main provider %s (%s)",
                             main_provider, resolved or main_model)
+                _mark_client_route_provider(client, main_provider)
                 return client, resolved or main_model
 
     # ── Step 2: user-configured fallback policy ─────────────────────────
@@ -5014,10 +5023,12 @@ def _resolve_auto(
         fb_client, fb_model, _fb_label = _try_configured_fallback_chain(
             task, main_provider or "auto", reason="main provider unavailable")
         if fb_client is not None:
+            _mark_client_route_provider(fb_client, _fb_label)
             return fb_client, fb_model
     fb_client, fb_model, _fb_label = _try_main_fallback_chain(
         task, main_provider or "auto", reason="main provider unavailable")
     if fb_client is not None:
+        _mark_client_route_provider(fb_client, _fb_label)
         return fb_client, fb_model
 
     # ── Step 3: aggregator / fallback chain ──────────────────────────────
@@ -5034,6 +5045,7 @@ def _resolve_auto(
                             label, model or "default", ", ".join(tried))
             else:
                 logger.info("Auxiliary auto-detect: using %s (%s)", label, model or "default")
+            _mark_client_route_provider(client, label)
             return client, model
         tried.append(label)
     logger.warning("Auxiliary auto-detect: no provider available (tried: %s). "
@@ -5064,23 +5076,29 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     """
     from openai import AsyncOpenAI
 
+    def converted(client):
+        route_provider = getattr(sync_client, "_hermes_route_provider", None)
+        if route_provider:
+            object.__setattr__(client, "_hermes_route_provider", route_provider)
+        return client, model
+
     if isinstance(sync_client, CodexAuxiliaryClient):
-        return AsyncCodexAuxiliaryClient(sync_client), model
+        return converted(AsyncCodexAuxiliaryClient(sync_client))
     if isinstance(sync_client, AnthropicAuxiliaryClient):
-        return AsyncAnthropicAuxiliaryClient(sync_client), model
+        return converted(AsyncAnthropicAuxiliaryClient(sync_client))
     if isinstance(sync_client, BedrockAuxiliaryClient):
-        return AsyncBedrockAuxiliaryClient(sync_client), model
+        return converted(AsyncBedrockAuxiliaryClient(sync_client))
     try:
         from agent.gemini_native_adapter import GeminiNativeClient, AsyncGeminiNativeClient
 
         if isinstance(sync_client, GeminiNativeClient):
-            return AsyncGeminiNativeClient(sync_client), model
+            return converted(AsyncGeminiNativeClient(sync_client))
     except ImportError:
         pass
     try:
         from agent.copilot_acp_client import CopilotACPClient
         if isinstance(sync_client, CopilotACPClient):
-            return sync_client, model
+            return converted(sync_client)
     except ImportError:
         pass
 
@@ -5129,7 +5147,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     # See _create_openai_client: disable SDK-internal retries so Hermes owns
     # the auxiliary retry/timeout budget (issue #54465).
     async_kwargs.setdefault("max_retries", 0)
-    return AsyncOpenAI(**async_kwargs), model
+    return converted(AsyncOpenAI(**async_kwargs))
 
 
 def _normalize_resolved_model(model_name: Optional[str], provider: str) -> Optional[str]:
@@ -7910,6 +7928,24 @@ async def _acreate_with_stream(
     )
 
 
+def _route_provider_name(label: str | None) -> str:
+    """Extract a concrete provider from a fallback diagnostic label."""
+    match = re.match(
+        r"(?:fallback_chain\[\d+\]|fallback_providers\[\d+\]|main-agent)\((.+)\)$",
+        label or "",
+    )
+    return match.group(1) if match else (label or "auto")
+
+
+def _record_route_info(
+    route_info: Optional[Dict[str, str]], provider: Optional[str], model: Optional[str]
+) -> None:
+    """Record the route selected for a call without a second config lookup."""
+    if route_info is not None:
+        route_info["provider"] = provider or "auto"
+        route_info["model"] = model or "default"
+
+
 @_relay_auxiliary_call
 def call_llm(
     task: str = None,
@@ -7930,6 +7966,7 @@ def call_llm(
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -8055,6 +8092,12 @@ def call_llm(
         resolved_provider,
         final_model,
         resolved_api_mode,
+    )
+    _record_route_info(
+        route_info,
+        getattr(client, "_hermes_route_provider", None)
+        or _route_provider_name(resolved_provider),
+        final_model,
     )
 
     # Log what we're about to do — makes auxiliary operations visible
@@ -8565,6 +8608,7 @@ def call_llm(
                         failed_model=_chain_failed_model)
 
             if fb_client is not None:
+                _record_route_info(route_info, _route_provider_name(fb_label), fb_model)
                 fb_resp = _call_fallback_candidate_sync(
                     fb_client, fb_model, fb_label,
                     task=task, messages=messages,
@@ -8580,6 +8624,7 @@ def call_llm(
                 fb_client, fb_model, fb_label = _try_payment_fallback(
                     resolved_provider, task, reason="stale fallback credential")
                 if fb_client is not None:
+                    _record_route_info(route_info, _route_provider_name(fb_label), fb_model)
                     fb_resp = _call_fallback_candidate_sync(
                         fb_client, fb_model, fb_label,
                         task=task, messages=messages,
@@ -8683,6 +8728,7 @@ async def async_call_llm(
     timeout: float = None,
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
@@ -8763,6 +8809,12 @@ async def async_call_llm(
         resolved_provider,
         final_model,
         resolved_api_mode,
+    )
+    _record_route_info(
+        route_info,
+        getattr(client, "_hermes_route_provider", None)
+        or _route_provider_name(resolved_provider),
+        final_model,
     )
 
     # Pass the client's actual base_url (not just resolved_base_url) so
@@ -9161,6 +9213,7 @@ async def async_call_llm(
                         failed_model=_chain_failed_model)
 
             if fb_client is not None:
+                _record_route_info(route_info, _route_provider_name(fb_label), fb_model)
                 # Convert sync fallback client to async
                 async_fb, async_fb_model = _to_async_client(
                     fb_client, fb_model or "", is_vision=(task == "vision")
@@ -9179,6 +9232,7 @@ async def async_call_llm(
                 fb_client, fb_model, fb_label = _try_payment_fallback(
                     resolved_provider, task, reason="stale fallback credential")
                 if fb_client is not None:
+                    _record_route_info(route_info, _route_provider_name(fb_label), fb_model)
                     async_fb, async_fb_model = _to_async_client(
                         fb_client, fb_model or "", is_vision=(task == "vision")
                     )

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -173,6 +173,7 @@ class _TrustPolicy:
     allow_any_model: bool = False  # True when allowed_models == ["*"]
     allow_agent_id_override: bool = False
     allow_profile_override: bool = False
+    allow_task_override: bool = False
 
 
 def _normalize_ref(raw: str) -> str:
@@ -243,6 +244,7 @@ def _resolve_trust_policy(plugin_id: str) -> _TrustPolicy:
         allow_any_model=allow_any_model,
         allow_agent_id_override=bool(llm_cfg.get("allow_agent_id_override", False)),
         allow_profile_override=bool(llm_cfg.get("allow_profile_override", False)),
+        allow_task_override=bool(llm_cfg.get("allow_task_override", False)),
     )
 
 
@@ -327,6 +329,66 @@ def _check_overrides(
         final_profile = requested_profile.strip()
 
     return final_provider, final_model, requested_agent_id, final_profile
+
+
+def _resolve_task_ownership(plugin_id: str) -> tuple[frozenset, frozenset]:
+    """Return plugin-owned and built-in auxiliary task keys.
+
+    Imports are lazy because plugin discovery imports this module. If either
+    registry is unavailable, its keys remain empty so authorization fails
+    closed rather than routing an unverified task.
+    """
+    owned: set = set()
+    builtin: set = set()
+    try:
+        from hermes_cli.plugins import get_plugin_auxiliary_tasks
+
+        for entry in get_plugin_auxiliary_tasks():
+            if entry.get("plugin") == plugin_id:
+                key = entry.get("key")
+                if isinstance(key, str) and key:
+                    owned.add(key)
+    except Exception:  # pragma: no cover - discovery unavailable
+        pass
+    try:
+        from hermes_cli.main import _AUX_TASKS
+
+        builtin = {key for key, _name, _description in _AUX_TASKS}
+    except Exception:  # pragma: no cover - built-in registry unavailable
+        pass
+    return frozenset(owned), frozenset(builtin)
+
+
+def _check_task(
+    policy: _TrustPolicy,
+    *,
+    plugin_id: str,
+    requested_task: Optional[str],
+) -> Optional[str]:
+    """Validate a task route, returning ``None`` for the main-model path."""
+    if not requested_task:
+        return None
+    task = requested_task.strip()
+    if not task or task.lower() == "auto":
+        return None
+
+    owned, builtin = _resolve_task_ownership(plugin_id)
+    if task in owned:
+        return task
+    if task in builtin and policy.allow_task_override:
+        return task
+
+    if task in builtin:
+        detail = (
+            f"the built-in auxiliary task {task!r} without "
+            f"plugins.entries.{plugin_id}.llm.allow_task_override"
+        )
+    else:
+        detail = f"auxiliary task {task!r} it did not register"
+    logger.warning("plugin_llm task routing denied: plugin %r requested %s", plugin_id, detail)
+    raise PluginLlmTrustError(
+        f"Plugin {plugin_id!r} cannot route through {detail}."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -545,28 +607,31 @@ def _resolve_attribution(
     provider_override: Optional[str],
     model_override: Optional[str],
     response: Any,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> tuple[str, str]:
     """Decide what to record as ``result.provider`` / ``result.model``.
 
     Precedence:
 
-    1. Explicit overrides win — if the plugin asked for ``provider="x"``
-       or ``model="y"``, that's what we record (it's what the call
-       actually targeted).
-    2. Otherwise we ask the host for the current main provider/model
-       via :func:`_read_main_provider` / :func:`_read_main_model`, since
-       those are what ``call_llm`` resolves to when ``provider=None``
-       and ``model=None`` are passed through. They reflect runtime
-       overrides set by ``set_runtime_main()``.
-    3. ``response.model`` (if present) overrides the recorded model
+    1. The route selected by ``auxiliary_client`` wins when available: it is
+       the route that actually served the invocation, including a fallback.
+    2. ``response.model`` (if present) overrides the recorded model
        string. Providers post-resolution often return a slightly
        different model id than the request (e.g. ``gpt-4o`` →
        ``gpt-4o-2024-08-06``); the plugin's audit log should reflect
        what actually ran.
-    4. If everything above is empty, fall back to ``"auto"`` /
+    3. Explicit overrides identify the target when route metadata is absent.
+    4. Otherwise the current main provider/model is used.
+    5. If everything above is empty, fall back to ``"auto"`` /
        ``"default"`` so the result object has non-empty strings.
     """
-    if provider_override:
+    route_info = route_info or {}
+    route_provider = route_info.get("provider")
+    route_model = route_info.get("model")
+
+    if route_provider:
+        provider = route_provider
+    elif provider_override:
         provider = provider_override
     else:
         try:
@@ -578,6 +643,8 @@ def _resolve_attribution(
     response_model = getattr(response, "model", None)
     if isinstance(response_model, str) and response_model.strip():
         model = response_model.strip()
+    elif route_model:
+        model = route_model
     elif model_override:
         model = model_override
     else:
@@ -631,6 +698,7 @@ class PluginLlm:
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
+        task: Optional[str] = None,
     ) -> PluginLlmCompleteResult:
         """Run a host-owned chat completion against the user's active model.
 
@@ -642,6 +710,7 @@ class PluginLlm:
         docstring).
         """
         policy = self._policy_loader(self._plugin_id)
+        eff_task = _check_task(policy, plugin_id=self._plugin_id, requested_task=task)
         eff_provider, eff_model, eff_agent, eff_profile = _check_overrides(
             policy,
             requested_provider=provider,
@@ -657,6 +726,7 @@ class PluginLlm:
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
+            task=eff_task,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -670,13 +740,14 @@ class PluginLlm:
                 "plugin_id": self._plugin_id,
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
+                "task": eff_task or "",
             },
         )
         logger.info(
-            "plugin_llm.complete plugin=%s provider=%s model=%s purpose=%s "
-            "tokens=%d",
-            self._plugin_id, real_provider, real_model, purpose or "",
-            usage.total_tokens,
+            "plugin_llm.complete plugin=%s provider=%s model=%s task=%s "
+            "purpose=%s tokens=%d",
+            self._plugin_id, real_provider, real_model, eff_task or "",
+            purpose or "", usage.total_tokens,
         )
         return result
 
@@ -697,6 +768,7 @@ class PluginLlm:
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
+        task: Optional[str] = None,
     ) -> PluginLlmStructuredResult:
         """Run a bounded host-owned structured completion.
 
@@ -716,6 +788,7 @@ class PluginLlm:
             raise ValueError("complete_structured requires at least one input block")
 
         policy = self._policy_loader(self._plugin_id)
+        eff_task = _check_task(policy, plugin_id=self._plugin_id, requested_task=task)
         eff_provider, eff_model, eff_agent, eff_profile = _check_overrides(
             policy,
             requested_provider=provider,
@@ -743,6 +816,7 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=extra_body,
+            task=eff_task,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -762,13 +836,14 @@ class PluginLlm:
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
                 "schema_name": schema_name or "",
+                "task": eff_task or "",
             },
         )
         logger.info(
             "plugin_llm.complete_structured plugin=%s provider=%s model=%s "
-            "purpose=%s content_type=%s tokens=%d",
-            self._plugin_id, real_provider, real_model, purpose or "",
-            content_type, usage.total_tokens,
+            "task=%s purpose=%s content_type=%s tokens=%d",
+            self._plugin_id, real_provider, real_model, eff_task or "",
+            purpose or "", content_type, usage.total_tokens,
         )
         return result
 
@@ -786,9 +861,11 @@ class PluginLlm:
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
+        task: Optional[str] = None,
     ) -> PluginLlmCompleteResult:
         """Async sibling of :meth:`complete`."""
         policy = self._policy_loader(self._plugin_id)
+        eff_task = _check_task(policy, plugin_id=self._plugin_id, requested_task=task)
         eff_provider, eff_model, eff_agent, eff_profile = _check_overrides(
             policy,
             requested_provider=provider,
@@ -804,10 +881,11 @@ class PluginLlm:
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
+            task=eff_task,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
-        return PluginLlmCompleteResult(
+        result = PluginLlmCompleteResult(
             text=text,
             provider=real_provider,
             model=real_model,
@@ -817,8 +895,16 @@ class PluginLlm:
                 "plugin_id": self._plugin_id,
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
+                "task": eff_task or "",
             },
         )
+        logger.info(
+            "plugin_llm.acomplete plugin=%s provider=%s model=%s task=%s "
+            "purpose=%s tokens=%d",
+            self._plugin_id, real_provider, real_model, eff_task or "",
+            purpose or "", usage.total_tokens,
+        )
+        return result
 
     async def acomplete_structured(
         self,
@@ -837,6 +923,7 @@ class PluginLlm:
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
+        task: Optional[str] = None,
     ) -> PluginLlmStructuredResult:
         """Async sibling of :meth:`complete_structured`."""
         if not instructions or not instructions.strip():
@@ -845,6 +932,7 @@ class PluginLlm:
             raise ValueError("acomplete_structured requires at least one input block")
 
         policy = self._policy_loader(self._plugin_id)
+        eff_task = _check_task(policy, plugin_id=self._plugin_id, requested_task=task)
         eff_provider, eff_model, eff_agent, eff_profile = _check_overrides(
             policy,
             requested_provider=provider,
@@ -870,13 +958,14 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=extra_body,
+            task=eff_task,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
         parsed, content_type = _parse_structured_text(
             text=text, json_mode=json_mode, json_schema=json_schema
         )
-        return PluginLlmStructuredResult(
+        result = PluginLlmStructuredResult(
             text=text,
             provider=real_provider,
             model=real_model,
@@ -889,8 +978,16 @@ class PluginLlm:
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
                 "schema_name": schema_name or "",
+                "task": eff_task or "",
             },
         )
+        logger.info(
+            "plugin_llm.acomplete_structured plugin=%s provider=%s model=%s "
+            "task=%s purpose=%s content_type=%s tokens=%d",
+            self._plugin_id, real_provider, real_model, eff_task or "",
+            purpose or "", content_type, usage.total_tokens,
+        )
+        return result
 
     # -- internals ---------------------------------------------------------
 
@@ -927,6 +1024,7 @@ class PluginLlm:
         max_tokens: Optional[int],
         timeout: Optional[float],
         extra_body: Optional[Dict[str, Any]] = None,
+        task: Optional[str] = None,
     ) -> tuple[str, str, Any]:
         """Invoke the host's ``call_llm``. Lazy-imports
         ``agent.auxiliary_client`` to avoid circular deps at plugin
@@ -941,13 +1039,15 @@ class PluginLlm:
                 max_tokens=max_tokens,
                 timeout=timeout,
                 extra_body=extra_body,
+                task=task,
             )
         from agent.auxiliary_client import call_llm
         merged_extra = dict(extra_body or {})
         if profile_override:
             merged_extra.setdefault("metadata", {})["auth_profile"] = profile_override
+        route_info: Optional[Dict[str, str]] = {} if task else None
         response = call_llm(
-            task=None,
+            task=task,
             provider=provider_override,
             model=model_override,
             messages=messages,
@@ -955,11 +1055,13 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=merged_extra or None,
+            route_info=route_info,
         )
         provider, model = _resolve_attribution(
             provider_override=provider_override,
             model_override=model_override,
             response=response,
+            route_info=route_info,
         )
         return provider, model, response
 
@@ -974,6 +1076,7 @@ class PluginLlm:
         max_tokens: Optional[int],
         timeout: Optional[float],
         extra_body: Optional[Dict[str, Any]] = None,
+        task: Optional[str] = None,
     ) -> tuple[str, str, Any]:
         if self._async_caller is not None:
             return await self._async_caller(
@@ -985,13 +1088,15 @@ class PluginLlm:
                 max_tokens=max_tokens,
                 timeout=timeout,
                 extra_body=extra_body,
+                task=task,
             )
         from agent.auxiliary_client import async_call_llm
         merged_extra = dict(extra_body or {})
         if profile_override:
             merged_extra.setdefault("metadata", {})["auth_profile"] = profile_override
+        route_info: Optional[Dict[str, str]] = {} if task else None
         response = await async_call_llm(
-            task=None,
+            task=task,
             provider=provider_override,
             model=model_override,
             messages=messages,
@@ -999,11 +1104,13 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=merged_extra or None,
+            route_info=route_info,
         )
         provider, model = _resolve_attribution(
             provider_override=provider_override,
             model_override=model_override,
             response=response,
+            route_info=route_info,
         )
         return provider, model, response
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1137,9 +1137,13 @@ class PluginContext:
                 f"Pick a plugin-namespaced key (e.g. '{self.manifest.name}_{key}')."
             )
 
+        # Match the identity bound to ctx.llm so PluginLlm can authorize an
+        # owned task even when a manifest's key differs from its display name.
+        owner_id = self.manifest.key or self.manifest.name
+
         # Reject duplicate registrations across plugins
         existing = self._manager._aux_tasks.get(key)
-        if existing is not None and existing.get("plugin") != self.manifest.name:
+        if existing is not None and existing.get("plugin") != owner_id:
             raise ValueError(
                 f"Plugin '{self.manifest.name}' cannot register auxiliary task "
                 f"{key!r} — already registered by plugin "
@@ -1165,7 +1169,7 @@ class PluginContext:
             "display_name": display_name,
             "description": description,
             "defaults": merged_defaults,
-            "plugin": self.manifest.name,
+            "plugin": owner_id,
         }
         logger.debug(
             "Plugin %s registered auxiliary task: %s (%s)",

--- a/tests/agent/test_plugin_llm_task_routing.py
+++ b/tests/agent/test_plugin_llm_task_routing.py
@@ -1,0 +1,328 @@
+"""Regression coverage for plugin-owned auxiliary task routing."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent.plugin_llm import (
+    PluginLlmTextInput,
+    PluginLlmTrustError,
+    _TrustPolicy,
+    _check_task,
+    _resolve_attribution,
+    make_plugin_llm_for_test,
+)
+
+
+def _response(text: str = "ok") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+def _policy() -> _TrustPolicy:
+    return _TrustPolicy(plugin_id="plugin-key")
+
+
+def _set_tasks(monkeypatch, entries: list[dict[str, str]], builtins: list[str] = []) -> None:
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_auxiliary_tasks", lambda: entries)
+    monkeypatch.setattr(
+        "hermes_cli.main._AUX_TASKS", [(key, key, "") for key in builtins]
+    )
+
+
+def test_task_gate_allows_owned_and_rejects_foreign(monkeypatch, caplog):
+    _set_tasks(monkeypatch, [{"key": "classifier", "plugin": "plugin-key"}])
+    assert _check_task(_policy(), plugin_id="plugin-key", requested_task=" classifier ") == "classifier"
+    assert _check_task(_policy(), plugin_id="plugin-key", requested_task="auto") is None
+
+    _set_tasks(monkeypatch, [{"key": "classifier", "plugin": "other"}])
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(PluginLlmTrustError, match="classifier"):
+            _check_task(_policy(), plugin_id="plugin-key", requested_task="classifier")
+    assert any("plugin-key" in record.getMessage() for record in caplog.records)
+
+
+def test_builtin_task_requires_explicit_opt_in(monkeypatch):
+    _set_tasks(monkeypatch, [], ["vision"])
+    with pytest.raises(PluginLlmTrustError, match="allow_task_override"):
+        _check_task(_policy(), plugin_id="plugin-key", requested_task="vision")
+    allowed = _TrustPolicy(plugin_id="plugin-key", allow_task_override=True)
+    assert _check_task(allowed, plugin_id="plugin-key", requested_task="vision") == "vision"
+
+
+def test_all_public_variants_preserve_owned_task_and_audit(monkeypatch):
+    _set_tasks(monkeypatch, [{"key": "classifier", "plugin": "plugin-key"}])
+    calls: list[dict[str, Any]] = []
+
+    def sync_caller(**kwargs: Any):
+        calls.append(kwargs)
+        return "aux-provider", "aux-model", _response()
+
+    async def async_caller(**kwargs: Any):
+        calls.append(kwargs)
+        return "aux-provider", "aux-model", _response('{"kind":"ok"}')
+
+    llm = make_plugin_llm_for_test(
+        plugin_id="plugin-key", policy=_policy(), sync_caller=sync_caller, async_caller=async_caller
+    )
+    complete = llm.complete([{"role": "user", "content": "x"}], task="classifier")
+    structured = llm.complete_structured(
+        instructions="classify", input=[PluginLlmTextInput(text="x")], task="classifier"
+    )
+    async_complete = asyncio.run(
+        llm.acomplete([{"role": "user", "content": "x"}], task="classifier")
+    )
+    async_structured = asyncio.run(
+        llm.acomplete_structured(
+            instructions="classify", input=[PluginLlmTextInput(text="x")], task="classifier"
+        )
+    )
+    for result in (complete, structured, async_complete, async_structured):
+        assert (result.provider, result.model) == ("aux-provider", "aux-model")
+        assert result.audit["task"] == "classifier"
+    assert [call["task"] for call in calls] == ["classifier"] * 4
+
+
+def test_async_variants_write_resolved_route_audit_logs(monkeypatch, caplog):
+    _set_tasks(monkeypatch, [{"key": "classifier", "plugin": "plugin-key"}])
+
+    async def async_caller(**_kwargs: Any):
+        return "aux-provider", "aux-model", _response('{"kind":"ok"}')
+
+    llm = make_plugin_llm_for_test(
+        plugin_id="plugin-key", policy=_policy(), async_caller=async_caller
+    )
+    with caplog.at_level(logging.INFO, logger="agent.plugin_llm"):
+        asyncio.run(
+            llm.acomplete(
+                [{"role": "user", "content": "x"}],
+                purpose="async-chat",
+                task="classifier",
+            )
+        )
+        asyncio.run(
+            llm.acomplete_structured(
+                instructions="classify",
+                input=[PluginLlmTextInput(text="x")],
+                purpose="async-structured",
+                task="classifier",
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "plugin_llm.acomplete plugin=plugin-key provider=aux-provider "
+        "model=aux-model task=classifier purpose=async-chat tokens=2" in message
+        for message in messages
+    )
+    assert any(
+        "plugin_llm.acomplete_structured plugin=plugin-key provider=aux-provider "
+        "model=aux-model task=classifier purpose=async-structured "
+        "content_type=text tokens=2" in message
+        for message in messages
+    )
+
+
+def test_task_route_uses_real_resolver_and_reports_the_selected_route(tmp_path, monkeypatch, caplog):
+    from agent import auxiliary_client
+    from hermes_cli import config as config_mod
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """model:\n  provider: main-provider\n  model: main-model\nauxiliary:\n  classifier:\n    provider: aux-provider\n    model: aux-model\n""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(config_mod, "_LOAD_CONFIG_CACHE", {})
+    monkeypatch.setattr(config_mod, "_RAW_CONFIG_CACHE", {})
+
+    manager = PluginManager()
+    manager._discovered = True
+    ctx = PluginContext(PluginManifest(name="display", key="plugin-key"), manager)
+    ctx.register_auxiliary_task("classifier", display_name="Classifier", description="test")
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda: manager)
+
+    selected: dict[str, str] = {}
+
+    def fake_cached(provider, model, **_kwargs):
+        selected.update(provider=provider, model=model)
+        return SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **_kwargs: _response()))
+        ), model
+
+    monkeypatch.setattr(auxiliary_client, "_get_cached_client", fake_cached)
+    with caplog.at_level(logging.INFO, logger="agent.plugin_llm"):
+        result = ctx.llm.complete([{"role": "user", "content": "x"}], task="classifier")
+
+    assert selected == {"provider": "aux-provider", "model": "aux-model"}
+    assert (result.provider, result.model) == ("aux-provider", "aux-model")
+    assert result.audit["task"] == "classifier"
+    assert any("provider=aux-provider model=aux-model task=classifier" in record.getMessage() for record in caplog.records)
+
+
+def test_task_route_fallback_reports_successful_provider_and_model(tmp_path, monkeypatch):
+    from agent import auxiliary_client
+    from hermes_cli import config as config_mod
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """auxiliary:\n  classifier:\n    provider: primary-provider\n    model: primary-model\n    fallback_chain:\n      - provider: fallback-provider\n        model: fallback-model\n""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(config_mod, "_LOAD_CONFIG_CACHE", {})
+    monkeypatch.setattr(config_mod, "_RAW_CONFIG_CACHE", {})
+    _set_tasks(monkeypatch, [{"key": "classifier", "plugin": "plugin-key"}])
+    monkeypatch.setattr(auxiliary_client, "_transient_retry_count", lambda: 0)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_get_cached_client",
+        lambda *_args, **_kwargs: (
+            SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **_kwargs: (_ for _ in ()).throw(ConnectionError("down"))))),
+            "primary-model",
+        ),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "resolve_provider_client",
+        lambda _provider, model, **_kwargs: (
+            SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **_kwargs: _response()))),
+            model,
+        ),
+    )
+
+    result = make_plugin_llm_for_test(plugin_id="plugin-key", policy=_policy()).complete(
+        [{"role": "user", "content": "x"}], task="classifier"
+    )
+    assert (result.provider, result.model) == ("fallback-provider", "fallback-model")
+
+
+def test_async_task_route_fallback_reports_successful_provider_and_model(tmp_path, monkeypatch):
+    from agent import auxiliary_client
+    from hermes_cli import config as config_mod
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """auxiliary:\n  classifier:\n    provider: primary-provider\n    model: primary-model\n    fallback_chain:\n      - provider: fallback-provider\n        model: fallback-model\n""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(config_mod, "_LOAD_CONFIG_CACHE", {})
+    monkeypatch.setattr(config_mod, "_RAW_CONFIG_CACHE", {})
+    _set_tasks(monkeypatch, [{"key": "classifier", "plugin": "plugin-key"}])
+
+    async def fail(**_kwargs):
+        raise ConnectionError("down")
+
+    async def succeed(**_kwargs):
+        return _response()
+
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_get_cached_client",
+        lambda *_args, **_kwargs: (
+            SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=fail))),
+            "primary-model",
+        ),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "resolve_provider_client",
+        lambda _provider, model, **_kwargs: (
+            SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=succeed))),
+            model,
+        ),
+    )
+    monkeypatch.setattr(auxiliary_client, "_to_async_client", lambda client, model, **_kwargs: (client, model))
+
+    result = asyncio.run(
+        make_plugin_llm_for_test(plugin_id="plugin-key", policy=_policy()).acomplete(
+            [{"role": "user", "content": "x"}], task="classifier"
+        )
+    )
+    assert (result.provider, result.model) == ("fallback-provider", "fallback-model")
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+def test_unavailable_task_provider_reports_configured_fallback(tmp_path, monkeypatch, async_mode):
+    from agent import auxiliary_client
+    from hermes_cli import config as config_mod
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """auxiliary:\n  classifier:\n    provider: unavailable-provider\n    model: primary-model\n    fallback_chain:\n      - provider: fallback-provider\n        model: fallback-model\n""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(config_mod, "_LOAD_CONFIG_CACHE", {})
+    monkeypatch.setattr(config_mod, "_RAW_CONFIG_CACHE", {})
+    _set_tasks(monkeypatch, [{"key": "classifier", "plugin": "plugin-key"}])
+    monkeypatch.setattr(auxiliary_client, "_get_cached_client", lambda *_args, **_kwargs: (None, None))
+
+    if async_mode:
+        async def create(**_kwargs):
+            return _response()
+    else:
+        def create(**_kwargs):
+            return _response()
+
+    fallback_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "resolve_provider_client",
+        lambda _provider, model, **_kwargs: (fallback_client, model),
+    )
+    if async_mode:
+        monkeypatch.setattr(
+            auxiliary_client, "_to_async_client", lambda client, model, **_kwargs: (client, model)
+        )
+        result = asyncio.run(
+            make_plugin_llm_for_test(plugin_id="plugin-key", policy=_policy()).acomplete(
+                [{"role": "user", "content": "x"}], task="classifier"
+            )
+        )
+    else:
+        result = make_plugin_llm_for_test(plugin_id="plugin-key", policy=_policy()).complete(
+            [{"role": "user", "content": "x"}], task="classifier"
+        )
+    assert (result.provider, result.model) == ("fallback-provider", "fallback-model")
+
+
+def test_default_call_retains_main_route_path(monkeypatch):
+    _set_tasks(monkeypatch, [])
+    seen: dict[str, Any] = {}
+
+    def caller(**kwargs: Any):
+        seen.update(kwargs)
+        return "main-provider", "main-model", _response()
+
+    result = make_plugin_llm_for_test(plugin_id="plugin-key", policy=_policy(), sync_caller=caller).complete(
+        [{"role": "user", "content": "x"}]
+    )
+    assert seen["task"] is None
+    assert result.audit["task"] == ""
+    assert (result.provider, result.model) == ("main-provider", "main-model")
+
+
+def test_successful_fallback_route_beats_requested_override_for_attribution():
+    provider, model = _resolve_attribution(
+        provider_override="primary-provider",
+        model_override="primary-model",
+        response=_response(),
+        route_info={"provider": "fallback-provider", "model": "fallback-model"},
+    )
+    assert (provider, model) == ("fallback-provider", "fallback-model")

--- a/website/docs/developer-guide/plugin-llm-access.md
+++ b/website/docs/developer-guide/plugin-llm-access.md
@@ -223,6 +223,7 @@ result = ctx.llm.complete(
     agent_id=None,         # optional, gated
     profile=None,          # optional, gated — explicit auth-profile name
     purpose="optional-audit-string",
+    task=None,             # optional plugin-owned auxiliary slot
 )
 # → PluginLlmCompleteResult(text, provider, model, agent_id, usage, audit)
 ```
@@ -237,6 +238,11 @@ as the host's main config (`model.provider` + `model.model`). Set
 just `model=` to use the user's active provider with a different
 model on it. Set both to switch providers entirely. Either argument
 without operator opt-in raises `PluginLlmTrustError`.
+
+`task=` routes a call through `auxiliary.<task>` rather than the main model.
+Unset, blank, and `"auto"` retain the main-model path. A plugin can always use
+a slot it registered with `ctx.register_auxiliary_task()`; foreign or unknown
+slots are rejected before dispatch.
 
 ### `complete_structured()`
 
@@ -260,6 +266,7 @@ result = ctx.llm.complete_structured(
     agent_id=None,
     profile=None,
     purpose=None,
+    task=None,
 )
 # → PluginLlmStructuredResult(text, provider, model, agent_id,
 #                             usage, parsed, content_type, audit)
@@ -297,7 +304,7 @@ class PluginLlmCompleteResult:
     model: str                   # whatever the provider returned for this call
     agent_id: str                # whose model/auth was used
     usage: PluginLlmUsage        # tokens + cache + cost estimate
-    audit: Dict[str, Any]        # plugin_id, purpose, profile
+    audit: Dict[str, Any]        # plugin_id, purpose, profile, task
 
 @dataclass
 class PluginLlmStructuredResult:
@@ -362,6 +369,10 @@ plugins:
         # Allow the plugin to request a specific stored auth profile
         # (e.g. a different OAuth account on the same provider).
         allow_profile_override: false
+
+        # Allow host-owned built-in auxiliary tasks. Plugin-owned slots do
+        # not require this grant.
+        allow_task_override: false
 ```
 
 The plugin id is the manifest `name:` field for flat plugins, or the
@@ -378,6 +389,7 @@ path-derived key for nested plugins (`image_gen/openai`,
 | ↳ allowlist     | —       | `allowed_models: [...]`          |
 | `agent_id=`     | denied  | `allow_agent_id_override: true`  |
 | `profile=`      | denied  | `allow_profile_override: true`   |
+| built-in `task=` | denied | `allow_task_override: true`      |
 
 Each override is independently gated. Granting `allow_model_override`
 does **not** also grant `allow_provider_override` — a plugin trusted
@@ -394,14 +406,18 @@ it gets the provider gate as well.
   useful work — it just runs against the active provider and model.
   Operators only need to think about `plugins.entries` for plugins
   that want finer routing.
+* A plugin-owned `task=` is authorized by the registered slot owner, not this
+  override flag. A foreign or unknown task always raises `PluginLlmTrustError`.
 
 ## What the host owns
 
 A complete list of the things `ctx.llm` does for the plugin so you
 don't have to:
 
-* **Provider resolution.** Reads `model.provider` + `model.model`
-  from the user's config (or the explicit overrides when trusted).
+* **Provider resolution.** Reads `model.provider` + `model.model` from the
+  user's config, or `auxiliary.<task>` for a task-routed call. Result and audit
+  metadata identify the provider/model that actually served the call, including
+  a successful fallback.
 * **Auth.** Pulls API keys, OAuth tokens, or refresh tokens from
   `~/.hermes/auth.json` / env, including the credential pool when
   one is configured. The plugin never sees them.
@@ -420,7 +436,7 @@ don't have to:
   `jsonschema` is installed; logs a debug line and skips strict
   validation otherwise.
 * **Audit log.** Each call writes one INFO line to `agent.log` with
-  the plugin id, provider/model, purpose, and token totals.
+  the plugin id, selected provider/model, task, purpose, and token totals.
 
 ## What the plugin owns
 
@@ -458,7 +474,8 @@ own model call — for any reason, structured or not — `ctx.llm`.
 ## Reference
 
 * Implementation: [`agent/plugin_llm.py`](https://github.com/NousResearch/hermes-agent/blob/main/agent/plugin_llm.py)
-* Tests: [`tests/agent/test_plugin_llm.py`](https://github.com/NousResearch/hermes-agent/blob/main/tests/agent/test_plugin_llm.py)
+* Tests: [`tests/agent/test_plugin_llm.py`](https://github.com/NousResearch/hermes-agent/blob/main/tests/agent/test_plugin_llm.py) and
+  [`tests/agent/test_plugin_llm_task_routing.py`](https://github.com/NousResearch/hermes-agent/blob/main/tests/agent/test_plugin_llm_task_routing.py)
 * Reference plugins (companion repo):
   * [`plugin-llm-example`](https://github.com/NousResearch/hermes-example-plugins/tree/main/plugin-llm-example) — sync structured extraction with image input
   * [`plugin-llm-async-example`](https://github.com/NousResearch/hermes-example-plugins/tree/main/plugin-llm-async-example) — async with `asyncio.gather()`

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/plugin-llm-access.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/plugin-llm-access.md
@@ -193,6 +193,7 @@ result = ctx.llm.complete(
     agent_id=None,         # 可选，受门控
     profile=None,          # 可选，受门控——显式指定认证 profile 名称
     purpose="optional-audit-string",
+    task=None,             # 可选，plugin 自有辅助模型槽
 )
 # → PluginLlmCompleteResult(text, provider, model, agent_id, usage, audit)
 ```
@@ -200,6 +201,8 @@ result = ctx.llm.complete(
 普通对话补全。`messages` 采用标准 OpenAI 格式——`{"role": "...", "content": "..."}` 字典列表。多轮 prompt（system + few-shot user/assistant 对 + 最终 user）的用法与 OpenAI SDK 完全一致。
 
 `provider=` 和 `model=` 相互独立，格式与宿主主配置（`model.provider` + `model.model`）相同。仅设置 `model=` 可在用户当前激活的 provider 上使用不同模型。同时设置两者则完全切换 provider。任一参数在未获运营人员授权时均会抛出 `PluginLlmTrustError`。
+
+`task=` 会通过 `auxiliary.<task>` 路由调用。未设置、空字符串和 `"auto"` 保持主模型路径。plugin 始终可以使用自己通过 `ctx.register_auxiliary_task()` 注册的槽；外部或未知槽会在分发前被拒绝。
 
 ### `complete_structured()`
 
@@ -223,6 +226,7 @@ result = ctx.llm.complete_structured(
     agent_id=None,
     profile=None,
     purpose=None,
+    task=None,
 )
 # → PluginLlmStructuredResult(text, provider, model, agent_id,
 #                             usage, parsed, content_type, audit)
@@ -252,7 +256,7 @@ class PluginLlmCompleteResult:
     model: str                   # provider 为本次调用返回的模型标识
     agent_id: str                # 使用了哪个 agent 的模型/认证
     usage: PluginLlmUsage        # token 数 + 缓存 + 费用估算
-    audit: Dict[str, Any]        # plugin_id、purpose、profile
+    audit: Dict[str, Any]        # plugin_id、purpose、profile、task
 
 @dataclass
 class PluginLlmStructuredResult(PluginLlmCompleteResult):
@@ -305,6 +309,9 @@ plugins:
         # 允许 plugin 请求特定的存储认证 profile
         # （如同一 provider 上的不同 OAuth 账户）。
         allow_profile_override: false
+
+        # 允许使用宿主内置辅助任务。plugin 自有任务不需要此授权。
+        allow_task_override: false
 ```
 
 Plugin id 对于扁平 plugin 是 manifest 中的 `name:` 字段，对于嵌套 plugin 是路径派生的键（`image_gen/openai`、`memory/honcho` 等）。
@@ -319,6 +326,7 @@ Plugin id 对于扁平 plugin 是 manifest 中的 `name:` 字段，对于嵌套 
 | ↳ 允许列表      | —     | `allowed_models: [...]`          |
 | `agent_id=`     | 拒绝  | `allow_agent_id_override: true`  |
 | `profile=`      | 拒绝  | `allow_profile_override: true`   |
+| 内置 `task=`    | 拒绝  | `allow_task_override: true`      |
 
 每项覆盖独立门控。授予 `allow_model_override` **不会**同时授予 `allow_provider_override`——被信任可选择模型的 plugin，在未获得 provider 门控授权前仍固定在用户当前激活的 provider 上。
 
@@ -326,19 +334,20 @@ Plugin id 对于扁平 plugin 是 manifest 中的 `name:` 字段，对于嵌套 
 
 * 请求塑形参数——`temperature`、`max_tokens`、`timeout`、`system_prompt`、`purpose`、`messages`、`instructions`、`input`、`json_schema`、`schema_name`、`json_mode`——始终允许；它们不涉及凭据或路由选择。
 * 默认拒绝策略意味着未配置的 plugin 仍可完成有用的工作——只是针对当前激活的 provider 和模型运行。运营人员只需在 plugin 明确需要更精细路由时才考虑 `plugins.entries`。
+* plugin 自有的 `task=` 根据已注册任务的所有者授权；外部或未知任务始终抛出 `PluginLlmTrustError`。
 
 ## 宿主负责的内容
 
 以下是 `ctx.llm` 为 plugin 代劳的完整列表，你无需自行处理：
 
-* **Provider 解析。** 从用户配置中读取 `model.provider` + `model.model`（或在受信任时读取显式覆盖值）。
+* **Provider 解析。** 从用户配置中读取 `model.provider` + `model.model`，或在任务路由时读取 `auxiliary.<task>`。结果和审计元数据会标识实际服务调用的 provider/模型，包括成功的回退路由。
 * **认证。** 从 `~/.hermes/auth.json` / 环境变量中提取 API 密钥、OAuth token 或刷新 token，包括配置了凭据池时的处理。Plugin 永远看不到这些内容。
 * **视觉路由。** 当提供图像输入而用户当前激活的文本模型仅支持文本时，宿主自动回退到已配置的视觉模型。
 * **回退链。** 若用户主 provider 返回 5xx 或 429，请求在向 plugin 返回错误前会经过 Hermes 常规的聚合器感知回退流程。
 * **超时。** 遵循你的 `timeout=` 参数，回退到 `auxiliary.<task>.timeout` 配置或全局辅助默认值。
 * **JSON 塑形。** 在你请求 JSON 时向 provider 发送 `response_format`，若 provider 返回了代码围栏格式的响应则在本地重新解析。
 * **Schema 验证。** 安装了 `jsonschema` 时对你的 `json_schema` 进行验证；否则记录一行 debug 日志并跳过严格验证。
-* **审计日志。** 每次调用向 `agent.log` 写入一条 INFO 日志，包含 plugin id、provider/模型、purpose 和 token 总量。
+* **审计日志。** 每次调用向 `agent.log` 写入一条 INFO 日志，包含 plugin id、实际选定的 provider/模型、task、purpose 和 token 总量。
 
 ## Plugin 负责的内容
 
@@ -363,7 +372,8 @@ Plugin id 对于扁平 plugin 是 manifest 中的 `name:` 字段，对于嵌套 
 ## 参考资料
 
 * 实现：[`agent/plugin_llm.py`](https://github.com/NousResearch/hermes-agent/blob/main/agent/plugin_llm.py)
-* 测试：[`tests/agent/test_plugin_llm.py`](https://github.com/NousResearch/hermes-agent/blob/main/tests/agent/test_plugin_llm.py)
+* 测试：[`tests/agent/test_plugin_llm.py`](https://github.com/NousResearch/hermes-agent/blob/main/tests/agent/test_plugin_llm.py) 和
+  [`tests/agent/test_plugin_llm_task_routing.py`](https://github.com/NousResearch/hermes-agent/blob/main/tests/agent/test_plugin_llm_task_routing.py)
 * 参考 plugin（配套仓库）：
   * [`plugin-llm-example`](https://github.com/NousResearch/hermes-example-plugins/tree/main/plugin-llm-example) — 带图像输入的同步结构化提取
   * [`plugin-llm-async-example`](https://github.com/NousResearch/hermes-example-plugins/tree/main/plugin-llm-async-example) — 使用 `asyncio.gather()` 的异步示例


### PR DESCRIPTION
## What does this PR do?

Fixes task-routed Plugin LLM calls so their result metadata, audit payloads,
and logs identify the provider/model that actually served the request. The
route metadata is produced by the same auxiliary resolver and fallback flow
that dispatches inference, avoiding a second lookup against the main route.

This is the standalone attribution-reliability requirement from #72372. It
complements, but does not replace, the broader task-routing proposal in #64174
and PR #65734.

## Related Issue

Fixes #72372

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/plugin_llm.py`: add validated `task=` routing to all PluginLlm
  variants and consume resolver-owned route metadata for results, audits, and
  logs.
- `agent/auxiliary_client.py`: retain the concrete provider across auto
  resolution, sync/async conversion, unavailable-client recovery, and runtime
  fallback.
- `hermes_cli/plugins.py`: store auxiliary-task ownership using the same
  canonical plugin ID bound to `ctx.llm`.
- `tests/agent/test_plugin_llm_task_routing.py`: cover real temp-HERMES_HOME
  resolution, all public variants, ownership, main-route compatibility, and
  sync/async fallback attribution.
- Update the canonical and zh-Hans Plugin LLM guides.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_plugin_llm.py tests/agent/test_plugin_llm_task_routing.py tests/hermes_cli/test_plugin_auxiliary_tasks.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_runtime_cache_key.py`.
   Expected: 459 tests pass.
2. The new temp-`HERMES_HOME` test registers `classifier`, configures distinct
   `main-*` and `aux-*` routes, invokes `ctx.llm.complete(task="classifier")`,
   and verifies the resolver plus result/audit/log attribution all select
   `aux-provider` / `aux-model`.
3. Run `python scripts/check-windows-footguns.py --diff HEAD^`.
   Expected: no Windows footguns.

The full `scripts/run_tests.sh` wrapper was also run. It reports 44 failures in
22 unrelated existing files, including Linux-only `systemctl` expectations,
macOS `/tmp` path normalization, and existing approval/CUA regressions. No
failure occurred in files changed by this PR or their focused resolver tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full CI-parity wrapper ran; unrelated failures are documented above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin) with the hermetic test wrapper

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A: no global configuration schema change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A: existing plugin and auxiliary routing architecture)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A: no model tool schema changed)

## For New Skills

Not applicable: this PR does not add or modify a skill.

## Screenshots / Logs

Not applicable. The focused integration test asserts the emitted Plugin LLM log
contains `provider=aux-provider model=aux-model task=classifier`.

Prepared by OpenCode (AI agent on behalf of Magnus Hedemark).
