### PR TITLE
fix(desktop): auto-scroll slash/@ popover to keep keyboard selection visible

### DIFF
--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -1,5 +1,5 @@
 import type { Unstable_TriggerItem } from '@assistant-ui/core'
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
@@ -69,11 +69,21 @@ export function ComposerTriggerPopover({
   const { t } = useI18n()
   const copy = t.composer
   const isSlash = kind === '/'
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Scroll the active item into view when keyboard navigation moves the highlight.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const el = container.querySelector('[data-highlighted]') as HTMLElement | null
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
 
   let lastGroup: string | undefined
 
   return (
     <div
+      ref={containerRef}
       className={placement === 'bottom' ? COMPLETION_DRAWER_BELOW_CLASS : COMPLETION_DRAWER_CLASS}
       data-slot="composer-completion-drawer"
       data-state="open"


### PR DESCRIPTION
## Summary

When navigating the slash command (`/`) or mention (`@`) popover with arrow keys, if the user moves past the visible area, the highlighted item scrolls out of view. The user has to manually scroll with the mouse to see which command is selected.

## Fix

Add a `useEffect` in `ComposerTriggerPopover` that watches `activeIndex` and calls `scrollIntoView({ block: "nearest" })` on the highlighted element. This keeps the keyboard-selected row visible without jarring jumps — `block: "nearest"` only scrolls the minimum amount needed.

## How it works

```
activeIndex changes → useEffect fires → querySelector("[data-highlighted]") → scrollIntoView({ block: "nearest" })
```

The `data-highlighted` attribute is already set on the active `<button>` in the existing render loop, so no new DOM attributes needed.

## Files changed

| File | Change |
|------|--------|
| `apps/desktop/src/app/chat/composer/trigger-popover.tsx` | +11/-1: add containerRef + useEffect scroll |