### PR TITLE
fix(desktop): isolate backend Python fallback environment

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -5,8 +5,10 @@ import { test } from 'vitest'
 
 import {
   appendUniquePathEntries,
+  buildDesktopBackendChildEnv,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  buildDesktopPythonBackend,
   hermesManagedNodePathEntries,
   normalizeHermesHomeRoot,
   pathEnvKey,
@@ -105,7 +107,7 @@ test('desktop backend PATH preserves first occurrence and avoids duplicates', ()
   )
 })
 
-test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () => {
+test('buildDesktopBackendEnv replaces inherited PYTHONPATH and extends backend PATH', () => {
   const env = buildDesktopBackendEnv({
     hermesHome: '/Users/test/.hermes',
     pythonPathEntries: ['/repo/hermes-agent'],
@@ -118,7 +120,7 @@ test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () =
     pathModule: path.posix
   })
 
-  assert.equal(env.PYTHONPATH, '/repo/hermes-agent:/existing/pythonpath')
+  assert.equal(env.PYTHONPATH, '/repo/hermes-agent')
   assert.equal(env.VIRTUAL_ENV, '/Users/test/.hermes/hermes-agent/venv')
   assert.ok(
     env.PATH.startsWith(
@@ -126,6 +128,79 @@ test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () =
     )
   )
   assert.ok(env.PATH.includes('/opt/homebrew/bin'))
+})
+
+test('actual system-Python resolver wiring strips inherited virtualenv state', () => {
+  const foreignVenv = '/tmp/foreign/.venv'
+
+  const currentEnv = {
+    PATH: `${foreignVenv}/bin:/custom/bin:/usr/bin`,
+    PYTHONHOME: '/tmp/foreign/python-home',
+    PYTHONPATH: `${foreignVenv}/lib/python3.11/site-packages`,
+    SAFE_PARENT_VALUE: 'preserved',
+    VIRTUAL_ENV: foreignVenv
+  }
+
+  const backend = buildDesktopPythonBackend({
+    root: '/repo/hermes-agent',
+    label: 'Hermes system Python fallback',
+    backendArgs: ['serve', '--port', '0'],
+    command: '/usr/bin/python3',
+    runtimeVenvRoot: null,
+    sitePackagesEntries: [],
+    hermesHome: '/home/test/.hermes',
+    currentEnv,
+    platform: 'linux',
+    pathModule: path.posix
+  })
+
+  assert.equal(backend.command, '/usr/bin/python3')
+  assert.deepEqual(backend.args, ['-m', 'hermes_cli.main', 'serve', '--port', '0'])
+  assert.equal(backend.env.VIRTUAL_ENV, undefined)
+  assert.equal(backend.env.PYTHONPATH, '/repo/hermes-agent')
+  assert.equal(backend.env.PATH.split(':').includes(`${foreignVenv}/bin`), false)
+  assert.ok(backend.env.PATH.split(':').includes('/custom/bin'))
+
+  const childEnv = buildDesktopBackendChildEnv({
+    currentEnv,
+    backendEnv: backend.env,
+    overrides: { HERMES_HOME: '/home/test/.hermes' }
+  })
+
+  assert.equal(childEnv.VIRTUAL_ENV, undefined)
+  assert.equal(childEnv.PYTHONHOME, undefined)
+  assert.equal(childEnv.PYTHONPATH, '/repo/hermes-agent')
+  assert.equal(childEnv.PATH.split(':').includes(`${foreignVenv}/bin`), false)
+  assert.equal(childEnv.SAFE_PARENT_VALUE, 'preserved')
+  assert.equal(childEnv.HERMES_HOME, '/home/test/.hermes')
+})
+
+test('pip-installed system Python descriptor clears inherited Python state without injecting a source root', () => {
+  const foreignVenv = '/tmp/foreign/.venv'
+
+  const backend = buildDesktopPythonBackend({
+    root: null,
+    label: 'installed hermes_cli module via /usr/bin/python3',
+    backendArgs: ['serve'],
+    command: '/usr/bin/python3',
+    runtimeVenvRoot: null,
+    sitePackagesEntries: [],
+    hermesHome: '/home/test/.hermes',
+    currentEnv: {
+      PATH: `${foreignVenv}/bin:/usr/bin`,
+      PYTHONHOME: '/tmp/foreign/python-home',
+      PYTHONPATH: `${foreignVenv}/lib/python3.11/site-packages`,
+      VIRTUAL_ENV: foreignVenv
+    },
+    platform: 'linux',
+    pathModule: path.posix
+  })
+
+  assert.equal(backend.root, null)
+  assert.equal(backend.env.VIRTUAL_ENV, undefined)
+  assert.equal(backend.env.PYTHONPATH, '')
+  assert.equal(backend.env.PATH.split(':').includes(`${foreignVenv}/bin`), false)
+  assert.ok(backend.env.PATH.split(':').includes('/usr/bin'))
 })
 
 test('buildDesktopBackendEnv forces PYTHONUTF8 unless the user set it explicitly', () => {
@@ -161,19 +236,23 @@ test('normalizeHermesHomeRoot maps profile homes back to the global Hermes root'
 })
 
 test('Windows PATH casing and delimiter are preserved without POSIX sane entries', () => {
+  const foreignVenv = 'C:\\Users\\test\\legacy-venv'
+
   const env = buildDesktopBackendEnv({
     hermesHome: 'C:\\Users\\test\\AppData\\Local\\hermes',
     pythonPathEntries: ['C:\\repo\\hermes-agent'],
     venvRoot: 'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv',
     currentEnv: {
-      Path: 'C:\\Windows\\System32;C:\\Windows',
-      PYTHONPATH: 'C:\\existing\\pythonpath'
+      Path: `${foreignVenv}\\Scripts;C:\\Windows\\System32;C:\\Windows`,
+      PYTHONPATH: 'C:\\existing\\pythonpath',
+      virtual_env: foreignVenv
     },
     platform: 'win32',
     pathModule: path.win32
   })
 
   assert.equal(pathEnvKey({ Path: 'x' }, 'win32'), 'Path')
+
   assert.equal(env.PATH, undefined)
   // Windows leads with the portable layout (install.ps1 unpacks node.exe
   // straight into node\, no bin\), then the POSIX shape for migrated installs.
@@ -184,8 +263,21 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
   )
   assert.ok(env.Path.includes('\\venv\\Scripts;'))
   assert.ok(env.Path.includes(';C:\\Windows\\System32;C:\\Windows'))
+  assert.equal(env.Path.toLowerCase().includes(`${foreignVenv}\\scripts`.toLowerCase()), false)
   assert.equal(env.Path.includes('/opt/homebrew/bin'), false)
   assert.equal(env.VIRTUAL_ENV, 'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv')
+
+  const childEnv = buildDesktopBackendChildEnv({
+    currentEnv: {
+      Path: `${foreignVenv}\\SCRIPTS;C:\\Windows\\System32`,
+      virtual_env: foreignVenv
+    },
+    platform: 'win32',
+    pathModule: path.win32
+  })
+
+  assert.equal(childEnv.virtual_env, undefined)
+  assert.equal(childEnv.Path.toLowerCase().includes(`${foreignVenv}\\scripts`.toLowerCase()), false)
 })
 
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {

--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -119,6 +119,7 @@ test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () =
   })
 
   assert.equal(env.PYTHONPATH, '/repo/hermes-agent:/existing/pythonpath')
+  assert.equal(env.VIRTUAL_ENV, '/Users/test/.hermes/hermes-agent/venv')
   assert.ok(
     env.PATH.startsWith(
       '/Users/test/.hermes/node/bin:/Users/test/.hermes/node:/Users/test/.hermes/hermes-agent/venv/bin:'
@@ -184,6 +185,7 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
   assert.ok(env.Path.includes('\\venv\\Scripts;'))
   assert.ok(env.Path.includes(';C:\\Windows\\System32;C:\\Windows'))
   assert.equal(env.Path.includes('/opt/homebrew/bin'), false)
+  assert.equal(env.VIRTUAL_ENV, 'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv')
 })
 
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -125,12 +125,13 @@ function buildDesktopBackendEnv({
   currentEnv = process.env,
   platform = process.platform,
   pathModule = pathModuleForPlatform(platform)
-}: any = {}) {
+}: any = {}): Record<string, string> {
   const delimiter = delimiterForPlatform(platform)
   const currentPythonPath = currentEnv?.PYTHONPATH || ''
   const key = pathEnvKey(currentEnv, platform)
 
   return {
+    ...(venvRoot ? { VIRTUAL_ENV: venvRoot } : {}),
     PYTHONPATH: appendUniquePathEntries([...pythonPathEntries, currentPythonPath], { delimiter }),
     // Force PEP 540 UTF-8 mode in the spawned Python backend so its stdio and
     // subprocess defaults are UTF-8 even on non-UTF-8 Windows locales (GBK,

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -36,6 +36,42 @@ function currentPathValue(env = process.env, platform = process.platform) {
   return env?.[key] || ''
 }
 
+function environmentValue(env = process.env, name: string) {
+  const key = Object.keys(env || {}).find(key => key.toUpperCase() === name.toUpperCase())
+
+  return key ? env?.[key] : undefined
+}
+
+function removeVenvBinFromPath({
+  currentPath = '',
+  venvRoot,
+  platform = process.platform,
+  pathModule = pathModuleForPlatform(platform)
+}: any = {}) {
+  if (!venvRoot) {
+    return currentPath
+  }
+
+  const delimiter = delimiterForPlatform(platform)
+
+  const venvBin = pathModule.resolve(
+    pathModule.join(venvRoot, platform === 'win32' ? 'Scripts' : 'bin')
+  )
+
+  const normalize = value => {
+    const resolved = pathModule.resolve(String(value))
+
+    return platform === 'win32' ? resolved.toLowerCase() : resolved
+  }
+
+  const normalizedVenvBin = normalize(venvBin)
+
+  return String(currentPath)
+    .split(delimiter)
+    .filter(entry => entry && normalize(entry) !== normalizedVenvBin)
+    .join(delimiter)
+}
+
 function appendUniquePathEntries(entries, { delimiter = path.delimiter } = {}) {
   const seen = new Set()
   const ordered = []
@@ -127,12 +163,21 @@ function buildDesktopBackendEnv({
   pathModule = pathModuleForPlatform(platform)
 }: any = {}): Record<string, string> {
   const delimiter = delimiterForPlatform(platform)
-  const currentPythonPath = currentEnv?.PYTHONPATH || ''
   const key = pathEnvKey(currentEnv, platform)
+
+  const currentPath = removeVenvBinFromPath({
+    currentPath: currentPathValue(currentEnv, platform),
+    venvRoot: environmentValue(currentEnv, 'VIRTUAL_ENV'),
+    platform,
+    pathModule
+  })
 
   return {
     ...(venvRoot ? { VIRTUAL_ENV: venvRoot } : {}),
-    PYTHONPATH: appendUniquePathEntries([...pythonPathEntries, currentPythonPath], { delimiter }),
+    // Never carry parent PYTHONPATH into the backend. The selected source root
+    // and its owning venv site-packages are supplied explicitly by the
+    // resolver; inheriting anything else can mix Python ABIs.
+    PYTHONPATH: appendUniquePathEntries(pythonPathEntries, { delimiter }),
     // Force PEP 540 UTF-8 mode in the spawned Python backend so its stdio and
     // subprocess defaults are UTF-8 even on non-UTF-8 Windows locales (GBK,
     // cp1252, ...). hermes_bootstrap sets this inside the child too, but only
@@ -143,20 +188,91 @@ function buildDesktopBackendEnv({
     [key]: buildDesktopBackendPath({
       hermesHome,
       venvRoot,
-      currentPath: currentPathValue(currentEnv, platform),
+      currentPath,
       platform,
       pathModule
     })
   }
 }
 
+function buildDesktopBackendChildEnv({
+  currentEnv = process.env,
+  backendEnv = {},
+  overrides = {},
+  platform = process.platform,
+  pathModule = pathModuleForPlatform(platform)
+}: any = {}): Record<string, string> {
+  const sanitized = { ...currentEnv }
+  const inheritedPythonKeys = new Set(['PYTHONHOME', 'PYTHONPATH', 'VIRTUAL_ENV'])
+  const inheritedVenvRoot = environmentValue(currentEnv, 'VIRTUAL_ENV')
+
+  for (const key of Object.keys(sanitized)) {
+    if (inheritedPythonKeys.has(key.toUpperCase())) {
+      delete sanitized[key]
+    }
+  }
+
+  const key = pathEnvKey(sanitized, platform)
+  const currentPath = currentPathValue(sanitized, platform)
+
+  if (currentPath) {
+    sanitized[key] = removeVenvBinFromPath({
+      currentPath,
+      venvRoot: inheritedVenvRoot,
+      platform,
+      pathModule
+    })
+  }
+
+  return {
+    ...sanitized,
+    ...backendEnv,
+    ...overrides
+  }
+}
+
+function buildDesktopPythonBackend({
+  root,
+  label,
+  backendArgs,
+  command,
+  runtimeVenvRoot,
+  sitePackagesEntries = [],
+  hermesHome,
+  currentEnv = process.env,
+  platform = process.platform,
+  pathModule = pathModuleForPlatform(platform),
+  bootstrap = false
+}: any) {
+  return {
+    kind: 'python' as const,
+    label,
+    command,
+    args: ['-m', 'hermes_cli.main', ...backendArgs],
+    env: buildDesktopBackendEnv({
+      hermesHome,
+      pythonPathEntries: [root, ...sitePackagesEntries],
+      venvRoot: runtimeVenvRoot,
+      currentEnv,
+      platform,
+      pathModule
+    }),
+    root,
+    bootstrap,
+    shell: false as const
+  }
+}
+
 export {
   appendUniquePathEntries,
+  buildDesktopBackendChildEnv,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  buildDesktopPythonBackend,
   delimiterForPlatform,
   hermesManagedNodePathEntries,
   normalizeHermesHomeRoot,
   pathEnvKey,
-  POSIX_SANE_PATH_ENTRIES
+  POSIX_SANE_PATH_ENTRIES,
+  removeVenvBinFromPath
 }

--- a/apps/desktop/electron/backend-probes.test.ts
+++ b/apps/desktop/electron/backend-probes.test.ts
@@ -13,6 +13,7 @@ import path from 'node:path'
 import { test } from 'vitest'
 
 import {
+  buildHermesProbeEnv,
   canImportHermesCli,
   DEFAULT_PROBE_TIMEOUT_MS,
   hermesRuntimeImportProbe,
@@ -28,6 +29,27 @@ import {
 // non-zero) and as a way to script verifyHermesCli's success path
 // (a tiny script we write to disk that exits 0 on --version).
 const NODE_BIN = process.execPath
+
+test('Hermes runtime probes sanitize inherited virtualenv state', () => {
+  const foreignVenv = '/tmp/foreign/.venv'
+
+  const env = buildHermesProbeEnv({
+    currentEnv: {
+      PATH: `${foreignVenv}/bin:/custom/bin:/usr/bin`,
+      PYTHONHOME: '/tmp/foreign/python-home',
+      PYTHONPATH: `${foreignVenv}/lib/python3.11/site-packages`,
+      SAFE_PARENT_VALUE: 'preserved',
+      VIRTUAL_ENV: foreignVenv
+    },
+    env: { PYTHONPATH: '/repo/hermes-agent' }
+  })
+
+  assert.equal(env.VIRTUAL_ENV, undefined)
+  assert.equal(env.PYTHONHOME, undefined)
+  assert.equal(env.PYTHONPATH, '/repo/hermes-agent')
+  assert.equal(env.PATH.split(':').includes(`${foreignVenv}/bin`), false)
+  assert.equal(env.SAFE_PARENT_VALUE, 'preserved')
+})
 
 test('canImportHermesCli returns false when path is falsy', () => {
   assert.equal(canImportHermesCli(''), false)
@@ -99,6 +121,41 @@ test('verifyHermesCli returns true when --version exits 0', () => {
     } catch {
       void 0
     }
+  }
+})
+
+test.skipIf(process.platform === 'win32')('verifyHermesCli sanitizes inherited Python state before probing', () => {
+  const scriptPath = path.join(os.tmpdir(), `hermes-probes-env-${Date.now()}-${process.pid}`)
+  const foreignVenv = '/tmp/foreign/.venv'
+
+  fs.writeFileSync(
+    scriptPath,
+    `#!/usr/bin/env node
+const contaminated =
+  process.env.VIRTUAL_ENV ||
+  process.env.PYTHONHOME ||
+  process.env.PYTHONPATH !== '/expected/pythonpath' ||
+  process.env.PATH.split(':').includes('${foreignVenv}/bin')
+process.exit(contaminated ? 1 : 0)
+`
+  )
+  fs.chmodSync(scriptPath, 0o755)
+
+  try {
+    assert.equal(
+      verifyHermesCli(scriptPath, {
+        currentEnv: {
+          PATH: `${foreignVenv}/bin:${path.dirname(process.execPath)}:/usr/bin:/bin`,
+          PYTHONHOME: '/tmp/foreign/python-home',
+          PYTHONPATH: '/tmp/foreign/site-packages',
+          VIRTUAL_ENV: foreignVenv
+        },
+        env: { PYTHONPATH: '/expected/pythonpath' }
+      }),
+      true
+    )
+  } finally {
+    fs.unlinkSync(scriptPath)
   }
 })
 

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -35,6 +35,8 @@
 
 import { execFileSync } from 'node:child_process'
 
+import { buildDesktopBackendChildEnv } from './backend-env'
+
 /** Default probe budget. 5s false-negativeed healthy Windows cold starts (#61764). */
 const DEFAULT_PROBE_TIMEOUT_MS = 15_000
 
@@ -141,14 +143,21 @@ function hermesRuntimeImportProbe() {
  * @param {object} [opts.env] - Additional environment for the probe.
  * @returns {boolean}
  */
-function canImportHermesCli(pythonPath: string, opts: { env?: Record<string, string> } = {}) {
+function buildHermesProbeEnv({ currentEnv = process.env, env = {} }: any = {}) {
+  return buildDesktopBackendChildEnv({ currentEnv, backendEnv: env })
+}
+
+function canImportHermesCli(
+  pythonPath: string,
+  opts: { currentEnv?: Record<string, string>; env?: Record<string, string> } = {}
+) {
   if (!pythonPath) {
     return false
   }
 
   try {
     execProbeSync(pythonPath, ['-c', hermesRuntimeImportProbe()], {
-      env: { ...process.env, ...(opts.env || {}) },
+      env: buildHermesProbeEnv({ currentEnv: opts.currentEnv, env: opts.env }),
       stdio: 'ignore',
       timeout: PROBE_TIMEOUT_MS,
       windowsHide: true
@@ -190,16 +199,20 @@ function shouldTrustHermesOverride(hermesOverride?: string) {
   return typeof hermesOverride === 'string' && hermesOverride.trim().length > 0
 }
 
-function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
+function verifyHermesCli(
+  hermesCommand: string,
+  opts: { currentEnv?: Record<string, string>; env?: Record<string, string>; shell?: boolean } = {}
+) {
   if (!hermesCommand) {
     return false
   }
 
   try {
     execProbeSync(hermesCommand, ['--version'], {
+      env: buildHermesProbeEnv({ currentEnv: opts.currentEnv, env: opts.env }),
       stdio: 'ignore',
       timeout: PROBE_TIMEOUT_MS,
-      shell: Boolean(opts?.shell),
+      shell: Boolean(opts.shell),
       windowsHide: true
     })
 
@@ -210,6 +223,7 @@ function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
 }
 
 export {
+  buildHermesProbeEnv,
   canImportHermesCli,
   DEFAULT_PROBE_TIMEOUT_MS,
   execProbeSync,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -220,6 +220,7 @@ import { hiddenWindowsChildOptions } from './windows-child-options'
 import {
   buildPathExtCandidates,
   chooseUpdaterArgs,
+  getVenvRootForPython,
   getVenvSitePackagesEntries,
   resolveVenvHermesCommand
 } from './windows-hermes-path'
@@ -3830,6 +3831,7 @@ function createPythonBackend(root, label, backendArgs, options: any = {}) {
   const venvRoot = path.join(root, 'venv')
   const venvPython = getVenvPython(venvRoot)
   const command = IS_WINDOWS && fileExists(venvPython) ? venvPython : python
+  const runtimeVenvRoot = getVenvRootForPython(command)
 
   return {
     kind: 'python',
@@ -3838,8 +3840,8 @@ function createPythonBackend(root, label, backendArgs, options: any = {}) {
     args: ['-m', 'hermes_cli.main', ...backendArgs],
     env: buildDesktopBackendEnv({
       hermesHome: HERMES_HOME,
-      pythonPathEntries: [root, ...getVenvSitePackagesEntries(venvRoot)],
-      venvRoot
+      pythonPathEntries: [root, ...getVenvSitePackagesEntries(runtimeVenvRoot)],
+      venvRoot: runtimeVenvRoot
     }),
     root,
     bootstrap: Boolean(options.bootstrap),

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,7 +35,13 @@ import { classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
-import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
+import {
+  buildDesktopBackendChildEnv,
+  buildDesktopBackendEnv,
+  buildDesktopPythonBackend,
+  hermesManagedNodePathEntries,
+  normalizeHermesHomeRoot
+} from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import {
   canImportHermesCli,
@@ -1813,7 +1819,7 @@ function unpackedPathFor(filePath) {
   return filePath.replace(/app\.asar(?=$|[\\/])/, 'app.asar.unpacked')
 }
 
-function findOnPath(command) {
+function findOnPath(command, env = process.env) {
   if (!command) {
     return null
   }
@@ -1830,7 +1836,7 @@ function findOnPath(command) {
     return command
   }
 
-  const pathEntries = String(process.env.PATH || '')
+  const pathEntries = String(env.PATH || '')
     .split(path.delimiter)
     .filter(Boolean)
 
@@ -1840,7 +1846,7 @@ function findOnPath(command) {
   // shell-script shim named `hermes` — must not shadow `hermes.cmd`/`hermes.exe`.
   // The empty entry is kept LAST so callers that already include the extension
   // (py.exe, pwsh.exe, powershell.exe) still resolve.
-  const extensions = buildPathExtCandidates(process.env.PATHEXT, IS_WINDOWS)
+  const extensions = buildPathExtCandidates(env.PATHEXT, IS_WINDOWS)
 
   for (const entry of pathEntries) {
     for (const extension of extensions) {
@@ -1922,7 +1928,11 @@ function backendSupportsServe(backend) {
       // and its timeout-only retry instead of a thinner local bound.
       execProbeSync(backend.command, [...prefix, 'serve', '--help'], {
         cwd: backend.root || undefined,
-        env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
+        env: buildDesktopBackendChildEnv({
+          currentEnv: process.env,
+          backendEnv: backend.env || {},
+          overrides: { HERMES_HOME }
+        }),
         timeout: PROBE_TIMEOUT_MS,
         stdio: 'ignore',
         // `.cmd`/`.bat` shim backends carry shell: true in their descriptor
@@ -2023,10 +2033,16 @@ function findPythonForRoot(root) {
 }
 
 function findSystemPython() {
+  // System-Python discovery must ignore an activated parent virtualenv. The
+  // child is launched with this same isolation contract; selecting a foreign
+  // venv's absolute interpreter first would preserve its pyvenv.cfg ownership
+  // even after VIRTUAL_ENV/PYTHONHOME/PYTHONPATH are cleared.
+  const systemPythonEnv = buildDesktopBackendChildEnv({ currentEnv: process.env })
+
   if (!IS_WINDOWS) {
-    // POSIX systems: PATH lookup is safe.
+    // POSIX systems: search PATH after removing the parent venv's bin entry.
     for (const command of ['python3', 'python']) {
-      const candidate = findOnPath(command)
+      const candidate = findOnPath(command, systemPythonEnv)
 
       if (candidate) {
         return candidate
@@ -2134,7 +2150,7 @@ function findSystemPython() {
   // print(sys.executable)"` resolves to the actual python.exe path of
   // the requested version. We try in version-priority order so the
   // first hit wins.
-  const pyExe = findOnPath('py.exe')
+  const pyExe = findOnPath('py.exe', systemPythonEnv)
 
   if (pyExe) {
     for (const version of SUPPORTED_VERSIONS) {
@@ -3625,7 +3641,7 @@ function isActiveRuntimeUsable() {
     fileExists(venvPython) &&
     canImportHermesCli(venvPython, {
       env: {
-        PYTHONPATH: [ACTIVE_HERMES_ROOT, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
+        PYTHONPATH: ACTIVE_HERMES_ROOT
       }
     })
   )
@@ -3833,20 +3849,16 @@ function createPythonBackend(root, label, backendArgs, options: any = {}) {
   const command = IS_WINDOWS && fileExists(venvPython) ? venvPython : python
   const runtimeVenvRoot = getVenvRootForPython(command)
 
-  return {
-    kind: 'python',
+  return buildDesktopPythonBackend({
+    root,
     label,
     command,
-    args: ['-m', 'hermes_cli.main', ...backendArgs],
-    env: buildDesktopBackendEnv({
-      hermesHome: HERMES_HOME,
-      pythonPathEntries: [root, ...getVenvSitePackagesEntries(runtimeVenvRoot)],
-      venvRoot: runtimeVenvRoot
-    }),
-    root,
-    bootstrap: Boolean(options.bootstrap),
-    shell: false
-  }
+    backendArgs,
+    runtimeVenvRoot,
+    sitePackagesEntries: getVenvSitePackagesEntries(runtimeVenvRoot),
+    hermesHome: HERMES_HOME,
+    bootstrap: Boolean(options.bootstrap)
+  })
 }
 
 // createActiveBackend — build a backend pointing at ACTIVE_HERMES_ROOT, the
@@ -3856,21 +3868,18 @@ function createPythonBackend(root, label, backendArgs, options: any = {}) {
 function createActiveBackend(backendArgs) {
   const venvPython = getVenvPython(VENV_ROOT)
   const command = fileExists(venvPython) ? venvPython : findSystemPython()
+  const runtimeVenvRoot = getVenvRootForPython(command)
 
-  return {
-    kind: 'python',
+  return buildDesktopPythonBackend({
+    root: ACTIVE_HERMES_ROOT,
     label: `Hermes at ${ACTIVE_HERMES_ROOT}`,
     command,
-    args: ['-m', 'hermes_cli.main', ...backendArgs],
-    env: buildDesktopBackendEnv({
-      hermesHome: HERMES_HOME,
-      pythonPathEntries: [ACTIVE_HERMES_ROOT, ...getVenvSitePackagesEntries(VENV_ROOT)],
-      venvRoot: VENV_ROOT
-    }),
-    root: ACTIVE_HERMES_ROOT,
-    bootstrap: true,
-    shell: false
-  }
+    backendArgs,
+    runtimeVenvRoot,
+    sitePackagesEntries: getVenvSitePackagesEntries(runtimeVenvRoot),
+    hermesHome: HERMES_HOME,
+    bootstrap: true
+  })
 }
 
 function resolveHermesBackend(backendArgs) {
@@ -4010,15 +4019,16 @@ function resolveHermesBackend(backendArgs) {
     // failure, fall through to step 6 so the bootstrap runner pulls
     // a uv-managed 3.11 into %LOCALAPPDATA%\hermes\hermes-agent\venv.
     if (canImportHermesCli(python)) {
-      return {
-        kind: 'python',
+      return buildDesktopPythonBackend({
+        root: null,
         label: `installed hermes_cli module via ${python}`,
         command: python,
-        args: ['-m', 'hermes_cli.main', ...backendArgs],
+        backendArgs,
+        runtimeVenvRoot: null,
+        sitePackagesEntries: [],
+        hermesHome: HERMES_HOME,
         bootstrap: false,
-        env: {},
-        shell: false
-      }
+      })
     }
 
     rememberLog(`Ignoring system Python ${python}: hermes_cli is not importable; falling through to bootstrap.`)
@@ -8196,21 +8206,23 @@ async function spawnPoolBackend(profile, entry) {
     backend.args,
     hiddenWindowsChildOptions({
       cwd: hermesCwd,
-      env: {
-        ...process.env,
-        HERMES_HOME,
-        ...backend.env,
-        // Pin the gateway's tool/terminal cwd to the same directory we chose for
-        // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
-        // can still point at the install dir even when spawn cwd is home.
-        TERMINAL_CWD: hermesCwd,
-        HERMES_DASHBOARD_SESSION_TOKEN: token,
-        // Marks this dashboard backend as desktop-spawned so it runs the cron
-        // scheduler tick loop (the gateway isn't running under the app).
-        HERMES_DESKTOP: '1',
-        HERMES_WEB_DIST: webDist,
-        ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-      },
+      env: buildDesktopBackendChildEnv({
+        currentEnv: process.env,
+        backendEnv: backend.env,
+        overrides: {
+          HERMES_HOME,
+          // Pin the gateway's tool/terminal cwd to the same directory we chose for
+          // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
+          // can still point at the install dir even when spawn cwd is home.
+          TERMINAL_CWD: hermesCwd,
+          HERMES_DASHBOARD_SESSION_TOKEN: token,
+          // Marks this dashboard backend as desktop-spawned so it runs the cron
+          // scheduler tick loop (the gateway isn't running under the app).
+          HERMES_DESKTOP: '1',
+          HERMES_WEB_DIST: webDist,
+          ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
+        }
+      }),
       shell: backend.shell,
       stdio: ['ignore', 'pipe', 'pipe']
     })
@@ -8484,26 +8496,28 @@ async function startHermes() {
       backend.args,
       hiddenWindowsChildOptions({
         cwd: hermesCwd,
-        env: {
-          ...process.env,
-          // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
-          // resolves to the SAME location our resolveHermesHome() picked. Without
-          // this pin, Python falls back to ~/.hermes on every platform — fine on
-          // mac/linux (where our default matches), but on Windows our default is
-          // %LOCALAPPDATA%\hermes, which differs from C:\Users\<u>\.hermes.
-          // Mismatch would split config / sessions / .env / logs across two
-          // directories. install.ps1 sets HERMES_HOME via setx; the desktop
-          // can't reliably do that, so we set it inline for every spawn.
-          HERMES_HOME,
-          ...backend.env,
-          TERMINAL_CWD: hermesCwd,
-          HERMES_DASHBOARD_SESSION_TOKEN: token,
-          // Marks this dashboard backend as desktop-spawned so it runs the cron
-          // scheduler tick loop (the gateway isn't running under the app).
-          HERMES_DESKTOP: '1',
-          HERMES_WEB_DIST: webDist,
-          ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-        },
+        env: buildDesktopBackendChildEnv({
+          currentEnv: process.env,
+          backendEnv: backend.env,
+          overrides: {
+            // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
+            // resolves to the SAME location our resolveHermesHome() picked. Without
+            // this pin, Python falls back to ~/.hermes on every platform — fine on
+            // mac/linux (where our default matches), but on Windows our default is
+            // %LOCALAPPDATA%\hermes, which differs from C:\Users\<u>\.hermes.
+            // Mismatch would split config / sessions / .env / logs across two
+            // directories. install.ps1 sets HERMES_HOME via setx; the desktop
+            // can't reliably do that, so we set it inline for every spawn.
+            HERMES_HOME,
+            TERMINAL_CWD: hermesCwd,
+            HERMES_DASHBOARD_SESSION_TOKEN: token,
+            // Marks this dashboard backend as desktop-spawned so it runs the cron
+            // scheduler tick loop (the gateway isn't running under the app).
+            HERMES_DESKTOP: '1',
+            HERMES_WEB_DIST: webDist,
+            ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
+          }
+        }),
         shell: backend.shell,
         stdio: ['ignore', 'pipe', 'pipe']
       })

--- a/apps/desktop/electron/windows-hermes-path.test.ts
+++ b/apps/desktop/electron/windows-hermes-path.test.ts
@@ -17,9 +17,11 @@ import path from 'node:path'
 
 import { test } from 'vitest'
 
+import { buildDesktopBackendEnv } from './backend-env'
 import {
   buildPathExtCandidates,
   chooseUpdaterArgs,
+  getVenvRootForPython,
   getVenvSitePackagesEntries,
   resolveVenvHermesCommand
 } from './windows-hermes-path'
@@ -211,4 +213,58 @@ test('getVenvSitePackagesEntries: returns empty for a falsy venvRoot', () => {
   assert.deepEqual(getVenvSitePackagesEntries('', { isWindows: true, directoryExists: () => true }), [])
   assert.deepEqual(getVenvSitePackagesEntries(null, { isWindows: true, directoryExists: () => true }), [])
   assert.deepEqual(getVenvSitePackagesEntries(undefined, { isWindows: true, directoryExists: () => true }), [])
+})
+
+test('POSIX backend keeps selected .venv Python, VIRTUAL_ENV, PATH, and site-packages on one ABI', () => {
+  const sourceRoot = '/repo/hermes-agent'
+  const selectedPython = `${sourceRoot}/.venv/bin/python`
+  const selectedVenv = `${sourceRoot}/.venv`
+  const managedVenv = `${sourceRoot}/venv`
+
+  const existing = new Set([
+    `${selectedVenv}/pyvenv.cfg`,
+    `${managedVenv}/pyvenv.cfg`,
+    `${selectedVenv}/lib/python3.11/site-packages`,
+    `${managedVenv}/lib/python3.12/site-packages`
+  ])
+
+  const venvRoot = getVenvRootForPython(selectedPython, {
+    isWindows: false,
+    fileExists: p => existing.has(p),
+    pathModule: path.posix
+  })
+
+  assert.equal(venvRoot, selectedVenv)
+
+  const sitePackages = getVenvSitePackagesEntries(venvRoot, {
+    isWindows: false,
+    directoryExists: p => existing.has(p),
+    readFile: p => (p === `${selectedVenv}/pyvenv.cfg` ? 'version_info = 3.11.15\n' : undefined)
+  })
+
+  const env = buildDesktopBackendEnv({
+    hermesHome: '/home/test/.hermes',
+    pythonPathEntries: [sourceRoot, ...sitePackages],
+    venvRoot,
+    currentEnv: { PATH: '/usr/bin:/bin' },
+    platform: 'linux',
+    pathModule: path.posix
+  })
+
+  assert.equal(env.VIRTUAL_ENV, selectedVenv)
+  assert.equal(env.PYTHONPATH, `${sourceRoot}:${selectedVenv}/lib/python3.11/site-packages`)
+  assert.ok(env.PATH.split(':').includes(`${selectedVenv}/bin`))
+  assert.equal(env.PATH.split(':').includes(`${managedVenv}/bin`), false)
+  assert.equal(env.PYTHONPATH.includes(`${managedVenv}/lib/python3.12/site-packages`), false)
+})
+
+test('getVenvRootForPython rejects a system interpreter with no owning pyvenv.cfg', () => {
+  assert.equal(
+    getVenvRootForPython('/usr/bin/python3', {
+      isWindows: false,
+      fileExists: () => false,
+      pathModule: path.posix
+    }),
+    null
+  )
 })

--- a/apps/desktop/electron/windows-hermes-path.test.ts
+++ b/apps/desktop/electron/windows-hermes-path.test.ts
@@ -268,3 +268,24 @@ test('getVenvRootForPython rejects a system interpreter with no owning pyvenv.cf
     null
   )
 })
+
+test('getVenvRootForPython owns Windows Scripts/python.exe via adjacent pyvenv.cfg', () => {
+  const venvRoot = 'C:\\repo\\hermes-agent\\.venv'
+
+  assert.equal(
+    getVenvRootForPython(`${venvRoot}\\Scripts\\python.exe`, {
+      isWindows: true,
+      fileExists: p => p.toLowerCase() === `${venvRoot}\\pyvenv.cfg`.toLowerCase(),
+      pathModule: path.win32
+    }),
+    venvRoot
+  )
+  assert.equal(
+    getVenvRootForPython(`${venvRoot}\\SCRIPTS\\python.exe`, {
+      isWindows: true,
+      fileExists: p => p.toLowerCase() === `${venvRoot}\\pyvenv.cfg`.toLowerCase(),
+      pathModule: path.win32
+    }),
+    venvRoot
+  )
+})

--- a/apps/desktop/electron/windows-hermes-path.ts
+++ b/apps/desktop/electron/windows-hermes-path.ts
@@ -164,6 +164,50 @@ export function getVenvSitePackagesEntries(
   return entries
 }
 
+/**
+ * Return the virtual-environment root that owns an executed Python binary.
+ *
+ * Desktop must derive VIRTUAL_ENV, PATH, and injected site-packages from this
+ * same root. Mixing `.venv/bin/python` with `venv/lib/pythonX.Y/site-packages`
+ * can load Python wrappers from one ABI beside native extensions for another.
+ */
+export function getVenvRootForPython(
+  python: string | undefined | null,
+  opts: {
+    isWindows?: boolean
+    fileExists?: (p: string) => boolean
+    pathModule?: typeof path.posix | typeof path.win32
+  } = {}
+): string | null {
+  if (!python) {
+    return null
+  }
+
+  const isWindows = opts.isWindows ?? process.platform === 'win32'
+  const pathModule = opts.pathModule ?? (isWindows ? path.win32 : path.posix)
+
+  const fileExists =
+    opts.fileExists ??
+    ((p: string) => {
+      try {
+        return fs.statSync(p).isFile()
+      } catch {
+        return false
+      }
+    })
+
+  const scriptsDir = pathModule.dirname(pathModule.resolve(String(python)))
+  const expectedDir = isWindows ? 'scripts' : 'bin'
+
+  if (pathModule.basename(scriptsDir).toLowerCase() !== expectedDir) {
+    return null
+  }
+
+  const venvRoot = pathModule.dirname(scriptsDir)
+
+  return fileExists(pathModule.join(venvRoot, 'pyvenv.cfg')) ? venvRoot : null
+}
+
 export interface ResolveVenvHermesCommandDeps {
   isWindows: boolean
   isCommandScript: (command: string) => boolean

--- a/apps/desktop/electron/windows-hermes-path.ts
+++ b/apps/desktop/electron/windows-hermes-path.ts
@@ -305,9 +305,7 @@ export function resolveVenvHermesCommand(
   if (
     !canImportHermesCli(python, {
       env: {
-        PYTHONPATH: [...(directoryExists(root) ? [root] : []), process.env.PYTHONPATH]
-          .filter((entry): entry is string => Boolean(entry))
-          .join(path.delimiter)
+        ...(directoryExists(root) ? { PYTHONPATH: root } : {})
       }
     })
   ) {


### PR DESCRIPTION
## Summary

Keep the Desktop backend interpreter and Python environment owned by the same runtime, including the system-Python fallback path.

The first commit resolves the selected Python executable, `VIRTUAL_ENV`, `PATH`, and managed site-packages from a single venv root. The second commit closes the fallback gap: when Desktop must use system Python, it removes inherited parent `VIRTUAL_ENV`, `PYTHONHOME`, foreign `PYTHONPATH`, and parent-venv `bin`/`Scripts` PATH entries. The same sanitized environment is used for runtime compatibility/import probes.

## Reproduction

On a Linux ARM64 source checkout, Desktop selected a legacy Python 3.11 `.venv` interpreter while the child environment exposed managed Python 3.12 site-packages. The backend then failed at startup with:

```
ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
```

This PR prevents that cross-ABI environment mix and adds regression coverage for a parent activated venv contaminating the system-Python fallback.

## Coverage

- System-Python fallback explicitly clears inherited `VIRTUAL_ENV`, `PYTHONHOME`, and foreign `PYTHONPATH`.
- Removes the inherited venv `bin` / `Scripts` entry from PATH, including Windows path casing.
- Tests the resolver descriptor-to-child-environment wiring, not only isolated helpers.
- Adds Windows `Scripts/python.exe` ownership coverage.
- Applies the isolation contract to Desktop compatibility/import probes.
- Sanitizes command-backend `--version` probes and system-Python PATH discovery so an activated foreign venv cannot pass discovery and fail under the isolated child environment.

## Validation

- `npx vitest run --project electron` — 942 passed, 2 skipped
- `npm run typecheck`
- `npm run lint` — no errors (existing warnings only)
- `npm run build`
- `npm run pack` on Linux ARM64
- `git diff --check`

## Related

- #57854 addresses broader Desktop `PYTHONPATH` leakage but does not cover this system-fallback/probe ownership path.
- #58897 reports the same Python-version-mismatch `pydantic_core` failure in the Windows Gateway path.
- #22054 reports venv PATH shadowing on POSIX.

## Current-main refresh

Replayed onto current `main` on 2026-08-05. Current main added a newer last-ditch pip-installed system-Python resolver rung after the original submission; the second commit now routes that sibling path through the same sanitized backend descriptor and adds behavioral coverage for it.

This is intentionally one PR with two ordered commits: the fallback isolation commit completes the primary environment-ownership fix and should not be merged independently.
