### PR TITLE
fix(agent): skip context files for chat-platform sessions (#72268)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -487,10 +487,19 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # (developing Hermes). Every other surface (desktop chat panel,
         # gateway daemons) self-spawns into the install tree, where the
         # fallback would inject this repo's contributor AGENTS.md (#64590).
-        context_files_prompt = _r.build_context_files_prompt(
-            cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
-            context_length=_ctx_len,
-            allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+        #
+        # Chat platforms (telegram, discord, slack, …) are not interactive
+        # coding surfaces — skip loading AGENTS.md/CLAUDE.md/.cursorrules
+        # into chat sessions to avoid leaking project context (#72268).
+        from agent.coding_context import INTERACTIVE_CODING_PLATFORMS
+        _platform = (agent.platform or "").strip().lower()
+        if _platform and _platform not in INTERACTIVE_CODING_PLATFORMS:
+            context_files_prompt = None
+        else:
+            context_files_prompt = _r.build_context_files_prompt(
+                cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
+                context_length=_ctx_len,
+                allow_install_tree_fallback=agent.platform in ("cli", "tui"))
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 


### PR DESCRIPTION
## Summary

Fixes #72268. `build_context_files_prompt()` discovers and injects AGENTS.md/CLAUDE.md/.cursorrules from the session's working directory. It was called unconditionally from `agent/system_prompt.py` whenever `skip_context_files` is False (the default for gateway sessions), with no awareness of `coding_context` or platform.

Chat platforms (telegram, discord, slack, ...) are intentionally absent from `INTERACTIVE_CODING_PLATFORMS` -- "a chat bot in a group is not pair-programming" (`agent/coding_context.py`). Gate the call on the platform set so context files are only loaded for coding surfaces.

## Changes

- **agent/system_prompt.py**: Import `INTERACTIVE_CODING_PLATFORMS` from `agent.coding_context` and skip `build_context_files_prompt()` when the platform is not an interactive coding surface.

## Testing

- Syntax: `python3 -m py_compile agent/system_prompt.py` -- OK
- Lint: `ruff check agent/system_prompt.py` -- All checks passed
- Existing tests: 33 passed (test_api_content_sidecar.py)
