### PR TITLE
fix(self-hosted-oidc): classify non-JWT tokens as InvalidCodeError instead of ProviderError

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -615,6 +615,12 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             )
         except jwt.PyJWKClientError as exc:
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
+        except jwt.InvalidTokenError as exc:
+            # Not shaped like a JWT at all (e.g. a session issued by a
+            # different provider) — not an IDP/JWKS reachability problem.
+            # verify_session() catches this and returns None so other
+            # providers in the chain get a turn.
+            raise InvalidCodeError(f"token is not a valid JWT: {exc}") from exc
         except Exception as exc:  # pragma: no cover - defensive
             raise ProviderError(f"JWKS lookup failed: {exc!r}") from exc
 


### PR DESCRIPTION
## Summary

When multiple dashboard-auth providers are registered (e.g. `self-hosted` OIDC alongside `basic` auth), a session token issued by one provider gets tried against every registered provider's `verify_session()`. If `self-hosted` is tried against a non-JWT token (e.g. a `basic`-auth token), `get_signing_key_from_jwt()` raises `jwt.InvalidTokenError`, which was caught by a generic `except Exception` and wrapped as `ProviderError('JWKS lookup failed: ...')`.

This is misleading — the IDP was never contacted; the token just isn't shaped like a JWT. This fix adds a specific `except jwt.InvalidTokenError` clause before the generic catch that raises `InvalidCodeError` instead, mirroring the existing pattern for `jwt.ExpiredSignatureError`. `verify_session()` catches `InvalidCodeError` and returns `None` so the next provider in the chain gets a clean turn.

## Test plan

- [x] `uv run pytest tests/plugins/dashboard_auth/test_self_hosted_provider.py -q` — 83 passed
- [x] The fix follows the exact same pattern already used for `jwt.ExpiredSignatureError` in the same function

Fixes #70947