### PR TITLE
fix(api): forward subagent lifecycle on /v1/runs stream (salvage #51642)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5975,7 +5975,43 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": ts,
                     "text": preview or "",
                 })
-            # _thinking and subagent_progress are intentionally not forwarded
+            elif event_type in {"subagent.start", "subagent.complete"}:
+                event = {
+                    "event": event_type,
+                    "run_id": run_id,
+                    "timestamp": ts,
+                }
+                if preview is not None:
+                    event["preview"] = preview
+                for key in (
+                    "goal",
+                    "task_count",
+                    "task_index",
+                    "subagent_id",
+                    "parent_id",
+                    "depth",
+                    "model",
+                    "tool_count",
+                    "status",
+                    "summary",
+                    "duration_seconds",
+                    "input_tokens",
+                    "output_tokens",
+                    "reasoning_tokens",
+                    "api_calls",
+                    "cost_usd",
+                    "files_read",
+                    "files_written",
+                    "output_tail",
+                ):
+                    value = kwargs.get(key)
+                    if value is not None:
+                        event[key] = value
+                _push(event)
+            # _thinking, subagent.tool, and subagent_progress are intentionally
+            # not forwarded on the /v1/runs stream: they are high-volume UI
+            # noise. Lifecycle boundaries (start/complete) still need to land
+            # so clients can observe delegate_task timeouts and failures.
 
         return _callback
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5982,12 +5982,15 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": ts,
                 }
                 if preview is not None:
-                    event["preview"] = preview
+                    event["preview"] = redact_sensitive_text(
+                        str(preview), force=True
+                    )
                 for key in (
                     "goal",
                     "task_count",
                     "task_index",
                     "subagent_id",
+                    "child_session_id",
                     "parent_id",
                     "depth",
                     "model",
@@ -6005,8 +6008,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     "output_tail",
                 ):
                     value = kwargs.get(key)
-                    if value is not None:
-                        event[key] = value
+                    if value is None:
+                        continue
+                    # Free-text fields can carry child terminal/tool output —
+                    # force the same secret redaction the API applies to error
+                    # text before it leaves the process on a public stream.
+                    if key in ("goal", "summary", "output_tail") and isinstance(
+                        value, str
+                    ):
+                        value = redact_sensitive_text(value, force=True)
+                    event[key] = value
                 _push(event)
             # _thinking, subagent.tool, and subagent_progress are intentionally
             # not forwarded on the /v1/runs stream: they are high-volume UI

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -891,6 +891,57 @@ class TestAgentExecution:
         assert captured["service_tier"] == "priority"
 
 
+class TestRunEventCallback:
+    @pytest.mark.asyncio
+    async def test_forwards_subagent_lifecycle_events(self, adapter):
+        run_id = "run_subagent_events"
+        loop = asyncio.get_running_loop()
+        queue = asyncio.Queue()
+        adapter._run_streams[run_id] = queue
+        adapter._run_statuses.pop(run_id, None)
+
+        callback = adapter._make_run_event_callback(run_id, loop)
+
+        callback(
+            "subagent.start",
+            preview="research candidate issue",
+            goal="research candidate issue",
+            task_index=0,
+            task_count=1,
+            subagent_id="deleg_123",
+        )
+        callback(
+            "subagent.complete",
+            preview="Timed out after 300s",
+            goal="research candidate issue",
+            task_index=0,
+            task_count=1,
+            subagent_id="deleg_123",
+            status="timeout",
+            duration_seconds=300.0,
+            summary="Subagent timed out after 300s with 2 API call(s) completed.",
+            api_calls=2,
+        )
+
+        start_event = await asyncio.wait_for(queue.get(), timeout=1.0)
+        complete_event = await asyncio.wait_for(queue.get(), timeout=1.0)
+
+        assert start_event["event"] == "subagent.start"
+        assert start_event["preview"] == "research candidate issue"
+        assert start_event["task_index"] == 0
+        assert start_event["task_count"] == 1
+        assert start_event["subagent_id"] == "deleg_123"
+
+        assert complete_event["event"] == "subagent.complete"
+        assert complete_event["preview"] == "Timed out after 300s"
+        assert complete_event["status"] == "timeout"
+        assert complete_event["duration_seconds"] == 300.0
+        assert complete_event["api_calls"] == 2
+        assert "timed out after 300s" in complete_event["summary"]
+
+        assert adapter._run_statuses[run_id]["last_event"] == "subagent.complete"
+
+
 # ---------------------------------------------------------------------------
 # /health endpoint
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -941,6 +941,36 @@ class TestRunEventCallback:
 
         assert adapter._run_statuses[run_id]["last_event"] == "subagent.complete"
 
+    @pytest.mark.asyncio
+    async def test_subagent_events_redact_secrets_and_carry_child_session(self, adapter):
+        """Free-text fields (goal/summary/output_tail/preview) must pass the
+        forced secret redaction before hitting the public /v1/runs stream,
+        and child_session_id must survive the allowlist so clients can
+        correlate the child's session."""
+        run_id = "run_subagent_redact"
+        loop = asyncio.get_running_loop()
+        queue = asyncio.Queue()
+        adapter._run_streams[run_id] = queue
+        adapter._run_statuses.pop(run_id, None)
+
+        callback = adapter._make_run_event_callback(run_id, loop)
+        secret = "sk-proj-abcdef1234567890abcdef1234567890abcdef12"
+        callback(
+            "subagent.complete",
+            preview=f"leaked {secret}",
+            goal=f"use key {secret} to fetch data",
+            subagent_id="deleg_999",
+            child_session_id="child-sess-42",
+            status="completed",
+            summary=f"exported OPENAI_API_KEY={secret} then ran",
+            output_tail=f"env shows {secret}",
+        )
+
+        event = await asyncio.wait_for(queue.get(), timeout=1.0)
+        assert event["child_session_id"] == "child-sess-42"
+        for field in ("preview", "goal", "summary", "output_tail"):
+            assert secret not in event[field], field
+
 
 # ---------------------------------------------------------------------------
 # /health endpoint


### PR DESCRIPTION
## Summary

`/v1/runs/{id}/events` now forwards `subagent.start` / `subagent.complete` lifecycle events, so API clients can observe delegate_task timeouts and failures instead of runs going silent (#51294). High-volume `subagent.tool` / progress events stay suppressed.

Salvage of #51642 by @LeonSGP43 (cherry-picked, authorship preserved) plus the hardening the sweeper review asked for.

## Changes

- `gateway/platforms/api_server.py` (contributor commit): forward lifecycle boundaries with an allowlisted field set (goal, status, summary, duration, tokens, cost, output_tail, ...).
- Hardening (ours): free-text fields (`preview`/`goal`/`summary`/`output_tail`) pass `redact_sensitive_text(force=True)` before hitting the public stream — same treatment the API applies to error text; `child_session_id` added to the allowlist so clients can correlate the child's session. Both were flagged in the sweeper review and left unaddressed.
- Tests: contributor's forwarding test + a redaction/correlation test (secret injected into every free-text field never survives; `child_session_id` does).

## Validation

| | Before | After |
|---|---|---|
| Delegation timeout on /v1/runs | invisible (run just hangs then completes) | `subagent.complete · status=timeout` event |
| Secret in child summary | would egress verbatim | redacted |

256/256 `tests/gateway/test_api_server.py`.

## Credit

@LeonSGP43's #51642, cherry-picked with authorship preserved. Fixes #51294.

## Infographic

![runs-subagent-lifecycle](https://v3b.fal.media/files/b/0aa3e088/dfrwJL5rU3d3xo3GgzAGH_MpHoVfSF.png)
