### PR TITLE
fix(transports): strip no-op service_tier from chat_completions API kwargs

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -509,6 +509,18 @@ class ChatCompletionsTransport(ProviderTransport):
         if overrides:
             api_kwargs.update(overrides)
 
+        # Strip no-op service_tier values.  Only "priority" is meaningful
+        # (OpenAI Priority Processing); empty / "normal" / "default" are the
+        # provider's own default and sending them is at best redundant and at
+        # worst a hard HTTP 400 on providers that reject the parameter
+        # entirely (e.g. Poe — "Unsupported parameter: service_tier").  The
+        # desktop app always sends ``fast: false`` on session create, which
+        # sets ``service_tier=""`` / ``"normal"`` via the session-override
+        # path; without this strip that leaks to every custom-provider call.
+        _st = api_kwargs.get("service_tier")
+        if isinstance(_st, str) and _st.strip().lower() in ("", "normal", "default", "standard"):
+            api_kwargs.pop("service_tier", None)
+
         return api_kwargs
 
     def _build_kwargs_from_profile(self, profile, model, sanitized, tools, params):
@@ -626,6 +638,11 @@ class ChatCompletionsTransport(ProviderTransport):
                     extra_body.update(v)
                 else:
                     api_kwargs[k] = v
+
+        # Strip no-op service_tier values — see the legacy path for rationale.
+        _st = api_kwargs.get("service_tier")
+        if isinstance(_st, str) and _st.strip().lower() in ("", "normal", "default", "standard"):
+            api_kwargs.pop("service_tier", None)
 
         if extra_body:
             # Native Gemini (generativelanguage.googleapis.com, non-/openai)

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -644,6 +644,26 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["service_tier"] == "priority"
 
+    def test_noop_service_tier_normal_is_stripped(self, transport):
+        """service_tier="normal" is a no-op (the provider default) and is
+        rejected as an unknown parameter by providers like Poe. Strip it."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.5", messages=msgs,
+            request_overrides={"service_tier": "normal"},
+        )
+        assert "service_tier" not in kw
+
+    def test_noop_service_tier_empty_is_stripped(self, transport):
+        """Empty-string service_tier (sent by the desktop app's fast=false
+        session-create path) must not leak to the API call."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.5", messages=msgs,
+            request_overrides={"service_tier": ""},
+        )
+        assert "service_tier" not in kw
+
     def test_fixed_temperature(self, transport):
         """Fixed temperature is now set via ProviderProfile.fixed_temperature."""
         from providers.base import ProviderProfile


### PR DESCRIPTION
## Problem

Custom OpenAI-compatible providers like **Poe** reject the `service_tier` parameter with HTTP 400:

> Unsupported parameter: service_tier. Poe does not support client-specified service tiers or priority processing.

This happens because the **desktop app always sends `fast: false`** on session create (`use-session-actions/index.ts` line 184), which flows through the gateway session-override path as `service_tier=""` → `model_config["service_tier"] = "normal"`. That no-op value then leaks into the API request kwargs via `request_overrides` and reaches providers that do not accept the parameter.

## Root Cause

Only `"priority"` is a meaningful `service_tier` value (OpenAI Priority Processing). Empty string, `"normal"`, `"default"`, and `"standard"` are all the provider's own default — sending them is at best redundant and at worst a hard 400 on providers that reject the parameter entirely.

The existing guard (`resolve_fast_mode_overrides`) only returns `service_tier` for OpenAI fast-eligible models, but the desktop session-create path bypasses that guard by setting `service_tier` on the agent at build time.

## Fix

Strip no-op `service_tier` values from `api_kwargs` in both code paths of `ChatCompletionsTransport.build_kwargs`:

1. **Legacy path** (unregistered/custom providers — line 510+)
2. **Profile path** (registered providers — line 628+)

This mirrors the existing pattern in `codex.py` (line 388) where xAI strips `service_tier` for the same reason on the Codex Responses API.

The strip is gated on the value being a no-op string (`""`, `"normal"`, `"default"`, `"standard"`). `"priority"` passes through untouched so OpenAI fast-mode remains functional.

## Testing

- Added 2 regression tests: `test_noop_service_tier_normal_is_stripped` and `test_noop_service_tier_empty_is_stripped`
- All 93 existing chat_completions transport tests pass
- All 107 codex transport tests pass
- All 97 custom provider / provider parity tests pass

## Reproduction

Verified against the live Poe API:
- `service_tier: "normal"` → HTTP 400 (rejected)
- `service_tier` omitted → HTTP 200 (works)
- `service_tier: "priority"` → still passes through (OpenAI fast-mode unaffected)