### PR TITLE
feat: add universal rich local fallback routes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -19,6 +19,7 @@ preserved.
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import re
@@ -2308,7 +2309,6 @@ def init_agent(
                 # connections, clients); in that case fall back to the built-in
                 # compressor with an ACCURATE message rather than silently
                 # mislabelling it "not found".
-                import copy
                 try:
                     _selected_engine = copy.deepcopy(_candidate)
                 except Exception as _copy_err:
@@ -2659,6 +2659,9 @@ def init_agent(
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "max_tokens": agent.max_tokens,
+        "request_overrides": copy.deepcopy(agent.request_overrides),
+        "config_context_length": agent._config_context_length,
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         # Context engine state that _try_activate_fallback() overwrites.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1424,6 +1424,12 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._client_kwargs = dict(rt["client_kwargs"])
+        if "max_tokens" in rt:
+            agent.max_tokens = rt["max_tokens"]
+        if "request_overrides" in rt:
+            agent.request_overrides = copy.deepcopy(rt["request_overrides"])
+        if "config_context_length" in rt:
+            agent._config_context_length = rt["config_context_length"]
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
         # native-vs-proxy split (older sessions saved before this PR).
@@ -2384,6 +2390,9 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "max_tokens": getattr(agent, "max_tokens", None),
+        "request_overrides": copy.deepcopy(getattr(agent, "request_overrides", {})),
+        "config_context_length": getattr(agent, "_config_context_length", None),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_config": dict(agent.reasoning_config) if getattr(agent, "reasoning_config", None) else None,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3937,6 +3937,12 @@ def _auth_refresh_provider_for_route(
     from the selected client's base URL so auth refresh works for auto →
     Copilot/Codex/Anthropic/Nous routes too. (#20832)
     """
+    fallback_label = re.fullmatch(
+        r"fallback_(?:chain|providers)\[\d+\]\(([^)]+)\)",
+        str(resolved_provider or ""),
+    )
+    if fallback_label:
+        resolved_provider = fallback_label.group(1)
     normalized = _normalize_aux_provider(resolved_provider)
     if normalized and normalized != "auto":
         return normalized
@@ -3949,6 +3955,40 @@ def _auth_refresh_provider_for_route(
     if base_url_host_matches(client_base_url, "inference-api.nousresearch.com"):
         return "nous"
     return normalized
+
+
+def _fallback_entry_settings(task: Optional[str], fb_label: str) -> Dict[str, Any]:
+    """Return the normalized route settings represented by a fallback label."""
+    entry: Any = None
+    configured_match = re.match(r"fallback_chain\[(\d+)\]", fb_label or "")
+    profile_match = re.match(r"fallback_providers\[(\d+)\]", fb_label or "")
+    try:
+        if configured_match and task:
+            chain = _get_auxiliary_task_config(task).get("fallback_chain")
+            entry = chain[int(configured_match.group(1))] if isinstance(chain, list) else None
+        elif profile_match:
+            from hermes_cli.config import load_config
+            from hermes_cli.fallback_config import get_fallback_chain
+
+            chain = get_fallback_chain(load_config() or {})
+            entry = chain[int(profile_match.group(1))]
+    except Exception:
+        return {}
+    if not isinstance(entry, dict):
+        return {}
+    try:
+        from hermes_cli.fallback_config import normalize_fallback_entry
+
+        settings_entry = dict(entry)
+        injected_model = not bool(str(settings_entry.get("model") or "").strip())
+        if injected_model:
+            settings_entry["model"] = "__route_settings__"
+        normalized = normalize_fallback_entry(settings_entry) or {}
+        if injected_model:
+            normalized.pop("model", None)
+        return normalized
+    except Exception:
+        return {}
 
 
 def _fallback_entry_timeout(task: Optional[str], fb_label: str) -> Optional[float]:
@@ -3969,17 +4009,8 @@ def _fallback_entry_timeout(task: Optional[str], fb_label: str) -> Optional[floa
     has no ``timeout``, or the value is invalid — callers then keep the
     task-level timeout, preserving existing behavior.
     """
-    if not task or not fb_label:
-        return None
-    m = re.match(r"fallback_chain\[(\d+)\]", fb_label)
-    if not m:
-        return None
-    try:
-        chain = _get_auxiliary_task_config(task).get("fallback_chain")
-        entry = chain[int(m.group(1))] if isinstance(chain, list) else None
-        raw = entry.get("timeout") if isinstance(entry, dict) else None
-    except Exception:
-        return None
+    entry = _fallback_entry_settings(task, fb_label)
+    raw = entry.get("request_timeout_seconds", entry.get("timeout"))
     if isinstance(raw, (int, float)) and not isinstance(raw, bool) and raw > 0:
         return float(raw)
     return None
@@ -4019,6 +4050,19 @@ def _call_fallback_candidate_sync(
     fallback tuned differently from the primary is allowed its own budget
     (#62452).
     """
+    route_settings = _fallback_entry_settings(task, fb_label)
+    route_max_tokens = route_settings.get("max_output_tokens", route_settings.get("max_tokens"))
+    route_output_tokens: Optional[int] = (
+        route_max_tokens
+        if isinstance(route_max_tokens, int) and not isinstance(route_max_tokens, bool)
+        else None
+    )
+    if route_output_tokens is not None:
+        max_tokens = route_output_tokens
+    route_extra_body = route_settings.get("extra_body")
+    if isinstance(route_extra_body, dict):
+        effective_extra_body = {**effective_extra_body, **route_extra_body}
+    route_extra_headers = route_settings.get("extra_headers")
     fb_timeout = _fallback_entry_timeout(task, fb_label)
     if fb_timeout is not None and fb_timeout != effective_timeout:
         logger.info(
@@ -4034,6 +4078,13 @@ def _call_fallback_candidate_sync(
         tools=tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
         base_url=fb_base, task=task)
+    if route_output_tokens is not None:
+        fb_kwargs.update(auxiliary_max_tokens_param(route_output_tokens, model=fb_model))
+    if isinstance(route_extra_headers, dict) and route_extra_headers:
+        fb_kwargs["extra_headers"] = {
+            **dict(fb_kwargs.get("extra_headers") or {}),
+            **route_extra_headers,
+        }
     try:
         return _validate_llm_response(
             fb_client.chat.completions.create(**fb_kwargs), task)
@@ -4051,6 +4102,18 @@ def _call_fallback_candidate_sync(
                     extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
                     base_url=str(getattr(retry_client, "base_url", "") or fb_base), task=task)
+                if route_output_tokens is not None:
+                    retry_kwargs.update(
+                        auxiliary_max_tokens_param(
+                            route_output_tokens,
+                            model=retry_model or fb_model,
+                        )
+                    )
+                if isinstance(route_extra_headers, dict) and route_extra_headers:
+                    retry_kwargs["extra_headers"] = {
+                        **dict(retry_kwargs.get("extra_headers") or {}),
+                        **route_extra_headers,
+                    }
                 try:
                     return _validate_llm_response(
                         retry_client.chat.completions.create(**retry_kwargs), task)
@@ -4085,6 +4148,19 @@ async def _call_fallback_candidate_async(
     reasoning_config: Optional[dict],
 ) -> Optional[Any]:
     """Async mirror of :func:`_call_fallback_candidate_sync`."""
+    route_settings = _fallback_entry_settings(task, fb_label)
+    route_max_tokens = route_settings.get("max_output_tokens", route_settings.get("max_tokens"))
+    route_output_tokens: Optional[int] = (
+        route_max_tokens
+        if isinstance(route_max_tokens, int) and not isinstance(route_max_tokens, bool)
+        else None
+    )
+    if route_output_tokens is not None:
+        max_tokens = route_output_tokens
+    route_extra_body = route_settings.get("extra_body")
+    if isinstance(route_extra_body, dict):
+        effective_extra_body = {**effective_extra_body, **route_extra_body}
+    route_extra_headers = route_settings.get("extra_headers")
     fb_timeout = _fallback_entry_timeout(task, fb_label)
     if fb_timeout is not None and fb_timeout != effective_timeout:
         logger.info(
@@ -4100,6 +4176,13 @@ async def _call_fallback_candidate_async(
         tools=tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
         base_url=fb_base, task=task)
+    if route_output_tokens is not None:
+        fb_kwargs.update(auxiliary_max_tokens_param(route_output_tokens, model=fb_model))
+    if isinstance(route_extra_headers, dict) and route_extra_headers:
+        fb_kwargs["extra_headers"] = {
+            **dict(fb_kwargs.get("extra_headers") or {}),
+            **route_extra_headers,
+        }
     try:
         return _validate_llm_response(
             await fb_client.chat.completions.create(**fb_kwargs), task)
@@ -4118,6 +4201,18 @@ async def _call_fallback_candidate_async(
                     extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
                     base_url=str(getattr(retry_client, "base_url", "") or fb_base), task=task)
+                if route_output_tokens is not None:
+                    retry_kwargs.update(
+                        auxiliary_max_tokens_param(
+                            route_output_tokens,
+                            model=retry_model or fb_model,
+                        )
+                    )
+                if isinstance(route_extra_headers, dict) and route_extra_headers:
+                    retry_kwargs["extra_headers"] = {
+                        **dict(retry_kwargs.get("extra_headers") or {}),
+                        **route_extra_headers,
+                    }
                 try:
                     return _validate_llm_response(
                         await retry_client.chat.completions.create(**retry_kwargs), task)
@@ -4428,19 +4523,45 @@ def _fallback_entry_api_key(entry: Dict[str, Any]) -> Optional[str]:
 
 def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optional[str]]:
     """Resolve one fallback entry through the central provider router."""
-    provider = str(entry.get("provider") or "").strip()
-    model = str(entry.get("model") or "").strip() or None
+    from hermes_cli.fallback_config import resolve_fallback_runtime
+
+    runtime = resolve_fallback_runtime(entry)
+    provider = str(runtime.get("provider") or "").strip()
+    model = str(runtime.get("model") or "").strip() or None
     if not provider or not model:
         return None, None
-    base_url = str(entry.get("base_url") or "").strip() or None
-    api_key = _fallback_entry_api_key(entry)
-    api_mode = str(entry.get("api_mode") or entry.get("transport") or "").strip() or None
+    base_url = str(runtime.get("base_url") or "").strip() or None
+    api_key = runtime.get("api_key") or None
+    api_mode = str(runtime.get("api_mode") or "").strip() or None
+    if provider.lower() == "lmstudio":
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        from hermes_cli.models import ensure_lmstudio_model_loaded
+
+        route_context = runtime.get("context_length")
+        target_context = max(
+            route_context if isinstance(route_context, int) else 0,
+            MINIMUM_CONTEXT_LENGTH,
+        )
+        loaded_context = ensure_lmstudio_model_loaded(
+            model,
+            base_url,
+            api_key,
+            target_context,
+            timeout=float(runtime.get("request_timeout_seconds") or 120.0),
+            transition_policy=runtime.get("model_transition_policy"),
+            require_context_minimum=True,
+        )
+        if loaded_context is None:
+            raise RuntimeError(
+                f"LM Studio could not load auxiliary fallback {model!r} "
+                f"with at least {target_context:,} context tokens"
+            )
     return resolve_provider_client(
         provider,
         model=model,
-        explicit_base_url=base_url,
-        explicit_api_key=api_key,
-        api_mode=api_mode,
+        explicit_base_url=base_url or "",
+        explicit_api_key=str(api_key or ""),
+        api_mode=api_mode or "",
     )
 
 
@@ -4516,7 +4637,7 @@ def _try_main_fallback_chain(
                 task or "call", reason, failed_provider or "auto", label,
                 resolved_model or fb_model,
             )
-            return fb_client, resolved_model or fb_model, fb_provider
+            return fb_client, resolved_model or fb_model, label
         tried.append(label)
 
     if tried:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -15,6 +15,7 @@ sites unchanged.  Symbols that tests patch on ``run_agent`` (e.g.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import math
@@ -44,6 +45,7 @@ from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
+_MISSING_RUNTIME_VALUE = object()
 
 # When the fallback chain is fully exhausted on a non-rate-limit failure
 # (e.g. every provider returns a non-retryable client error like HTTP 400),
@@ -1574,6 +1576,92 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
 
 
 
+def _snapshot_fallback_runtime(agent) -> dict[str, Any]:
+    """Capture every mutable runtime field touched during fallback activation."""
+    deep_attrs = {"request_overrides", "reasoning_config"}
+    shallow_attrs = {"_client_kwargs", "_transport_cache"}
+    attrs = (
+        "model",
+        "provider",
+        "requested_provider",
+        "base_url",
+        "api_mode",
+        "api_key",
+        "client",
+        "_anthropic_client",
+        "_anthropic_api_key",
+        "_anthropic_base_url",
+        "_is_anthropic_oauth",
+        "_client_kwargs",
+        "_use_prompt_caching",
+        "_use_native_cache_layout",
+        "_credential_pool",
+        "_credential_pool_entry_id",
+        "_config_context_length",
+        "max_tokens",
+        "request_overrides",
+        "reasoning_config",
+        "_cached_system_prompt",
+        "_pending_fallback_notice",
+        "_fallback_activated",
+        "_transport_cache",
+    )
+    snapshot: dict[str, Any] = {}
+    for attr in attrs:
+        value = getattr(agent, attr, _MISSING_RUNTIME_VALUE)
+        if value is not _MISSING_RUNTIME_VALUE and attr in deep_attrs:
+            value = copy.deepcopy(value)
+        elif value is not _MISSING_RUNTIME_VALUE and attr in shallow_attrs:
+            value = dict(value) if isinstance(value, dict) else value
+        snapshot[attr] = value
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        compressor_attrs = (
+            "model",
+            "base_url",
+            "api_key",
+            "provider",
+            "api_mode",
+            "context_length",
+            "threshold_tokens",
+        )
+        snapshot["__compressor__"] = {
+            attr: getattr(compressor, attr, _MISSING_RUNTIME_VALUE)
+            for attr in compressor_attrs
+        }
+    return snapshot
+
+
+def _restore_fallback_runtime(agent, snapshot: dict[str, Any]) -> None:
+    """Restore a failed activation without rebuilding clients or prompts."""
+    for attr, value in snapshot.items():
+        if attr == "__compressor__":
+            continue
+        if value is _MISSING_RUNTIME_VALUE:
+            try:
+                delattr(agent, attr)
+            except AttributeError:
+                pass
+            continue
+        if attr in {"request_overrides", "reasoning_config"}:
+            value = copy.deepcopy(value)
+        elif attr in {"_client_kwargs", "_transport_cache"}:
+            value = dict(value)
+        setattr(agent, attr, value)
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        for attr, value in snapshot.get("__compressor__", {}).items():
+            if value is _MISSING_RUNTIME_VALUE:
+                try:
+                    delattr(compressor, attr)
+                except AttributeError:
+                    pass
+            else:
+                setattr(compressor, attr, value)
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -1671,28 +1759,23 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     # Use centralized router for client construction.
     # raw_codex=True because the main agent needs direct responses.stream()
     # access for Codex providers.
+    activation_snapshot = _snapshot_fallback_runtime(agent)
     try:
         from agent.auxiliary_client import resolve_provider_client
-        # Pass base_url and api_key from fallback config so custom
-        # endpoints (e.g. Ollama Cloud) resolve correctly instead of
-        # falling through to OpenRouter defaults.
-        fb_base_url_hint = (fb.get("base_url") or "").strip() or None
-        fb_api_key_hint = (fb.get("api_key") or "").strip() or None
-        if not fb_api_key_hint:
-            # key_env and api_key_env are both documented aliases (see
-            # _normalize_custom_provider_entry in hermes_cli/config.py).
-            fb_key_env = (fb.get("key_env") or fb.get("api_key_env") or "").strip()
-            if fb_key_env:
-                fb_api_key_hint = os.getenv(fb_key_env, "").strip() or None
-        # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
-        # when no explicit key is in the fallback config. Host match
-        # (not substring) — see GHSA-76xc-57q6-vm5m.
-        if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
-            fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
+        from hermes_cli.fallback_config import resolve_fallback_runtime
+
+        fb_runtime = resolve_fallback_runtime(fb)
+        fb_provider = str(fb_runtime.get("provider") or fb_provider).strip().lower()
+        fb_model = str(fb_runtime.get("model") or fb_model).strip()
+        fb_base_url_hint = str(fb_runtime.get("base_url") or "").strip() or None
+        fb_api_key_hint = fb_runtime.get("api_key") or None
+        fb_api_mode_hint = str(fb_runtime.get("api_mode") or "").strip() or None
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
-            explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_base_url=fb_base_url_hint or "",
+            explicit_api_key=str(fb_api_key_hint or ""),
+            api_mode=fb_api_mode_hint or "",
+        )
         if fb_client is None:
             logger.warning(
                 "Fallback to %s failed: provider not configured",
@@ -1709,43 +1792,80 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        # Trust the canonical runtime's API mode. Legacy providers that are
+        # only known to the downstream client router keep the established
+        # provider/URL/model inference path.
+        fb_api_mode = fb_api_mode_hint or "chat_completions"
+        # The constructed client's endpoint is the transport source of truth.
+        # Some first-party OAuth routers intentionally ignore an explicit route
+        # URL; pairing their token/headers with the untrusted hint here would
+        # leak credentials when request-local clients are rebuilt.
         fb_base_url = str(fb_client.base_url)
-        _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
-            fb_api_mode = "codex_responses"
-        elif (
-            fb_provider == "anthropic"
-            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
-            or base_url_hostname(fb_base_url) == "api.anthropic.com"
-        ):
-            # Custom providers (e.g. cron-anthropic) point at the native
-            # api.anthropic.com host with no "/anthropic" path suffix, so the
-            # name/suffix checks above miss them and they default to
-            # chat_completions → POST /v1/chat/completions → 404. Match the
-            # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
-            fb_api_mode = "anthropic_messages"
-        elif _fb_is_azure:
-            # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
-            # support the Responses API. Stay on chat_completions.
-            fb_api_mode = "chat_completions"
-        elif agent._is_direct_openai_url(fb_base_url):
-            fb_api_mode = "codex_responses"
-        elif agent._provider_model_requires_responses_api(
+        if not fb_api_mode_hint:
+            _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
+            if fb_provider == "openai-codex":
+                fb_api_mode = "codex_responses"
+            elif (
+                fb_provider == "anthropic"
+                or fb_base_url.rstrip("/").lower().endswith("/anthropic")
+                or base_url_hostname(fb_base_url) == "api.anthropic.com"
+            ):
+                fb_api_mode = "anthropic_messages"
+            elif _fb_is_azure:
+                fb_api_mode = "chat_completions"
+            elif agent._is_direct_openai_url(fb_base_url):
+                fb_api_mode = "codex_responses"
+            elif agent._provider_model_requires_responses_api(
+                fb_model,
+                provider=fb_provider,
+            ):
+                fb_api_mode = "codex_responses"
+            elif fb_provider == "bedrock" or (
+                base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
+                and base_url_host_matches(fb_base_url, "amazonaws.com")
+            ):
+                fb_api_mode = "bedrock_converse"
+
+        route_context_length = fb_runtime.get("context_length")
+        if not isinstance(route_context_length, int) or route_context_length <= 0:
+            route_context_length = None
+
+        # Resolve and, for LM Studio, validate the target before mutating the
+        # live agent. A load/unload failure can then advance the chain without
+        # leaking partial provider or request state from this candidate.
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
+
+        fb_context_length = get_model_context_length(
             fb_model,
+            base_url=fb_base_url,
+            api_key=fb_api_key_hint if isinstance(fb_api_key_hint, str) else "",
             provider=fb_provider,
+            config_context_length=route_context_length,
+            custom_providers=getattr(agent, "_custom_providers", None),
+        )
+        transition_policy = fb_runtime.get("model_transition_policy")
+        if fb_provider == "lmstudio" and (
+            (getattr(agent, "lmstudio_load_mode", "explicit") or "explicit").strip().lower()
+            != "jit"
+            or transition_policy == "sequential"
         ):
-            # GPT-5.x models usually need Responses API, but keep
-            # provider-specific exceptions like Copilot gpt-5-mini on
-            # chat completions.
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
+            from hermes_cli.models import ensure_lmstudio_model_loaded
+
+            load_target = max(route_context_length or 0, MINIMUM_CONTEXT_LENGTH)
+            loaded_context = ensure_lmstudio_model_loaded(
+                fb_model,
+                fb_base_url,
+                fb_api_key_hint,
+                load_target,
+                timeout=float(fb_runtime.get("request_timeout_seconds") or 120.0),
+                transition_policy=transition_policy,
+                require_context_minimum=True,
+            )
+            if loaded_context is None:
+                raise RuntimeError(
+                    f"LM Studio could not load fallback model {fb_model!r} "
+                    f"with at least {load_target:,} context tokens"
+                )
 
         old_model = agent.model
         old_provider = agent.provider
@@ -1753,12 +1873,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
         # the stale value from the previous model.  See #22387.
-        agent._config_context_length = None
+        agent._config_context_length = route_context_length
         agent.model = fb_model
         agent.provider = fb_provider
         agent.requested_provider = fb_provider
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
+        primary_runtime = getattr(agent, "_primary_runtime", {}) or {}
+        if "max_output_tokens" in fb_runtime:
+            agent.max_tokens = fb_runtime["max_output_tokens"]
+        elif "max_tokens" in primary_runtime:
+            agent.max_tokens = primary_runtime["max_tokens"]
+        if "request_overrides" in fb_runtime:
+            agent.request_overrides = copy.deepcopy(fb_runtime["request_overrides"])
+        elif "request_overrides" in primary_runtime:
+            agent.request_overrides = copy.deepcopy(primary_runtime["request_overrides"])
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
@@ -1786,9 +1915,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 agent._credential_pool_entry_id = None
         if getattr(agent, "_credential_pool", None) is None:
             try:
-                from agent.credential_pool import load_pool
+                fallback_pool = fb_runtime.get("credential_pool")
+                if fallback_pool is None:
+                    from agent.credential_pool import load_pool
 
-                fallback_pool = load_pool(fb_provider)
+                    fallback_pool = load_pool(fb_provider)
                 if fallback_pool and fallback_pool.has_credentials():
                     agent._credential_pool = fallback_pool
                     logger.info(
@@ -1804,7 +1935,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # Honor per-provider / per-model request_timeout_seconds for the
         # fallback target (same knob the primary client uses).  None = use
         # SDK default.
-        _fb_timeout = get_provider_request_timeout(fb_provider, fb_model)
+        _fb_timeout = fb_runtime.get("request_timeout_seconds")
+        if _fb_timeout is None:
+            _fb_timeout = get_provider_request_timeout(fb_provider, fb_model)
 
         if fb_api_mode == "anthropic_messages":
             # Build native Anthropic client instead of using OpenAI client
@@ -1813,8 +1946,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
             agent._anthropic_base_url = fb_base_url
+            anthropic_kwargs = {}
+            if isinstance(_fb_timeout, (int, float)):
+                anthropic_kwargs["timeout"] = _fb_timeout
             agent._anthropic_client = build_anthropic_client(
-                effective_key, agent._anthropic_base_url, timeout=_fb_timeout,
+                effective_key,
+                agent._anthropic_base_url,
+                **anthropic_kwargs,
             )
             agent._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
             agent.client = None
@@ -1834,6 +1972,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_headers = getattr(fb_client, "_custom_headers", None)
             if not fb_headers:
                 fb_headers = getattr(fb_client, "default_headers", None)
+            route_headers = fb_runtime.get("extra_headers")
+            if isinstance(route_headers, dict):
+                merged_headers = dict(fb_headers or {})
+                merged_headers.update(route_headers)
+                fb_headers = merged_headers
             agent._client_kwargs = {
                 "api_key": fb_client.api_key,
                 "base_url": fb_base_url,
@@ -1841,8 +1984,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             }
             if _fb_timeout is not None:
                 agent._client_kwargs["timeout"] = _fb_timeout
+            if _fb_timeout is not None or route_headers:
                 # Rebuild the shared OpenAI client so the configured
-                # timeout takes effect on the very next fallback request,
+                # timeout / headers take effect on the very next fallback request,
                 # not only after a later credential-rotation rebuild.
                 agent._replace_primary_openai_client(reason="fallback_timeout_apply")
 
@@ -1859,9 +2003,6 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             )
         )
 
-        # LM Studio: preload before probing the fallback's context length.
-        agent._ensure_lmstudio_runtime_loaded()
-
         # Update context compressor limits for the fallback model.
         # Without this, compression decisions use the primary model's
         # context window (e.g. 200K) instead of the fallback's (e.g. 32K),
@@ -1870,18 +2011,6 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # (model.context_length in config.yaml) is respected — without this,
         # the fallback activation drops to 128K even when config says 204800.
         if hasattr(agent, 'context_compressor') and agent.context_compressor:
-            from agent.model_metadata import get_model_context_length
-            # ``agent.api_key`` may be callable (Entra ID); the
-            # context-length resolver expects a string for live
-            # probes. Foundry typically resolves via config/static
-            # catalogs anyway, so coerce defensively.
-            _fb_ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
-            fb_context_length = get_model_context_length(
-                agent.model, base_url=agent.base_url,
-                api_key=_fb_ctx_api_key, provider=agent.provider,
-                config_context_length=getattr(agent, "_config_context_length", None),
-                custom_providers=getattr(agent, "_custom_providers", None),
-            )
             agent.context_compressor.update_model(
                 model=agent.model,
                 context_length=fb_context_length,
@@ -1942,6 +2071,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _reset_stale_streak(agent)
         return True
     except Exception as e:
+        _restore_fallback_runtime(agent, activation_snapshot)
         if fb_provider == "nous":
             unavailable.add(fb_key)
         logger.error("Failed to activate fallback %s: %s", fb_model, e)

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -6,6 +6,26 @@ import os
 from typing import Any
 
 
+_FALLBACK_ENTRY_KEYS = {
+    "provider",
+    "model",
+    "base_url",
+    "api_key",
+    "key_env",
+    "api_key_env",
+    "api_mode",
+    "transport",
+    "context_length",
+    "max_output_tokens",
+    "max_tokens",
+    "extra_body",
+    "extra_headers",
+    "timeout",
+    "request_timeout_seconds",
+    "model_transition_policy",
+}
+
+
 def _normalized_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
@@ -31,6 +51,110 @@ def resolve_entry_api_key(entry: dict[str, Any] | None) -> str | None:
     return None
 
 
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str) and value.strip().isdigit():
+        parsed = int(value.strip())
+        return parsed if parsed > 0 else None
+    return None
+
+
+def _positive_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def normalize_fallback_entry(entry: Any) -> dict[str, Any] | None:
+    """Validate one fallback route and discard unsupported route-level keys.
+
+    Provider-specific request fields belong under ``extra_body``.  Keeping a
+    small allowlist here prevents an arbitrary config key from becoming an SDK
+    constructor or request kwarg when the route is activated.
+    """
+    if not isinstance(entry, dict):
+        return None
+    provider = str(entry.get("provider") or "").strip()
+    model = str(entry.get("model") or "").strip()
+    if not provider or not model:
+        return None
+
+    normalized = {key: entry[key] for key in _FALLBACK_ENTRY_KEYS if key in entry}
+    normalized["provider"] = provider
+    normalized["model"] = model
+
+    base_url = _normalized_base_url(entry.get("base_url"))
+    if base_url:
+        normalized["base_url"] = base_url
+    else:
+        normalized.pop("base_url", None)
+
+    for key in ("api_key", "key_env", "api_key_env"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            normalized[key] = value.strip()
+        else:
+            normalized.pop(key, None)
+
+    api_mode = entry.get("api_mode") or entry.get("transport")
+    if api_mode is not None:
+        from hermes_cli.runtime_provider import _parse_api_mode
+
+        parsed_api_mode = _parse_api_mode(api_mode)
+    else:
+        parsed_api_mode = None
+    if parsed_api_mode:
+        normalized["api_mode"] = parsed_api_mode
+    else:
+        normalized.pop("api_mode", None)
+    normalized.pop("transport", None)
+
+    for key in ("context_length", "max_output_tokens", "max_tokens"):
+        if key in normalized:
+            parsed = _positive_int(normalized[key])
+            if parsed is None:
+                normalized.pop(key, None)
+            else:
+                normalized[key] = parsed
+
+    for key in ("timeout", "request_timeout_seconds"):
+        if key in normalized:
+            parsed = _positive_float(normalized[key])
+            if parsed is None:
+                normalized.pop(key, None)
+            else:
+                normalized[key] = parsed
+
+    if "extra_body" in normalized and not isinstance(normalized["extra_body"], dict):
+        normalized.pop("extra_body", None)
+    elif "extra_body" in normalized:
+        normalized["extra_body"] = dict(normalized["extra_body"])
+
+    if "extra_headers" in normalized:
+        from hermes_cli.config import normalize_extra_headers
+
+        route_headers = normalize_extra_headers(normalized["extra_headers"])
+        if route_headers:
+            normalized["extra_headers"] = route_headers
+        else:
+            normalized.pop("extra_headers", None)
+
+    policy = str(normalized.get("model_transition_policy") or "").strip().lower()
+    if policy == "sequential":
+        normalized["model_transition_policy"] = policy
+    else:
+        normalized.pop("model_transition_policy", None)
+
+    return normalized
+
+
 def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
     if isinstance(raw, dict):
         candidates = [raw]
@@ -41,22 +165,9 @@ def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
 
     entries: list[dict[str, Any]] = []
     for entry in candidates:
-        if not isinstance(entry, dict):
-            continue
-        provider = str(entry.get("provider") or "").strip()
-        model = str(entry.get("model") or "").strip()
-        if not provider or not model:
-            continue
-
-        normalized = dict(entry)
-        normalized["provider"] = provider
-        normalized["model"] = model
-
-        base_url = _normalized_base_url(entry.get("base_url"))
-        if base_url:
-            normalized["base_url"] = base_url
-
-        entries.append(normalized)
+        normalized = normalize_fallback_entry(entry)
+        if normalized is not None:
+            entries.append(normalized)
     return entries
 
 
@@ -90,3 +201,80 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
             chain.append(entry)
 
     return chain
+
+
+def resolve_fallback_runtime(entry: dict[str, Any]) -> dict[str, Any]:
+    """Resolve one fallback through the canonical runtime-provider pipeline.
+
+    Named custom-provider defaults are retained, then explicit route fields
+    override them.  The returned dict is the complete target runtime used by
+    the main agent and auxiliary callers.
+    """
+    normalized = normalize_fallback_entry(entry)
+    if normalized is None:
+        raise ValueError("fallback entry requires non-empty provider and model")
+
+    from hermes_cli.auth import AuthError
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    explicit_api_key = resolve_entry_api_key(normalized)
+    try:
+        runtime = dict(
+            resolve_runtime_provider(
+                requested=normalized["provider"],
+                explicit_api_key=explicit_api_key,
+                explicit_base_url=normalized.get("base_url"),
+                target_model=normalized["model"],
+            )
+        )
+    except AuthError:
+        # Preserve legacy fallback routing when the central resolver cannot
+        # obtain credentials up front. The downstream client router performs
+        # its own provider-specific auth lookup and returns no client when that
+        # also fails. Validation and secret-scope errors are not caught here.
+        runtime = {
+            "provider": normalized["provider"],
+            "requested_provider": normalized["provider"],
+            "model": normalized["model"],
+        }
+        if normalized.get("base_url"):
+            runtime["base_url"] = normalized["base_url"]
+        if explicit_api_key:
+            runtime["api_key"] = explicit_api_key
+        if normalized.get("api_mode"):
+            runtime["api_mode"] = normalized["api_mode"]
+    runtime["model"] = normalized["model"]
+    if normalized.get("api_mode"):
+        runtime["api_mode"] = normalized["api_mode"]
+
+    for key in ("context_length", "model_transition_policy"):
+        if key in normalized:
+            runtime[key] = normalized[key]
+
+    route_max = normalized.get("max_output_tokens") or normalized.get("max_tokens")
+    if route_max is not None:
+        runtime["max_output_tokens"] = route_max
+
+    route_timeout = normalized.get("request_timeout_seconds")
+    if route_timeout is None:
+        route_timeout = normalized.get("timeout")
+    if route_timeout is not None:
+        runtime["request_timeout_seconds"] = route_timeout
+
+    route_body = normalized.get("extra_body")
+    if isinstance(route_body, dict):
+        overrides = runtime.get("request_overrides")
+        overrides = dict(overrides) if isinstance(overrides, dict) else {}
+        inherited_body = overrides.get("extra_body")
+        merged_body = dict(inherited_body) if isinstance(inherited_body, dict) else {}
+        merged_body.update(route_body)
+        overrides["extra_body"] = merged_body
+        runtime["request_overrides"] = overrides
+
+    if isinstance(normalized.get("extra_headers"), dict):
+        inherited_headers = runtime.get("extra_headers")
+        merged_headers = dict(inherited_headers) if isinstance(inherited_headers, dict) else {}
+        merged_headers.update(normalized["extra_headers"])
+        runtime["extra_headers"] = merged_headers
+
+    return runtime

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3377,22 +3377,41 @@ def ensure_lmstudio_model_loaded(
     api_key: Optional[str],
     target_context_length: int,
     timeout: float = 120.0,
+    *,
+    transition_policy: Optional[str] = None,
+    require_context_minimum: bool = False,
 ) -> Optional[int]:
-    """Ensure LM Studio has ``model`` loaded with at least ``target_context_length``.
+    """Ensure LM Studio has ``model`` loaded at the required context length.
 
-    No-op when an instance is already loaded with sufficient context. Otherwise
-    POSTs ``/api/v1/models/load`` to (re)load with the target context, capped
-    at the model's ``max_context_length``. Returns the resolved loaded context
-    length, or ``None`` when the probe / load failed.
+    ``transition_policy="sequential"`` is an explicit opt-in for memory-bound
+    hosts: loaded LLM instances are unloaded through LM Studio's documented
+    ``POST /api/v1/models/unload`` endpoint before the target is loaded. Loaded
+    embedding models are unrelated and are never evicted. Unload requests use a
+    short bounded timeout; model loads retain the caller's longer bounded timeout.
+
+    Existing callers retain the historical best-effort behavior: context is
+    clamped to the model maximum and older servers need not echo load config.
+    Rich fallback routes set ``require_context_minimum`` (and sequential routes
+    imply it), making the configured context a verified minimum contract.
     """
     server_root = _lmstudio_server_root(base_url)
     if not server_root:
         return None
+    if isinstance(target_context_length, bool) or target_context_length <= 0:
+        raise ValueError("target_context_length must be a positive integer")
+
+    policy = str(transition_policy or "").strip().lower()
+    if policy not in {"", "sequential"}:
+        raise ValueError(f"Unsupported LM Studio model transition policy: {transition_policy!r}")
+    strict_context = require_context_minimum or policy == "sequential"
 
     headers = _lmstudio_request_headers(api_key)
-
     try:
-        raw_models = _lmstudio_fetch_raw_models(api_key=api_key, base_url=base_url, timeout=10)
+        raw_models = _lmstudio_fetch_raw_models(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=min(10.0, max(1.0, timeout)),
+        )
     except Exception:
         raw_models = None
     if raw_models is None:
@@ -3410,18 +3429,79 @@ def ensure_lmstudio_model_loaded(
 
     max_ctx = target_entry.get("max_context_length")
     if isinstance(max_ctx, int) and max_ctx > 0:
+        if strict_context and max_ctx < target_context_length:
+            raise RuntimeError(
+                f"LM Studio model {model!r} supports at most {max_ctx:,} context tokens; "
+                f"the fallback route requires {target_context_length:,}"
+            )
         target_context_length = min(target_context_length, max_ctx)
 
+    loaded_contexts: list[int] = []
     for inst in target_entry.get("loaded_instances") or []:
         cfg = inst.get("config") if isinstance(inst, dict) else None
         loaded_ctx = cfg.get("context_length") if isinstance(cfg, dict) else None
-        if isinstance(loaded_ctx, int) and loaded_ctx >= target_context_length:
-            return loaded_ctx
+        if isinstance(loaded_ctx, int):
+            loaded_contexts.append(loaded_ctx)
+    sufficient_loaded_context = next(
+        (value for value in loaded_contexts if value >= target_context_length),
+        None,
+    )
 
-    body = json.dumps({
+    if policy == "sequential":
+        unload_headers = dict(headers)
+        unload_headers["Content-Type"] = "application/json"
+        unload_timeout = min(30.0, max(1.0, float(timeout)))
+        conflicting_instances: list[str] = []
+        for raw in raw_models:
+            if not isinstance(raw, dict):
+                continue
+            if str(raw.get("type") or "").strip().lower() == "embedding":
+                continue
+            raw_is_target = raw is target_entry
+            if raw_is_target and sufficient_loaded_context is not None:
+                continue
+            for inst in raw.get("loaded_instances") or []:
+                if not isinstance(inst, dict):
+                    continue
+                instance_id = str(inst.get("id") or inst.get("instance_id") or "").strip()
+                if instance_id and instance_id not in conflicting_instances:
+                    conflicting_instances.append(instance_id)
+
+        for instance_id in conflicting_instances:
+            unload_request = urllib.request.Request(
+                server_root + "/api/v1/models/unload",
+                data=json.dumps({"instance_id": instance_id}).encode(),
+                headers=unload_headers,
+                method="POST",
+            )
+            try:
+                with _urlopen_model_catalog_request(
+                    unload_request,
+                    timeout=unload_timeout,
+                ) as resp:
+                    resp.read()
+            except Exception as exc:
+                raise RuntimeError(
+                    f"LM Studio failed to unload conflicting model instance "
+                    f"{instance_id!r} before loading {model!r}: {exc}"
+                ) from exc
+
+    if sufficient_loaded_context is not None:
+        return sufficient_loaded_context
+
+    load_payload: dict[str, Any] = {
         "model": model,
         "context_length": target_context_length,
-    }).encode()
+    }
+    if strict_context:
+        load_payload["echo_load_config"] = True
+    if policy == "sequential":
+        # LM Studio's native API otherwise defaults to parallel=4, unlike the
+        # CLI's historical default of one prediction. Sequential fallback is
+        # explicitly the memory-bounded policy, so keep both model residency
+        # and KV-cache concurrency bounded.
+        load_payload["parallel"] = 1
+    body = json.dumps(load_payload).encode()
     load_headers = dict(headers)
     load_headers["Content-Type"] = "application/json"
     try:
@@ -3432,10 +3512,31 @@ def ensure_lmstudio_model_loaded(
             method="POST",
         )
         with _urlopen_model_catalog_request(load_request, timeout=timeout) as resp:
-            resp.read()
-    except Exception:
+            response_body = resp.read()
+            payload = json.loads(response_body.decode() or "{}") if strict_context else {}
+    except Exception as exc:
+        if policy == "sequential":
+            raise RuntimeError(f"LM Studio failed to load model {model!r}: {exc}") from exc
         return None
-    return target_context_length
+
+    load_config = payload.get("load_config") if isinstance(payload, dict) else None
+    loaded_context = load_config.get("context_length") if isinstance(load_config, dict) else None
+    if not strict_context:
+        return target_context_length
+    if not isinstance(loaded_context, int) or loaded_context < target_context_length:
+        reported = loaded_context if isinstance(loaded_context, int) else "unknown"
+        raise RuntimeError(
+            f"LM Studio loaded {model!r} with context {reported}, below the "
+            f"required {target_context_length:,}"
+        )
+    if policy == "sequential":
+        loaded_parallel = load_config.get("parallel") if isinstance(load_config, dict) else None
+        if loaded_parallel != 1:
+            raise RuntimeError(
+                f"LM Studio loaded {model!r} with parallel={loaded_parallel!r}; "
+                "sequential fallback requires parallel=1"
+            )
+    return loaded_context
 
 
 def lmstudio_model_reasoning_options(

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1095,6 +1095,8 @@ def _resolve_named_custom_runtime(
             pool_result["model"] = model_name
         if isinstance(custom_provider.get("max_output_tokens"), int):
             pool_result["max_output_tokens"] = custom_provider["max_output_tokens"]
+        if isinstance(custom_provider.get("context_length"), int):
+            pool_result["context_length"] = custom_provider["context_length"]
         request_overrides = _custom_provider_request_overrides(custom_provider)
         if request_overrides:
             pool_result["request_overrides"] = {
@@ -1139,6 +1141,8 @@ def _resolve_named_custom_runtime(
         result["model"] = custom_provider["model"]
     if isinstance(custom_provider.get("max_output_tokens"), int):
         result["max_output_tokens"] = custom_provider["max_output_tokens"]
+    if isinstance(custom_provider.get("context_length"), int):
+        result["context_length"] = custom_provider["context_length"]
     # Per-provider extra HTTP headers (proxies, gateways, custom auth).
     # Values may carry credentials — NEVER log them.
     if custom_provider.get("extra_headers"):
@@ -1652,13 +1656,17 @@ def resolve_runtime_provider(
     from hermes_cli.config import is_provider_enabled, load_config
     _full_cfg = load_config()
     _provs_cfg = _full_cfg.get("providers") if isinstance(_full_cfg, dict) else None
-    if isinstance(_provs_cfg, dict):
-        _block = _provs_cfg.get(requested_provider)
+    def _raise_if_provider_disabled(provider_key: str) -> None:
+        if not isinstance(_provs_cfg, dict):
+            return
+        _block = _provs_cfg.get(provider_key)
         if isinstance(_block, dict) and not is_provider_enabled(_block):
             raise ValueError(
-                f"provider {requested_provider!r} is disabled in config "
-                f"(providers.{requested_provider}.enabled: false)"
+                f"provider {provider_key!r} is disabled in config "
+                f"(providers.{provider_key}.enabled: false)"
             )
+
+    _raise_if_provider_disabled(requested_provider)
 
     if requested_provider == "moa":
         return {
@@ -1716,6 +1724,7 @@ def resolve_runtime_provider(
     # margin) by get_vertex_config(); mid-session expiry is additionally
     # recovered on 401 by run_agent._try_refresh_vertex_client_credentials().
     if requested_provider in ("vertex", "google-vertex", "vertex-ai", "gcp-vertex", "vertexai"):
+        _raise_if_provider_disabled("vertex")
         from agent.vertex_adapter import get_vertex_config
 
         token, base_url = get_vertex_config()
@@ -1789,6 +1798,9 @@ def resolve_runtime_provider(
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
     )
+    # Alias entries (for example ``kimi`` -> ``kimi-coding``) must not bypass
+    # an explicit disable on the canonical provider block.
+    _raise_if_provider_disabled(provider)
     model_cfg = _get_model_config()
     explicit_runtime = _resolve_explicit_runtime(
         provider=provider,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -6351,6 +6351,7 @@ class TestCompressionFallbackContextFilter:
             "L3 bug: main chain returned the first reachable candidate "
             "without screening by context window.")
         assert model == "huge-1m"
+        assert label == "fallback_providers[1](p-large)"
 
     # ── L4: unknown context passthrough ────────────────────────────────
 
@@ -6625,3 +6626,78 @@ class TestCustomEndpointApiKeyInheritance:
             )
 
         assert captured.get("api_key") == "no-key-required"
+
+
+class TestRichFallbackRouteHeaders:
+    def test_sync_candidate_applies_and_merges_route_headers(self):
+        import agent.auxiliary_client as ac
+
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+        client = MagicMock()
+        client.base_url = "https://fallback.example/v1"
+        client.chat.completions.create.return_value = response
+        route = {"extra_headers": {"X-Route": "fallback"}}
+
+        with patch.object(ac, "_fallback_entry_settings", return_value=route), patch.object(
+            ac,
+            "_build_call_kwargs",
+            return_value={"extra_headers": {"X-Base": "base"}},
+        ):
+            result = ac._call_fallback_candidate_sync(
+                client,
+                "fallback-model",
+                "fallback_providers[0](custom)",
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                temperature=0.2,
+                max_tokens=100,
+                tools=None,
+                effective_timeout=30.0,
+                effective_extra_body={},
+                reasoning_config=None,
+            )
+
+        assert result is response
+        assert client.chat.completions.create.call_args.kwargs["extra_headers"] == {
+            "X-Base": "base",
+            "X-Route": "fallback",
+        }
+
+    @pytest.mark.asyncio
+    async def test_async_candidate_applies_and_merges_route_headers(self):
+        import agent.auxiliary_client as ac
+
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+        client = MagicMock()
+        client.base_url = "https://fallback.example/v1"
+        client.chat.completions.create = AsyncMock(return_value=response)
+        route = {"extra_headers": {"X-Route": "fallback"}}
+
+        with patch.object(ac, "_fallback_entry_settings", return_value=route), patch.object(
+            ac,
+            "_build_call_kwargs",
+            return_value={"extra_headers": {"X-Base": "base"}},
+        ):
+            result = await ac._call_fallback_candidate_async(
+                client,
+                "fallback-model",
+                "fallback_providers[0](custom)",
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                temperature=0.2,
+                max_tokens=100,
+                tools=None,
+                effective_timeout=30.0,
+                effective_extra_body={},
+                reasoning_config=None,
+            )
+
+        assert result is response
+        assert client.chat.completions.create.call_args.kwargs["extra_headers"] == {
+            "X-Base": "base",
+            "X-Route": "fallback",
+        }

--- a/tests/agent/test_compression_fallback_budget.py
+++ b/tests/agent/test_compression_fallback_budget.py
@@ -21,7 +21,11 @@ from unittest.mock import patch
 
 import pytest
 
-from agent.auxiliary_client import _fallback_entry_timeout, _call_fallback_candidate_sync
+from agent.auxiliary_client import (
+    _call_fallback_candidate_sync,
+    _fallback_entry_settings,
+    _fallback_entry_timeout,
+)
 from agent.context_compressor import ContextCompressor
 
 
@@ -92,6 +96,72 @@ def test_fallback_candidate_call_uses_entry_timeout():
         )
     assert resp is not None
     assert seen.get("timeout") == 240.0
+
+
+def test_fallback_candidate_call_uses_route_output_and_extra_body_settings():
+    """Auxiliary callers use the same rich route settings as the main agent."""
+    seen = {}
+
+    class _FakeCompletions:
+        def create(self, **kwargs):
+            seen.update(kwargs)
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+            )
+
+    fb_client = SimpleNamespace(
+        base_url="http://localhost:1234/v1",
+        chat=SimpleNamespace(completions=_FakeCompletions()),
+    )
+    chain = [
+        {
+            "provider": "lmstudio",
+            "model": "large-local",
+            "max_output_tokens": 16_384,
+            "extra_body": {"temperature": 1.0, "top_p": 0.95, "top_k": 20},
+        }
+    ]
+    with _patch_task_config(chain):
+        response = _call_fallback_candidate_sync(
+            fb_client,
+            "large-local",
+            "fallback_chain[0](lmstudio)",
+            task="compression",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=None,
+            max_tokens=777,
+            tools=None,
+            effective_timeout=30.0,
+            effective_extra_body={"primary_only": True},
+            reasoning_config=None,
+        )
+
+    assert response is not None
+    assert seen["max_tokens"] == 16_384
+    assert seen["extra_body"] == {
+        "primary_only": True,
+        "temperature": 1.0,
+        "top_p": 0.95,
+        "top_k": 20,
+    }
+
+
+def test_profile_fallback_label_resolves_rich_route_settings():
+    chain = [
+        {
+            "provider": "lmstudio",
+            "model": "large-local",
+            "max_output_tokens": 16_384,
+            "extra_body": {"temperature": 1.0},
+        }
+    ]
+    with patch("hermes_cli.config.load_config", return_value={"fallback_providers": chain}):
+        settings = _fallback_entry_settings(
+            "compression", "fallback_providers[0](lmstudio)"
+        )
+
+    assert settings["max_output_tokens"] == 16_384
+    assert settings["extra_body"] == {"temperature": 1.0}
 
 
 def test_fallback_candidate_without_entry_timeout_keeps_task_timeout():

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1195,6 +1195,82 @@ class TestRunJobSessionPersistence:
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 
+    def test_explicit_primary_retains_rich_profile_fallback_chain(self, tmp_path):
+        rich_chain = [
+            {
+                "provider": "lmstudio",
+                "model": "large-local",
+                "base_url": "http://localhost:1234/v1",
+                "context_length": 65_536,
+                "max_output_tokens": 16_384,
+                "extra_body": {"temperature": 1.0, "top_p": 0.95, "top_k": 20},
+                "model_transition_policy": "sequential",
+            },
+            {
+                "provider": "lmstudio",
+                "model": "small-local",
+                "base_url": "http://localhost:1234/v1",
+                "context_length": 65_536,
+            },
+        ]
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  default: profile-primary\n"
+            "  provider: openrouter\n"
+            "fallback_providers:\n"
+            "  - provider: lmstudio\n"
+            "    model: large-local\n"
+            "    base_url: http://localhost:1234/v1\n"
+            "    context_length: 65536\n"
+            "    max_output_tokens: 16384\n"
+            "    extra_body:\n"
+            "      temperature: 1.0\n"
+            "      top_p: 0.95\n"
+            "      top_k: 20\n"
+            "    model_transition_policy: sequential\n"
+            "  - provider: lmstudio\n"
+            "    model: small-local\n"
+            "    base_url: http://localhost:1234/v1\n"
+            "    context_length: 65536\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "explicit-primary",
+            "name": "explicit primary",
+            "prompt": "hello",
+            "provider": "openai-codex",
+            "model": "gpt-primary",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://primary.invalid/v1",
+                     "provider": "openai-codex",
+                     "api_mode": "codex_responses",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["provider"] == "openai-codex"
+        assert kwargs["model"] == "gpt-primary"
+        assert kwargs["fallback_model"] == rich_chain
+
     def test_run_job_suppresses_empty_turn_explainer(self, tmp_path):
         """An empty model turn becomes the '⚠️ No reply…' explainer (#34452).
         For cron, that abnormal-empty explainer must be treated as empty so it

--- a/tests/hermes_cli/test_lmstudio_sequential_transition.py
+++ b/tests/hermes_cli/test_lmstudio_sequential_transition.py
@@ -1,0 +1,299 @@
+"""LM Studio load and sequential model-transition policy contracts."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+class _Response:
+    def __init__(self, payload=None):
+        self.payload = payload or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+
+def _model(key, *, loaded=None, max_context_length=262_144):
+    return {
+        "type": "llm",
+        "key": key,
+        "max_context_length": max_context_length,
+        "loaded_instances": loaded or [],
+    }
+
+
+def _instance(instance_id, context_length=65_536):
+    return {"id": instance_id, "config": {"context_length": context_length}}
+
+
+def test_cold_load_receives_exact_context_and_verifies_echoed_result():
+    from hermes_cli import models
+
+    requests = []
+
+    def urlopen(request, timeout):
+        requests.append((request.full_url, json.loads(request.data), timeout))
+        return _Response(
+            {
+                "status": "loaded",
+                "instance_id": "large-local",
+                "load_config": {"context_length": 65_536},
+            }
+        )
+
+    with patch.object(
+        models,
+        "_lmstudio_fetch_raw_models",
+        return_value=[_model("large-local")],
+    ), patch.object(models, "_urlopen_model_catalog_request", side_effect=urlopen):
+        loaded = models.ensure_lmstudio_model_loaded(
+            "large-local",
+            "http://localhost:1234/v1",
+            "local-key",
+            target_context_length=65_536,
+            timeout=120,
+            require_context_minimum=True,
+        )
+
+    assert loaded == 65_536
+    assert requests == [
+        (
+            "http://localhost:1234/api/v1/models/load",
+            {
+                "model": "large-local",
+                "context_length": 65_536,
+                "echo_load_config": True,
+            },
+            120,
+        )
+    ]
+
+
+def test_load_rejects_model_whose_maximum_is_below_required_minimum():
+    from hermes_cli import models
+
+    with patch.object(
+        models,
+        "_lmstudio_fetch_raw_models",
+        return_value=[_model("small-context", max_context_length=32_768)],
+    ), patch.object(models, "_urlopen_model_catalog_request") as urlopen:
+        with pytest.raises(RuntimeError, match="65,536|65536"):
+            models.ensure_lmstudio_model_loaded(
+                "small-context",
+                "http://localhost:1234/v1",
+                None,
+                target_context_length=65_536,
+                require_context_minimum=True,
+            )
+
+    urlopen.assert_not_called()
+
+
+def test_load_rejects_echoed_context_below_configured_minimum():
+    from hermes_cli import models
+
+    with patch.object(
+        models,
+        "_lmstudio_fetch_raw_models",
+        return_value=[_model("large-local")],
+    ), patch.object(
+        models,
+        "_urlopen_model_catalog_request",
+        return_value=_Response(
+            {
+                "status": "loaded",
+                "instance_id": "large-local",
+                "load_config": {"context_length": 32_768},
+            }
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="below|required"):
+            models.ensure_lmstudio_model_loaded(
+                "large-local",
+                "http://localhost:1234/v1",
+                None,
+                target_context_length=65_536,
+                require_context_minimum=True,
+            )
+
+
+def test_non_route_load_preserves_historical_context_clamp_and_payload():
+    from hermes_cli import models
+
+    requests = []
+
+    def urlopen(request, timeout):
+        requests.append(json.loads(request.data))
+        return _Response()
+
+    with patch.object(
+        models,
+        "_lmstudio_fetch_raw_models",
+        return_value=[_model("small-context", max_context_length=32_768)],
+    ), patch.object(models, "_urlopen_model_catalog_request", side_effect=urlopen):
+        loaded = models.ensure_lmstudio_model_loaded(
+            "small-context",
+            "http://localhost:1234/v1",
+            None,
+            target_context_length=65_536,
+        )
+
+    assert loaded == 32_768
+    assert requests == [{"model": "small-context", "context_length": 32_768}]
+
+
+def test_sequential_policy_unloads_conflicting_llm_before_loading_target():
+    from hermes_cli import models
+
+    events = []
+
+    def urlopen(request, timeout):
+        payload = json.loads(request.data)
+        if request.full_url.endswith("/unload"):
+            events.append(("unload", payload["instance_id"], timeout))
+            return _Response({"instance_id": payload["instance_id"]})
+        assert payload["parallel"] == 1
+        events.append(("load", payload["model"], payload["context_length"], timeout))
+        return _Response(
+            {
+                "status": "loaded",
+                "instance_id": payload["model"],
+                "load_config": {
+                    "context_length": payload["context_length"],
+                    "parallel": payload["parallel"],
+                },
+            }
+        )
+
+    catalog = [
+        _model("small-local", loaded=[_instance("small-local")]),
+        _model("large-local"),
+        {
+            "type": "embedding",
+            "key": "embedding-model",
+            "loaded_instances": [_instance("embedding-model", 2_048)],
+        },
+    ]
+    with patch.object(models, "_lmstudio_fetch_raw_models", return_value=catalog), patch.object(
+        models, "_urlopen_model_catalog_request", side_effect=urlopen
+    ):
+        loaded = models.ensure_lmstudio_model_loaded(
+            "large-local",
+            "http://localhost:1234/v1",
+            None,
+            target_context_length=65_536,
+            transition_policy="sequential",
+            timeout=120,
+        )
+
+    assert loaded == 65_536
+    assert events == [
+        ("unload", "small-local", 30.0),
+        ("load", "large-local", 65_536, 120),
+    ]
+    assert all("embedding-model" not in event for event in events)
+
+
+def test_sequential_unload_failure_is_bounded_and_never_starts_target_load():
+    from hermes_cli import models
+
+    events = []
+
+    def urlopen(request, timeout):
+        payload = json.loads(request.data)
+        events.append((request.full_url, payload, timeout))
+        raise TimeoutError("bounded unload timeout")
+
+    with patch.object(
+        models,
+        "_lmstudio_fetch_raw_models",
+        return_value=[
+            _model("small-local", loaded=[_instance("small-local")]),
+            _model("large-local"),
+        ],
+    ), patch.object(models, "_urlopen_model_catalog_request", side_effect=urlopen):
+        with pytest.raises(RuntimeError, match="unload"):
+            models.ensure_lmstudio_model_loaded(
+                "large-local",
+                "http://localhost:1234/v1",
+                None,
+                target_context_length=65_536,
+                transition_policy="sequential",
+            )
+
+    assert len(events) == 1
+    assert events[0][0].endswith("/api/v1/models/unload")
+    assert events[0][2] == 30.0
+
+
+def test_failed_large_load_then_small_fallback_never_has_simultaneous_residency():
+    from hermes_cli import models
+
+    state: dict[str, str | None] = {"resident": "small-local"}
+    events = []
+
+    def catalog(**_kwargs):
+        rows = []
+        for key in ("large-local", "small-local"):
+            loaded = [_instance(key)] if state["resident"] == key else []
+            rows.append(_model(key, loaded=loaded))
+        return rows
+
+    def urlopen(request, timeout):
+        payload = json.loads(request.data)
+        if request.full_url.endswith("/unload"):
+            events.append(("unload", payload["instance_id"]))
+            assert state["resident"] == payload["instance_id"]
+            state["resident"] = None
+            return _Response({"instance_id": payload["instance_id"]})
+        model = payload["model"]
+        assert payload["parallel"] == 1
+        events.append(("load", model))
+        assert state["resident"] is None
+        if model == "large-local":
+            raise TimeoutError("large load failed")
+        state["resident"] = model
+        return _Response(
+            {
+                "status": "loaded",
+                "instance_id": model,
+                "load_config": {
+                    "context_length": payload["context_length"],
+                    "parallel": payload["parallel"],
+                },
+            }
+        )
+
+    with patch.object(models, "_lmstudio_fetch_raw_models", side_effect=catalog), patch.object(
+        models, "_urlopen_model_catalog_request", side_effect=urlopen
+    ):
+        with pytest.raises(RuntimeError, match="load"):
+            models.ensure_lmstudio_model_loaded(
+                "large-local",
+                "http://localhost:1234/v1",
+                None,
+                65_536,
+                transition_policy="sequential",
+            )
+        assert state["resident"] is None
+        assert models.ensure_lmstudio_model_loaded(
+            "small-local",
+            "http://localhost:1234/v1",
+            None,
+            65_536,
+            transition_policy="sequential",
+        ) == 65_536
+
+    assert state["resident"] == "small-local"
+    assert events == [
+        ("unload", "small-local"),
+        ("load", "large-local"),
+        ("load", "small-local"),
+    ]

--- a/tests/hermes_cli/test_rich_fallback_runtime.py
+++ b/tests/hermes_cli/test_rich_fallback_runtime.py
@@ -1,0 +1,200 @@
+"""Contract tests for rich, route-specific fallback runtime resolution."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def test_rich_fallback_runtime_uses_central_resolver_and_route_overrides():
+    from hermes_cli.fallback_config import resolve_fallback_runtime
+
+    entry = {
+        "provider": "custom:local",
+        "model": "large-local",
+        "base_url": "http://localhost:1234/v1",
+        "transport": "chat_completions",
+        "context_length": 65_536,
+        "max_output_tokens": 16_384,
+        "extra_body": {
+            "temperature": 1.0,
+            "top_p": 0.95,
+            "top_k": 20,
+            "presence_penalty": 1.5,
+        },
+        "request_timeout_seconds": 600,
+        "model_transition_policy": "sequential",
+    }
+    named_runtime = {
+        "provider": "custom",
+        "requested_provider": "custom:local",
+        "base_url": "http://localhost:1234/v1",
+        "api_key": "local-key",
+        "api_mode": "chat_completions",
+        "context_length": 32_768,
+        "max_output_tokens": 4_096,
+        "request_overrides": {"extra_body": {"named_default": True}},
+    }
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value=named_runtime,
+    ) as resolve:
+        runtime = resolve_fallback_runtime(entry)
+
+    resolve.assert_called_once_with(
+        requested="custom:local",
+        explicit_api_key=None,
+        explicit_base_url="http://localhost:1234/v1",
+        target_model="large-local",
+    )
+    assert runtime["model"] == "large-local"
+    assert runtime["api_mode"] == "chat_completions"
+    assert runtime["context_length"] == 65_536
+    assert runtime["max_output_tokens"] == 16_384
+    assert runtime["request_timeout_seconds"] == 600.0
+    assert runtime["model_transition_policy"] == "sequential"
+    assert runtime["request_overrides"] == {
+        "extra_body": {
+            "named_default": True,
+            "temperature": 1.0,
+            "top_p": 0.95,
+            "top_k": 20,
+            "presence_penalty": 1.5,
+        }
+    }
+
+
+def test_fallback_normalization_filters_unknown_route_keys():
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    chain = get_fallback_chain(
+        {
+            "fallback_providers": [
+                {
+                    "provider": "lmstudio",
+                    "model": "local-model",
+                    "base_url": "http://localhost:1234/v1/",
+                    "context_length": 65_536,
+                    "max_tokens": 16_384,
+                    "extra_body": {"temperature": 0.8},
+                    "extra_headers": {"X-Route": 7, "X-Drop": None},
+                    "arbitrary_payload": {"unsafe": True},
+                    "request_overrides": {"stream": True},
+                }
+            ]
+        }
+    )
+
+    assert chain == [
+        {
+            "provider": "lmstudio",
+            "model": "local-model",
+            "base_url": "http://localhost:1234/v1",
+            "context_length": 65_536,
+            "max_tokens": 16_384,
+            "extra_body": {"temperature": 0.8},
+            "extra_headers": {"X-Route": "7"},
+        }
+    ]
+
+
+def test_fallback_api_mode_uses_canonical_runtime_allowlist():
+    from hermes_cli.fallback_config import normalize_fallback_entry
+    from hermes_cli.runtime_provider import _VALID_API_MODES
+
+    for mode in _VALID_API_MODES:
+        normalized = normalize_fallback_entry(
+            {"provider": "custom", "model": "model", "api_mode": mode.upper()}
+        )
+        assert normalized is not None
+        assert normalized["api_mode"] == mode
+
+    normalized = normalize_fallback_entry(
+        {"provider": "custom", "model": "model", "api_mode": "future_stale_mode"}
+    )
+    assert normalized is not None
+    assert "api_mode" not in normalized
+
+
+def test_same_endpoint_distinct_models_remain_ordered_and_nondeduplicated():
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    first = {
+        "provider": "lmstudio",
+        "model": "large-local",
+        "base_url": "http://localhost:1234/v1",
+    }
+    second = {
+        "provider": "lmstudio",
+        "model": "small-local",
+        "base_url": "http://localhost:1234/v1",
+    }
+    assert get_fallback_chain({"fallback_providers": [first, second]}) == [first, second]
+
+
+def test_legacy_simple_fallback_merge_semantics_are_unchanged():
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    modern = {"provider": "openrouter", "model": "modern"}
+    duplicate_legacy = {"provider": "openrouter", "model": "modern"}
+    distinct_legacy = {"provider": "openai", "model": "legacy"}
+    assert get_fallback_chain(
+        {
+            "fallback_providers": [modern],
+            "fallback_model": [duplicate_legacy, distinct_legacy],
+        }
+    ) == [modern, distinct_legacy]
+
+
+def test_fallback_runtime_does_not_invent_provider_specific_or_anthropic_routing():
+    from hermes_cli.fallback_config import resolve_fallback_runtime
+
+    resolved = {
+        "provider": "lmstudio",
+        "requested_provider": "lmstudio",
+        "base_url": "http://localhost:1234/v1",
+        "api_key": "local",
+        "api_mode": "chat_completions",
+    }
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value=resolved,
+    ):
+        runtime = resolve_fallback_runtime(
+            {"provider": "lmstudio", "model": "local-model"}
+        )
+
+    assert runtime["provider"] == "lmstudio"
+    assert runtime["api_mode"] == "chat_completions"
+    assert "anthropic" not in repr(runtime).lower()
+
+
+def test_fallback_runtime_does_not_swallow_disabled_provider_error():
+    from hermes_cli.fallback_config import resolve_fallback_runtime
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        side_effect=ValueError(
+            "provider 'lmstudio' is disabled in config "
+            "(providers.lmstudio.enabled: false)"
+        ),
+    ):
+        with pytest.raises(ValueError, match="is disabled in config"):
+            resolve_fallback_runtime(
+                {"provider": "lmstudio", "model": "local-model"}
+            )
+
+
+def test_fallback_runtime_alias_cannot_bypass_disabled_canonical_provider():
+    from hermes_cli.fallback_config import resolve_fallback_runtime
+
+    config = {"providers": {"kimi-coding": {"enabled": False}}}
+    with patch("hermes_cli.config.load_config", return_value=config):
+        with pytest.raises(ValueError, match="providers.kimi-coding.enabled"):
+            resolve_fallback_runtime(
+                {
+                    "provider": "kimi",
+                    "model": "kimi-k2.5",
+                    "api_key": "fixture-key",
+                }
+            )

--- a/tests/run_agent/test_fallback_credential_isolation.py
+++ b/tests/run_agent/test_fallback_credential_isolation.py
@@ -27,10 +27,16 @@ def _make_pool(provider, n_entries=1):
     entry = MagicMock()
     entry.id = f"{provider}-entry-0"
     entry.runtime_api_key = f"key-{provider}"
-    entry.runtime_base_url = f"https://{provider}.example.com/v1"
+    runtime_base_url = (
+        "https://chatgpt.com/backend-api/codex"
+        if provider == "openai-codex"
+        else f"https://{provider}.example.com/v1"
+    )
+    entry.runtime_base_url = runtime_base_url
     entry.access_token = f"token-{provider}"
-    entry.base_url = f"https://{provider}.example.com/v1"
+    entry.base_url = runtime_base_url
     pool.current.return_value = entry
+    pool.select.return_value = entry
     pool.mark_exhausted_and_rotate.return_value = entry
     return pool
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -7,6 +7,7 @@ advancement through multiple providers.
 
 from unittest.mock import MagicMock, patch
 
+from agent.error_classifier import FailoverReason
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
@@ -371,3 +372,246 @@ class TestFallbackChainDedup:
         assert called == [("xai", "grok-4.5")]
         assert agent.provider == "xai"
         assert agent.model == "grok-4.5"
+
+
+class TestRichFallbackActivation:
+    def test_oauth_fallback_uses_constructed_client_endpoint_not_route_hint(self):
+        fallback = {
+            "provider": "openai-codex",
+            "model": "gpt-5.3-codex",
+            "base_url": "https://attacker.invalid/v1",
+        }
+        agent = _make_agent(fallback_model=[fallback])
+        runtime = {
+            "provider": "openai-codex",
+            "requested_provider": "openai-codex",
+            "model": "gpt-5.3-codex",
+            "base_url": "https://attacker.invalid/v1",
+            "api_key": "oauth-token",
+            "api_mode": "codex_responses",
+        }
+        client = _mock_client(
+            "https://chatgpt.com/backend-api/codex", "oauth-token"
+        )
+
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "hermes_cli.fallback_config.resolve_fallback_runtime",
+                return_value=runtime,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(client, "gpt-5.3-codex"),
+            ),
+        ):
+            assert (
+                agent._try_activate_fallback(reason=FailoverReason.format_error)
+                is True
+            )
+
+        canonical_url = "https://chatgpt.com/backend-api/codex"
+        client_kwargs = getattr(agent, "_client_kwargs")
+        assert agent.base_url == canonical_url
+        assert client_kwargs["base_url"] == canonical_url
+        assert "attacker.invalid" not in repr(client_kwargs)
+
+    def test_hard_400_fallback_applies_route_context_output_and_request_settings(self):
+        fallback = {
+            "provider": "lmstudio",
+            "model": "large-local",
+            "base_url": "http://localhost:1234/v1",
+            "context_length": 65_536,
+            "max_output_tokens": 16_384,
+            "extra_body": {"temperature": 1.0, "top_p": 0.95, "top_k": 20},
+            "model_transition_policy": "sequential",
+        }
+        agent = _make_agent(fallback_model=[fallback])
+        agent.provider = "openai-codex"
+        agent.model = "primary-model"
+        agent.base_url = "https://primary.invalid/v1"
+        agent.max_tokens = 777
+        agent.request_overrides = {"extra_body": {"primary": True}}
+        agent._config_context_length = 200_000
+        agent.__dict__["lmstudio_load_mode"] = "jit"
+        agent._primary_runtime.update(
+            {
+                "provider": "openai-codex",
+                "model": "primary-model",
+                "base_url": "https://primary.invalid/v1",
+                "max_tokens": 777,
+                "request_overrides": {"extra_body": {"primary": True}},
+                "config_context_length": 200_000,
+            }
+        )
+        runtime = {
+            "provider": "lmstudio",
+            "requested_provider": "lmstudio",
+            "model": "large-local",
+            "base_url": "http://localhost:1234/v1",
+            "api_key": "local-key",
+            "api_mode": "chat_completions",
+            "context_length": 65_536,
+            "max_output_tokens": 16_384,
+            "request_overrides": {
+                "extra_body": {"temperature": 1.0, "top_p": 0.95, "top_k": 20}
+            },
+            "model_transition_policy": "sequential",
+        }
+
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "hermes_cli.fallback_config.resolve_fallback_runtime",
+                return_value=runtime,
+            ) as resolve_runtime,
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client("http://localhost:1234/v1", "local-key"), None),
+            ),
+            patch(
+                "hermes_cli.models.ensure_lmstudio_model_loaded",
+                return_value=65_536,
+            ) as ensure_loaded,
+        ):
+            assert agent._try_activate_fallback(reason=FailoverReason.format_error) is True
+
+        resolve_runtime.assert_called_once_with(fallback)
+        ensure_loaded.assert_called_once_with(
+            "large-local",
+            "http://localhost:1234/v1",
+            "local-key",
+            65_536,
+            timeout=120.0,
+            transition_policy="sequential",
+            require_context_minimum=True,
+        )
+        assert agent.provider == "lmstudio"
+        assert agent.model == "large-local"
+        assert agent._config_context_length == 65_536
+        assert agent.max_tokens == 16_384
+        assert agent.request_overrides == runtime["request_overrides"]
+        # The primary snapshot remains available for rollback or a later route.
+        assert agent._primary_runtime["max_tokens"] == 777
+        assert agent._primary_runtime["request_overrides"] == {
+            "extra_body": {"primary": True}
+        }
+
+    def test_partial_first_activation_rolls_back_before_next_route(self):
+        fallbacks = [
+            {
+                "provider": "lmstudio",
+                "model": "large-local",
+                "base_url": "http://localhost:1234/v1",
+            },
+            {
+                "provider": "lmstudio",
+                "model": "small-local",
+                "base_url": "http://localhost:1234/v1",
+            },
+        ]
+        agent = _make_agent(fallback_model=fallbacks)
+        primary_client = agent.client
+        agent.provider = "openai-codex"
+        agent.model = "primary-model"
+        agent.base_url = "https://primary.invalid/v1"
+        agent.max_tokens = 777
+        agent.request_overrides = {"extra_body": {"primary": True}}
+        agent._config_context_length = 200_000
+        agent._cached_system_prompt = "primary prompt"
+        agent._primary_runtime.update(
+            {
+                "provider": "openai-codex",
+                "model": "primary-model",
+                "base_url": "https://primary.invalid/v1",
+                "max_tokens": 777,
+                "request_overrides": {"extra_body": {"primary": True}},
+                "config_context_length": 200_000,
+            }
+        )
+        first_runtime = {
+            "provider": "lmstudio",
+            "requested_provider": "lmstudio",
+            "model": "large-local",
+            "base_url": "http://localhost:1234/v1",
+            "api_key": "local-key",
+            "api_mode": "chat_completions",
+            "context_length": 65_536,
+            "max_output_tokens": 16_384,
+            "request_overrides": {"extra_body": {"route": "large"}},
+        }
+        second_runtime = {
+            "provider": "lmstudio",
+            "requested_provider": "lmstudio",
+            "model": "small-local",
+            "base_url": "http://localhost:1234/v1",
+            "api_key": "local-key",
+            "api_mode": "chat_completions",
+            "context_length": 32_768,
+            "max_output_tokens": 4_096,
+            "request_overrides": {"extra_body": {"route": "small"}},
+        }
+        resolution_count = 0
+
+        def resolve_runtime(entry):
+            nonlocal resolution_count
+            resolution_count += 1
+            if resolution_count == 1:
+                return first_runtime
+            # The first route failed after mutating runtime state. It must have
+            # been restored atomically before route two is even resolved.
+            assert agent.provider == "openai-codex"
+            assert agent.model == "primary-model"
+            assert agent.base_url == "https://primary.invalid/v1"
+            assert agent.client is primary_client
+            assert agent.max_tokens == 777
+            assert agent.request_overrides == {"extra_body": {"primary": True}}
+            assert agent._config_context_length == 200_000
+            assert agent._cached_system_prompt == "primary prompt"
+            return second_runtime
+
+        def rewrite_identity(target, model, provider):
+            target._cached_system_prompt = f"{provider}/{model}"
+
+        # Fail after the first route has applied settings and rewritten the
+        # prompt; the recursive route walk must see a fully restored primary.
+        agent._buffer_status = MagicMock(side_effect=[RuntimeError("late activation failure"), None])
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "hermes_cli.fallback_config.resolve_fallback_runtime",
+                side_effect=resolve_runtime,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                side_effect=[
+                    (_mock_client("http://localhost:1234/v1"), None),
+                    (_mock_client("http://localhost:1234/v1"), None),
+                ],
+            ),
+            patch(
+                "hermes_cli.models.ensure_lmstudio_model_loaded",
+                side_effect=[65_536, 64_000],
+            ),
+            patch(
+                "agent.chat_completion_helpers.rewrite_prompt_model_identity",
+                side_effect=rewrite_identity,
+            ),
+        ):
+            assert agent._try_activate_fallback(reason=FailoverReason.format_error) is True
+
+        assert resolution_count == 2
+        assert agent.model == "small-local"
+        assert agent._config_context_length == 32_768
+        assert agent.max_tokens == 4_096
+        assert agent.request_overrides == {"extra_body": {"route": "small"}}
+        assert agent._cached_system_prompt == "lmstudio/small-local"

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -97,6 +97,64 @@ fallback_providers:
     key_env: MY_LOCAL_KEY            # env var name containing the API key
 ```
 
+### Route-Specific Runtime Settings
+
+Fallback entries can carry the same endpoint and request settings as a named
+custom provider. Explicit values on the fallback entry override the named
+provider's defaults:
+
+```yaml
+fallback_providers:
+  - provider: lmstudio
+    model: openai/gpt-oss-120b
+    base_url: http://localhost:1234/v1
+    context_length: 65536
+    max_output_tokens: 16384
+    request_timeout_seconds: 120
+    extra_body:
+      temperature: 1.0
+      top_p: 0.95
+      top_k: 20
+```
+
+Supported route fields are `base_url`, `api_key`, `key_env` (or
+`api_key_env`), `api_mode` (or `transport`), `context_length`,
+`max_output_tokens` (or `max_tokens`), `request_timeout_seconds` (or
+`timeout`), `extra_headers`, and `extra_body`. Invalid values and unsupported
+top-level keys are ignored rather than forwarded to the provider SDK.
+
+Hermes applies provider, model, client, API mode, timeout, context, output
+limit, and request overrides as one runtime transition. If activation fails,
+the prior runtime is restored before Hermes tries the next chain entry.
+
+#### Sequential LM Studio transitions
+
+On memory-constrained machines that can host only one large LLM at a time,
+opt in per route with `model_transition_policy: sequential`:
+
+```yaml
+fallback_providers:
+  - provider: lmstudio
+    model: openai/gpt-oss-120b
+    base_url: http://localhost:1234/v1
+    context_length: 65536
+    model_transition_policy: sequential
+  - provider: lmstudio
+    model: qwen/qwen3-coder-30b
+    base_url: http://localhost:1234/v1
+    context_length: 65536
+    model_transition_policy: sequential
+```
+
+For a sequential route, Hermes discovers loaded instances, unloads conflicting
+LLM instances through LM Studio's documented REST API, then loads the target
+with `parallel=1` to keep KV-cache concurrency memory-bounded. Embedding models
+are not unloaded. Unloads use a short bounded timeout; model loads use the
+route's longer bounded timeout. Hermes requests and verifies the configured
+context length exactly—if the model's maximum or LM Studio's actual load result
+is below that minimum, that fallback fails and the chain advances. Without this
+option, existing LM Studio loading behavior is unchanged.
+
 ### When Fallback Triggers
 
 The fallback activates automatically when the primary model fails with:
@@ -109,9 +167,9 @@ The fallback activates automatically when the primary model fails with:
 
 When triggered, Hermes:
 
-1. Resolves credentials for the fallback provider
-2. Builds a new API client
-3. Swaps the model, provider, and client in-place
+1. Resolves the complete fallback runtime and credentials
+2. Validates any required local-model transition and builds a new API client
+3. Atomically swaps the model, provider, client, and route-specific request settings
 4. Resets the retry counter and continues the conversation
 
 The switch is seamless — your conversation history, tool calls, and context are preserved. The agent continues from exactly where it left off, just using a different model.


### PR DESCRIPTION
## Summary

- make `fallback_providers` rich route objects flow through main, auxiliary, cron, and resume paths without collapsing to model-only strings
- add bounded sequential LM Studio transitions that unload only conflicting non-embedding LLMs, load with `parallel=1`, verify context/parallel state, and restore primary runtime state safely
- apply route-specific provider/model, endpoint, scoped credentials, timeout, context/output limits, `extra_body`, and `extra_headers`, including refreshed auxiliary retries
- harden provider-disable handling across aliases and prevent first-party OAuth credentials from following untrusted route URL hints
- document the rich route contract and add regression coverage for activation rollback, credential isolation, scheduler forwarding, and real local model transitions

## Verification

- Focused fallback suite: `60 passed`
- Added rich-runtime + auxiliary-header contracts: `10 passed`
- Scheduler forwarding regression: `1 passed`
- Broad impacted suite: `363 passed, 1 failed`; the failure is the pre-existing timing-sensitive Codex stream timeout assertion. The identical test failed on untouched `origin/main` at `0.1444s < 0.14`, and passed standalone on this branch.
- Real LM Studio smoke:
  - `qwen3.5-122b-a10b` loaded at context `65536`, `parallel=1`; non-empty inference
  - `qwen/qwen3.6-27b` restored at context `65536`, `parallel=1`; non-empty inference
  - same-model no-op activation completed and final `restored_27b=true`
- Isolated installed-environment contract: `3 passed` (imports from isolated artifact copy, rich route resolution, sequential transition)
- `ruff check .`: passed
- Windows footgun scan: passed (`826` files)
- changed runtime `compileall`: passed
- `git diff --check`: passed
- lint differential versus untouched `origin/main`: Ruff `0 -> 0`; ty has no new code diagnostics and six fewer diagnostics overall. Both refs hit the same known `ty` panic in unchanged `tools/checkpoint_manager.py` (absolute-path/solver-ID text makes it appear as one new and one fixed panic).
- `npm run build`: passed for both Docusaurus locales; repository-existing broken-link/anchor warnings remain
- Independent fresh-context Codex logic/security review: `PASS`, no blocking findings

## Packaging note

A direct wheel build is intentionally rejected by the repository's distribution policy unless `HERMES_NIX_BUILD=1` is set. Rather than bypass that policy, verification used a clean source snapshot in `/tmp`, an isolated venv, and a PEP 660 install; all three installed-package contracts passed.

## Non-blocking baseline notes

- `npm ci` reports existing dependency audit findings: 2 low, 5 moderate, 8 high, 1 critical.
- The advisory `ty` gate still panics on unchanged `tools/checkpoint_manager.py` on both branch and baseline.
