### PR TITLE
fix(update): repair missing Node workspaces on no-op

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10104,6 +10104,29 @@ def _npm_lockfile_changed(hermes_root: Path) -> bool:
     # node_modules means the cache was recorded by another checkout.
     if not (PROJECT_ROOT / "node_modules").is_dir():
         return True
+    # A root node_modules directory alone is not enough for npm workspaces.
+    # A scoped install for another workspace can leave that directory and the
+    # manifest digest intact while removing the TUI/dashboard links. Require
+    # each runtime workspace link whenever its source manifest exists.
+    required_workspace_links = (
+        (
+            PROJECT_ROOT / "ui-tui" / "package.json",
+            PROJECT_ROOT / "node_modules" / "hermes-tui",
+        ),
+        (
+            PROJECT_ROOT / "ui-tui" / "packages" / "hermes-ink" / "package.json",
+            PROJECT_ROOT / "node_modules" / "@hermes" / "ink",
+        ),
+        (
+            PROJECT_ROOT / "web" / "package.json",
+            PROJECT_ROOT / "node_modules" / "web",
+        ),
+    )
+    if any(
+        source.is_file() and not installed.exists()
+        for source, installed in required_workspace_links
+    ):
+        return True
     try:
         # Key the cache by PROJECT_ROOT so parallel worktrees don't collide.
         cache_key = hashlib.sha256(str(PROJECT_ROOT).encode()).hexdigest()[:12]
@@ -10212,7 +10235,7 @@ def _update_node_dependencies() -> list[str]:
                 (PROJECT_ROOT / workspace / "package.json").exists()
                 for workspace in ("ui-tui", "web")
             ):
-                failed.append("ui-tui, web workspaces")
+                failed.append("ui-tui, @hermes/ink, web workspaces")
             return failed
         return []
 
@@ -10269,9 +10292,20 @@ def _update_node_dependencies() -> list[str]:
             print(f"    {stderr.splitlines()[-1]}")
         return _partial_update_failure("repo root")
 
-    # Step 2: install only the workspaces update needs (ui-tui, web).
+    # Step 2: install only the workspaces update needs. Select the nested Ink
+    # workspace explicitly: selecting ui-tui alone does not guarantee npm
+    # recreates node_modules/@hermes/ink after another scoped install removed
+    # that link.
     # --workspace selects specific workspaces; the rest (desktop) are skipped.
-    ws_args = [*extra_args, "--workspace", "ui-tui", "--workspace", "web"]
+    ws_args = [
+        *extra_args,
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "ui-tui/packages/hermes-ink",
+        "--workspace",
+        "web",
+    ]
     ws_result = _run_npm_install_deterministic(
         npm,
         PROJECT_ROOT,
@@ -10281,14 +10315,40 @@ def _update_node_dependencies() -> list[str]:
     )
     if ws_result.returncode == 0:
         _record_npm_lockfile_hash(shared_hermes_root)
-        print("  ✓ repo root + ui-tui, web workspaces (desktop skipped)")
+        print("  ✓ repo root + ui-tui, @hermes/ink, web workspaces (desktop skipped)")
         return []
 
     print("  ⚠ npm workspace install failed")
     stderr = (ws_result.stderr or "").strip() if ws_result.stderr else ""
     if stderr:
         print(f"    {stderr.splitlines()[-1]}")
-    return _partial_update_failure("ui-tui, web workspaces")
+    return _partial_update_failure("ui-tui, @hermes/ink, web workspaces")
+
+
+def _repair_node_dependencies_if_needed() -> bool:
+    """Repair stale or missing runtime workspaces on a zero-commit update.
+
+    Returns True when an install was performed. A failed repair exits nonzero
+    so ``hermes update`` cannot report an unhealthy checkout as current.
+    """
+    if not (PROJECT_ROOT / "package.json").is_file():
+        return False
+
+    from hermes_constants import get_default_hermes_root
+
+    if not _npm_lockfile_changed(get_default_hermes_root()):
+        return False
+
+    print("→ Repairing Node.js workspace dependencies...")
+    node_failures = _update_node_dependencies()
+    if node_failures:
+        failed_labels = ", ".join(node_failures)
+        print(f"✗ Node.js workspace dependency repair failed ({failed_labels}).")
+        print("  Fix npm/Node.js, then re-run: hermes update")
+        raise SystemExit(1)
+
+    print("✓ Node.js workspace dependencies repaired!")
+    return True
 
 
 class _UpdateOutputStream:
@@ -12020,7 +12080,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
-            else:
+            node_repaired = _repair_node_dependencies_if_needed()
+
+            if healthy and not node_repaired:
                 print("✓ Already up to date!")
             if runtime_repaired is not None and not _is_windows():
                 print()

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -67,7 +67,8 @@ def _patch_managed_uv(request):
 
     with patch("hermes_cli.managed_uv.resolve_uv", side_effect=_fake_resolve_uv), \
          patch("hermes_cli.managed_uv.ensure_uv", side_effect=_fake_ensure_uv), \
-         patch("hermes_cli.managed_uv.update_managed_uv", side_effect=_fake_update_managed_uv):
+         patch("hermes_cli.managed_uv.update_managed_uv", side_effect=_fake_update_managed_uv), \
+         patch("hermes_cli.main._repair_node_dependencies_if_needed", return_value=False):
         yield
 
 
@@ -118,6 +119,36 @@ class TestCmdUpdateNpmLockfileCache:
 
         assert hm._npm_lockfile_changed(tmp_path) is True
 
+    def test_npm_lockfile_changed_when_core_workspace_link_is_missing(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        (tmp_path / "package-lock.json").write_text('{"lockfileVersion": 3}')
+        (tmp_path / "package.json").write_text(
+            '{"workspaces": ["ui-tui", "ui-tui/packages/*", "web"]}'
+        )
+        for manifest in (
+            tmp_path / "ui-tui" / "package.json",
+            tmp_path / "ui-tui" / "packages" / "hermes-ink" / "package.json",
+            tmp_path / "web" / "package.json",
+        ):
+            manifest.parent.mkdir(parents=True, exist_ok=True)
+            manifest.write_text("{}")
+        for installed in (
+            tmp_path / "node_modules" / "hermes-tui",
+            tmp_path / "node_modules" / "@hermes" / "ink",
+            tmp_path / "node_modules" / "web",
+        ):
+            installed.mkdir(parents=True)
+
+        hm._record_npm_lockfile_hash(tmp_path)
+        assert hm._npm_lockfile_changed(tmp_path) is False
+
+        (tmp_path / "node_modules" / "@hermes" / "ink").rmdir()
+        assert hm._npm_lockfile_changed(tmp_path) is True
+
     def test_record_npm_lockfile_hash(self, tmp_path, monkeypatch):
         from hermes_cli import main as hm
 
@@ -165,6 +196,7 @@ class TestCmdUpdateNpmLockfileCache:
         (tmp_path / "apps" / "desktop").mkdir(parents=True)
         (tmp_path / "apps" / "desktop" / "package.json").write_text("{}")
         (tmp_path / "node_modules").mkdir()
+        (tmp_path / "node_modules" / "hermes-tui").mkdir()
         hm._record_npm_lockfile_hash(tmp_path)
         assert hm._npm_lockfile_changed(tmp_path) is False
 
@@ -380,6 +412,24 @@ class TestCmdUpdateBranchFallback:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
+    def test_update_already_current_repairs_node_workspaces(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+        with patch.object(
+            hm, "_repair_node_dependencies_if_needed", return_value=True
+        ) as repair:
+            cmd_update(mock_args)
+
+        repair.assert_called_once_with()
+        assert "Already up to date!" not in capsys.readouterr().out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
     def test_zero_commit_runtime_repair_requires_process_restart(
         self, mock_run, _mock_which, mock_args, capsys, tmp_path
     ):
@@ -475,7 +525,7 @@ class TestCmdUpdateBranchFallback:
 
         # cmd_update runs npm commands in these locations:
         #   1. repo root  — root-only install (--workspaces=false)
-        #   2. repo root  — workspace install (--workspace ui-tui --workspace web)
+        #   2. repo root  — scoped ui-tui, @hermes/ink, and web install
         #   3. web/       — npm ci --silent (if lockfile not at root)
         #                  via _build_web_ui (subprocess.run)
         #   4. web/       — npm run build (_run_with_idle_timeout)
@@ -507,6 +557,8 @@ class TestCmdUpdateBranchFallback:
             "--progress=false",
             "--workspace",
             "ui-tui",
+            "--workspace",
+            "ui-tui/packages/hermes-ink",
             "--workspace",
             "web",
         ]

--- a/tests/hermes_cli/test_update_node_workspace_repair.py
+++ b/tests/hermes_cli/test_update_node_workspace_repair.py
@@ -1,0 +1,68 @@
+"""Regression tests for zero-commit Node workspace repair."""
+
+from unittest.mock import patch
+
+import pytest
+
+import hermes_constants
+from hermes_cli import main as hm
+
+
+def _prepare_project(tmp_path, monkeypatch):
+    monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "package.json").write_text("{}")
+    monkeypatch.setattr(hermes_constants, "get_default_hermes_root", lambda: tmp_path)
+
+
+def test_zero_commit_node_repair_skips_healthy_install(
+    tmp_path, monkeypatch, capsys
+):
+    _prepare_project(tmp_path, monkeypatch)
+
+    with (
+        patch.object(hm, "_npm_lockfile_changed", return_value=False),
+        patch.object(hm, "_update_node_dependencies") as update,
+    ):
+        assert hm._repair_node_dependencies_if_needed() is False
+
+    update.assert_not_called()
+    assert capsys.readouterr().out == ""
+
+
+def test_zero_commit_node_repair_runs_when_workspace_install_is_unhealthy(
+    tmp_path, monkeypatch, capsys
+):
+    _prepare_project(tmp_path, monkeypatch)
+
+    with (
+        patch.object(hm, "_npm_lockfile_changed", return_value=True),
+        patch.object(hm, "_update_node_dependencies", return_value=[]) as update,
+    ):
+        assert hm._repair_node_dependencies_if_needed() is True
+
+    update.assert_called_once_with()
+    out = capsys.readouterr().out
+    assert "Repairing Node.js workspace dependencies" in out
+    assert "Node.js workspace dependencies repaired" in out
+
+
+def test_zero_commit_node_repair_exits_nonzero_on_install_failure(
+    tmp_path, monkeypatch, capsys
+):
+    _prepare_project(tmp_path, monkeypatch)
+
+    with (
+        patch.object(hm, "_npm_lockfile_changed", return_value=True),
+        patch.object(
+            hm,
+            "_update_node_dependencies",
+            return_value=["ui-tui, @hermes/ink, web workspaces"],
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        hm._repair_node_dependencies_if_needed()
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "dependency repair failed" in out
+    assert "re-run: hermes update" in out


### PR DESCRIPTION
## Summary

Repair missing runtime Node workspace links even when a checkout has zero new Git commits, and select the nested `@hermes/ink` workspace explicitly during update.

## Problem

`_update_node_dependencies()` currently caches only the root lock/manifest digest plus the existence of `node_modules/`. A scoped npm operation can leave that directory and cache digest intact while deleting one or more runtime workspace links:

- `node_modules/hermes-tui`
- `node_modules/@hermes/ink`
- `node_modules/web`

The updater then skips npm forever. On a zero-commit update it prints `Already up to date!`, even though TUI/Web type resolution or builds are broken.

The current scoped install also selects `ui-tui` and `web`, but not the nested `ui-tui/packages/hermes-ink` workspace explicitly. Selecting the parent does not reliably recreate the nested workspace link after another scoped install removes it.

## Changes

- treat any missing runtime workspace link as an invalid npm cache when its source manifest exists
- explicitly select all three runtime workspaces:
  - `ui-tui`
  - `ui-tui/packages/hermes-ink`
  - `web`
- include `@hermes/ink` in success/failure reporting
- add `_repair_node_dependencies_if_needed()` to the zero-commit update path, symmetric with the existing unhealthy-venv repair
- suppress `Already up to date!` when a repair actually ran
- exit nonzero when the repair fails instead of claiming a healthy/current installation
- add healthy-skip, repair-success, repair-failure, missing-link cache, command-shape, and no-op updater regressions

No fork/upstream synchronization or local-commit update behavior changes.

## Verification

On base `b9ba7c78e41b5d187e2c8fb446655c4b71c42aa5`:

- updater modules: **55 tests passed, 0 failed**
- Ruff: pass
- `git diff --check`: pass

Real end-to-end execution in a disposable checkout (only the cache-root accessor redirected to `/tmp`; npm and updater code were real):

1. removed all three runtime workspace links
2. `_repair_node_dependencies_if_needed()` ran actual root + scoped npm installs
3. all three links were restored
4. a second call returned `False` and did not run npm
5. removed only `node_modules/@hermes/ink`
6. repair detected and recreated it
7. `node_modules/hermes` remained absent, proving Desktop was still skipped

The repaired graph then passed:

- TUI/Ink check: typecheck, lint, **1,389 passed / 1 skipped**
- TUI production build: pass
- Web check: typecheck, **106 passed**, lint with 0 errors
- Web production build: pass
