### PR TITLE
fix: translate cache paths to container-visible paths in truncation footers (#72389)

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2752,6 +2752,9 @@ def _truncate_snapshot(snapshot_text: str, max_chars: int = SNAPSHOT_SUMMARIZE_T
         return snapshot_text
 
     stored_path = _store_full_snapshot(snapshot_text)
+    if stored_path is not None:
+        from tools.credential_files import to_agent_visible_cache_path
+        stored_path = to_agent_visible_cache_path(stored_path)
 
     lines = snapshot_text.split('\n')
     result: list[str] = []

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -545,6 +545,9 @@ def _truncate_with_footer(
 
     total = len(content)
     stored_path = _store_full_text(url, content)
+    if stored_path is not None:
+        from tools.credential_files import to_agent_visible_cache_path
+        stored_path = to_agent_visible_cache_path(stored_path)
     shown = len(head) + len(tail)
 
     footer_lines = [


### PR DESCRIPTION
## Summary

When `web_extract` or `browser_snapshot` truncates long content, the footer includes a `read_file` command pointing to the stored full text in `cache/web`. These paths are host-absolute (e.g. `/home/user/.hermes/cache/web/...`) which is unreachable from Docker backends where the mount point is `/root/.hermes/cache/web/...`.

This translates `stored_path` through `to_agent_visible_cache_path()` before embedding it in the footer, so the suggested `read_file` command works on Docker backends without manual path substitution.

## Changes

- `tools/web_tools.py`: In `_truncate_with_footer()`, translate `stored_path` via `to_agent_visible_cache_path()` after `_store_full_text()` returns.
- `tools/browser_tool.py`: In `_truncate_snapshot()`, translate `stored_path` via `to_agent_visible_cache_path()` after `_store_full_snapshot()` returns.

## Test Plan

- [x] `tests/tools/test_web_tools_truncate.py` — 12 passed
- [x] `tests/tools/test_browser_hardening.py::TestTruncateSnapshot` — 8 passed
- [ ] Manual Docker backend verification: run `web_extract` on a long page, confirm footer path uses `/root/.hermes/cache/web/...`

Fixes #72389
