### PR TITLE
fix(doctor): detect OpenRouter credential pool keys

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -102,6 +102,38 @@ def _safe_which(cmd: str) -> str | None:
         return None
 
 
+def _resolve_openrouter_doctor_key() -> str:
+    """Resolve OpenRouter auth from dotenv/environment or its credential pool.
+
+    ``hermes auth add openrouter`` stores manual keys in the credential pool,
+    while Doctor historically checked only the environment. Use ``peek``
+    rather than ``select`` so diagnosis cannot advance pool rotation or mutate
+    inference state.
+    """
+    try:
+        from hermes_cli.auth import has_usable_secret
+        from hermes_cli.config import get_env_value_prefer_dotenv
+
+        key = (get_env_value_prefer_dotenv("OPENROUTER_API_KEY") or "").strip()
+        if has_usable_secret(key):
+            return key
+
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("openrouter")
+        entry = pool.peek() if pool and pool.has_credentials() else None
+        key = str(
+            getattr(entry, "runtime_api_key", "")
+            or getattr(entry, "access_token", "")
+            or ""
+        ).strip()
+        return key if has_usable_secret(key) else ""
+    except Exception:
+        # Doctor should report an unavailable probe, not crash because an auth
+        # store is unreadable or temporarily locked.
+        return ""
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -2017,7 +2049,7 @@ def run_doctor(args):
     _probes: list = []  # list of (label, callable) submitted in display order
 
     def _probe_openrouter() -> _ConnectivityResult:
-        key = os.getenv("OPENROUTER_API_KEY")
+        key = _resolve_openrouter_doctor_key()
         if not key:
             return _ConnectivityResult(
                 "OpenRouter API",

--- a/tests/hermes_cli/test_doctor_openrouter_pool.py
+++ b/tests/hermes_cli/test_doctor_openrouter_pool.py
@@ -1,0 +1,83 @@
+"""Regression tests for OpenRouter credential-pool detection in Doctor."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.doctor import _resolve_openrouter_doctor_key
+
+
+def test_doctor_resolves_manual_openrouter_pool_credential_without_rotation():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.peek.return_value = SimpleNamespace(access_token="manual-pool-key")
+
+    with (
+        patch("hermes_cli.config.get_env_value_prefer_dotenv", return_value=None),
+        patch("agent.credential_pool.load_pool", return_value=pool) as load_pool,
+    ):
+        assert _resolve_openrouter_doctor_key() == "manual-pool-key"
+
+    load_pool.assert_called_once_with("openrouter")
+    pool.peek.assert_called_once_with()
+    pool.select.assert_not_called()
+
+
+def test_doctor_prefers_dotenv_openrouter_key_without_loading_pool():
+    with (
+        patch(
+            "hermes_cli.config.get_env_value_prefer_dotenv",
+            return_value="dotenv-key",
+        ),
+        patch("agent.credential_pool.load_pool") as load_pool,
+    ):
+        assert _resolve_openrouter_doctor_key() == "dotenv-key"
+
+    load_pool.assert_not_called()
+
+
+def test_doctor_accepts_runtime_api_key_from_pool_entry():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.peek.return_value = SimpleNamespace(
+        runtime_api_key="runtime-pool-key",
+        access_token="stored-token",
+    )
+
+    with (
+        patch("hermes_cli.config.get_env_value_prefer_dotenv", return_value=None),
+        patch("agent.credential_pool.load_pool", return_value=pool),
+    ):
+        assert _resolve_openrouter_doctor_key() == "runtime-pool-key"
+
+
+def test_doctor_rejects_placeholder_pool_secret():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.peek.return_value = SimpleNamespace(access_token="placeholder")
+
+    with (
+        patch("hermes_cli.config.get_env_value_prefer_dotenv", return_value=None),
+        patch("agent.credential_pool.load_pool", return_value=pool),
+    ):
+        assert _resolve_openrouter_doctor_key() == ""
+
+
+def test_doctor_returns_empty_for_empty_pool_without_peeking():
+    pool = MagicMock()
+    pool.has_credentials.return_value = False
+
+    with (
+        patch("hermes_cli.config.get_env_value_prefer_dotenv", return_value=None),
+        patch("agent.credential_pool.load_pool", return_value=pool),
+    ):
+        assert _resolve_openrouter_doctor_key() == ""
+
+    pool.peek.assert_not_called()
+
+
+def test_doctor_returns_empty_when_auth_store_is_unreadable():
+    with (
+        patch("hermes_cli.config.get_env_value_prefer_dotenv", return_value=None),
+        patch("agent.credential_pool.load_pool", side_effect=OSError("locked")),
+    ):
+        assert _resolve_openrouter_doctor_key() == ""


### PR DESCRIPTION
## Summary

Teach `hermes doctor` to recognize OpenRouter credentials stored by `hermes auth add openrouter`, without rotating or mutating the credential pool.

## Problem

The OpenRouter connectivity probe currently reads only `os.getenv("OPENROUTER_API_KEY")`.

Manual credentials added through Hermes auth are stored in the provider credential pool, so Doctor can report `OpenRouter API (not configured)` while inference is correctly authenticated through that pool.

## Changes

Add `_resolve_openrouter_doctor_key()` with this precedence:

1. Hermes-managed dotenv/environment resolution via `get_env_value_prefer_dotenv`
2. OpenRouter credential pool via non-mutating `peek()`
3. prefer `runtime_api_key`, then `access_token`
4. reject empty/placeholder secrets through the existing `has_usable_secret` contract
5. degrade to an unavailable probe when the auth store is unreadable rather than crashing Doctor

The resolver deliberately does **not** call `select()`, so diagnosis cannot advance rotation or alter inference state.

## Verification

On base `b9ba7c78e41b5d187e2c8fb446655c4b71c42aa5`:

- all Hermes CLI Doctor modules: **97 tests passed, 0 failed**
- new cases cover:
  - manual pool token
  - dotenv precedence / pool not loaded
  - `runtime_api_key` preference
  - placeholder rejection
  - empty pool without `peek()`
  - unreadable store fallback
  - explicit `select()` non-use
- Ruff: pass
- `git diff --check`: pass

Real persistence-path check with an isolated temporary `HERMES_HOME`:

1. wrote a synthetic OpenRouter entry through `write_credential_pool`
2. resolved it through the production Doctor helper
3. confirmed the result came from the pool
4. confirmed `auth.json` was byte-identical before and after

No user credentials or live auth store were used.
