### PR TITLE
fix(gateway): redact recognizable secrets in verbose-mode tool-progress args

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2899,7 +2899,20 @@ class BasePlatformAdapter(ABC):
         if mode == "verbose":
             if event.args:
                 import json
-                args_str = json.dumps(event.args, ensure_ascii=False, default=str)
+                from agent.display import redact_tool_args_for_display
+                # Verbose mode renders the full args dict, unlike the
+                # capped preview path below (build_tool_preview()) which
+                # already redacts. Without this, a browser_type call
+                # carrying a credential typed into a form (e.g. pulled from
+                # a password manager) reached chat history verbatim in
+                # verbose mode, even though the SAME tool's own result
+                # payload was already redacted via
+                # redact_browser_typed_text_for_display() in
+                # tools/browser_tool.py -- this call's arguments (rendered
+                # here BEFORE the tool even runs) were a separate,
+                # unguarded surface (issue #72298, #10520).
+                safe_args = redact_tool_args_for_display(event.tool_name, event.args) or event.args
+                args_str = json.dumps(safe_args, ensure_ascii=False, default=str)
                 if preview_max_len > 0 and len(args_str) > preview_max_len:
                     args_str = args_str[:preview_max_len - 3] + "..."
                 return f"{emoji} {event.tool_name}({list(event.args.keys())})\n{args_str}"

--- a/tests/gateway/test_stream_events.py
+++ b/tests/gateway/test_stream_events.py
@@ -180,3 +180,61 @@ def test_dispatch_swallows_render_errors():
     adapter.render_message_event = _boom
     d = GatewayEventDispatcher(adapter, _FakeSink())
     d.dispatch(MessageChunk("x"))  # must not raise
+
+
+# ── Verbose-mode tool arg redaction (issue #72298, #10520) ──────────────────
+
+class TestVerboseModeToolArgRedaction:
+    """A browser_type call carrying a recognizable-secret value (e.g. an API
+    key pulled from a password manager) must be redacted in the verbose
+    tool-progress display, not just in the tool's own RESULT payload
+    (tools/browser_tool.py already redacts that separately via
+    redact_browser_typed_text_for_display()). This is the display-side gap
+    the automated review on the stalled #10661 flagged: verbose mode
+    serialized event.args directly with no redaction pass at all, so a
+    credential-shaped value reached chat history before the tool even ran.
+    """
+
+    def test_recognizable_secret_in_browser_type_args_is_redacted(self):
+        adapter = _base_adapter()
+        event = ToolCallChunk(
+            tool_name="browser_type",
+            args={"ref": "@e3", "text": "sk-ant-api03-FAKEsecretvalue1234567890abcdefgh"},
+        )
+        rendered = adapter.format_tool_event(event, mode="verbose", preview_max_len=0)
+        assert "sk-ant-api03-FAKEsecretvalue1234567890abcdefgh" not in rendered, (
+            f"Recognizable secret leaked into verbose tool-progress display: {rendered!r}"
+        )
+
+    def test_normal_typed_text_stays_readable(self):
+        """The existing contract (commit 6c58878e7, test_display.py) keeps
+        normal typed text visible for debuggability -- this fix must not
+        regress that by over-redacting."""
+        adapter = _base_adapter()
+        event = ToolCallChunk(
+            tool_name="browser_type",
+            args={"ref": "@e3", "text": "123 Main Street, Springfield"},
+        )
+        rendered = adapter.format_tool_event(event, mode="verbose", preview_max_len=0)
+        assert "123 Main Street, Springfield" in rendered
+
+    def test_non_browser_type_tool_args_unaffected(self):
+        """redact_tool_args_for_display() is browser_type-specific; other
+        tools' verbose args must render exactly as before."""
+        adapter = _base_adapter()
+        event = ToolCallChunk(
+            tool_name="terminal",
+            args={"command": "ls -la /home/user"},
+        )
+        rendered = adapter.format_tool_event(event, mode="verbose", preview_max_len=0)
+        assert "ls -la /home/user" in rendered
+
+    def test_compact_and_new_modes_unaffected(self):
+        """This fix only touches the verbose branch; compact preview modes
+        already went through build_tool_preview()'s own redaction path and
+        must render unchanged."""
+        adapter = _base_adapter()
+        event = ToolCallChunk(tool_name="terminal", preview="ls -la")
+        for mode in ("all", "new"):
+            rendered = adapter.format_tool_event(event, mode=mode)
+            assert rendered is not None


### PR DESCRIPTION
## Context

Addresses #72298 (duplicate of the still-open #10520).

## Problem

A `browser_type` call typing a credential (pulled from a password manager) into a web form reached Telegram chat history in plaintext, visible in the "Typing..." tool-progress indicator.

`tools/browser_tool.py`'s `browser_type()` already redacts recognizable secrets in its own RESULT payload, and `agent/tool_executor.py`'s logging/callback paths already call `redact_tool_args_for_display()` at every construction site (apparently hardened since the stalled #10661 was opened in April). But `gateway/platforms/base.py::format_tool_event()`'s verbose-mode branch serialized `event.args` -- the raw tool CALL arguments, rendered before the tool even runs -- directly via `json.dumps()` with no redaction at all.

## Fix

Apply the existing `redact_tool_args_for_display()` to `event.args` before serializing in the verbose branch.

## Scope note

Per @teknium1's review of the stalled #10661 (which this does NOT supersede -- that PR's approach of unconditionally hiding all typed text conflicts with the existing "normal typed text stays readable" contract asserted by `tests/agent/test_display.py`): this closes the one remaining unguarded display surface the review identified. It does NOT change the underlying redaction policy (pattern-based secret detection, not password-field-type detection) -- a human-chosen password that doesn't match any recognized secret pattern still isn't redacted here, same as elsewhere in the codebase. Moving to field-type-based redaction is the broader policy decision the review flagged and is out of scope for this targeted fix.

## Verification

4 new tests pass; 83/83 in the full `tests/gateway/test_stream_events.py` + `tests/agent/test_display.py` files (no regression to the existing readability contract).