### PR TITLE
feat(gateway): add authenticated async dispatch hook

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3371,11 +3371,12 @@ _DEFAULT_TRANSIENT_RETRIES = 2
 _TRANSIENT_RETRY_BACKOFF_BASE = 1.0
 
 
-def _transient_retry_count() -> int:
+def _transient_retry_count(task: Optional[str] = None) -> int:
     """Number of same-provider retries for a transient transport blip.
 
-    Read from ``auxiliary.transient_retries`` in config.yaml (default 2 →
-    3 total attempts). Clamped to [0, 6] to bound worst-case wall time. A
+    Read first from ``auxiliary.<task>.transient_retries``, then from the
+    global ``auxiliary.transient_retries`` in config.yaml (default 2 → 3 total
+    attempts). Clamped to [0, 6] to bound worst-case wall time. A
     connection blip to a pinned auxiliary target (e.g. a MoA reference
     advisor) has no meaningful provider fallback, so a couple of retries with
     backoff is the difference between recovering and silently losing the call.
@@ -3384,7 +3385,10 @@ def _transient_retry_count() -> int:
     try:
         from hermes_cli.config import cfg_get, load_config
 
-        val = cfg_get(load_config(), "auxiliary", "transient_retries")
+        config = load_config()
+        val = cfg_get(config, "auxiliary", task, "transient_retries") if task else None
+        if val is None:
+            val = cfg_get(config, "auxiliary", "transient_retries")
         if val is None:
             return _DEFAULT_TRANSIENT_RETRIES
         n = int(val)
@@ -7906,7 +7910,7 @@ def call_llm(
                     transient_err,
                 )
                 raise
-            _max_transient_retries = _transient_retry_count()
+            _max_transient_retries = _transient_retry_count(task)
             _last_transient = transient_err
             for _attempt in range(1, _max_transient_retries + 1):
                 _backoff = min(_TRANSIENT_RETRY_BACKOFF_BASE * (2.0 ** (_attempt - 1)), 8.0)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12474,6 +12474,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "please resend shortly."
             )
 
+        # Authenticated fast-path plugins run only after authorization,
+        # slash-command/control handling, lobby routing, and drain checks.
+        # This is deliberately awaitable so a bounded network lookup can
+        # return directly without creating or inflating an agent session.
+        if not is_internal:
+            try:
+                from hermes_cli.plugins import invoke_hook_async as _invoke_hook_async
+
+                _post_auth_results = await _invoke_hook_async(
+                    "post_auth_gateway_dispatch",
+                    event=event,
+                    gateway=self,
+                    session_store=self.session_store,
+                    session_key=_quick_key,
+                    adapter=self._adapter_for_source(source),
+                )
+            except Exception as _hook_exc:
+                logger.warning("post_auth_gateway_dispatch invocation failed: %s", _hook_exc)
+                _post_auth_results = []
+
+            for _result in _post_auth_results:
+                if not isinstance(_result, dict):
+                    continue
+                _action = str(_result.get("action", "")).strip().lower()
+                if _action == "reply":
+                    _reply = _result.get("text")
+                    if isinstance(_reply, str):
+                        return _reply
+                if _action == "skip":
+                    logger.info(
+                        "post_auth_gateway_dispatch skip: reason=%s session=%s",
+                        _result.get("reason"),
+                        _quick_key,
+                    )
+                    return None
+                if _action == "rewrite":
+                    _new_text = _result.get("text")
+                    if isinstance(_new_text, str):
+                        event = dataclasses.replace(event, text=_new_text)
+                        source = event.source
+                    break
+                if _action == "allow":
+                    break
+
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
         # are numerous await points (hooks, vision enrichment, STT,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -171,6 +171,11 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Authenticated, awaitable gateway hook. Fired after authorization and
+    # command/control interception, immediately before an agent session is
+    # claimed. Plugins may return allow, skip, rewrite, or reply actions.
+    # Kwargs: event, gateway, session_store, session_key, adapter.
+    "post_auth_gateway_dispatch",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.
@@ -1945,6 +1950,32 @@ class PluginManager:
                 )
         return results
 
+    async def invoke_hook_async(self, hook_name: str, **kwargs: Any) -> List[Any]:
+        """Call registered callbacks, awaiting async results when necessary.
+
+        Failures are isolated per callback, matching :meth:`invoke_hook`.
+        Synchronous callbacks remain supported so plugins can migrate without
+        changing their registration shape.
+        """
+        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        callbacks = self._hooks.get(hook_name, [])
+        results: List[Any] = []
+        for cb in callbacks:
+            try:
+                ret = cb(**kwargs)
+                if inspect.isawaitable(ret):
+                    ret = await ret
+                if ret is not None:
+                    results.append(ret)
+            except Exception as exc:
+                logger.warning(
+                    "Async hook '%s' callback %s raised: %s",
+                    hook_name,
+                    getattr(cb, "__name__", repr(cb)),
+                    exc,
+                )
+        return results
+
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
@@ -2071,6 +2102,11 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+async def invoke_hook_async(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Invoke a lifecycle hook and await async plugin callbacks."""
+    return await get_plugin_manager().invoke_hook_async(hook_name, **kwargs)
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3369,6 +3369,22 @@ class TestTransientTransportRetry:
         assert primary.chat.completions.create.call_count == 2
         assert fb_client.chat.completions.create.call_count == 1
 
+    def test_transient_retry_policy_receives_auxiliary_task_name(self):
+        primary = MagicMock()
+        primary.base_url = "https://openrouter.ai/api/v1"
+        primary.chat.completions.create.side_effect = Exception("connection reset by peer")
+        p1, p2, p3 = self._patches(primary)
+        with (
+            p1, p2, p3,
+            patch("agent.auxiliary_client._transient_retry_count", return_value=0) as retry_count,
+            patch("agent.auxiliary_client._try_configured_fallback_chain", return_value=(None, None, "")),
+            patch("agent.auxiliary_client._try_main_agent_model_fallback", return_value=(None, None, None)),
+            pytest.raises(Exception, match="connection reset"),
+        ):
+            call_llm(task="kyss_fast_lane", messages=[{"role": "user", "content": "hi"}])
+        retry_count.assert_called_once_with("kyss_fast_lane")
+        assert primary.chat.completions.create.call_count == 1
+
     def test_compression_skips_same_provider_retry_on_timeout(self):
         """A timeout on the critical compression path must NOT retry the same
         provider (that doubles the user-visible stall, issue #54465) — it

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -177,3 +177,38 @@ async def test_internal_events_bypass_hook(monkeypatch):
     # Even though the hook would say skip, internal events bypass it.
     await runner._handle_message(event)
     assert called["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_post_auth_hook_replies_without_starting_agent(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+
+    async def _fake_async_hook(name, **kwargs):
+        assert name == "post_auth_gateway_dispatch"
+        assert kwargs["session_key"]
+        return [{"action": "reply", "text": "fast answer"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", _fake_async_hook)
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    runner._handle_message_with_agent = AsyncMock(side_effect=AssertionError("agent must not start"))
+
+    assert await runner._handle_message(_make_event("quick search")) == "fast answer"
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_auth_hook_is_not_called_for_unauthorized_sender(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    called = {"count": 0}
+
+    async def _fake_async_hook(name, **kwargs):
+        called["count"] += 1
+        return [{"action": "reply", "text": "unsafe"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", _fake_async_hook)
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    runner.pairing_store.generate_code.return_value = None
+
+    assert await runner._handle_message(_make_event("quick search")) is None
+    assert called["count"] == 0

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -635,6 +635,26 @@ class TestPluginHooks:
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS
 
+    def test_valid_hooks_include_post_auth_gateway_dispatch(self):
+        assert "post_auth_gateway_dispatch" in VALID_HOOKS
+
+    @pytest.mark.asyncio
+    async def test_async_hook_awaits_callbacks_and_isolates_failures(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir, "async_dispatch_plugin",
+            register_body=(
+                "async def callback(**kw):\n"
+                "        return {'action': 'reply', 'text': 'fast'}\n"
+                "    ctx.register_hook('post_auth_gateway_dispatch', callback)"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        mgr = PluginManager()
+        mgr.discover_and_load()
+        results = await mgr.invoke_hook_async("post_auth_gateway_dispatch", event=object())
+        assert results == [{"action": "reply", "text": "fast"}]
+
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"


### PR DESCRIPTION
## Outcome

Add an authenticated, awaitable gateway dispatch hook after authorization and command/control handling. Plugins can return `reply`, `skip`, `rewrite`, or `allow` without creating a full agent session.

Also allow auxiliary tasks to set a task-specific transient retry count. This keeps latency-bounded routes from multiplying their timeout while preserving the existing global retry default elsewhere.

## Why

Pre-auth gateway hooks cannot safely serve user-specific fast paths. Ordinary requests currently have to enter the full session and inherit large histories, tools, and multi-call loops. A post-auth hook gives bounded plugins a safe interception point while leaving authorization, commands, drain handling, and full-agent fallback intact.

## Safety

- Internal events bypass the hook.
- Unauthorized senders cannot reach it.
- Callback failures are isolated and fail open.
- Existing synchronous plugin callbacks remain supported.
- Per-task retries fall back to the existing global policy when unset.

## Evidence

- Targeted gateway, plugin, and auxiliary-client suite: 488 tests passed on current upstream main.
- `git diff --check` passed.
