### PR TITLE
fix(tests): require pytest when probing for a virtualenv

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -33,17 +33,44 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ── Activate venv ───────────────────────────────────────────────────────────
+# Probe order matters: repo-local venvs win over the shared ~/.hermes one.
+# A venv only qualifies if pytest is actually importable — a venv that exists
+# but was never populated (or was created for a different purpose) would
+# otherwise shadow a working one later in the list and fail with a bare
+# "No module named pytest".
+CANDIDATES=("$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv")
 VENV=""
-for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
-  if [ -f "$candidate/bin/activate" ]; then
+SKIPPED_NO_PYTEST=()
+
+for candidate in "${CANDIDATES[@]}"; do
+  [ -x "$candidate/bin/python" ] || continue
+  if "$candidate/bin/python" -c "import pytest" >/dev/null 2>&1; then
     VENV="$candidate"
     break
   fi
+  SKIPPED_NO_PYTEST+=("$candidate")
 done
 
 if [ -z "$VENV" ]; then
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+  if [ ${#SKIPPED_NO_PYTEST[@]} -gt 0 ]; then
+    echo "error: found virtualenv(s) without pytest installed:" >&2
+    for v in "${SKIPPED_NO_PYTEST[@]}"; do
+      echo "         $v" >&2
+    done
+    echo "       install the dev extras into one of them, e.g.:" >&2
+    echo "         ${SKIPPED_NO_PYTEST[0]}/bin/python -m pip install -e '.[dev]'" >&2
+  else
+    echo "error: no virtualenv found. Looked in:" >&2
+    for c in "${CANDIDATES[@]}"; do
+      echo "         $c" >&2
+    done
+  fi
   exit 1
+fi
+
+if [ ${#SKIPPED_NO_PYTEST[@]} -gt 0 ]; then
+  echo "note: skipped venv without pytest: ${SKIPPED_NO_PYTEST[*]}" >&2
+  echo "      using $VENV" >&2
 fi
 
 PYTHON="$VENV/bin/python"


### PR DESCRIPTION
## Problem

`scripts/run_tests.sh` picks a virtualenv on the existence of `bin/activate` alone:

```bash
for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
  if [ -f "$candidate/bin/activate" ]; then
```

A checkout carrying a `.venv` that was created for something else — or that never had the dev extras installed — wins the probe and the run dies with a bare `No module named pytest`, even when a fully populated `venv/` sits right next to it. The probe order reads like a preference list but behaves as a hard first-match.

Observed on a checkout with both directories present:

```
$ scripts/run_tests.sh tests/agent/test_subdirectory_hints.py
Discovered 1 test files (0 tests) ...
  ║ /Users/…/.venv/bin/python: No module named pytest
=== Summary: 1 files, 0 tests passed, 0 failed (0% complete) ===
```

Note the summary reports **0 failed** — the run looks green at a glance. The practical workaround is to call `pytest` directly, which is exactly what this wrapper exists to prevent.

## Change

A candidate now has to prove `import pytest` succeeds before it is accepted, so the order expresses preference rather than first-match. Two diagnostics come with it:

- venvs that exist but lack pytest are named on stderr along with the one actually chosen, so a surprising interpreter selection is visible rather than silent
- when nothing qualifies, the error lists every path tried and the `pip install -e '.[dev]'` command to fix it

## Verification

Same checkout, after the change:

```
note: skipped venv without pytest: /Users/…/.venv
      using /Users/…/venv
=== Summary: 1 files, 32 tests passed, 0 failed (100% complete) ===
```

Both failure paths exercised against scratch directories:

- no venv at all → error names all three probed paths
- venv present without pytest → error names it and prints the pip command

`bash -n` clean.
