### PR TITLE
fix(model_normalize): strip aggregator provider prefix to prevent double-namespacing (#72418)

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -410,6 +410,18 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     # --- Aggregators: need vendor/model format ---
     if provider in _AGGREGATOR_PROVIDERS:
+        # Strip matching provider prefix to avoid double-namespacing
+        # e.g. "openrouter/deepseek-v4-pro" → "deepseek-v4-pro" →
+        # "deepseek/deepseek-v4-pro" (issue #72418).
+        stripped = _strip_matching_provider_prefix(name, provider)
+        if stripped != name:
+            result = _prepend_vendor(stripped)
+            # Only accept if vendor detection succeeded; otherwise the
+            # original prefix was probably the correct vendor (e.g.
+            # "nous/hermes-3" on the nous provider).
+            if "/" in result:
+                return result
+            return name
         return _prepend_vendor(name)
 
     # --- OpenCode Zen / OpenCode Go: flat-namespace resellers.

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -163,6 +163,16 @@ class TestAggregatorProviders:
         result = normalize_model_for_provider("anthropic/claude-sonnet-4.6", "openrouter")
         assert result == "anthropic/claude-sonnet-4.6"
 
+    def test_provider_prefix_stripped_before_vendor_prepend(self):
+        """openrouter/deepseek-v4-pro → deepseek/deepseek-v4-pro (#72418)."""
+        result = normalize_model_for_provider("openrouter/deepseek-v4-pro", "openrouter")
+        assert result == "deepseek/deepseek-v4-pro"
+
+    def test_provider_prefix_kept_when_vendor_unknown(self):
+        """nous/hermes-3 stays as-is since 'hermes' has no known vendor."""
+        result = normalize_model_for_provider("nous/hermes-3", "nous")
+        assert result == "nous/hermes-3"
+
 
 class TestIssue6211NativeProviderPrefixNormalization:
     @pytest.mark.parametrize("model,target_provider,expected", [


### PR DESCRIPTION
## Summary

When a model name carries the aggregator provider as its prefix (e.g. `openrouter/deepseek-v4-pro` when the target provider is `openrouter`), `_prepend_vendor()` sees the `/` and returns the name unchanged. OpenRouter then rejects it with HTTP 400 "not a valid model ID" because the correct slug is `deepseek/deepseek-v4-pro`.

## Root Cause

`_prepend_vendor()` at `hermes_cli/model_normalize.py:330` passes through any name containing `/`:

```python
if "/" in model_name:
    return model_name  # ← passes through even if prefix = provider, not vendor
```

When the aggregator provider path at line 412 calls `_prepend_vendor(name)` directly, a name like `openrouter/deepseek-v4-pro` survives untouched.

## Fix

Strip the matching aggregator provider prefix before calling `_prepend_vendor()`. If vendor detection succeeds after stripping, use the re-vendored result. If vendor detection fails (the original prefix was probably the correct vendor, e.g. `nous/hermes-3`), preserve the original name unchanged.

## Changes

- `hermes_cli/model_normalize.py`: In the aggregator branch of `normalize_model_for_provider`, call `_strip_matching_provider_prefix(name, provider)` before `_prepend_vendor()`. Only accept the re-vendored result if vendor detection adds a prefix.
- `tests/hermes_cli/test_model_normalize.py`: Two new test cases in `TestAggregatorProviders`:
  - `test_provider_prefix_stripped_before_vendor_prepend`: `openrouter/deepseek-v4-pro` → `deepseek/deepseek-v4-pro`
  - `test_provider_prefix_kept_when_vendor_unknown`: `nous/hermes-3` → `nous/hermes-3` (preserved)

## Test Plan

- [x] All 87 tests in `test_model_normalize.py` pass
- [x] Existing aggregator tests still pass (`openrouter` + `nous` vendor prepend)
- [x] Existing `test_vendor_already_present` still passes (`anthropic/claude-sonnet-4.6` on openrouter)

Fixes #72418