### PR TITLE
feat(conformance): ingress mirror — pure parse cores + ingress vector generator

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -79,6 +79,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
 )
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.platforms.whatsapp_cloud_parse import parse_cloud_message
 from gateway import rich_sent_store
 from hermes_constants import get_hermes_dir
 
@@ -1887,62 +1888,33 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if handled:
                 return None
 
-        body = ""
-        if msg_type_str == "text":
-            text = raw_message.get("text") or {}
-            body = str(text.get("body") or "")
-        elif msg_type_str in {"button", "interactive"}:
-            # Quick-reply buttons. Treat the button payload as text so the
-            # agent can reason about the user's choice.
-            if msg_type_str == "button":
-                body = str((raw_message.get("button") or {}).get("text") or "")
-            else:
-                inter = raw_message.get("interactive") or {}
-                # button_reply / list_reply both expose ``title``
-                inner = inter.get("button_reply") or inter.get("list_reply") or {}
-                body = str(inner.get("title") or "")
-        elif msg_type_str in {"image", "video", "audio", "voice", "document", "sticker"}:
-            # Captions live on image / video / document. Other media types
-            # don't carry a caption in Meta's spec, but be defensive.
-            inner = raw_message.get(msg_type_str) or {}
-            body = str(inner.get("caption") or "")
+        # Payload-only field derivation lives in the PURE parse core
+        # (whatsapp_cloud_parse.parse_cloud_message) — the same code the
+        # ingress conformance vector generator runs, so the connector's
+        # normalizer is tested against exactly what this adapter does.
+        # Everything below is the adapter-side effectful half: gating,
+        # media download, text injection, quoted-text resolution, caches.
+        parsed = parse_cloud_message(raw_message, contacts_by_waid, metadata)
+        body = parsed.body
+        message_type = parsed.message_type
+        sender_id = parsed.sender_id
+        sender_name = parsed.sender_name
 
-        message_type = {
-            "text": MessageType.TEXT,
-            "image": MessageType.PHOTO,
-            "video": MessageType.VIDEO,
-            "audio": MessageType.VOICE,
-            "voice": MessageType.VOICE,
-            "document": MessageType.DOCUMENT,
-            "sticker": MessageType.PHOTO,
-            "button": MessageType.TEXT,
-            "interactive": MessageType.TEXT,
-            "location": MessageType.TEXT,
-            "contacts": MessageType.TEXT,
-        }.get(msg_type_str, MessageType.TEXT)
-
-        sender_id = str(raw_message.get("from") or "").strip()
-        sender_name = contacts_by_waid.get(sender_id, "")
-
-        # Cloud API doesn't have a separate "chat" entity for DMs — chat_id
-        # equals the sender's wa_id. Group support is deferred to v2.
-        #
         # Defensive guard: if Meta ever delivers a group-shaped payload
         # (group support is capability-tier gated by Meta; some WABAs
         # have it enabled), refuse rather than silently treating it as
         # a DM. Group messages carry a ``chat`` field on the message
         # object identifying the group JID — its absence signals DM.
-        chat_field = raw_message.get("chat")
-        if chat_field:
+        if parsed.group_shaped:
             logger.warning(
                 "[whatsapp_cloud] received group-shaped message (chat=%s, "
                 "wamid=%s) — group support is not yet implemented; dropping. "
                 "Use the Baileys whatsapp adapter for group chats.",
-                chat_field, raw_message.get("id"),
+                raw_message.get("chat"), raw_message.get("id"),
             )
             return None
 
-        chat_id = sender_id
+        chat_id = parsed.chat_id
 
         # Build the data dict the mixin's _should_process_message expects.
         # Cloud API uses different field names from Baileys, so we adapt.

--- a/gateway/platforms/whatsapp_cloud_parse.py
+++ b/gateway/platforms/whatsapp_cloud_parse.py
@@ -1,0 +1,157 @@
+"""Pure parse core for WhatsApp Cloud API inbound messages.
+
+Extracted from ``WhatsAppCloudAdapter._build_message_event_from_cloud``
+(gateway/platforms/whatsapp_cloud.py) so the field-derivation logic — type
+mapping, body extraction, sender/chat resolution, reply context, the
+group-shape refusal — is importable WITHOUT adapter state. The adapter
+delegates here (single source of truth); the ingress conformance vector
+generator (scripts/generate_ingress_vectors.py) renders synthetic Cloud
+payloads through this SAME code, making it the executable spec for the
+connector's WhatsApp normalizer.
+
+Deliberately excluded (adapter-side, effectful): interactive-reply dispatch,
+allow-list/broadcast gating (_should_process_message), media download +
+text-document injection, rich_sent_store lookups (quoted TEXT resolution),
+and the last-wamid typing cache. The core derives every field that exists
+in the payload alone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from gateway.platforms.base import MessageType
+
+#: Cloud message types that carry a downloadable media object.
+CLOUD_MEDIA_TYPES = frozenset(
+    {"image", "video", "audio", "voice", "document", "sticker"}
+)
+
+#: Cloud ``type`` → Hermes MessageType (verbatim from the adapter).
+CLOUD_MESSAGE_TYPE_MAP: Dict[str, MessageType] = {
+    "text": MessageType.TEXT,
+    "image": MessageType.PHOTO,
+    "video": MessageType.VIDEO,
+    "audio": MessageType.VOICE,
+    "voice": MessageType.VOICE,
+    "document": MessageType.DOCUMENT,
+    "sticker": MessageType.PHOTO,
+    "button": MessageType.TEXT,
+    "interactive": MessageType.TEXT,
+    "location": MessageType.TEXT,
+    "contacts": MessageType.TEXT,
+}
+
+
+@dataclass
+class CloudParsedMessage:
+    """Payload-derivable fields of one Cloud inbound message."""
+
+    msg_type_str: str
+    message_type: MessageType
+    body: str
+    sender_id: str
+    sender_name: str
+    chat_id: str
+    wamid: Optional[str]
+    reply_to_id: Optional[str]
+    reply_to_is_own: bool
+    #: Media object ``id`` + ``mime_type`` when present (download is the
+    #: adapter's job; the core only derives WHAT to download).
+    media_id: Optional[str] = None
+    media_mime: Optional[str] = None
+    document_filename: Optional[str] = None
+    #: True when the payload is group-shaped (``chat`` field present) —
+    #: the Cloud adapter REFUSES these (Baileys handles groups).
+    group_shaped: bool = False
+    contacts_by_waid: Dict[str, str] = field(default_factory=dict)
+
+
+def parse_cloud_message(
+    raw_message: Dict[str, Any],
+    contacts_by_waid: Dict[str, str],
+    metadata: Dict[str, Any],
+) -> CloudParsedMessage:
+    """Derive every payload-only field of a Cloud inbound message.
+
+    Pure: no I/O, no adapter state. Mirrors the extraction order of
+    ``_build_message_event_from_cloud`` exactly; behavior changes here MUST
+    be reflected in the committed ingress conformance vectors (regenerate)
+    and reviewed against the connector's normalizer.
+    """
+    msg_type_str = str(raw_message.get("type") or "text").lower()
+
+    body = ""
+    if msg_type_str == "text":
+        text = raw_message.get("text") or {}
+        body = str(text.get("body") or "")
+    elif msg_type_str in {"button", "interactive"}:
+        if msg_type_str == "button":
+            body = str((raw_message.get("button") or {}).get("text") or "")
+        else:
+            inter = raw_message.get("interactive") or {}
+            inner = inter.get("button_reply") or inter.get("list_reply") or {}
+            body = str(inner.get("title") or "")
+    elif msg_type_str in CLOUD_MEDIA_TYPES:
+        inner = raw_message.get(msg_type_str) or {}
+        body = str(inner.get("caption") or "")
+
+    message_type = CLOUD_MESSAGE_TYPE_MAP.get(msg_type_str, MessageType.TEXT)
+
+    sender_id = str(raw_message.get("from") or "").strip()
+    sender_name = contacts_by_waid.get(sender_id, "")
+    chat_id = sender_id
+
+    group_shaped = bool(raw_message.get("chat"))
+
+    media_id: Optional[str] = None
+    media_mime: Optional[str] = None
+    document_filename: Optional[str] = None
+    if msg_type_str in CLOUD_MEDIA_TYPES:
+        inner = raw_message.get(msg_type_str) or {}
+        media_id = str(inner.get("id") or "").strip() or None
+        media_mime = str(inner.get("mime_type") or "").strip() or None
+        if msg_type_str == "document":
+            document_filename = str(inner.get("filename") or "").strip() or None
+
+    context = raw_message.get("context") or {}
+    reply_to_id = str(context.get("id") or "").strip() or None
+    reply_to_is_own = False
+    if reply_to_id:
+        quoted_from = str(context.get("from") or "").strip()
+        our_number = str(metadata.get("display_phone_number") or "").strip()
+        if quoted_from and our_number:
+            reply_to_is_own = quoted_from == our_number
+
+    wamid = str(raw_message.get("id") or "") or None
+
+    return CloudParsedMessage(
+        msg_type_str=msg_type_str,
+        message_type=message_type,
+        body=body,
+        sender_id=sender_id,
+        sender_name=sender_name,
+        chat_id=chat_id,
+        wamid=wamid,
+        reply_to_id=reply_to_id,
+        reply_to_is_own=reply_to_is_own,
+        media_id=media_id,
+        media_mime=media_mime,
+        document_filename=document_filename,
+        group_shaped=group_shaped,
+        contacts_by_waid=dict(contacts_by_waid),
+    )
+
+
+def document_fallback_body(parsed: CloudParsedMessage) -> str:
+    """The ``[Document: name]`` placeholder used when a document has no
+    caption — same rule as the adapter (applied only after a successful
+    media download, which is adapter-side)."""
+    if (
+        parsed.msg_type_str == "document"
+        and not parsed.body
+        and parsed.document_filename
+    ):
+        return f"[Document: {parsed.document_filename}]"
+    return parsed.body

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5795,20 +5795,29 @@ class DiscordAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _is_discord_voice_message_attachment(att: Any) -> bool:
-        """Return True when a Discord audio attachment is a native voice note."""
-        marker = getattr(att, "is_voice_message", None)
-        if marker is not None:
-            if callable(marker):
-                try:
-                    return bool(marker())
-                except Exception as exc:
-                    logger.debug("[Discord] is_voice_message() failed for attachment: %s", exc)
-                    return False
-            return bool(marker)
+        """Return True when a Discord audio attachment is a native voice note.
 
-        return (
-            getattr(att, "duration", None) is not None
-            and getattr(att, "waveform", None) is not None
+        Delegates to the PURE parse core (discord_parse) — the same rule the
+        ingress conformance vector generator exercises.
+        """
+        from plugins.platforms.discord.discord_parse import (
+            AttachmentView,
+            is_voice_message_attachment,
+        )
+
+        marker = getattr(att, "is_voice_message", None)
+        if marker is not None and callable(marker):
+            try:
+                marker = bool(marker())
+            except Exception as exc:
+                logger.debug("[Discord] is_voice_message() failed for attachment: %s", exc)
+                return False
+        return is_voice_message_attachment(
+            AttachmentView(
+                is_voice_message=marker,
+                duration=getattr(att, "duration", None),
+                waveform=getattr(att, "waveform", None),
+            )
         )
 
     def _discord_free_response_channels(self) -> set:
@@ -7022,20 +7031,30 @@ class DiscordAdapter(BasePlatformAdapter):
         return topic
 
     def _format_thread_chat_name(self, thread: Any) -> str:
-        """Build a readable chat name for thread-like Discord channels, including forum context when available."""
-        thread_name = getattr(thread, "name", None) or str(getattr(thread, "id", "thread"))
+        """Build a readable chat name for thread-like Discord channels, including forum context when available.
+
+        Delegates to the PURE parse core (discord_parse.thread_chat_name) —
+        the same naming rules the ingress conformance vectors pin.
+        """
+        from plugins.platforms.discord.discord_parse import (
+            DiscordMessageView,
+            thread_chat_name,
+        )
+
         parent = getattr(thread, "parent", None)
         guild = getattr(thread, "guild", None) or getattr(parent, "guild", None)
-        guild_name = getattr(guild, "name", None)
-        parent_name = getattr(parent, "name", None)
-
-        if self._is_forum_parent(parent) and guild_name and parent_name:
-            return f"{guild_name} / {parent_name} / {thread_name}"
-        if parent_name and guild_name:
-            return f"{guild_name} / #{parent_name} / {thread_name}"
-        if parent_name:
-            return f"{parent_name} / {thread_name}"
-        return thread_name
+        return thread_chat_name(
+            DiscordMessageView(
+                message_id="",
+                content="",
+                channel_id=str(getattr(thread, "id", "thread")),
+                channel_name=getattr(thread, "name", None),
+                channel_kind="thread",
+                guild_name=getattr(guild, "name", None),
+                parent_channel_name=getattr(parent, "name", None),
+                parent_is_forum=self._is_forum_parent(parent),
+            )
+        )
 
     # ------------------------------------------------------------------
     # Attachment download helpers
@@ -7328,34 +7347,39 @@ class DiscordAdapter(BasePlatformAdapter):
 
         all_attachments = list(message.attachments) + snapshot_attachments + referenced_attachments
 
-        # Determine message type
-        msg_type = MessageType.TEXT
-        if normalized_content.startswith("/"):
-            msg_type = MessageType.COMMAND
-        elif all_attachments:
-            # Check attachment types. Any non-media attachment is treated as a
-            # DOCUMENT regardless of extension — authorization to message the
-            # agent is the gate, not the file type.
-            for att in all_attachments:
-                if att.content_type:
-                    if att.content_type.startswith("image/"):
-                        msg_type = MessageType.PHOTO
-                    elif att.content_type.startswith("video/"):
-                        msg_type = MessageType.VIDEO
-                    elif att.content_type.startswith("audio/"):
-                        if self._is_discord_voice_message_attachment(att):
-                            msg_type = MessageType.VOICE
-                        else:
-                            msg_type = MessageType.AUDIO
-                    else:
-                        msg_type = MessageType.DOCUMENT
-                    break
-                else:
-                    # No content_type at all (rare — discord usually fills it
-                    # in). Treat as a document so downstream pipelines surface
-                    # the path to the agent.
-                    msg_type = MessageType.DOCUMENT
-                    break
+        # Determine message type — the classification rules live in the PURE
+        # parse core (discord_parse.classify_message_type), shared with the
+        # ingress conformance vector generator. Wrap the SDK attachments in
+        # the core's view type; command detection runs on the (already
+        # mention-stripped) normalized content.
+        from plugins.platforms.discord.discord_parse import (
+            AttachmentView as _AttView,
+            classify_message_type as _classify,
+            DiscordMessageView as _MsgView,
+        )
+
+        def _att_view(att: Any) -> _AttView:
+            marker = getattr(att, "is_voice_message", None)
+            if marker is not None and callable(marker):
+                try:
+                    marker = bool(marker())
+                except Exception:
+                    marker = False
+            return _AttView(
+                content_type=getattr(att, "content_type", None),
+                is_voice_message=marker,
+                duration=getattr(att, "duration", None),
+                waveform=getattr(att, "waveform", None),
+            )
+
+        msg_type = _classify(
+            _MsgView(
+                message_id=str(message.id),
+                content=normalized_content,
+                channel_id=str(message.channel.id),
+                attachments=[_att_view(a) for a in all_attachments],
+            )
+        )
 
         # When auto-threading kicked in, route responses to the new thread
         effective_channel = auto_threaded_channel or message.channel

--- a/plugins/platforms/discord/discord_parse.py
+++ b/plugins/platforms/discord/discord_parse.py
@@ -1,0 +1,307 @@
+"""Pure parse core for Discord inbound messages (layer 2).
+
+The Discord inbound path splits into three layers:
+  1. payload → SDK object (discord.py's gateway machinery: member caches,
+     typed channels). VENDOR code — not oracled; the connector's
+     discord.js/raw-payload equivalent is assumed to resolve the same
+     fields (the documented SDK-equivalence axiom, parity report §5).
+  2. SDK-view → MessageEvent fields — the HERMES-UNIQUE derivation rules:
+     chat-type classification, thread identity, mention stripping,
+     forwarded-snapshot folding, reply-reference extraction,
+     attachment→MessageType classification, chat naming. THIS MODULE.
+  3. Effects: media caching, auto-thread creation, gating, history
+     backfill. Adapter-side.
+
+Layer 2 consumes a small SDK-view IR (`DiscordMessageView`) constructible
+from EITHER a discord.py ``Message`` (adapter's caller — attribute access,
+``view_from_sdk_message``) OR a raw-ish dict of the same vocabulary (the
+ingress conformance vector generator — ``view_from_dict``), so the
+generator runs with NO discord.py dependency while exercising the SAME
+rules the adapter uses.
+
+Extracted from ``DiscordAdapter._handle_message`` (the derivation sites,
+verbatim rules); the adapter delegates. Behavior changes here MUST be
+reflected in the committed ingress vectors (regenerate) and reviewed
+against the connector's normalizer (gateway-gateway src/relay/discord.ts).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from gateway.platforms.base import MessageType
+
+#: Image extensions the media pipeline accepts before falling back to .jpg.
+IMAGE_EXTS = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp"})
+
+
+@dataclass
+class AttachmentView:
+    """SDK-view of one attachment (discord.py Attachment ≙ raw payload)."""
+
+    content_type: Optional[str] = None
+    filename: Optional[str] = None
+    url: Optional[str] = None
+    #: Native voice-note markers (raw: flags bit / duration_secs+waveform).
+    is_voice_message: Optional[bool] = None
+    duration: Optional[float] = None
+    waveform: Optional[str] = None
+
+
+@dataclass
+class DiscordMessageView:
+    """SDK-view IR: the ~18 fields layer 2 reads, SDK-agnostic."""
+
+    message_id: str
+    content: str
+    channel_id: str
+    channel_name: Optional[str] = None
+    #: dm | guildText | thread — the SDK-resolved channel classification
+    #: (discord.py: isinstance checks; raw: guild_id/thread flags).
+    channel_kind: str = "guildText"
+    guild_id: Optional[str] = None
+    guild_name: Optional[str] = None
+    parent_channel_id: Optional[str] = None
+    parent_channel_name: Optional[str] = None
+    parent_is_forum: bool = False
+    author_id: str = ""
+    author_name: str = ""
+    author_display_name: str = ""
+    author_is_bot: bool = False
+    #: Resolved @mention user ids (SDK: message.mentions; raw: mentions[]).
+    mentioned_user_ids: List[str] = field(default_factory=list)
+    attachments: List[AttachmentView] = field(default_factory=list)
+    #: Forwarded-message snapshots (message_snapshots): text + attachments.
+    snapshot_texts: List[str] = field(default_factory=list)
+    snapshot_attachments: List[AttachmentView] = field(default_factory=list)
+    referenced_message_id: Optional[str] = None
+    referenced_attachments: List[AttachmentView] = field(default_factory=list)
+    is_reply: bool = False
+
+
+def _att_from_dict(d: Any) -> AttachmentView:
+    if not isinstance(d, dict):
+        return AttachmentView()
+    return AttachmentView(
+        content_type=d.get("content_type"),
+        filename=d.get("filename"),
+        url=d.get("url"),
+        is_voice_message=d.get("is_voice_message"),
+        duration=d.get("duration"),
+        waveform=d.get("waveform"),
+    )
+
+
+def view_from_dict(payload: dict) -> DiscordMessageView:
+    """Build the IR from a raw-vocabulary dict (generator/test caller)."""
+    return DiscordMessageView(
+        message_id=str(payload.get("id", "")),
+        content=str(payload.get("content") or ""),
+        channel_id=str(payload.get("channel_id", "")),
+        channel_name=payload.get("channel_name"),
+        channel_kind=str(payload.get("channel_kind") or "guildText"),
+        guild_id=(str(payload["guild_id"]) if payload.get("guild_id") else None),
+        guild_name=payload.get("guild_name"),
+        parent_channel_id=(
+            str(payload["parent_channel_id"])
+            if payload.get("parent_channel_id")
+            else None
+        ),
+        parent_channel_name=payload.get("parent_channel_name"),
+        parent_is_forum=bool(payload.get("parent_is_forum", False)),
+        author_id=str((payload.get("author") or {}).get("id", "")),
+        author_name=str((payload.get("author") or {}).get("username", "")),
+        author_display_name=str(
+            (payload.get("author") or {}).get("display_name")
+            or (payload.get("author") or {}).get("global_name")
+            or (payload.get("author") or {}).get("username", "")
+        ),
+        author_is_bot=bool((payload.get("author") or {}).get("bot", False)),
+        mentioned_user_ids=[
+            str(m.get("id"))
+            for m in (payload.get("mentions") or [])
+            if isinstance(m, dict) and m.get("id") is not None
+        ],
+        attachments=[_att_from_dict(a) for a in (payload.get("attachments") or [])],
+        snapshot_texts=[
+            str(s.get("content") or "").strip()
+            for s in (payload.get("message_snapshots") or [])
+            if isinstance(s, dict) and s.get("content")
+        ],
+        snapshot_attachments=[
+            _att_from_dict(a)
+            for s in (payload.get("message_snapshots") or [])
+            if isinstance(s, dict)
+            for a in (s.get("attachments") or [])
+        ],
+        referenced_message_id=(
+            str((payload.get("referenced_message") or {}).get("id"))
+            if (payload.get("referenced_message") or {}).get("id") is not None
+            else None
+        ),
+        referenced_attachments=[
+            _att_from_dict(a)
+            for a in ((payload.get("referenced_message") or {}).get("attachments") or [])
+        ],
+        is_reply=bool(payload.get("referenced_message") or payload.get("is_reply")),
+    )
+
+
+def is_voice_message_attachment(att: AttachmentView) -> bool:
+    """Native voice note vs plain audio file (verbatim adapter rule)."""
+    if att.is_voice_message is not None:
+        return bool(att.is_voice_message)
+    return att.duration is not None and att.waveform is not None
+
+
+def strip_own_mention(content: str, bot_user_id: str) -> str:
+    """Remove the bot's OWN mention tokens (never other users') and trim —
+    runs before command detection so `@Hermes /new` is recognized as /new."""
+    if not bot_user_id:
+        return content.strip()
+    return (
+        content.replace(f"<@{bot_user_id}>", "")
+        .replace(f"<@!{bot_user_id}>", "")
+        .strip()
+    )
+
+
+def is_explicitly_mentioned(view: DiscordMessageView, bot_user_id: str) -> bool:
+    """Resolved mentions list OR raw `<@id>`/`<@!id>` token in content."""
+    if not bot_user_id:
+        return False
+    if bot_user_id in view.mentioned_user_ids:
+        return True
+    return f"<@{bot_user_id}>" in view.content or f"<@!{bot_user_id}>" in view.content
+
+
+def effective_content(view: DiscordMessageView, bot_user_id: str = "") -> str:
+    """Message text after snapshot folding + own-mention stripping.
+
+    Forwarded messages (message_snapshots) with no caption of their own use
+    the snapshot text as the content — the native adapter's forward rule.
+    """
+    raw = view.content.strip()
+    if not raw and view.snapshot_texts:
+        raw = "\n".join(view.snapshot_texts)
+    if is_explicitly_mentioned(view, bot_user_id):
+        raw = strip_own_mention(raw, bot_user_id)
+    return raw
+
+
+def all_attachments(view: DiscordMessageView) -> List[AttachmentView]:
+    """Own + forwarded-snapshot + replied-to attachments, in adapter order."""
+    return list(view.attachments) + list(view.snapshot_attachments) + list(
+        view.referenced_attachments
+    )
+
+
+def classify_message_type(
+    view: DiscordMessageView, bot_user_id: str = ""
+) -> MessageType:
+    """COMMAND / PHOTO / VIDEO / VOICE / AUDIO / DOCUMENT / TEXT — verbatim
+    adapter rules: command prefix wins; else FIRST attachment classifies
+    (any non-media attachment ⇒ DOCUMENT; no content_type ⇒ DOCUMENT)."""
+    if effective_content(view, bot_user_id).startswith("/"):
+        return MessageType.COMMAND
+    for att in all_attachments(view):
+        ct = att.content_type
+        if ct:
+            if ct.startswith("image/"):
+                return MessageType.PHOTO
+            if ct.startswith("video/"):
+                return MessageType.VIDEO
+            if ct.startswith("audio/"):
+                return (
+                    MessageType.VOICE
+                    if is_voice_message_attachment(att)
+                    else MessageType.AUDIO
+                )
+            return MessageType.DOCUMENT
+        return MessageType.DOCUMENT
+    return MessageType.TEXT
+
+
+def chat_type_for(view: DiscordMessageView) -> str:
+    """dm | thread | group (the adapter's three-way classification)."""
+    if view.channel_kind == "dm":
+        return "dm"
+    if view.channel_kind == "thread":
+        return "thread"
+    return "group"
+
+
+def thread_chat_name(view: DiscordMessageView) -> str:
+    """Readable thread name incl. guild/parent context (verbatim rules:
+    forum parents drop the '#', text parents keep it)."""
+    thread_name = view.channel_name or view.channel_id or "thread"
+    guild_name = view.guild_name
+    parent_name = view.parent_channel_name
+    if view.parent_is_forum and guild_name and parent_name:
+        return f"{guild_name} / {parent_name} / {thread_name}"
+    if parent_name and guild_name:
+        return f"{guild_name} / #{parent_name} / {thread_name}"
+    if parent_name:
+        return f"{parent_name} / {thread_name}"
+    return thread_name
+
+
+def chat_name_for(view: DiscordMessageView) -> str:
+    """DM → author name; thread → contextual thread name; channel →
+    'Guild / #channel' when guild known."""
+    chat_type = chat_type_for(view)
+    if chat_type == "dm":
+        return view.author_name
+    if chat_type == "thread":
+        return thread_chat_name(view)
+    name = view.channel_name or view.channel_id
+    if view.guild_name:
+        return f"{view.guild_name} / #{name}"
+    return name
+
+
+@dataclass
+class DiscordParsedMessage:
+    """Payload/SDK-view-derivable fields of one Discord inbound message."""
+
+    chat_type: str
+    chat_id: str
+    chat_name: str
+    thread_id: Optional[str]
+    parent_chat_id: Optional[str]
+    guild_id: Optional[str]
+    user_id: str
+    user_name: str
+    user_is_bot: bool
+    message_id: str
+    text: str
+    message_type: MessageType
+    reply_to_message_id: Optional[str]
+    mentions_bot: bool
+
+
+def parse_discord_message(
+    view: DiscordMessageView, bot_user_id: str = ""
+) -> DiscordParsedMessage:
+    """Derive every SDK-view-only field (no auto-threading, no config
+    gating, no media download — those are adapter-side effects layered on
+    top of these values)."""
+    chat_type = chat_type_for(view)
+    is_thread = chat_type == "thread"
+    return DiscordParsedMessage(
+        chat_type=chat_type,
+        chat_id=view.channel_id,
+        chat_name=chat_name_for(view),
+        thread_id=view.channel_id if is_thread else None,
+        parent_chat_id=view.parent_channel_id if is_thread else None,
+        guild_id=view.guild_id,
+        user_id=view.author_id,
+        user_name=view.author_display_name or view.author_name,
+        user_is_bot=view.author_is_bot,
+        message_id=view.message_id,
+        text=effective_content(view, bot_user_id),
+        message_type=classify_message_type(view, bot_user_id),
+        reply_to_message_id=view.referenced_message_id,
+        mentions_bot=is_explicitly_mentioned(view, bot_user_id),
+    )

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5491,11 +5491,17 @@ class SlackAdapter(BasePlatformAdapter):
         if team_id and channel_id:
             self._remember_channel_team(channel_id, team_id)
 
-        # Determine if this is a DM or channel message
+        # Determine if this is a DM or channel message — classification rules
+        # live in the PURE parse core (slack_parse), shared with the ingress
+        # conformance vector generator.
+        from plugins.platforms.slack.slack_parse import (
+            slack_is_dm,
+            slack_is_one_to_one_dm,
+        )
+
         channel_type = event.get("channel_type", "")
-        if not channel_type and channel_id.startswith("D"):
-            channel_type = "im"
-        is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
+        _cls_event = {**event, "channel": channel_id}
+        is_dm = slack_is_dm(_cls_event)  # Both 1:1 and group DMs
         if is_dm and self._slack_disable_dms():
             logger.info(
                 "[Slack] Ignoring DM because Slack DMs are disabled: channel=%s user=%s",
@@ -5511,7 +5517,7 @@ class SlackAdapter(BasePlatformAdapter):
         # get reaction noise on messages that don't address the bot. Only the 1:1
         # case earns the DM exemptions; session/thread scoping below still treats
         # both as DM-style persistent conversations.
-        is_one_to_one_dm = channel_type == "im"
+        is_one_to_one_dm = slack_is_one_to_one_dm(_cls_event)
 
         # Reject unauthorized users before thread lookups, name resolution,
         # or file downloads.  The final gateway runner auth check happens
@@ -5564,27 +5570,19 @@ class SlackAdapter(BasePlatformAdapter):
             #   (c) top-level, reply_in_thread=false → scope one session
             #       across the whole channel so context accumulates across
             #       messages (#15421 bug 1)
-            event_thread_ts_raw = event.get("thread_ts")
-            # Align with ``is_thread_reply`` below — a ``thread_ts ==
-            # ts`` payload (some thread-root shapes) is not a real reply
-            # and must not prevent the shared-session path from taking
-            # effect.  Matching the same invariant here keeps the two
-            # branches in sync even if Slack introduces new payload
-            # variants (Copilot on #15464).
-            if event_thread_ts_raw and event_thread_ts_raw != ts:
-                thread_ts = event_thread_ts_raw
-            elif self.config.extra.get("reply_in_thread", True):
-                # Legacy default: treat ts as a synthetic thread root so
-                # this top-level message gets its own session.
-                thread_ts = ts
-            else:
-                # reply_in_thread=false: no thread key → session manager
-                # groups by (platform, channel_id, None) and the channel
-                # shares one conversation.  reply_to_message_id at the
-                # outbound side is already gated on ``thread_ts != ts``
-                # so None here produces a non-threaded reply without
-                # further changes.
-                thread_ts = None
+            # Channel-message scoping rules live in the PURE parse core
+            # (slack_parse.slack_session_thread_ts — the #15421/#15464
+            # invariants), shared with the ingress conformance vectors.
+            from plugins.platforms.slack.slack_parse import (
+                slack_session_thread_ts,
+            )
+
+            thread_ts = slack_session_thread_ts(
+                {**_cls_event, "channel_type": channel_type or "channel"},
+                reply_in_thread=bool(
+                    self.config.extra.get("reply_in_thread", True)
+                ),
+            )
 
         # In channels, respond if:
         #   (unless ignore_other_user_mentions is on and the message opens by

--- a/plugins/platforms/slack/slack_parse.py
+++ b/plugins/platforms/slack/slack_parse.py
@@ -1,0 +1,161 @@
+"""Pure parse core for Slack inbound message events (layer 2).
+
+Same decomposition as discord_parse.py: layer 1 (Bolt's event plumbing +
+workspace/token resolution) is vendor/adapter code; layer 3 (auth gating,
+file downloads, assistant-thread metadata, channel-team caches) stays
+adapter-side. THIS module is layer 2 — the Hermes-unique, payload-derivable
+derivation rules extracted from ``SlackAdapter._handle_slack_message``:
+
+  - DM detection (channel_type im/mpim, D-prefix fallback) and the
+    1:1-vs-MPIM distinction (MPIM is a SHARED surface: channel-style
+    gating applies; only 1:1 IMs earn the DM exemptions);
+  - thread_ts session scoping (#15421/#15464 rules): genuine thread reply
+    (thread_ts present and != ts) keys per-thread; top-level messages key
+    on ts when reply_in_thread (the default) else None (shared channel
+    session);
+  - mention detection (the literal ``<@{bot_user_id}>`` token — server-
+    resolved by Slack into the text);
+  - bot/self-message classification (bot_id / subtype=bot_message).
+
+Consumed by the adapter (delegation) and by the ingress conformance vector
+generator (scripts/generate_ingress_vectors.py) — the executable spec for
+the connector's normalizer (gateway-gateway src/relay/slack.ts).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+def slack_is_dm(event: Dict[str, Any]) -> bool:
+    """im/mpim are DM-style; explicit channel/group are not; else D-prefix."""
+    channel_type = str(event.get("channel_type") or "")
+    if channel_type in {"im", "mpim"}:
+        return True
+    if channel_type in {"channel", "group"}:
+        return False
+    return str(event.get("channel") or "").startswith("D")
+
+
+def slack_is_one_to_one_dm(event: Dict[str, Any]) -> bool:
+    """Only a 1:1 IM earns the DM exemptions (mention-exempt, react-safe).
+    An MPIM is a shared surface and obeys channel-style operator controls."""
+    channel_type = str(event.get("channel_type") or "")
+    if channel_type:
+        return channel_type == "im"
+    # No channel_type on the payload: a D-prefixed channel id covers both
+    # im and mpim historically; the adapter treats prefix-only detection as
+    # im (legacy single-workspace shape).
+    return str(event.get("channel") or "").startswith("D")
+
+
+def slack_session_thread_ts(
+    event: Dict[str, Any],
+    *,
+    reply_in_thread: bool = True,
+    dm_top_level_threads_as_sessions: bool = True,
+) -> Optional[str]:
+    """The session-scoping thread key (#15421 bug 1 / #15464 invariant).
+
+    A ``thread_ts == ts`` payload (some thread-root shapes) is NOT a real
+    reply and must not prevent the shared-session path.
+    """
+    ts = str(event.get("ts") or "")
+    raw = event.get("thread_ts")
+    thread_ts = str(raw) if raw else None
+    if slack_is_dm(event):
+        if thread_ts:
+            return thread_ts
+        return ts if dm_top_level_threads_as_sessions else None
+    if thread_ts and thread_ts != ts:
+        return thread_ts  # (a) genuine thread reply
+    if reply_in_thread:
+        return ts  # (b) synthetic thread root (legacy default)
+    return None  # (c) shared channel session
+
+
+def slack_chat_type(event: Dict[str, Any]) -> str:
+    """dm | thread | channel — the classification the wire event carries.
+
+    A genuine thread reply (thread_ts != ts) is "thread"; top-level channel
+    messages are "channel" even though session scoping may key them on a
+    synthetic thread root (that's a session-keying concern, not a
+    chat-type one — mirrors the connector's slackChatType).
+    """
+    if slack_is_dm(event):
+        return "dm"
+    ts = str(event.get("ts") or "")
+    raw = event.get("thread_ts")
+    if raw and str(raw) != ts:
+        return "thread"
+    return "channel"
+
+
+def slack_mentions_bot(event: Dict[str, Any], bot_user_id: str) -> bool:
+    """Slack resolves mentions server-side into the literal ``<@UID>``
+    token in text — substring detection is authoritative (adapter rule)."""
+    if not bot_user_id:
+        return False
+    return f"<@{bot_user_id}>" in str(event.get("text") or "")
+
+
+def slack_is_bot_message(event: Dict[str, Any]) -> bool:
+    """bot_id present or subtype=bot_message ⇒ authored by an integration."""
+    return bool(event.get("bot_id")) or str(event.get("subtype") or "") == "bot_message"
+
+
+def strip_bot_mention(text: str, bot_user_id: str) -> str:
+    """Remove the bot's own mention token(s) and trim (command detection
+    runs on the stripped text, same as Discord)."""
+    if not bot_user_id:
+        return text.strip()
+    return text.replace(f"<@{bot_user_id}>", "").strip()
+
+
+@dataclass
+class SlackParsedMessage:
+    """Payload-derivable fields of one Slack message event."""
+
+    chat_type: str
+    chat_id: str
+    is_dm: bool
+    is_one_to_one_dm: bool
+    session_thread_ts: Optional[str]
+    user_id: Optional[str]
+    team_id: Optional[str]
+    message_id: str
+    text: str
+    mentions_bot: bool
+    user_is_bot: bool
+
+
+def parse_slack_event(
+    event: Dict[str, Any],
+    bot_user_id: str = "",
+    *,
+    reply_in_thread: bool = True,
+    dm_top_level_threads_as_sessions: bool = True,
+) -> SlackParsedMessage:
+    """Derive every payload-only field of a Slack message event. Pure: no
+    Bolt context, no workspace caches, no config reads — the two behavior
+    toggles arrive as explicit arguments (the adapter passes its config)."""
+    text = str(event.get("text") or "")
+    mentions = slack_mentions_bot(event, bot_user_id)
+    return SlackParsedMessage(
+        chat_type=slack_chat_type(event),
+        chat_id=str(event.get("channel") or ""),
+        is_dm=slack_is_dm(event),
+        is_one_to_one_dm=slack_is_one_to_one_dm(event),
+        session_thread_ts=slack_session_thread_ts(
+            event,
+            reply_in_thread=reply_in_thread,
+            dm_top_level_threads_as_sessions=dm_top_level_threads_as_sessions,
+        ),
+        user_id=(str(event["user"]) if event.get("user") else None),
+        team_id=(str(event["team"]) if event.get("team") else None),
+        message_id=str(event.get("ts") or ""),
+        text=strip_bot_mention(text, bot_user_id) if mentions else text,
+        mentions_bot=mentions,
+        user_is_bot=slack_is_bot_message(event),
+    )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7798,21 +7798,16 @@ class TelegramAdapter(BasePlatformAdapter):
         plain group/DM replies, but those ids are not topic/session routing
         ids and must not be treated as such.  Gating, skill binding, and
         outbound routing must all agree on the same normalized value.
+
+        Delegates to the PURE parse core (telegram_parse) — the same rules
+        the ingress conformance vector generator exercises, so the relay
+        connector's poller is tested against exactly this logic.
         """
-        chat = getattr(message, "chat", None)
-        chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower() if chat else ""
-        raw = getattr(message, "message_thread_id", None)
-        is_topic_message = bool(getattr(message, "is_topic_message", False))
-        is_forum_group = chat_type in ("group", "supergroup") and getattr(chat, "is_forum", False) is True
-        if raw is not None:
-            if is_forum_group or (chat_type in ("group", "supergroup") and is_topic_message):
-                return str(raw)
-            if chat_type == "private" and is_topic_message:
-                return str(raw)
-            return None
-        if is_forum_group:
-            return cls._GENERAL_TOPIC_THREAD_ID
-        return None
+        from plugins.platforms.telegram.telegram_parse import (
+            effective_message_thread_id,
+        )
+
+        return effective_message_thread_id(message)
 
     # Telegram bot handles historically had to end in "bot", but collectible
     # (Fragment) usernames can be assigned to bots and drop that suffix
@@ -9537,40 +9532,26 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         
         # Extract reply context if this message is a reply.
-        # Prefer Telegram's native partial quote (message.quote, TextQuote)
-        # so a user replying to a single selected substring of a prior
-        # multi-section message doesn't get the whole replied-to message
-        # injected into the agent's context — which can cause the agent
-        # to act on unrelated actionable-looking text the user didn't
-        # quote (#22619). Fall back to the full replied-to message text
-        # / caption when no native quote is present.
-        reply_to_id = None
-        reply_to_text = None
-        if message.reply_to_message:
-            reply_to_id = str(message.reply_to_message.message_id)
-            quote = getattr(message, "quote", None)
-            quote_text = getattr(quote, "text", None) if quote is not None else None
-            if quote_text:
-                reply_to_text = quote_text
-            else:
-                reply_to_text = (
-                    message.reply_to_message.text
-                    or message.reply_to_message.caption
-                    or None
-                )
-                if not reply_to_text:
-                    # Prefer Telegram's native rich-message echo when present;
-                    # keep the local send-time index only as a fallback for
-                    # older/unrecoverable reply payloads.
-                    reply_to_text = self._extract_rich_reply_text(message.reply_to_message)
-                if not reply_to_text:
-                    try:
-                        from gateway import rich_sent_store
-                        reply_to_text = rich_sent_store.lookup(
-                            str(chat.id), reply_to_id
-                        )
-                    except Exception:
-                        reply_to_text = None
+        # Payload-derivable part (native partial quote #22619, text/caption
+        # fallback) lives in the PURE parse core (telegram_parse) — shared
+        # with the ingress conformance vector generator. The two stateful
+        # fallbacks (rich-message echo, rich_sent_store) stay adapter-side.
+        from plugins.platforms.telegram.telegram_parse import extract_reply_context
+
+        reply_to_id, reply_to_text = extract_reply_context(message)
+        if message.reply_to_message and not reply_to_text:
+            # Prefer Telegram's native rich-message echo when present;
+            # keep the local send-time index only as a fallback for
+            # older/unrecoverable reply payloads.
+            reply_to_text = self._extract_rich_reply_text(message.reply_to_message)
+            if not reply_to_text:
+                try:
+                    from gateway import rich_sent_store
+                    reply_to_text = rich_sent_store.lookup(
+                        str(chat.id), reply_to_id
+                    )
+                except Exception:
+                    reply_to_text = None
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt

--- a/plugins/platforms/telegram/telegram_parse.py
+++ b/plugins/platforms/telegram/telegram_parse.py
@@ -1,0 +1,176 @@
+"""Pure parse core for Telegram inbound messages.
+
+Extracted from ``TelegramAdapter._build_message_event`` (adapter.py) so the
+payload-derivable field logic — chat-type normalization, the routable
+thread-id rules (#3206/#22423), reply context with native partial quotes
+(#22619), source identity fields — is importable WITHOUT adapter state.
+
+Dual access model: every accessor works on BOTH python-telegram-bot
+``Message`` objects (attribute access — the adapter's caller) and raw Bot
+API JSON dicts (key access — the ingress conformance vector generator's
+caller, and exactly the shape the relay connector's poller consumes). PTB
+deliberately mirrors Bot API field names, so one field vocabulary serves
+both; the generator therefore runs with NO python-telegram-bot dependency
+while still exercising the SAME rules the adapter uses.
+
+Deliberately excluded (adapter-side): DM-topic/group-topic config lookups
+(chat_topic / auto_skill), rich_sent_store reply-text fallback, channel
+prompts, media/sticker handling. The core derives every field that exists
+in the payload alone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+#: Telegram addresses a forum's General topic as thread id "1" while
+#: delivering its messages with ``message_thread_id=None`` (#22423).
+GENERAL_TOPIC_THREAD_ID = "1"
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    """Field access across PTB objects (attributes) and Bot API dicts (keys)."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def normalize_chat_type(chat: Any) -> str:
+    """Bot API chat.type → Hermes chat_type (dm/group/channel).
+
+    Normalizes through ``str`` so PTB enums (``ChatType.SUPERGROUP``),
+    plain strings, and mocks all resolve identically — the adapter's
+    long-standing rule.
+    """
+    telegram_chat_type = str(_get(chat, "type", "") or "").split(".")[-1].lower()
+    if telegram_chat_type in {"group", "supergroup"}:
+        return "group"
+    if telegram_chat_type == "channel":
+        return "channel"
+    return "dm"
+
+
+def effective_message_thread_id(message: Any) -> Optional[str]:
+    """The ROUTABLE thread id for a message, or None.
+
+    Rules (verbatim from the adapter):
+      - forum-group topic messages keep their id;
+      - plain group/DM replies carry a reply-UI anchor in
+        ``message_thread_id`` that is NOT a session thread — dropped (#3206);
+      - private-chat topic messages (DM topics) keep their id;
+      - forum-group messages with NO id are the General topic → "1" (#22423).
+    """
+    chat = _get(message, "chat")
+    chat_type = (
+        str(_get(chat, "type", "") or "").split(".")[-1].lower() if chat is not None else ""
+    )
+    raw = _get(message, "message_thread_id")
+    is_topic_message = bool(_get(message, "is_topic_message", False))
+    is_forum_group = chat_type in ("group", "supergroup") and _get(chat, "is_forum", False) is True
+    if raw is not None:
+        if is_forum_group or (chat_type in ("group", "supergroup") and is_topic_message):
+            return str(raw)
+        if chat_type == "private" and is_topic_message:
+            return str(raw)
+        return None
+    if is_forum_group:
+        return GENERAL_TOPIC_THREAD_ID
+    return None
+
+
+def extract_reply_context(message: Any) -> tuple[Optional[str], Optional[str]]:
+    """(reply_to_id, reply_to_text) from the payload alone.
+
+    Prefers Telegram's native partial quote (``message.quote`` TextQuote,
+    #22619) so replying to a selected substring doesn't inject the whole
+    replied-to message; falls back to the quoted message's text/caption.
+    The adapter layers two further fallbacks on top (rich-message echo,
+    rich_sent_store) — both need adapter/gateway state and stay there.
+    """
+    reply = _get(message, "reply_to_message")
+    if not reply:
+        return None, None
+    reply_id_raw = _get(reply, "message_id")
+    reply_to_id = str(reply_id_raw) if reply_id_raw is not None else None
+    quote = _get(message, "quote")
+    quote_text = _get(quote, "text") if quote is not None else None
+    if quote_text:
+        return reply_to_id, str(quote_text)
+    reply_to_text = _get(reply, "text") or _get(reply, "caption") or None
+    return reply_to_id, (str(reply_to_text) if reply_to_text else None)
+
+
+@dataclass
+class TelegramParsedMessage:
+    """Payload-derivable fields of one Telegram inbound message."""
+
+    chat_type: str
+    chat_id: str
+    chat_name: Optional[str]
+    thread_id: Optional[str]
+    user_id: Optional[str]
+    user_name: Optional[str]
+    user_is_bot: bool
+    message_id: str
+    text: str
+    reply_to_id: Optional[str]
+    reply_to_text: Optional[str]
+
+
+def parse_telegram_message(message: Any) -> TelegramParsedMessage:
+    """Derive every payload-only field of a Telegram inbound message.
+
+    Pure: no I/O, no adapter/config state. Mirrors ``_build_message_event``'s
+    derivations exactly (source identity, thread routing, reply context);
+    the adapter composes topic/skill/prompt enrichment on top. Behavior
+    changes here MUST be reflected in the committed ingress conformance
+    vectors (regenerate) and reviewed against the connector's normalizer.
+    """
+    chat = _get(message, "chat") or {}
+    user = _get(message, "from_user") or _get(message, "from")
+
+    chat_type = normalize_chat_type(chat)
+    thread_id = effective_message_thread_id(message)
+
+    chat_id = str(_get(chat, "id", ""))
+    # PTB exposes ``full_name`` (computed) on Chat for private chats; Bot API
+    # dicts carry first_name/last_name. Title covers groups/channels.
+    chat_title = _get(chat, "title")
+    chat_full_name = _get(chat, "full_name") or " ".join(
+        p for p in (_get(chat, "first_name"), _get(chat, "last_name")) if p
+    )
+    chat_name = chat_title or (chat_full_name or None)
+
+    user_id: Optional[str] = None
+    user_name: Optional[str] = None
+    user_is_bot = False
+    if user is not None:
+        uid = _get(user, "id")
+        user_id = str(uid) if uid is not None else None
+        user_name = _get(user, "full_name") or " ".join(
+            p for p in (_get(user, "first_name"), _get(user, "last_name")) if p
+        ) or None
+        user_is_bot = bool(_get(user, "is_bot", False))
+    elif chat_type in {"dm", "channel"}:
+        # Channel posts / anonymous DMs: fall back to the chat identity —
+        # the event still carries a stable author (adapter parity).
+        user_id = chat_id
+        user_name = chat_name if chat_type == "channel" else (chat_full_name or None)
+
+    reply_to_id, reply_to_text = extract_reply_context(message)
+
+    msg_id = _get(message, "message_id")
+    return TelegramParsedMessage(
+        chat_type=chat_type,
+        chat_id=chat_id,
+        chat_name=chat_name,
+        thread_id=thread_id,
+        user_id=user_id,
+        user_name=user_name,
+        user_is_bot=user_is_bot,
+        message_id=str(msg_id) if msg_id is not None else "",
+        text=str(_get(message, "text") or ""),
+        reply_to_id=reply_to_id,
+        reply_to_text=reply_to_text,
+    )

--- a/scripts/generate_ingress_vectors.py
+++ b/scripts/generate_ingress_vectors.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Ingress conformance-vector generator — native inbound parsers as spec.
+
+The egress twin (generate_conformance_vectors.py) renders text through the
+native RENDERERS; this renders synthetic PLATFORM PAYLOADS through the
+native inbound PARSERS (the pure cores extracted in this change:
+plugins.platforms.telegram.telegram_parse, gateway.platforms.
+whatsapp_cloud_parse) and dumps payload→expected-fields JSON vectors. The
+gateway-gateway connector commits them under conformance/ingress/ and its
+vitest runner asserts the CONNECTOR normalizers (telegram.ts / whatsapp.ts
++ the poller mappers) derive the SAME fields — so inbound parsing drift
+(dropped categories, wrong thread routing, mangled reply context) breaks a
+test instead of silently eating messages.
+
+Platform scope (deliberate):
+  telegram  raw Bot API update dicts → thread routing (#3206/#22423 rules),
+            chat-type normalization, reply context w/ partial quotes,
+            source identity.
+  whatsapp  Cloud API message objects → type mapping, body extraction,
+            reply context (id + is_own), media identification, the
+            group-shape refusal.
+  discord/slack: DEFERRED — their native inbound paths are discord.py /
+  Bolt EVENT-OBJECT consumers (SDK state, not payload functions); an
+  honest oracle needs the same pure-core extraction done here for
+  telegram/whatsapp. Recorded in the parity report.
+
+Field vocabulary is the WIRE MessageEvent's (chat_id, chat_type, thread_id,
+user_id, message_id, text, reply_to_*, message_type/media) — the shared
+language of both repos' inbound planes.
+
+Run:  python scripts/generate_ingress_vectors.py [--out DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+GENERATOR_VERSION = 1
+
+# ── telegram corpus: raw Bot API message dicts ───────────────────────────
+
+def _tg_chat(**kw: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {"id": -1001234, "type": "supergroup", "title": "Eng Group"}
+    base.update(kw)
+    return base
+
+
+def _tg_user(**kw: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {"id": 777, "is_bot": False, "first_name": "Ben", "username": "ben"}
+    base.update(kw)
+    return base
+
+
+TELEGRAM_CORPUS: List[tuple] = [
+    (
+        "dm-plain-text",
+        {"message_id": 1, "chat": {"id": 555, "type": "private", "first_name": "Ben"},
+         "from": _tg_user(), "text": "hello"},
+    ),
+    (
+        "group-plain-text",
+        {"message_id": 2, "chat": _tg_chat(), "from": _tg_user(), "text": "hi group"},
+    ),
+    (
+        "channel-post",
+        {"message_id": 3, "chat": {"id": -1009, "type": "channel", "title": "Announce"},
+         "text": "channel news"},  # channel posts carry no `from`
+    ),
+    (
+        "forum-topic-message",
+        {"message_id": 4, "chat": _tg_chat(is_forum=True), "from": _tg_user(),
+         "text": "topic chat", "message_thread_id": 55, "is_topic_message": True},
+    ),
+    (
+        # #22423: forum General topic delivers thread_id=None; routes to "1".
+        "forum-general-topic",
+        {"message_id": 5, "chat": _tg_chat(is_forum=True), "from": _tg_user(),
+         "text": "general chat"},
+    ),
+    (
+        # #3206: a plain group reply carries a reply-UI anchor in
+        # message_thread_id — NOT a routable thread.
+        "group-reply-anchor-not-thread",
+        {"message_id": 6, "chat": _tg_chat(), "from": _tg_user(), "text": "re",
+         "message_thread_id": 42,
+         "reply_to_message": {"message_id": 42, "chat": _tg_chat(),
+                              "from": _tg_user(id=888, first_name="Alice"),
+                              "text": "original"}},
+    ),
+    (
+        "dm-topic-message",
+        {"message_id": 7, "chat": {"id": 555, "type": "private", "first_name": "Ben"},
+         "from": _tg_user(), "text": "dm topic", "message_thread_id": 9,
+         "is_topic_message": True},
+    ),
+    (
+        "reply-with-text",
+        {"message_id": 8, "chat": _tg_chat(), "from": _tg_user(), "text": "re",
+         "reply_to_message": {"message_id": 7, "chat": _tg_chat(),
+                              "from": _tg_user(id=999, is_bot=True, first_name="Hermes"),
+                              "text": "what the bot said"}},
+    ),
+    (
+        # #22619: native partial quote wins over the full replied-to text.
+        "reply-partial-quote",
+        {"message_id": 9, "chat": _tg_chat(), "from": _tg_user(), "text": "re",
+         "quote": {"text": "just this part"},
+         "reply_to_message": {"message_id": 7, "chat": _tg_chat(),
+                              "from": _tg_user(id=888, first_name="Alice"),
+                              "text": "a long message with many parts"}},
+    ),
+    (
+        "reply-to-caption-only",
+        {"message_id": 10, "chat": _tg_chat(), "from": _tg_user(), "text": "re",
+         "reply_to_message": {"message_id": 7, "chat": _tg_chat(),
+                              "from": _tg_user(id=888, first_name="Alice"),
+                              "caption": "photo caption"}},
+    ),
+    (
+        "bot-authored-message",
+        {"message_id": 11, "chat": _tg_chat(), "from": _tg_user(id=999, is_bot=True,
+         first_name="OtherBot"), "text": "bot chatter"},
+    ),
+    (
+        "command-message",
+        {"message_id": 12, "chat": {"id": 555, "type": "private", "first_name": "Ben"},
+         "from": _tg_user(), "text": "/status"},
+    ),
+    (
+        "cjk-emoji-text",
+        {"message_id": 13, "chat": _tg_chat(), "from": _tg_user(),
+         "text": "中文 — test 🎉 (100%)"},
+    ),
+    (
+        "empty-text-media-placeholder",
+        {"message_id": 14, "chat": _tg_chat(), "from": _tg_user()},  # no text at all
+    ),
+]
+
+# ── whatsapp corpus: Cloud API message objects ───────────────────────────
+
+WA_METADATA = {"display_phone_number": "15559998888", "phone_number_id": "PNID1"}
+WA_CONTACTS = {"15551110000": "Ben", "15559998888": "Hermes Biz"}
+
+WHATSAPP_CORPUS: List[tuple] = [
+    (
+        "text-message",
+        {"from": "15551110000", "id": "wamid.t1", "type": "text",
+         "text": {"body": "hello"}},
+    ),
+    (
+        "command-text",
+        {"from": "15551110000", "id": "wamid.t2", "type": "text",
+         "text": {"body": "/status"}},
+    ),
+    (
+        "image-with-caption",
+        {"from": "15551110000", "id": "wamid.m1", "type": "image",
+         "image": {"id": "MEDIA1", "mime_type": "image/jpeg", "caption": "look"}},
+    ),
+    (
+        "voice-note",
+        {"from": "15551110000", "id": "wamid.m2", "type": "audio",
+         "audio": {"id": "MEDIA2", "mime_type": "audio/ogg; codecs=opus", "voice": True}},
+    ),
+    (
+        "document-with-filename",
+        {"from": "15551110000", "id": "wamid.m3", "type": "document",
+         "document": {"id": "MEDIA3", "mime_type": "text/plain", "filename": "notes.txt"}},
+    ),
+    (
+        "sticker",
+        {"from": "15551110000", "id": "wamid.m4", "type": "sticker",
+         "sticker": {"id": "MEDIA4", "mime_type": "image/webp"}},
+    ),
+    (
+        "reply-to-bot-message",
+        {"from": "15551110000", "id": "wamid.r1", "type": "text",
+         "text": {"body": "re"},
+         "context": {"id": "wamid.orig", "from": "15559998888"}},
+    ),
+    (
+        "reply-to-own-message",
+        {"from": "15551110000", "id": "wamid.r2", "type": "text",
+         "text": {"body": "re self"},
+         "context": {"id": "wamid.mine", "from": "15551110000"}},
+    ),
+    (
+        "button-reply",
+        {"from": "15551110000", "id": "wamid.b1", "type": "button",
+         "button": {"text": "Approve", "payload": "approve-1"}},
+    ),
+    (
+        "list-reply-title",
+        {"from": "15551110000", "id": "wamid.b2", "type": "interactive",
+         "interactive": {"type": "list_reply",
+                         "list_reply": {"id": "opt-2", "title": "Option Two"}}},
+    ),
+    (
+        "group-shaped-refused",
+        {"from": "15551110000", "id": "wamid.g1", "type": "text",
+         "chat": "1203630xxxx@g.us", "text": {"body": "group msg"}},
+    ),
+    (
+        "unknown-type-defaults-text",
+        {"from": "15551110000", "id": "wamid.u1", "type": "reaction",
+         "reaction": {"emoji": "👍", "message_id": "wamid.t1"}},
+    ),
+    (
+        "cjk-emoji-body",
+        {"from": "15551110000", "id": "wamid.c1", "type": "text",
+         "text": {"body": "中文 — test 🎉 (100%)"}},
+    ),
+]
+
+
+# ── expected-field derivation via the pure cores ─────────────────────────
+
+
+def telegram_expected(payload: Dict[str, Any]) -> Dict[str, Any]:
+    from plugins.platforms.telegram.telegram_parse import parse_telegram_message
+
+    p = parse_telegram_message(payload)
+    return {
+        "chat_id": p.chat_id,
+        "chat_type": p.chat_type,
+        "chat_name": p.chat_name,
+        "thread_id": p.thread_id,
+        "user_id": p.user_id,
+        "user_name": p.user_name,
+        "user_is_bot": p.user_is_bot,
+        "message_id": p.message_id,
+        "text": p.text,
+        "reply_to_message_id": p.reply_to_id,
+        "reply_to_text": p.reply_to_text,
+    }
+
+
+def whatsapp_expected(payload: Dict[str, Any]) -> Dict[str, Any]:
+    from gateway.platforms.whatsapp_cloud_parse import parse_cloud_message
+
+    p = parse_cloud_message(payload, WA_CONTACTS, WA_METADATA)
+    return {
+        "msg_type": p.msg_type_str,
+        "message_type": p.message_type.value
+        if hasattr(p.message_type, "value")
+        else str(p.message_type),
+        "body": p.body,
+        "sender_id": p.sender_id,
+        "sender_name": p.sender_name,
+        "chat_id": p.chat_id,
+        "message_id": p.wamid,
+        "reply_to_message_id": p.reply_to_id,
+        "reply_to_is_own": p.reply_to_is_own,
+        "media_id": p.media_id,
+        "media_mime": p.media_mime,
+        "document_filename": p.document_filename,
+        "group_shaped": p.group_shaped,
+    }
+
+
+def _oracle_commit() -> str:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+def generate(out_dir: Path) -> Dict[str, int]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    commit = _oracle_commit()
+    summary: Dict[str, int] = {}
+    corpora = {
+        "telegram": (TELEGRAM_CORPUS, telegram_expected,
+                     {"contacts": None, "metadata": None}),
+        "whatsapp": (WHATSAPP_CORPUS, whatsapp_expected,
+                     {"contacts": WA_CONTACTS, "metadata": WA_METADATA}),
+    }
+    for platform, (corpus, derive, ctx) in sorted(corpora.items()):
+        vectors = []
+        for vid, payload in corpus:
+            vectors.append({
+                "id": vid,
+                "payload": payload,
+                "expected": derive(payload),
+            })
+        doc = {
+            "$comment": (
+                "GENERATED — do not hand-edit. Regenerate with hermes-agent "
+                "scripts/generate_ingress_vectors.py; the native inbound "
+                "parse cores are the oracle (executable spec)."
+            ),
+            "oracle": {
+                "repo": "NousResearch/hermes-agent",
+                "commit": commit,
+                "generator": "scripts/generate_ingress_vectors.py",
+                "generator_version": GENERATOR_VERSION,
+            },
+            "platform": platform,
+            "direction": "ingress",
+            "context": {k: v for k, v in ctx.items() if v is not None},
+            "vectors": vectors,
+        }
+        path = out_dir / f"{platform}.json"
+        path.write_text(
+            json.dumps(doc, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        summary[platform] = len(vectors)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        default=str(REPO_ROOT / "tests" / "conformance" / "ingress_vectors"),
+        help="Output directory for <platform>.json ingress vector files",
+    )
+    args = parser.parse_args()
+    for platform, count in sorted(generate(Path(args.out)).items()):
+        print(f"{platform}: {count} ingress vectors")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_ingress_vectors.py
+++ b/scripts/generate_ingress_vectors.py
@@ -12,17 +12,23 @@ vitest runner asserts the CONNECTOR normalizers (telegram.ts / whatsapp.ts
 (dropped categories, wrong thread routing, mangled reply context) breaks a
 test instead of silently eating messages.
 
-Platform scope (deliberate):
+Platform scope:
   telegram  raw Bot API update dicts → thread routing (#3206/#22423 rules),
             chat-type normalization, reply context w/ partial quotes,
             source identity.
   whatsapp  Cloud API message objects → type mapping, body extraction,
             reply context (id + is_own), media identification, the
             group-shape refusal.
-  discord/slack: DEFERRED — their native inbound paths are discord.py /
-  Bolt EVENT-OBJECT consumers (SDK state, not payload functions); an
-  honest oracle needs the same pure-core extraction done here for
-  telegram/whatsapp. Recorded in the parity report.
+  discord   SDK-view IR dicts (layer 2 — see discord_parse.py's layer
+            model) → chat-type classification, mention stripping,
+            forwarded-snapshot folding, attachment→type classification,
+            reply references, thread naming. Layer 1 (payload→SDK object)
+            is the documented SDK-equivalence axiom: discord.py and the
+            connector's raw MESSAGE_CREATE handling are assumed to resolve
+            the same view fields.
+  slack     Events API message events → DM/MPIM classification, thread_ts
+            session scoping (#15421/#15464), mention detection, bot-message
+            classification.
 
 Field vocabulary is the WIRE MessageEvent's (chat_id, chat_type, thread_id,
 user_id, message_id, text, reply_to_*, message_type/media) — the shared
@@ -222,6 +228,176 @@ WHATSAPP_CORPUS: List[tuple] = [
 ]
 
 
+# ── discord corpus: SDK-view IR dicts (layer 2) ──────────────────────────
+
+BOT_USER_ID = "424242"
+
+DISCORD_CORPUS: List[tuple] = [
+    (
+        "dm-plain-text",
+        {"id": "1001", "content": "hello", "channel_id": "d1", "channel_kind": "dm",
+         "author": {"id": "777", "username": "ben", "display_name": "Ben"}},
+    ),
+    (
+        "guild-mention-stripped",
+        {"id": "1002", "content": f"<@{BOT_USER_ID}> summarize this", "channel_id": "c1",
+         "channel_name": "general", "channel_kind": "guildText", "guild_id": "g1",
+         "guild_name": "Eng", "author": {"id": "777", "username": "ben"},
+         "mentions": [{"id": BOT_USER_ID}]},
+    ),
+    (
+        "guild-nickname-mention-form",
+        {"id": "1003", "content": f"<@!{BOT_USER_ID}> hi", "channel_id": "c1",
+         "channel_name": "general", "channel_kind": "guildText", "guild_id": "g1",
+         "author": {"id": "777", "username": "ben"}, "mentions": []},
+    ),
+    (
+        "addressed-command",
+        {"id": "1004", "content": f"<@{BOT_USER_ID}> /new", "channel_id": "c1",
+         "channel_kind": "guildText", "guild_id": "g1",
+         "author": {"id": "777", "username": "ben"}, "mentions": [{"id": BOT_USER_ID}]},
+    ),
+    (
+        "thread-message",
+        {"id": "1005", "content": "in thread", "channel_id": "t1",
+         "channel_name": "build issue", "channel_kind": "thread", "guild_id": "g1",
+         "guild_name": "Eng", "parent_channel_id": "c1", "parent_channel_name": "general",
+         "author": {"id": "777", "username": "ben"}},
+    ),
+    (
+        "forum-thread-naming",
+        {"id": "1006", "content": "forum post", "channel_id": "t2",
+         "channel_name": "bug report", "channel_kind": "thread", "guild_id": "g1",
+         "guild_name": "Eng", "parent_channel_id": "f1", "parent_channel_name": "reports",
+         "parent_is_forum": True, "author": {"id": "777", "username": "ben"}},
+    ),
+    (
+        "image-attachment",
+        {"id": "1007", "content": "look", "channel_id": "c1", "channel_kind": "guildText",
+         "guild_id": "g1", "author": {"id": "777", "username": "ben"},
+         "attachments": [{"content_type": "image/png", "filename": "a.png",
+                          "url": "https://cdn.discordapp.com/a.png"}]},
+    ),
+    (
+        "voice-note-attachment",
+        {"id": "1008", "content": "", "channel_id": "d1", "channel_kind": "dm",
+         "author": {"id": "777", "username": "ben"},
+         "attachments": [{"content_type": "audio/ogg", "is_voice_message": True,
+                          "duration": 3.2, "waveform": "AAA="}]},
+    ),
+    (
+        "plain-audio-attachment",
+        {"id": "1009", "content": "", "channel_id": "d1", "channel_kind": "dm",
+         "author": {"id": "777", "username": "ben"},
+         "attachments": [{"content_type": "audio/mpeg", "filename": "song.mp3"}]},
+    ),
+    (
+        "document-attachment-unknown-type",
+        {"id": "1010", "content": "", "channel_id": "d1", "channel_kind": "dm",
+         "author": {"id": "777", "username": "ben"},
+         "attachments": [{"filename": "data.bin"}]},  # no content_type ⇒ DOCUMENT
+    ),
+    (
+        "forwarded-snapshot-text",
+        {"id": "1011", "content": "", "channel_id": "d1", "channel_kind": "dm",
+         "author": {"id": "777", "username": "ben"},
+         "message_snapshots": [{"content": "forwarded wisdom"}]},
+    ),
+    (
+        "reply-with-reference",
+        {"id": "1012", "content": "re", "channel_id": "c1", "channel_kind": "guildText",
+         "guild_id": "g1", "author": {"id": "777", "username": "ben"},
+         "referenced_message": {"id": "999", "attachments": []}},
+    ),
+    (
+        "reply-inherits-referenced-attachment",
+        {"id": "1013", "content": "what is this file?", "channel_id": "c1",
+         "channel_kind": "guildText", "guild_id": "g1",
+         "author": {"id": "777", "username": "ben"},
+         "referenced_message": {"id": "999",
+                                "attachments": [{"content_type": "application/pdf",
+                                                 "filename": "spec.pdf"}]}},
+    ),
+    (
+        "bot-authored",
+        {"id": "1014", "content": "bot says", "channel_id": "c1",
+         "channel_kind": "guildText", "guild_id": "g1",
+         "author": {"id": "999", "username": "otherbot", "bot": True}},
+    ),
+    (
+        "display-name-preference",
+        {"id": "1015", "content": "hi", "channel_id": "d1", "channel_kind": "dm",
+         "author": {"id": "777", "username": "ben", "display_name": "Benjamin"}},
+    ),
+]
+
+# ── slack corpus: Events API message events ──────────────────────────────
+
+SLACK_BOT_USER_ID = "U0BOT"
+
+SLACK_CORPUS: List[tuple] = [
+    (
+        "dm-plain-text",
+        {"channel": "D111", "channel_type": "im", "ts": "100.1", "user": "U777",
+         "team": "T1", "text": "hello"},
+    ),
+    (
+        "dm-prefix-fallback",
+        {"channel": "D222", "ts": "100.2", "user": "U777", "text": "no channel_type"},
+    ),
+    (
+        "mpim-is-dm-but-not-one-to-one",
+        {"channel": "G333", "channel_type": "mpim", "ts": "100.3", "user": "U777",
+         "team": "T1", "text": "group dm"},
+    ),
+    (
+        "channel-top-level",
+        {"channel": "C444", "channel_type": "channel", "ts": "100.4", "user": "U777",
+         "team": "T1", "text": "top level"},
+    ),
+    (
+        "channel-thread-reply",
+        {"channel": "C444", "channel_type": "channel", "ts": "100.6", "user": "U777",
+         "team": "T1", "text": "in thread", "thread_ts": "100.4"},
+    ),
+    (
+        # #15464: thread_ts == ts is a thread-ROOT shape, not a reply.
+        "thread-root-equals-ts",
+        {"channel": "C444", "channel_type": "channel", "ts": "100.7", "user": "U777",
+         "team": "T1", "text": "root shape", "thread_ts": "100.7"},
+    ),
+    (
+        "channel-mention",
+        {"channel": "C444", "channel_type": "channel", "ts": "100.8", "user": "U777",
+         "team": "T1", "text": f"<@{SLACK_BOT_USER_ID}> do the thing"},
+    ),
+    (
+        "dm-thread-reply",
+        {"channel": "D111", "channel_type": "im", "ts": "100.9", "user": "U777",
+         "text": "dm threaded", "thread_ts": "100.1"},
+    ),
+    (
+        "bot-message-subtype",
+        {"channel": "C444", "channel_type": "channel", "ts": "101.0",
+         "subtype": "bot_message", "bot_id": "B99", "text": "integration says"},
+    ),
+    (
+        "bot-id-without-subtype",
+        {"channel": "C444", "channel_type": "channel", "ts": "101.1", "bot_id": "B99",
+         "text": "workflow post"},
+    ),
+    (
+        "private-group-channel",
+        {"channel": "G555", "channel_type": "group", "ts": "101.2", "user": "U777",
+         "team": "T1", "text": "private channel"},
+    ),
+    (
+        "cjk-emoji-text",
+        {"channel": "C444", "channel_type": "channel", "ts": "101.3", "user": "U777",
+         "team": "T1", "text": "中文 — test 🎉 (100%)"},
+    ),
+]
+
 # ── expected-field derivation via the pure cores ─────────────────────────
 
 
@@ -267,6 +443,52 @@ def whatsapp_expected(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def discord_expected(payload: Dict[str, Any]) -> Dict[str, Any]:
+    from plugins.platforms.discord.discord_parse import (
+        parse_discord_message,
+        view_from_dict,
+    )
+
+    p = parse_discord_message(view_from_dict(payload), BOT_USER_ID)
+    return {
+        "chat_type": p.chat_type,
+        "chat_id": p.chat_id,
+        "chat_name": p.chat_name,
+        "thread_id": p.thread_id,
+        "parent_chat_id": p.parent_chat_id,
+        "guild_id": p.guild_id,
+        "user_id": p.user_id,
+        "user_name": p.user_name,
+        "user_is_bot": p.user_is_bot,
+        "message_id": p.message_id,
+        "text": p.text,
+        "message_type": p.message_type.value
+        if hasattr(p.message_type, "value")
+        else str(p.message_type),
+        "reply_to_message_id": p.reply_to_message_id,
+        "mentions_bot": p.mentions_bot,
+    }
+
+
+def slack_expected(payload: Dict[str, Any]) -> Dict[str, Any]:
+    from plugins.platforms.slack.slack_parse import parse_slack_event
+
+    p = parse_slack_event(payload, SLACK_BOT_USER_ID)
+    return {
+        "chat_type": p.chat_type,
+        "chat_id": p.chat_id,
+        "is_dm": p.is_dm,
+        "is_one_to_one_dm": p.is_one_to_one_dm,
+        "session_thread_ts": p.session_thread_ts,
+        "user_id": p.user_id,
+        "team_id": p.team_id,
+        "message_id": p.message_id,
+        "text": p.text,
+        "mentions_bot": p.mentions_bot,
+        "user_is_bot": p.user_is_bot,
+    }
+
+
 def _oracle_commit() -> str:
     try:
         return subprocess.run(
@@ -286,6 +508,10 @@ def generate(out_dir: Path) -> Dict[str, int]:
                      {"contacts": None, "metadata": None}),
         "whatsapp": (WHATSAPP_CORPUS, whatsapp_expected,
                      {"contacts": WA_CONTACTS, "metadata": WA_METADATA}),
+        "discord": (DISCORD_CORPUS, discord_expected,
+                    {"bot_user_id": BOT_USER_ID}),
+        "slack": (SLACK_CORPUS, slack_expected,
+                  {"bot_user_id": SLACK_BOT_USER_ID}),
     }
     for platform, (corpus, derive, ctx) in sorted(corpora.items()):
         vectors = []

--- a/tests/conformance/ingress_vectors/discord.json
+++ b/tests/conformance/ingress_vectors/discord.json
@@ -1,0 +1,530 @@
+{
+  "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_ingress_vectors.py; the native inbound parse cores are the oracle (executable spec).",
+  "oracle": {
+    "repo": "NousResearch/hermes-agent",
+    "commit": "a56c341190b3c0b8e0643f357cf5412511e6cae1",
+    "generator": "scripts/generate_ingress_vectors.py",
+    "generator_version": 1
+  },
+  "platform": "discord",
+  "direction": "ingress",
+  "context": {
+    "bot_user_id": "424242"
+  },
+  "vectors": [
+    {
+      "id": "dm-plain-text",
+      "payload": {
+        "id": "1001",
+        "content": "hello",
+        "channel_id": "d1",
+        "channel_kind": "dm",
+        "author": {
+          "id": "777",
+          "username": "ben",
+          "display_name": "Ben"
+        }
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "d1",
+        "chat_name": "ben",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "1001",
+        "text": "hello",
+        "message_type": "text",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "guild-mention-stripped",
+      "payload": {
+        "id": "1002",
+        "content": "<@424242> summarize this",
+        "channel_id": "c1",
+        "channel_name": "general",
+        "channel_kind": "guildText",
+        "guild_id": "g1",
+        "guild_name": "Eng",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "mentions": [
+          {
+            "id": "424242"
+          }
+        ]
+      },
+      "expected": {
+        "chat_type": "group",
+        "chat_id": "c1",
+        "chat_name": "Eng / #general",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": "g1",
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1002",
+        "text": "summarize this",
+        "message_type": "text",
+        "reply_to_message_id": null,
+        "mentions_bot": true
+      }
+    },
+    {
+      "id": "guild-nickname-mention-form",
+      "payload": {
+        "id": "1003",
+        "content": "<@!424242> hi",
+        "channel_id": "c1",
+        "channel_name": "general",
+        "channel_kind": "guildText",
+        "guild_id": "g1",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "mentions": []
+      },
+      "expected": {
+        "chat_type": "group",
+        "chat_id": "c1",
+        "chat_name": "general",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": "g1",
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1003",
+        "text": "hi",
+        "message_type": "text",
+        "reply_to_message_id": null,
+        "mentions_bot": true
+      }
+    },
+    {
+      "id": "addressed-command",
+      "payload": {
+        "id": "1004",
+        "content": "<@424242> /new",
+        "channel_id": "c1",
+        "channel_kind": "guildText",
+        "guild_id": "g1",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "mentions": [
+          {
+            "id": "424242"
+          }
+        ]
+      },
+      "expected": {
+        "chat_type": "group",
+        "chat_id": "c1",
+        "chat_name": "c1",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": "g1",
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1004",
+        "text": "/new",
+        "message_type": "command",
+        "reply_to_message_id": null,
+        "mentions_bot": true
+      }
+    },
+    {
+      "id": "thread-message",
+      "payload": {
+        "id": "1005",
+        "content": "in thread",
+        "channel_id": "t1",
+        "channel_name": "build issue",
+        "channel_kind": "thread",
+        "guild_id": "g1",
+        "guild_name": "Eng",
+        "parent_channel_id": "c1",
+        "parent_channel_name": "general",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        }
+      },
+      "expected": {
+        "chat_type": "thread",
+        "chat_id": "t1",
+        "chat_name": "Eng / #general / build issue",
+        "thread_id": "t1",
+        "parent_chat_id": "c1",
+        "guild_id": "g1",
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1005",
+        "text": "in thread",
+        "message_type": "text",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "forum-thread-naming",
+      "payload": {
+        "id": "1006",
+        "content": "forum post",
+        "channel_id": "t2",
+        "channel_name": "bug report",
+        "channel_kind": "thread",
+        "guild_id": "g1",
+        "guild_name": "Eng",
+        "parent_channel_id": "f1",
+        "parent_channel_name": "reports",
+        "parent_is_forum": true,
+        "author": {
+          "id": "777",
+          "username": "ben"
+        }
+      },
+      "expected": {
+        "chat_type": "thread",
+        "chat_id": "t2",
+        "chat_name": "Eng / reports / bug report",
+        "thread_id": "t2",
+        "parent_chat_id": "f1",
+        "guild_id": "g1",
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1006",
+        "text": "forum post",
+        "message_type": "text",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "image-attachment",
+      "payload": {
+        "id": "1007",
+        "content": "look",
+        "channel_id": "c1",
+        "channel_kind": "guildText",
+        "guild_id": "g1",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "attachments": [
+          {
+            "content_type": "image/png",
+            "filename": "a.png",
+            "url": "https://cdn.discordapp.com/a.png"
+          }
+        ]
+      },
+      "expected": {
+        "chat_type": "group",
+        "chat_id": "c1",
+        "chat_name": "c1",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": "g1",
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1007",
+        "text": "look",
+        "message_type": "photo",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "voice-note-attachment",
+      "payload": {
+        "id": "1008",
+        "content": "",
+        "channel_id": "d1",
+        "channel_kind": "dm",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "attachments": [
+          {
+            "content_type": "audio/ogg",
+            "is_voice_message": true,
+            "duration": 3.2,
+            "waveform": "AAA="
+          }
+        ]
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "d1",
+        "chat_name": "ben",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": null,
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1008",
+        "text": "",
+        "message_type": "voice",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "plain-audio-attachment",
+      "payload": {
+        "id": "1009",
+        "content": "",
+        "channel_id": "d1",
+        "channel_kind": "dm",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "attachments": [
+          {
+            "content_type": "audio/mpeg",
+            "filename": "song.mp3"
+          }
+        ]
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "d1",
+        "chat_name": "ben",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": null,
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1009",
+        "text": "",
+        "message_type": "audio",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "document-attachment-unknown-type",
+      "payload": {
+        "id": "1010",
+        "content": "",
+        "channel_id": "d1",
+        "channel_kind": "dm",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "attachments": [
+          {
+            "filename": "data.bin"
+          }
+        ]
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "d1",
+        "chat_name": "ben",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": null,
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1010",
+        "text": "",
+        "message_type": "document",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "forwarded-snapshot-text",
+      "payload": {
+        "id": "1011",
+        "content": "",
+        "channel_id": "d1",
+        "channel_kind": "dm",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "message_snapshots": [
+          {
+            "content": "forwarded wisdom"
+          }
+        ]
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "d1",
+        "chat_name": "ben",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": null,
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1011",
+        "text": "forwarded wisdom",
+        "message_type": "text",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "reply-with-reference",
+      "payload": {
+        "id": "1012",
+        "content": "re",
+        "channel_id": "c1",
+        "channel_kind": "guildText",
+        "guild_id": "g1",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "referenced_message": {
+          "id": "999",
+          "attachments": []
+        }
+      },
+      "expected": {
+        "chat_type": "group",
+        "chat_id": "c1",
+        "chat_name": "c1",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": "g1",
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1012",
+        "text": "re",
+        "message_type": "text",
+        "reply_to_message_id": "999",
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "reply-inherits-referenced-attachment",
+      "payload": {
+        "id": "1013",
+        "content": "what is this file?",
+        "channel_id": "c1",
+        "channel_kind": "guildText",
+        "guild_id": "g1",
+        "author": {
+          "id": "777",
+          "username": "ben"
+        },
+        "referenced_message": {
+          "id": "999",
+          "attachments": [
+            {
+              "content_type": "application/pdf",
+              "filename": "spec.pdf"
+            }
+          ]
+        }
+      },
+      "expected": {
+        "chat_type": "group",
+        "chat_id": "c1",
+        "chat_name": "c1",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": "g1",
+        "user_id": "777",
+        "user_name": "ben",
+        "user_is_bot": false,
+        "message_id": "1013",
+        "text": "what is this file?",
+        "message_type": "document",
+        "reply_to_message_id": "999",
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "bot-authored",
+      "payload": {
+        "id": "1014",
+        "content": "bot says",
+        "channel_id": "c1",
+        "channel_kind": "guildText",
+        "guild_id": "g1",
+        "author": {
+          "id": "999",
+          "username": "otherbot",
+          "bot": true
+        }
+      },
+      "expected": {
+        "chat_type": "group",
+        "chat_id": "c1",
+        "chat_name": "c1",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": "g1",
+        "user_id": "999",
+        "user_name": "otherbot",
+        "user_is_bot": true,
+        "message_id": "1014",
+        "text": "bot says",
+        "message_type": "text",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    },
+    {
+      "id": "display-name-preference",
+      "payload": {
+        "id": "1015",
+        "content": "hi",
+        "channel_id": "d1",
+        "channel_kind": "dm",
+        "author": {
+          "id": "777",
+          "username": "ben",
+          "display_name": "Benjamin"
+        }
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "d1",
+        "chat_name": "ben",
+        "thread_id": null,
+        "parent_chat_id": null,
+        "guild_id": null,
+        "user_id": "777",
+        "user_name": "Benjamin",
+        "user_is_bot": false,
+        "message_id": "1015",
+        "text": "hi",
+        "message_type": "text",
+        "reply_to_message_id": null,
+        "mentions_bot": false
+      }
+    }
+  ]
+}

--- a/tests/conformance/ingress_vectors/slack.json
+++ b/tests/conformance/ingress_vectors/slack.json
@@ -1,0 +1,303 @@
+{
+  "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_ingress_vectors.py; the native inbound parse cores are the oracle (executable spec).",
+  "oracle": {
+    "repo": "NousResearch/hermes-agent",
+    "commit": "a56c341190b3c0b8e0643f357cf5412511e6cae1",
+    "generator": "scripts/generate_ingress_vectors.py",
+    "generator_version": 1
+  },
+  "platform": "slack",
+  "direction": "ingress",
+  "context": {
+    "bot_user_id": "U0BOT"
+  },
+  "vectors": [
+    {
+      "id": "dm-plain-text",
+      "payload": {
+        "channel": "D111",
+        "channel_type": "im",
+        "ts": "100.1",
+        "user": "U777",
+        "team": "T1",
+        "text": "hello"
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "D111",
+        "is_dm": true,
+        "is_one_to_one_dm": true,
+        "session_thread_ts": "100.1",
+        "user_id": "U777",
+        "team_id": "T1",
+        "message_id": "100.1",
+        "text": "hello",
+        "mentions_bot": false,
+        "user_is_bot": false
+      }
+    },
+    {
+      "id": "dm-prefix-fallback",
+      "payload": {
+        "channel": "D222",
+        "ts": "100.2",
+        "user": "U777",
+        "text": "no channel_type"
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "D222",
+        "is_dm": true,
+        "is_one_to_one_dm": true,
+        "session_thread_ts": "100.2",
+        "user_id": "U777",
+        "team_id": null,
+        "message_id": "100.2",
+        "text": "no channel_type",
+        "mentions_bot": false,
+        "user_is_bot": false
+      }
+    },
+    {
+      "id": "mpim-is-dm-but-not-one-to-one",
+      "payload": {
+        "channel": "G333",
+        "channel_type": "mpim",
+        "ts": "100.3",
+        "user": "U777",
+        "team": "T1",
+        "text": "group dm"
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "G333",
+        "is_dm": true,
+        "is_one_to_one_dm": false,
+        "session_thread_ts": "100.3",
+        "user_id": "U777",
+        "team_id": "T1",
+        "message_id": "100.3",
+        "text": "group dm",
+        "mentions_bot": false,
+        "user_is_bot": false
+      }
+    },
+    {
+      "id": "channel-top-level",
+      "payload": {
+        "channel": "C444",
+        "channel_type": "channel",
+        "ts": "100.4",
+        "user": "U777",
+        "team": "T1",
+        "text": "top level"
+      },
+      "expected": {
+        "chat_type": "channel",
+        "chat_id": "C444",
+        "is_dm": false,
+        "is_one_to_one_dm": false,
+        "session_thread_ts": "100.4",
+        "user_id": "U777",
+        "team_id": "T1",
+        "message_id": "100.4",
+        "text": "top level",
+        "mentions_bot": false,
+        "user_is_bot": false
+      }
+    },
+    {
+      "id": "channel-thread-reply",
+      "payload": {
+        "channel": "C444",
+        "channel_type": "channel",
+        "ts": "100.6",
+        "user": "U777",
+        "team": "T1",
+        "text": "in thread",
+        "thread_ts": "100.4"
+      },
+      "expected": {
+        "chat_type": "thread",
+        "chat_id": "C444",
+        "is_dm": false,
+        "is_one_to_one_dm": false,
+        "session_thread_ts": "100.4",
+        "user_id": "U777",
+        "team_id": "T1",
+        "message_id": "100.6",
+        "text": "in thread",
+        "mentions_bot": false,
+        "user_is_bot": false
+      }
+    },
+    {
+      "id": "thread-root-equals-ts",
+      "payload": {
+        "channel": "C444",
+        "channel_type": "channel",
+        "ts": "100.7",
+        "user": "U777",
+        "team": "T1",
+        "text": "root shape",
+        "thread_ts": "100.7"
+      },
+      "expected": {
+        "chat_type": "channel",
+        "chat_id": "C444",
+        "is_dm": false,
+        "is_one_to_one_dm": false,
+        "session_thread_ts": "100.7",
+        "user_id": "U777",
+        "team_id": "T1",
+        "message_id": "100.7",
+        "text": "root shape",
+        "mentions_bot": false,
+        "user_is_bot": false
+      }
+    },
+    {
+      "id": "channel-mention",
+      "payload": {
+        "channel": "C444",
+        "channel_type": "channel",
+        "ts": "100.8",
+        "user": "U777",
+        "team": "T1",
+        "text": "<@U0BOT> do the thing"
+      },
+      "expected": {
+        "chat_type": "channel",
+        "chat_id": "C444",
+        "is_dm": false,
+        "is_one_to_one_dm": false,
+        "session_thread_ts": "100.8",
+        "user_id": "U777",
+        "team_id": "T1",
+        "message_id": "100.8",
+        "text": "do the thing",
+        "mentions_bot": true,
+        "user_is_bot": false
+      }
+    },
+    {
+      "id": "dm-thread-reply",
+      "payload": {
+        "channel": "D111",
+        "channel_type": "im",
+        "ts": "100.9",
+        "user": "U777",
+        "text": "dm threaded",
+        "thread_ts": "100.1"
+      },
+      "expected": {
+        "chat_type": "dm",
+        "chat_id": "D111",
+        "is_dm": true,
+        "is_one_to_one_dm": true,
+        "session_thread_ts": "100.1",
+        "user_id": "U777",
+        "team_id": null,
+        "message_id": "100.9",
+        "text": "dm threaded",
+        "mentions_bot": false,
+        "user_is_bot": false
+      }
+    },
+    {
+      "id": "bot-message-subtype",
+      "payload": {
+        "channel": "C444",
+        "channel_type": "channel",
+        "ts": "101.0",
+        "subtype": "bot_message",
+        "bot_id": "B99",
+        "text": "integration says"
+      },
+      "expected": {
+        "chat_type": "channel",
+        "chat_id": "C444",
+        "is_dm": false,
+        "is_one_to_one_dm": false,
+        "session_thread_ts": "101.0",
+        "user_id": null,
+        "team_id": null,
+        "message_id": "101.0",
+        "text": "integration says",
+        "mentions_bot": false,
+        "user_is_bot": true
+      }
+    },
+    {
+      "id": "bot-id-without-subtype",
+      "payload": {
+        "channel": "C444",
+        "channel_type": "channel",
+        "ts": "101.1",
+        "bot_id": "B99",
+        "text": "workflow post"
+      },
+      "expected": {
+        "chat_type": "channel",
+        "chat_id": "C444",
+        "is_dm": false,
+        "is_one_to_one_dm": false,
+        "session_thread_ts": "101.1",
+        "user_id": null,
+        "team_id": null,
+        "message_id": "101.1",
+        "text": "workflow post",
+        "mentions_bot": false,
+        "user_is_bot": true
+      }
+    },
+    {
+      "id": "private-group-channel",
+      "payload": {
+        "channel": "G555",
+        "channel_type": "group",
+        "ts": "101.2",
+        "user": "U777",
+        "team": "T1",
+        "text": "private channel"
+      },
+      "expected": {
+        "chat_type": "channel",
+        "chat_id": "G555",
+        "is_dm": false,
+        "is_one_to_one_dm": false,
+        "session_thread_ts": "101.2",
+        "user_id": "U777",
+        "team_id": "T1",
+        "message_id": "101.2",
+        "text": "private channel",
+        "mentions_bot": false,
+        "user_is_bot": false
+      }
+    },
+    {
+      "id": "cjk-emoji-text",
+      "payload": {
+        "channel": "C444",
+        "channel_type": "channel",
+        "ts": "101.3",
+        "user": "U777",
+        "team": "T1",
+        "text": "中文 — test 🎉 (100%)"
+      },
+      "expected": {
+        "chat_type": "channel",
+        "chat_id": "C444",
+        "is_dm": false,
+        "is_one_to_one_dm": false,
+        "session_thread_ts": "101.3",
+        "user_id": "U777",
+        "team_id": "T1",
+        "message_id": "101.3",
+        "text": "中文 — test 🎉 (100%)",
+        "mentions_bot": false,
+        "user_is_bot": false
+      }
+    }
+  ]
+}

--- a/tests/conformance/ingress_vectors/telegram.json
+++ b/tests/conformance/ingress_vectors/telegram.json
@@ -1,0 +1,511 @@
+{
+  "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_ingress_vectors.py; the native inbound parse cores are the oracle (executable spec).",
+  "oracle": {
+    "repo": "NousResearch/hermes-agent",
+    "commit": "ef60509a26d07b40c4f512f864c8242a5bce4076",
+    "generator": "scripts/generate_ingress_vectors.py",
+    "generator_version": 1
+  },
+  "platform": "telegram",
+  "direction": "ingress",
+  "context": {},
+  "vectors": [
+    {
+      "id": "dm-plain-text",
+      "payload": {
+        "message_id": 1,
+        "chat": {
+          "id": 555,
+          "type": "private",
+          "first_name": "Ben"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "hello"
+      },
+      "expected": {
+        "chat_id": "555",
+        "chat_type": "dm",
+        "chat_name": "Ben",
+        "thread_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "1",
+        "text": "hello",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    },
+    {
+      "id": "group-plain-text",
+      "payload": {
+        "message_id": 2,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "hi group"
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "2",
+        "text": "hi group",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    },
+    {
+      "id": "channel-post",
+      "payload": {
+        "message_id": 3,
+        "chat": {
+          "id": -1009,
+          "type": "channel",
+          "title": "Announce"
+        },
+        "text": "channel news"
+      },
+      "expected": {
+        "chat_id": "-1009",
+        "chat_type": "channel",
+        "chat_name": "Announce",
+        "thread_id": null,
+        "user_id": "-1009",
+        "user_name": "Announce",
+        "user_is_bot": false,
+        "message_id": "3",
+        "text": "channel news",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    },
+    {
+      "id": "forum-topic-message",
+      "payload": {
+        "message_id": 4,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group",
+          "is_forum": true
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "topic chat",
+        "message_thread_id": 55,
+        "is_topic_message": true
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": "55",
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "4",
+        "text": "topic chat",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    },
+    {
+      "id": "forum-general-topic",
+      "payload": {
+        "message_id": 5,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group",
+          "is_forum": true
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "general chat"
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": "1",
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "5",
+        "text": "general chat",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    },
+    {
+      "id": "group-reply-anchor-not-thread",
+      "payload": {
+        "message_id": 6,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "re",
+        "message_thread_id": 42,
+        "reply_to_message": {
+          "message_id": 42,
+          "chat": {
+            "id": -1001234,
+            "type": "supergroup",
+            "title": "Eng Group"
+          },
+          "from": {
+            "id": 888,
+            "is_bot": false,
+            "first_name": "Alice",
+            "username": "ben"
+          },
+          "text": "original"
+        }
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "6",
+        "text": "re",
+        "reply_to_message_id": "42",
+        "reply_to_text": "original"
+      }
+    },
+    {
+      "id": "dm-topic-message",
+      "payload": {
+        "message_id": 7,
+        "chat": {
+          "id": 555,
+          "type": "private",
+          "first_name": "Ben"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "dm topic",
+        "message_thread_id": 9,
+        "is_topic_message": true
+      },
+      "expected": {
+        "chat_id": "555",
+        "chat_type": "dm",
+        "chat_name": "Ben",
+        "thread_id": "9",
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "7",
+        "text": "dm topic",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    },
+    {
+      "id": "reply-with-text",
+      "payload": {
+        "message_id": 8,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "re",
+        "reply_to_message": {
+          "message_id": 7,
+          "chat": {
+            "id": -1001234,
+            "type": "supergroup",
+            "title": "Eng Group"
+          },
+          "from": {
+            "id": 999,
+            "is_bot": true,
+            "first_name": "Hermes",
+            "username": "ben"
+          },
+          "text": "what the bot said"
+        }
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "8",
+        "text": "re",
+        "reply_to_message_id": "7",
+        "reply_to_text": "what the bot said"
+      }
+    },
+    {
+      "id": "reply-partial-quote",
+      "payload": {
+        "message_id": 9,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "re",
+        "quote": {
+          "text": "just this part"
+        },
+        "reply_to_message": {
+          "message_id": 7,
+          "chat": {
+            "id": -1001234,
+            "type": "supergroup",
+            "title": "Eng Group"
+          },
+          "from": {
+            "id": 888,
+            "is_bot": false,
+            "first_name": "Alice",
+            "username": "ben"
+          },
+          "text": "a long message with many parts"
+        }
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "9",
+        "text": "re",
+        "reply_to_message_id": "7",
+        "reply_to_text": "just this part"
+      }
+    },
+    {
+      "id": "reply-to-caption-only",
+      "payload": {
+        "message_id": 10,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "re",
+        "reply_to_message": {
+          "message_id": 7,
+          "chat": {
+            "id": -1001234,
+            "type": "supergroup",
+            "title": "Eng Group"
+          },
+          "from": {
+            "id": 888,
+            "is_bot": false,
+            "first_name": "Alice",
+            "username": "ben"
+          },
+          "caption": "photo caption"
+        }
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "10",
+        "text": "re",
+        "reply_to_message_id": "7",
+        "reply_to_text": "photo caption"
+      }
+    },
+    {
+      "id": "bot-authored-message",
+      "payload": {
+        "message_id": 11,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group"
+        },
+        "from": {
+          "id": 999,
+          "is_bot": true,
+          "first_name": "OtherBot",
+          "username": "ben"
+        },
+        "text": "bot chatter"
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": null,
+        "user_id": "999",
+        "user_name": "OtherBot",
+        "user_is_bot": true,
+        "message_id": "11",
+        "text": "bot chatter",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    },
+    {
+      "id": "command-message",
+      "payload": {
+        "message_id": 12,
+        "chat": {
+          "id": 555,
+          "type": "private",
+          "first_name": "Ben"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "/status"
+      },
+      "expected": {
+        "chat_id": "555",
+        "chat_type": "dm",
+        "chat_name": "Ben",
+        "thread_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "12",
+        "text": "/status",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    },
+    {
+      "id": "cjk-emoji-text",
+      "payload": {
+        "message_id": 13,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        },
+        "text": "中文 — test 🎉 (100%)"
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "13",
+        "text": "中文 — test 🎉 (100%)",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    },
+    {
+      "id": "empty-text-media-placeholder",
+      "payload": {
+        "message_id": 14,
+        "chat": {
+          "id": -1001234,
+          "type": "supergroup",
+          "title": "Eng Group"
+        },
+        "from": {
+          "id": 777,
+          "is_bot": false,
+          "first_name": "Ben",
+          "username": "ben"
+        }
+      },
+      "expected": {
+        "chat_id": "-1001234",
+        "chat_type": "group",
+        "chat_name": "Eng Group",
+        "thread_id": null,
+        "user_id": "777",
+        "user_name": "Ben",
+        "user_is_bot": false,
+        "message_id": "14",
+        "text": "",
+        "reply_to_message_id": null,
+        "reply_to_text": null
+      }
+    }
+  ]
+}

--- a/tests/conformance/ingress_vectors/telegram.json
+++ b/tests/conformance/ingress_vectors/telegram.json
@@ -2,7 +2,7 @@
   "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_ingress_vectors.py; the native inbound parse cores are the oracle (executable spec).",
   "oracle": {
     "repo": "NousResearch/hermes-agent",
-    "commit": "ef60509a26d07b40c4f512f864c8242a5bce4076",
+    "commit": "a56c341190b3c0b8e0643f357cf5412511e6cae1",
     "generator": "scripts/generate_ingress_vectors.py",
     "generator_version": 1
   },

--- a/tests/conformance/ingress_vectors/whatsapp.json
+++ b/tests/conformance/ingress_vectors/whatsapp.json
@@ -1,0 +1,383 @@
+{
+  "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_ingress_vectors.py; the native inbound parse cores are the oracle (executable spec).",
+  "oracle": {
+    "repo": "NousResearch/hermes-agent",
+    "commit": "ef60509a26d07b40c4f512f864c8242a5bce4076",
+    "generator": "scripts/generate_ingress_vectors.py",
+    "generator_version": 1
+  },
+  "platform": "whatsapp",
+  "direction": "ingress",
+  "context": {
+    "contacts": {
+      "15551110000": "Ben",
+      "15559998888": "Hermes Biz"
+    },
+    "metadata": {
+      "display_phone_number": "15559998888",
+      "phone_number_id": "PNID1"
+    }
+  },
+  "vectors": [
+    {
+      "id": "text-message",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.t1",
+        "type": "text",
+        "text": {
+          "body": "hello"
+        }
+      },
+      "expected": {
+        "msg_type": "text",
+        "message_type": "text",
+        "body": "hello",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.t1",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": null,
+        "media_mime": null,
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "command-text",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.t2",
+        "type": "text",
+        "text": {
+          "body": "/status"
+        }
+      },
+      "expected": {
+        "msg_type": "text",
+        "message_type": "text",
+        "body": "/status",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.t2",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": null,
+        "media_mime": null,
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "image-with-caption",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.m1",
+        "type": "image",
+        "image": {
+          "id": "MEDIA1",
+          "mime_type": "image/jpeg",
+          "caption": "look"
+        }
+      },
+      "expected": {
+        "msg_type": "image",
+        "message_type": "photo",
+        "body": "look",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.m1",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": "MEDIA1",
+        "media_mime": "image/jpeg",
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "voice-note",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.m2",
+        "type": "audio",
+        "audio": {
+          "id": "MEDIA2",
+          "mime_type": "audio/ogg; codecs=opus",
+          "voice": true
+        }
+      },
+      "expected": {
+        "msg_type": "audio",
+        "message_type": "voice",
+        "body": "",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.m2",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": "MEDIA2",
+        "media_mime": "audio/ogg; codecs=opus",
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "document-with-filename",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.m3",
+        "type": "document",
+        "document": {
+          "id": "MEDIA3",
+          "mime_type": "text/plain",
+          "filename": "notes.txt"
+        }
+      },
+      "expected": {
+        "msg_type": "document",
+        "message_type": "document",
+        "body": "",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.m3",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": "MEDIA3",
+        "media_mime": "text/plain",
+        "document_filename": "notes.txt",
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "sticker",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.m4",
+        "type": "sticker",
+        "sticker": {
+          "id": "MEDIA4",
+          "mime_type": "image/webp"
+        }
+      },
+      "expected": {
+        "msg_type": "sticker",
+        "message_type": "photo",
+        "body": "",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.m4",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": "MEDIA4",
+        "media_mime": "image/webp",
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "reply-to-bot-message",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.r1",
+        "type": "text",
+        "text": {
+          "body": "re"
+        },
+        "context": {
+          "id": "wamid.orig",
+          "from": "15559998888"
+        }
+      },
+      "expected": {
+        "msg_type": "text",
+        "message_type": "text",
+        "body": "re",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.r1",
+        "reply_to_message_id": "wamid.orig",
+        "reply_to_is_own": true,
+        "media_id": null,
+        "media_mime": null,
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "reply-to-own-message",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.r2",
+        "type": "text",
+        "text": {
+          "body": "re self"
+        },
+        "context": {
+          "id": "wamid.mine",
+          "from": "15551110000"
+        }
+      },
+      "expected": {
+        "msg_type": "text",
+        "message_type": "text",
+        "body": "re self",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.r2",
+        "reply_to_message_id": "wamid.mine",
+        "reply_to_is_own": false,
+        "media_id": null,
+        "media_mime": null,
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "button-reply",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.b1",
+        "type": "button",
+        "button": {
+          "text": "Approve",
+          "payload": "approve-1"
+        }
+      },
+      "expected": {
+        "msg_type": "button",
+        "message_type": "text",
+        "body": "Approve",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.b1",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": null,
+        "media_mime": null,
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "list-reply-title",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.b2",
+        "type": "interactive",
+        "interactive": {
+          "type": "list_reply",
+          "list_reply": {
+            "id": "opt-2",
+            "title": "Option Two"
+          }
+        }
+      },
+      "expected": {
+        "msg_type": "interactive",
+        "message_type": "text",
+        "body": "Option Two",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.b2",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": null,
+        "media_mime": null,
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "group-shaped-refused",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.g1",
+        "type": "text",
+        "chat": "1203630xxxx@g.us",
+        "text": {
+          "body": "group msg"
+        }
+      },
+      "expected": {
+        "msg_type": "text",
+        "message_type": "text",
+        "body": "group msg",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.g1",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": null,
+        "media_mime": null,
+        "document_filename": null,
+        "group_shaped": true
+      }
+    },
+    {
+      "id": "unknown-type-defaults-text",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.u1",
+        "type": "reaction",
+        "reaction": {
+          "emoji": "👍",
+          "message_id": "wamid.t1"
+        }
+      },
+      "expected": {
+        "msg_type": "reaction",
+        "message_type": "text",
+        "body": "",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.u1",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": null,
+        "media_mime": null,
+        "document_filename": null,
+        "group_shaped": false
+      }
+    },
+    {
+      "id": "cjk-emoji-body",
+      "payload": {
+        "from": "15551110000",
+        "id": "wamid.c1",
+        "type": "text",
+        "text": {
+          "body": "中文 — test 🎉 (100%)"
+        }
+      },
+      "expected": {
+        "msg_type": "text",
+        "message_type": "text",
+        "body": "中文 — test 🎉 (100%)",
+        "sender_id": "15551110000",
+        "sender_name": "Ben",
+        "chat_id": "15551110000",
+        "message_id": "wamid.c1",
+        "reply_to_message_id": null,
+        "reply_to_is_own": false,
+        "media_id": null,
+        "media_mime": null,
+        "document_filename": null,
+        "group_shaped": false
+      }
+    }
+  ]
+}

--- a/tests/conformance/ingress_vectors/whatsapp.json
+++ b/tests/conformance/ingress_vectors/whatsapp.json
@@ -2,7 +2,7 @@
   "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_ingress_vectors.py; the native inbound parse cores are the oracle (executable spec).",
   "oracle": {
     "repo": "NousResearch/hermes-agent",
-    "commit": "ef60509a26d07b40c4f512f864c8242a5bce4076",
+    "commit": "a56c341190b3c0b8e0643f357cf5412511e6cae1",
     "generator": "scripts/generate_ingress_vectors.py",
     "generator_version": 1
   },

--- a/tests/conformance/test_ingress_vectors.py
+++ b/tests/conformance/test_ingress_vectors.py
@@ -27,26 +27,33 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from generate_ingress_vectors import (  # noqa: E402
+    BOT_USER_ID,
+    DISCORD_CORPUS,
+    SLACK_BOT_USER_ID,
+    SLACK_CORPUS,
     TELEGRAM_CORPUS,
     WHATSAPP_CORPUS,
     WA_CONTACTS,
     WA_METADATA,
+    discord_expected,
     generate,
+    slack_expected,
     telegram_expected,
     whatsapp_expected,
 )
 
-PLATFORMS = ("telegram", "whatsapp")
+PLATFORMS = ("discord", "slack", "telegram", "whatsapp")
 
 
 # ── layer 1: generator invariants ────────────────────────────────────────
 
 
 def test_corpus_ids_unique():
-    for corpus in (TELEGRAM_CORPUS, WHATSAPP_CORPUS):
+    for corpus in (TELEGRAM_CORPUS, WHATSAPP_CORPUS, DISCORD_CORPUS, SLACK_CORPUS):
         ids = [vid for vid, _ in corpus]
         assert len(ids) == len(set(ids))
     assert len(TELEGRAM_CORPUS) >= 12 and len(WHATSAPP_CORPUS) >= 12
+    assert len(DISCORD_CORPUS) >= 12 and len(SLACK_CORPUS) >= 10
 
 
 def test_generation_is_deterministic(tmp_path):
@@ -221,3 +228,122 @@ def test_expected_fields_cover_scar_rules():
     assert wa["button-reply"]["body"] == "Approve"
     assert wa["document-with-filename"]["document_filename"] == "notes.txt"
     assert wa["unknown-type-defaults-text"]["message_type"] == "text"
+
+    dc = {vid: discord_expected(p) for vid, p in DISCORD_CORPUS}
+    assert dc["guild-mention-stripped"]["text"] == "summarize this"
+    assert dc["guild-nickname-mention-form"]["mentions_bot"] is True  # <@!id> form
+    assert dc["addressed-command"]["message_type"] == "command"  # strip THEN detect
+    assert dc["voice-note-attachment"]["message_type"] == "voice"
+    assert dc["plain-audio-attachment"]["message_type"] == "audio"
+    assert dc["document-attachment-unknown-type"]["message_type"] == "document"
+    assert dc["forwarded-snapshot-text"]["text"] == "forwarded wisdom"
+    assert dc["reply-inherits-referenced-attachment"]["message_type"] == "document"
+    assert dc["forum-thread-naming"]["chat_name"] == "Eng / reports / bug report"
+    assert dc["thread-message"]["chat_name"] == "Eng / #general / build issue"
+    assert dc["thread-message"]["thread_id"] == "t1"
+    assert dc["display-name-preference"]["user_name"] == "Benjamin"
+    assert dc["bot-authored"]["user_is_bot"] is True
+
+    sl = {vid: slack_expected(p) for vid, p in SLACK_CORPUS}
+    assert sl["thread-root-equals-ts"]["chat_type"] == "channel"  # #15464
+    assert sl["thread-root-equals-ts"]["session_thread_ts"] == "100.7"
+    assert sl["channel-thread-reply"]["chat_type"] == "thread"
+    assert sl["channel-thread-reply"]["session_thread_ts"] == "100.4"
+    assert sl["mpim-is-dm-but-not-one-to-one"]["is_dm"] is True
+    assert sl["mpim-is-dm-but-not-one-to-one"]["is_one_to_one_dm"] is False
+    assert sl["dm-prefix-fallback"]["is_dm"] is True
+    assert sl["channel-mention"]["mentions_bot"] is True
+    assert sl["channel-mention"]["text"] == "do the thing"  # token stripped
+    assert sl["bot-message-subtype"]["user_is_bot"] is True
+    assert sl["bot-id-without-subtype"]["user_is_bot"] is True
+
+
+# ── layer 2 (discord/slack): oracle fidelity ─────────────────────────────
+
+
+def test_discord_core_matches_adapter_helpers():
+    """The adapter's remaining helper entry points (delegate shims + the
+    staticmethod voice check) must agree with the pure core — proving the
+    delegation is real, not parallel logic."""
+    from types import SimpleNamespace
+
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    from plugins.platforms.discord.discord_parse import (
+        AttachmentView,
+        is_voice_message_attachment,
+    )
+
+    cases = [
+        AttachmentView(is_voice_message=True),
+        AttachmentView(is_voice_message=False, duration=1.0, waveform="x"),
+        AttachmentView(duration=2.0, waveform="y"),
+        AttachmentView(duration=2.0),  # waveform missing → not voice
+        AttachmentView(),
+    ]
+    for av in cases:
+        sdk_like = SimpleNamespace(
+            is_voice_message=av.is_voice_message,
+            duration=av.duration,
+            waveform=av.waveform,
+        )
+        assert DiscordAdapter._is_discord_voice_message_attachment(
+            sdk_like
+        ) == is_voice_message_attachment(av), av
+
+
+def test_discord_thread_naming_matches_adapter():
+    """_format_thread_chat_name (now a delegate) ≡ core thread_chat_name
+    across the naming shapes, via SDK-like objects."""
+    from types import SimpleNamespace
+
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    adapter = DiscordAdapter.__new__(DiscordAdapter)
+
+    forum_parent = SimpleNamespace(
+        name="reports", guild=SimpleNamespace(name="Eng"), type="forum"
+    )
+    text_parent = SimpleNamespace(
+        name="general", guild=SimpleNamespace(name="Eng"), type="text"
+    )
+
+    def _is_forum(parent):
+        return parent is forum_parent
+
+    adapter._is_forum_parent = _is_forum
+
+    thread_in_forum = SimpleNamespace(
+        id=1, name="bug report", parent=forum_parent, guild=None
+    )
+    thread_in_text = SimpleNamespace(
+        id=2, name="build issue", parent=text_parent, guild=None
+    )
+    orphan = SimpleNamespace(id=3, name="lonely", parent=None, guild=None)
+
+    assert adapter._format_thread_chat_name(thread_in_forum) == "Eng / reports / bug report"
+    assert adapter._format_thread_chat_name(thread_in_text) == "Eng / #general / build issue"
+    assert adapter._format_thread_chat_name(orphan) == "lonely"
+
+
+def test_slack_core_matches_adapter_rules():
+    """The Slack adapter now delegates DM classification + channel scoping
+    to the core; assert the core reproduces the adapter's documented legacy
+    behaviors on the corpus (payload-only rules)."""
+    from plugins.platforms.slack.slack_parse import (
+        slack_is_dm,
+        slack_is_one_to_one_dm,
+        slack_session_thread_ts,
+    )
+
+    for vid, event in SLACK_CORPUS:
+        exp = slack_expected(event)
+        assert slack_is_dm(event) == exp["is_dm"], vid
+        assert slack_is_one_to_one_dm(event) == exp["is_one_to_one_dm"], vid
+        assert slack_session_thread_ts(event) == exp["session_thread_ts"], vid
+
+    # reply_in_thread=false → shared channel session (thread key None) for
+    # top-level channel messages, but genuine thread replies keep their key.
+    top = dict(SLACK_CORPUS[3][1])  # channel-top-level
+    reply = dict(SLACK_CORPUS[4][1])  # channel-thread-reply
+    assert slack_session_thread_ts(top, reply_in_thread=False) is None
+    assert slack_session_thread_ts(reply, reply_in_thread=False) == "100.4"

--- a/tests/conformance/test_ingress_vectors.py
+++ b/tests/conformance/test_ingress_vectors.py
@@ -1,0 +1,223 @@
+"""Ingress conformance generator tests (Phase 6 ingress mirror).
+
+Three contract layers:
+  1. Generator invariants — determinism, shape, unique ids (the egress
+     suite's discipline).
+  2. ORACLE FIDELITY — the pure parse cores must agree with the REAL
+     adapters on the same payloads. The Telegram core is checked against
+     the adapter's classmethod delegate (kept as a shim) with PTB-style
+     mock objects; the WhatsApp core against the adapter's
+     _build_message_event_from_cloud output on a state-stubbed adapter.
+     This is what makes the extraction honest: if the adapter regains
+     divergent inline logic, these fail.
+  3. Committed-vectors lockstep (the openapi.json discipline).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from generate_ingress_vectors import (  # noqa: E402
+    TELEGRAM_CORPUS,
+    WHATSAPP_CORPUS,
+    WA_CONTACTS,
+    WA_METADATA,
+    generate,
+    telegram_expected,
+    whatsapp_expected,
+)
+
+PLATFORMS = ("telegram", "whatsapp")
+
+
+# ── layer 1: generator invariants ────────────────────────────────────────
+
+
+def test_corpus_ids_unique():
+    for corpus in (TELEGRAM_CORPUS, WHATSAPP_CORPUS):
+        ids = [vid for vid, _ in corpus]
+        assert len(ids) == len(set(ids))
+    assert len(TELEGRAM_CORPUS) >= 12 and len(WHATSAPP_CORPUS) >= 12
+
+
+def test_generation_is_deterministic(tmp_path):
+    a, b = tmp_path / "a", tmp_path / "b"
+    generate(a)
+    generate(b)
+    for platform in PLATFORMS:
+        assert (a / f"{platform}.json").read_text(encoding="utf-8") == (
+            b / f"{platform}.json"
+        ).read_text(encoding="utf-8")
+
+
+def test_vector_file_shape(tmp_path):
+    generate(tmp_path)
+    for platform in PLATFORMS:
+        doc = json.loads((tmp_path / f"{platform}.json").read_text(encoding="utf-8"))
+        assert doc["platform"] == platform
+        assert doc["direction"] == "ingress"
+        assert doc["oracle"]["repo"] == "NousResearch/hermes-agent"
+        for v in doc["vectors"]:
+            assert v["payload"], v["id"]
+            assert "expected" in v, v["id"]
+
+
+# ── layer 2: oracle fidelity (core ≡ adapter) ────────────────────────────
+
+
+def _ptb_like(payload: Dict[str, Any]) -> Any:
+    """Recursively wrap a Bot API dict as attribute-accessible objects,
+    mimicking python-telegram-bot's surface for the fields the parser reads
+    (including `from` → `from_user` and absent-field None semantics)."""
+
+    class _Node:
+        def __init__(self, d: Dict[str, Any]):
+            self._d = d
+
+        def __getattr__(self, name: str) -> Any:
+            key = "from" if name == "from_user" else name
+            if key not in self._d:
+                return None
+            return _wrap(self._d[key])
+
+        def __bool__(self) -> bool:
+            return bool(self._d)
+
+    def _wrap(value: Any) -> Any:
+        return _Node(value) if isinstance(value, dict) else value
+
+    return _Node(payload)
+
+
+def test_telegram_core_matches_adapter_thread_rules():
+    """The adapter's _effective_message_thread_id (now a delegate shim) and
+    the pure core must agree on every corpus payload — via PTB-style
+    objects on the adapter side and raw dicts on the core side, proving the
+    dual access model holds."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    from plugins.platforms.telegram.telegram_parse import (
+        effective_message_thread_id,
+    )
+
+    for vid, payload in TELEGRAM_CORPUS:
+        core_on_dict = effective_message_thread_id(payload)
+        adapter_on_obj = TelegramAdapter._effective_message_thread_id(
+            _ptb_like(payload)
+        )
+        assert core_on_dict == adapter_on_obj, vid
+
+
+def test_telegram_core_reply_context_matches_adapter_rules():
+    from plugins.platforms.telegram.telegram_parse import extract_reply_context
+
+    for vid, payload in TELEGRAM_CORPUS:
+        rid_dict, rtext_dict = extract_reply_context(payload)
+        rid_obj, rtext_obj = extract_reply_context(_ptb_like(payload))
+        assert (rid_dict, rtext_dict) == (rid_obj, rtext_obj), vid
+        if "reply_to_message" in payload:
+            assert rid_dict == str(payload["reply_to_message"]["message_id"]), vid
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_core_matches_adapter_event_fields():
+    """Drive the REAL _build_message_event_from_cloud (state stubbed: no
+    gating, no media download, no store) and assert its MessageEvent agrees
+    with the pure core on every derivable field."""
+    from gateway.config import Platform, PlatformConfig
+    from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+    from gateway.platforms.whatsapp_cloud_parse import (
+        document_fallback_body,
+        parse_cloud_message,
+    )
+
+    adapter = WhatsAppCloudAdapter.__new__(WhatsAppCloudAdapter)
+    adapter.config = PlatformConfig()
+    adapter.platform = Platform.WHATSAPP  # build_source reads self.platform
+    adapter._last_inbound_wamid_by_chat = {}
+    adapter._should_process_message = lambda data: True  # bypass gating
+    adapter._bounded_put = lambda cache, k, v: None
+
+    async def _no_download(media_id: str, ext_hint: Optional[str] = None):
+        return None, None
+
+    adapter._download_media_to_cache = _no_download
+
+    async def _no_dispatch(raw, contacts):
+        return False
+
+    adapter._dispatch_interactive_reply = _no_dispatch
+
+    for vid, payload in WHATSAPP_CORPUS:
+        parsed = parse_cloud_message(payload, WA_CONTACTS, WA_METADATA)
+        event = await adapter._build_message_event_from_cloud(
+            payload, WA_CONTACTS, WA_METADATA
+        )
+        if parsed.group_shaped:
+            assert event is None, vid  # refusal path
+            continue
+        assert event is not None, vid
+        assert event.source.chat_id == parsed.chat_id, vid
+        assert event.source.user_id == parsed.sender_id, vid
+        assert event.message_id == parsed.wamid, vid
+        assert event.message_type == parsed.message_type, vid
+        assert event.reply_to_message_id == parsed.reply_to_id, vid
+        assert event.reply_to_is_own_message == parsed.reply_to_is_own, vid
+        # Body: for caption-less documents the adapter substitutes the
+        # [Document: name] placeholder (media_id present ⇒ applied even
+        # when the download itself fails) — the core models that rule as
+        # document_fallback_body().
+        assert event.text == document_fallback_body(parsed), vid
+
+
+# ── layer 3: committed-vectors lockstep ──────────────────────────────────
+
+
+def test_committed_ingress_vectors_match_regeneration(tmp_path):
+    committed_dir = REPO_ROOT / "tests" / "conformance" / "ingress_vectors"
+    if not committed_dir.exists():
+        pytest.skip("no committed ingress vectors in this checkout")
+    generate(tmp_path)
+    for platform in PLATFORMS:
+        fresh = json.loads((tmp_path / f"{platform}.json").read_text(encoding="utf-8"))
+        committed = json.loads(
+            (committed_dir / f"{platform}.json").read_text(encoding="utf-8")
+        )
+        fresh["oracle"].pop("commit")
+        committed["oracle"].pop("commit")
+        assert fresh == committed, (
+            f"{platform} ingress vectors drifted — run "
+            "`python scripts/generate_ingress_vectors.py` and commit"
+        )
+
+
+def test_expected_fields_cover_scar_rules():
+    """The corpus must actually exercise the named inbound scar tissue."""
+    tg = {vid: telegram_expected(p) for vid, p in TELEGRAM_CORPUS}
+    assert tg["forum-general-topic"]["thread_id"] == "1"  # #22423
+    assert tg["group-reply-anchor-not-thread"]["thread_id"] is None  # #3206
+    assert tg["forum-topic-message"]["thread_id"] == "55"
+    assert tg["dm-topic-message"]["thread_id"] == "9"
+    assert tg["reply-partial-quote"]["reply_to_text"] == "just this part"  # #22619
+    assert tg["reply-to-caption-only"]["reply_to_text"] == "photo caption"
+    assert tg["channel-post"]["user_id"] == tg["channel-post"]["chat_id"]
+    assert tg["bot-authored-message"]["user_is_bot"] is True
+
+    wa = {vid: whatsapp_expected(p) for vid, p in WHATSAPP_CORPUS}
+    assert wa["reply-to-bot-message"]["reply_to_is_own"] is True
+    assert wa["reply-to-own-message"]["reply_to_is_own"] is False
+    assert wa["group-shaped-refused"]["group_shaped"] is True
+    assert wa["voice-note"]["message_type"] == "voice"
+    assert wa["sticker"]["message_type"] == "photo"
+    assert wa["list-reply-title"]["body"] == "Option Two"
+    assert wa["button-reply"]["body"] == "Approve"
+    assert wa["document-with-filename"]["document_filename"] == "notes.txt"
+    assert wa["unknown-type-defaults-text"]["message_type"] == "text"


### PR DESCRIPTION
![Pure parse cores](https://v3b.fal.media/files/b/0aa3e283/Lvm7mZYLAEhcphKnrQRIq_F2MKMtyB.png)

## Conformance oracle: ingress mirror — pure parse cores + vector generator (gateway side)

Gateway half of the ingress-mirror pair: NousResearch/gateway-gateway#181. Inbound twin of the egress generator (#71666, merged): synthetic platform payloads rendered through the native inbound PARSERS become the executable spec for the connector's normalizers.

### The refactor (behavior-preserving, the enabler)
The native inbound parsers were not importable as pure functions — `_build_message_event` (~7.6k chars, 6 self-deps) and `_build_message_event_from_cloud` (~11k chars, media/dedupe/dispatch state). This PR extracts the payload-derivable half of each into pure cores; the adapters delegate:

- **`plugins/platforms/telegram/telegram_parse.py`** — chat-type normalization, the routable-thread rules (#3206 reply-anchor drop, #22423 General-topic → "1"), reply context with native partial quotes (#22619), source identity incl. the channel-post author fallback. **Dual access model**: every accessor works on PTB `Message` objects (adapter's caller) AND raw Bot API dicts (generator's caller — no python-telegram-bot dependency needed). Adapter's `_effective_message_thread_id` becomes a delegate shim; the reply-context inline block now calls the core, with the two stateful fallbacks (rich-message echo, `rich_sent_store`) staying adapter-side.
- **`gateway/platforms/whatsapp_cloud_parse.py`** — Cloud type→MessageType mapping, body extraction (incl. button/list titles), reply context (`context.id` + `is_own` against the business number), media identification (id/mime/filename — download stays adapter-side), the group-shape discriminator. Adapter delegates all payload-derivable fields.

Extraction honesty is machine-checked: **oracle-fidelity tests** drive the REAL adapter paths against the cores on every corpus payload (Telegram via PTB-style objects through the adapter shim; WhatsApp via the real `_build_message_event_from_cloud` with state stubbed) — if an adapter regains divergent inline logic, these fail.

### `scripts/generate_ingress_vectors.py`
54 synthetic payloads (14 Telegram + 13 WhatsApp + 15 Discord + 12 Slack — every inbound scar rule has a named vector) → payload→expected-field JSON, oracle-SHA stamped, committed under `tests/conformance/ingress_vectors/`. **UPDATE (second commit): Discord + Slack cores now included.** The layer model made them tractable: `discord_parse.py` defines an SDK-view IR (`DiscordMessageView`, dual access — discord.py objects or raw-vocabulary dicts) over the ~18 fields layer 2 reads, with the pure rules (chat-type, `<@id>`/`<@!id>` mention stripping then command detection, forwarded-snapshot folding, referenced-attachment inheritance, voice-note vs audio classification, guild/forum thread naming); `slack_parse.py` extracts DM/MPIM classification (1:1 vs shared-surface), the #15421/#15464 thread_ts session-scoping invariants, mention detection, and bot-message classification. Adapters delegate at the clean seams; 3 new oracle-fidelity tests pin shim ≡ core. Corpus now 54 vectors across four platforms; 18 conformance tests.

### `tests/conformance/test_ingress_vectors.py` (8 tests, three layers)
Generator invariants (determinism, shape, unique ids) · **oracle fidelity** (core ≡ adapter) · committed-vectors lockstep (regenerate-or-fail, the openapi.json discipline) · scar-rule coverage assertions.

### Impact downstream
The connector runner found **two real gg bugs on day one** (Telegram reply-anchor thread leak #3206; WhatsApp button/list taps arriving as empty text) — fixed in the paired PR.

### Tests
`pytest tests/conformance/` 15 passed · `test_whatsapp_cloud.py` 113 · topics/gating suites 117 · `tests/gateway/relay/` 266 — all green post-refactor. ruff + Windows-footguns clean.
