### PR TITLE
fix(agent): guard vars(response) against plain dict in malformed-response path (#72408)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2290,7 +2290,7 @@ def run_conversation(
                         provider_name = f"model={response.model}"
                     
                     # Check for x-openrouter-provider or similar metadata
-                    if provider_name == "Unknown" and response:
+                    if provider_name == "Unknown" and response and hasattr(response, "__dict__"):
                         # Log all response attributes for debugging
                         resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
                         if agent.verbose_logging:


### PR DESCRIPTION
## Summary

Fixes #72408. The malformed-response diagnostic branch calls `vars(response)` without checking whether `response` has `__dict__`. When a provider returns a plain dict instead of an SDK response object, `vars()` raises `TypeError`, crashing the request and hiding the real underlying issue.

## Changes

- **agent/conversation_loop.py**: Add `hasattr(response, "__dict__")` guard before `vars(response)` call, matching the pattern already used in `anthropic_adapter.py`'s `_to_plain_data()`.

## Testing

- Syntax: `python3 -m py_compile agent/conversation_loop.py` -- OK
- 1-line change, no behavioral impact on normal code paths
