### PR TITLE
fix(gateway): restrict relay media URL detection to same-origin (#71559)

### DIFF
--- a/gateway/relay/media.py
+++ b/gateway/relay/media.py
@@ -91,7 +91,11 @@ class RelayMediaClient:
 
     def is_relay_media_url(self, url: str) -> bool:
         """Is ``url`` a connector re-host reference (needs our bearer to GET)?"""
-        return "/relay/media/" in (url or "")
+        if not url or not self._base_url:
+            return False
+        # Must be on the same origin and under /relay/media/ path as our base URL
+        prefix = f"{self._base_url.rstrip('/')}/relay/media/"
+        return url.startswith(prefix)
 
     async def upload(
         self,

--- a/tests/gateway/relay/test_relay_media.py
+++ b/tests/gateway/relay/test_relay_media.py
@@ -270,6 +270,13 @@ def test_client_recognizes_rehost_urls():
     c = RelayMediaClient("https://c.example", "gw1", "sec")
     assert c.is_relay_media_url("https://c.example/relay/media/abc") is True
     assert c.is_relay_media_url("https://cdn.discordapp.com/a/b.png") is False
+    # Must reject different-origin URLs even with matching path segment
+    assert c.is_relay_media_url("https://evil.example/relay/media/abc") is False
+    assert c.is_relay_media_url("https://cdn.example/files/relay/media/photo.png") is False
+    # Must reject subdomain matching
+    assert c.is_relay_media_url("https://evil.c.example/relay/media/abc") is False
+    # Must reject empty URLs
+    assert c.is_relay_media_url("") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

RelayMediaClient.is_relay_media_url() previously classified any URL containing '/relay/media/' as a connector-hosted relay reference, regardless of origin. This meant external URLs like `https://evil.example/relay/media/abc` were treated as authenticated relay media and could receive the relay Authorization bearer.

## Fix

Verify the URL starts with the configured base URL prefix before checking the /relay/media/ path segment. This ensures only re-host references from the connector's own origin are treated as such.

## Testing

- `pytest tests/gateway/relay/test_relay_media.py` — 15 passed
- Added test cases for: different-origin URLs, subdomain matching, empty URLs

Closes #71559