### PR TITLE
fix(azure-foundry): preserve callable Entra ID token provider in aux calls (#72421)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1317,8 +1317,16 @@ def _resolve_azure_foundry_runtime(
 
     Raises :class:`AuthError` when required values are missing.
     """
-    explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url_clean = str(explicit_base_url or "").strip().rstrip("/")
+
+    # Preserve callable token providers (Entra ID bearer provider forwarded
+    # from the main runtime's api_key). str() would convert callables to
+    # "<function ... at 0x...>" which gets sent to Azure as an invalid bearer
+    # token, causing HTTP 401. (#72421)
+    if callable(explicit_api_key):
+        pass  # keep callable as-is
+    else:
+        explicit_api_key = str(explicit_api_key or "").strip()
 
     cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
     cfg_base_url = ""


### PR DESCRIPTION
## Summary

When the main Hermes conversation uses Azure Foundry with Entra ID authentication, auxiliary LLM tasks (title generation, smart approval, compression) fail with HTTP 401.

## Root Cause

\`_resolve_azure_foundry_runtime()\` converted \`explicit_api_key\` to \`str()\` unconditionally. The main runtime forwards the Entra ID token provider (a \`Callable[[], str]\`) as \`explicit_api_key\`. \`str()\` on a callable yields something like \`\"<function build_token_provider.<locals>.get_token at 0x7f...>\"\` which is then sent to Azure as an invalid bearer token → HTTP 401.

## Fix

Skip \`str()\` conversion when the value is callable. The OpenAI SDK already accepts \`Callable[[], str]\` for \`api_key\` (calling it before every request), so the callable passes through correctly and the auxiliary client authenticates like the main agent.

## Testing

- \`pytest tests/hermes_cli/test_azure_foundry_entra.py\` — 16 passed
- Existing test \`test_entra_with_explicit_api_key_uses_string_escape_hatch\` still passes (string \`--api-key\` override still works correctly)

Closes #72421