### PR TITLE
fix(model_normalize): strip aggregator provider prefix to prevent double-namespacing (#72418)

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -410,7 +410,8 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     # --- Aggregators: need vendor/model format ---
     if provider in _AGGREGATOR_PROVIDERS:
-        return _prepend_vendor(name)
+        stripped = _strip_matching_provider_prefix(name, provider)
+        return _prepend_vendor(stripped)
 
     # --- OpenCode Zen / OpenCode Go: flat-namespace resellers.
     #     Their /v1/models API returns bare IDs only (no vendor prefix), and


### PR DESCRIPTION
## Summary

Fixes #72418. When a model name has the current aggregator provider as its prefix (e.g. `openrouter/deepseek-v4-pro` via OpenRouter), `_prepend_vendor` passes it through unchanged because it treats any slash-bearing name as already-resolved. This produces HTTP 400 "not a valid model ID".

## Changes

- **hermes_cli/model_normalize.py**: For aggregator providers (OpenRouter, Nous, KiloCode), strip the matching provider prefix before calling `_prepend_vendor` so vendor detection can run correctly. `openrouter/deepseek-v4-pro` → `deepseek-v4-pro` → `deepseek/deepseek-v4-pro`.

## Testing

- Syntax: `python3 -m py_compile hermes_cli/model_normalize.py` -- OK
- Lint: `ruff check hermes_cli/model_normalize.py` -- All checks passed
- Existing tests: 85 passed (test_model_normalize.py)
