### PR TITLE
feat(compression): add bounded fresh-session handoff

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1775,6 +1775,25 @@ def init_agent(
         _api_retries = 3
     agent._api_max_retries = _api_retries
 
+    # Bounded packet-only handoff after repeated context compression. This
+    # deliberately uses the durable SessionDB handoff surface and never rotates
+    # sessions itself while compression is in flight.
+    try:
+        from agent.compression_handoff import configure_auto_handoff_on_compression
+
+        configure_auto_handoff_on_compression(agent, _agent_section)
+    except Exception as _handoff_cfg_err:
+        _ra().logger.warning(
+            "Auto handoff-on-compression config ignored: %s", _handoff_cfg_err
+        )
+        agent._auto_handoff_on_compression_enabled = False
+        agent._auto_handoff_after_compressions = 2
+        agent._auto_handoff_max_auto_handoffs = 1
+        agent._auto_handoff_mode = "packet"
+        agent._auto_handoff_platform = ""
+        agent._auto_handoff_artifact_dir = "handoffs"
+        agent._auto_handoff_count = 0
+
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit
     # Configuration via config.yaml (compression section)

--- a/agent/compression_handoff.py
+++ b/agent/compression_handoff.py
@@ -1,0 +1,345 @@
+"""Automatic handoff packet generation for repeated context compression.
+
+This module deliberately builds on the current SessionDB handoff primitives
+instead of rotating agent sessions itself.  A compression threshold can now
+produce a redacted markdown handoff packet and, when explicitly configured,
+mark the current durable session as pending handoff to a gateway platform.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Optional
+
+from agent.redact import redact_sensitive_text
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HANDOFF_ARTIFACT_DIR = "handoffs"
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def configure_auto_handoff_on_compression(agent: Any, agent_config: dict[str, Any]) -> None:
+    """Populate agent attributes from ``agent.auto_handoff_on_compression``.
+
+    Bad config is tolerated: this feature must never prevent agent startup or
+    normal compression.
+    """
+    raw = agent_config.get("auto_handoff_on_compression", {}) if isinstance(agent_config, dict) else {}
+    if raw is True:
+        raw = {"enabled": True}
+    if not isinstance(raw, dict):
+        raw = {}
+
+    agent._auto_handoff_on_compression_enabled = _truthy(raw.get("enabled", False))
+    try:
+        agent._auto_handoff_after_compressions = max(
+            1, int(raw.get("after_compressions", 2) or 2)
+        )
+    except (TypeError, ValueError):
+        agent._auto_handoff_after_compressions = 2
+    try:
+        agent._auto_handoff_max_auto_handoffs = max(
+            0, int(raw.get("max_auto_handoffs", 1) or 0)
+        )
+    except (TypeError, ValueError):
+        agent._auto_handoff_max_auto_handoffs = 1
+
+    mode = str(raw.get("mode", "packet") or "packet").strip().lower()
+    # Legacy aliases from the pre-refactor branch.  ``fresh_session`` is
+    # intentionally not replayed: current Hermes has durable SessionDB handoff
+    # and in-place compaction primitives, so this refactor avoids ad-hoc child
+    # session rotation during compression.
+    if mode in {"prompt_user", "artifact", "packet"}:
+        mode = "packet"
+    elif mode in {"platform", "request_handoff", "handoff"}:
+        mode = "platform"
+    else:
+        logger.warning(
+            "Invalid agent.auto_handoff_on_compression.mode=%r — using packet",
+            mode,
+        )
+        mode = "packet"
+    agent._auto_handoff_mode = mode
+    agent._auto_handoff_platform = str(raw.get("platform", "") or "").strip().lower()
+    agent._auto_handoff_artifact_dir = str(
+        raw.get("handoff_artifact_dir", DEFAULT_HANDOFF_ARTIFACT_DIR)
+        or DEFAULT_HANDOFF_ARTIFACT_DIR
+    )
+    agent._auto_handoff_count = 0
+
+
+def _handoff_safe_slug(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value or "session").strip("-._")
+    return slug[:80] or "session"
+
+
+def _resolve_handoff_dir(raw_dir: str) -> Path:
+    """Resolve a handoff artifact directory under active HERMES_HOME."""
+    raw = (raw_dir or DEFAULT_HANDOFF_ARTIFACT_DIR).strip()
+    path = Path(raw).expanduser()
+    hermes_home = get_hermes_home().expanduser().resolve()
+    if path.is_absolute():
+        resolved = path.resolve()
+    else:
+        parts = path.parts
+        if parts and parts[0] == ".hermes":
+            resolved = hermes_home.joinpath(*parts[1:]).resolve()
+        else:
+            resolved = (hermes_home / path).resolve()
+    try:
+        resolved.relative_to(hermes_home)
+    except ValueError as exc:
+        raise ValueError("handoff_artifact_dir must resolve under HERMES_HOME") from exc
+    return resolved
+
+
+def _truncate(value: Any, limit: int = 4000) -> str:
+    text = redact_sensitive_text(str(value or ""))
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n...[truncated {len(text) - limit:,} chars]"
+
+
+def _git_snapshot() -> dict[str, str]:
+    """Best-effort git metadata for a handoff packet; never raises."""
+    cwd = Path.cwd()
+
+    def _run(args: list[str], limit: int = 3000) -> str:
+        try:
+            proc = subprocess.run(
+                ["git", *args],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except Exception:
+            return ""
+        if proc.returncode != 0:
+            return ""
+        return _truncate(proc.stdout.strip(), limit)
+
+    return {
+        "workspace": str(cwd),
+        "branch": _run(["branch", "--show-current"], 500),
+        "status": _run(["status", "--short"]),
+        "recent_commits": _run(["log", "-3", "--oneline"]),
+    }
+
+
+def _todo_lines(agent: Any) -> list[str]:
+    store = getattr(agent, "_todo_store", None)
+    if store is None or not hasattr(store, "read"):
+        return ["- No active todo snapshot available."]
+    try:
+        items = store.read() or []
+    except Exception:
+        items = []
+    if not items:
+        return ["- No active todos recorded."]
+    lines: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        status = _truncate(item.get("status", "pending"), 80)
+        item_id = _truncate(item.get("id", "?"), 120)
+        content = _truncate(item.get("content", ""), 1000)
+        lines.append(f"- [{status}] {item_id}: {content}")
+    return lines or ["- No active todos recorded."]
+
+
+def _message_lines(messages: list[dict[str, Any]], *, max_messages: int = 8) -> list[str]:
+    if not messages:
+        return ["- No compressed context messages available."]
+    selected = messages[-max_messages:]
+    lines: list[str] = []
+    omitted = max(0, len(messages) - len(selected))
+    if omitted:
+        lines.append(
+            f"- Omitted {omitted} older compressed message(s); inspect the prior session transcript if needed."
+        )
+    for idx, msg in enumerate(selected, start=max(0, len(messages) - len(selected)) + 1):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "?")
+        content = _truncate(msg.get("content", ""), 1800).replace("\n", "\n  ")
+        lines.append(f"- Message {idx} ({role}):\n  {content}")
+    return lines or ["- No compressed context messages available."]
+
+
+def build_compression_handoff_packet(
+    agent: Any,
+    compressed_messages: list[dict[str, Any]],
+    *,
+    approx_tokens: Optional[int] = None,
+    trigger_description: str = "repeated context compression crossed the configured handoff threshold",
+) -> str:
+    """Build a compact, redacted markdown packet for a human or future session."""
+    session_id = str(getattr(agent, "session_id", "") or "unknown")
+    old_title = ""
+    session_db = getattr(agent, "_session_db", None)
+    if session_db is not None:
+        try:
+            old_title = session_db.get_session_title(session_id) or ""
+        except Exception:
+            old_title = ""
+    git = _git_snapshot()
+    compression_count = getattr(getattr(agent, "context_compressor", None), "compression_count", 0)
+    lines = [
+        "# Hermes compression handoff packet",
+        "",
+        f"Generated because {trigger_description}.",
+        "Use this packet as context only; verify live repo/system state before editing or taking external actions.",
+        "",
+        "## Session",
+        f"- Session ID: `{_truncate(session_id, 200)}`",
+        f"- Title: {_truncate(old_title or '(untitled)', 500)}",
+        f"- Platform: `{_truncate(getattr(agent, 'platform', '') or 'cli', 120)}`",
+        f"- Model/provider: `{_truncate(getattr(agent, 'model', '') or '?', 200)}` / `{_truncate(getattr(agent, 'provider', '') or '?', 120)}`",
+        f"- Compression count: {compression_count}",
+        f"- Approx tokens before compression: {approx_tokens:,}" if approx_tokens else "- Approx tokens before compression: unknown",
+        "",
+        "## Workspace snapshot",
+        f"- Path: `{_truncate(git['workspace'], 1000)}`",
+        f"- Branch: `{_truncate(git['branch'] or '(unknown/non-git)', 500)}`",
+        "- `git status --short`:",
+        "```text",
+        _truncate(git["status"] or "(clean or unavailable)", 3000),
+        "```",
+        "- Recent commits:",
+        "```text",
+        _truncate(git["recent_commits"] or "(unavailable)", 3000),
+        "```",
+        "",
+        "## Active todos",
+        *_todo_lines(agent),
+        "",
+        "## Compressed context tail",
+        *_message_lines(compressed_messages),
+        "",
+        "## Recommended restart discipline",
+        "- Verify `git status --short` and inspect referenced files before editing.",
+        "- Continue the in-progress todo first; do not repeat completed work unless verification shows it is missing.",
+        "- Ask before destructive actions, protected/default branch writes, or externally visible changes unless already approved in the live session.",
+    ]
+    return redact_sensitive_text("\n".join(lines).rstrip() + "\n")
+
+
+def write_compression_handoff_packet(agent: Any, packet: str) -> Optional[Path]:
+    try:
+        directory = _resolve_handoff_dir(getattr(agent, "_auto_handoff_artifact_dir", DEFAULT_HANDOFF_ARTIFACT_DIR))
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        from datetime import datetime
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        filename = (
+            f"{_handoff_safe_slug(getattr(agent, 'session_id', '') or 'session')}"
+            f"-{timestamp}-handoff.md"
+        )
+        path = directory / filename
+        # Refuse to overwrite an existing path and create the packet private
+        # from the first byte. This avoids timestamp-collision clobbering and a
+        # world-readable intermediate file on permissive umasks.
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(redact_sensitive_text(packet))
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+        return path
+    except Exception as exc:
+        logger.warning("Could not write compression handoff packet: %s", exc)
+        return None
+
+
+def _threshold_reached(agent: Any) -> bool:
+    if not getattr(agent, "_auto_handoff_on_compression_enabled", False):
+        return False
+    try:
+        max_handoffs = int(getattr(agent, "_auto_handoff_max_auto_handoffs", 1) or 0)
+    except (TypeError, ValueError):
+        max_handoffs = 1
+    if max_handoffs <= 0:
+        return False
+    try:
+        used = int(getattr(agent, "_auto_handoff_count", 0) or 0)
+    except (TypeError, ValueError):
+        used = 0
+    if used >= max_handoffs:
+        return False
+    try:
+        after = max(1, int(getattr(agent, "_auto_handoff_after_compressions", 2) or 2))
+    except (TypeError, ValueError):
+        after = 2
+    try:
+        count = int(getattr(getattr(agent, "context_compressor", None), "compression_count", 0) or 0)
+    except (TypeError, ValueError):
+        count = 0
+    return count >= after
+
+
+def maybe_trigger_compression_handoff(
+    agent: Any,
+    compressed_messages: list[dict[str, Any]],
+    *,
+    approx_tokens: Optional[int] = None,
+) -> Optional[Path]:
+    """Create a handoff artifact and optionally request platform handoff.
+
+    Returns the artifact path when a packet was written; returns ``None`` when
+    disabled, below threshold, bounded out, or write failed.  This function is
+    fail-open: compression continues even if handoff setup fails.
+    """
+    if not _threshold_reached(agent):
+        return None
+
+    agent._auto_handoff_count = int(getattr(agent, "_auto_handoff_count", 0) or 0) + 1
+    packet = build_compression_handoff_packet(
+        agent,
+        compressed_messages,
+        approx_tokens=approx_tokens,
+    )
+    artifact_path = write_compression_handoff_packet(agent, packet)
+
+    mode = str(getattr(agent, "_auto_handoff_mode", "packet") or "packet").lower()
+    platform = str(getattr(agent, "_auto_handoff_platform", "") or "").strip().lower()
+    requested = False
+    if mode == "platform" and platform:
+        session_db = getattr(agent, "_session_db", None)
+        request_handoff = getattr(session_db, "request_handoff", None)
+        if callable(request_handoff):
+            try:
+                requested = bool(request_handoff(getattr(agent, "session_id", ""), platform))
+            except Exception as exc:
+                logger.warning("Compression handoff request failed: %s", exc)
+        if not requested:
+            try:
+                agent._emit_warning(
+                    f"⚠ Compression handoff packet written, but automatic handoff to {platform} could not be queued."
+                )
+            except Exception:
+                pass
+
+    try:
+        suffix = f" Handoff to {platform} queued." if requested else ""
+        location = f" Packet: {artifact_path}" if artifact_path else " Packet write failed."
+        agent._emit_status(
+            "⚠ Repeated compression reached the auto-handoff threshold."
+            f"{location}{suffix}"
+        )
+    except Exception:
+        pass
+    return artifact_path

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2287,6 +2287,17 @@ def compress_context(
             agent._compression_warning = _cc_msg
             agent._emit_status(_cc_msg)
 
+        try:
+            from agent.compression_handoff import maybe_trigger_compression_handoff
+
+            maybe_trigger_compression_handoff(
+                agent,
+                compressed,
+                approx_tokens=approx_tokens,
+            )
+        except Exception as _handoff_err:
+            logger.debug("auto handoff-on-compression skipped: %s", _handoff_err)
+
         # Emit session:compress event so hooks (e.g. MemPalace sync) can ingest
         # the completed old session before its details are lost. In in-place mode
         # there is no old id (same session); ``in_place=True`` tells hooks the

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -814,6 +814,18 @@ agent:
   # underneath this wrapper — this is the Hermes-level loop.
   # api_max_retries: 3
 
+  # Optionally write a bounded, redacted handoff packet after repeated context
+  # compression. mode "platform" additionally queues a durable handoff request
+  # to the configured gateway platform; this feature never rotates sessions
+  # directly while compression is in flight.
+  # auto_handoff_on_compression:
+  #   enabled: false
+  #   after_compressions: 2
+  #   max_auto_handoffs: 1
+  #   mode: packet
+  #   platform: ""
+  #   handoff_artifact_dir: handoffs
+
   # After the agent edits code without fresh passing verification, nudge it to
   # verify before finishing. The default "auto" enables it on interactive
   # coding surfaces (CLI, TUI, desktop) and programmatic callers, and disables

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -983,6 +983,18 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Opt-in packet generation after repeated compression. mode="packet"
+        # writes a redacted artifact under HERMES_HOME; mode="platform" also
+        # queues SessionDB.request_handoff() for the configured platform. This
+        # path never rotates sessions while compression is in flight.
+        "auto_handoff_on_compression": {
+            "enabled": False,
+            "after_compressions": 2,
+            "max_auto_handoffs": 1,
+            "mode": "packet",
+            "platform": "",
+            "handoff_artifact_dir": "handoffs",
+        },
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/tests/run_agent/test_auto_handoff_on_compression.py
+++ b/tests/run_agent/test_auto_handoff_on_compression.py
@@ -1,0 +1,270 @@
+"""Focused tests for compression auto-handoff refactor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import stat
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+from agent.compression_handoff import (
+    build_compression_handoff_packet,
+    configure_auto_handoff_on_compression,
+    maybe_trigger_compression_handoff,
+)
+from agent.conversation_compression import compress_context
+from run_agent import AIAgent
+
+
+class FakeCompressor:
+    def __init__(self, returned: list[dict[str, str]], count: int = 2):
+        self.returned = returned
+        self.compression_count = max(0, count - 1)
+        self.target_count = count
+        self._last_compress_aborted = False
+        self._last_summary_error = None
+        self._last_aux_model_failure_model = None
+        self._last_aux_model_failure_error = None
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.session_start_calls: list[dict[str, Any]] = []
+
+    def compress(self, *args, **kwargs):
+        self.compression_count = self.target_count
+        return [m.copy() for m in self.returned]
+
+    def on_session_start(self, session_id: str, **kwargs):
+        self.session_start_calls.append({"session_id": session_id, **kwargs})
+
+
+class FakeTodos:
+    def format_for_injection(self):
+        return "[Your active task list was preserved across context compression]\n- [>] work. Keep going"
+
+    def read(self):
+        return [{"id": "work", "content": "Keep going", "status": "in_progress"}]
+
+
+class FakeSessionDB:
+    def __init__(self):
+        self.archived: list[tuple[str, list[dict[str, Any]]]] = []
+        self.handoffs: list[tuple[str, str]] = []
+        self.prompts: list[tuple[str, str]] = []
+
+    def get_session_title(self, session_id):
+        return "Compression handoff"
+
+    def try_acquire_compression_lock(self, *args, **kwargs):
+        return True
+
+    def release_compression_lock(self, *args, **kwargs):
+        return None
+
+    def archive_and_compact(self, session_id, compressed):
+        self.archived.append((session_id, compressed))
+
+    def update_system_prompt(self, session_id, prompt):
+        self.prompts.append((session_id, prompt))
+
+    def request_handoff(self, session_id, platform):
+        self.handoffs.append((session_id, platform))
+        return True
+
+
+class FakeMemory:
+    def on_session_switch(self, *args, **kwargs):
+        return None
+
+    def on_pre_compress(self, *args, **kwargs):
+        return None
+
+
+def make_agent(tmp_path: Path, compressor: FakeCompressor) -> Any:
+    agent = cast(Any, object.__new__(AIAgent))
+    agent.context_compressor = compressor
+    agent.session_id = "session-old"
+    agent.model = "test-model"
+    agent.provider = "openai-codex"
+    agent.platform = "cli"
+    agent.tools = []
+    agent.log_prefix = ""
+    agent.compression_in_place = True
+    agent._compression_feasibility_checked = True
+    agent._session_db = FakeSessionDB()
+    agent._session_db_created = True
+    agent._session_init_model_config = {"max_iterations": 90}
+    agent._memory_manager = FakeMemory()
+    agent._todo_store = FakeTodos()
+    agent._cached_system_prompt = None
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._last_compaction_in_place = False
+    agent._last_compression_lock_error_sid = None
+    agent._last_compression_lock_warning_sid = None
+    agent._compression_lock_ttl_seconds = 300
+    agent._compression_lock_refresh_interval = None
+    agent._auto_handoff_on_compression_enabled = False
+    agent._auto_handoff_after_compressions = 2
+    agent._auto_handoff_max_auto_handoffs = 1
+    agent._auto_handoff_mode = "packet"
+    agent._auto_handoff_platform = ""
+    agent._auto_handoff_artifact_dir = "handoffs"
+    agent._auto_handoff_count = 0
+    agent._invalidate_system_prompt = lambda *a, **kw: None
+    agent._build_system_prompt = lambda *a, **kw: "new-system-prompt"
+    agent._emit_status = lambda message: None
+    agent._emit_warning = lambda message: None
+    agent.commit_memory_session = lambda *a, **kw: None
+    return agent
+
+
+def test_configure_auto_handoff_aliases_legacy_modes():
+    agent = SimpleNamespace()
+    configure_auto_handoff_on_compression(
+        agent,
+        {
+            "auto_handoff_on_compression": {
+                "enabled": "yes",
+                "after_compressions": "3",
+                "max_auto_handoffs": "2",
+                "mode": "fresh_session",
+                "platform": "discord",
+                "handoff_artifact_dir": ".hermes/handoffs",
+            }
+        },
+    )
+
+    assert agent._auto_handoff_on_compression_enabled is True
+    assert agent._auto_handoff_after_compressions == 3
+    assert agent._auto_handoff_max_auto_handoffs == 2
+    # Old fresh-session rotation is intentionally not replayed; current refactor
+    # falls back to packet/platform handoff primitives.
+    assert agent._auto_handoff_mode == "packet"
+    assert agent._auto_handoff_platform == "discord"
+    assert agent._auto_handoff_artifact_dir == ".hermes/handoffs"
+    assert agent._auto_handoff_count == 0
+
+
+def test_aiagent_initializes_auto_handoff_config_from_yaml():
+    cfg = {
+        "agent": {
+            "auto_handoff_on_compression": {
+                "enabled": True,
+                "after_compressions": "3",
+                "max_auto_handoffs": "2",
+                "mode": "platform",
+                "platform": "discord",
+                "handoff_artifact_dir": "custom-handoffs",
+            }
+        }
+    }
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+    ):
+        agent = cast(
+            Any,
+            AIAgent(
+                api_key="dummy",
+                base_url="https://example.test/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            ),
+        )
+
+    assert agent._auto_handoff_on_compression_enabled is True
+    assert agent._auto_handoff_after_compressions == 3
+    assert agent._auto_handoff_max_auto_handoffs == 2
+    assert agent._auto_handoff_mode == "platform"
+    assert agent._auto_handoff_platform == "discord"
+    assert agent._auto_handoff_artifact_dir == "custom-handoffs"
+
+
+def test_maybe_trigger_writes_packet_and_queues_current_session_handoff(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    compressor = FakeCompressor([{"role": "user", "content": "compressed summary"}], count=2)
+    compressor.compression_count = 2
+    agent = make_agent(tmp_path, compressor)
+    agent._auto_handoff_on_compression_enabled = True
+    agent._auto_handoff_mode = "platform"
+    agent._auto_handoff_platform = "discord"
+
+    path = maybe_trigger_compression_handoff(
+        agent,
+        [{"role": "user", "content": "compressed summary"}],
+        approx_tokens=123_456,
+    )
+
+    assert path is not None and path.exists()
+    packet = path.read_text(encoding="utf-8")
+    assert "# Hermes compression handoff packet" in packet
+    assert "compressed summary" in packet
+    assert "Keep going" in packet
+    assert agent._session_db.handoffs == [("session-old", "discord")]
+    assert agent._auto_handoff_count == 1
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_maybe_trigger_is_bounded_by_max_auto_handoffs(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    compressor = FakeCompressor([{"role": "user", "content": "compressed summary"}], count=3)
+    agent = make_agent(tmp_path, compressor)
+    agent._auto_handoff_on_compression_enabled = True
+    agent._auto_handoff_count = 1
+    agent._auto_handoff_max_auto_handoffs = 1
+
+    path = maybe_trigger_compression_handoff(agent, [{"role": "user", "content": "summary"}])
+
+    assert path is None
+    assert not (tmp_path / "handoffs").exists()
+    assert agent._session_db.handoffs == []
+
+
+def test_packet_redacts_secret_like_content(tmp_path):
+    compressor = FakeCompressor([{"role": "user", "content": "unused"}], count=2)
+    agent = make_agent(tmp_path, compressor)
+
+    packet = build_compression_handoff_packet(
+        agent,
+        [{"role": "user", "content": "Use OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz123456"}],
+    )
+
+    assert "sk-abcdefghijklmnopqrstuvwxyz123456" not in packet
+    assert "OPENAI_API_KEY=" in packet
+
+
+def test_compress_context_triggers_packet_without_session_rotation(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    returned = [
+        {"role": "user", "content": "compressed summary"},
+        {"role": "assistant", "content": "tail"},
+    ]
+    compressor = FakeCompressor(returned, count=2)
+    agent = make_agent(tmp_path, compressor)
+    agent._auto_handoff_on_compression_enabled = True
+    agent._auto_handoff_mode = "packet"
+
+    messages, prompt = compress_context(
+        agent,
+        [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ],
+        "",
+        approx_tokens=250_000,
+    )
+
+    assert prompt == "new-system-prompt"
+    assert agent.session_id == "session-old"
+    assert agent._last_compaction_in_place is True
+    assert agent._session_db.archived[-1][0] == "session-old"
+    assert messages[:2] == returned
+    packet_paths = list((tmp_path / "handoffs").glob("*.md"))
+    assert len(packet_paths) == 1
+    assert "compressed summary" in packet_paths[0].read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add bounded handoff-packet construction in `agent/compression_handoff.py`
- let compression-sensitive flows prepare a fresh-session handoff instead of repeatedly compressing in place
- add focused regression coverage for bounded handoff behavior

## Why
#20372 asks for a first-class fresh-session handoff mode when repeated compression becomes risky. The earlier implementation lane in #29293 proved the product need, but this validated current-main port is now a much cleaner branch to review.

Supersedes: #29293

## Safety and scope
- opt-in and separately bounded by compression count and maximum handoffs
- redacts packet content and constrains artifact paths under the configured Hermes home
- never rotates a session while compression is in flight
- does not include the separate max-turn auto-continue feature

## Validation
- `python -m pytest -q tests/run_agent/test_auto_handoff_on_compression.py tests/agent/test_context_compressor.py tests/run_agent/test_compression_boundary.py` — 226 passed
- default-config contract, changed Python compilation, and `git diff --check` — passed
