### PR TITLE
fix(models): preserve Codex route context window contract

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2012,6 +2012,9 @@ def _fetch_codex_oauth_context_lengths_with_source(
         if not isinstance(item, dict):
             continue
         slug = item.get("slug")
+        # Deliberately ignore max_context_window here. It is the raw model
+        # ceiling, while context_window is the request/session limit enforced
+        # by chatgpt.com/backend-api/codex (GPT-5.4 can report 1M vs 272K).
         ctx = item.get("context_window")
         if isinstance(slug, str) and isinstance(ctx, int) and ctx > 0:
             result[slug.strip()] = ctx

--- a/tests/agent/test_codex_route_context_contract.py
+++ b/tests/agent/test_codex_route_context_contract.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock, patch
+
+
+def test_codex_live_probe_uses_route_window_not_raw_model_maximum():
+    """Codex OAuth must budget against the route-enforced context_window."""
+    import agent.model_metadata as mm
+
+    mm._codex_oauth_context_cache = {}
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {
+        "models": [
+            {
+                "slug": "gpt-5.4",
+                "context_window": 272_000,
+                "max_context_window": 1_000_000,
+            }
+        ]
+    }
+
+    with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+         patch("agent.model_metadata.save_context_length"):
+        resolved = mm.get_model_context_length(
+            model="gpt-5.4",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="fake-token",
+            provider="openai-codex",
+        )
+
+    assert resolved == 272_000


### PR DESCRIPTION
## Summary
- ignore `max_context_window` when resolving Codex OAuth route limits
- keep treating `context_window` as the enforced Codex request/session ceiling
- add a regression test for live metadata that advertises `context_window=272000` and `max_context_window=1000000` for the same slug

## Why
Codex OAuth can expose a raw model ceiling that is larger than the request/session limit actually enforced on the Codex route. Budgeting Hermes against the raw maximum reintroduces the route/API mismatch that closed PR #16735 and closed issue #27918 documented.

Related history:
- #14935 established `context_window` as the Codex contract
- #27918 was closed after live verification that Codex OAuth remains 272K while the direct OpenAI API can be higher
- #16735 proposed preferring `max_context_window`; this PR hardens the opposite contract with an explicit regression test
- #49449 is a broader context/output override lane, but it does not yet hit the provider-aware Codex route resolver this PR targets

## Validation
- `python -m pytest -q tests/agent/test_codex_route_context_contract.py tests/agent/test_model_metadata.py` — 133 passed
- changed Python compilation and `git diff --check` — passed
