### PR TITLE
fix(auxiliary): reach the main agent model when a sibling aux model fails on the same provider (salvage #59561)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4335,18 +4335,23 @@ def _try_configured_fallback_chain(
     ``base_url``, and ``api_key`` are optional.
 
     ``failed_model`` narrows the skip check to the exact (provider, model)
-    pair that just failed, rather than the whole provider. Without it (the
-    "no client could be built" callers, where credentials/auth are broken
-    for the whole provider regardless of model) every entry sharing that
-    provider is skipped, same as before. With it (the runtime request-error
-    callers), a chain that intentionally lists several models under the
-    same provider — e.g. two more NVIDIA NIM models after the primary NIM
-    model times out — is no longer skipped wholesale; only the entry that
-    is an exact match for what just failed is skipped, so the chain can
-    still serve the request from the same provider instead of jumping
-    straight to the main-agent-model safety net. See issue where an NVIDIA
-    NIM timeout on the primary compression model fell through to the main
-    Codex model instead of trying the two other configured NIM fallbacks.
+    pair that just failed, rather than the whole provider. Without it every
+    entry sharing the failed provider is skipped (the original behaviour).
+    Callers pass it only when a sibling model on the same provider could
+    plausibly recover:
+
+    - Model-specific runtime failures (timeout, connection, rate limit,
+      model-incompatible, invalid response) pass ``failed_model`` so a
+      chain that intentionally lists several models under the same provider
+      — e.g. two more NVIDIA NIM models after the primary NIM model times
+      out — is not skipped wholesale. Only the exact model that failed is
+      skipped; the siblings still run instead of jumping straight to the
+      main-agent-model safety net.
+    - Provider-wide failures (auth 401, payment 402) and "no client could
+      be built" callers leave ``failed_model`` as None, keeping the whole
+      provider skipped — the shared credentials/account behind every model
+      on that provider are broken, so a sibling can't help and the
+      main-agent-model safety net should be reached instead.
 
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
@@ -8099,6 +8104,15 @@ def call_llm(
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
 
+            # Narrow the configured-chain skip to the exact model that
+            # failed ONLY for model-specific failures. Auth (401) and
+            # payment (402) errors are provider-wide — the credentials or
+            # account behind every model on that provider are the same — so
+            # a sibling model can't recover; keep skipping the whole
+            # provider so the main-agent-model safety net is still reached.
+            _chain_failed_model = (
+                None if reason in ("auth error", "payment error") else final_model
+            )
             # Fallback order (#26882, #26803):
             #   1. User-configured fallback_chain (per-task) if set
             #   2. For auto: top-level main fallback_providers/fallback_model
@@ -8108,7 +8122,7 @@ def call_llm(
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason,
-                    failed_model=final_model)
+                    failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_fallback_chain(
                         task, resolved_provider or "auto", reason=reason)
@@ -8118,7 +8132,7 @@ def call_llm(
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason,
-                    failed_model=final_model)
+                    failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
@@ -8635,6 +8649,15 @@ async def async_call_llm(
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
 
+            # Narrow the configured-chain skip to the exact model that
+            # failed ONLY for model-specific failures. Auth (401) and
+            # payment (402) errors are provider-wide — the credentials or
+            # account behind every model on that provider are the same — so
+            # a sibling model can't recover; keep skipping the whole
+            # provider so the main-agent-model safety net is still reached.
+            _chain_failed_model = (
+                None if reason in ("auth error", "payment error") else final_model
+            )
             # Fallback order (#26882, #26803):
             #   1. User-configured fallback_chain (per-task) if set
             #   2. For auto: top-level main fallback_providers/fallback_model
@@ -8644,7 +8667,7 @@ async def async_call_llm(
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason,
-                    failed_model=final_model)
+                    failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_fallback_chain(
                         task, resolved_provider or "auto", reason=reason)
@@ -8654,7 +8677,7 @@ async def async_call_llm(
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason,
-                    failed_model=final_model)
+                    failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4326,12 +4326,27 @@ def _try_configured_fallback_chain(
     task: str,
     failed_provider: str,
     reason: str = "error",
+    failed_model: Optional[str] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try user-configured fallback_chain for a specific auxiliary task.
 
     Reads auxiliary.<task>.fallback_chain from config.yaml and tries each
     entry in order.  Each entry must have at least ``provider``; ``model``,
     ``base_url``, and ``api_key`` are optional.
+
+    ``failed_model`` narrows the skip check to the exact (provider, model)
+    pair that just failed, rather than the whole provider. Without it (the
+    "no client could be built" callers, where credentials/auth are broken
+    for the whole provider regardless of model) every entry sharing that
+    provider is skipped, same as before. With it (the runtime request-error
+    callers), a chain that intentionally lists several models under the
+    same provider — e.g. two more NVIDIA NIM models after the primary NIM
+    model times out — is no longer skipped wholesale; only the entry that
+    is an exact match for what just failed is skipped, so the chain can
+    still serve the request from the same provider instead of jumping
+    straight to the main-agent-model safety net. See issue where an NVIDIA
+    NIM timeout on the primary compression model fell through to the main
+    Codex model instead of trying the two other configured NIM fallbacks.
 
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
@@ -4345,6 +4360,7 @@ def _try_configured_fallback_chain(
         return None, None, ""
 
     skip = failed_provider.lower().strip()
+    skip_model = (failed_model or "").strip().lower() or None
     tried = []
     min_ctx = _task_minimum_context_length(task)
 
@@ -4352,9 +4368,14 @@ def _try_configured_fallback_chain(
         if not isinstance(entry, dict):
             continue
         fb_provider = str(entry.get("provider", "")).strip()
-        if not fb_provider or fb_provider.lower() == skip:
+        if not fb_provider:
             continue
-        fb_model = str(entry.get("model", "")).strip() or None
+        fb_model_raw = str(entry.get("model", "")).strip()
+        if fb_provider.lower() == skip and (
+            skip_model is None or fb_model_raw.lower() == skip_model
+        ):
+            continue
+        fb_model = fb_model_raw or None
 
         label = f"fallback_chain[{i}]({fb_provider})"
 
@@ -8086,7 +8107,8 @@ def call_llm(
             fb_client, fb_model, fb_label = (None, None, "")
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason,
+                    failed_model=final_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_fallback_chain(
                         task, resolved_provider or "auto", reason=reason)
@@ -8095,7 +8117,8 @@ def call_llm(
                         resolved_provider, task, reason=reason)
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason,
+                    failed_model=final_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
@@ -8620,7 +8643,8 @@ async def async_call_llm(
             fb_client, fb_model, fb_label = (None, None, "")
             if is_auto:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason,
+                    failed_model=final_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_fallback_chain(
                         task, resolved_provider or "auto", reason=reason)
@@ -8629,7 +8653,8 @@ async def async_call_llm(
                         resolved_provider, task, reason=reason)
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason,
+                    failed_model=final_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4188,6 +4188,7 @@ def _try_main_agent_model_fallback(
     failed_provider: str,
     task: str = None,
     reason: str = "error",
+    failed_model: Optional[str] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Last-resort fallback to the user's main agent provider + model.
 
@@ -4196,8 +4197,23 @@ def _try_main_agent_model_fallback(
     layer: if nothing the user asked for can serve the request, try the
     main chat model before giving up.
 
-    Skips when the failed provider already IS the main provider (no point
-    retrying the same backend that just failed).
+    ``failed_model`` narrows the same-provider skip to the exact
+    (provider, model) pair that just failed, mirroring
+    :func:`_try_configured_fallback_chain`.  This matters for self-hosted /
+    custom endpoints serving several models behind one provider label: the
+    aux compression model timing out says nothing about the health of the
+    main agent model deployed on the same URL (real incident: aux
+    ``glm-5.2`` hung and timed out while main ``macaron-v1-venti`` on the
+    identical endpoint was serving 448K-token turns fine — the
+    provider-label skip discarded the one fallback that would have worked).
+
+    - Model-specific runtime failures (timeout, connection, rate limit,
+      model-incompatible, invalid response) pass ``failed_model``: skip the
+      main model only when it IS the exact model that failed.
+    - Provider-wide failures (auth 401, payment 402) and legacy callers
+      leave ``failed_model`` as None, keeping the whole-provider skip —
+      the shared credentials/account are broken, so the main model on the
+      same provider cannot help either.
 
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
@@ -4215,8 +4231,12 @@ def _try_main_agent_model_fallback(
         return None, None, ""
 
     skip = (failed_provider or "").lower().strip()
-    if main_provider.lower() == skip:
-        # The thing that failed IS the main model — nothing to fall back to.
+    skip_model = (failed_model or "").strip().lower() or None
+    if main_provider.lower() == skip and (
+        skip_model is None or main_model.lower() == skip_model
+    ):
+        # The thing that failed IS the main model (or the failure was
+        # provider-wide) — nothing to fall back to.
         return None, None, ""
     if _is_provider_unhealthy(main_provider):
         _log_skip_unhealthy(main_provider, task)
@@ -8135,7 +8155,8 @@ def call_llm(
                     failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason)
+                        resolved_provider, task, reason=reason,
+                        failed_model=_chain_failed_model)
 
             if fb_client is not None:
                 fb_resp = _call_fallback_candidate_sync(
@@ -8680,7 +8701,8 @@ async def async_call_llm(
                     failed_model=_chain_failed_model)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason)
+                        resolved_provider, task, reason=reason,
+                        failed_model=_chain_failed_model)
 
             if fb_client is not None:
                 # Convert sync fallback client to async

--- a/contributors/emails/okalentiev@gmail.com
+++ b/contributors/emails/okalentiev@gmail.com
@@ -1,0 +1,1 @@
+okalentiev

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3167,6 +3167,47 @@ class TestTryMainAgentModelFallback:
             client, model, label = _try_main_agent_model_fallback("glm", task="vision")
         assert client is None
 
+    def test_same_provider_different_model_falls_back_when_failed_model_given(self):
+        """Self-hosted shape: aux model and main model share one custom
+        provider label. A timeout on the aux model must still reach the main
+        model — same provider, DIFFERENT model (real incident: aux glm-5.2
+        timed out while main macaron-v1-venti on the same endpoint was
+        healthy; the provider-label skip discarded the working fallback)."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._read_main_provider", return_value="custom"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="mindai/macaron-v1-venti"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "mindai/macaron-v1-venti")):
+            client, model, label = _try_main_agent_model_fallback(
+                "custom", task="compression", failed_model="zai-org/glm-5.2")
+        assert client is fake_client
+        assert model == "mindai/macaron-v1-venti"
+        assert label == "main-agent(custom)"
+
+    def test_same_provider_same_model_still_skips_with_failed_model(self):
+        """When the model that failed IS the main model, there is nothing to
+        fall back to — the narrowed skip must not regress into a self-retry."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        with patch("agent.auxiliary_client._read_main_provider", return_value="custom"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="mindai/macaron-v1-venti"):
+            client, model, label = _try_main_agent_model_fallback(
+                "custom", task="compression",
+                failed_model="MindAI/Macaron-V1-Venti")  # case-insensitive match
+        assert client is None and model is None and label == ""
+
+    def test_same_provider_no_failed_model_keeps_provider_wide_skip(self):
+        """Legacy / provider-wide callers (auth 401, payment 402) pass no
+        failed_model: the whole-provider skip must be preserved so broken
+        shared credentials don't trigger a doomed main-model attempt."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        with patch("agent.auxiliary_client._read_main_provider", return_value="custom"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="mindai/macaron-v1-venti"):
+            client, model, label = _try_main_agent_model_fallback(
+                "custom", task="compression")
+        assert client is None and model is None and label == ""
+
 
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2920,9 +2920,12 @@ class TestAuxiliaryFallbackLayering:
             )
 
         assert main_chain_client.chat.completions.create.called
+        # Payment errors are provider-wide, so the configured chain is
+        # asked to skip the whole provider (failed_model=None), not just
+        # the failed model — a sibling model can't recover from a 402.
         mock_task_chain.assert_called_once_with(
             "title_generation", "auto", reason="payment error",
-            failed_model="qwen/qwen3.5-122b-a10b")
+            failed_model=None)
         mock_main_chain.assert_called_once_with(
             "title_generation", "auto", reason="payment error")
         mock_builtin_chain.assert_not_called()
@@ -3359,6 +3362,44 @@ class TestTransientTransportRetry:
         # Primary tried ONCE only — no same-provider timeout retry — then fallback.
         assert primary.chat.completions.create.call_count == 1
         assert fb_client.chat.completions.create.call_count == 1
+
+    def test_timeout_forwards_failed_model_to_configured_chain(self):
+        """A timeout is model-specific, so call_llm must forward the failed
+        model to the configured chain (failed_model=<model>, not None). This
+        lets a same-provider sibling in the chain be tried instead of the
+        whole provider being skipped — the exact NVIDIA NIM bug's trigger.
+        """
+        class _Timeout(Exception):
+            pass
+        _Timeout.__name__ = "APITimeoutError"
+
+        primary = MagicMock()
+        primary.base_url = "https://integrate.api.nvidia.com/v1"
+        primary.chat.completions.create.side_effect = _Timeout("Request timed out.")
+
+        fb_client = MagicMock()
+        fb_client.base_url = "https://integrate.api.nvidia.com/v1"
+        fb_client.chat.completions.create.return_value = {"fallback": True}
+
+        p1, p2, p3 = self._patches(primary)
+        with (
+            p1, p2, p3,
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(fb_client, "sibling-model", "fallback_chain[0](openrouter)"),
+            ) as mock_chain,
+            patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+                return_value=(None, None, ""),
+            ),
+        ):
+            result = call_llm(task="compression", messages=[{"role": "user", "content": "hi"}])
+        assert result == {"fallback": True}
+        _, kwargs = mock_chain.call_args
+        assert kwargs.get("failed_model") == "some-model", (
+            "A timeout is model-specific — the failed model must be forwarded "
+            "so a same-provider sibling can be tried, not skipped wholesale."
+        )
 
     def test_non_compression_still_retries_same_provider_on_timeout(self):
         """The timeout skip is scoped to compression only; other auxiliary

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2858,6 +2858,7 @@ class TestAuxiliaryFallbackLayering:
             "title_generation",
             "nvidia",
             reason="invalid provider response",
+            failed_model="minimaxai/minimax-m3",
         )
         mock_main.assert_not_called()
 
@@ -2891,6 +2892,7 @@ class TestAuxiliaryFallbackLayering:
             "compression",
             "nvidia",
             reason="invalid provider response",
+            failed_model="minimaxai/minimax-m3",
         )
 
     def test_auto_provider_uses_task_then_main_chain_before_builtin_chain(self, monkeypatch):
@@ -2919,7 +2921,8 @@ class TestAuxiliaryFallbackLayering:
 
         assert main_chain_client.chat.completions.create.called
         mock_task_chain.assert_called_once_with(
-            "title_generation", "auto", reason="payment error")
+            "title_generation", "auto", reason="payment error",
+            failed_model="qwen/qwen3.5-122b-a10b")
         mock_main_chain.assert_called_once_with(
             "title_generation", "auto", reason="payment error")
         mock_builtin_chain.assert_not_called()
@@ -6306,6 +6309,106 @@ class TestCompressionFallbackContextFilter:
 
         assert client is large_client
         assert model == "large-512k"
+
+    # ── same-provider, different-model chain entries ────────────────────
+    # A configured fallback_chain may legitimately list several models
+    # under the *same* provider (e.g. two more NVIDIA NIM models after the
+    # primary NIM model). failed_provider alone must not skip those
+    # sibling entries — only failed_model narrows the skip to the exact
+    # (provider, model) pair that just failed.
+
+    def test_same_provider_sibling_model_not_skipped_when_failed_model_given(
+        self, monkeypatch
+    ):
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        sibling_client = MagicMock(name="sibling_nim_client")
+        entries = [
+            self._make_chain_entry("nvidia", "minimaxai/minimax-m3"),
+            self._make_chain_entry("nvidia", "deepseek-ai/deepseek-v4-flash"),
+        ]
+
+        def fake_resolve(entry):
+            if entry is entries[0]:
+                return sibling_client, "minimaxai/minimax-m3"
+            raise AssertionError("second entry should not be reached")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries} if task == "compression" else {},
+        )
+
+        with patch("agent.auxiliary_client._resolve_fallback_entry",
+                   side_effect=fake_resolve), \
+             patch("agent.auxiliary_client.get_model_context_length",
+                   return_value=1_048_576):
+            client, model, label = _try_configured_fallback_chain(
+                task="compression",
+                failed_provider="nvidia",
+                failed_model="deepseek-ai/deepseek-v4-pro",
+            )
+
+        assert client is sibling_client, (
+            "A same-provider entry with a DIFFERENT model must still be "
+            "tried when failed_model narrows the skip — regression for the "
+            "bug where an NVIDIA NIM timeout fell straight through to the "
+            "main Codex model instead of trying the other two configured "
+            "NIM models."
+        )
+        assert model == "minimaxai/minimax-m3"
+        assert "nvidia" in label
+
+    def test_same_provider_same_model_still_skipped(self, monkeypatch):
+        """The exact (provider, model) pair that just failed is still
+        skipped — failed_model narrows the skip, it doesn't disable it."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        entries = [
+            self._make_chain_entry("nvidia", "deepseek-ai/deepseek-v4-pro"),
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries} if task == "compression" else {},
+        )
+
+        with patch("agent.auxiliary_client._resolve_fallback_entry",
+                   side_effect=AssertionError("must not be resolved")):
+            client, model, label = _try_configured_fallback_chain(
+                task="compression",
+                failed_provider="nvidia",
+                failed_model="deepseek-ai/deepseek-v4-pro",
+            )
+
+        assert client is None
+        assert model is None
+        assert label == ""
+
+    def test_same_provider_skipped_wholesale_without_failed_model(self, monkeypatch):
+        """Backward compat: callers that don't know the failed model (e.g.
+        client-build failures where the whole provider is unreachable)
+        still skip every entry sharing that provider, as before."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        entries = [
+            self._make_chain_entry("nvidia", "minimaxai/minimax-m3"),
+            self._make_chain_entry("nvidia", "deepseek-ai/deepseek-v4-flash"),
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries} if task == "compression" else {},
+        )
+
+        with patch("agent.auxiliary_client._resolve_fallback_entry",
+                   side_effect=AssertionError("must not be resolved")):
+            client, model, label = _try_configured_fallback_chain(
+                task="compression", failed_provider="nvidia",
+            )
+
+        assert client is None
+        assert model is None
+        assert label == ""
 
     # ── L3: main fallback chain ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Compression (and every auxiliary task) can now fall back to the main agent model when the failed aux model shares its provider label — single-provider users with a separate aux model previously had zero working fallbacks.

Salvages **#59561** by @okalentiev (configured `fallback_chain` same-provider skip fix, both commits cherry-picked with authorship preserved) and widens the same `failed_model` narrowing to the `_try_main_agent_model_fallback` safety-net layer he didn't touch.

## Root cause

All fallback layers skipped candidates on a **provider-label string match**, treating "same provider" as "same failure domain". That premise is wrong for self-hosted / custom endpoints serving several models behind one URL. Real incident (0.19.0 debug dump, Raspberry Pi user, single custom endpoint, no other API keys):

```
Auxiliary compression: using custom (zai-org/glm-5.2)
Auxiliary compression: timeout on the critical path; ... The read operation timed out
Auxiliary compression: connection error on custom and all fallbacks exhausted
    (fallback_chain + main agent model). Raising original error.
```

The log claims the main agent model was tried. It wasn't: aux `glm-5.2` failed on provider `custom`, main provider is also `custom` → label-only skip returned nothing — while main `mindai/macaron-v1-venti` on the identical endpoint was serving 448K-token turns. Compression aborted, the session wedged over threshold, and the anti-thrash breaker tripped ("context over threshold but compression is currently blocked (ineffective)").

## Changes

- `agent/auxiliary_client.py`
  - **#59561 (cherry-picked):** `_try_configured_fallback_chain` takes `failed_model`; skip narrows to the exact (provider, model) pair for model-specific failures; auth 401 / payment 402 keep the provider-wide skip (shared credentials — a sibling can't help)
  - **Widening (ours):** `_try_main_agent_model_fallback` gets the same `failed_model` narrowing; both sync and async `call_llm` sites pass `_chain_failed_model` through
- `tests/agent/test_auxiliary_client.py`: #59561's chain tests + 3 new safety-net tests (same provider + different model falls back; same provider + same model still skips, case-insensitive; no `failed_model` keeps provider-wide skip)
- `contributors/emails/okalentiev@gmail.com`

## Validation

| Check | Result |
|---|---|
| `tests/agent/test_auxiliary_client.py` | 369 passed |
| Sabotage run (old provider-only skip restored) | new regression test FAILS, as required |
| E2E with real config read (incident shape: custom provider, aux glm-5.2 fails, main macaron) | fallback served `main-agent(custom)` |
| E2E provider-wide shape (no `failed_model`) | still skipped |
| ruff | clean |

## Infographic

![Auxiliary fallback: skip the model, not the provider](https://v3b.fal.media/files/b/0aa3e2e0/BrgDOy1OzFcRvmd1genNa_ONh2JxjJ.png)
