### PR TITLE
fix(gateway): keep multiplexed /approvals authorization and persistent mode writes on the routed profile

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15032,6 +15032,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+    @_contextmanager
+    def _profile_config_scope_for_source(self, source: SessionSource):
+        """Yield the config owned by an inbound source's routed profile.
+
+        Secondary adapters already wrap their entire handler in
+        ``_profile_runtime_scope``. Sources routed through a primary/shared
+        adapter do not, so command access checks and persistent command writes
+        must install that same scope explicitly.
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            yield self.config
+            return
+
+        profile_home = self._resolve_profile_home_for_source(source)
+        with _profile_runtime_scope(profile_home):
+            yield load_gateway_config()
+
     def _check_slash_access(
         self, source: SessionSource, canonical_cmd: str
     ) -> Optional[str]:
@@ -15049,7 +15066,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if not canonical_cmd:
             return None
-        policy = _policy_for_source(self.config, source)
+        with self._profile_config_scope_for_source(source) as source_config:
+            policy = _policy_for_source(source_config, source)
         if not policy.enabled or policy.can_run(source.user_id, canonical_cmd):
             return None
         logger.info(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3658,10 +3658,11 @@ class GatewaySlashCommandsMixin:
         # This mutates profile-wide security policy. The central slash gate can
         # allow selected commands to non-admin users, so enforce admin again at
         # this side-effect boundary. Unconfigured policies remain unrestricted.
-        policy = policy_for_source(self.config, event.source)
-        if requested and not policy.is_admin(event.source.user_id):
-            return "Only gateway admins can change the persistent approval mode."
-        result = run_approval_mode_command(requested)
+        with self._profile_config_scope_for_source(event.source) as source_config:
+            policy = policy_for_source(source_config, event.source)
+            if requested and not policy.is_admin(event.source.user_id):
+                return "Only gateway admins can change the persistent approval mode."
+            result = run_approval_mode_command(requested)
         # Approval checks load config dynamically; do not evict the cached agent
         # or alter its system prompt/tool schema (prompt-cache prefix is sacred).
         return result.message

--- a/tests/gateway/test_approvals_command.py
+++ b/tests/gateway/test_approvals_command.py
@@ -7,19 +7,25 @@ import pytest
 import yaml
 
 import gateway.run as gateway_run
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource
 
 
-def _event(text: str = "/approvals") -> MessageEvent:
+def _event(
+    text: str = "/approvals",
+    *,
+    user_id: str = "user-1",
+    profile: str | None = None,
+) -> MessageEvent:
     return MessageEvent(
         text=text,
         source=SessionSource(
             platform=Platform.TELEGRAM,
-            user_id="user-1",
+            user_id=user_id,
             chat_id="chat-1",
             chat_type="dm",
+            profile=profile,
         ),
     )
 
@@ -34,6 +40,15 @@ def _runner():
     runner._is_user_authorized = lambda _source: True
     runner.session_store = SimpleNamespace(get_or_create_session=lambda _source: None)
     return runner
+
+
+def _clear_config_caches() -> None:
+    from hermes_cli import managed_scope
+    from hermes_cli.config import _LOAD_CONFIG_CACHE, _RAW_CONFIG_CACHE
+
+    _LOAD_CONFIG_CACHE.clear()
+    _RAW_CONFIG_CACHE.clear()
+    managed_scope.invalidate_managed_cache()
 
 
 @pytest.mark.asyncio
@@ -89,3 +104,84 @@ async def test_gateway_live_dispatch_routes_and_persists_approvals_command(tmp_p
 
     assert output == "Approval mode: manual (persistent profile setting)."
     assert yaml.safe_load((home / "config.yaml").read_text())["approvals"]["mode"] == "manual"
+
+
+@pytest.mark.asyncio
+async def test_multiplex_approvals_change_persists_only_to_routed_profile(
+    tmp_path, monkeypatch
+):
+    default_home = tmp_path / "default"
+    routed_home = tmp_path / "routed"
+    default_home.mkdir()
+    routed_home.mkdir()
+    (default_home / "config.yaml").write_text(
+        yaml.safe_dump({"approvals": {"mode": "manual"}}),
+        encoding="utf-8",
+    )
+    (routed_home / "config.yaml").write_text(
+        yaml.safe_dump({"approvals": {"mode": "smart"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(tmp_path / "missing-managed"))
+    _clear_config_caches()
+
+    runner = _runner()
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._resolve_profile_home_for_source = lambda _source: routed_home
+
+    output = await runner._handle_approvals_command(
+        _event("/approvals off", profile="routed")
+    )
+
+    default_config = yaml.safe_load((default_home / "config.yaml").read_text())
+    routed_config = yaml.safe_load((routed_home / "config.yaml").read_text())
+    assert output == "Approval mode: off (persistent profile setting)."
+    assert default_config["approvals"]["mode"] == "manual"
+    assert routed_config["approvals"]["mode"] == "off"
+
+
+def test_multiplex_slash_access_uses_routed_profile_admin_policy(
+    tmp_path, monkeypatch
+):
+    default_home = tmp_path / "default"
+    routed_home = tmp_path / "routed"
+    default_home.mkdir()
+    routed_home.mkdir()
+    (default_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "telegram": {
+                    "allow_admin_from": ["default-admin"],
+                    "user_allowed_commands": [],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (routed_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "telegram": {
+                    "allow_admin_from": ["routed-admin"],
+                    "user_allowed_commands": [],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(tmp_path / "missing-managed"))
+    _clear_config_caches()
+
+    runner = _runner()
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.config.platforms = gateway_run.load_gateway_config().platforms
+    runner._resolve_profile_home_for_source = lambda _source: routed_home
+
+    denial = runner._check_slash_access(
+        _event(user_id="routed-admin", profile="routed").source,
+        "approvals",
+    )
+
+    assert denial is None


### PR DESCRIPTION
## What?

In multiplex gateways, `/approvals` used the default profile’s admin policy and configuration even when the message was routed to another profile. The command could report success while changing the wrong profile’s persistent approval mode.

## Fix

Scope both slash-command authorization and `/approvals` reads/writes to the routed profile. Single-profile behavior remains unchanged.

Follow-up to #63517. No duplicate PR or issue found.

## Tests

- Main: default changed from `manual` to `off`; routed profile incorrectly remained `smart`.
- Fixed: default remains `manual`; routed profile changes to `off`.
- 5 focused tests passed.
- 96 related gateway/multiplex tests passed.
- Ruff, compileall, and `git diff --check` passed.