### PR TITLE
fix(desktop): add files pane parent navigation

### DIFF
--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -1,8 +1,8 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesReadDirResult } from '@/global'
-import { $connection, setCurrentCwd } from '@/store/session'
+import { $connection, $currentCwd, setActiveSessionId, setCurrentCwd } from '@/store/session'
 
 import { resetProjectTreeState } from './files/use-project-tree'
 
@@ -17,6 +17,7 @@ function installBridge() {
 describe('RightSidebarPane', () => {
   beforeEach(() => {
     $connection.set(null)
+    setActiveSessionId(null)
     resetProjectTreeState()
     readDir.mockReset()
     readDir.mockResolvedValue({ entries: [{ isDirectory: false, name: 'README.md', path: '/repo/README.md' }] })
@@ -26,6 +27,7 @@ describe('RightSidebarPane', () => {
   afterEach(() => {
     cleanup()
     $connection.set(null)
+    setActiveSessionId(null)
     setCurrentCwd('')
     resetProjectTreeState()
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
@@ -44,6 +46,75 @@ describe('RightSidebarPane', () => {
 
     // The freeform folder picker is retired.
     expect(screen.queryByRole('button', { name: 'Open folder' })).toBeNull()
+  })
+
+  it('browses the parent directory without changing the session workspace', async () => {
+    setCurrentCwd('/repo/child')
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    const up = await screen.findByRole('button', { name: 'Go to parent folder' })
+
+    readDir.mockClear()
+    fireEvent.click(up)
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo'))
+    expect($currentCwd.get()).toBe('/repo/child')
+  })
+
+  it('browses to the POSIX root from a top-level directory', async () => {
+    setCurrentCwd('/repo')
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    const up = await screen.findByRole('button', { name: 'Go to parent folder' })
+
+    readDir.mockClear()
+    fireEvent.click(up)
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/'))
+  })
+
+  it('resets the browser when switching sessions with the same workspace', async () => {
+    setCurrentCwd('/repo/child')
+    setActiveSessionId('session-a')
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Go to parent folder' }))
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo'))
+
+    readDir.mockClear()
+    act(() => setActiveSessionId('session-b'))
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo/child'))
+  })
+
+  it('browses to the root of a Windows drive', async () => {
+    setCurrentCwd('C:\\repo')
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    const up = await screen.findByRole('button', { name: 'Go to parent folder' })
+
+    readDir.mockClear()
+    fireEvent.click(up)
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('C:\\'))
+  })
+
+  it('stops at a Windows UNC share root', async () => {
+    setCurrentCwd('\\\\server\\share\\folder')
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    const up = await screen.findByRole('button', { name: 'Go to parent folder' })
+
+    readDir.mockClear()
+    fireEvent.click(up)
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('\\\\server\\share'))
+    await waitFor(() => expect((up as HTMLButtonElement).disabled).toBe(true))
   })
 
   it('shows no tree for a detached chat (no working dir)', async () => {

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react'
 import type { ComponentProps } from 'react'
+import { useEffect, useState } from 'react'
 
 import { TreeSkeleton } from '@/components/chat/skeletons'
 import { ErrorBoundary } from '@/components/error-boundary'
@@ -13,12 +14,37 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { setCurrentSessionPreviewTarget } from '@/store/preview'
-import { $currentCwd } from '@/store/session'
+import { $activeSessionId, $currentCwd } from '@/store/session'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
 import { ProjectTree } from './files/tree'
 import { useProjectTree } from './files/use-project-tree'
+
+function parentDirectory(path: string): null | string {
+  const trimmed = path.trim()
+  const normalized = trimmed.replace(/[\\/]+$/, '') || (trimmed.startsWith('/') ? '/' : trimmed)
+  const driveRootChild = normalized.match(/^([A-Za-z]:)([\\/])[^\\/]+$/)
+  const uncShareRoot = /^[\\/]{2}[^\\/]+[\\/][^\\/]+$/.test(normalized)
+
+  if (uncShareRoot) {
+    return null
+  }
+
+  if (driveRootChild) {
+    return `${driveRootChild[1]}${driveRootChild[2]}`
+  }
+
+  const separator = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+
+  if (separator < 0 || (separator === 0 && !normalized.startsWith('/'))) {
+    return null
+  }
+
+  const parent = normalized.slice(0, separator) || (normalized.startsWith('/') ? '/' : null)
+
+  return parent && parent !== normalized ? parent : null
+}
 
 interface RightSidebarPaneProps {
   onActivateFile: (path: string) => void
@@ -29,13 +55,22 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
   const { t } = useI18n()
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
+  const activeSessionId = useStore($activeSessionId)
   const currentCwd = useStore($currentCwd).trim()
+  const [browserCwd, setBrowserCwd] = useState(currentCwd)
+
+  // A session switch resets the browser to that session's workspace. Within a
+  // session, navigation stays local to this pane so viewing a parent folder
+  // cannot silently change where the agent runs.
+  useEffect(() => {
+    setBrowserCwd(currentCwd)
+  }, [activeSessionId, currentCwd])
 
   // The file tree is simply "browse the session's working directory". If the
   // session has a cwd — a repo, a sibling worktree, or any folder — show it. A
   // bare/detached chat (resolveNewSessionCwd → '') has none, so it shows the
   // empty hint instead of whatever dir Hermes happens to run from.
-  const hasWorkspace = Boolean(currentCwd)
+  const hasWorkspace = Boolean(browserCwd)
 
   const {
     collapseAll,
@@ -48,7 +83,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
     rootError,
     rootLoading,
     setNodeOpen
-  } = useProjectTree(hasWorkspace ? currentCwd : '')
+  } = useProjectTree(hasWorkspace ? browserCwd : '')
 
   const cwdName =
     effectiveCwd
@@ -69,6 +104,14 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
       setCurrentSessionPreviewTarget(preview, 'file-browser', path)
     } catch (error) {
       notifyError(error, r.previewUnavailable)
+    }
+  }
+
+  const navigateUp = () => {
+    const parent = parentDirectory(effectiveCwd)
+
+    if (parent) {
+      setBrowserCwd(parent)
     }
   }
 
@@ -95,6 +138,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
         onActivateFolder={onActivateFolder}
         onCollapseAll={collapseAll}
         onLoadChildren={loadChildren}
+        onNavigateUp={navigateUp}
         onNodeOpenChange={setNodeOpen}
         onPreviewFile={previewFile}
         onRefresh={() => void refreshRoot()}
@@ -109,6 +153,7 @@ interface FilesystemTabProps extends FileTreeBodyProps {
   cwdName: string
   hasWorkspace: boolean
   onCollapseAll: () => void
+  onNavigateUp: () => void
   onRefresh: () => void
 }
 
@@ -132,6 +177,7 @@ function FilesystemTab({
   onActivateFolder,
   onCollapseAll,
   onLoadChildren,
+  onNavigateUp,
   onNodeOpenChange,
   onPreviewFile,
   onRefresh,
@@ -139,6 +185,7 @@ function FilesystemTab({
 }: FilesystemTabProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
+  const canNavigateUp = Boolean(parentDirectory(cwd))
 
   // No working directory (a bare/detached chat) → no tree, just a terse hint.
   // Switching workspace is a project/worktree action, never a raw folder picker.
@@ -152,6 +199,18 @@ function FilesystemTab({
         <div className="flex min-w-0 flex-1">
           <SidebarPanelLabel>{cwdName}</SidebarPanelLabel>
         </div>
+        <Tip label={r.navigateUp}>
+          <Button
+            aria-label={r.navigateUp}
+            className={cn(HEADER_ACTION_LABEL_REVEAL, !canNavigateUp && 'pointer-events-none opacity-0')}
+            disabled={!canNavigateUp}
+            onClick={onNavigateUp}
+            size="icon-xs"
+            variant="ghost"
+          >
+            <Codicon name="arrow-up" size="0.8125rem" />
+          </Button>
+        </Tip>
         <Tip label={r.refreshTree}>
           <Button
             aria-label={r.refreshTree}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2079,6 +2079,7 @@ export const ar = defineLocale({
     remotePickerSelect: 'تحديد المجلد',
     folderTip: cwd => `المجلد الحالي: ${cwd}`,
     openFolder: 'فتح مجلد',
+    navigateUp: 'الانتقال إلى المجلد الأب',
     refreshTree: 'تحديث الشجرة',
     collapseAll: 'طي الكل',
     previewUnavailable: 'المعاينة غير متاحة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2440,6 +2440,7 @@ export const en: Translations = {
     remotePickerSelect: 'Select folder',
     folderTip: cwd => `${cwd} — click to change folder`,
     openFolder: 'Open folder',
+    navigateUp: 'Go to parent folder',
     refreshTree: 'Refresh tree',
     collapseAll: 'Collapse all folders',
     previewUnavailable: 'Preview unavailable',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2310,6 +2310,7 @@ export const ja = defineLocale({
     remotePickerSelect: 'フォルダーを選択',
     folderTip: cwd => `${cwd} — クリックしてフォルダーを変更`,
     openFolder: 'フォルダーを開く',
+    navigateUp: '親フォルダーに移動',
     refreshTree: 'ツリーを更新',
     collapseAll: 'すべてのフォルダーを折りたたむ',
     previewUnavailable: 'プレビューは利用できません',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2049,6 +2049,7 @@ export interface Translations {
     remotePickerSelect: string
     folderTip: (cwd: string) => string
     openFolder: string
+    navigateUp: string
     refreshTree: string
     collapseAll: string
     previewUnavailable: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2237,6 +2237,7 @@ export const zhHant = defineLocale({
     remotePickerSelect: '選擇資料夾',
     folderTip: cwd => `${cwd} — 點擊以變更資料夾`,
     openFolder: '開啟資料夾',
+    navigateUp: '前往上層資料夾',
     refreshTree: '重新整理檔案樹',
     collapseAll: '收合所有資料夾',
     previewUnavailable: '預覽不可用',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2617,6 +2617,7 @@ export const zh: Translations = {
     remotePickerSelect: '选择文件夹',
     folderTip: cwd => `${cwd} — 点击更改文件夹`,
     openFolder: '打开文件夹',
+    navigateUp: '转到上级文件夹',
     refreshTree: '刷新文件树',
     collapseAll: '折叠所有文件夹',
     previewUnavailable: '预览不可用',


### PR DESCRIPTION
## Summary
- add a Files-pane Up control that browses parent folders without changing the agent session workspace
- reset Files-pane browsing when the active session or workspace changes
- support POSIX, Windows drive, and UNC share roots; prevent navigation above a UNC share root
- add localized accessible labels and coverage for each navigation boundary

## Verification
- `npm run test:ui -- --run src/app/right-sidebar/index.test.tsx` (7 passed)
- `npm run typecheck`
- `npm run lint -- --quiet`
- independent code review: passed

Note: the full Desktop UI suite was started, but did not complete within the 10-minute execution limit; no failing test was observed before it was stopped.