### PR TITLE
fix(kanban): honor max_retries across mixed failure kinds

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3051,13 +3051,13 @@ def write_txn(conn: sqlite3.Connection, *, allow_nested: bool = False):
     Nesting is an explicit opt-in: a caller already inside a transaction
     gets a loud ``RuntimeError`` unless it passes ``allow_nested=True``,
     in which case a SQLite savepoint is used instead of a second
-    ``BEGIN IMMEDIATE``. Only composition primitives that graph builders
-    deliberately run under one outer commit (``create_task``,
-    ``add_comment``) opt in — helpers with post-commit side effects
-    (``complete_task`` & co.) must never run under an open outer
-    transaction, because their side effects (workspace cleanup, ready
-    recomputation, failure-counter clears) would fire while the outer
-    transaction can still roll back.
+    ``BEGIN IMMEDIATE``. Composition primitives that deliberately run
+    under one outer commit (for example ``create_task``, ``add_comment``,
+    and dispatcher failure accounting) opt in. Helpers with post-commit
+    side effects (``complete_task`` & co.) must never run under an open
+    outer transaction, because their side effects (workspace cleanup,
+    ready recomputation, failure-counter clears) would fire while the
+    outer transaction can still roll back.
 
     The explicit ROLLBACK on exception is wrapped in try/except so that
     a SQLite auto-rollback (which leaves no active transaction) does not
@@ -8411,6 +8411,10 @@ def enforce_max_runtime(
                 (retry_status, tid, pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
+                error_text = (
+                    f"elapsed {int(elapsed)}s > limit "
+                    f"{int(row['max_runtime_seconds'])}s"
+                )
                 payload = {
                     "pid": pid,
                     "elapsed_seconds": int(elapsed),
@@ -8421,31 +8425,26 @@ def enforce_max_runtime(
                 run_id = _end_run(
                     conn, tid,
                     outcome="timed_out", status="timed_out",
-                    error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
+                    error=error_text,
                     metadata=payload,
                 )
                 _append_event(
                     conn, tid, "timed_out", payload, run_id=run_id,
                 )
                 timed_out.append(tid)
-        # Increment the unified failure counter. Outside the write_txn
-        # above because ``_record_task_failure`` opens its own. If the
-        # breaker trips, this flips the retried task to ``blocked`` and
-        # emits a ``gave_up`` event on top of the ``timed_out`` we
-        # already emitted.
-        if cur.rowcount == 1:
-            _record_task_failure(
-                conn, tid,
-                error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
-                outcome="timed_out",
-                release_claim=False,
-                end_run=False,
-                event_payload_extra={
-                    "pid": pid,
-                    "sigkill": killed,
-                    "retry_status": retry_status,
-                },
-            )
+                _record_task_failure(
+                    conn, tid,
+                    error=error_text,
+                    outcome="timed_out",
+                    release_claim=False,
+                    end_run=False,
+                    event_payload_extra={
+                        "pid": pid,
+                        "sigkill": killed,
+                        "retry_status": retry_status,
+                    },
+                    _allow_nested=True,
+                )
     return timed_out
 
 
@@ -8692,13 +8691,10 @@ def _error_fingerprint(error_text: str) -> str:
 # tool call next time), so a protocol violation is NOT deterministic — give it a
 # bounded retry before the breaker trips instead of blocking on the first hit.
 #
-# The budget is a violation-only STREAK, not a share of the unified
-# ``consecutive_failures`` counter: it counts consecutive clean-exit protocol
-# violations (derived from run history by ``_protocol_violation_streak``), so
-# earlier timeouts / nonzero exits neither consume nor extend it, and a
-# below-budget violation does not tick the unified counter either. A per-task
-# ``max_retries`` overrides this bound — the same "task override wins"
-# precedence ``_record_task_failure`` documents for every other failure kind.
+# Without a per-task override, the budget is a violation-only STREAK, not a
+# share of the unified ``consecutive_failures`` counter. With an explicit
+# ``max_retries``, violations use that unified counter like every other
+# non-neutral failure (#72174).
 _PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
 
 # How far back to walk a task's closed runs when counting the violation
@@ -8773,9 +8769,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     When the reap registry shows the worker exited cleanly (rc=0) but
     the task was still ``running`` in the DB, treat it as a protocol
     violation (worker answered conversationally without calling
-    ``kanban_complete`` / ``kanban_block``) and trip the circuit breaker
-    on the first occurrence — retrying a worker whose CLI keeps
-    returning 0 without a terminal transition just loops forever.
+    ``kanban_complete`` / ``kanban_block``). Without a per-task
+    ``max_retries``, violations use their own bounded consecutive streak;
+    with an explicit override, they share the unified failure counter
+    with crashes and timeouts.
 
     When the reap registry shows the worker exited with the rate-limit
     sentinel (``KANBAN_RATE_LIMIT_EXIT_CODE``), the worker bailed on a
@@ -8788,12 +8785,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
-    # Per-crash details collected inside the main txn, used after it
-    # closes to run ``_record_task_failure`` (which needs its own
-    # write_txn so can't nest). ``protocol_violation`` flags the
-    # clean-exit-but-still-running case, which is accounted against its
-    # own bounded violation streak instead of the unified failure
-    # counter (see the post-txn loop below).
+    auto_blocked: list[str] = []
+    # Crash details are accounted before this transaction commits, keeping
+    # requeue, run closure, and failure accounting atomic.
     crash_details: list[tuple[str, int, str, bool, str]] = []
     # (task_id, pid, claimer, protocol_violation, error_text)
     # Worker-exit observer payloads (RFC #58548), collected inside the main
@@ -8950,89 +8944,72 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (row["id"], pid, row["claim_lock"],
                          protocol_violation, error_text)
                     )
-    # Outside the main txn: account each crashed task and maybe trip the
-    # breaker (the retried task transitions to blocked with a ``gave_up`` event
-    # on top of the event we already emitted).
-    #
-    # Protocol-violation crashes (clean exit, no terminal tool call) get a
-    # BOUNDED retry, not an immediate trip: empirically ~96% of these tasks
-    # complete on a later run (a goal-mode finalize nudge, or the model simply
-    # emitting kanban_complete/kanban_block next time), so blocking on the first
-    # occurrence just churned them through the respawn cycle. The retry budget
-    # is a violation-only streak (``_protocol_violation_streak``): earlier
-    # timeouts / nonzero exits neither consume nor extend it, and a
-    # below-budget violation does not tick the unified
-    # ``consecutive_failures`` counter, so the two budgets stay independent.
-    # A per-task ``max_retries`` overrides the violation bound with the same
-    # top precedence it has for every other failure kind. Systemic same-error
-    # crashes still trip immediately.
-    auto_blocked: list[str] = []
-    if crash_details:
-        # Fingerprint errors to detect systemic failures.
-        _fp_counts: dict[str, int] = {}
-        for _, _, _, _, err_text in crash_details:
-            fp = _error_fingerprint(err_text)
-            _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
-        for tid, pid, claimer, protocol_violation, error_text in crash_details:
-            if protocol_violation:
-                streak = _protocol_violation_streak(conn, tid)
-                trow = conn.execute(
-                    "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
-                ).fetchone()
-                if trow is None:
-                    continue  # task deleted mid-loop
-                task_override = (
-                    trow["max_retries"] if "max_retries" in trow.keys() else None
+        if crash_details:
+            fingerprint_counts: dict[str, int] = {}
+            for _, _, _, _, err_text in crash_details:
+                fingerprint = _error_fingerprint(err_text)
+                fingerprint_counts[fingerprint] = (
+                    fingerprint_counts.get(fingerprint, 0) + 1
                 )
-                violation_limit = (
-                    int(task_override)
-                    if task_override is not None
-                    else _PROTOCOL_VIOLATION_FAILURE_LIMIT
-                )
-                if streak < violation_limit:
-                    # Below budget: the task is already back at ``ready``
-                    # (respawn allowed) with ``last_failure_error`` stamped.
-                    # Deliberately no ``_record_task_failure`` call — a
-                    # below-budget violation must not consume the unified
-                    # failure budget, just as other failure kinds don't
-                    # consume this one.
-                    continue
-                # Streak reached the bound: trip the breaker. ``force_trip``
-                # skips the threshold resolution inside
-                # ``_record_task_failure`` because the decision — including
-                # the per-task ``max_retries`` override — was already made
-                # against the violation streak above.
-                tripped = _record_task_failure(
-                    conn, tid,
-                    error=error_text,
-                    outcome="crashed",
-                    failure_limit=violation_limit,
-                    force_trip=True,
-                    release_claim=False,
-                    end_run=False,
-                    event_payload_extra={
-                        "pid": pid,
-                        "claimer": claimer,
-                        "protocol_violations": streak,
-                        "protocol_violation_limit": violation_limit,
-                    },
-                )
+            for tid, pid, claimer, protocol_violation, error_text in crash_details:
+                if protocol_violation:
+                    task_row = conn.execute(
+                        "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
+                    ).fetchone()
+                    if task_row is None:
+                        continue
+                    if task_row["max_retries"] is None:
+                        streak = _protocol_violation_streak(conn, tid)
+                        if streak < _PROTOCOL_VIOLATION_FAILURE_LIMIT:
+                            continue
+                        tripped = _record_task_failure(
+                            conn, tid,
+                            error=error_text,
+                            outcome="crashed",
+                            failure_limit=_PROTOCOL_VIOLATION_FAILURE_LIMIT,
+                            force_trip=True,
+                            release_claim=False,
+                            end_run=False,
+                            event_payload_extra={
+                                "pid": pid,
+                                "claimer": claimer,
+                                "protocol_violations": streak,
+                                "protocol_violation_limit":
+                                    _PROTOCOL_VIOLATION_FAILURE_LIMIT,
+                            },
+                            _allow_nested=True,
+                        )
+                    else:
+                        tripped = _record_task_failure(
+                            conn, tid,
+                            error=error_text,
+                            outcome="crashed",
+                            release_claim=False,
+                            end_run=False,
+                            event_payload_extra={
+                                "pid": pid,
+                                "claimer": claimer,
+                                "protocol_violation": True,
+                            },
+                            _allow_nested=True,
+                        )
+                else:
+                    fingerprint = _error_fingerprint(error_text)
+                    tripped = _record_task_failure(
+                        conn, tid,
+                        error=error_text,
+                        outcome="crashed",
+                        failure_limit=(
+                            1 if fingerprint_counts.get(fingerprint, 0) >= 3
+                            else None
+                        ),
+                        release_claim=False,
+                        end_run=False,
+                        event_payload_extra={"pid": pid, "claimer": claimer},
+                        _allow_nested=True,
+                    )
                 if tripped:
                     auto_blocked.append(tid)
-                continue
-            fp = _error_fingerprint(error_text)
-            is_systemic = _fp_counts.get(fp, 0) >= 3
-            tripped = _record_task_failure(
-                conn, tid,
-                error=error_text,
-                outcome="crashed",
-                failure_limit=1 if is_systemic else None,
-                release_claim=False,
-                end_run=False,
-                event_payload_extra={"pid": pid, "claimer": claimer},
-            )
-            if tripped:
-                auto_blocked.append(tid)
     # Stash auto-blocked ids on the function for the dispatch loop to pick up.
     # Keeps the public return type (``list[str]``) stable for direct callers
     # and tests that destructure the result; ``dispatch_once`` reads this
@@ -9069,6 +9046,7 @@ def _record_task_failure(
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    _allow_nested: bool = False,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -9108,15 +9086,15 @@ def _record_task_failure(
     counter-vs-threshold comparison (the resolution order above is then
     only reported in the ``gave_up`` payload, not re-evaluated). Callers
     use it when they have already applied their own bounded-retry policy
-    — e.g. the clean-exit protocol-violation streak in
-    ``detect_crashed_workers``, which resolves the per-task
-    ``max_retries`` override against the violation streak itself. The
-    failure is still counted into ``consecutive_failures``.
+    — currently the clean-exit protocol-violation streak for tasks
+    without an explicit ``max_retries``. Tasks with an override use the
+    normal unified counter and threshold resolution instead. A forced
+    trip is still counted into ``consecutive_failures``.
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     blocked = False
-    with write_txn(conn):
+    with write_txn(conn, allow_nested=_allow_nested):
         row = conn.execute(
             "SELECT consecutive_failures, status, max_retries, current_run_id "
             "FROM tasks WHERE id = ?", (task_id,),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7600,13 +7600,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # the override governs the unified counter instead (#72174).
                 streak = _protocol_violation_streak(conn, tid)
                 if task_override is None:
-                    # Default policy (PR #64353): a protocol violation is
-                    # accounted against its own bounded, violation-only
-                    # streak, independent of the unified
-                    # ``consecutive_failures`` counter every other failure
-                    # kind uses — an earlier crash/timeout neither consumes
-                    # nor extends it, and a below-budget violation does not
-                    # tick the unified counter either.
+                    # Default policy (PR #64353) — see the block comment
+                    # above ``auto_blocked`` for the full rationale.
                     if streak < _PROTOCOL_VIOLATION_FAILURE_LIMIT:
                         # Below budget: the task is already back at
                         # ``ready`` (respawn allowed) with
@@ -7637,20 +7632,13 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         },
                     )
                 else:
-                    # Explicit per-task override (#72174 fix): an explicit
-                    # ``max_retries`` is a contract on the task's TOTAL
-                    # retry budget, so a violation must count into the same
-                    # unified ``consecutive_failures`` counter every other
-                    # failure kind feeds — NOT the dedicated violation-only
-                    # streak above, which a mixed sequence of ordinary
-                    # crashes/timeouts and below-streak-budget violations
-                    # could ride past the explicit cap without ever
-                    # tripping it. ``_record_task_failure`` already
-                    # resolves ``task.max_retries`` with top precedence
-                    # (same as every other failure kind), so this is the
-                    # identical call the plain-crash branch below makes —
-                    # it increments the counter unconditionally (even when
-                    # it doesn't trip) and trips exactly at the override.
+                    # Explicit override (#72174 fix) — see the block comment
+                    # above ``auto_blocked``. ``_record_task_failure``
+                    # already resolves ``task.max_retries`` with top
+                    # precedence, so this is the identical call the
+                    # plain-crash branch below makes: it increments the
+                    # unified counter unconditionally and trips exactly at
+                    # the override.
                     tripped = _record_task_failure(
                         conn, tid,
                         error=error_text,
@@ -7662,7 +7650,6 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                             "claimer": claimer,
                             "protocol_violation": True,
                             "protocol_violations": streak,
-                            "protocol_violation_limit": int(task_override),
                         },
                     )
                 if tripped:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7118,6 +7118,10 @@ def enforce_max_runtime(
                 (tid, pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
+                error_text = (
+                    f"elapsed {int(elapsed)}s > limit "
+                    f"{int(row['max_runtime_seconds'])}s"
+                )
                 payload = {
                     "pid": pid,
                     "elapsed_seconds": int(elapsed),
@@ -7127,27 +7131,24 @@ def enforce_max_runtime(
                 run_id = _end_run(
                     conn, tid,
                     outcome="timed_out", status="timed_out",
-                    error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
+                    error=error_text,
                     metadata=payload,
                 )
                 _append_event(
                     conn, tid, "timed_out", payload, run_id=run_id,
                 )
                 timed_out.append(tid)
-        # Increment the unified failure counter. Outside the write_txn
-        # above because ``_record_task_failure`` opens its own. If the
-        # breaker trips, this flips the task ``ready → blocked`` and
-        # emits a ``gave_up`` event on top of the ``timed_out`` we
-        # already emitted.
-        if cur.rowcount == 1:
-            _record_task_failure(
-                conn, tid,
-                error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
-                outcome="timed_out",
-                release_claim=False,
-                end_run=False,
-                event_payload_extra={"pid": pid, "sigkill": killed},
-            )
+                # Requeue, run closure, and failure accounting are one
+                # atomic state transition. A competing dispatcher cannot
+                # claim the transient ``ready`` state between them.
+                _record_task_failure_in_txn(
+                    conn, tid,
+                    error=error_text,
+                    outcome="timed_out",
+                    release_claim=False,
+                    end_run=False,
+                    event_payload_extra={"pid": pid, "sigkill": killed},
+                )
     return timed_out
 
 
@@ -7391,9 +7392,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     When the reap registry shows the worker exited cleanly (rc=0) but
     the task was still ``running`` in the DB, treat it as a protocol
     violation (worker answered conversationally without calling
-    ``kanban_complete`` / ``kanban_block``) and trip the circuit breaker
-    on the first occurrence — retrying a worker whose CLI keeps
-    returning 0 without a terminal transition just loops forever.
+    ``kanban_complete`` / ``kanban_block``). Tasks without an explicit
+    ``max_retries`` use the bounded violation-only streak; tasks with an
+    explicit override count the violation into their unified failure budget.
 
     When the reap registry shows the worker exited with the rate-limit
     sentinel (``KANBAN_RATE_LIMIT_EXIT_CODE``), the worker bailed on a
@@ -7406,14 +7407,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
-    # Per-crash details collected inside the main txn, used after it
-    # closes to run ``_record_task_failure`` (which needs its own
-    # write_txn so can't nest). ``protocol_violation`` flags the
-    # clean-exit-but-still-running case. When the task has no explicit
-    # ``max_retries`` it's accounted against its own bounded violation
-    # streak instead of the unified failure counter; an explicit
-    # ``max_retries`` counts it into the unified counter instead (#72174 —
-    # see the post-txn loop below).
+    auto_blocked: list[str] = []
+    # Per-crash details are collected and accounted before the main write
+    # transaction commits. Keeping requeue/run closure/failure accounting in
+    # one transaction prevents another dispatcher from claiming a transient
+    # ``ready`` task before the breaker can block it.
+    # ``protocol_violation`` flags the clean-exit-but-still-running case.
     crash_details: list[tuple[str, int, str, bool, str]] = []
     # (task_id, pid, claimer, protocol_violation, error_text)
     with write_txn(conn):
@@ -7554,120 +7553,87 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (row["id"], pid, row["claim_lock"],
                          protocol_violation, error_text)
                     )
-    # Outside the main txn: account each crashed task and maybe trip the
-    # breaker (the task transitions ready → blocked with a ``gave_up`` event
-    # on top of the event we already emitted).
-    #
-    # Protocol-violation crashes (clean exit, no terminal tool call) get a
-    # BOUNDED retry, not an immediate trip: empirically ~96% of these tasks
-    # complete on a later run (a goal-mode finalize nudge, or the model simply
-    # emitting kanban_complete/kanban_block next time), so blocking on the first
-    # occurrence just churned them through the respawn cycle.
-    #
-    # Without an explicit per-task ``max_retries`` the retry budget is a
-    # violation-only streak (``_protocol_violation_streak``): earlier
-    # timeouts / nonzero exits neither consume nor extend it, and a
-    # below-budget violation does not tick the unified
-    # ``consecutive_failures`` counter, so the two budgets stay independent.
-    #
-    # An EXPLICIT per-task ``max_retries`` (#72174) instead counts the
-    # violation into the unified ``consecutive_failures`` counter, same as
-    # every other failure kind — it's the task's total retry contract, so a
-    # mix of ordinary crashes and violations can't ride past it just because
-    # neither failure kind's own bound was individually reached. Systemic
-    # same-error crashes still trip immediately.
-    auto_blocked: list[str] = []
-    if crash_details:
-        # Fingerprint errors to detect systemic failures.
-        _fp_counts: dict[str, int] = {}
-        for _, _, _, _, err_text in crash_details:
-            fp = _error_fingerprint(err_text)
-            _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
-        for tid, pid, claimer, protocol_violation, error_text in crash_details:
-            if protocol_violation:
-                trow = conn.execute(
-                    "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
-                ).fetchone()
-                if trow is None:
-                    continue  # task deleted mid-loop
-                task_override = (
-                    trow["max_retries"] if "max_retries" in trow.keys() else None
+        # Account every reaped crash before this write transaction commits.
+        # That makes ``running → ready/blocked`` plus run closure and breaker
+        # accounting one atomic transition: no dispatcher can claim the
+        # transient ``ready`` state in between.
+        #
+        # Protocol violations without a task override use the independent,
+        # violation-only streak. An explicit override instead uses the
+        # unified failure counter. Systemic same-error crashes fast-trip only
+        # when no task-level override supersedes the dispatcher limit.
+        if crash_details:
+            _fp_counts: dict[str, int] = {}
+            for _, _, _, _, err_text in crash_details:
+                fp = _error_fingerprint(err_text)
+                _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
+            for tid, pid, claimer, protocol_violation, error_text in crash_details:
+                if protocol_violation:
+                    trow = conn.execute(
+                        "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
+                    ).fetchone()
+                    if trow is None:
+                        continue  # task deleted mid-loop
+                    task_override = (
+                        trow["max_retries"]
+                        if "max_retries" in trow.keys() else None
+                    )
+                    if task_override is None:
+                        streak = _protocol_violation_streak(conn, tid)
+                        if streak < _PROTOCOL_VIOLATION_FAILURE_LIMIT:
+                            # Below the default violation-only budget: keep
+                            # the already-requeued task ready and do not touch
+                            # the unified failure counter.
+                            continue
+                        tripped = _record_task_failure_in_txn(
+                            conn, tid,
+                            error=error_text,
+                            outcome="crashed",
+                            failure_limit=_PROTOCOL_VIOLATION_FAILURE_LIMIT,
+                            force_trip=True,
+                            release_claim=False,
+                            end_run=False,
+                            event_payload_extra={
+                                "pid": pid,
+                                "claimer": claimer,
+                                "protocol_violations": streak,
+                                "protocol_violation_limit":
+                                    _PROTOCOL_VIOLATION_FAILURE_LIMIT,
+                            },
+                        )
+                    else:
+                        # The explicit override is a unified total-failure
+                        # budget. Do not attach the default policy's bounded
+                        # violation-streak diagnostic: it is irrelevant here
+                        # and truncates after _PROTOCOL_VIOLATION_SCAN_LIMIT.
+                        tripped = _record_task_failure_in_txn(
+                            conn, tid,
+                            error=error_text,
+                            outcome="crashed",
+                            release_claim=False,
+                            end_run=False,
+                            event_payload_extra={
+                                "pid": pid,
+                                "claimer": claimer,
+                                "protocol_violation": True,
+                            },
+                        )
+                    if tripped:
+                        auto_blocked.append(tid)
+                    continue
+                fp = _error_fingerprint(error_text)
+                is_systemic = _fp_counts.get(fp, 0) >= 3
+                tripped = _record_task_failure_in_txn(
+                    conn, tid,
+                    error=error_text,
+                    outcome="crashed",
+                    failure_limit=1 if is_systemic else None,
+                    release_claim=False,
+                    end_run=False,
+                    event_payload_extra={"pid": pid, "claimer": claimer},
                 )
-                # Diagnostic only below — how many CONSECUTIVE clean-exit
-                # violations led up to this one. When no override is set
-                # this also gates the decision (see the branch below); when
-                # an override IS set it's informational context only, since
-                # the override governs the unified counter instead (#72174).
-                streak = _protocol_violation_streak(conn, tid)
-                if task_override is None:
-                    # Default policy (PR #64353) — see the block comment
-                    # above ``auto_blocked`` for the full rationale.
-                    if streak < _PROTOCOL_VIOLATION_FAILURE_LIMIT:
-                        # Below budget: the task is already back at
-                        # ``ready`` (respawn allowed) with
-                        # ``last_failure_error`` stamped. Deliberately no
-                        # ``_record_task_failure`` call — a below-budget
-                        # violation must not consume the unified failure
-                        # budget, just as other failure kinds don't consume
-                        # this one.
-                        continue
-                    # Streak reached the bound: trip the breaker.
-                    # ``force_trip`` skips the threshold resolution inside
-                    # ``_record_task_failure`` because the decision was
-                    # already made against the violation streak above.
-                    tripped = _record_task_failure(
-                        conn, tid,
-                        error=error_text,
-                        outcome="crashed",
-                        failure_limit=_PROTOCOL_VIOLATION_FAILURE_LIMIT,
-                        force_trip=True,
-                        release_claim=False,
-                        end_run=False,
-                        event_payload_extra={
-                            "pid": pid,
-                            "claimer": claimer,
-                            "protocol_violations": streak,
-                            "protocol_violation_limit":
-                                _PROTOCOL_VIOLATION_FAILURE_LIMIT,
-                        },
-                    )
-                else:
-                    # Explicit override (#72174 fix) — see the block comment
-                    # above ``auto_blocked``. ``_record_task_failure``
-                    # already resolves ``task.max_retries`` with top
-                    # precedence, so this is the identical call the
-                    # plain-crash branch below makes: it increments the
-                    # unified counter unconditionally and trips exactly at
-                    # the override.
-                    tripped = _record_task_failure(
-                        conn, tid,
-                        error=error_text,
-                        outcome="crashed",
-                        release_claim=False,
-                        end_run=False,
-                        event_payload_extra={
-                            "pid": pid,
-                            "claimer": claimer,
-                            "protocol_violation": True,
-                            "protocol_violations": streak,
-                        },
-                    )
                 if tripped:
                     auto_blocked.append(tid)
-                continue
-            fp = _error_fingerprint(error_text)
-            is_systemic = _fp_counts.get(fp, 0) >= 3
-            tripped = _record_task_failure(
-                conn, tid,
-                error=error_text,
-                outcome="crashed",
-                failure_limit=1 if is_systemic else None,
-                release_claim=False,
-                end_run=False,
-                event_payload_extra={"pid": pid, "claimer": claimer},
-            )
-            if tripped:
-                auto_blocked.append(tid)
     # Stash auto-blocked ids on the function for the dispatch loop to pick up.
     # Keeps the public return type (``list[str]``) stable for direct callers
     # and tests that destructure the result; ``dispatch_once`` reads this
@@ -7733,117 +7699,156 @@ def _record_task_failure(
     streak in ``detect_crashed_workers``, which decides independently of
     this function's own threshold resolution. The failure is still counted
     into ``consecutive_failures``. When a task HAS an explicit
-    ``max_retries`` override, ``detect_crashed_workers`` instead calls this
-    function WITHOUT ``force_trip`` for protocol violations too, so the
-    override is resolved right here with the same top precedence as every
-    other failure kind (see resolution order above) — see #72174.
+    ``max_retries`` override, ``detect_crashed_workers`` calls the
+    in-transaction implementation WITHOUT ``force_trip`` for protocol
+    violations too, so the override is resolved with the same top precedence
+    as every other failure kind (see resolution order above) — see #72174.
+    """
+    with write_txn(conn):
+        return _record_task_failure_in_txn(
+            conn, task_id, error,
+            outcome=outcome,
+            failure_limit=failure_limit,
+            force_trip=force_trip,
+            release_claim=release_claim,
+            end_run=end_run,
+            event_payload_extra=event_payload_extra,
+        )
+
+
+def _record_task_failure_in_txn(
+    conn: sqlite3.Connection,
+    task_id: str,
+    error: str,
+    *,
+    outcome: str,
+    failure_limit: int = None,
+    force_trip: bool = False,
+    release_claim: bool = False,
+    end_run: bool = False,
+    event_payload_extra: Optional[dict] = None,
+) -> bool:
+    """In-transaction implementation of ``_record_task_failure``.
+
+    The caller must already own a ``write_txn``. Crash and timeout reapers use
+    this directly so requeue/run closure/failure accounting commit atomically;
+    other callers use the wrapper above.
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
-    blocked = False
-    with write_txn(conn):
-        row = conn.execute(
-            "SELECT consecutive_failures, status, max_retries "
-            "FROM tasks WHERE id = ?", (task_id,),
-        ).fetchone()
-        if row is None:
-            return False
-        failures = int(row["consecutive_failures"]) + 1
+    row = conn.execute(
+        "SELECT consecutive_failures, status, max_retries "
+        "FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    failures = int(row["consecutive_failures"]) + 1
+    cur_status = row["status"]
 
-        # Per-task override wins over both caller-supplied and default
-        # thresholds. None (the common case) falls through.
-        task_override = (
-            row["max_retries"] if "max_retries" in row.keys() else None
-        )
-        if task_override is not None:
-            effective_limit = int(task_override)
-            limit_source = "task"
-        else:
-            effective_limit = int(failure_limit)
-            limit_source = "dispatcher"
+    # A timeout/crash caller must have requeued the exact run to ``ready``
+    # earlier in this same transaction. Refuse to mutate a replacement claim
+    # if a future caller violates that contract.
+    if not release_claim and cur_status != "ready":
+        return False
 
-        if force_trip or failures >= effective_limit:
-            # Trip the breaker.
-            if release_claim:
-                # Spawn path: still running, also clear claim state.
-                conn.execute(
-                    "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
-                    "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status IN ('running', 'ready')",
-                    (failures, error[:500], task_id),
-                )
-            else:
-                # Timeout/crash path: task is already at ``ready``
-                # with claim cleared; just flip to blocked + update
-                # counter fields.
-                conn.execute(
-                    "UPDATE tasks SET status = 'blocked', "
-                    "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status IN ('ready', 'running')",
-                    (failures, error[:500], task_id),
-                )
-            run_id = None
-            if end_run:
-                # Only the spawn path has an open run to close.
-                run_id = _end_run(
-                    conn, task_id,
-                    outcome="gave_up", status="gave_up",
-                    error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "trigger_outcome": outcome,
-                        "effective_limit": effective_limit,
-                        "limit_source": limit_source,
-                    },
-                )
-            payload = {
-                "failures": failures,
-                "effective_limit": effective_limit,
-                "limit_source": limit_source,
-                "error": error[:500],
-                "trigger_outcome": outcome,
-            }
-            if event_payload_extra:
-                payload.update(event_payload_extra)
-            _append_event(
-                conn, task_id, "gave_up", payload, run_id=run_id,
+    # Per-task override wins over both caller-supplied and default
+    # thresholds. None (the common case) falls through.
+    task_override = (
+        row["max_retries"] if "max_retries" in row.keys() else None
+    )
+    if task_override is not None:
+        effective_limit = int(task_override)
+        limit_source = "task"
+    else:
+        effective_limit = int(failure_limit)
+        limit_source = "dispatcher"
+
+    if force_trip or failures >= effective_limit:
+        # Trip the breaker.
+        if release_claim:
+            # Spawn path: still running (or a ready task in legacy direct
+            # callers), also clear claim state.
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, "
+                "consecutive_failures = ?, last_failure_error = ? "
+                "WHERE id = ? AND status IN ('running', 'ready')",
+                (failures, error[:500], task_id),
             )
-            blocked = True
         else:
-            # Below threshold.
-            if release_claim:
-                # Spawn path: transition running → ready + clear claim.
-                conn.execute(
-                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
-                    "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status = 'running'",
-                    (failures, error[:500], task_id),
-                )
-            else:
-                # Timeout/crash path: task is already at ``ready`` via
-                # its own UPDATE. Just bookkeep the counter + last error.
-                conn.execute(
-                    "UPDATE tasks SET consecutive_failures = ?, "
-                    "last_failure_error = ? WHERE id = ?",
-                    (failures, error[:500], task_id),
-                )
-            if end_run:
-                # Spawn path: close the open run with outcome.
-                run_id = _end_run(
-                    conn, task_id,
-                    outcome=outcome, status=outcome,
-                    error=error[:500],
-                    metadata={"failures": failures},
-                )
-                _append_event(
-                    conn, task_id, outcome,
-                    {"error": error[:500], "failures": failures},
-                    run_id=run_id,
-                )
-            # Timeout/crash path's caller already emitted its own event.
-    return blocked
+            # Timeout/crash path: task is already at ``ready`` with claim
+            # cleared by the same write transaction.
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'blocked', "
+                "consecutive_failures = ?, last_failure_error = ? "
+                "WHERE id = ? AND status = 'ready'",
+                (failures, error[:500], task_id),
+            )
+        if cur.rowcount != 1:
+            return False
+        run_id = None
+        if end_run:
+            # Only the spawn path has an open run to close.
+            run_id = _end_run(
+                conn, task_id,
+                outcome="gave_up", status="gave_up",
+                error=error[:500],
+                metadata={
+                    "failures": failures,
+                    "trigger_outcome": outcome,
+                    "effective_limit": effective_limit,
+                    "limit_source": limit_source,
+                },
+            )
+        payload = {
+            "failures": failures,
+            "effective_limit": effective_limit,
+            "limit_source": limit_source,
+            "error": error[:500],
+            "trigger_outcome": outcome,
+        }
+        if event_payload_extra:
+            payload.update(event_payload_extra)
+        _append_event(
+            conn, task_id, "gave_up", payload, run_id=run_id,
+        )
+        return True
+
+    # Below threshold.
+    if release_claim:
+        # Spawn path: transition running → ready + clear claim.
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL, "
+            "consecutive_failures = ?, last_failure_error = ? "
+            "WHERE id = ? AND status = 'running'",
+            (failures, error[:500], task_id),
+        )
+    else:
+        # Timeout/crash path: task is already at ``ready`` via its own
+        # CAS in this transaction. Just bookkeep the counter + last error.
+        cur = conn.execute(
+            "UPDATE tasks SET consecutive_failures = ?, "
+            "last_failure_error = ? WHERE id = ? AND status = 'ready'",
+            (failures, error[:500], task_id),
+        )
+    if cur.rowcount != 1:
+        return False
+    if end_run:
+        # Spawn path: close the open run with outcome.
+        run_id = _end_run(
+            conn, task_id,
+            outcome=outcome, status=outcome,
+            error=error[:500],
+            metadata={"failures": failures},
+        )
+        _append_event(
+            conn, task_id, outcome,
+            {"error": error[:500], "failures": failures},
+            run_id=run_id,
+        )
+    # Timeout/crash path's caller already emitted its own event.
+    return False
 
 
 # Backward-compat alias. Old name is referenced from tests and possibly

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7302,13 +7302,21 @@ def _error_fingerprint(error_text: str) -> str:
 # tool call next time), so a protocol violation is NOT deterministic — give it a
 # bounded retry before the breaker trips instead of blocking on the first hit.
 #
-# The budget is a violation-only STREAK, not a share of the unified
-# ``consecutive_failures`` counter: it counts consecutive clean-exit protocol
-# violations (derived from run history by ``_protocol_violation_streak``), so
-# earlier timeouts / nonzero exits neither consume nor extend it, and a
-# below-budget violation does not tick the unified counter either. A per-task
-# ``max_retries`` overrides this bound — the same "task override wins"
-# precedence ``_record_task_failure`` documents for every other failure kind.
+# The DEFAULT budget (no per-task override) is a violation-only STREAK, not a
+# share of the unified ``consecutive_failures`` counter: it counts consecutive
+# clean-exit protocol violations (derived from run history by
+# ``_protocol_violation_streak``), so earlier timeouts / nonzero exits
+# neither consume nor extend it, and a below-budget violation does not tick
+# the unified counter either.
+#
+# An explicit per-task ``max_retries`` (#72174) instead counts violations
+# into the SAME unified ``consecutive_failures`` counter every other failure
+# kind uses — it's a contract on the task's total retry budget, so a mixed
+# sequence of ordinary crashes/timeouts and violations must not ride past it
+# just because no single failure kind alone reached its own bound. This is
+# the same "task override wins" precedence ``_record_task_failure`` documents
+# for every other failure kind; see the branch in
+# ``detect_crashed_workers`` that dispatches on whether ``max_retries`` is set.
 _PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
 
 # How far back to walk a task's closed runs when counting the violation
@@ -7401,9 +7409,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
-    # clean-exit-but-still-running case, which is accounted against its
-    # own bounded violation streak instead of the unified failure
-    # counter (see the post-txn loop below).
+    # clean-exit-but-still-running case. When the task has no explicit
+    # ``max_retries`` it's accounted against its own bounded violation
+    # streak instead of the unified failure counter; an explicit
+    # ``max_retries`` counts it into the unified counter instead (#72174 —
+    # see the post-txn loop below).
     crash_details: list[tuple[str, int, str, bool, str]] = []
     # (task_id, pid, claimer, protocol_violation, error_text)
     with write_txn(conn):
@@ -7552,14 +7562,20 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # BOUNDED retry, not an immediate trip: empirically ~96% of these tasks
     # complete on a later run (a goal-mode finalize nudge, or the model simply
     # emitting kanban_complete/kanban_block next time), so blocking on the first
-    # occurrence just churned them through the respawn cycle. The retry budget
-    # is a violation-only streak (``_protocol_violation_streak``): earlier
+    # occurrence just churned them through the respawn cycle.
+    #
+    # Without an explicit per-task ``max_retries`` the retry budget is a
+    # violation-only streak (``_protocol_violation_streak``): earlier
     # timeouts / nonzero exits neither consume nor extend it, and a
     # below-budget violation does not tick the unified
     # ``consecutive_failures`` counter, so the two budgets stay independent.
-    # A per-task ``max_retries`` overrides the violation bound with the same
-    # top precedence it has for every other failure kind. Systemic same-error
-    # crashes still trip immediately.
+    #
+    # An EXPLICIT per-task ``max_retries`` (#72174) instead counts the
+    # violation into the unified ``consecutive_failures`` counter, same as
+    # every other failure kind — it's the task's total retry contract, so a
+    # mix of ordinary crashes and violations can't ride past it just because
+    # neither failure kind's own bound was individually reached. Systemic
+    # same-error crashes still trip immediately.
     auto_blocked: list[str] = []
     if crash_details:
         # Fingerprint errors to detect systemic failures.
@@ -7569,7 +7585,6 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
         for tid, pid, claimer, protocol_violation, error_text in crash_details:
             if protocol_violation:
-                streak = _protocol_violation_streak(conn, tid)
                 trow = conn.execute(
                     "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
                 ).fetchone()
@@ -7578,39 +7593,78 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 task_override = (
                     trow["max_retries"] if "max_retries" in trow.keys() else None
                 )
-                violation_limit = (
-                    int(task_override)
-                    if task_override is not None
-                    else _PROTOCOL_VIOLATION_FAILURE_LIMIT
-                )
-                if streak < violation_limit:
-                    # Below budget: the task is already back at ``ready``
-                    # (respawn allowed) with ``last_failure_error`` stamped.
-                    # Deliberately no ``_record_task_failure`` call — a
-                    # below-budget violation must not consume the unified
-                    # failure budget, just as other failure kinds don't
-                    # consume this one.
-                    continue
-                # Streak reached the bound: trip the breaker. ``force_trip``
-                # skips the threshold resolution inside
-                # ``_record_task_failure`` because the decision — including
-                # the per-task ``max_retries`` override — was already made
-                # against the violation streak above.
-                tripped = _record_task_failure(
-                    conn, tid,
-                    error=error_text,
-                    outcome="crashed",
-                    failure_limit=violation_limit,
-                    force_trip=True,
-                    release_claim=False,
-                    end_run=False,
-                    event_payload_extra={
-                        "pid": pid,
-                        "claimer": claimer,
-                        "protocol_violations": streak,
-                        "protocol_violation_limit": violation_limit,
-                    },
-                )
+                # Diagnostic only below — how many CONSECUTIVE clean-exit
+                # violations led up to this one. When no override is set
+                # this also gates the decision (see the branch below); when
+                # an override IS set it's informational context only, since
+                # the override governs the unified counter instead (#72174).
+                streak = _protocol_violation_streak(conn, tid)
+                if task_override is None:
+                    # Default policy (PR #64353): a protocol violation is
+                    # accounted against its own bounded, violation-only
+                    # streak, independent of the unified
+                    # ``consecutive_failures`` counter every other failure
+                    # kind uses — an earlier crash/timeout neither consumes
+                    # nor extends it, and a below-budget violation does not
+                    # tick the unified counter either.
+                    if streak < _PROTOCOL_VIOLATION_FAILURE_LIMIT:
+                        # Below budget: the task is already back at
+                        # ``ready`` (respawn allowed) with
+                        # ``last_failure_error`` stamped. Deliberately no
+                        # ``_record_task_failure`` call — a below-budget
+                        # violation must not consume the unified failure
+                        # budget, just as other failure kinds don't consume
+                        # this one.
+                        continue
+                    # Streak reached the bound: trip the breaker.
+                    # ``force_trip`` skips the threshold resolution inside
+                    # ``_record_task_failure`` because the decision was
+                    # already made against the violation streak above.
+                    tripped = _record_task_failure(
+                        conn, tid,
+                        error=error_text,
+                        outcome="crashed",
+                        failure_limit=_PROTOCOL_VIOLATION_FAILURE_LIMIT,
+                        force_trip=True,
+                        release_claim=False,
+                        end_run=False,
+                        event_payload_extra={
+                            "pid": pid,
+                            "claimer": claimer,
+                            "protocol_violations": streak,
+                            "protocol_violation_limit":
+                                _PROTOCOL_VIOLATION_FAILURE_LIMIT,
+                        },
+                    )
+                else:
+                    # Explicit per-task override (#72174 fix): an explicit
+                    # ``max_retries`` is a contract on the task's TOTAL
+                    # retry budget, so a violation must count into the same
+                    # unified ``consecutive_failures`` counter every other
+                    # failure kind feeds — NOT the dedicated violation-only
+                    # streak above, which a mixed sequence of ordinary
+                    # crashes/timeouts and below-streak-budget violations
+                    # could ride past the explicit cap without ever
+                    # tripping it. ``_record_task_failure`` already
+                    # resolves ``task.max_retries`` with top precedence
+                    # (same as every other failure kind), so this is the
+                    # identical call the plain-crash branch below makes —
+                    # it increments the counter unconditionally (even when
+                    # it doesn't trip) and trips exactly at the override.
+                    tripped = _record_task_failure(
+                        conn, tid,
+                        error=error_text,
+                        outcome="crashed",
+                        release_claim=False,
+                        end_run=False,
+                        event_payload_extra={
+                            "pid": pid,
+                            "claimer": claimer,
+                            "protocol_violation": True,
+                            "protocol_violations": streak,
+                            "protocol_violation_limit": int(task_override),
+                        },
+                    )
                 if tripped:
                     auto_blocked.append(tid)
                 continue
@@ -7688,10 +7742,14 @@ def _record_task_failure(
     counter-vs-threshold comparison (the resolution order above is then
     only reported in the ``gave_up`` payload, not re-evaluated). Callers
     use it when they have already applied their own bounded-retry policy
-    — e.g. the clean-exit protocol-violation streak in
-    ``detect_crashed_workers``, which resolves the per-task
-    ``max_retries`` override against the violation streak itself. The
-    failure is still counted into ``consecutive_failures``.
+    — e.g. the default (no per-task override) clean-exit protocol-violation
+    streak in ``detect_crashed_workers``, which decides independently of
+    this function's own threshold resolution. The failure is still counted
+    into ``consecutive_failures``. When a task HAS an explicit
+    ``max_retries`` override, ``detect_crashed_workers`` instead calls this
+    function WITHOUT ``force_trip`` for protocol violations too, so the
+    override is resolved right here with the same top precedence as every
+    other failure kind (see resolution order above) — see #72174.
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1372,6 +1372,12 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
 
 
 
+
+
+
+
+
+
 def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
     """A new subscription must NOT replay historical terminal events.
 
@@ -1400,3 +1406,5 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
+
+

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1372,12 +1372,6 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
 
 
 
-
-
-
-
-
-
 def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
     """A new subscription must NOT replay historical terminal events.
 
@@ -1406,5 +1400,4 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1400,4 +1400,3 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-

--- a/tests/hermes_cli/test_kanban_retry_accounting.py
+++ b/tests/hermes_cli/test_kanban_retry_accounting.py
@@ -1,0 +1,317 @@
+"""Retry-accounting regressions for the Kanban dispatcher.
+
+These tests stay separate from the broad core-functionality suite so retry
+budget and transaction-boundary coverage survives pruning of unrelated Kanban
+tests.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _drive_worker_exit(conn, task_id, fake_pid, raw_status):
+    """Claim a task, record a dead worker status, and run one reaper pass."""
+    import hermes_cli.kanban_db as current_kb
+
+    host = current_kb._claimer_id().split(":", 1)[0]
+    claimed = current_kb.claim_task(
+        conn, task_id, claimer=f"{host}:retry-accounting-test",
+    )
+    assert claimed is not None, "task was not claimable for the next attempt"
+    current_kb._set_worker_pid(conn, task_id, fake_pid)
+    current_kb._record_worker_exit(fake_pid, raw_status)
+    original_alive = current_kb._pid_alive
+    current_kb._pid_alive = lambda _pid: False
+    try:
+        return current_kb.detect_crashed_workers(conn)
+    finally:
+        current_kb._pid_alive = original_alive
+
+
+def _drive_protocol_violation(conn, task_id, fake_pid):
+    return _drive_worker_exit(conn, task_id, fake_pid, 0)
+
+
+def _drive_nonzero_crash(conn, task_id, fake_pid):
+    # W_EXITCODE(1, 0) == 256: a normal exit with status 1.
+    return _drive_worker_exit(conn, task_id, fake_pid, 256)
+
+
+def test_explicit_max_retries_counts_mixed_failure_kinds(kanban_home):
+    """Issue #72174: an explicit cap bounds all non-neutral failures."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="mixed-explicit-cap",
+            assignee="worker",
+            max_retries=3,
+        )
+
+        _drive_nonzero_crash(conn, task_id, 994000)
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 1
+
+        _drive_protocol_violation(conn, task_id, 994001)
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 2
+
+        _drive_protocol_violation(conn, task_id, 994002)
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 3
+
+        gave_up = [
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "gave_up"
+        ]
+        assert len(gave_up) == 1
+        payload = gave_up[0].payload or {}
+        assert payload.get("failures") == 3
+        assert payload.get("effective_limit") == 3
+        assert payload.get("limit_source") == "task"
+        assert payload.get("protocol_violation") is True
+        assert "protocol_violation_limit" not in payload
+        assert kb.claim_task(conn, task_id) is None
+
+
+def test_protocol_violation_accounting_is_atomic_with_requeue(
+    kanban_home, monkeypatch,
+):
+    """A review contender cannot claim between requeue and give-up."""
+    conn = kb.connect()
+    contender_started = threading.Event()
+    contender_done = threading.Event()
+    contender_result = {}
+    contender_errors = []
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="atomic-protocol-accounting",
+            assignee="worker",
+            max_retries=1,
+        )
+        host = kb._claimer_id().split(":", 1)[0]
+        implementation = kb.claim_task(
+            conn, task_id, claimer=f"{host}:implementer",
+        )
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="ready for review",
+            reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        assert kb.claim_review_task(
+            conn, task_id, claimer=f"{host}:old",
+        ) is not None
+        kb._set_worker_pid(conn, task_id, 994100)
+        kb._record_worker_exit(994100, 0)
+
+        def contender():
+            other = kb.connect()
+            try:
+                assert contender_started.wait(timeout=5)
+                claimed = kb.claim_review_task(
+                    other, task_id, claimer=f"{host}:contender",
+                )
+                contender_result["claimed"] = claimed is not None
+                if claimed is not None:
+                    kb._set_worker_pid(other, task_id, 994101)
+            except BaseException as exc:
+                contender_errors.append(exc)
+            finally:
+                other.close()
+                contender_done.set()
+
+        thread = threading.Thread(target=contender, daemon=True)
+        thread.start()
+
+        original_record_failure = kb._record_task_failure
+
+        def widen_pre_fix_transaction_gap(*args, **kwargs):
+            if not args[0].in_transaction:
+                assert contender_done.wait(timeout=5), (
+                    "contending claim did not finish in the transaction gap"
+                )
+            return original_record_failure(*args, **kwargs)
+
+        monkeypatch.setattr(
+            kb, "_record_task_failure", widen_pre_fix_transaction_gap,
+        )
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+        def trace(sql):
+            if "UPDATE tasks SET status = 'review'" in sql:
+                contender_started.set()
+
+        conn.set_trace_callback(trace)
+        kb.detect_crashed_workers(conn)
+        conn.set_trace_callback(None)
+        contender_started.set()
+        thread.join(timeout=5)
+
+        assert not thread.is_alive(), "contending dispatcher thread leaked"
+        assert not contender_errors, contender_errors
+        assert contender_result.get("claimed") is False
+        _assert_blocked_and_fully_released(conn, task_id)
+    finally:
+        conn.set_trace_callback(None)
+        contender_started.set()
+        conn.close()
+
+
+def test_timeout_accounting_is_atomic_with_requeue(kanban_home, monkeypatch):
+    """A contender cannot claim between timeout requeue and give-up."""
+    conn = kb.connect()
+    contender_started = threading.Event()
+    contender_done = threading.Event()
+    contender_result = {}
+    contender_errors = []
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="atomic-timeout-accounting",
+            assignee="worker",
+            max_runtime_seconds=1,
+            max_retries=1,
+        )
+        host = kb._claimer_id().split(":", 1)[0]
+        assert kb.claim_task(conn, task_id, claimer=f"{host}:old") is not None
+        kb._set_worker_pid(conn, task_id, 994300)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? "
+                "WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
+                (int(time.time()) - 30, task_id),
+            )
+
+        def contender():
+            other = kb.connect()
+            try:
+                assert contender_started.wait(timeout=5)
+                claimed = kb.claim_task(
+                    other, task_id, claimer=f"{host}:contender",
+                )
+                contender_result["claimed"] = claimed is not None
+                if claimed is not None:
+                    kb._set_worker_pid(other, task_id, 994301)
+            except BaseException as exc:
+                contender_errors.append(exc)
+            finally:
+                other.close()
+                contender_done.set()
+
+        thread = threading.Thread(target=contender, daemon=True)
+        thread.start()
+
+        original_record_failure = kb._record_task_failure
+
+        def widen_pre_fix_transaction_gap(*args, **kwargs):
+            if not args[0].in_transaction:
+                assert contender_done.wait(timeout=5), (
+                    "contending claim did not finish in the timeout transaction gap"
+                )
+            return original_record_failure(*args, **kwargs)
+
+        monkeypatch.setattr(
+            kb, "_record_task_failure", widen_pre_fix_transaction_gap,
+        )
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+        def trace(sql):
+            if "UPDATE tasks SET status = 'ready'" in sql:
+                contender_started.set()
+
+        conn.set_trace_callback(trace)
+        timed_out = kb.enforce_max_runtime(
+            conn, signal_fn=lambda _pid, _sig: None,
+        )
+        conn.set_trace_callback(None)
+        contender_started.set()
+        thread.join(timeout=5)
+
+        assert task_id in timed_out
+        assert not thread.is_alive(), "contending dispatcher thread leaked"
+        assert not contender_errors, contender_errors
+        assert contender_result.get("claimed") is False
+        _assert_blocked_and_fully_released(conn, task_id)
+    finally:
+        conn.set_trace_callback(None)
+        contender_started.set()
+        conn.close()
+
+
+def _assert_blocked_and_fully_released(conn, task_id):
+    row = conn.execute(
+        "SELECT status, claim_lock, claim_expires, worker_pid, current_run_id "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    assert row["status"] == "blocked"
+    assert row["claim_lock"] is None
+    assert row["claim_expires"] is None
+    assert row["worker_pid"] is None
+    assert row["current_run_id"] is None
+    open_runs = conn.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE task_id = ? AND ended_at IS NULL",
+        (task_id,),
+    ).fetchone()[0]
+    assert open_runs == 0
+    gave_up = [
+        event
+        for event in kb.list_events(conn, task_id)
+        if event.kind == "gave_up"
+    ]
+    assert len(gave_up) == 1
+
+
+def test_explicit_retry_payload_omits_capped_violation_streak(kanban_home):
+    """Unified retry events must not report a truncated violation streak."""
+    with kb.connect() as conn:
+        limit = kb._PROTOCOL_VIOLATION_SCAN_LIMIT + 1
+        task_id = kb.create_task(
+            conn,
+            title="large-explicit-cap",
+            assignee="worker",
+            max_retries=limit,
+        )
+        for index in range(limit):
+            _drive_protocol_violation(conn, task_id, 994200 + index)
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == limit
+        gave_up = [
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "gave_up"
+        ]
+        assert len(gave_up) == 1
+        payload = gave_up[0].payload or {}
+        assert payload.get("failures") == limit
+        assert payload.get("effective_limit") == limit
+        assert payload.get("limit_source") == "task"
+        assert payload.get("protocol_violation") is True
+        assert "protocol_violations" not in payload

--- a/tests/hermes_cli/test_kanban_retry_accounting.py
+++ b/tests/hermes_cli/test_kanban_retry_accounting.py
@@ -1,0 +1,302 @@
+"""Retry-accounting regressions for the Kanban dispatcher.
+
+These tests stay separate from the broad core-functionality suite so retry
+budget and transaction-boundary coverage survives pruning of unrelated Kanban
+tests.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _drive_worker_exit(conn, task_id, fake_pid, raw_status):
+    """Claim a task, record a dead worker status, and run one reaper pass."""
+    import hermes_cli.kanban_db as current_kb
+
+    host = current_kb._claimer_id().split(":", 1)[0]
+    claimed = current_kb.claim_task(
+        conn, task_id, claimer=f"{host}:retry-accounting-test",
+    )
+    assert claimed is not None, "task was not claimable for the next attempt"
+    current_kb._set_worker_pid(conn, task_id, fake_pid)
+    current_kb._record_worker_exit(fake_pid, raw_status)
+    original_alive = current_kb._pid_alive
+    current_kb._pid_alive = lambda _pid: False
+    try:
+        return current_kb.detect_crashed_workers(conn)
+    finally:
+        current_kb._pid_alive = original_alive
+
+
+def _drive_protocol_violation(conn, task_id, fake_pid):
+    return _drive_worker_exit(conn, task_id, fake_pid, 0)
+
+
+def _drive_nonzero_crash(conn, task_id, fake_pid):
+    # W_EXITCODE(1, 0) == 256: a normal exit with status 1.
+    return _drive_worker_exit(conn, task_id, fake_pid, 256)
+
+
+def test_explicit_max_retries_counts_mixed_failure_kinds(kanban_home):
+    """Issue #72174: an explicit cap bounds all non-neutral failures."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="mixed-explicit-cap",
+            assignee="worker",
+            max_retries=3,
+        )
+
+        _drive_nonzero_crash(conn, task_id, 994000)
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 1
+
+        _drive_protocol_violation(conn, task_id, 994001)
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 2
+
+        _drive_protocol_violation(conn, task_id, 994002)
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 3
+
+        gave_up = [
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "gave_up"
+        ]
+        assert len(gave_up) == 1
+        payload = gave_up[0].payload or {}
+        assert payload.get("failures") == 3
+        assert payload.get("effective_limit") == 3
+        assert payload.get("limit_source") == "task"
+        assert payload.get("protocol_violation") is True
+        assert "protocol_violation_limit" not in payload
+        assert kb.claim_task(conn, task_id) is None
+
+
+def test_protocol_violation_accounting_is_atomic_with_requeue(
+    kanban_home, monkeypatch,
+):
+    """A contender cannot claim between protocol requeue and give-up."""
+    conn = kb.connect()
+    contender_started = threading.Event()
+    contender_done = threading.Event()
+    contender_result = {}
+    contender_errors = []
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="atomic-protocol-accounting",
+            assignee="worker",
+            max_retries=1,
+        )
+        host = kb._claimer_id().split(":", 1)[0]
+        assert kb.claim_task(conn, task_id, claimer=f"{host}:old") is not None
+        kb._set_worker_pid(conn, task_id, 994100)
+        kb._record_worker_exit(994100, 0)
+
+        def contender():
+            other = kb.connect()
+            try:
+                assert contender_started.wait(timeout=5)
+                claimed = kb.claim_task(
+                    other, task_id, claimer=f"{host}:contender",
+                )
+                contender_result["claimed"] = claimed is not None
+                if claimed is not None:
+                    kb._set_worker_pid(other, task_id, 994101)
+            except BaseException as exc:
+                contender_errors.append(exc)
+            finally:
+                other.close()
+                contender_done.set()
+
+        thread = threading.Thread(target=contender, daemon=True)
+        thread.start()
+
+        original_record_failure = kb._record_task_failure
+
+        def widen_pre_fix_transaction_gap(*args, **kwargs):
+            assert contender_done.wait(timeout=5), (
+                "contending claim did not finish in the transaction gap"
+            )
+            return original_record_failure(*args, **kwargs)
+
+        monkeypatch.setattr(
+            kb, "_record_task_failure", widen_pre_fix_transaction_gap,
+        )
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+        def trace(sql):
+            if "UPDATE tasks SET status = 'ready'" in sql:
+                contender_started.set()
+
+        conn.set_trace_callback(trace)
+        kb.detect_crashed_workers(conn)
+        conn.set_trace_callback(None)
+        contender_started.set()
+        thread.join(timeout=5)
+
+        assert not thread.is_alive(), "contending dispatcher thread leaked"
+        assert not contender_errors, contender_errors
+        assert contender_result.get("claimed") is False
+        _assert_blocked_and_fully_released(conn, task_id)
+    finally:
+        conn.set_trace_callback(None)
+        contender_started.set()
+        conn.close()
+
+
+def test_timeout_accounting_is_atomic_with_requeue(kanban_home, monkeypatch):
+    """A contender cannot claim between timeout requeue and give-up."""
+    conn = kb.connect()
+    contender_started = threading.Event()
+    contender_done = threading.Event()
+    contender_result = {}
+    contender_errors = []
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="atomic-timeout-accounting",
+            assignee="worker",
+            max_runtime_seconds=1,
+            max_retries=1,
+        )
+        host = kb._claimer_id().split(":", 1)[0]
+        assert kb.claim_task(conn, task_id, claimer=f"{host}:old") is not None
+        kb._set_worker_pid(conn, task_id, 994300)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? "
+                "WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
+                (int(time.time()) - 30, task_id),
+            )
+
+        def contender():
+            other = kb.connect()
+            try:
+                assert contender_started.wait(timeout=5)
+                claimed = kb.claim_task(
+                    other, task_id, claimer=f"{host}:contender",
+                )
+                contender_result["claimed"] = claimed is not None
+                if claimed is not None:
+                    kb._set_worker_pid(other, task_id, 994301)
+            except BaseException as exc:
+                contender_errors.append(exc)
+            finally:
+                other.close()
+                contender_done.set()
+
+        thread = threading.Thread(target=contender, daemon=True)
+        thread.start()
+
+        original_record_failure = kb._record_task_failure
+
+        def widen_pre_fix_transaction_gap(*args, **kwargs):
+            assert contender_done.wait(timeout=5), (
+                "contending claim did not finish in the timeout transaction gap"
+            )
+            return original_record_failure(*args, **kwargs)
+
+        monkeypatch.setattr(
+            kb, "_record_task_failure", widen_pre_fix_transaction_gap,
+        )
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+        def trace(sql):
+            if "UPDATE tasks SET status = 'ready'" in sql:
+                contender_started.set()
+
+        conn.set_trace_callback(trace)
+        timed_out = kb.enforce_max_runtime(
+            conn, signal_fn=lambda _pid, _sig: None,
+        )
+        conn.set_trace_callback(None)
+        contender_started.set()
+        thread.join(timeout=5)
+
+        assert task_id in timed_out
+        assert not thread.is_alive(), "contending dispatcher thread leaked"
+        assert not contender_errors, contender_errors
+        assert contender_result.get("claimed") is False
+        _assert_blocked_and_fully_released(conn, task_id)
+    finally:
+        conn.set_trace_callback(None)
+        contender_started.set()
+        conn.close()
+
+
+def _assert_blocked_and_fully_released(conn, task_id):
+    row = conn.execute(
+        "SELECT status, claim_lock, claim_expires, worker_pid, current_run_id "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    assert row["status"] == "blocked"
+    assert row["claim_lock"] is None
+    assert row["claim_expires"] is None
+    assert row["worker_pid"] is None
+    assert row["current_run_id"] is None
+    open_runs = conn.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE task_id = ? AND ended_at IS NULL",
+        (task_id,),
+    ).fetchone()[0]
+    assert open_runs == 0
+    gave_up = [
+        event
+        for event in kb.list_events(conn, task_id)
+        if event.kind == "gave_up"
+    ]
+    assert len(gave_up) == 1
+
+
+def test_explicit_retry_payload_omits_capped_violation_streak(kanban_home):
+    """Unified retry events must not report a truncated violation streak."""
+    with kb.connect() as conn:
+        limit = kb._PROTOCOL_VIOLATION_SCAN_LIMIT + 1
+        task_id = kb.create_task(
+            conn,
+            title="large-explicit-cap",
+            assignee="worker",
+            max_retries=limit,
+        )
+        for index in range(limit):
+            _drive_protocol_violation(conn, task_id, 994200 + index)
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == limit
+        gave_up = [
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "gave_up"
+        ]
+        assert len(gave_up) == 1
+        payload = gave_up[0].payload or {}
+        assert payload.get("failures") == limit
+        assert payload.get("effective_limit") == limit
+        assert payload.get("limit_source") == "task"
+        assert payload.get("protocol_violation") is True
+        assert "protocol_violations" not in payload

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -417,12 +417,13 @@ set) and can be disabled with `HERMES_KANBAN_STOP_NUDGE=0`.
 **Dispatcher-side recovery:** If the nudges are exhausted or the worker crashes
 before reaching the nudge, the dispatcher gives the violation a **bounded retry**
 (up to `_PROTOCOL_VIOLATION_FAILURE_LIMIT` consecutive violations, default 3)
-before auto-blocking the task instead of respawning it into the same loop. The
-budget counts only *consecutive* clean-exit protocol violations — interleaved
-rate-limited requeues are neutral, and any other failure kind resets the
-streak — and a per-task `max_retries` overrides the bound. This usually means
-the model wrote a plain-text answer and exited without using the Kanban tool
-surface.
+before auto-blocking the task instead of respawning it into the same loop. A
+protocol violation usually means the model wrote a plain-text answer and
+exited without using the Kanban tool surface. Without an explicit per-task
+`max_retries`, the budget counts only *consecutive* clean-exit protocol
+violations: rate-limited requeues are neutral and other failures reset the
+streak. With `max_retries=N`, every non-neutral failure instead counts into the
+same unified total, so the task blocks on its Nth failed run.
 
 The lifecycle plus the load-bearing reference details (workspace kinds, deliverable `artifacts`, claiming created cards) ship in that system-prompt block, so every worker has them regardless of which profile it runs under — no per-profile skill setup required.
 
@@ -1149,8 +1150,8 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `reconciled` | `{reason, claim_lock, claim_expires, worker_pid}` | Orphaned-card reconciliation: the card was `running` with broken claim bookkeeping (`claim_lock` or `claim_expires` NULL — crash mid-claim, manual SQL, DB restore) and no live worker, so none of the TTL/crash/stale paths could ever recover it. The dispatcher requeued it to `ready` with an explanatory comment. Gated by `kanban.reconcile_orphans` in config.yaml (default `true`). |
 | `respawn_guarded` | `{reason}` | Dispatcher refused to re-spawn this ready task this tick. Reasons: `blocker_auth` (last failure was a quota/auth/429 error — wait for the rate window to reset), `recent_success` (a completed run happened in the last hour — wait for review before re-running), `active_pr` (a GitHub PR URL appears in a recent comment — a prior worker already opened a PR). The task stays in `ready`; the next tick gets another chance to spawn. If the underlying condition persists, the normal `consecutive_failures` circuit breaker will auto-block via `gave_up` after `failure_limit` failures. |
 | `spawn_failed` | `{error, failures}` | One spawn attempt failed (missing PATH, workspace unmountable, …). Counter increments; task returns to `ready` for retry. |
-| `protocol_violation` | `{pid, claimer, exit_code, protocol_violation}` | Worker exited successfully while the task was still `running`, usually because it answered without calling `kanban_complete` or `kanban_block`. Emitted on every violation (the payload's `protocol_violation: true` marker is copied into the run metadata and feeds the violation-only retry budget). Below the budget — up to `_PROTOCOL_VIOLATION_FAILURE_LIMIT` (default 3) *consecutive* violations, per-task `max_retries` overriding — the task simply returns to `ready` for another attempt; when the streak reaches the bound the dispatcher also emits `gave_up` and auto-blocks. |
-| `gave_up` | `{failures, effective_limit, limit_source, error}` | Circuit breaker fired after N consecutive non-successful attempts. Task auto-blocks with the last error. The effective limit resolves as task `max_retries`, then dispatcher `failure_limit` / `kanban.failure_limit`, then the built-in default. |
+| `protocol_violation` | `{pid, claimer, exit_code, protocol_violation}` | Worker exited successfully while the task was still `running`, usually because it answered without calling `kanban_complete` or `kanban_block`. Without an explicit `max_retries`, violations use their own consecutive streak (default limit 3). With `max_retries=N`, they count into the unified `consecutive_failures` total with crashes and timeouts, and the task blocks on the Nth non-neutral failure. |
+| `gave_up` | `{failures, effective_limit, limit_source, error}` | Circuit breaker fired after N consecutive non-neutral failures. Rate-limited and stale/reclaimed requeues do not increment the counter. The effective limit resolves as task `max_retries`, then dispatcher `failure_limit` / `kanban.failure_limit`, then the built-in default. |
 
 `hermes kanban tail <id>` shows these for a single task. `hermes kanban watch` streams them board-wide.
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -420,8 +420,9 @@ streak. This default, independent streak only applies when the task has no
 explicit `max_retries` set. Once a task sets an explicit `max_retries=N`, that
 is a cap on the task's *total* retry budget: violations count into the same
 unified failure counter as crashes and timeouts, so the task blocks on its Nth
-non-successful attempt overall, regardless of how many of those attempts were
-violations versus other failure kinds.
+non-neutral failure overall, regardless of how many failures were violations
+versus other failure kinds. Rate-limited and stale/reclaimed requeues remain
+neutral and do not consume either retry budget.
 
 The lifecycle plus the load-bearing reference details (workspace kinds, deliverable `artifacts`, claiming created cards) ship in that system-prompt block, so every worker has them regardless of which profile it runs under — no per-profile skill setup required.
 
@@ -1003,7 +1004,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `respawn_guarded` | `{reason}` | Dispatcher refused to re-spawn this ready task this tick. Reasons: `blocker_auth` (last failure was a quota/auth/429 error — wait for the rate window to reset), `recent_success` (a completed run happened in the last hour — wait for review before re-running), `active_pr` (a GitHub PR URL appears in a recent comment — a prior worker already opened a PR). The task stays in `ready`; the next tick gets another chance to spawn. If the underlying condition persists, the normal `consecutive_failures` circuit breaker will auto-block via `gave_up` after `failure_limit` failures. |
 | `spawn_failed` | `{error, failures}` | One spawn attempt failed (missing PATH, workspace unmountable, …). Counter increments; task returns to `ready` for retry. |
 | `protocol_violation` | `{pid, claimer, exit_code, protocol_violation}` | Worker exited successfully while the task was still `running`, usually because it answered without calling `kanban_complete` or `kanban_block`. Emitted on every violation (the payload's `protocol_violation: true` marker is copied into the run metadata). Without an explicit per-task `max_retries`, the violation is checked against its own violation-only streak — up to `_PROTOCOL_VIOLATION_FAILURE_LIMIT` (default 3) *consecutive* violations — and the task simply returns to `ready` until the streak reaches the bound, at which point the dispatcher also emits `gave_up` and auto-blocks. With an explicit `max_retries=N` set, the violation instead counts into the same unified `consecutive_failures` total as any other failure kind, and blocks on the Nth total failure. |
-| `gave_up` | `{failures, effective_limit, limit_source, error}` | Circuit breaker fired after N consecutive non-successful attempts. Task auto-blocks with the last error. The effective limit resolves as task `max_retries`, then dispatcher `failure_limit` / `kanban.failure_limit`, then the built-in default. |
+| `gave_up` | `{failures, effective_limit, limit_source, error}` | Circuit breaker fired after N consecutive non-neutral failures. Task auto-blocks with the last error. Rate-limited and stale/reclaimed requeues do not increment this counter. The effective limit resolves as task `max_retries`, then dispatcher `failure_limit` / `kanban.failure_limit`, then the built-in default. |
 
 `hermes kanban tail <id>` shows these for a single task. `hermes kanban watch` streams them board-wide.
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -414,8 +414,13 @@ before reaching the nudge, the dispatcher gives the violation a **bounded retry*
 before auto-blocking the task instead of respawning it into the same loop. The
 budget counts only *consecutive* clean-exit protocol violations — interleaved
 rate-limited requeues are neutral, and any other failure kind resets the
-streak — and a per-task `max_retries` overrides the bound. This usually means
-the model wrote a plain-text answer and exited without using the Kanban tool
+streak. This default, independent streak only applies when the task has no
+explicit `max_retries` set. Once a task sets an explicit `max_retries=N`, that
+is a cap on the task's *total* retry budget: violations count into the same
+unified failure counter as crashes and timeouts, so the task blocks on its Nth
+non-successful attempt overall, regardless of how many of those attempts were
+violations versus other failure kinds. This usually means the model wrote a
+plain-text answer and exited without using the Kanban tool
 surface.
 
 The lifecycle plus the load-bearing reference details (workspace kinds, deliverable `artifacts`, claiming created cards) ship in that system-prompt block, so every worker has them regardless of which profile it runs under — no per-profile skill setup required.
@@ -997,7 +1002,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `stale` | `{elapsed_seconds, last_heartbeat_at, heartbeat_age_seconds, timeout_seconds, pid, terminated}` | Task ran longer than `kanban.dispatch_stale_timeout_seconds` (default 4 h) AND no `kanban_heartbeat` arrived in the last hour. Dispatcher SIGTERM'd the host-local worker (if any), reset the task to `ready` for re-dispatch. Does NOT tick the failure counter (stale is dispatcher-side absence detection, not a worker fault). Workers running long operations should call `kanban_heartbeat` at least once an hour to avoid this. |
 | `respawn_guarded` | `{reason}` | Dispatcher refused to re-spawn this ready task this tick. Reasons: `blocker_auth` (last failure was a quota/auth/429 error — wait for the rate window to reset), `recent_success` (a completed run happened in the last hour — wait for review before re-running), `active_pr` (a GitHub PR URL appears in a recent comment — a prior worker already opened a PR). The task stays in `ready`; the next tick gets another chance to spawn. If the underlying condition persists, the normal `consecutive_failures` circuit breaker will auto-block via `gave_up` after `failure_limit` failures. |
 | `spawn_failed` | `{error, failures}` | One spawn attempt failed (missing PATH, workspace unmountable, …). Counter increments; task returns to `ready` for retry. |
-| `protocol_violation` | `{pid, claimer, exit_code, protocol_violation}` | Worker exited successfully while the task was still `running`, usually because it answered without calling `kanban_complete` or `kanban_block`. Emitted on every violation (the payload's `protocol_violation: true` marker is copied into the run metadata and feeds the violation-only retry budget). Below the budget — up to `_PROTOCOL_VIOLATION_FAILURE_LIMIT` (default 3) *consecutive* violations, per-task `max_retries` overriding — the task simply returns to `ready` for another attempt; when the streak reaches the bound the dispatcher also emits `gave_up` and auto-blocks. |
+| `protocol_violation` | `{pid, claimer, exit_code, protocol_violation}` | Worker exited successfully while the task was still `running`, usually because it answered without calling `kanban_complete` or `kanban_block`. Emitted on every violation (the payload's `protocol_violation: true` marker is copied into the run metadata). Without an explicit per-task `max_retries`, the violation is checked against its own violation-only streak — up to `_PROTOCOL_VIOLATION_FAILURE_LIMIT` (default 3) *consecutive* violations — and the task simply returns to `ready` until the streak reaches the bound, at which point the dispatcher also emits `gave_up` and auto-blocks. With an explicit `max_retries=N` set, the violation instead counts into the same unified `consecutive_failures` total as any other failure kind, and blocks on the Nth total failure. |
 | `gave_up` | `{failures, effective_limit, limit_source, error}` | Circuit breaker fired after N consecutive non-successful attempts. Task auto-blocks with the last error. The effective limit resolves as task `max_retries`, then dispatcher `failure_limit` / `kanban.failure_limit`, then the built-in default. |
 
 `hermes kanban tail <id>` shows these for a single task. `hermes kanban watch` streams them board-wide.

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -411,7 +411,9 @@ set) and can be disabled with `HERMES_KANBAN_STOP_NUDGE=0`.
 **Dispatcher-side recovery:** If the nudges are exhausted or the worker crashes
 before reaching the nudge, the dispatcher gives the violation a **bounded retry**
 (up to `_PROTOCOL_VIOLATION_FAILURE_LIMIT` consecutive violations, default 3)
-before auto-blocking the task instead of respawning it into the same loop. The
+before auto-blocking the task instead of respawning it into the same loop. A
+protocol violation usually means the model wrote a plain-text answer and
+exited without using the Kanban tool surface. The retry
 budget counts only *consecutive* clean-exit protocol violations — interleaved
 rate-limited requeues are neutral, and any other failure kind resets the
 streak. This default, independent streak only applies when the task has no
@@ -419,9 +421,7 @@ explicit `max_retries` set. Once a task sets an explicit `max_retries=N`, that
 is a cap on the task's *total* retry budget: violations count into the same
 unified failure counter as crashes and timeouts, so the task blocks on its Nth
 non-successful attempt overall, regardless of how many of those attempts were
-violations versus other failure kinds. This usually means the model wrote a
-plain-text answer and exited without using the Kanban tool
-surface.
+violations versus other failure kinds.
 
 The lifecycle plus the load-bearing reference details (workspace kinds, deliverable `artifacts`, claiming created cards) ship in that system-prompt block, so every worker has them regardless of which profile it runs under — no per-profile skill setup required.
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -293,7 +293,7 @@ kanban_complete(summary="decomposed into 2 research tasks + 1 writer; linked dep
 3. 在长时间操作期间每隔几分钟调用一次 `kanban_heartbeat(note="...")`。**如果你的工作可能运行超过 1 小时，请至少每小时调用一次 `kanban_heartbeat`** —— 调度器会回收运行时间超过 `kanban.dispatch_stale_timeout_seconds`（默认 4 小时）且最近一小时内没有心跳的任务，认为 worker 在没有清理的情况下崩溃了。回收是无害的（任务返回 `ready` 重新调度，不增加失败计数器），但你会失去当前运行的进度。
 4. 以 `kanban_complete(summary="...", metadata={...})` 完成，或在卡住时以 `kanban_block(reason="...")` 完成。
 
-最终的 `kanban_complete` / `kanban_block` 调用是 worker 协议的一部分。如果 worker 进程以状态 0 退出而任务仍处于 `running` 状态，调度器将其视为协议违规，发出 `protocol_violation` 事件，并在下一个 tick 自动阻塞任务而不是重新启动它进入同一循环。这通常意味着模型写了一个纯文本答案并退出，而没有使用 Kanban 工具界面。
+最终的 `kanban_complete` / `kanban_block` 调用是 worker 协议的一部分。如果 worker 进程以状态 0 退出而任务仍处于 `running` 状态，调度器将其视为协议违规并发出 `protocol_violation` 事件。这通常意味着模型写了纯文本答案并退出，而没有使用 Kanban 工具界面。未显式设置 `max_retries` 时，调度器使用独立的连续协议违规预算（默认 3 次）；显式设置 `max_retries=N` 时，协议违规与崩溃、超时共同计入统一失败计数，并在第 N 次非中性失败时阻塞。限流及 stale/reclaimed 重新排队保持中性。
 
 ### 为特定任务固定额外 skill
 
@@ -855,8 +855,8 @@ hermes kanban runs t_abcd
 | `stale` | `{elapsed_seconds, last_heartbeat_at, heartbeat_age_seconds, timeout_seconds, pid, terminated}` | 任务运行时间超过 `kanban.dispatch_stale_timeout_seconds`（默认 4 小时）**且**最近一小时内没有 `kanban_heartbeat`。调度器向本地 worker（如有）发送 SIGTERM，将任务重置为 `ready` 重新调度。**不**增加失败计数器（stale 是调度器端的缺席检测，不是 worker 故障）。运行长时间操作的 Worker 应至少每小时调用一次 `kanban_heartbeat` 以避免此情况。 |
 | `respawn_guarded` | `{reason}` | 调度器拒绝在本 tick 重新启动此就绪任务。原因：`blocker_auth`（上次失败是配额/认证/429 错误 —— 等待速率窗口重置）、`recent_success`（最近一小时内有完成的运行 —— 在重新运行前等待审查）、`active_pr`（最近的评论中出现 GitHub PR URL —— 先前的 worker 已经打开了 PR）。任务保持在 `ready`；下一个 tick 有另一次启动机会。如果底层条件持续存在，正常的 `consecutive_failures` 熔断器将在 `failure_limit` 次失败后通过 `gave_up` 自动阻塞。 |
 | `spawn_failed` | `{error, failures}` | 一次启动尝试失败（PATH 缺失、工作区无法挂载等）。计数器递增；任务返回 `ready` 重试。 |
-| `protocol_violation` | `{pid, claimer, exit_code}` | Worker 在任务仍处于 `running` 状态时成功退出，通常是因为它回答了问题而没有调用 `kanban_complete` 或 `kanban_block`。调度器还会立即发出 `gave_up` 并自动阻塞，而不是重试。 |
-| `gave_up` | `{failures, effective_limit, limit_source, error}` | N 次连续不成功尝试后熔断器触发。任务以最后一个错误自动阻塞。有效限制解析为任务 `max_retries`，然后是调度器 `failure_limit` / `kanban.failure_limit`，然后是内置默认值。 |
+| `protocol_violation` | `{pid, claimer, exit_code, protocol_violation}` | Worker 在任务仍处于 `running` 状态时成功退出，通常是因为它回答了问题而没有调用 `kanban_complete` 或 `kanban_block`。未显式设置 `max_retries` 时按独立的连续协议违规预算重试；显式设置 `max_retries=N` 时计入统一失败总数，并在第 N 次非中性失败时阻塞。 |
+| `gave_up` | `{failures, effective_limit, limit_source, error}` | N 次连续非中性失败后熔断器触发。任务以最后一个错误自动阻塞；限流及 stale/reclaimed 重新排队不增加该计数器。有效限制解析为任务 `max_retries`，然后是调度器 `failure_limit` / `kanban.failure_limit`，然后是内置默认值。 |
 
 `hermes kanban tail <id>` 显示单个任务的这些事件。`hermes kanban watch` 在整个看板范围内流式传输它们。
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -289,7 +289,7 @@ kanban_complete(summary="decomposed into 2 research tasks + 1 writer; linked dep
 3. 在长时间操作期间每隔几分钟调用一次 `kanban_heartbeat(note="...")`。**如果你的工作可能运行超过 1 小时，请至少每小时调用一次 `kanban_heartbeat`** —— 调度器会回收运行时间超过 `kanban.dispatch_stale_timeout_seconds`（默认 4 小时）且最近一小时内没有心跳的任务，认为 worker 在没有清理的情况下崩溃了。回收是无害的（任务返回 `ready` 重新调度，不增加失败计数器），但你会失去当前运行的进度。
 4. 以 `kanban_complete(summary="...", metadata={...})` 完成，或在卡住时以 `kanban_block(reason="...")` 完成。
 
-最终的 `kanban_complete` / `kanban_block` 调用是 worker 协议的一部分。如果 worker 进程以状态 0 退出而任务仍处于 `running` 状态，调度器将其视为协议违规，发出 `protocol_violation` 事件，并在下一个 tick 自动阻塞任务而不是重新启动它进入同一循环。这通常意味着模型写了一个纯文本答案并退出，而没有使用 Kanban 工具界面。
+最终的 `kanban_complete` / `kanban_block` 调用是 worker 协议的一部分。如果 worker 进程以状态 0 退出而任务仍处于 `running` 状态，调度器将其视为协议违规并发出 `protocol_violation` 事件。这通常意味着模型写了纯文本答案并退出，而没有使用 Kanban 工具界面。未显式设置 `max_retries` 时，调度器使用独立的连续协议违规预算（默认 3 次），达到上限后自动阻塞；显式设置 `max_retries=N` 时，协议违规与崩溃、超时共同计入统一失败计数，并在第 N 次非中性失败时阻塞。限流及 stale/reclaimed 重新排队保持中性，不消耗这两种预算。
 
 ### 为特定任务固定额外 skill
 
@@ -755,8 +755,8 @@ hermes kanban runs t_abcd
 | `stale` | `{elapsed_seconds, last_heartbeat_at, heartbeat_age_seconds, timeout_seconds, pid, terminated}` | 任务运行时间超过 `kanban.dispatch_stale_timeout_seconds`（默认 4 小时）**且**最近一小时内没有 `kanban_heartbeat`。调度器向本地 worker（如有）发送 SIGTERM，将任务重置为 `ready` 重新调度。**不**增加失败计数器（stale 是调度器端的缺席检测，不是 worker 故障）。运行长时间操作的 Worker 应至少每小时调用一次 `kanban_heartbeat` 以避免此情况。 |
 | `respawn_guarded` | `{reason}` | 调度器拒绝在本 tick 重新启动此就绪任务。原因：`blocker_auth`（上次失败是配额/认证/429 错误 —— 等待速率窗口重置）、`recent_success`（最近一小时内有完成的运行 —— 在重新运行前等待审查）、`active_pr`（最近的评论中出现 GitHub PR URL —— 先前的 worker 已经打开了 PR）。任务保持在 `ready`；下一个 tick 有另一次启动机会。如果底层条件持续存在，正常的 `consecutive_failures` 熔断器将在 `failure_limit` 次失败后通过 `gave_up` 自动阻塞。 |
 | `spawn_failed` | `{error, failures}` | 一次启动尝试失败（PATH 缺失、工作区无法挂载等）。计数器递增；任务返回 `ready` 重试。 |
-| `protocol_violation` | `{pid, claimer, exit_code}` | Worker 在任务仍处于 `running` 状态时成功退出，通常是因为它回答了问题而没有调用 `kanban_complete` 或 `kanban_block`。调度器还会立即发出 `gave_up` 并自动阻塞，而不是重试。 |
-| `gave_up` | `{failures, effective_limit, limit_source, error}` | N 次连续不成功尝试后熔断器触发。任务以最后一个错误自动阻塞。有效限制解析为任务 `max_retries`，然后是调度器 `failure_limit` / `kanban.failure_limit`，然后是内置默认值。 |
+| `protocol_violation` | `{pid, claimer, exit_code, protocol_violation}` | Worker 在任务仍处于 `running` 状态时成功退出，通常是因为它回答了问题而没有调用 `kanban_complete` 或 `kanban_block`。未显式设置 `max_retries` 时按独立的连续协议违规预算重试；显式设置 `max_retries=N` 时计入统一失败总数，并在第 N 次非中性失败时阻塞。 |
+| `gave_up` | `{failures, effective_limit, limit_source, error}` | N 次连续非中性失败后熔断器触发。任务以最后一个错误自动阻塞；限流及 stale/reclaimed 重新排队不增加该计数器。有效限制解析为任务 `max_retries`，然后是调度器 `failure_limit` / `kanban.failure_limit`，然后是内置默认值。 |
 
 `hermes kanban tail <id>` 显示单个任务的这些事件。`hermes kanban watch` 在整个看板范围内流式传输它们。
 


### PR DESCRIPTION
## What does this PR do?

Fixes task-level `max_retries` accounting when ordinary failures and clean-exit `protocol_violation` outcomes are mixed.

With an explicit task override, every non-neutral failure now increments the same consecutive-failure counter, so `max_retries=N` blocks on the Nth failed run as documented. Tasks without an override retain the existing independent protocol-violation streak policy, and rate-limited or stale/reclaimed requeues remain neutral.

The change also makes crash, timeout, and protocol-violation requeue/run-closure/failure-accounting updates atomic. This prevents another dispatcher connection from claiming the task between requeue and retry accounting. Explicit-override `gave_up` events no longer expose a capped protocol-only streak as if it were exact.

## Related Issue

Fixes #72174

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Count mixed crash, timeout, spawn-failure, and protocol-violation outcomes against an explicit task `max_retries` override.
- Preserve the default protocol-only streak policy when no task override is configured.
- Keep rate-limited and stale/reclaimed requeues neutral.
- Perform requeue, run closure, event emission, and retry accounting in one SQLite write transaction.
- Preserve `ready` versus `review` retry lanes and post-commit worker lifecycle hooks from current `main`.
- Add exact mixed-failure, two-connection race, timeout race, and high-limit metadata tests.
- Update the English and Simplified Chinese Kanban documentation and internal transaction/retry comments.

## How to Test

Run:

```bash
python -m pytest -q \
  tests/hermes_cli/test_kanban_retry_accounting.py \
  tests/hermes_cli/test_kanban_review_lifecycle_complete.py \
  tests/hermes_cli/test_kanban_core_functionality.py \
  tests/hermes_cli/test_kanban_db.py
python -m py_compile hermes_cli/kanban_db.py
git diff --check upstream/main...HEAD
```

Result on current `upstream/main` (`0807673e1`): **78 passed, 2 skipped**; compile and whitespace checks passed.

The regression test drives one ordinary crash followed by two protocol violations for a task with `max_retries=3`. The task now transitions `ready → ready → blocked`, persists counters `1 → 2 → 3`, emits one `gave_up`, and rejects a fourth claim. Two-connection tests also verify that crash/protocol and timeout accounting cannot expose a transient claimable `ready` or `review` state.

Additional validation:

- Reproduced the exact issue sequence on current `main`: before the fix, three failed runs left the task `ready` with `consecutive_failures=1`, and a fourth claim succeeded.
- Ran `scripts/run_tests.sh` on macOS. All changed-area Kanban tests passed. The full repository run reported 31 failures across 21 unrelated platform/network/media files. Representative `/tmp` path, Computer Use platform, and Linux abstract-socket failures were reproduced in a clean worktree at current `upstream/main`.
- An independent code review found no Critical or Important issues; its stale internal-comment findings were incorporated before the final verification.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix, the issue sequence remained `ready → ready → ready` with counters `1 → 1 → 1`, and a fourth claim succeeded. After the fix, it becomes `ready → ready → blocked` with counters `1 → 2 → 3`, exactly one `gave_up` event, no lingering claim/current run/open run, and the fourth claim is rejected.
