### PR TITLE
fix(langfuse): scope key-prefix placeholder guard to Langfuse Cloud hosts

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -622,8 +622,8 @@ TOOL_CATEGORIES = {
                 "name": "Langfuse Self-Hosted",
                 "tag": "Self-hosted Langfuse instance",
                 "env_vars": [
-                    {"key": "HERMES_LANGFUSE_PUBLIC_KEY", "prompt": "Langfuse public key (pk-lf-...)"},
-                    {"key": "HERMES_LANGFUSE_SECRET_KEY", "prompt": "Langfuse secret key (sk-lf-...)"},
+                    {"key": "HERMES_LANGFUSE_PUBLIC_KEY", "prompt": "Langfuse public key (as issued by your endpoint)"},
+                    {"key": "HERMES_LANGFUSE_SECRET_KEY", "prompt": "Langfuse secret key (as issued by your endpoint)"},
                     {"key": "HERMES_LANGFUSE_BASE_URL", "prompt": "Langfuse server URL (e.g. http://localhost:3000)", "default": "http://localhost:3000"},
                 ],
                 "post_setup": "langfuse",

--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -20,11 +20,26 @@ hermes plugins enable observability/langfuse
 
 Set these in `~/.hermes/.env` (or via `hermes tools`):
 
+**Langfuse Cloud** — keys are issued by the platform in this format:
+
 ```bash
 HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-...
 HERMES_LANGFUSE_SECRET_KEY=sk-lf-...
-HERMES_LANGFUSE_BASE_URL=https://cloud.langfuse.com   # or your self-hosted URL
+HERMES_LANGFUSE_BASE_URL=https://cloud.langfuse.com
 ```
+
+**Self-hosted / custom endpoint** — use credentials issued by your endpoint:
+
+```bash
+HERMES_LANGFUSE_PUBLIC_KEY=<your-endpoint-public-key>
+HERMES_LANGFUSE_SECRET_KEY=<your-endpoint-secret-key>
+HERMES_LANGFUSE_BASE_URL=https://your-langfuse-endpoint.example.com
+```
+
+> The `pk-lf-` / `sk-lf-` prefix is validated only when the base URL
+> points at Langfuse Cloud (`*.langfuse.com`). For custom endpoints,
+> any non-empty credentials are accepted and authenticated by the
+> endpoint itself.
 
 Without the SDK or credentials the hooks no-op silently — the plugin fails
 open.

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -68,16 +68,28 @@ _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
 _READ_FILE_TAIL_LINES = 15
 
-# Langfuse-issued keys always carry these prefixes (cloud or self-hosted —
-# the prefix is baked into the server-side issuance flow, not a UI hint).
-# Anything else (`placeholder`, `test-key`, `your-langfuse-key`, etc.) is a
-# leftover template value and would cause the SDK to silently accept the
-# credentials at construction time but drop every trace at flush time.
+# Langfuse Cloud always issues keys with these prefixes (the prefix is baked
+# into the server-side issuance flow, not a UI hint). Anything else
+# (`placeholder`, `test-key`, `your-langfuse-key`, etc.) is a leftover
+# template value and would cause the SDK to silently accept the credentials
+# at construction time but drop every trace at flush time.
 # See #23823 — the silent-failure bug this guard fixes.
+#
+# The prefix check only applies when the configured base URL is a known
+# Langfuse Cloud host. Custom / self-hosted Langfuse-compatible endpoints may
+# issue operator-defined credentials in any format, so their non-empty keys
+# are passed through to the SDK and authenticated by the endpoint itself
+# (#72484).
 _LANGFUSE_KEY_PREFIXES: Dict[str, str] = {
     "HERMES_LANGFUSE_PUBLIC_KEY": "pk-lf-",
     "HERMES_LANGFUSE_SECRET_KEY": "sk-lf-",
 }
+
+# Hosts (and subdomains) for which Langfuse-issued key prefixes are
+# guaranteed. cloud.langfuse.com / us.cloud.langfuse.com / eu.cloud.langfuse.com
+# all fall under langfuse.com.
+_LANGFUSE_CLOUD_HOST_SUFFIX = "langfuse.com"
+_DEFAULT_LANGFUSE_BASE_URL = "https://cloud.langfuse.com"
 
 
 def _env(name: str, default: str = "") -> str:
@@ -126,9 +138,35 @@ def _redact_key_preview(value: str) -> str:
     return repr(value[:6] + "...")
 
 
+def _is_langfuse_cloud_host(base_url: str) -> bool:
+    """Return ``True`` when ``base_url`` points at Langfuse Cloud.
+
+    Only Langfuse Cloud (``langfuse.com`` and its subdomains, e.g.
+    ``cloud.langfuse.com`` / ``us.cloud.langfuse.com``) is guaranteed to
+    issue ``pk-lf-`` / ``sk-lf-`` prefixed keys, so the placeholder
+    prefix guard is scoped to those hosts. Custom or self-hosted
+    Langfuse-compatible endpoints may use operator-issued credentials
+    in any format — for them this returns ``False`` and the endpoint
+    authenticates the credentials itself (#72484). Unparseable URLs are
+    treated as custom endpoints: the operator explicitly configured
+    them, and the SDK will surface any connection problem.
+    """
+    from urllib.parse import urlparse
+
+    try:
+        host = (urlparse(base_url).hostname or "").lower()
+    except Exception:
+        return False
+    return host == _LANGFUSE_CLOUD_HOST_SUFFIX or host.endswith(
+        "." + _LANGFUSE_CLOUD_HOST_SUFFIX
+    )
+
+
 def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
     """Return an error message if ``value`` is not a real Langfuse key.
 
+    Only meaningful for Langfuse Cloud endpoints — the caller must skip
+    this check for custom base URLs (see :func:`_is_langfuse_cloud_host`).
     Returns ``None`` when the value matches the documented Langfuse
     prefix for ``env_name``, or when no prefix is registered for the
     name (in which case we trust the operator).  When validation
@@ -171,6 +209,12 @@ def _get_langfuse() -> Optional[Langfuse]:
         _LANGFUSE_CLIENT = _INIT_FAILED
         return None
 
+    base_url = (
+        _env("HERMES_LANGFUSE_BASE_URL")
+        or _env("LANGFUSE_BASE_URL")
+        or _DEFAULT_LANGFUSE_BASE_URL
+    )
+
     # Reject placeholder credentials with a one-shot warning so the
     # operator sees the misconfiguration instead of silently shipping a
     # broken observability stack (#23823).  The SDK does not validate
@@ -179,26 +223,31 @@ def _get_langfuse() -> Optional[Langfuse]:
     # to post them, by which point the warning is buried under whatever
     # else the process is logging.  Catch it here, surface it once, and
     # short-circuit via the same _INIT_FAILED path as the empty case.
-    placeholder_issues = [
-        msg
-        for msg in (
-            _validate_langfuse_key("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
-            _validate_langfuse_key("HERMES_LANGFUSE_SECRET_KEY", secret_key),
-        )
-        if msg
-    ]
-    if placeholder_issues:
-        logger.warning(
-            "Langfuse plugin: credentials look like placeholders, traces will "
-            "NOT be emitted (%s). Set real Langfuse keys (pk-lf-... / sk-lf-...) "
-            "or unset HERMES_LANGFUSE_PUBLIC_KEY / HERMES_LANGFUSE_SECRET_KEY to "
-            "silence this warning.",
-            "; ".join(placeholder_issues),
-        )
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
+    #
+    # The prefix heuristic is only valid for Langfuse Cloud — custom /
+    # self-hosted Langfuse-compatible endpoints may issue credentials in
+    # any format, so for them non-empty keys are passed straight to the
+    # SDK and the endpoint authenticates them (#72484).
+    if _is_langfuse_cloud_host(base_url):
+        placeholder_issues = [
+            msg
+            for msg in (
+                _validate_langfuse_key("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
+                _validate_langfuse_key("HERMES_LANGFUSE_SECRET_KEY", secret_key),
+            )
+            if msg
+        ]
+        if placeholder_issues:
+            logger.warning(
+                "Langfuse plugin: credentials look like placeholders, traces will "
+                "NOT be emitted (%s). Set real Langfuse keys (pk-lf-... / sk-lf-...) "
+                "or unset HERMES_LANGFUSE_PUBLIC_KEY / HERMES_LANGFUSE_SECRET_KEY to "
+                "silence this warning.",
+                "; ".join(placeholder_issues),
+            )
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
-    base_url = _env("HERMES_LANGFUSE_BASE_URL") or _env("LANGFUSE_BASE_URL") or "https://cloud.langfuse.com"
     environment = _env("HERMES_LANGFUSE_ENV") or _env("LANGFUSE_ENV")
     release = _env("HERMES_LANGFUSE_RELEASE") or _env("LANGFUSE_RELEASE")
     sample_rate = _env("HERMES_LANGFUSE_SAMPLE_RATE")

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -154,7 +154,11 @@ def _is_langfuse_cloud_host(base_url: str) -> bool:
     from urllib.parse import urlparse
 
     try:
-        host = (urlparse(base_url).hostname or "").lower()
+        # urlparse preserves a terminal dot (DNS root notation, e.g.
+        # https://cloud.langfuse.com.), so strip it before comparison
+        # so the placeholder guard still fires for Cloud URLs typed
+        # with an explicit root (#72484 review).
+        host = (urlparse(base_url).hostname or "").lower().rstrip(".")
     except Exception:
         return False
     return host == _LANGFUSE_CLOUD_HOST_SUFFIX or host.endswith(

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -467,6 +467,7 @@ class TestPlaceholderKeyDetection:
         for k in (
             "HERMES_LANGFUSE_PUBLIC_KEY", "HERMES_LANGFUSE_SECRET_KEY",
             "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY",
+            "HERMES_LANGFUSE_BASE_URL", "LANGFUSE_BASE_URL",
         ):
             monkeypatch.delenv(k, raising=False)
 
@@ -687,6 +688,143 @@ class TestPlaceholderKeyDetection:
         assert "placeholders" not in caplog.text.lower(), (
             f"Valid Langfuse keys tripped the placeholder guard: {caplog.text!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Custom-endpoint credential pass-through (#72484).
+#
+# The pk-lf- / sk-lf- prefix is only guaranteed for keys issued by Langfuse
+# Cloud.  Custom / self-hosted Langfuse-compatible ingestion endpoints may
+# issue operator-defined credentials in any format; rejecting those as
+# "placeholders" broke valid deployments and — because the failure is cached
+# via _INIT_FAILED — permanently disabled tracing until restart.  The fix
+# scopes the prefix guard to Langfuse Cloud hosts (langfuse.com and its
+# subdomains) and passes non-empty credentials through for any other
+# configured base URL, letting the endpoint authenticate them itself.
+# ---------------------------------------------------------------------------
+
+
+class TestCustomEndpointCredentials:
+    LOGGER_NAME = "plugins.observability.langfuse"
+
+    def _fresh_plugin(self, monkeypatch=None):
+        mod_name = "plugins.observability.langfuse"
+        sys.modules.pop(mod_name, None)
+        mod = importlib.import_module(mod_name)
+        if monkeypatch is not None:
+            _FakeLangfuse.instances.clear()
+            monkeypatch.setattr(mod, "Langfuse", _FakeLangfuse, raising=False)
+        return mod
+
+    _clear_env = staticmethod(TestPlaceholderKeyDetection._clear_env)
+
+    # -- host classification helper ------------------------------------------
+
+    @pytest.mark.parametrize("base_url", [
+        "https://cloud.langfuse.com",
+        "https://us.cloud.langfuse.com",
+        "https://eu.cloud.langfuse.com",
+        "https://langfuse.com",
+        "https://CLOUD.LANGFUSE.COM",          # case-insensitive host match
+        "https://cloud.langfuse.com:443/path",
+    ])
+    def test_cloud_hosts_detected(self, monkeypatch, base_url):
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin()
+        assert plugin._is_langfuse_cloud_host(base_url) is True
+
+    @pytest.mark.parametrize("base_url", [
+        "https://langfuse-compatible.example.internal",
+        "https://langfuse.mycompany.com",
+        "http://localhost:3000",
+        "https://notlangfuse.com",             # suffix must match on a dot boundary
+        "https://evil-langfuse.com",
+        "https://langfuse.com.evil.example",   # cloud host must END the hostname
+        "not a url at all",
+    ])
+    def test_non_cloud_hosts_detected(self, monkeypatch, base_url):
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin()
+        assert plugin._is_langfuse_cloud_host(base_url) is False
+
+    # -- end-to-end _get_langfuse() behaviour --------------------------------
+
+    def test_custom_endpoint_accepts_non_prefixed_credentials(self, monkeypatch, caplog):
+        """The exact repro from #72484: a custom base URL with valid
+        operator-issued (non-``pk-lf-``/``sk-lf-``) credentials must
+        construct the SDK client and must NOT warn about placeholders."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "custom-public-key")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "custom-secret-key")
+        monkeypatch.setenv(
+            "HERMES_LANGFUSE_BASE_URL",
+            "https://langfuse-compatible.example.internal",
+        )
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            client = plugin._get_langfuse()
+        assert isinstance(client, _FakeLangfuse)
+        assert client.kwargs["public_key"] == "custom-public-key"
+        assert client.kwargs["secret_key"] == "custom-secret-key"
+        assert client.kwargs["base_url"] == "https://langfuse-compatible.example.internal"
+        assert "placeholders" not in caplog.text.lower(), (
+            f"Custom-endpoint credentials tripped the placeholder guard: {caplog.text!r}"
+        )
+
+    def test_custom_endpoint_via_legacy_base_url_env(self, monkeypatch, caplog):
+        """The legacy bare ``LANGFUSE_BASE_URL`` alias must scope the
+        prefix guard exactly like the canonical HERMES_-prefixed var."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "custom-public-key")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "custom-secret-key")
+        monkeypatch.setenv("LANGFUSE_BASE_URL", "http://localhost:3000")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            client = plugin._get_langfuse()
+        assert isinstance(client, _FakeLangfuse)
+        assert client.kwargs["base_url"] == "http://localhost:3000"
+        assert "placeholders" not in caplog.text.lower()
+
+    def test_custom_endpoint_still_requires_non_empty_credentials(self, monkeypatch, caplog):
+        """Skipping the prefix guard must NOT weaken the missing-credentials
+        gate: a custom base URL with empty keys still silently opts out."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv(
+            "HERMES_LANGFUSE_BASE_URL",
+            "https://langfuse-compatible.example.internal",
+        )
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        assert _FakeLangfuse.instances == []
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert warnings == []
+
+    def test_default_base_url_still_enforces_prefix_guard(self, monkeypatch, caplog):
+        """No base URL configured → defaults to Langfuse Cloud → the #23823
+        placeholder guard must keep firing exactly as before."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "placeholder")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "placeholder")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        assert "placeholders" in caplog.text.lower()
+        assert _FakeLangfuse.instances == []
+
+    def test_explicit_cloud_base_url_still_enforces_prefix_guard(self, monkeypatch, caplog):
+        """Explicitly pointing at Langfuse Cloud (including regional
+        subdomains) keeps the prefix guard active."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "custom-public-key")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "custom-secret-key")
+        monkeypatch.setenv("HERMES_LANGFUSE_BASE_URL", "https://us.cloud.langfuse.com")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        assert "placeholders" in caplog.text.lower()
+        assert _FakeLangfuse.instances == []
 
 
 class TestRequestMessageCoercion:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -26,7 +26,7 @@ class TestManifest:
         assert (PLUGIN_DIR / "__init__.py").exists()
 
     def test_manifest_fields(self):
-        data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
+        data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text(encoding="utf-8"))
         assert data["name"] == "langfuse"
         assert data["version"]
         # All six hooks the plugin implements.

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -722,10 +722,12 @@ class TestCustomEndpointCredentials:
 
     @pytest.mark.parametrize("base_url", [
         "https://cloud.langfuse.com",
+        "https://cloud.langfuse.com.",          # dns root dot notation
         "https://us.cloud.langfuse.com",
+        "https://us.cloud.langfuse.com.",       # dns root dot on subdomain
         "https://eu.cloud.langfuse.com",
         "https://langfuse.com",
-        "https://CLOUD.LANGFUSE.COM",          # case-insensitive host match
+        "https://CLOUD.LANGFUSE.COM",           # case-insensitive host match
         "https://cloud.langfuse.com:443/path",
     ])
     def test_cloud_hosts_detected(self, monkeypatch, base_url):

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -161,13 +161,15 @@ pip install langfuse
 hermes plugins enable observability/langfuse
 ```
 
-Then put the credentials in `~/.hermes/.env`:
+Then put the credentials in `~/.hermes/.env`. For **Langfuse Cloud**, keys use the platform-issued `pk-lf-` / `sk-lf-` format:
 
 ```bash
 HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-...
 HERMES_LANGFUSE_SECRET_KEY=sk-lf-...
-HERMES_LANGFUSE_BASE_URL=https://cloud.langfuse.com   # or your self-hosted URL
+HERMES_LANGFUSE_BASE_URL=https://cloud.langfuse.com
 ```
+
+For a **self-hosted or custom endpoint**, use the credentials issued by that endpoint and set `HERMES_LANGFUSE_BASE_URL` to its address:
 
 **How it works:**
 


### PR DESCRIPTION
## What does this PR do?

The bundled `observability/langfuse` plugin unconditionally rejected credentials that do not carry the `pk-lf-` / `sk-lf-` prefix, treating them as placeholders. That heuristic is only guaranteed for keys issued by **Langfuse Cloud** — custom or self-hosted Langfuse-compatible ingestion endpoints may issue operator-defined credentials in any format. Because the rejection is cached via `_INIT_FAILED`, a single format mismatch permanently disabled tracing until process restart.

This PR scopes the prefix placeholder guard to Langfuse Cloud hosts only, exactly as the issue suggests, while fully preserving the #23823 placeholder protection for cloud/default URLs.

## Related Issue

Fixes #72484

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`plugins/observability/langfuse/__init__.py`:

- `_get_langfuse()` now resolves `base_url` **before** credential validation.
- Added `_is_langfuse_cloud_host()`: the prefix placeholder guard only runs when the configured host is Langfuse Cloud (`langfuse.com` or a subdomain, matched case-insensitively on a dot boundary — so `evil-langfuse.com` / `langfuse.com.evil.example` do **not** qualify).
- For any other endpoint, non-empty credentials are passed straight to the Langfuse SDK and the endpoint authenticates them itself.

`tests/plugins/test_langfuse_plugin.py`:

- New `TestCustomEndpointCredentials` regression suite (see How to Test).
- `TestPlaceholderKeyDetection._clear_env` now also clears `HERMES_LANGFUSE_BASE_URL` / `LANGFUSE_BASE_URL` so developer machines with a custom URL configured can't skew the existing guard tests.
- Drive-by: added `encoding="utf-8"` to a bare `read_text()` flagged by `scripts/check-windows-footguns.py` (pre-existing; the script scans every file a PR touches).

**What is preserved:**

- **#23823 guard intact**: with the default (unset) base URL or any `*.langfuse.com` URL, placeholder values like `placeholder` / `test-key` still produce the one-shot warning and short-circuit via `_INIT_FAILED`.
- **Missing-credentials gate unchanged**: empty keys still silently opt out, for custom endpoints too.
- One-shot warning semantics and the `_INIT_FAILED` caching model are untouched.

## How to Test

1. Repro the bug on `main`: set `HERMES_LANGFUSE_BASE_URL=https://langfuse.internal.example.com`, `HERMES_LANGFUSE_PUBLIC_KEY=custom-public-key`, `HERMES_LANGFUSE_SECRET_KEY=custom-secret-key` → plugin logs the placeholder warning and permanently disables tracing.
2. On this branch, same env → the Langfuse SDK client is constructed and traces flow to the custom endpoint; no warning.
3. Regression: unset the base URL (or point it at `cloud.langfuse.com`) with `HERMES_LANGFUSE_PUBLIC_KEY=placeholder` → the #23823 one-shot warning still fires and the plugin opts out.
4. Run the test suite: `scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py` → 66 passed. New `TestCustomEndpointCredentials` covers: exact issue repro, legacy `LANGFUSE_BASE_URL` alias, custom endpoint + empty keys (still silent opt-out), default/explicit cloud URLs (guard still fires), and a host-classification matrix incl. lookalike/suffix-boundary hosts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite via `scripts/run_tests.sh` — all langfuse plugin tests pass (66/66); the handful of failures elsewhere in the full run (acp/gateway/anthropic-adapter) reproduce identically on a clean `origin/main` worktree and are unrelated to this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] Relevant documentation updated — N/A (behavior change is documented in code comments; no user-facing docs describe the prefix guard)
- [x] `cli-config.yaml.example` — N/A (no config keys added or changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python `urllib.parse` change; `scripts/check-windows-footguns.py --diff origin/main` passes
- [x] Tool descriptions/schemas — N/A (no tool behavior changed)
