### PR TITLE
Fix: split concatenated JSON tool_call arguments instead of discarding them

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -37,6 +37,7 @@ from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
+    _split_concatenated_json_objects,
 )
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 from tools.terminal_tool import is_persistent_env
@@ -3084,6 +3085,32 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     try:
                         json.loads(arguments)
                     except json.JSONDecodeError:
+                        # Some models (observed: Gemini 3.5 Flash) try to
+                        # call the same tool for N items by concatenating
+                        # N complete JSON objects instead of emitting N
+                        # separate tool_calls. Detect that narrow pattern
+                        # first — it needs splitting into multiple tool
+                        # calls, not string repair. Falls through to
+                        # normal single-object repair for every other
+                        # malformation (truncation, trailing commas, etc).
+                        split_args = _split_concatenated_json_objects(arguments)
+                        if split_args is not None:
+                            logger.warning(
+                                "Split concatenated tool_call arguments for "
+                                "%s into %d separate calls",
+                                tool_name, len(split_args),
+                            )
+                            for split_idx, split_arg in enumerate(split_args):
+                                mock_tool_calls.append(SimpleNamespace(
+                                    id=f"{tc['id']}_split{split_idx}",
+                                    type=tc["type"],
+                                    extra_content=tc.get("extra_content"),
+                                    function=SimpleNamespace(
+                                        name=tc["function"]["name"],
+                                        arguments=split_arg,
+                                    ),
+                                ))
+                            continue
                         # Attempt repair before flagging as truncated.
                         # Models like GLM-5.1 via Ollama produce trailing
                         # commas, unclosed brackets, Python None, etc.

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -279,6 +279,76 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     return "{}"
 
 
+def _split_concatenated_json_objects(raw: str) -> list | None:
+    """If ``raw`` is 2+ complete top-level JSON objects concatenated with
+    no separator, return the list of individual JSON strings; else None.
+
+    Some models (observed: Gemini 3.5 Flash, both on built-in tools like
+    ``search_files`` and single-item-schema MCP tools) try to express
+    "call this tool N times for N items" by emitting N complete JSON
+    objects back-to-back in a single tool_call's arguments field instead
+    of emitting N separate tool_calls, e.g.
+    ``{"path": "a.json"}{"path": "b.json"}``. This is invalid as a single
+    argument object and previously fell through to
+    ``_repair_tool_call_arguments``, which cannot fix it (no amount of
+    brace-balancing repairs a second complete object) and returns ``"{}"``,
+    silently discarding every item but the first. Detecting this narrow
+    pattern lets the caller expand it into N separate tool calls instead.
+
+    Deliberately conservative: bails to ``None`` (unchanged behavior,
+    falls through to normal single-object repair) unless every character
+    is accounted for by 2+ individually-valid JSON objects with only
+    whitespace between them. A genuinely truncated single object (e.g.
+    cut off mid-array before ever closing) never reaches depth 0 twice,
+    so it always returns None here, not a false split.
+    """
+    s = raw.strip()
+    if not s or s[0] != "{":
+        return None
+
+    objects = []
+    depth = 0
+    in_string = False
+    escape = False
+    start = 0
+    for i, ch in enumerate(s):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                objects.append(s[start:i + 1])
+                j = i + 1
+                while j < len(s) and s[j].isspace():
+                    j += 1
+                start = j
+            elif depth < 0:
+                return None
+
+    if len(objects) < 2:
+        return None
+    if start != len(s):
+        return None
+
+    for obj in objects:
+        try:
+            json.loads(obj)
+        except json.JSONDecodeError:
+            return None
+    return objects
+
+
 def close_interrupted_tool_sequence(messages: list, final_response: Any = None) -> bool:
     """Append a synthetic assistant turn when an interrupted tail is a tool result.
 
@@ -469,6 +539,7 @@ __all__ = [
     "_sanitize_messages_surrogates",
     "_escape_invalid_chars_in_json_strings",
     "_repair_tool_call_arguments",
+    "_split_concatenated_json_objects",
     "_strip_non_ascii",
     "_sanitize_messages_non_ascii",
     "_sanitize_tools_non_ascii",

--- a/run_agent.py
+++ b/run_agent.py
@@ -176,6 +176,7 @@ from agent.message_sanitization import (  # noqa: F401
     _sanitize_messages_surrogates,
     _escape_invalid_chars_in_json_strings,
     _repair_tool_call_arguments,
+    _split_concatenated_json_objects,
     _strip_non_ascii,
     _sanitize_messages_non_ascii,
     _sanitize_tools_non_ascii,

--- a/tests/run_agent/test_split_concatenated_json_objects.py
+++ b/tests/run_agent/test_split_concatenated_json_objects.py
@@ -1,0 +1,89 @@
+"""Tests for _split_concatenated_json_objects — detects models emitting N
+complete JSON objects back-to-back in a single tool_call's arguments
+instead of N separate tool_calls (observed with Gemini 3.5 Flash on both
+built-in tools like search_files and MCP tools with single-item schemas)."""
+
+import json
+
+from run_agent import _split_concatenated_json_objects
+
+
+class TestSplitConcatenatedJsonObjects:
+    def test_two_simple_objects(self):
+        raw = '{"path": "a.json"}{"path": "b.json"}'
+        result = _split_concatenated_json_objects(raw)
+        assert result == ['{"path": "a.json"}', '{"path": "b.json"}']
+
+    def test_three_objects(self):
+        raw = '{"id": "111"}{"id": "222"}{"id": "333"}'
+        result = _split_concatenated_json_objects(raw)
+        assert len(result) == 3
+        assert [json.loads(r)["id"] for r in result] == ["111", "222", "333"]
+
+    def test_whitespace_between_objects(self):
+        raw = '{"a": 1}\n  {"b": 2}'
+        result = _split_concatenated_json_objects(raw)
+        assert result is not None
+        assert len(result) == 2
+
+    def test_nested_objects_within_each_item(self):
+        raw = '{"data": {"nested": true}}{"data": {"nested": false}}'
+        result = _split_concatenated_json_objects(raw)
+        assert len(result) == 2
+        assert json.loads(result[0])["data"]["nested"] is True
+        assert json.loads(result[1])["data"]["nested"] is False
+
+    # -- Must NOT match: single valid object --
+
+    def test_single_object_returns_none(self):
+        assert _split_concatenated_json_objects('{"a": 1}') is None
+
+    # -- Must NOT match: genuinely truncated single object --
+
+    def test_genuinely_truncated_object_returns_none(self):
+        raw = (
+            '{"dataPoints": [{"type": "Tech Stack"}, '
+            '{"type": "Competitors"}],'
+        )
+        assert _split_concatenated_json_objects(raw) is None
+
+    def test_empty_string_returns_none(self):
+        assert _split_concatenated_json_objects("") is None
+
+    def test_non_json_garbage_returns_none(self):
+        assert _split_concatenated_json_objects("not json at all") is None
+
+    def test_trailing_garbage_after_last_object_returns_none(self):
+        assert _split_concatenated_json_objects('{"a": 1} trailing garbage') is None
+
+    def test_unbalanced_extra_closing_brace_returns_none(self):
+        assert _split_concatenated_json_objects('{"a": 1}}') is None
+
+    # -- String-aware scanning: `}{ ` inside a string value must not be
+    #    mistaken for an object boundary --
+
+    def test_braces_inside_string_value_not_mistaken_for_boundary(self):
+        raw = '{"a": "text with }{ inside a string"}{"b": 2}'
+        result = _split_concatenated_json_objects(raw)
+        assert result is not None
+        assert len(result) == 2
+        assert json.loads(result[0])["a"] == "text with }{ inside a string"
+        assert json.loads(result[1])["b"] == 2
+
+    def test_escaped_quote_inside_string_does_not_break_scanning(self):
+        raw = r'{"a": "she said \"hi\""}{"b": 2}'
+        result = _split_concatenated_json_objects(raw)
+        assert result is not None
+        assert len(result) == 2
+
+    # -- Real-world production case: a file-read tool with two paths --
+
+    def test_real_world_read_file_two_paths(self):
+        raw = (
+            '{"path": "./report_a.json"}'
+            '{"path": "./report_b.json"}'
+        )
+        result = _split_concatenated_json_objects(raw)
+        assert len(result) == 2
+        paths = [json.loads(r)["path"] for r in result]
+        assert paths == ["./report_a.json", "./report_b.json"]


### PR DESCRIPTION
Fixes #72488

## Problem

Gemini 3.5 Flash occasionally emits multiple complete JSON objects concatenated back-to-back in a single `tool_call`'s `arguments` field instead of separate `tool_calls` entries, when asked to process a list of items through a single-item-parameter tool. The existing repair pipeline (`_repair_tool_call_arguments`) can't fix this — it's built to repair one malformed/truncated object, not to split two-or-more complete concatenated objects — so it falls through to the last-resort `\"{}\"` replacement, silently discarding the whole batch.

## Fix

- Added `_split_concatenated_json_objects` to `agent/message_sanitization.py`: a string-aware (quote/escape-tracking) scanner that detects the narrow "2+ complete top-level JSON objects, only whitespace between them" pattern and returns the list of individual JSON strings. Falls through to `None` (unchanged behavior) for every other malformation, including a genuinely truncated single object — verified with a dedicated regression test using a real truncated-object example.
- Wired into the execution-time repair site in `agent/chat_completion_helpers.py`: tries the split before falling through to `_repair_tool_call_arguments`. On a successful split, expands the single malformed tool_call into N separate valid tool_calls (with unique derived IDs) instead of collapsing to `{}`.
- Re-exported from `run_agent.py` alongside the existing `_repair_tool_call_arguments` re-export, for consistency with the module's existing backward-compat re-export pattern.
- 13 new unit tests in `tests/run_agent/test_split_concatenated_json_objects.py`.

## Testing

All 13 new tests pass, plus the full existing `tests/run_agent/test_repair_tool_call_arguments.py`, `test_streaming_tool_call_repair.py`, and `test_tool_call_args_sanitizer.py` suites (53 tests total, no regressions).

This has also been verified in a live production deployment: a task that previously failed with a generic "response truncated" condition after this exact malformed-tool-call pattern fired repeatedly now completes successfully, with the new split path firing and correctly recovering the intended tool calls.