### PR TITLE
fix(signal): detect M4A-branded voice notes so iOS audio reaches STT

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -100,6 +100,14 @@ def _guess_extension(data: bytes) -> str:
     if data[:4] == b"%PDF":
         return ".pdf"
     if len(data) >= 8 and data[4:8] == b"ftyp":
+        # iOS Signal delivers voice notes as MP4-container AAC carrying an
+        # audio ftyp brand ("M4A ", "M4B "). Returning ".mp4" for those made
+        # them cache as documents and STT reject them ("Invalid file
+        # format") even though the bytes are valid audio. Read the brand so
+        # audio-branded files land as ".m4a" and route to the audio cache.
+        brand = data[8:12].lower() if len(data) >= 12 else b""
+        if brand in (b"m4a ", b"m4b "):
+            return ".m4a"
         return ".mp4"
     if data[:4] == b"OggS":
         return ".ogg"

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -164,6 +164,26 @@ class TestSignalHelpers:
         from gateway.platforms.signal import _guess_extension
         assert _guess_extension(b"\x00\x00\x00\x18ftypisom" + b"\x00" * 100) == ".mp4"
 
+    def test_guess_extension_m4a_audio_brand(self):
+        """iOS Signal voice notes are MP4-container AAC with an M4A ftyp brand.
+
+        Classifying them as ``.mp4`` sent them to the document cache and made
+        STT reject the upload ("Invalid file format") even though the bytes
+        were valid audio. Audio brands must resolve to ``.m4a``.
+        """
+        from gateway.platforms.signal import _guess_extension, _is_audio_ext
+        for brand in (b"M4A ", b"M4B ", b"m4a "):
+            data = b"\x00\x00\x00\x1cftyp" + brand + b"\x00" * 100
+            assert _guess_extension(data) == ".m4a", brand
+            assert _is_audio_ext(_guess_extension(data)) is True
+
+    def test_guess_extension_video_brands_stay_mp4(self):
+        """Real video ftyp brands must not be swept up by the M4A fix."""
+        from gateway.platforms.signal import _guess_extension
+        for brand in (b"isom", b"mp42", b"avc1", b"qt  "):
+            data = b"\x00\x00\x00\x1cftyp" + brand + b"\x00" * 100
+            assert _guess_extension(data) == ".mp4", brand
+
     def test_guess_extension_aac_adts_unprotected(self):
         """ADTS AAC, MPEG-4, no CRC (the canonical Android Signal voice note).
 


### PR DESCRIPTION
## What does this PR do?

Fixes inbound **iOS Signal voice notes** never reaching STT.

iOS delivers voice notes as MP4-container AAC carrying an **audio `ftyp` brand** (`M4A `). `_guess_extension()` in `gateway/platforms/signal.py` returned `".mp4"` for *every* `ftyp` file regardless of brand, so those attachments:

- failed `_is_audio_ext(".mp4")` → cached via `cache_document_from_bytes()` instead of `cache_audio_from_bytes()`, and
- were rejected by the STT upload even when transcription was attempted:

```
API error: Error code: 400 - {'error': {'message': "Invalid file format.
Supported formats: ['flac','m4a','mp3','mp4','mpeg','mpga','oga','ogg','wav','webm']"}}
```

The rest of the adapter is already fully wired for M4A — `.m4a` is present in both `_is_audio_ext()` and `_EXT_TO_MIME` (`audio/mp4`). Only the byte sniffer never produced `.m4a`.

This is the **iOS counterpart to #47766**, which fixed the same end-user symptom for *Android* (raw ADTS AAC). Android was covered; iOS still silently fell through.

## Related Issue

No existing issue — found while debugging a live gateway. Closest related work:
- #47766 (merged) — Android ADTS AAC voice notes; same symptom, different container.
- #50690 (open) — the `RIFF`/`WAVE` sibling gap in this same function. **Not a duplicate:** that PR adds a `RIFF` branch and does not touch the `ftyp` branch. The two are independent and do not conflict.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/signal.py` — `_guess_extension()` now reads the 4-byte brand at offset 8 of an `ftyp` box and returns `".m4a"` for audio brands (`M4A `, `M4B `). All other brands keep returning `".mp4"`.
- `tests/gateway/test_signal.py` — two regression tests:
  - `test_guess_extension_m4a_audio_brand` — audio brands sniff to `.m4a` **and** satisfy `_is_audio_ext()`.
  - `test_guess_extension_video_brands_stay_mp4` — `isom`/`mp42`/`avc1`/`qt  ` still return `.mp4`.

The approach deliberately mirrors the brand/form-type disambiguation this function already uses for `RIFF` (`WEBP` vs `WAVE`) and for ADTS AAC vs MP3 — no new helper, no new imports, 3 lines of logic.

## How to Test

Against a **real iOS Signal voice note** (bytes begin `00 00 00 1c 66 74 79 70 4d 34 41 20` → `ftypM4A `):

```python
from gateway.platforms.signal import _guess_extension, _is_audio_ext
from tools.transcription_tools import transcribe_audio, SUPPORTED_FORMATS

raw = open("ios_voice_note", "rb").read()
ext = _guess_extension(raw)          # before: '.mp4'   after: '.m4a'
_is_audio_ext(ext)                   # before: False    after: True
ext in SUPPORTED_FORMATS             # before: False    after: True
```

End-to-end on the same bytes:

- **before:** `transcribe_audio()` → `400 Invalid file format`
- **after:** `transcribe_audio()` → `success=True` with a correct transcript

Suite (canonical runner, per-file isolation):

```
$ scripts/run_tests.sh tests/gateway/test_signal.py \
    tests/gateway/test_signal_format.py tests/gateway/test_signal_rate_limit.py
=== Summary: 3 files, 212 tests passed, 0 failed (100% complete) ===
```

Wider `tests/gateway/ tests/tools/` run shows no new failures — the failures present are identical with and without this branch applied (verified by stashing the change and re-running clean `main`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all relevant tests pass
- [x] I've added tests for my changes
