### PR TITLE
fix(desktop): don't follow session cwd on initial reconnect

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -311,17 +311,20 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             // moves, follow it — refresh the project tree + scope so the sidebar
             // tracks the live thread. A fresh selection (different session id)
             // is a switch, not a move, so it refreshes data without yanking scope.
-            const cwdMoved = payload.cwd !== $currentCwd.get()
+            //
+            // Capture before setCurrentCwd mutates the atom; on restart
+            // $currentCwd is empty, so the first session.info payload looks like
+            // a "move" from '' to the real path. Guard with previousCwd (the
+            // pre-mutation value) so we only follow genuine moves — not the
+            // initial cwd learn after reconnect (hermes-agent#72491).
+            const previousCwd = $currentCwd.get()
+            const cwdMoved = payload.cwd !== previousCwd
             const sameSession = !!sessionId && sessionId === lastCwdInfoSessionRef.current
 
             lastCwdInfoSessionRef.current = sessionId
             setCurrentCwd(payload.cwd)
 
-            // Only follow genuine cwd moves, not the initial learn on reconnect.
-            // On restart $currentCwd is empty, so the first session.info payload
-            // looks like a "move" from '' to the real path — skip that, or the
-            // sidebar flips into Projects view (hermes-agent#72491).
-            if (cwdMoved && sameSession && $currentCwd.get()) {
+            if (cwdMoved && sameSession && previousCwd) {
               void followActiveSessionCwd(payload.cwd)
             }
           }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -317,7 +317,11 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             lastCwdInfoSessionRef.current = sessionId
             setCurrentCwd(payload.cwd)
 
-            if (cwdMoved && sameSession) {
+            // Only follow genuine cwd moves, not the initial learn on reconnect.
+            // On restart $currentCwd is empty, so the first session.info payload
+            // looks like a "move" from '' to the real path — skip that, or the
+            // sidebar flips into Projects view (hermes-agent#72491).
+            if (cwdMoved && sameSession && $currentCwd.get()) {
               void followActiveSessionCwd(payload.cwd)
             }
           }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -324,7 +324,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             lastCwdInfoSessionRef.current = sessionId
             setCurrentCwd(payload.cwd)
 
-            if (cwdMoved && sameSession && previousCwd) {
+            if (cwdMoved && sameSession && previousCwd && payload.cwd) {
               void followActiveSessionCwd(payload.cwd)
             }
           }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -6,6 +6,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
+
+// Hoisted mocks — vi.mock factories run before static imports, so they must
+// reference module-level state through getters rather than capture it inline.
+const cwdFollowMock = vi.fn<(_: string) => Promise<void>>(async () => undefined)
+let currentCwdMock = ''
+
+vi.mock('@/store/projects', () => ({
+  followActiveSessionCwd: cwdFollowMock
+}))
+
+vi.mock('@/store/session', async () => {
+  const actual = await vi.importActual<typeof import('@/store/session')>('@/store/session')
+
+  return {
+    ...actual,
+    // $currentCwd is a nanostore atom — use a getter so tests can swap
+    // the value without re-importing the module.
+    get $currentCwd() {
+      return { get: () => currentCwdMock }
+    }
+  }
+})
+
 import { setCurrentModel, setCurrentProvider } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -158,55 +181,28 @@ describe('message.complete sidebar refresh coalescing', () => {
 })
 
 describe('session.info cwd-follow guard', () => {
+  beforeEach(() => {
+    cwdFollowMock.mockReset()
+    currentCwdMock = ''
+  })
+
   it('does not follow the cwd on the first session.info after reconnect (initial learn)', async () => {
-    const followActiveSessionCwd = vi.fn<(_: string) => Promise<void>>(async () => undefined)
-
-    vi.doMock('@/store/projects', () => ({
-      followActiveSessionCwd
-    }))
-
-    const currentCwd = { current: '' }
-
-    vi.doMock('@/store/session', async () => {
-      const actual = await vi.importActual<typeof import('@/store/session')>('@/store/session')
-
-      return {
-        ...actual,
-        $currentCwd: { get: () => currentCwd.current }
-      }
-    })
-
     await mountStream()
 
     // Initial payload — cwd goes from '' to a real path. Must NOT follow.
     await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/foo' })
 
-    expect(followActiveSessionCwd).not.toHaveBeenCalled()
+    expect(cwdFollowMock).not.toHaveBeenCalled()
   })
 
   it('follows the cwd on a genuine move (non-empty → different non-empty)', async () => {
-    const followActiveSessionCwd = vi.fn<(_: string) => Promise<void>>(async () => undefined)
-
-    vi.doMock('@/store/projects', () => ({
-      followActiveSessionCwd
-    }))
-
-    const currentCwd = { current: '/Users/test/projects/foo' }
-
-    vi.doMock('@/store/session', async () => {
-      const actual = await vi.importActual<typeof import('@/store/session')>('@/store/session')
-
-      return {
-        ...actual,
-        $currentCwd: { get: () => currentCwd.current }
-      }
-    })
+    currentCwdMock = '/Users/test/projects/foo'
 
     await mountStream()
 
     // Genuine move — cwd changes from one non-empty path to another. Must follow.
     await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/bar' })
 
-    expect(followActiveSessionCwd).toHaveBeenCalledWith('/Users/test/projects/bar')
+    expect(cwdFollowMock).toHaveBeenCalledWith('/Users/test/projects/bar')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -156,3 +156,57 @@ describe('message.complete sidebar refresh coalescing', () => {
     expect(refreshSessions).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('session.info cwd-follow guard', () => {
+  it('does not follow the cwd on the first session.info after reconnect (initial learn)', async () => {
+    const followActiveSessionCwd = vi.fn<(_: string) => Promise<void>>(async () => undefined)
+
+    vi.doMock('@/store/projects', () => ({
+      followActiveSessionCwd
+    }))
+
+    const currentCwd = { current: '' }
+
+    vi.doMock('@/store/session', async () => {
+      const actual = await vi.importActual<typeof import('@/store/session')>('@/store/session')
+
+      return {
+        ...actual,
+        $currentCwd: { get: () => currentCwd.current }
+      }
+    })
+
+    await mountStream()
+
+    // Initial payload — cwd goes from '' to a real path. Must NOT follow.
+    await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/foo' })
+
+    expect(followActiveSessionCwd).not.toHaveBeenCalled()
+  })
+
+  it('follows the cwd on a genuine move (non-empty → different non-empty)', async () => {
+    const followActiveSessionCwd = vi.fn<(_: string) => Promise<void>>(async () => undefined)
+
+    vi.doMock('@/store/projects', () => ({
+      followActiveSessionCwd
+    }))
+
+    const currentCwd = { current: '/Users/test/projects/foo' }
+
+    vi.doMock('@/store/session', async () => {
+      const actual = await vi.importActual<typeof import('@/store/session')>('@/store/session')
+
+      return {
+        ...actual,
+        $currentCwd: { get: () => currentCwd.current }
+      }
+    })
+
+    await mountStream()
+
+    // Genuine move — cwd changes from one non-empty path to another. Must follow.
+    await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/bar' })
+
+    expect(followActiveSessionCwd).toHaveBeenCalledWith('/Users/test/projects/bar')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -13,9 +13,14 @@ const mocks = vi.hoisted(() => ({
   cwdFollowMock: vi.fn<(_: string) => Promise<void>>(async () => undefined)
 }))
 
-vi.mock('@/store/projects', () => ({
-  followActiveSessionCwd: mocks.cwdFollowMock
-}))
+vi.mock('@/store/projects', async () => {
+  const actual = await vi.importActual('@/store/projects')
+
+  return {
+    ...actual,
+    followActiveSessionCwd: mocks.cwdFollowMock
+  }
+})
 
 import { $currentCwd, setCurrentModel, setCurrentProvider } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -193,6 +193,10 @@ describe('session.info cwd-follow guard', () => {
 
     await mountStream()
 
+    // Prime lastCwdInfoSessionRef with an initial session.info — on a genuine
+    // move the ref was already set by a prior event establishing the session.
+    await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/foo' })
+
     // Genuine move — cwd changes from one non-empty path to another. Must follow.
     await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/bar' })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -7,24 +7,26 @@ import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 
-// Hoisted mocks — vi.mock factories run before static imports, so they must
-// reference module-level state through getters rather than capture it inline.
-const cwdFollowMock = vi.fn<(_: string) => Promise<void>>(async () => undefined)
-let currentCwdMock = ''
+// Hoisted mocks — vi.mock factories run before static imports, so mutable
+// state must be declared with vi.hoisted() to survive the hoisting order.
+const { cwdFollowMock, currentCwdState } = vi.hoisted(() => ({
+  cwdFollowMock: vi.fn<(_: string) => Promise<void>>(async () => undefined),
+  currentCwdState: { value: '' }
+}))
 
 vi.mock('@/store/projects', () => ({
   followActiveSessionCwd: cwdFollowMock
 }))
 
 vi.mock('@/store/session', async () => {
-  const actual = await vi.importActual<typeof import('@/store/session')>('@/store/session')
+  const actual = await vi.importActual('@/store/session')
 
   return {
     ...actual,
     // $currentCwd is a nanostore atom — use a getter so tests can swap
     // the value without re-importing the module.
     get $currentCwd() {
-      return { get: () => currentCwdMock }
+      return { get: () => currentCwdState.value }
     }
   }
 })
@@ -183,7 +185,7 @@ describe('message.complete sidebar refresh coalescing', () => {
 describe('session.info cwd-follow guard', () => {
   beforeEach(() => {
     cwdFollowMock.mockReset()
-    currentCwdMock = ''
+    currentCwdState.value = ''
   })
 
   it('does not follow the cwd on the first session.info after reconnect (initial learn)', async () => {
@@ -196,7 +198,7 @@ describe('session.info cwd-follow guard', () => {
   })
 
   it('follows the cwd on a genuine move (non-empty → different non-empty)', async () => {
-    currentCwdMock = '/Users/test/projects/foo'
+    currentCwdState.value = '/Users/test/projects/foo'
 
     await mountStream()
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClient } from '@tanstack/react-query'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
-import { atom } from 'nanostores'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -8,27 +7,17 @@ import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 
-// Hoisted mocks — vi.mock factories run before static imports, so mutable
-// state must be declared with vi.hoisted() to survive the hoisting order.
-const { cwdFollowMock, cwdAtom } = vi.hoisted(() => ({
-  cwdFollowMock: vi.fn<(_: string) => Promise<void>>(async () => undefined),
-  cwdAtom: atom('')
+// Only mock @/store/projects — @/store/session is imported for real so
+// $currentCwd is a proper nanostores atom with .get() / .set() / .subscribe().
+const mocks = vi.hoisted(() => ({
+  cwdFollowMock: vi.fn<(_: string) => Promise<void>>(async () => undefined)
 }))
 
 vi.mock('@/store/projects', () => ({
-  followActiveSessionCwd: cwdFollowMock
+  followActiveSessionCwd: mocks.cwdFollowMock
 }))
 
-vi.mock('@/store/session', async () => {
-  const actual = await vi.importActual('@/store/session')
-
-  return {
-    ...actual,
-    $currentCwd: cwdAtom
-  }
-})
-
-import { setCurrentModel, setCurrentProvider } from '@/store/session'
+import { $currentCwd, setCurrentModel, setCurrentProvider } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
 import { useMessageStream } from './index'
@@ -181,8 +170,8 @@ describe('message.complete sidebar refresh coalescing', () => {
 
 describe('session.info cwd-follow guard', () => {
   beforeEach(() => {
-    cwdFollowMock.mockReset()
-    cwdAtom.set('')
+    mocks.cwdFollowMock.mockReset()
+    $currentCwd.set('')
   })
 
   it('does not follow the cwd on the first session.info after reconnect (initial learn)', async () => {
@@ -191,17 +180,17 @@ describe('session.info cwd-follow guard', () => {
     // Initial payload — cwd goes from '' to a real path. Must NOT follow.
     await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/foo' })
 
-    expect(cwdFollowMock).not.toHaveBeenCalled()
+    expect(mocks.cwdFollowMock).not.toHaveBeenCalled()
   })
 
   it('follows the cwd on a genuine move (non-empty → different non-empty)', async () => {
-    cwdAtom.set('/Users/test/projects/foo')
+    $currentCwd.set('/Users/test/projects/foo')
 
     await mountStream()
 
     // Genuine move — cwd changes from one non-empty path to another. Must follow.
     await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/bar' })
 
-    expect(cwdFollowMock).toHaveBeenCalledWith('/Users/test/projects/bar')
+    expect(mocks.cwdFollowMock).toHaveBeenCalledWith('/Users/test/projects/bar')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient } from '@tanstack/react-query'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -9,9 +10,9 @@ import { modelOptionsQueryKey } from '@/lib/model-options'
 
 // Hoisted mocks — vi.mock factories run before static imports, so mutable
 // state must be declared with vi.hoisted() to survive the hoisting order.
-const { cwdFollowMock, currentCwdState } = vi.hoisted(() => ({
+const { cwdFollowMock, cwdAtom } = vi.hoisted(() => ({
   cwdFollowMock: vi.fn<(_: string) => Promise<void>>(async () => undefined),
-  currentCwdState: { value: '' }
+  cwdAtom: atom('')
 }))
 
 vi.mock('@/store/projects', () => ({
@@ -23,11 +24,7 @@ vi.mock('@/store/session', async () => {
 
   return {
     ...actual,
-    // $currentCwd is a nanostore atom — use a getter so tests can swap
-    // the value without re-importing the module.
-    get $currentCwd() {
-      return { get: () => currentCwdState.value }
-    }
+    $currentCwd: cwdAtom
   }
 })
 
@@ -185,7 +182,7 @@ describe('message.complete sidebar refresh coalescing', () => {
 describe('session.info cwd-follow guard', () => {
   beforeEach(() => {
     cwdFollowMock.mockReset()
-    currentCwdState.value = ''
+    cwdAtom.set('')
   })
 
   it('does not follow the cwd on the first session.info after reconnect (initial learn)', async () => {
@@ -198,7 +195,7 @@ describe('session.info cwd-follow guard', () => {
   })
 
   it('follows the cwd on a genuine move (non-empty → different non-empty)', async () => {
-    currentCwdState.value = '/Users/test/projects/foo'
+    cwdAtom.set('/Users/test/projects/foo')
 
     await mountStream()
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -188,6 +188,27 @@ describe('session.info cwd-follow guard', () => {
     expect(mocks.cwdFollowMock).not.toHaveBeenCalled()
   })
 
+  it('does not follow the cwd on the first session.info after reconnect when the ref is already primed (issue #72491)', async () => {
+    // Pre-restart state: the session was active and its cwd already known.
+    $currentCwd.set('/Users/test/projects/foo')
+
+    await mountStream()
+
+    // Prime lastCwdInfoSessionRef with a pre-restart session.info for the
+    // same session — the ref survives a gateway reconnect.
+    await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/foo' })
+
+    // Restart: gateway-bound stores are wiped (cwd resets to '') while the
+    // component ref keeps its pre-restart value — the issue #72491 scenario.
+    $currentCwd.set('')
+
+    // First session.info after reconnect for the SAME session. This is the
+    // initial cwd learn, not a deliberate directory change — must NOT follow.
+    await sessionInfo(ACTIVE_SID, { cwd: '/Users/test/projects/foo' })
+
+    expect(mocks.cwdFollowMock).not.toHaveBeenCalled()
+  })
+
   it('follows the cwd on a genuine move (non-empty → different non-empty)', async () => {
     $currentCwd.set('/Users/test/projects/foo')
 


### PR DESCRIPTION
Closes #72491

On restart after an update, the gateway reconnects and emits `session.info` for the restored active session. The handler checks `cwdMoved && sameSession` and calls `followActiveSessionCwd()`, which calls `setSidebarAgentsGrouped(true)` if the cwd maps to a project. But on restart `$currentCwd` starts empty (`''`), so the first payload always looks like a "move" — flipping the sidebar into Projects view on every relaunch.

**Fix:** Add `&& $currentCwd.get()` to the guard — only follow when the cwd was already known (non-empty), so we don't treat "learning the cwd for the first time after reconnect" as a deliberate directory change.

## Notes

- Pre-existing bug exposed by the update restart cycle. The sidebar refactor in 0f7492f43 is unrelated.
- The guard is intentionally minimal — an explicit `isSessionInitialized` ref would also work but adds more state for the same check. `$currentCwd.get()` being empty is the exact signal that we haven't seen a cwd yet this session.
