### PR TITLE
fix(desktop): detect global truncation in legacy sidebar path

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -157,7 +157,7 @@ import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
-import { fetchPrimaryProfileSessions } from './profile-session-routing'
+import { fetchPrimaryProfileSessions, profilesTruncatedFrom } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
@@ -10082,6 +10082,7 @@ async function interceptSessionRequestForRemote(request) {
     }
 
     const recentsSp = sliceParams('recents_limit', '20', { profile: recentsProfile })
+    const recentsCap = Number(searchParams.get('recents_limit')) || 20
     const recentsExclude = searchParams.get('recents_exclude')
 
     if (recentsExclude) {
@@ -10107,7 +10108,16 @@ async function interceptSessionRequestForRemote(request) {
       recents: {
         sessions: rowsOf(recents),
         total: Number(recents?.total) || 0,
-        profile_totals: recents?.profile_totals || {}
+        profile_totals: recents?.profile_totals || {},
+        // The per-slice responses carry exact per-profile totals but no
+        // truncation flags (the batched route computes those server-side);
+        // derive them here so remote-profile setups keep the per-profile
+        // "Load more" affordance the local fast path gets for free.
+        profiles_truncated: profilesTruncatedFrom(
+          rowsOf(recents) as Array<{ profile?: string }>,
+          recentsCap,
+          (recents?.profile_totals || {}) as Record<string, number>
+        )
       },
       cron: { sessions: rowsOf(cron) },
       messaging: {

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { fetchPrimaryProfileSessions } from './profile-session-routing'
+import { fetchPrimaryProfileSessions, profilesTruncatedFrom } from './profile-session-routing'
 
 test('primary session reads use the profile-aware request path', async () => {
   const calls: Array<{ profile: string | null; path: string }> = []
@@ -27,4 +27,44 @@ test('primary session reads preserve the empty-list fallback', async () => {
   })
 
   assert.deepEqual(result, { sessions: [], total: 0, profile_totals: {} })
+})
+
+test('per-profile truncation prefers exact totals over the global window', () => {
+  const rows = [
+    ...Array.from({ length: 30 }, (_, i) => ({ profile: 'default', id: `d-${i}` })),
+    ...Array.from({ length: 20 }, (_, i) => ({ profile: 'coder', id: `c-${i}` }))
+  ]
+
+  // default has 30 of 60 on disk → truncated; coder has all 20 → complete.
+  assert.deepEqual(profilesTruncatedFrom(rows, 50, { default: 60, coder: 20 }), {
+    default: true,
+    coder: false
+  })
+})
+
+test('totals-only profiles stay truncated so the global Load more surfaces', () => {
+  const rows = [
+    ...Array.from({ length: 30 }, (_, i) => ({ profile: 'default', id: `d-${i}` })),
+    ...Array.from({ length: 20 }, (_, i) => ({ profile: 'coder', id: `c-${i}` }))
+  ]
+
+  // archive has 10 sessions on disk but none in this window.
+  assert.deepEqual(profilesTruncatedFrom(rows, 50, { default: 60, coder: 20, archive: 10 }), {
+    default: true,
+    coder: false,
+    archive: true
+  })
+})
+
+test('falls back to the global-full heuristic when totals are absent', () => {
+  const rows = Array.from({ length: 50 }, (_, i) => ({ profile: 'default', id: `s-${i}` }))
+
+  assert.deepEqual(profilesTruncatedFrom(rows, 50), { default: true })
+  assert.deepEqual(profilesTruncatedFrom(rows, 50, {}), { default: true })
+})
+
+test('a complete profile is not truncated', () => {
+  const rows = Array.from({ length: 20 }, (_, i) => ({ profile: 'coder', id: `c-${i}` }))
+
+  assert.deepEqual(profilesTruncatedFrom(rows, 50, { coder: 20 }), { coder: false })
 })

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -7,6 +7,41 @@ export interface ProfileSessionsResponse {
 
 type FetchJsonForProfile = (profile: string | null, path: string) => Promise<unknown>
 
+/** Which profiles still have rows on disk beyond the returned page. Mirrors
+ *  the renderer's derivation in src/hermes.ts — the Electron and renderer
+ *  sides of the seam must agree. Exact `profile_totals` when the slice
+ *  response carries them (pre-truncation per-profile counts, already paid for
+ *  by the request), the window-full heuristic otherwise. */
+export function profilesTruncatedFrom(
+  sessions: ReadonlyArray<{ profile?: string }>,
+  cap: number,
+  profileTotals?: Record<string, number>
+): Record<string, boolean> {
+  const globalTruncated = sessions.length >= cap
+  const counts = new Map<string, number>()
+
+  for (const session of sessions) {
+    const key = session?.profile || 'default'
+
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+
+  // Include totals-only profiles (rows on disk, none returned in this window).
+  const names = new Set([...counts.keys(), ...Object.keys(profileTotals ?? {})])
+
+  return Object.fromEntries(
+    [...names].map(name => {
+      const count = counts.get(name) ?? 0
+
+      if (profileTotals && typeof profileTotals[name] === 'number') {
+        return [name, count < profileTotals[name]]
+      }
+
+      return [name, globalTruncated || count >= cap]
+    })
+  )
+}
+
 export async function fetchPrimaryProfileSessions(
   searchParams: URLSearchParams,
   fetchJsonForProfile: FetchJsonForProfile

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -420,11 +420,13 @@ describe('Hermes REST helpers', () => {
         profile: 'default',
         title: `default-${i}`
       }))
+
       const coderSessions = Array.from({ length: 20 }, (_, i) => ({
         id: `c-${i}`,
         profile: 'coder',
         title: `coder-${i}`
       }))
+
       const sessions = [...defaultSessions, ...coderSessions]
 
       api.mockImplementation(({ path }: { path: string }) => {
@@ -501,6 +503,57 @@ describe('Hermes REST helpers', () => {
 
       // Global window filled: mark truncated via fallback heuristic.
       expect(result.recents.profiles_truncated).toEqual({ default: true })
+    })
+
+    it('marks a totals-only profile truncated when it has rows on disk but none in the window', async () => {
+      // archive has 10 sessions on disk, all older than the global window —
+      // its rows must stay reachable via the global "Load more".
+      const defaultSessions = Array.from({ length: 30 }, (_, i) => ({
+        id: `d-${i}`,
+        profile: 'default',
+        title: `default-${i}`
+      }))
+
+      const coderSessions = Array.from({ length: 20 }, (_, i) => ({
+        id: `c-${i}`,
+        profile: 'coder',
+        title: `coder-${i}`
+      }))
+
+      const sessions = [...defaultSessions, ...coderSessions]
+
+      api.mockImplementation(({ path }: { path: string }) => {
+        if (path.startsWith('/api/profiles/sessions/sidebar')) {
+          return Promise.reject(new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}'))
+        }
+
+        if (path.includes('source=cron')) {
+          return Promise.resolve({ ...emptySessionsResponse, sessions: [], total: 0 })
+        }
+
+        if (path.includes('exclude_sources=cron%2Cdesktop')) {
+          return Promise.resolve({ ...emptySessionsResponse, sessions: [], total: 0 })
+        }
+
+        return Promise.resolve({
+          ...emptySessionsResponse,
+          sessions,
+          total: 90,
+          profile_totals: { default: 60, coder: 20, archive: 10 }
+        })
+      })
+
+      const result = await listSidebarSessions({
+        recentsProfile: 'all',
+        recentsLimit: 50,
+        recentsExclude: ['cron', 'tool'],
+        cronLimit: 50,
+        messagingLimit: 100,
+        messagingExclude: ['cron', 'desktop']
+      })
+
+      // archive returned 0 of its 10 → truncated, so Load more stays visible.
+      expect(result.recents.profiles_truncated).toEqual({ default: true, coder: false, archive: true })
     })
   })
 })

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -152,9 +152,9 @@ describe('Hermes REST helpers', () => {
     // Slices reassembled from the legacy per-slice route with the same
     // scoping: recents on the caller's profile, cron + messaging cross-profile.
     expect(result.recents.sessions.map(s => s.id)).toEqual(['recent-1'])
-    // One row back against a 30-row window: the profile is fully loaded, so
-    // the legacy path must not claim there's another page.
-    expect(result.recents.profiles_truncated).toEqual({ default: false })
+    // One row returned against a known total of 7 — the profile still has more
+    // on disk, so the legacy path must claim another page exists.
+    expect(result.recents.profiles_truncated).toEqual({ default: true })
     expect(result.cron.sessions.map(s => s.id)).toEqual(['cron-1'])
     expect(result.messaging.sessions.map(s => s.id)).toEqual(['msg-1'])
 
@@ -409,5 +409,98 @@ describe('Hermes REST helpers', () => {
         path: '/api/model/options?refresh=1&include_unconfigured=1'
       })
     )
+  })
+
+  describe('profilesTruncatedFrom legacy truncation semantics', () => {
+    it('marks a profile truncated when returned count is less than its known total', async () => {
+      // profile_totals: default has 60 total, coder has 20 total.
+      // Backend returns 30 default + 20 coder = 50 sessions (global cap hit).
+      const defaultSessions = Array.from({ length: 30 }, (_, i) => ({
+        id: `d-${i}`,
+        profile: 'default',
+        title: `default-${i}`
+      }))
+      const coderSessions = Array.from({ length: 20 }, (_, i) => ({
+        id: `c-${i}`,
+        profile: 'coder',
+        title: `coder-${i}`
+      }))
+      const sessions = [...defaultSessions, ...coderSessions]
+
+      api.mockImplementation(({ path }: { path: string }) => {
+        if (path.startsWith('/api/profiles/sessions/sidebar')) {
+          return Promise.reject(new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}'))
+        }
+
+        if (path.includes('source=cron')) {
+          return Promise.resolve({ ...emptySessionsResponse, sessions: [], total: 0 })
+        }
+
+        if (path.includes('exclude_sources=cron%2Cdesktop')) {
+          return Promise.resolve({ ...emptySessionsResponse, sessions: [], total: 0 })
+        }
+
+        return Promise.resolve({
+          ...emptySessionsResponse,
+          sessions,
+          total: 80,
+          profile_totals: { default: 60, coder: 20 }
+        })
+      })
+
+      const result = await listSidebarSessions({
+        recentsProfile: 'all',
+        recentsLimit: 50,
+        recentsExclude: ['cron', 'tool'],
+        cronLimit: 50,
+        messagingLimit: 100,
+        messagingExclude: ['cron', 'desktop']
+      })
+
+      // default has 30 returned out of 60 → truncated
+      // coder has all 20 returned out of 20 → NOT truncated
+      expect(result.recents.profiles_truncated).toEqual({ default: true, coder: false })
+    })
+
+    it('falls back to global-full heuristic when profile_totals is absent', async () => {
+      const sessions = Array.from({ length: 50 }, (_, i) => ({
+        id: `s-${i}`,
+        profile: 'default',
+        title: `session-${i}`
+      }))
+
+      api.mockImplementation(({ path }: { path: string }) => {
+        if (path.startsWith('/api/profiles/sessions/sidebar')) {
+          return Promise.reject(new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}'))
+        }
+
+        if (path.includes('source=cron')) {
+          return Promise.resolve({ ...emptySessionsResponse, sessions: [], total: 0 })
+        }
+
+        if (path.includes('exclude_sources=cron%2Cdesktop')) {
+          return Promise.resolve({ ...emptySessionsResponse, sessions: [], total: 0 })
+        }
+
+        return Promise.resolve({
+          ...emptySessionsResponse,
+          sessions,
+          total: 200
+          // No profile_totals — even older backend
+        })
+      })
+
+      const result = await listSidebarSessions({
+        recentsProfile: 'all',
+        recentsLimit: 50,
+        recentsExclude: ['cron', 'tool'],
+        cronLimit: 50,
+        messagingLimit: 100,
+        messagingExclude: ['cron', 'desktop']
+      })
+
+      // Global window filled: mark truncated via fallback heuristic.
+      expect(result.recents.profiles_truncated).toEqual({ default: true })
+    })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -445,8 +445,15 @@ export interface SidebarSessionSlice {
 
 /** Which profiles filled their per-profile window in a returned page. The
  *  legacy per-slice endpoint doesn't report this, so derive it from the rows:
- *  a profile at (or over) the cap still has more on disk. */
+ *  a profile at (or over) the cap still has more on disk.
+ *
+ *  The backend combines all profiles' sessions then globally truncates to cap,
+ *  so a single profile's window may be under the cap even when the *total*
+ *  returned rows hit it — meaning every profile in the result is truncated,
+ *  not just the ones whose individual count reached cap. Check the global
+ *  total first. */
 function profilesTruncatedFrom(sessions: SessionInfo[], cap: number): Record<string, boolean> {
+  const globalTruncated = sessions.length >= cap
   const counts = new Map<string, number>()
 
   for (const session of sessions) {
@@ -455,7 +462,7 @@ function profilesTruncatedFrom(sessions: SessionInfo[], cap: number): Record<str
     counts.set(key, (counts.get(key) ?? 0) + 1)
   }
 
-  return Object.fromEntries([...counts].map(([name, count]) => [name, count >= cap]))
+  return Object.fromEntries([...counts].map(([name, count]) => [name, globalTruncated || count >= cap]))
 }
 
 export interface SidebarSessionsResponse {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -443,15 +443,18 @@ export interface SidebarSessionSlice {
   profiles_truncated?: Record<string, boolean>
 }
 
-/** Which profiles filled their per-profile window in a returned page. The
+/** Which profiles still have rows on disk beyond the returned page. The
  *  legacy per-slice endpoint doesn't report `profiles_truncated`, so derive it
  *  from the rows. When the endpoint carries `profile_totals` (the exact
- *  conversation count per profile), compare each profile's returned count
- *  against its known total — the most precise signal, and already paid for by
- *  the request. When `profile_totals` is absent (even older backends), fall
- *  back to checking whether each profile's window filled the cap, or whether
- *  the global window was full (meaning every profile in the result likely has
- *  more rows on disk). */
+ *  conversation count per profile, computed before global windowing), compare
+ *  each profile's returned count against its known total — the most precise
+ *  signal, and already paid for by the request. Profiles with rows on disk but
+ *  none in this window (pushed out by the global merge) count as truncated
+ *  too, so their rows stay reachable via the global "Load more". When
+ *  `profile_totals` is absent (even older backends), fall back to checking
+ *  whether each profile's window filled the cap, or whether the global window
+ *  was full (meaning every profile in the result likely has more rows on
+ *  disk). */
 function profilesTruncatedFrom(
   sessions: SessionInfo[],
   cap: number,
@@ -466,8 +469,13 @@ function profilesTruncatedFrom(
     counts.set(key, (counts.get(key) ?? 0) + 1)
   }
 
+  // Include totals-only profiles (rows on disk, none returned in this window).
+  const names = new Set([...counts.keys(), ...Object.keys(profileTotals ?? {})])
+
   return Object.fromEntries(
-    [...counts].map(([name, count]) => {
+    [...names].map(name => {
+      const count = counts.get(name) ?? 0
+
       // Exact total known → truncated whenever the loaded window is smaller.
       if (profileTotals && typeof profileTotals[name] === 'number') {
         return [name, count < profileTotals[name]]

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -444,15 +444,19 @@ export interface SidebarSessionSlice {
 }
 
 /** Which profiles filled their per-profile window in a returned page. The
- *  legacy per-slice endpoint doesn't report this, so derive it from the rows:
- *  a profile at (or over) the cap still has more on disk.
- *
- *  The backend combines all profiles' sessions then globally truncates to cap,
- *  so a single profile's window may be under the cap even when the *total*
- *  returned rows hit it — meaning every profile in the result is truncated,
- *  not just the ones whose individual count reached cap. Check the global
- *  total first. */
-function profilesTruncatedFrom(sessions: SessionInfo[], cap: number): Record<string, boolean> {
+ *  legacy per-slice endpoint doesn't report `profiles_truncated`, so derive it
+ *  from the rows. When the endpoint carries `profile_totals` (the exact
+ *  conversation count per profile), compare each profile's returned count
+ *  against its known total — the most precise signal, and already paid for by
+ *  the request. When `profile_totals` is absent (even older backends), fall
+ *  back to checking whether each profile's window filled the cap, or whether
+ *  the global window was full (meaning every profile in the result likely has
+ *  more rows on disk). */
+function profilesTruncatedFrom(
+  sessions: SessionInfo[],
+  cap: number,
+  profileTotals?: Record<string, number>
+): Record<string, boolean> {
   const globalTruncated = sessions.length >= cap
   const counts = new Map<string, number>()
 
@@ -462,7 +466,16 @@ function profilesTruncatedFrom(sessions: SessionInfo[], cap: number): Record<str
     counts.set(key, (counts.get(key) ?? 0) + 1)
   }
 
-  return Object.fromEntries([...counts].map(([name, count]) => [name, globalTruncated || count >= cap]))
+  return Object.fromEntries(
+    [...counts].map(([name, count]) => {
+      // Exact total known → truncated whenever the loaded window is smaller.
+      if (profileTotals && typeof profileTotals[name] === 'number') {
+        return [name, count < profileTotals[name]]
+      }
+
+      return [name, globalTruncated || count >= cap]
+    })
+  )
 }
 
 export interface SidebarSessionsResponse {
@@ -536,7 +549,7 @@ async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<S
 
   return {
     recents: {
-      profiles_truncated: profilesTruncatedFrom(recents.sessions, req.recentsLimit),
+      profiles_truncated: profilesTruncatedFrom(recents.sessions, req.recentsLimit, recents.profile_totals),
       sessions: recents.sessions
     },
     cron: { sessions: cron.sessions },


### PR DESCRIPTION
Closes #72492

`profilesTruncatedFrom()` compares per-profile session counts against the global fetch cap. But the backend combines all profiles' sessions then globally truncates to the cap. If 50 sessions come back split 30/20 across two profiles, both return `false` (30 < 50, 20 < 50) — even though the query was capped and both profiles genuinely have more rows on disk. The "Load more" button never renders.

**Fix:** Check the global session count against cap first. If the total window is full, every profile in the result is effectively truncated.

## Notes

- The batched `/api/profiles/sessions/sidebar` endpoint reports `profiles_truncated` correctly per-profile before the global `_window()` truncation. This only affects the legacy per-slice fallback path, hit when the runtime predates the batched route.
- The global and per-profile caps are the same value (`recentsLimit`), so `globalTruncated || count >= cap` is correct. If they ever diverge, per-profile counts would still catch the high-profile edge case.
