### PR TITLE
feat(kanban): add default-off review-required effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,28 @@ review-required Kanban effect candidate; earlier history lives in the git log.
     APPROVE, unbound/manual review conflict, stale running review) and
     alert-only detection of legacy untyped review text (never auto-creates a
     review card).
+  - The authoritative review card is assigned to the valid `review` profile.
+  - A new head never spawns a *parallel* review while the bound old-head review
+    is still active (running/done/review/blocked): the reconciler returns the
+    typed `DRAINING_ACTIVE_REVIEW` disposition and leaves the lane unchanged.
+  - Before minting, the reconciler detects manual/unbound parentless review
+    cards for the same repo/PR and returns typed
+    `CONFLICT_MANUAL_REVIEW_UNBOUND` instead of racing them; every generated
+    card carries a durable, discoverable reverse effect identity (a
+    `review_card_minted` event + `[hermes-review-effect]` body marker +
+    `created_by='kanban_effects'` stamp).
+  - SQLite durability: a *done* effect must have a non-null `target_task_id`
+    (`CHECK`), and at most one *leased* effect exists per lane (partial
+    `UNIQUE` index). `install_effects_schema()` is migration-safe — it rebuilds
+    a pre-remediation table in place without losing rows.
+  - Observation freshness defaults to 60s; before committing, the reconciler
+    re-checks the full readiness predicate (temporal/status/policy/checks/head)
+    against the already-injected observation under the lock — no network, and no
+    `assert` for stale input.
+  - An explicit, default-off `scan`/`list` harness CLI
+    (`python -m hermes_cli.kanban_effects`) reconciles due effects against
+    injected observations and prints typed per-effect dispositions. It is not
+    wired into any dispatcher/cron/loop.
   - See `docs/kanban/review-required-effect.md` for the full design and the
     R01–R21 requirement map.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+Notable developer-facing changes. This file starts at the introduction of the
+review-required Kanban effect candidate; earlier history lives in the git log.
+
+## Unreleased
+
+### Added — repository-only candidate (default-off, **not live / not applied**)
+
+- **Review-required Kanban effect candidate** (`hermes_cli/kanban_effects.py`).
+  A durable, exactly-once effect that lets a worker declare, when it completes
+  or blocks a task, that a GitHub PR must pass review at an exact head commit
+  before downstream QA/Release cards proceed. This is a **repository-only**
+  design, **default-off**, and is **not wired into the dispatcher, cron,
+  gateway, plugins, or config** — it is exercised only by tests and an explicit
+  offline harness.
+  - The effect/outbox/lane tables are created **only** by the explicit
+    `install_effects_schema()` installer. They are intentionally absent from
+    `SCHEMA_SQL` and from every `connect`/`init_db`/migration/startup/read-only
+    path, so a fresh normal Kanban DB has none of them.
+  - Deterministic canonical lane/effect/payload identities (including the
+    source task for effect provenance); durable effect
+    state machine (pending→leased→done/failed→dlq) with lease/expiry, retry
+    backoff, and DLQ; `UNIQUE` constraints + compare-and-swap for idempotency.
+  - Injected, **network-free** GitHub observation interface; a missing
+    required-check policy returns typed `NOT_READY(REQUIRED_CHECK_POLICY_MISSING)`.
+    The reconciler never performs network I/O while a DB transaction is held.
+  - Alert-only downstream containment (downstream ran without an exact-head
+    APPROVE, unbound/manual review conflict, stale running review) and
+    alert-only detection of legacy untyped review text (never auto-creates a
+    review card).
+  - See `docs/kanban/review-required-effect.md` for the full design and the
+    R01–R21 requirement map.
+
+### Changed
+
+- `hermes_cli/kanban_db.py`: `create_task` and `link_tasks` are refactored into
+  transaction-internal helpers (`_create_task_locked`, `_link_tasks_locked`)
+  behind behavior-unchanged public wrappers, so they can compose inside one
+  outer write transaction with no nested `BEGIN`.
+- `complete_task` / `block_task` accept an optional, schema-validated
+  `review_required` payload. **Absent payload preserves existing behavior
+  exactly.** A valid payload persists a source/outbox effect record inside the
+  same transition transaction *when the effect schema is installed*; on a normal
+  (default-off) board it is validated and then a no-op. An invalid payload is
+  rejected with a typed error before any state change.
+- `tools/kanban_tools.py`: `kanban_complete` / `kanban_block` expose the
+  optional `review_required` argument (documented as experimental /
+  repository-only / default-off).

--- a/docs/kanban/review-required-effect.md
+++ b/docs/kanban/review-required-effect.md
@@ -1,0 +1,132 @@
+# Review-required Kanban effect — repository candidate (default-off, not live)
+
+> **Status: repository-only candidate. Default-off. Not wired into the live
+> product and not applied to any running board.** This document describes a
+> design that exists in the tree to be reviewed and exercised by tests. Nothing
+> here runs in the dispatcher, cron, gateway, plugins, or config. A fresh
+> production Kanban DB has none of the tables this feature uses.
+
+## What it is
+
+A durable, exactly-once "effect" mechanism that lets a worker declare, at the
+moment it completes or blocks a task, that a GitHub PR must pass review at an
+**exact head commit** before downstream QA/Release cards may proceed.
+
+The producer writes a validated, typed record inside the **same transaction**
+as the status change. A separate, explicitly-invoked reconciler later turns
+that record into exactly one authoritative review card, using an **injected**
+(never network-fetched-under-lock) GitHub observation to decide readiness.
+
+Code lives in [`hermes_cli/kanban_effects.py`](../../hermes_cli/kanban_effects.py);
+the producer hooks are in `complete_task` / `block_task` in
+[`hermes_cli/kanban_db.py`](../../hermes_cli/kanban_db.py); the optional tool
+argument is in [`tools/kanban_tools.py`](../../tools/kanban_tools.py). Tests are
+in [`tests/hermes_cli/test_kanban_effects.py`](../../tests/hermes_cli/test_kanban_effects.py).
+
+## Why it is default-off and how
+
+The effect/outbox/lane tables are created **only** by the explicit installer
+`kanban_effects.install_effects_schema(conn)`. They are deliberately **not** in
+`SCHEMA_SQL`, and no `connect`, `init_db`, migration, dispatcher tick, cron,
+gateway watcher, plugin, config path, or read-only operation ever creates them.
+So:
+
+* A normal board never gains these tables.
+* The producer (`complete_task` / `block_task` with a `review_required`
+  payload) validates the payload but **records nothing** when the tables are
+  absent — a safe no-op. Passing no payload is byte-for-byte the old behavior.
+* Only tests and an offline harness that call `install_effects_schema` see any
+  effect at all.
+
+## Data model (installer-only tables)
+
+| table | role |
+|---|---|
+| `kanban_effect_lanes` | one lane per `(repo, pr, kind)`; holds the CAS `revision`, the bound `review_task_id`, and the reviewed `head_sha`. `UNIQUE(repo, pr_number, kind)`. |
+| `kanban_effects` | the durable state machine: `state` (pending→leased→done/failed→dlq), `attempts`/`max_attempts`, `lease_owner`/`lease_expires_at`, monotonic `next_attempt_at` backoff, `payload_hash`, CAS `revision`, bound `target_task_id`. `UNIQUE(source_task_id, lane_id, payload_hash)` preserves independent source provenance while deduplicating replay. |
+| `kanban_effect_outbox` | the append-once source record written in the transition txn, keyed by the deterministic `effect_id`. |
+
+### Canonical identities
+
+* `canonical_lane_id(repo, pr, kind)` — deterministic per PR lane.
+* `canonical_payload_hash(payload)` — deterministic, key-order-independent
+  identity of *what review is required* (`repo`, `pr`, exact `head_sha`,
+  `required_checks`). `downstream_task_ids` are a binding hint and are **not**
+  part of payload identity.
+* `canonical_effect_id(lane_id, payload_hash, source_task_id)` — one effect per
+  source handoff + (lane, payload); distinct implementation sources retain
+  provenance while duplicate replays collapse via `INSERT OR IGNORE`.
+
+Correctness never relies on `tasks.idempotency_key`.
+
+## Producer contract
+
+```python
+kb.complete_task(conn, task_id, summary="…", review_required={
+    "kind": "review_required",
+    "repo": "owner/name",
+    "pr_number": 123,
+    "head_sha": "<exact 40-char hex>",
+    "required_checks": ["ci"],              # optional policy tightening
+    "downstream_task_ids": ["t_qa", "t_rel"] # optional binding hint
+})
+```
+
+* Absent payload → existing behavior, exactly.
+* Present but invalid → `EffectValidationError` (typed `code`) **before** any
+  state change; the task is not mutated.
+* Present + valid + schema installed → one lane/effect/outbox record persisted
+  inside the completion/block transaction.
+
+`block_task` takes the same optional `review_required` argument and records the
+effect in each successful block routing (`blocked`, dependency→`todo`, loop→`triage`).
+
+## Reconciler
+
+`reconcile_effect(conn, effect_id, observer, *, now)`:
+
+1. **Lease** the effect (own txn, CAS on `revision`).
+2. **Observe** GitHub through the injected `GithubObserver` — strictly
+   **outside** any DB transaction (no network under lock).
+3. **Evaluate readiness** (pure): a missing required-check policy returns
+   `NOT_READY(REQUIRED_CHECK_POLICY_MISSING)`; a head mismatch is `STALE_HEAD`;
+   a closed PR / merge conflict / unfinished / failed check are each typed
+   NOT_READY. Not-ready schedules a backoff retry, or moves to the DLQ once
+   `max_attempts` is exhausted.
+4. **One outer write transaction**: re-read the effect payload hash + revision,
+   re-check head freshness, CAS the lane forward, **create or reuse exactly one
+   parentless exact-head review card**, re-parent the pre-created downstream
+   QA/Release cards under it and demote any `todo`/`ready` ones to `todo`, then
+   bind `effect.target_task_id` + `lane.review_task_id` and mark the effect
+   `done`. The transaction-internal `_create_task_locked` / `_link_tasks_locked`
+   helpers compose here with **no nested `BEGIN`**.
+
+The injected observation interface performs **no network I/O**; the offline
+harness and tests use `InMemoryGithubObserver`.
+
+## Downstream containment (alert only)
+
+Nothing is auto-remediated. The scanner surfaces:
+
+* `DOWNSTREAM_RAN_WITHOUT_EXACT_HEAD_APPROVE` — a downstream card is
+  running/done without a compatible exact-head APPROVE (R18).
+* `UNBOUND_REVIEW_CONFLICT` — a manual/unbound review card conflicts with the
+  lane's single authoritative card (R19).
+* `STALE_RUNNING_REVIEW` — a running review whose head has moved on; drain it,
+  do not spawn a parallel review (R20).
+
+Legacy untyped, free-text review requests (`detect_legacy_review_text`) produce
+an **alert only** and never auto-create a review card (R21).
+
+## Explicitly out of scope (not wired)
+
+No dispatcher tick, cron, plugin, gateway watcher, or config reads or drives any
+of this. There is no automatic reconciliation loop. The reconciler and scanner
+are invoked only by tests and a would-be offline harness.
+
+## Requirement map
+
+R01–R21 are enumerated in the module docstring of `hermes_cli/kanban_effects.py`
+and each is covered by a test in `tests/hermes_cli/test_kanban_effects.py`,
+including 20-worker concurrency (exactly-once), fake-clock retry/DLQ, and the
+no-nested-`BEGIN` regression.

--- a/docs/kanban/review-required-effect.md
+++ b/docs/kanban/review-required-effect.md
@@ -43,7 +43,7 @@ So:
 | table | role |
 |---|---|
 | `kanban_effect_lanes` | one lane per `(repo, pr, kind)`; holds the CAS `revision`, the bound `review_task_id`, and the reviewed `head_sha`. `UNIQUE(repo, pr_number, kind)`. |
-| `kanban_effects` | the durable state machine: `state` (pending→leased→done/failed→dlq), `attempts`/`max_attempts`, `lease_owner`/`lease_expires_at`, monotonic `next_attempt_at` backoff, `payload_hash`, CAS `revision`, bound `target_task_id`. `UNIQUE(source_task_id, lane_id, payload_hash)` preserves independent source provenance while deduplicating replay. |
+| `kanban_effects` | the durable state machine: `state` (pending→leased→done/failed→dlq), `attempts`/`max_attempts`, `lease_owner`/`lease_expires_at`, monotonic `next_attempt_at` backoff, `payload_hash`, CAS `revision`, bound `target_task_id`. `UNIQUE(source_task_id, lane_id, payload_hash)` preserves independent source provenance while deduplicating replay. `CHECK (state <> 'done' OR target_task_id IS NOT NULL)` forbids a terminal *done* effect with no bound target; a partial `UNIQUE(lane_id) WHERE state='leased'` allows at most one in-flight reconcile per lane. |
 | `kanban_effect_outbox` | the append-once source record written in the transition txn, keyed by the deterministic `effect_id`. |
 
 ### Canonical identities
@@ -88,21 +88,48 @@ effect in each successful block routing (`blocked`, dependency→`todo`, loop→
 1. **Lease** the effect (own txn, CAS on `revision`).
 2. **Observe** GitHub through the injected `GithubObserver` — strictly
    **outside** any DB transaction (no network under lock).
-3. **Evaluate readiness** (pure): a missing required-check policy returns
-   `NOT_READY(REQUIRED_CHECK_POLICY_MISSING)`; a head mismatch is `STALE_HEAD`;
-   a closed PR / merge conflict / unfinished / failed check are each typed
-   NOT_READY. Not-ready schedules a backoff retry, or moves to the DLQ once
-   `max_attempts` is exhausted.
+3. **Evaluate readiness** (pure): an observation older than the freshness
+   window (**60s** by default) is `OBSERVATION_STALE`; a missing required-check
+   policy returns `NOT_READY(REQUIRED_CHECK_POLICY_MISSING)`; a head mismatch is
+   `STALE_HEAD`; a closed PR / merge conflict / unfinished / failed check are
+   each typed NOT_READY. Not-ready schedules a backoff retry, or moves to the
+   DLQ once `max_attempts` is exhausted.
 4. **One outer write transaction**: re-read the effect payload hash + revision,
-   re-check head freshness, CAS the lane forward, **create or reuse exactly one
-   parentless exact-head review card**, re-parent the pre-created downstream
-   QA/Release cards under it and demote any `todo`/`ready` ones to `todo`, then
-   bind `effect.target_task_id` + `lane.review_task_id` and mark the effect
-   `done`. The transaction-internal `_create_task_locked` / `_link_tasks_locked`
-   helpers compose here with **no nested `BEGIN`**.
+   **re-check the FULL readiness predicate** (temporal/status/policy/checks/exact
+   head) against the already-injected observation — under the lock, with no new
+   network call and no `assert` — CAS the lane forward, **create or reuse
+   exactly one parentless exact-head review card**, re-parent the pre-created
+   downstream QA/Release cards under it and demote any `todo`/`ready` ones to
+   `todo`, then bind `effect.target_task_id` + `lane.review_task_id` and mark
+   the effect `done`. The transaction-internal `_create_task_locked` /
+   `_link_tasks_locked` helpers compose here with **no nested `BEGIN`**.
+
+Before minting a fresh card the reconciler returns a typed disposition and
+leaves the lane unchanged (retried, never silently dropped) when:
+
+* the bound old-head review is still active (running/done/review/blocked) at a
+  different head — `DRAINING_ACTIVE_REVIEW`, so no *parallel* review is spawned;
+* a manual/unbound parentless review card already exists for the same repo/PR —
+  `CONFLICT_MANUAL_REVIEW_UNBOUND`, so a human reconciles it first.
+
+Every effect-minted card carries a durable, discoverable **reverse effect
+identity**: a `review_card_minted` event (`effect_id`/`lane_id`/`head_sha`) plus
+a `[hermes-review-effect]` body marker and a `created_by='kanban_effects'` stamp.
+`find_unbound_review_cards` / `effect_identity_of_card` use these to tell an
+auto-created card apart from a manual one.
 
 The injected observation interface performs **no network I/O**; the offline
 harness and tests use `InMemoryGithubObserver`.
+
+## Offline harness CLI (explicit, default-off)
+
+`python -m hermes_cli.kanban_effects scan [--now N] [--observations FILE]
+[--dry-run]` reconciles every due effect against **injected** observations
+(a JSON list — never the network) and prints a typed per-effect disposition
+(`reconciled` / `not_ready` / `draining` / `conflict` / `stale` / `skipped`).
+`… list [--state S]` dumps effect rows. On a normal default-off board (no effect
+tables) it fails loudly (exit 2). Nothing invokes it automatically — there is no
+reconcile loop, timer, cron, or dispatcher wiring.
 
 ## Downstream containment (alert only)
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3072,117 +3072,35 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
-                # Determine task status from parent status, unless the caller
-                # parks it directly in blocked for human-ops review or in
-                # triage for a specifier.
-                if initial_status == "blocked":
-                    task_status = "blocked"
-                    if parents:
-                        missing = _find_missing_parents(conn, parents)
-                        if missing:
-                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-                elif triage:
-                    task_status = "triage"
-                else:
-                    task_status = "ready"
-                    if parents:
-                        missing = _find_missing_parents(conn, parents)
-                        if missing:
-                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-                        # If any parent is not yet done, we're todo.
-                        rows = conn.execute(
-                            "SELECT status FROM tasks WHERE id IN "
-                            "(" + ",".join("?" * len(parents)) + ")",
-                            parents,
-                        ).fetchall()
-                        if any(r["status"] != "done" for r in rows):
-                            task_status = "todo"
-                # Even in triage mode we still need to validate parent ids
-                # so the eventual link rows don't dangle.
-                if triage and parents:
-                    missing = _find_missing_parents(conn, parents)
-                    if missing:
-                        raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-
-                # Project-linked worktree: a fresh worktree dir under the repo
-                # plus a deterministic branch (project slug + task id). Together
-                # these kill the random ``wt/<task-id>`` worker fallback and the
-                # unanchored ``.worktrees/<id>`` under the dispatcher's cwd.
-                if project_obj is not None and workspace_kind == "worktree":
-                    if project_repo and not workspace_path:
-                        workspace_path = os.path.join(
-                            project_repo, ".worktrees", task_id
-                        )
-                    if not branch_name:
-                        # _pdb was imported above when project_obj was resolved.
-                        try:
-                            branch_name = _pdb.branch_name_for(
-                                project_obj, task_id, title=title or ""
-                            )
-                        except Exception:
-                            branch_name = None
-
-                conn.execute(
-                    """
-                    INSERT INTO tasks (
-                        id, title, body, assignee, status, priority,
-                        created_by, created_at, workspace_kind, workspace_path,
-                        branch_name, project_id, tenant, idempotency_key,
-                        max_runtime_seconds,
-                        skills, max_retries, model_override, provider_override,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        task_id,
-                        title.strip(),
-                        body,
-                        assignee,
-                        task_status,
-                        priority,
-                        created_by,
-                        now,
-                        workspace_kind,
-                        workspace_path,
-                        branch_name,
-                        project_id,
-                        tenant,
-                        idempotency_key,
-                        int(max_runtime_seconds) if max_runtime_seconds is not None else None,
-                        json.dumps(skills_list) if skills_list is not None else None,
-                        int(max_retries) if max_retries is not None else None,
-                        model_override,
-                        provider_override,
-                        1 if goal_mode else 0,
-                        int(goal_max_turns) if goal_max_turns is not None else None,
-                        session_id,
-                    ),
-                )
-                for pid in parents:
-                    conn.execute(
-                        "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-                        (pid, task_id),
-                    )
-                _append_event(
+                _create_task_locked(
                     conn,
-                    task_id,
-                    "created",
-                    {
-                        "assignee": assignee,
-                        "status": task_status,
-                        "parents": list(parents),
-                        "tenant": tenant,
-                        "workspace_kind": workspace_kind,
-                        "workspace_path": workspace_path,
-                        "branch_name": branch_name,
-                        "project_id": project_id,
-                        "skills": list(skills_list) if skills_list else None,
-                        "goal_mode": bool(goal_mode) or None,
-                        "model_override": model_override,
-                        "provider_override": provider_override,
-                    },
+                    task_id=task_id,
+                    now=now,
+                    title=title,
+                    body=body,
+                    assignee=assignee,
+                    priority=priority,
+                    created_by=created_by,
+                    workspace_kind=workspace_kind,
+                    workspace_path=workspace_path,
+                    branch_name=branch_name,
+                    project_id=project_id,
+                    project_obj=project_obj,
+                    project_repo=project_repo,
+                    tenant=tenant,
+                    idempotency_key=idempotency_key,
+                    max_runtime_seconds=max_runtime_seconds,
+                    skills_list=skills_list,
+                    max_retries=max_retries,
+                    model_override=model_override,
+                    provider_override=provider_override,
+                    goal_mode=goal_mode,
+                    goal_max_turns=goal_max_turns,
+                    session_id=session_id,
+                    parents=parents,
+                    triage=triage,
+                    initial_status=initial_status,
                 )
-                _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -3190,6 +3108,159 @@ def create_task(
             # Retry with a fresh id.
             continue
     raise RuntimeError("unreachable")
+
+
+def _create_task_locked(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    now: int,
+    title: str,
+    body: Optional[str],
+    assignee: Optional[str],
+    priority: int,
+    created_by: Optional[str],
+    workspace_kind: str,
+    workspace_path: Optional[str],
+    branch_name: Optional[str],
+    project_id: Optional[str],
+    project_obj: Any,
+    project_repo: Optional[str],
+    tenant: Optional[str],
+    idempotency_key: Optional[str],
+    max_runtime_seconds: Optional[int],
+    skills_list: Optional[list[str]],
+    max_retries: Optional[int],
+    model_override: Optional[str],
+    provider_override: Optional[str],
+    goal_mode: bool,
+    goal_max_turns: Optional[int],
+    session_id: Optional[str],
+    parents: Iterable[str],
+    triage: bool,
+    initial_status: str,
+) -> None:
+    """Insert one task (+ its parent links, created-event, inherited subs).
+
+    Transaction-internal helper: **the caller must already hold an open write
+    transaction** (``write_txn``). It opens no ``BEGIN`` of its own, so it can
+    be composed inside a larger outer transaction (e.g. the review-required
+    effect reconciler) with no nested-BEGIN. The public :func:`create_task`
+    wrapper is behavior-unchanged: it resolves projects/skills/idempotency and
+    the id-collision retry loop around this helper exactly as before.
+    """
+    parents = tuple(parents)
+    # Determine task status from parent status, unless the caller
+    # parks it directly in blocked for human-ops review or in
+    # triage for a specifier.
+    if initial_status == "blocked":
+        task_status = "blocked"
+        if parents:
+            missing = _find_missing_parents(conn, parents)
+            if missing:
+                raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+    elif triage:
+        task_status = "triage"
+    else:
+        task_status = "ready"
+        if parents:
+            missing = _find_missing_parents(conn, parents)
+            if missing:
+                raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+            # If any parent is not yet done, we're todo.
+            rows = conn.execute(
+                "SELECT status FROM tasks WHERE id IN "
+                "(" + ",".join("?" * len(parents)) + ")",
+                parents,
+            ).fetchall()
+            if any(r["status"] != "done" for r in rows):
+                task_status = "todo"
+    # Even in triage mode we still need to validate parent ids
+    # so the eventual link rows don't dangle.
+    if triage and parents:
+        missing = _find_missing_parents(conn, parents)
+        if missing:
+            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+
+    # Project-linked worktree: a fresh worktree dir under the repo
+    # plus a deterministic branch (project slug + task id). Together
+    # these kill the random ``wt/<task-id>`` worker fallback and the
+    # unanchored ``.worktrees/<id>`` under the dispatcher's cwd.
+    if project_obj is not None and workspace_kind == "worktree":
+        if project_repo and not workspace_path:
+            workspace_path = os.path.join(
+                project_repo, ".worktrees", task_id
+            )
+        if not branch_name:
+            from hermes_cli import projects_db as _pdb
+            try:
+                branch_name = _pdb.branch_name_for(
+                    project_obj, task_id, title=title or ""
+                )
+            except Exception:
+                branch_name = None
+
+    conn.execute(
+        """
+        INSERT INTO tasks (
+            id, title, body, assignee, status, priority,
+            created_by, created_at, workspace_kind, workspace_path,
+            branch_name, project_id, tenant, idempotency_key,
+            max_runtime_seconds,
+            skills, max_retries, model_override, provider_override,
+            goal_mode, goal_max_turns, session_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            task_id,
+            title.strip(),
+            body,
+            assignee,
+            task_status,
+            priority,
+            created_by,
+            now,
+            workspace_kind,
+            workspace_path,
+            branch_name,
+            project_id,
+            tenant,
+            idempotency_key,
+            int(max_runtime_seconds) if max_runtime_seconds is not None else None,
+            json.dumps(skills_list) if skills_list is not None else None,
+            int(max_retries) if max_retries is not None else None,
+            model_override,
+            provider_override,
+            1 if goal_mode else 0,
+            int(goal_max_turns) if goal_max_turns is not None else None,
+            session_id,
+        ),
+    )
+    for pid in parents:
+        conn.execute(
+            "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+            (pid, task_id),
+        )
+    _append_event(
+        conn,
+        task_id,
+        "created",
+        {
+            "assignee": assignee,
+            "status": task_status,
+            "parents": list(parents),
+            "tenant": tenant,
+            "workspace_kind": workspace_kind,
+            "workspace_path": workspace_path,
+            "branch_name": branch_name,
+            "project_id": project_id,
+            "skills": list(skills_list) if skills_list else None,
+            "goal_mode": bool(goal_mode) or None,
+            "model_override": model_override,
+            "provider_override": provider_override,
+        },
+    )
+    _inherit_notify_subs(conn, task_id, parents, created_at=now)
 
 
 def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> list[str]:
@@ -3403,31 +3474,56 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
     with write_txn(conn):
-        missing = _find_missing_parents(conn, [parent_id, child_id])
-        if missing:
-            raise ValueError(f"unknown task(s): {', '.join(missing)}")
-        if _would_cycle(conn, parent_id, child_id):
-            raise ValueError(
-                f"linking {parent_id} -> {child_id} would create a cycle"
-            )
+        _link_tasks_locked(conn, parent_id=parent_id, child_id=child_id)
+
+
+def _link_tasks_locked(
+    conn: sqlite3.Connection, *, parent_id: str, child_id: str
+) -> None:
+    """Add a parent→child dependency edge. Transaction-internal helper.
+
+    **The caller must already hold an open write transaction.** It opens no
+    ``BEGIN`` of its own so it composes inside a larger outer transaction (e.g.
+    the review-required effect reconciler re-parenting downstream cards under
+    the authoritative review card) with no nested-BEGIN. Public
+    :func:`link_tasks` is the behavior-unchanged wrapper.
+    """
+    if parent_id == child_id:
+        raise ValueError("a task cannot depend on itself")
+    missing = _find_missing_parents(conn, [parent_id, child_id])
+    if missing:
+        raise ValueError(f"unknown task(s): {', '.join(missing)}")
+    if _would_cycle(conn, parent_id, child_id):
+        raise ValueError(
+            f"linking {parent_id} -> {child_id} would create a cycle"
+        )
+    conn.execute(
+        "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+        (parent_id, child_id),
+    )
+    # If child was ready but parent is not yet done, demote child to todo.
+    parent_status = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?", (parent_id,)
+    ).fetchone()["status"]
+    if parent_status != "done":
         conn.execute(
-            "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-            (parent_id, child_id),
+            "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+            (child_id,),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
-            conn.execute(
-                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
-                (child_id,),
-            )
-        _append_event(
-            conn, child_id, "linked",
-            {"parent": parent_id, "child": child_id},
-        )
-        _inherit_notify_subs(conn, child_id, (parent_id,))
+    _append_event(
+        conn, child_id, "linked",
+        {"parent": parent_id, "child": child_id},
+    )
+    _inherit_notify_subs(conn, child_id, (parent_id,))
+
+
+def _link_exists(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
+    """True if a parent→child dependency edge already exists."""
+    row = conn.execute(
+        "SELECT 1 FROM task_links WHERE parent_id = ? AND child_id = ? LIMIT 1",
+        (parent_id, child_id),
+    ).fetchone()
+    return row is not None
 
 
 def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
@@ -4689,6 +4785,7 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    review_required: Optional[dict] = None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4717,8 +4814,25 @@ def complete_task(
     Any suspected phantom references are recorded as a
     ``suspected_hallucinated_references`` event. This pass is advisory
     and never blocks.
+
+    ``review_required`` is an optional, schema-validated ``review_required``
+    effect payload (see :mod:`hermes_cli.kanban_effects`). When ``None`` this
+    function behaves byte-for-byte as before (R02). When present it is
+    validated up-front (an invalid payload raises before any state change —
+    R03) and, if the repository-only effect schema is installed on this board,
+    a durable source/outbox effect record is persisted inside the SAME
+    completion transaction (R01). On a normal (default-off) board with no
+    effect tables the validated payload is a safe no-op — the feature is not
+    live.
     """
     now = int(time.time())
+
+    # Validate the optional review-required effect payload BEFORE mutating any
+    # state, so an invalid payload is a clean no-op rejection (R03).
+    review_payload = None
+    if review_required is not None:
+        from hermes_cli import kanban_effects as _kfx
+        review_payload = _kfx.validate_review_required(review_required)
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
@@ -4848,6 +4962,18 @@ def complete_task(
             completed_payload,
             run_id=run_id,
         )
+        # Persist the review-required effect source/outbox record in the SAME
+        # completion transaction (repository-only, default-off). No-op unless
+        # the effect schema was explicitly installed on this board (R01).
+        if review_payload is not None:
+            from hermes_cli import kanban_effects as _kfx
+            _kfx.record_effect_locked(
+                conn,
+                source_task_id=task_id,
+                source_transition=_kfx.TRANSITION_COMPLETE,
+                payload=review_payload,
+                now=now,
+            )
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
     # its own txn so the completion itself is already durable by the
@@ -5469,6 +5595,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    review_required: Optional[dict] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -5501,6 +5628,27 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    # Validate the optional review-required effect payload BEFORE mutating any
+    # state (R03). Absent payload preserves existing behavior exactly (R02).
+    review_payload = None
+    if review_required is not None:
+        from hermes_cli import kanban_effects as _kfx
+        review_payload = _kfx.validate_review_required(review_required)
+
+    def _record_block_effect() -> None:
+        """Persist the review-required effect in the SAME block transaction
+        (R01). No-op unless the effect schema is installed (default-off)."""
+        if review_payload is None:
+            return
+        from hermes_cli import kanban_effects as _kfx
+        _kfx.record_effect_locked(
+            conn,
+            source_task_id=task_id,
+            source_transition=_kfx.TRANSITION_BLOCK,
+            payload=review_payload,
+            now=int(time.time()),
+        )
+
     routed_to = "blocked"
     recurrences = 0
     with write_txn(conn):
@@ -5552,6 +5700,7 @@ def block_task(
                 conn, task_id, "dependency_wait",
                 {"reason": reason, "kind": kind}, run_id=run_id,
             )
+            _record_block_effect()
             routed_to = "todo"
             _blocked_task = get_task(conn, task_id)
             _fire_kanban_lifecycle_hook(
@@ -5665,6 +5814,7 @@ def block_task(
                 {"reason": reason, "kind": kind, "recurrences": recurrences},
                 run_id=run_id,
             )
+        _record_block_effect()
         _blocked_task = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
         "kanban_task_blocked",

--- a/hermes_cli/kanban_effects.py
+++ b/hermes_cli/kanban_effects.py
@@ -67,8 +67,31 @@ R20 a stale running review is drained; no parallel review card is spawned.
 R21 legacy untyped review-ish text produces an alert only and never
     auto-creates a review card.
 
+Remediation of the PR #72496 review blockers (all default-off)
+--------------------------------------------------------------
+* The authoritative card's assignee is the valid ``review`` profile.
+* A new head never spawns a *parallel* review while the bound old-head review
+  is still active (running/done/review/blocked): the reconciler returns the
+  typed ``DRAINING_ACTIVE_REVIEW`` disposition and leaves the lane unchanged.
+* The ``kanban_effects`` table enforces, in SQLite, a non-null ``target_task_id``
+  on a *done* effect (``CHECK``) and at most one *leased* effect per lane
+  (partial ``UNIQUE`` index). ``install_effects_schema`` is migration-safe: it
+  rebuilds a pre-remediation table in place without losing rows.
+* Before minting, the reconciler detects manual/unbound parentless review cards
+  for the same repo/PR and returns typed ``CONFLICT_MANUAL_REVIEW_UNBOUND``
+  instead of racing them. A generated card carries a durable, discoverable
+  reverse effect identity (a ``review_card_minted`` event + a body marker) so a
+  scanner can tell it apart from a manual card.
+* Observation freshness defaults to 60s. Before committing, the reconciler
+  re-checks the FULL readiness predicate (temporal/status/policy/checks/head)
+  against the already-injected observation under the lock — no network, and no
+  ``assert`` (so ``-O`` cannot strip the stale-input gate).
+* An explicit, default-off ``scan``/``list`` harness CLI (``main``) exercises
+  the reconciler offline and reports typed per-effect dispositions. It is NOT
+  wired into any dispatcher/cron/loop.
+
 None of this is wired into the dispatcher, cron, plugins, or config. It exists
-to be exercised by tests and an explicit CLI/harness readback.
+to be exercised by tests and an explicit CLI/harness readback (``main``).
 """
 from __future__ import annotations
 
@@ -76,6 +99,7 @@ import hashlib
 import json
 import re
 import sqlite3
+import sys
 import time
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Optional, Protocol, runtime_checkable
@@ -114,6 +138,29 @@ CONTAINMENT_DOWNSTREAM_UNAPPROVED = "DOWNSTREAM_RAN_WITHOUT_EXACT_HEAD_APPROVE"
 CONTAINMENT_UNBOUND_REVIEW_CONFLICT = "UNBOUND_REVIEW_CONFLICT"
 CONTAINMENT_STALE_RUNNING_REVIEW = "STALE_RUNNING_REVIEW"
 
+# Reconcile dispositions that refuse to mint a card and leave the lane
+# unchanged (typed so the harness/scanner can report them, not silently drop).
+#   DRAINING_ACTIVE_REVIEW    — a new head arrived while the bound review card
+#                               for the old head is still active/draining; we
+#                               must NOT spawn a parallel review (R20-adjacent).
+#   CONFLICT_MANUAL_REVIEW_UNBOUND — a manually-created, unbound parentless
+#                               review card already exists for this repo/PR; a
+#                               human must reconcile it before we mint.
+DRAINING_ACTIVE_REVIEW = "DRAINING_ACTIVE_REVIEW"
+CONFLICT_MANUAL_REVIEW_UNBOUND = "CONFLICT_MANUAL_REVIEW_UNBOUND"
+
+# Statuses in which an already-bound old-head review is considered live and
+# must be drained (never raced with a parallel review) before a new head can
+# bind. ``ready``/``todo`` are NOT here: an un-started stale card is safe to
+# replace.
+_DRAINING_REVIEW_STATES = frozenset({"running", "done", "review", "blocked"})
+
+# Default freshness window for an injected observation (seconds). An observation
+# older than this is treated as OBSERVATION_STALE — we never reconcile against a
+# stale view of the PR. Deliberately tight (60s) so a reconcile acts only on a
+# just-taken observation.
+DEFAULT_FRESHNESS_SECONDS = 60
+
 # Retry policy defaults (seconds). Backoff is deterministic so a fake clock
 # in tests fully controls scheduling — no wall-clock sleeps anywhere.
 DEFAULT_MAX_ATTEMPTS = 5
@@ -124,9 +171,26 @@ _RETRY_BACKOFF_CAP_SECONDS = 3600
 _SHA40_RE = re.compile(r"[0-9a-f]{40}")
 _REPO_RE = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
 
-# Reviewer assignee for the authoritative card. Deliberately generic; nothing
-# in the live dispatcher routes on it because nothing dispatches this candidate.
-REVIEW_CARD_ASSIGNEE = "reviewer"
+# Assignee for the authoritative card. Must be a *valid profile name* the board
+# understands — the canonical review profile is ``review`` (not ``reviewer``,
+# which is not a profile). Nothing in the live dispatcher routes on it because
+# nothing dispatches this candidate, but the value must still be a legal
+# assignee so a would-be harness could claim the card.
+REVIEW_CARD_ASSIGNEE = "review"
+
+# Discoverable, machine-readable marker embedded in a generated review card's
+# body so a scanner can recognise an effect-minted card by content alone (the
+# durable ``review_card_minted`` event is the authoritative reverse identity;
+# this is a human/grep-friendly belt-and-suspenders).
+EFFECT_CARD_BODY_MARKER = "[hermes-review-effect]"
+
+# Event kind carrying the reverse typed effect identity of a generated card.
+EVENT_REVIEW_CARD_MINTED = "review_card_minted"
+
+# ``tasks.created_by`` stamped on every effect-minted review card. Detection
+# uses it (plus the durable event + body marker) to tell auto-created cards
+# apart from manual/unbound ones.
+EFFECT_CREATED_BY = "kanban_effects"
 
 
 # ---------------------------------------------------------------------------
@@ -430,7 +494,7 @@ def evaluate_readiness(
     observation: Optional[GithubObservation],
     *,
     now: int,
-    freshness_seconds: int = 900,
+    freshness_seconds: int = DEFAULT_FRESHNESS_SECONDS,
 ) -> ReadinessResult:
     """Pure readiness evaluation. No I/O, no DB, no mutation.
 
@@ -485,13 +549,33 @@ def evaluate_readiness(
     return ReadinessResult(READY, True, None)
 
 
+def _recheck_ready_locked(
+    payload: ReviewRequiredPayload,
+    observation: Optional[GithubObservation],
+    *,
+    now: int,
+    freshness_seconds: int = DEFAULT_FRESHNESS_SECONDS,
+) -> ReadinessResult:
+    """In-lock readiness re-check against the ALREADY-injected observation.
+
+    Re-evaluates the full predicate (temporal / status / policy / checks /
+    exact head) with no new network call, so a reconcile that leased while
+    ready but whose observation no longer satisfies the gate aborts the commit.
+    Uses plain control flow (never ``assert``) so stale input is rejected even
+    under ``python -O``.
+    """
+    return evaluate_readiness(
+        payload, observation, now=now, freshness_seconds=freshness_seconds
+    )
+
+
 # ---------------------------------------------------------------------------
 # Schema installer (R04, R05) — the ONLY place these tables are created.
 # ---------------------------------------------------------------------------
 
 _EFFECT_TABLES = ("kanban_effect_lanes", "kanban_effects", "kanban_effect_outbox")
 
-_INSTALL_SQL = """
+_LANES_SQL = """
 CREATE TABLE IF NOT EXISTS kanban_effect_lanes (
     lane_id        TEXT PRIMARY KEY,
     repo           TEXT NOT NULL,
@@ -506,8 +590,45 @@ CREATE TABLE IF NOT EXISTS kanban_effect_lanes (
     updated_at     INTEGER NOT NULL,
     UNIQUE (repo, pr_number, kind)
 );
+"""
 
-CREATE TABLE IF NOT EXISTS kanban_effects (
+_OUTBOX_SQL = """
+CREATE TABLE IF NOT EXISTS kanban_effect_outbox (
+    effect_id    TEXT PRIMARY KEY,
+    lane_id      TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    created_at   INTEGER NOT NULL
+);
+"""
+
+# Ordered column list so a rebuild's INSERT…SELECT is explicit and column-safe.
+_EFFECTS_COLUMNS = (
+    "effect_id, lane_id, source_task_id, source_transition, kind, "
+    "payload_json, payload_hash, revision, state, attempts, max_attempts, "
+    "lease_owner, lease_expires_at, next_attempt_at, last_code, last_error, "
+    "target_task_id, created_at, updated_at"
+)
+
+# Marker substring proving the CHECK constraint is present in a table's stored
+# DDL — used to decide whether an existing table needs a migration rebuild.
+_EFFECTS_CHECK_MARKER = "target_task_id IS NOT NULL"
+
+
+def _effects_ddl(table: str = "kanban_effects") -> str:
+    """DDL for the effects table (no ``IF NOT EXISTS`` — callers decide).
+
+    Two durability constraints over the original candidate:
+
+    * ``CHECK (state <> 'done' OR target_task_id IS NOT NULL)`` — a *done*
+      (successfully reconciled) effect must be bound to its target review card.
+      A terminal effect can never claim success with a NULL target.
+    * a partial ``UNIQUE`` index (created separately) enforces at most one
+      *leased* (in-flight reconciling) effect per lane, serializing reconcile
+      at the lane granularity as defense-in-depth beyond the lane CAS.
+    """
+    return f"""
+CREATE TABLE {table} (
     effect_id         TEXT PRIMARY KEY,
     lane_id           TEXT NOT NULL,
     source_task_id    TEXT NOT NULL,
@@ -530,33 +651,79 @@ CREATE TABLE IF NOT EXISTS kanban_effects (
     updated_at        INTEGER NOT NULL,
     -- One effect per source + (lane, payload). Different implementation
     -- sources preserve provenance; replay of one source handoff dedupes (R08).
-    UNIQUE (source_task_id, lane_id, payload_hash)
+    UNIQUE (source_task_id, lane_id, payload_hash),
+    -- A terminal (done) effect must be bound to its target review card.
+    CHECK (state <> 'done' OR target_task_id IS NOT NULL)
 );
+"""
 
-CREATE TABLE IF NOT EXISTS kanban_effect_outbox (
-    effect_id    TEXT PRIMARY KEY,
-    lane_id      TEXT NOT NULL,
-    kind         TEXT NOT NULL,
-    payload_hash TEXT NOT NULL,
-    created_at   INTEGER NOT NULL
-);
 
+_INDEXES_SQL = """
 CREATE INDEX IF NOT EXISTS idx_effects_state_next
     ON kanban_effects(state, next_attempt_at);
 CREATE INDEX IF NOT EXISTS idx_effects_lane
     ON kanban_effects(lane_id);
+-- At most one leased (in-flight) effect per lane (R09 defense-in-depth).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_effects_one_leased_per_lane
+    ON kanban_effects(lane_id) WHERE state = 'leased';
 """
 
 
+def _table_sql(conn: sqlite3.Connection, name: str) -> Optional[str]:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    if row is None:
+        return None
+    return row[0] if not isinstance(row, sqlite3.Row) else row["sql"]
+
+
+def _rebuild_effects_table(conn: sqlite3.Connection) -> None:
+    """Migration-safe, in-place rebuild that adds the new CHECK constraint to a
+    pre-remediation ``kanban_effects`` table without losing rows.
+
+    SQLite cannot ``ALTER TABLE … ADD CONSTRAINT``; the canonical fix is a
+    create-new / copy / drop / rename inside one transaction. The partial
+    ``UNIQUE`` index and secondary indexes are (re)created afterward by the
+    caller via ``CREATE … IF NOT EXISTS``.
+    """
+    from hermes_cli import kanban_db as kb
+
+    with kb.write_txn(conn):
+        conn.execute("DROP TABLE IF EXISTS kanban_effects__migrate")
+        conn.execute(_effects_ddl("kanban_effects__migrate"))
+        conn.execute(
+            f"INSERT INTO kanban_effects__migrate ({_EFFECTS_COLUMNS}) "
+            f"SELECT {_EFFECTS_COLUMNS} FROM kanban_effects"
+        )
+        conn.execute("DROP TABLE kanban_effects")
+        conn.execute("ALTER TABLE kanban_effects__migrate RENAME TO kanban_effects")
+
+
 def install_effects_schema(conn: sqlite3.Connection) -> None:
-    """Create the effect/outbox/lane tables. THE ONLY creation path.
+    """Create (or migrate) the effect/outbox/lane tables. THE ONLY creation path.
 
     Never call this from ``connect``, ``init_db``, migrations, the dispatcher,
     cron, gateway, plugins, config, or any read path. It exists for tests and
     the explicit offline harness so the feature stays default-off: a normal DB
     has none of these tables (R04, R05).
+
+    Idempotent and migration-safe: on a fresh DB it creates the tables with the
+    durability constraints; on a DB that still carries the pre-remediation
+    ``kanban_effects`` shape (no CHECK constraint) it rebuilds the table in
+    place, preserving rows, then (re)creates the indexes including the
+    one-leased-per-lane partial UNIQUE index.
     """
-    conn.executescript(_INSTALL_SQL)
+    conn.executescript(_LANES_SQL)
+    conn.executescript(_OUTBOX_SQL)
+
+    existing = _table_sql(conn, "kanban_effects")
+    if existing is None:
+        conn.executescript(_effects_ddl("kanban_effects"))
+    elif _EFFECTS_CHECK_MARKER not in existing:
+        _rebuild_effects_table(conn)
+
+    conn.executescript(_INDEXES_SQL)
 
 
 def effects_installed(conn: sqlite3.Connection) -> bool:
@@ -814,38 +981,45 @@ def lease_effect(
     """Atomically acquire a lease on a due effect via CAS. Opens its own
     write transaction — callers must NOT already hold one.
 
-    Wins only when the effect is pending-and-due, or leased-but-expired. The
+    Wins only when the effect is pending-and-due, or leased-but-expired, AND no
+    other effect on the same lane is already leased (the one-leased-per-lane
+    partial UNIQUE index serializes reconcile at the lane granularity). The
     revision is bumped so a stale holder's later CAS write fails. Returns the
     leased row, or ``None`` if it could not be leased (R10).
     """
     from hermes_cli import kanban_db as kb
 
-    with kb.write_txn(conn):
-        row = conn.execute(
-            "SELECT * FROM kanban_effects WHERE effect_id = ?", (effect_id,)
-        ).fetchone()
-        if row is None:
-            return None
-        state = row["state"]
-        rev = int(row["revision"])
-        leasable = (
-            (state == STATE_PENDING and int(row["next_attempt_at"]) <= now)
-            or (
-                state == STATE_LEASED
-                and (row["lease_expires_at"] is None or int(row["lease_expires_at"]) <= now)
+    try:
+        with kb.write_txn(conn):
+            row = conn.execute(
+                "SELECT * FROM kanban_effects WHERE effect_id = ?", (effect_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            state = row["state"]
+            rev = int(row["revision"])
+            leasable = (
+                (state == STATE_PENDING and int(row["next_attempt_at"]) <= now)
+                or (
+                    state == STATE_LEASED
+                    and (row["lease_expires_at"] is None or int(row["lease_expires_at"]) <= now)
+                )
             )
-        )
-        if not leasable:
-            return None
-        cur = conn.execute(
-            "UPDATE kanban_effects "
-            "SET state = ?, lease_owner = ?, lease_expires_at = ?, "
-            "    revision = revision + 1, updated_at = ? "
-            "WHERE effect_id = ? AND revision = ?",
-            (STATE_LEASED, owner, now + int(lease_ttl_seconds), now, effect_id, rev),
-        )
-        if cur.rowcount != 1:
-            return None
+            if not leasable:
+                return None
+            cur = conn.execute(
+                "UPDATE kanban_effects "
+                "SET state = ?, lease_owner = ?, lease_expires_at = ?, "
+                "    revision = revision + 1, updated_at = ? "
+                "WHERE effect_id = ? AND revision = ?",
+                (STATE_LEASED, owner, now + int(lease_ttl_seconds), now, effect_id, rev),
+            )
+            if cur.rowcount != 1:
+                return None
+    except sqlite3.IntegrityError:
+        # Another effect on this lane is already leased (one-leased-per-lane
+        # partial UNIQUE index). Treat as "could not lease" rather than an error.
+        return None
     return get_effect(conn, effect_id)
 
 
@@ -913,7 +1087,9 @@ def row_state(conn: sqlite3.Connection, effect_id: str) -> Optional[str]:
 
 @dataclass(frozen=True)
 class ReconcileResult:
-    status: str  # "reconciled" | "not_ready" | "skipped" | "stale"
+    # status: "reconciled" | "not_ready" | "skipped" | "stale" | "draining"
+    #         | "conflict"
+    status: str
     code: str
     effect_id: str
     review_task_id: Optional[str] = None
@@ -921,13 +1097,47 @@ class ReconcileResult:
     detail: Optional[str] = None
 
 
-class _StaleHeadInsideTxn(Exception):
-    """Internal: head drifted between lease and the reconcile txn.
+class _ReconcileBail(Exception):
+    """Internal base: a typed reason to abandon the reconcile write txn.
 
     Raised inside the reconcile write transaction so ``write_txn`` rolls back
     cleanly (no partial review card is ever committed); the public wrapper
-    converts it into a scheduled retry.
+    converts it into a typed, scheduled-retry disposition. Carries the typed
+    ``code`` and human ``detail`` the wrapper surfaces.
     """
+
+    def __init__(self, code: str, detail: Optional[str] = None) -> None:
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+class _NotReadyInsideTxn(_ReconcileBail):
+    """In-lock readiness re-check (temporal/status/policy/checks/head) failed.
+
+    Covers the former stale-head case *and* any other predicate that no longer
+    holds when re-evaluated against the injected observation under the lock —
+    without using ``assert`` (which ``-O`` strips) for stale input.
+    """
+
+
+class _DrainingActiveReview(_ReconcileBail):
+    """A new head arrived while the bound old-head review is still active.
+
+    We must not spawn a parallel review; leave the lane unchanged and drain.
+    """
+
+    def __init__(self, review_task_id: str, detail: Optional[str] = None) -> None:
+        super().__init__(DRAINING_ACTIVE_REVIEW, detail)
+        self.review_task_id = review_task_id
+
+
+class _ManualReviewConflict(_ReconcileBail):
+    """A manual/unbound parentless review card already exists for this repo/PR."""
+
+    def __init__(self, task_id: str, detail: Optional[str] = None) -> None:
+        super().__init__(CONFLICT_MANUAL_REVIEW_UNBOUND, detail)
+        self.task_id = task_id
 
 
 def _reconcile_effect_impl(
@@ -992,12 +1202,14 @@ def _reconcile_effect_impl(
         if row is None:
             return ReconcileResult("stale", "REVISION_DRIFT", effect_id)
 
-        # Belt-and-suspenders: the just-observed head must still equal the
-        # payload head (freshness re-check inside the lock; no re-fetch).
-        assert observation is not None  # readiness.ready implies non-None
-        if observation.head_sha != payload.head_sha:
-            # Fall out of the txn without mutation; schedule a retry after.
-            raise _StaleHeadInsideTxn()
+        # Re-check the FULL readiness predicate (temporal / status / policy /
+        # checks / exact head) against the already-injected observation, under
+        # the lock and with NO new network call. Any predicate that no longer
+        # holds bails out of the txn (rollback → typed scheduled retry). No
+        # ``assert`` is used, so `-O` cannot strip this gate on stale input.
+        recheck = _recheck_ready_locked(payload, observation, now=now)
+        if not recheck.ready:
+            raise _NotReadyInsideTxn(recheck.code, recheck.detail)
 
         lane_id = eff.lane_id
         lane = conn.execute(
@@ -1019,6 +1231,33 @@ def _reconcile_effect_impl(
             and kb.get_task(conn, review_task_id) is not None
         )
         if not reuse:
+            # A new head must NOT spawn a parallel review while the bound
+            # old-head review is still active/draining (running/done/review/
+            # blocked). Leave the lane unchanged and drain instead.
+            if review_task_id is not None and lane["head_sha"] != payload.head_sha:
+                existing = kb.get_task(conn, review_task_id)
+                if existing is not None and existing.status in _DRAINING_REVIEW_STATES:
+                    raise _DrainingActiveReview(
+                        review_task_id,
+                        f"old-head review {review_task_id} is {existing.status} at "
+                        f"{(lane['head_sha'] or '')[:8]}; drain before binding new head "
+                        f"{payload.head_sha[:8]} — no parallel review spawned",
+                    )
+
+            # A manual / unbound parentless review card for this repo/PR must be
+            # reconciled by a human before we mint an authoritative one.
+            manual = find_unbound_review_cards(
+                conn, payload.repo, payload.pr_number,
+                lane_review_task_id=review_task_id,
+            )
+            if manual:
+                raise _ManualReviewConflict(
+                    manual[0],
+                    f"manual/unbound review card(s) {manual} exist for "
+                    f"{payload.repo}#{payload.pr_number}; refusing to mint a parallel "
+                    "authoritative review",
+                )
+
             review_task_id = kb._new_task_id()
             kb._create_task_locked(
                 conn,
@@ -1032,7 +1271,11 @@ def _reconcile_effect_impl(
                     "Authoritative review card for PR "
                     f"{payload.repo}#{payload.pr_number} at exact head "
                     f"{payload.head_sha}. Auto-created by the review-required "
-                    "effect reconciler (repository-only candidate)."
+                    "effect reconciler (repository-only candidate).\n"
+                    # Discoverable, machine-readable reverse effect identity so a
+                    # scanner recognises this as effect-minted (not manual).
+                    f"{EFFECT_CARD_BODY_MARKER} "
+                    f"lane={eff.lane_id} effect={effect_id} head={payload.head_sha}"
                 ),
                 assignee=REVIEW_CARD_ASSIGNEE,
                 parents=(),
@@ -1042,7 +1285,7 @@ def _reconcile_effect_impl(
                 # worker has actually claimed it.
                 initial_status="ready",
                 priority=0,
-                created_by="kanban_effects",
+                created_by=EFFECT_CREATED_BY,
                 workspace_kind="scratch",
                 workspace_path=None,
                 branch_name=None,
@@ -1061,6 +1304,21 @@ def _reconcile_effect_impl(
                 session_id=None,
             )
             created_review = True
+            # Durable reverse typed effect identity for the minted card, so the
+            # scanner/harness can discover which effect + lane + head produced
+            # it even if the body is later edited (R19 detection).
+            kb._append_event(
+                conn,
+                review_task_id,
+                EVENT_REVIEW_CARD_MINTED,
+                {
+                    "effect_id": effect_id,
+                    "lane_id": eff.lane_id,
+                    "repo": payload.repo,
+                    "pr_number": payload.pr_number,
+                    "head_sha": payload.head_sha,
+                },
+            )
 
         # Attach the authoritative review card as the parent of the
         # pre-created downstream QA/Release cards and demote todo/ready to
@@ -1136,10 +1394,16 @@ def reconcile_effect(
 ) -> ReconcileResult:
     """Public reconcile entry point.
 
-    Delegates to :func:`_reconcile_effect_impl` and translates a head drift
-    detected inside the write transaction (``_StaleHeadInsideTxn``) into a
-    scheduled retry, so the caller never sees the internal sentinel and no
-    partial review card is committed on a late head change (R14).
+    Delegates to :func:`_reconcile_effect_impl` and translates a typed in-txn
+    bail (``_ReconcileBail``) — a failed in-lock readiness re-check, a draining
+    old-head review, or a manual/unbound review conflict — into a typed,
+    scheduled-retry disposition. The caller never sees the internal sentinel and
+    no partial review card is ever committed (R14, R19, R20-adjacent).
+
+    On every bail the lane is left unchanged (the write txn rolled back) and the
+    effect is retried after a backoff (or moved to the DLQ once ``max_attempts``
+    is exhausted), so a persistent conflict is durably surfaced rather than
+    silently dropped.
     """
     try:
         return _reconcile_effect_impl(
@@ -1150,18 +1414,25 @@ def reconcile_effect(
             owner=owner,
             lease_ttl_seconds=lease_ttl_seconds,
         )
-    except _StaleHeadInsideTxn:
+    except _ReconcileBail as bail:
         eff = get_effect(conn, effect_id)
         expected_rev = eff.revision if eff else 0
         state = _record_attempt_failure(
             conn,
             effect_id,
-            code=STALE_HEAD,
-            detail="head drifted between lease and reconcile",
+            code=bail.code,
+            detail=bail.detail,
             now=now,
             expected_revision=expected_rev,
         )
-        return ReconcileResult("not_ready", STALE_HEAD, effect_id, detail=state)
+        status = "draining" if isinstance(bail, _DrainingActiveReview) else (
+            "conflict" if isinstance(bail, _ManualReviewConflict) else "not_ready"
+        )
+        # Surface the offending task id in ``detail`` for the conflict/draining
+        # dispositions so the harness can point at it; otherwise carry the
+        # resulting effect state.
+        detail = bail.detail if bail.detail else state
+        return ReconcileResult(status, bail.code, effect_id, detail=detail)
 
 
 # ---------------------------------------------------------------------------
@@ -1271,6 +1542,135 @@ def scan_unbound_review_conflict(
     return findings
 
 
+# ---------------------------------------------------------------------------
+# Manual/unbound review detection + reverse effect identity (R19, blocker 4)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EffectCardIdentity:
+    """The reverse typed effect identity of an effect-minted review card,
+    recovered from its durable ``review_card_minted`` event."""
+
+    task_id: str
+    effect_id: str
+    lane_id: str
+    repo: str
+    pr_number: int
+    head_sha: str
+
+
+def effect_identity_of_card(
+    conn: sqlite3.Connection, task_id: Optional[str]
+) -> Optional[EffectCardIdentity]:
+    """Recover a review card's reverse effect identity, or ``None`` if the card
+    was not minted by the effect reconciler.
+
+    Reads the durable ``review_card_minted`` event (authoritative even if the
+    card body was later edited). This is what makes an effect-generated card
+    *discoverable* and distinguishable from a manual one.
+    """
+    if not task_id:
+        return None
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = ? AND payload IS NOT NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, EVENT_REVIEW_CARD_MINTED),
+    ).fetchone()
+    if row is None:
+        return None
+    try:
+        data = json.loads(row["payload"] if isinstance(row, sqlite3.Row) else row[0])
+    except (TypeError, ValueError):
+        return None
+    try:
+        return EffectCardIdentity(
+            task_id=task_id,
+            effect_id=str(data["effect_id"]),
+            lane_id=str(data["lane_id"]),
+            repo=str(data["repo"]),
+            pr_number=int(data["pr_number"]),
+            head_sha=str(data["head_sha"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _is_effect_generated_review(conn: sqlite3.Connection, task, body: Optional[str]) -> bool:
+    """True iff a card was produced by the effect reconciler (not manual).
+
+    Belt-and-suspenders across three independent signals: the durable
+    ``created_by`` stamp, the discoverable body marker, and the reverse-identity
+    event. Any one is sufficient — an editor stripping the body still leaves the
+    event and the stamp.
+    """
+    if getattr(task, "created_by", None) == EFFECT_CREATED_BY:
+        return True
+    if body and EFFECT_CARD_BODY_MARKER in body:
+        return True
+    return effect_identity_of_card(conn, getattr(task, "id", None)) is not None
+
+
+def find_unbound_review_cards(
+    conn: sqlite3.Connection,
+    repo: str,
+    pr_number: int,
+    *,
+    lane_review_task_id: Optional[str] = None,
+) -> list[str]:
+    """Return the ids of *manual / unbound* parentless review cards that refer
+    to ``repo#pr_number`` and were NOT minted by the effect reconciler.
+
+    Used both by the reconciler (to refuse minting a parallel authoritative
+    card while a human's unbound review card exists — typed
+    ``CONFLICT_MANUAL_REVIEW_UNBOUND``) and by the offline scanner. A card is
+    flagged when ALL hold:
+
+    * it looks like a review card (assignee/status ``review`` or "review" in
+      the title),
+    * it is parentless (an unbound root, not already re-parented under an
+      authoritative card),
+    * its title/body references the exact ``repo#pr`` (word-boundary, so
+      ``#42`` never matches ``#420``),
+    * it is not the lane's own bound authoritative card, and
+    * it is not itself effect-generated.
+    """
+    from hermes_cli import kanban_db as kb
+
+    ref = re.compile(re.escape(repo) + "#" + str(int(pr_number)) + r"(?!\d)")
+    like = f"%{repo}#{pr_number}%"
+    rows = conn.execute(
+        "SELECT * FROM tasks "
+        "WHERE status != 'archived' AND (title LIKE ? OR IFNULL(body,'') LIKE ?) "
+        "ORDER BY created_at, id",
+        (like, like),
+    ).fetchall()
+
+    out: list[str] = []
+    for row in rows:
+        task = kb.Task.from_row(row)
+        if lane_review_task_id is not None and task.id == lane_review_task_id:
+            continue
+        title = task.title or ""
+        body = task.body
+        looks_review = (
+            (task.assignee == "review")
+            or (task.status == "review")
+            or ("review" in title.lower())
+        )
+        if not looks_review:
+            continue
+        if not (ref.search(title) or (body and ref.search(body))):
+            continue
+        if kb.parent_ids(conn, task.id):
+            continue  # already bound under some parent — not an unbound root
+        if _is_effect_generated_review(conn, task, body):
+            continue
+        out.append(task.id)
+    return out
+
+
 _LEGACY_REVIEW_HINTS = re.compile(
     r"\b(needs?\s+review|please\s+review|review\s+required|awaiting\s+review|"
     r"ready\s+for\s+review|pr\s+review)\b",
@@ -1305,3 +1705,189 @@ def detect_legacy_review_text(text: Optional[str]) -> LegacyReviewAlert:
         "legacy untyped review request detected — alert only; no review card "
         "is auto-created. Re-emit as a typed review_required effect to bind a lane.",
     )
+
+
+# ---------------------------------------------------------------------------
+# Explicit offline harness CLI (default-off — NOT dispatcher/cron wired)
+# ---------------------------------------------------------------------------
+#
+# This entrypoint exists ONLY to be run by a human/operator or a test against a
+# board that has *already* had ``install_effects_schema`` applied. Nothing wires
+# it into the dispatcher, cron, gateway, plugins, config, or any automatic loop:
+# it must be invoked explicitly (``python -m hermes_cli.kanban_effects scan``)
+# and it performs no network I/O — every GitHub observation is *injected* from a
+# JSON file. On a normal default-off board (no effect tables) it fails loudly.
+
+
+def _observation_from_dict(item: Mapping[str, Any]) -> GithubObservation:
+    rcp = item.get("required_check_policy")
+    return GithubObservation(
+        repo=str(item["repo"]),
+        pr_number=int(item["pr_number"]),
+        head_sha=str(item["head_sha"]),
+        is_open=bool(item["is_open"]),
+        has_conflicts=bool(item.get("has_conflicts", False)),
+        checks=dict(item.get("checks") or {}),
+        required_check_policy=(tuple(rcp) if rcp is not None else None),
+        observed_at=int(item["observed_at"]),
+    )
+
+
+def _load_observer(path: Optional[str]) -> InMemoryGithubObserver:
+    """Build an in-memory observer from a JSON list of injected observations.
+
+    No path → an empty observer (every observe() → ``None`` → OBSERVATION_STALE),
+    which is a legitimate, network-free disposition outcome.
+    """
+    observer = InMemoryGithubObserver()
+    if not path:
+        return observer
+    from pathlib import Path
+
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("--observations must contain a JSON list of observations")
+    for item in data:
+        observer.set(_observation_from_dict(item))
+    return observer
+
+
+def _cmd_scan(args) -> int:
+    from hermes_cli import kanban_db as kb
+
+    now = int(args.now) if args.now is not None else int(time.time())
+    observer = _load_observer(args.observations)
+    dispositions: list[dict] = []
+    with kb.connect_closing() as conn:
+        if not effects_installed(conn):
+            raise EffectsNotInstalledError(
+                "effect schema not installed on this board — run the explicit "
+                "installer first (this feature is default-off)"
+            )
+        due = scan_due_effects(conn, now=now)
+        for eff in due:
+            if args.dry_run:
+                # Report the would-be disposition without leasing/mutating.
+                obs = observer.observe(eff.payload.repo, eff.payload.pr_number)
+                readiness = evaluate_readiness(eff.payload, obs, now=now)
+                dispositions.append(
+                    {
+                        "effect_id": eff.effect_id,
+                        "status": "dry_run",
+                        "code": readiness.code,
+                        "ready": readiness.ready,
+                        "detail": readiness.detail,
+                    }
+                )
+                continue
+            r = reconcile_effect(conn, eff.effect_id, observer, now=now)
+            dispositions.append(
+                {
+                    "effect_id": r.effect_id,
+                    "status": r.status,
+                    "code": r.code,
+                    "review_task_id": r.review_task_id,
+                    "created_review": r.created_review,
+                    "detail": r.detail,
+                }
+            )
+    print(
+        json.dumps(
+            {
+                "action": "scan",
+                "now": now,
+                "dry_run": bool(args.dry_run),
+                "scanned": len(dispositions),
+                "dispositions": dispositions,
+            }
+        )
+    )
+    return 0
+
+
+def _cmd_list(args) -> int:
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect_closing() as conn:
+        if not effects_installed(conn):
+            raise EffectsNotInstalledError(
+                "effect schema not installed on this board (default-off)"
+            )
+        effects = list_effects(conn, state=args.state)
+        rows = [
+            {
+                "effect_id": e.effect_id,
+                "lane_id": e.lane_id,
+                "state": e.state,
+                "attempts": e.attempts,
+                "next_attempt_at": e.next_attempt_at,
+                "target_task_id": e.target_task_id,
+                "last_code": e.last_code,
+            }
+            for e in effects
+        ]
+    print(json.dumps({"action": "list", "count": len(rows), "effects": rows}))
+    return 0
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    """Explicit, default-off offline harness. Returns a process exit code.
+
+    Subcommands:
+      * ``scan``  — reconcile every due effect using injected observations and
+        print a typed per-effect disposition outcome (``reconciled`` /
+        ``not_ready`` / ``draining`` / ``conflict`` / ``stale`` / ``skipped``),
+        or ``--dry-run`` to report the disposition without mutating.
+      * ``list``  — dump effect rows (optionally filtered by ``--state``).
+
+    Never invoked automatically; there is no reconcile loop, timer, or wiring.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="hermes-kanban-effects",
+        description=(
+            "Explicit, default-off offline harness for the repository-only "
+            "review-required effect candidate. Not wired into the dispatcher, "
+            "cron, gateway, plugins, or config. No network I/O."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_scan = sub.add_parser(
+        "scan", help="reconcile due effects using injected observations"
+    )
+    p_scan.add_argument(
+        "--now", type=int, default=None,
+        help="unix seconds to evaluate against (default: wall clock)",
+    )
+    p_scan.add_argument(
+        "--observations", default=None,
+        help="path to a JSON list of injected GitHub observations (no network)",
+    )
+    p_scan.add_argument(
+        "--dry-run", action="store_true",
+        help="report dispositions without leasing or mutating",
+    )
+    p_scan.set_defaults(func=_cmd_scan)
+
+    p_list = sub.add_parser("list", help="list effect rows")
+    p_list.add_argument(
+        "--state", default=None,
+        help="filter by state (pending/leased/done/failed/dlq)",
+    )
+    p_list.set_defaults(func=_cmd_list)
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        return int(args.func(args))
+    except EffectsNotInstalledError as exc:
+        print(
+            json.dumps({"error": "effects_not_installed", "detail": str(exc)}),
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - explicit manual invocation
+    raise SystemExit(main())

--- a/hermes_cli/kanban_effects.py
+++ b/hermes_cli/kanban_effects.py
@@ -1,0 +1,1307 @@
+"""Repository-only **candidate** for a review-required Kanban effect system.
+
+STATUS: repository-only, **default-off**, NOT wired into the live product.
+
+Nothing in this module is created by, imported by, or reachable from the
+normal Kanban runtime. The effect / outbox / lane tables it defines are
+**only** created by :func:`install_effects_schema`, which the dispatcher,
+cron, gateway, plugins, config, ``connect``/``init_db``/migrations, and every
+read-only path never call. A fresh production Kanban DB therefore has none of
+these tables — see ``tests/hermes_cli/test_kanban_effects.py`` for the guard.
+
+What this candidate models
+--------------------------
+When a worker finishes (``complete``) or parks (``block``) a task, it may emit
+an optional, schema-validated ``review_required`` payload describing a GitHub
+PR that must pass review before downstream QA/Release work proceeds. The
+producer persists a durable *source/outbox* record inside the SAME transition
+transaction as the status change (never comment metadata — comments are not an
+authority). A separate, explicitly-invoked reconciler later:
+
+  * re-reads the effect payload hash / revision and a freshly-*injected*
+    (never network-fetched-while-a-DB-transaction-is-held) GitHub observation,
+  * compare-and-swaps the canonical *lane* for the (repo, PR) pair,
+  * creates or reuses exactly one *parentless, exact-head* review card,
+  * attaches that authoritative review card as the parent of the pre-created
+    downstream QA/Release cards and demotes any ``todo``/``ready`` ones back to
+    ``todo``,
+  * binds the effect to its target card + lane, marking it durably done.
+
+Determinism, exactly-once and durability
+----------------------------------------
+Lane, effect and payload identities are deterministic content hashes. A lane is
+shared by a (repo, PR); an effect additionally includes its source task, so an
+identical replay collapses while independent implementation handoffs retain
+provenance. ``UNIQUE`` constraints + compare-and-swap make the producer and the
+reconciler idempotent under concurrency. Effects carry a
+durable state machine (pending → leased → done / failed → dlq) with a lease
+owner/expiry, an attempt counter, a monotonic ``next_attempt_at`` backoff, and
+a dead-letter terminal state.
+
+Requirement map (R01–R21)
+--------------------------
+R01 valid payload persists effect+outbox+lane in the transition txn.
+R02 absent payload preserves existing transition behavior byte-for-byte.
+R03 invalid payload is rejected with a typed code; no state change.
+R04 effect/outbox/lane tables exist only after ``install_effects_schema``.
+R05 a normal ``connect``/``init_db`` DB lacks the tables.
+R06 canonical lane identity is deterministic for a (repo, PR) pair.
+R07 canonical payload identity is deterministic and key-order independent.
+R08 duplicate emissions dedupe to one effect via UNIQUE(lane, payload_hash).
+R09 lane reconciliation is serialized by a revision compare-and-swap.
+R10 an effect can be leased; an expired lease is re-acquirable.
+R11 a not-ready effect retries with a monotonic ``next_attempt_at`` backoff.
+R12 an effect that exhausts ``max_attempts`` lands in the DLQ terminal state.
+R13 a missing required-check policy returns NOT_READY(REQUIRED_CHECK_POLICY_MISSING).
+R14 an observation whose head != payload head is STALE_HEAD; no card created.
+R15 a closed PR / merge conflict is NOT_READY; no card created.
+R16 a ready effect creates exactly one parentless exact-head review card and
+    reuses it on re-run for the same head.
+R17 reconcile attaches the review parent, demotes precreated todo/ready
+    QA/Release cards to todo, and binds the effect target + lane.
+R18 a downstream card left running/done without a compatible exact-head
+    APPROVE is reported as typed containment (alert only).
+R19 a manual / unbound Review card that conflicts with the authoritative lane
+    is reported as typed containment (alert only).
+R20 a stale running review is drained; no parallel review card is spawned.
+R21 legacy untyped review-ish text produces an alert only and never
+    auto-creates a review card.
+
+None of this is wired into the dispatcher, cron, plugins, or config. It exists
+to be exercised by tests and an explicit CLI/harness readback.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional, Protocol, runtime_checkable
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+KIND_REVIEW_REQUIRED = "review_required"
+
+# Durable effect states.
+STATE_PENDING = "pending"
+STATE_LEASED = "leased"
+STATE_DONE = "done"
+STATE_FAILED = "failed"
+STATE_DLQ = "dlq"
+
+# Source transitions that may emit an effect.
+TRANSITION_COMPLETE = "complete"
+TRANSITION_BLOCK = "block"
+_VALID_TRANSITIONS = frozenset({TRANSITION_COMPLETE, TRANSITION_BLOCK})
+
+# Readiness / not-ready codes (typed, stable strings).
+READY = "READY"
+REQUIRED_CHECK_POLICY_MISSING = "REQUIRED_CHECK_POLICY_MISSING"
+PR_CLOSED = "PR_CLOSED"
+HEAD_CONFLICT = "HEAD_CONFLICT"
+STALE_HEAD = "STALE_HEAD"
+CHECKS_INCOMPLETE = "CHECKS_INCOMPLETE"
+CHECKS_FAILED = "CHECKS_FAILED"
+OBSERVATION_STALE = "OBSERVATION_STALE"
+
+# Containment finding codes.
+CONTAINMENT_DOWNSTREAM_UNAPPROVED = "DOWNSTREAM_RAN_WITHOUT_EXACT_HEAD_APPROVE"
+CONTAINMENT_UNBOUND_REVIEW_CONFLICT = "UNBOUND_REVIEW_CONFLICT"
+CONTAINMENT_STALE_RUNNING_REVIEW = "STALE_RUNNING_REVIEW"
+
+# Retry policy defaults (seconds). Backoff is deterministic so a fake clock
+# in tests fully controls scheduling — no wall-clock sleeps anywhere.
+DEFAULT_MAX_ATTEMPTS = 5
+DEFAULT_LEASE_TTL_SECONDS = 300
+_RETRY_BACKOFF_BASE_SECONDS = 30
+_RETRY_BACKOFF_CAP_SECONDS = 3600
+
+_SHA40_RE = re.compile(r"[0-9a-f]{40}")
+_REPO_RE = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
+
+# Reviewer assignee for the authoritative card. Deliberately generic; nothing
+# in the live dispatcher routes on it because nothing dispatches this candidate.
+REVIEW_CARD_ASSIGNEE = "reviewer"
+
+
+# ---------------------------------------------------------------------------
+# Typed errors
+# ---------------------------------------------------------------------------
+
+
+class EffectValidationError(ValueError):
+    """A ``review_required`` payload failed schema validation.
+
+    Carries a stable ``code`` so producers can surface a typed rejection to
+    the model without state change (R03).
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+class EffectsNotInstalledError(RuntimeError):
+    """Raised by readback helpers when the effect tables are absent.
+
+    Producers never raise this (they no-op when the schema is not installed so
+    the default-off feature cannot break a normal transition); it exists so the
+    explicit CLI/harness scanner fails loudly instead of silently reading an
+    empty world.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Canonical identities (R06, R07)
+# ---------------------------------------------------------------------------
+
+
+def _sha16(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def canonical_lane_id(repo: str, pr_number: int, kind: str = KIND_REVIEW_REQUIRED) -> str:
+    """Deterministic lane identity for a (repo, PR, kind) triple.
+
+    A *lane* is the serialization point for all effects that concern one PR:
+    at most one authoritative review card ever exists per lane, and lane
+    reconciliation is CAS-guarded by a revision counter (R09).
+    """
+    canon = json.dumps(
+        {"repo": repo, "pr_number": int(pr_number), "kind": kind},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return "lane_" + _sha16(canon)
+
+
+def canonical_payload_hash(payload: "ReviewRequiredPayload") -> str:
+    """Deterministic, key-order-independent identity of *what review is required*.
+
+    Only the review-identity fields participate (repo, PR, exact head, required
+    checks). Binding hints such as ``downstream_task_ids`` are intentionally
+    excluded so re-emitting the same review with a different downstream hint
+    dedupes to the same effect rather than minting a new one.
+    """
+    canon = json.dumps(
+        {
+            "kind": payload.kind,
+            "repo": payload.repo,
+            "pr_number": payload.pr_number,
+            "head_sha": payload.head_sha,
+            "required_checks": (
+                sorted(payload.required_checks)
+                if payload.required_checks is not None
+                else None
+            ),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _sha16(canon)
+
+
+def canonical_effect_id(lane_id: str, payload_hash: str, source_task_id: str) -> str:
+    """Deterministic effect identity: one effect per source + lane + payload.
+
+    ``source_task_id`` is intentionally part of the identity: two independent
+    implementation handoffs must retain distinct provenance even when they
+    target the same PR/head. Replays of *one* source handoff compute the same
+    id, so ``INSERT OR IGNORE`` still collapses concurrent duplicate emissions
+    without using ``tasks.idempotency_key`` for correctness.
+    """
+    return "eff_" + _sha16(source_task_id + ":" + lane_id + ":" + payload_hash)
+
+
+# ---------------------------------------------------------------------------
+# Payload schema (R03)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReviewRequiredPayload:
+    """A validated ``review_required`` effect payload.
+
+    ``required_checks`` is the producer's declared required-check *policy*.
+    ``None`` means the producer did not declare one; the reconciler still
+    requires the *observation* to carry a policy (R13) — this field only
+    tightens the gate, it cannot relax it.
+    ``downstream_task_ids`` are the pre-created QA/Release cards the reconciler
+    should re-parent under the authoritative review card (binding hint only;
+    not part of payload identity).
+    """
+
+    kind: str
+    repo: str
+    pr_number: int
+    head_sha: str
+    required_checks: Optional[tuple[str, ...]] = None
+    downstream_task_ids: tuple[str, ...] = ()
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "kind": self.kind,
+                "repo": self.repo,
+                "pr_number": self.pr_number,
+                "head_sha": self.head_sha,
+                "required_checks": (
+                    list(self.required_checks)
+                    if self.required_checks is not None
+                    else None
+                ),
+                "downstream_task_ids": list(self.downstream_task_ids),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @staticmethod
+    def from_json(text: str) -> "ReviewRequiredPayload":
+        return validate_review_required(json.loads(text))
+
+
+def validate_review_required(raw: Any) -> ReviewRequiredPayload:
+    """Validate a raw ``review_required`` mapping into a typed payload.
+
+    Raises :class:`EffectValidationError` with a stable ``code`` on any
+    violation and never has a side effect, so a producer can validate before
+    mutating anything (R03). Missing/absent payloads are the caller's concern —
+    passing ``None`` here is itself an error.
+    """
+    if not isinstance(raw, Mapping):
+        raise EffectValidationError("BAD_PAYLOAD", "payload must be an object")
+
+    kind = raw.get("kind")
+    if kind is None:
+        raise EffectValidationError("MISSING_KIND", "kind is required")
+    if kind != KIND_REVIEW_REQUIRED:
+        raise EffectValidationError(
+            "BAD_KIND", f"kind must be {KIND_REVIEW_REQUIRED!r}, got {kind!r}"
+        )
+
+    repo = raw.get("repo")
+    if not repo or not isinstance(repo, str):
+        raise EffectValidationError("MISSING_REPO", "repo (owner/name) is required")
+    repo = repo.strip()
+    if not _REPO_RE.fullmatch(repo):
+        raise EffectValidationError(
+            "BAD_REPO", f"repo must be 'owner/name', got {repo!r}"
+        )
+
+    pr_raw = raw.get("pr_number")
+    if pr_raw is None:
+        raise EffectValidationError("MISSING_PR", "pr_number is required")
+    try:
+        pr_number = int(pr_raw)
+    except (TypeError, ValueError):
+        raise EffectValidationError("BAD_PR", f"pr_number must be an int, got {pr_raw!r}")
+    if pr_number <= 0:
+        raise EffectValidationError("BAD_PR", "pr_number must be positive")
+
+    head = raw.get("head_sha")
+    if not head or not isinstance(head, str):
+        raise EffectValidationError("MISSING_HEAD", "head_sha is required")
+    head = head.strip().lower()
+    if not _SHA40_RE.fullmatch(head):
+        raise EffectValidationError(
+            "BAD_HEAD", "head_sha must be an exact 40-character hex commit sha"
+        )
+
+    required_checks: Optional[tuple[str, ...]] = None
+    rc_raw = raw.get("required_checks")
+    if rc_raw is not None:
+        if not isinstance(rc_raw, (list, tuple)):
+            raise EffectValidationError(
+                "BAD_REQUIRED_CHECKS", "required_checks must be a list of strings"
+            )
+        cleaned: list[str] = []
+        for item in rc_raw:
+            if not isinstance(item, str) or not item.strip():
+                raise EffectValidationError(
+                    "BAD_REQUIRED_CHECKS", "required_checks entries must be non-empty strings"
+                )
+            cleaned.append(item.strip())
+        required_checks = tuple(cleaned)
+
+    downstream: tuple[str, ...] = ()
+    ds_raw = raw.get("downstream_task_ids")
+    if ds_raw is not None:
+        if isinstance(ds_raw, str):
+            ds_raw = [ds_raw]
+        if not isinstance(ds_raw, (list, tuple)):
+            raise EffectValidationError(
+                "BAD_DOWNSTREAM", "downstream_task_ids must be a list of task ids"
+            )
+        seen: set[str] = set()
+        cleaned_ds: list[str] = []
+        for item in ds_raw:
+            s = str(item).strip()
+            if s and s not in seen:
+                seen.add(s)
+                cleaned_ds.append(s)
+        downstream = tuple(cleaned_ds)
+
+    return ReviewRequiredPayload(
+        kind=KIND_REVIEW_REQUIRED,
+        repo=repo,
+        pr_number=pr_number,
+        head_sha=head,
+        required_checks=required_checks,
+        downstream_task_ids=downstream,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Injected GitHub observation (no network I/O — R13, R14, R15)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GithubObservation:
+    """A point-in-time, *injected* view of a PR. No network I/O ever.
+
+    ``required_check_policy`` is ``None`` when the repo/PR does not declare a
+    required-check policy — the reconciler treats that as NOT_READY rather than
+    silently approving (R13). ``checks`` maps check name → conclusion (e.g.
+    ``"success"``, ``"failure"``, ``"pending"``).
+    """
+
+    repo: str
+    pr_number: int
+    head_sha: str
+    is_open: bool
+    has_conflicts: bool
+    checks: Mapping[str, str]
+    required_check_policy: Optional[tuple[str, ...]]
+    observed_at: int
+
+    def __post_init__(self) -> None:
+        # Freeze the head at exactly 40 lowercase hex chars so downstream
+        # exact-head comparisons are total.
+        normalized = (self.head_sha or "").strip().lower()
+        object.__setattr__(self, "head_sha", normalized)
+
+
+@runtime_checkable
+class GithubObserver(Protocol):
+    """Injected observation source. Implementations MUST NOT perform network
+    I/O while any DB transaction is held; the reconciler calls ``observe``
+    strictly *before* opening its write transaction."""
+
+    def observe(self, repo: str, pr_number: int) -> Optional[GithubObservation]:
+        ...
+
+
+class InMemoryGithubObserver:
+    """Deterministic, in-memory observer for tests and the offline harness."""
+
+    def __init__(self) -> None:
+        self._by_key: dict[tuple[str, int], GithubObservation] = {}
+
+    def set(self, obs: GithubObservation) -> None:
+        self._by_key[(obs.repo, obs.pr_number)] = obs
+
+    def observe(self, repo: str, pr_number: int) -> Optional[GithubObservation]:
+        return self._by_key.get((repo, int(pr_number)))
+
+
+@dataclass(frozen=True)
+class ReadinessResult:
+    """Typed readiness verdict for a (payload, observation) pair."""
+
+    code: str
+    ready: bool
+    detail: Optional[str] = None
+
+    @property
+    def is_policy_missing(self) -> bool:
+        return self.code == REQUIRED_CHECK_POLICY_MISSING
+
+
+def evaluate_readiness(
+    payload: ReviewRequiredPayload,
+    observation: Optional[GithubObservation],
+    *,
+    now: int,
+    freshness_seconds: int = 900,
+) -> ReadinessResult:
+    """Pure readiness evaluation. No I/O, no DB, no mutation.
+
+    Order matters: a missing required-check policy short-circuits to
+    NOT_READY(REQUIRED_CHECK_POLICY_MISSING) (R13) so an unpoliced repo can
+    never be approved by omission. Head mismatch is STALE_HEAD (R14); a closed
+    PR or a merge conflict is NOT_READY (R15).
+    """
+    if observation is None:
+        return ReadinessResult(OBSERVATION_STALE, False, "no observation available")
+
+    if observation.observed_at > now:
+        return ReadinessResult(OBSERVATION_STALE, False, "observation from the future")
+    if (now - observation.observed_at) > freshness_seconds:
+        return ReadinessResult(
+            OBSERVATION_STALE, False, "observation older than freshness window"
+        )
+
+    # A missing required-check policy is a hard NOT_READY — never approve an
+    # unpoliced PR by omission.
+    if observation.required_check_policy is None:
+        return ReadinessResult(
+            REQUIRED_CHECK_POLICY_MISSING, False, "no required-check policy declared"
+        )
+
+    if not observation.is_open:
+        return ReadinessResult(PR_CLOSED, False, "PR is not open")
+    if observation.has_conflicts:
+        return ReadinessResult(HEAD_CONFLICT, False, "PR has merge conflicts")
+
+    # Exact-head gate: the observation must be for the exact commit the effect
+    # was emitted against, else it is stale (R14).
+    if observation.head_sha != payload.head_sha:
+        return ReadinessResult(
+            STALE_HEAD,
+            False,
+            f"observed head {observation.head_sha[:8]} != payload head {payload.head_sha[:8]}",
+        )
+
+    # Every required check (union of observation policy and payload policy)
+    # must have concluded successfully.
+    required = set(observation.required_check_policy)
+    if payload.required_checks:
+        required |= set(payload.required_checks)
+    for name in sorted(required):
+        conclusion = observation.checks.get(name)
+        if conclusion is None or conclusion in {"pending", "queued", "in_progress"}:
+            return ReadinessResult(CHECKS_INCOMPLETE, False, f"check {name!r} not concluded")
+        if conclusion != "success":
+            return ReadinessResult(CHECKS_FAILED, False, f"check {name!r} = {conclusion}")
+
+    return ReadinessResult(READY, True, None)
+
+
+# ---------------------------------------------------------------------------
+# Schema installer (R04, R05) — the ONLY place these tables are created.
+# ---------------------------------------------------------------------------
+
+_EFFECT_TABLES = ("kanban_effect_lanes", "kanban_effects", "kanban_effect_outbox")
+
+_INSTALL_SQL = """
+CREATE TABLE IF NOT EXISTS kanban_effect_lanes (
+    lane_id        TEXT PRIMARY KEY,
+    repo           TEXT NOT NULL,
+    pr_number      INTEGER NOT NULL,
+    kind           TEXT NOT NULL,
+    -- CAS revision guarding lane reconciliation (R09).
+    revision       INTEGER NOT NULL DEFAULT 0,
+    -- Bound authoritative review card + the exact head it reviews.
+    review_task_id TEXT,
+    head_sha       TEXT,
+    created_at     INTEGER NOT NULL,
+    updated_at     INTEGER NOT NULL,
+    UNIQUE (repo, pr_number, kind)
+);
+
+CREATE TABLE IF NOT EXISTS kanban_effects (
+    effect_id         TEXT PRIMARY KEY,
+    lane_id           TEXT NOT NULL,
+    source_task_id    TEXT NOT NULL,
+    source_transition TEXT NOT NULL,
+    kind              TEXT NOT NULL,
+    payload_json      TEXT NOT NULL,
+    payload_hash      TEXT NOT NULL,
+    -- CAS revision guarding effect state transitions.
+    revision          INTEGER NOT NULL DEFAULT 0,
+    state             TEXT NOT NULL,
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    max_attempts      INTEGER NOT NULL DEFAULT 5,
+    lease_owner       TEXT,
+    lease_expires_at  INTEGER,
+    next_attempt_at   INTEGER NOT NULL DEFAULT 0,
+    last_code         TEXT,
+    last_error        TEXT,
+    target_task_id    TEXT,
+    created_at        INTEGER NOT NULL,
+    updated_at        INTEGER NOT NULL,
+    -- One effect per source + (lane, payload). Different implementation
+    -- sources preserve provenance; replay of one source handoff dedupes (R08).
+    UNIQUE (source_task_id, lane_id, payload_hash)
+);
+
+CREATE TABLE IF NOT EXISTS kanban_effect_outbox (
+    effect_id    TEXT PRIMARY KEY,
+    lane_id      TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    created_at   INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_effects_state_next
+    ON kanban_effects(state, next_attempt_at);
+CREATE INDEX IF NOT EXISTS idx_effects_lane
+    ON kanban_effects(lane_id);
+"""
+
+
+def install_effects_schema(conn: sqlite3.Connection) -> None:
+    """Create the effect/outbox/lane tables. THE ONLY creation path.
+
+    Never call this from ``connect``, ``init_db``, migrations, the dispatcher,
+    cron, gateway, plugins, config, or any read path. It exists for tests and
+    the explicit offline harness so the feature stays default-off: a normal DB
+    has none of these tables (R04, R05).
+    """
+    conn.executescript(_INSTALL_SQL)
+
+
+def effects_installed(conn: sqlite3.Connection) -> bool:
+    """True iff every effect table exists in this DB.
+
+    Producers consult this so that emitting a payload against a normal
+    (un-installed) DB is a safe no-op rather than an error — the whole point of
+    default-off.
+    """
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN "
+        "(?, ?, ?)",
+        _EFFECT_TABLES,
+    ).fetchall()
+    present = {r[0] for r in rows}
+    return all(t in present for t in _EFFECT_TABLES)
+
+
+# ---------------------------------------------------------------------------
+# Producer — persist the source/outbox record in the transition txn (R01)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EffectRow:
+    effect_id: str
+    lane_id: str
+    source_task_id: str
+    source_transition: str
+    kind: str
+    payload_json: str
+    payload_hash: str
+    revision: int
+    state: str
+    attempts: int
+    max_attempts: int
+    lease_owner: Optional[str]
+    lease_expires_at: Optional[int]
+    next_attempt_at: int
+    last_code: Optional[str]
+    last_error: Optional[str]
+    target_task_id: Optional[str]
+    created_at: int
+    updated_at: int
+
+    @property
+    def payload(self) -> ReviewRequiredPayload:
+        return ReviewRequiredPayload.from_json(self.payload_json)
+
+    @property
+    def repo(self) -> str:
+        return self.payload.repo
+
+    @property
+    def pr_number(self) -> int:
+        return self.payload.pr_number
+
+
+def record_effect_locked(
+    conn: sqlite3.Connection,
+    *,
+    source_task_id: str,
+    source_transition: str,
+    payload: ReviewRequiredPayload,
+    now: Optional[int] = None,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> Optional[str]:
+    """Persist the source/outbox record for a valid effect. **Assumes the
+    caller already holds an open write transaction** (the same transaction as
+    the ``complete``/``block`` status change) — it opens no ``BEGIN`` of its
+    own, so it can never nest one (R01, no-nested-BEGIN).
+
+    Returns the (deterministic) effect id, or ``None`` when the effect schema
+    is not installed — a normal, default-off DB, where recording is a safe
+    no-op that leaves the transition untouched (R02 for the un-installed case).
+    """
+    if source_transition not in _VALID_TRANSITIONS:
+        raise ValueError(
+            f"source_transition must be one of {sorted(_VALID_TRANSITIONS)}"
+        )
+    if not effects_installed(conn):
+        return None
+
+    now = int(time.time()) if now is None else int(now)
+    lane_id = canonical_lane_id(payload.repo, payload.pr_number, payload.kind)
+    payload_hash = canonical_payload_hash(payload)
+    effect_id = canonical_effect_id(lane_id, payload_hash, source_task_id)
+
+    # Upsert the lane (deterministic identity; created lazily so the effect's
+    # lane_id always resolves). Never clobbers an existing lane's binding.
+    conn.execute(
+        "INSERT OR IGNORE INTO kanban_effect_lanes "
+        "(lane_id, repo, pr_number, kind, revision, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, 0, ?, ?)",
+        (lane_id, payload.repo, payload.pr_number, payload.kind, now, now),
+    )
+    # One effect per (lane, payload) — concurrent duplicate emissions collapse.
+    conn.execute(
+        "INSERT OR IGNORE INTO kanban_effects "
+        "(effect_id, lane_id, source_task_id, source_transition, kind, "
+        " payload_json, payload_hash, revision, state, attempts, max_attempts, "
+        " next_attempt_at, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?, ?)",
+        (
+            effect_id,
+            lane_id,
+            source_task_id,
+            source_transition,
+            payload.kind,
+            payload.to_json(),
+            payload_hash,
+            STATE_PENDING,
+            int(max_attempts),
+            now,
+            now,
+            now,
+        ),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO kanban_effect_outbox "
+        "(effect_id, lane_id, kind, payload_hash, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (effect_id, lane_id, payload.kind, payload_hash, now),
+    )
+    return effect_id
+
+
+# ---------------------------------------------------------------------------
+# Readback / scanner (explicit harness only — no dispatcher/cron wiring)
+# ---------------------------------------------------------------------------
+
+
+def _effect_from_row(row: sqlite3.Row) -> EffectRow:
+    return EffectRow(
+        effect_id=row["effect_id"],
+        lane_id=row["lane_id"],
+        source_task_id=row["source_task_id"],
+        source_transition=row["source_transition"],
+        kind=row["kind"],
+        payload_json=row["payload_json"],
+        payload_hash=row["payload_hash"],
+        revision=int(row["revision"]),
+        state=row["state"],
+        attempts=int(row["attempts"]),
+        max_attempts=int(row["max_attempts"]),
+        lease_owner=row["lease_owner"],
+        lease_expires_at=row["lease_expires_at"],
+        next_attempt_at=int(row["next_attempt_at"]),
+        last_code=row["last_code"],
+        last_error=row["last_error"],
+        target_task_id=row["target_task_id"],
+        created_at=int(row["created_at"]),
+        updated_at=int(row["updated_at"]),
+    )
+
+
+def get_effect(conn: sqlite3.Connection, effect_id: str) -> Optional[EffectRow]:
+    if not effects_installed(conn):
+        raise EffectsNotInstalledError("effect schema not installed on this DB")
+    row = conn.execute(
+        "SELECT * FROM kanban_effects WHERE effect_id = ?", (effect_id,)
+    ).fetchone()
+    return _effect_from_row(row) if row else None
+
+
+def list_effects(
+    conn: sqlite3.Connection, *, state: Optional[str] = None
+) -> list[EffectRow]:
+    if not effects_installed(conn):
+        raise EffectsNotInstalledError("effect schema not installed on this DB")
+    if state is None:
+        rows = conn.execute(
+            "SELECT * FROM kanban_effects ORDER BY created_at, effect_id"
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT * FROM kanban_effects WHERE state = ? ORDER BY created_at, effect_id",
+            (state,),
+        ).fetchall()
+    return [_effect_from_row(r) for r in rows]
+
+
+def scan_due_effects(conn: sqlite3.Connection, *, now: int) -> list[EffectRow]:
+    """Return effects eligible to be reconciled right now: pending and past
+    their ``next_attempt_at`` backoff, or leased with an expired lease.
+
+    Explicit readback for the offline harness — nothing calls this on a timer.
+    """
+    if not effects_installed(conn):
+        raise EffectsNotInstalledError("effect schema not installed on this DB")
+    rows = conn.execute(
+        "SELECT * FROM kanban_effects "
+        "WHERE (state = ? AND next_attempt_at <= ?) "
+        "   OR (state = ? AND (lease_expires_at IS NULL OR lease_expires_at <= ?)) "
+        "ORDER BY created_at, effect_id",
+        (STATE_PENDING, now, STATE_LEASED, now),
+    ).fetchall()
+    return [_effect_from_row(r) for r in rows]
+
+
+@dataclass(frozen=True)
+class LaneRow:
+    lane_id: str
+    repo: str
+    pr_number: int
+    kind: str
+    revision: int
+    review_task_id: Optional[str]
+    head_sha: Optional[str]
+    created_at: int
+    updated_at: int
+
+
+def get_lane(conn: sqlite3.Connection, lane_id: str) -> Optional[LaneRow]:
+    if not effects_installed(conn):
+        raise EffectsNotInstalledError("effect schema not installed on this DB")
+    row = conn.execute(
+        "SELECT * FROM kanban_effect_lanes WHERE lane_id = ?", (lane_id,)
+    ).fetchone()
+    if not row:
+        return None
+    return LaneRow(
+        lane_id=row["lane_id"],
+        repo=row["repo"],
+        pr_number=int(row["pr_number"]),
+        kind=row["kind"],
+        revision=int(row["revision"]),
+        review_task_id=row["review_task_id"],
+        head_sha=row["head_sha"],
+        created_at=int(row["created_at"]),
+        updated_at=int(row["updated_at"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lease / retry / DLQ (R10, R11, R12)
+# ---------------------------------------------------------------------------
+
+
+def _backoff_seconds(attempts: int) -> int:
+    """Deterministic exponential backoff, capped. No jitter → fully
+    reproducible under a fake clock."""
+    exp = min(attempts, 12)
+    return min(_RETRY_BACKOFF_BASE_SECONDS * (2 ** exp), _RETRY_BACKOFF_CAP_SECONDS)
+
+
+def lease_effect(
+    conn: sqlite3.Connection,
+    effect_id: str,
+    *,
+    owner: str,
+    now: int,
+    lease_ttl_seconds: int = DEFAULT_LEASE_TTL_SECONDS,
+) -> Optional[EffectRow]:
+    """Atomically acquire a lease on a due effect via CAS. Opens its own
+    write transaction — callers must NOT already hold one.
+
+    Wins only when the effect is pending-and-due, or leased-but-expired. The
+    revision is bumped so a stale holder's later CAS write fails. Returns the
+    leased row, or ``None`` if it could not be leased (R10).
+    """
+    from hermes_cli import kanban_db as kb
+
+    with kb.write_txn(conn):
+        row = conn.execute(
+            "SELECT * FROM kanban_effects WHERE effect_id = ?", (effect_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        state = row["state"]
+        rev = int(row["revision"])
+        leasable = (
+            (state == STATE_PENDING and int(row["next_attempt_at"]) <= now)
+            or (
+                state == STATE_LEASED
+                and (row["lease_expires_at"] is None or int(row["lease_expires_at"]) <= now)
+            )
+        )
+        if not leasable:
+            return None
+        cur = conn.execute(
+            "UPDATE kanban_effects "
+            "SET state = ?, lease_owner = ?, lease_expires_at = ?, "
+            "    revision = revision + 1, updated_at = ? "
+            "WHERE effect_id = ? AND revision = ?",
+            (STATE_LEASED, owner, now + int(lease_ttl_seconds), now, effect_id, rev),
+        )
+        if cur.rowcount != 1:
+            return None
+    return get_effect(conn, effect_id)
+
+
+def _record_attempt_failure(
+    conn: sqlite3.Connection,
+    effect_id: str,
+    *,
+    code: str,
+    detail: Optional[str],
+    now: int,
+    expected_revision: int,
+) -> str:
+    """Record a not-ready/failed reconcile attempt and schedule the next one,
+    or move the effect to the DLQ once ``max_attempts`` is exhausted (R11, R12).
+
+    Opens its own write transaction; CAS-guarded on ``expected_revision`` so a
+    stale reconciler cannot overwrite a newer state. Returns the resulting
+    state (``pending``, ``failed`` or ``dlq``).
+    """
+    from hermes_cli import kanban_db as kb
+
+    result_state = STATE_PENDING
+    with kb.write_txn(conn):
+        row = conn.execute(
+            "SELECT attempts, max_attempts, revision FROM kanban_effects "
+            "WHERE effect_id = ?",
+            (effect_id,),
+        ).fetchone()
+        if row is None:
+            return STATE_FAILED
+        if int(row["revision"]) != expected_revision:
+            # Someone else advanced the effect; do not clobber.
+            return row_state(conn, effect_id) or STATE_FAILED
+        attempts = int(row["attempts"]) + 1
+        max_attempts = int(row["max_attempts"])
+        if attempts >= max_attempts:
+            result_state = STATE_DLQ
+            next_at = now
+        else:
+            result_state = STATE_PENDING
+            next_at = now + _backoff_seconds(attempts)
+        conn.execute(
+            "UPDATE kanban_effects "
+            "SET state = ?, attempts = ?, next_attempt_at = ?, "
+            "    lease_owner = NULL, lease_expires_at = NULL, "
+            "    last_code = ?, last_error = ?, revision = revision + 1, "
+            "    updated_at = ? "
+            "WHERE effect_id = ? AND revision = ?",
+            (result_state, attempts, next_at, code, detail, now, effect_id, expected_revision),
+        )
+    return result_state
+
+
+def row_state(conn: sqlite3.Connection, effect_id: str) -> Optional[str]:
+    row = conn.execute(
+        "SELECT state FROM kanban_effects WHERE effect_id = ?", (effect_id,)
+    ).fetchone()
+    return row["state"] if row else None
+
+
+# ---------------------------------------------------------------------------
+# Reconciler — one outer write txn; network strictly outside it (R09, R16, R17)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    status: str  # "reconciled" | "not_ready" | "skipped" | "stale"
+    code: str
+    effect_id: str
+    review_task_id: Optional[str] = None
+    created_review: bool = False
+    detail: Optional[str] = None
+
+
+class _StaleHeadInsideTxn(Exception):
+    """Internal: head drifted between lease and the reconcile txn.
+
+    Raised inside the reconcile write transaction so ``write_txn`` rolls back
+    cleanly (no partial review card is ever committed); the public wrapper
+    converts it into a scheduled retry.
+    """
+
+
+def _reconcile_effect_impl(
+    conn: sqlite3.Connection,
+    effect_id: str,
+    observer: GithubObserver,
+    *,
+    now: int,
+    owner: str = "reconciler",
+    lease_ttl_seconds: int = DEFAULT_LEASE_TTL_SECONDS,
+) -> ReconcileResult:
+    """Drive one effect toward its terminal state.
+
+    Steps, in order, honoring "no network while a DB transaction is held":
+
+      1. Lease the effect (own txn, CAS).
+      2. Observe GitHub via the injected observer — OUTSIDE any transaction.
+      3. Evaluate readiness (pure). Not ready → schedule retry / DLQ.
+      4. In ONE outer write transaction: re-read the effect payload hash /
+         revision, CAS the lane, create-or-reuse exactly one parentless
+         exact-head review card, re-parent + demote the downstream QA/Release
+         cards, and bind the effect target + lane (R16, R17).
+    """
+    from hermes_cli import kanban_db as kb
+
+    if not effects_installed(conn):
+        raise EffectsNotInstalledError("effect schema not installed on this DB")
+
+    leased = lease_effect(
+        conn, effect_id, owner=owner, now=now, lease_ttl_seconds=lease_ttl_seconds
+    )
+    if leased is None:
+        return ReconcileResult("skipped", "NOT_LEASABLE", effect_id)
+
+    eff = leased
+    payload = eff.payload
+
+    # --- network / observation strictly OUTSIDE any DB transaction ---
+    observation = observer.observe(payload.repo, payload.pr_number)
+    readiness = evaluate_readiness(payload, observation, now=now)
+
+    if not readiness.ready:
+        state = _record_attempt_failure(
+            conn,
+            effect_id,
+            code=readiness.code,
+            detail=readiness.detail,
+            now=now,
+            expected_revision=eff.revision,
+        )
+        return ReconcileResult("not_ready", readiness.code, effect_id, detail=state)
+
+    # --- one outer write transaction ---
+    with kb.write_txn(conn):
+        # Re-read under the lock and CAS-guard on the exact payload hash +
+        # revision we leased. Any drift ⇒ bail without side effects.
+        row = conn.execute(
+            "SELECT * FROM kanban_effects WHERE effect_id = ? AND payload_hash = ? "
+            "AND revision = ? AND state = ? AND lease_owner = ?",
+            (effect_id, eff.payload_hash, eff.revision, STATE_LEASED, owner),
+        ).fetchone()
+        if row is None:
+            return ReconcileResult("stale", "REVISION_DRIFT", effect_id)
+
+        # Belt-and-suspenders: the just-observed head must still equal the
+        # payload head (freshness re-check inside the lock; no re-fetch).
+        assert observation is not None  # readiness.ready implies non-None
+        if observation.head_sha != payload.head_sha:
+            # Fall out of the txn without mutation; schedule a retry after.
+            raise _StaleHeadInsideTxn()
+
+        lane_id = eff.lane_id
+        lane = conn.execute(
+            "SELECT lane_id, revision, review_task_id, head_sha "
+            "FROM kanban_effect_lanes WHERE lane_id = ?",
+            (lane_id,),
+        ).fetchone()
+        if lane is None:
+            return ReconcileResult("stale", "LANE_MISSING", effect_id)
+        lane_rev = int(lane["revision"])
+
+        # Reuse the bound review card iff it exists AND reviews the exact head
+        # (R16). Otherwise mint a fresh parentless review card.
+        review_task_id = lane["review_task_id"]
+        created_review = False
+        reuse = (
+            review_task_id is not None
+            and lane["head_sha"] == payload.head_sha
+            and kb.get_task(conn, review_task_id) is not None
+        )
+        if not reuse:
+            review_task_id = kb._new_task_id()
+            kb._create_task_locked(
+                conn,
+                task_id=review_task_id,
+                now=now,
+                title=(
+                    f"Review {payload.repo}#{payload.pr_number} "
+                    f"@ {payload.head_sha[:8]}"
+                ),
+                body=(
+                    "Authoritative review card for PR "
+                    f"{payload.repo}#{payload.pr_number} at exact head "
+                    f"{payload.head_sha}. Auto-created by the review-required "
+                    "effect reconciler (repository-only candidate)."
+                ),
+                assignee=REVIEW_CARD_ASSIGNEE,
+                parents=(),
+                triage=False,
+                # A newly-created authoritative Review is ready to be claimed;
+                # it must not masquerade as already-running before any review
+                # worker has actually claimed it.
+                initial_status="ready",
+                priority=0,
+                created_by="kanban_effects",
+                workspace_kind="scratch",
+                workspace_path=None,
+                branch_name=None,
+                project_id=None,
+                project_obj=None,
+                project_repo=None,
+                tenant=None,
+                idempotency_key=None,
+                max_runtime_seconds=None,
+                skills_list=None,
+                max_retries=None,
+                model_override=None,
+                provider_override=None,
+                goal_mode=False,
+                goal_max_turns=None,
+                session_id=None,
+            )
+            created_review = True
+
+        # Attach the authoritative review card as the parent of the
+        # pre-created downstream QA/Release cards and demote todo/ready to
+        # todo. Running/done downstream cards are NOT demoted here — that is a
+        # containment concern surfaced by the scanner (R18).
+        for child_id in payload.downstream_task_ids:
+            child = kb.get_task(conn, child_id)
+            if child is None:
+                continue
+            if not kb._link_exists(conn, review_task_id, child_id):
+                kb._link_tasks_locked(conn, parent_id=review_task_id, child_id=child_id)
+            # _link_tasks_locked already demotes ready→todo; make the
+            # todo/ready→todo demotion explicit and idempotent.
+            conn.execute(
+                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status IN ('todo','ready')",
+                (child_id,),
+            )
+
+        # CAS the lane forward: bind the review card + head, bump revision.
+        cur = conn.execute(
+            "UPDATE kanban_effect_lanes "
+            "SET review_task_id = ?, head_sha = ?, revision = revision + 1, updated_at = ? "
+            "WHERE lane_id = ? AND revision = ?",
+            (review_task_id, payload.head_sha, now, lane_id, lane_rev),
+        )
+        if cur.rowcount != 1:
+            return ReconcileResult("stale", "LANE_CAS_LOST", effect_id)
+
+        # Bind + terminally complete the effect (CAS on its revision).
+        cur = conn.execute(
+            "UPDATE kanban_effects "
+            "SET state = ?, target_task_id = ?, lease_owner = NULL, "
+            "    lease_expires_at = NULL, last_code = ?, revision = revision + 1, "
+            "    updated_at = ? "
+            "WHERE effect_id = ? AND revision = ?",
+            (STATE_DONE, review_task_id, READY, now, effect_id, eff.revision),
+        )
+        if cur.rowcount != 1:
+            return ReconcileResult("stale", "EFFECT_CAS_LOST", effect_id)
+
+        kb._append_event(
+            conn,
+            review_task_id,
+            "review_effect_reconciled",
+            {
+                "effect_id": effect_id,
+                "lane_id": lane_id,
+                "repo": payload.repo,
+                "pr_number": payload.pr_number,
+                "head_sha": payload.head_sha,
+                "created_review": created_review,
+                "downstream_task_ids": list(payload.downstream_task_ids),
+            },
+        )
+
+    return ReconcileResult(
+        "reconciled",
+        READY,
+        effect_id,
+        review_task_id=review_task_id,
+        created_review=created_review,
+    )
+
+
+def reconcile_effect(
+    conn: sqlite3.Connection,
+    effect_id: str,
+    observer: GithubObserver,
+    *,
+    now: int,
+    owner: str = "reconciler",
+    lease_ttl_seconds: int = DEFAULT_LEASE_TTL_SECONDS,
+) -> ReconcileResult:
+    """Public reconcile entry point.
+
+    Delegates to :func:`_reconcile_effect_impl` and translates a head drift
+    detected inside the write transaction (``_StaleHeadInsideTxn``) into a
+    scheduled retry, so the caller never sees the internal sentinel and no
+    partial review card is committed on a late head change (R14).
+    """
+    try:
+        return _reconcile_effect_impl(
+            conn,
+            effect_id,
+            observer,
+            now=now,
+            owner=owner,
+            lease_ttl_seconds=lease_ttl_seconds,
+        )
+    except _StaleHeadInsideTxn:
+        eff = get_effect(conn, effect_id)
+        expected_rev = eff.revision if eff else 0
+        state = _record_attempt_failure(
+            conn,
+            effect_id,
+            code=STALE_HEAD,
+            detail="head drifted between lease and reconcile",
+            now=now,
+            expected_revision=expected_rev,
+        )
+        return ReconcileResult("not_ready", STALE_HEAD, effect_id, detail=state)
+
+
+# ---------------------------------------------------------------------------
+# Downstream containment + legacy detection (alert only — R18, R19, R20, R21)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContainmentFinding:
+    code: str
+    task_id: Optional[str]
+    detail: str
+
+
+def scan_downstream_containment(
+    conn: sqlite3.Connection,
+    lane_id: str,
+    *,
+    observation: Optional[GithubObservation],
+    approved_head_shas: Iterable[str] = (),
+) -> list[ContainmentFinding]:
+    """Report — never mutate — downstream cards that advanced without a
+    compatible exact-head APPROVE, plus unbound/stale review conflicts.
+
+    This is a readback for the offline harness. It emits alerts (R18/R19/R20);
+    it does not auto-remediate, demote, or spawn anything.
+    """
+    from hermes_cli import kanban_db as kb
+
+    if not effects_installed(conn):
+        raise EffectsNotInstalledError("effect schema not installed on this DB")
+
+    approved = {s.strip().lower() for s in approved_head_shas if s}
+    findings: list[ContainmentFinding] = []
+    lane = get_lane(conn, lane_id)
+    if lane is None:
+        return findings
+
+    exact_head = observation.head_sha if observation is not None else lane.head_sha
+    head_approved = bool(exact_head and exact_head in approved)
+
+    review_task_id = lane.review_task_id
+    if review_task_id is None:
+        return findings
+
+    # R20: a running review card whose reviewed head no longer matches the
+    # current observation is stale — it should be drained, and no *parallel*
+    # review card should be spawned (the lane binds exactly one).
+    review = kb.get_task(conn, review_task_id)
+    if (
+        review is not None
+        and review.status == "running"
+        and observation is not None
+        and lane.head_sha is not None
+        and lane.head_sha != observation.head_sha
+    ):
+        findings.append(
+            ContainmentFinding(
+                CONTAINMENT_STALE_RUNNING_REVIEW,
+                review_task_id,
+                f"running review reviews {lane.head_sha[:8]} but head is "
+                f"{observation.head_sha[:8]}; drain, do not spawn a parallel review",
+            )
+        )
+
+    # R18: downstream cards that ran/finished without a compatible exact-head
+    # APPROVE for the current head.
+    for child_id in kb.child_ids(conn, review_task_id):
+        child = kb.get_task(conn, child_id)
+        if child is None:
+            continue
+        if child.status in {"running", "done"} and not head_approved:
+            findings.append(
+                ContainmentFinding(
+                    CONTAINMENT_DOWNSTREAM_UNAPPROVED,
+                    child_id,
+                    f"downstream {child_id} is {child.status} but there is no "
+                    f"exact-head APPROVE for {exact_head[:8] if exact_head else '?'}",
+                )
+            )
+    return findings
+
+
+def scan_unbound_review_conflict(
+    conn: sqlite3.Connection,
+    lane_id: str,
+    candidate_review_task_ids: Iterable[str],
+) -> list[ContainmentFinding]:
+    """R19: report manually-created / unbound review cards that conflict with
+    the lane's single authoritative review card. Alert only."""
+    if not effects_installed(conn):
+        raise EffectsNotInstalledError("effect schema not installed on this DB")
+    lane = get_lane(conn, lane_id)
+    if lane is None or lane.review_task_id is None:
+        return []
+    findings: list[ContainmentFinding] = []
+    for tid in candidate_review_task_ids:
+        if tid and tid != lane.review_task_id:
+            findings.append(
+                ContainmentFinding(
+                    CONTAINMENT_UNBOUND_REVIEW_CONFLICT,
+                    tid,
+                    f"review card {tid} conflicts with authoritative "
+                    f"{lane.review_task_id} for lane {lane_id}",
+                )
+            )
+    return findings
+
+
+_LEGACY_REVIEW_HINTS = re.compile(
+    r"\b(needs?\s+review|please\s+review|review\s+required|awaiting\s+review|"
+    r"ready\s+for\s+review|pr\s+review)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class LegacyReviewAlert:
+    matched: bool
+    hint: Optional[str]
+    detail: str
+
+
+def detect_legacy_review_text(text: Optional[str]) -> LegacyReviewAlert:
+    """R21: legacy untyped, free-text review requests produce an ALERT ONLY.
+
+    This never returns a payload, never creates a review card, and never
+    touches the DB. It exists so a scanner can *surface* that a worker asked
+    for review in prose (instead of the typed ``review_required`` payload) and
+    a human can decide — the effect system refuses to infer authority from
+    untyped text.
+    """
+    if not text:
+        return LegacyReviewAlert(False, None, "no text")
+    m = _LEGACY_REVIEW_HINTS.search(text)
+    if not m:
+        return LegacyReviewAlert(False, None, "no legacy review phrasing detected")
+    return LegacyReviewAlert(
+        True,
+        m.group(0),
+        "legacy untyped review request detected — alert only; no review card "
+        "is auto-created. Re-emit as a typed review_required effect to bind a lane.",
+    )

--- a/tests/hermes_cli/test_kanban_effects.py
+++ b/tests/hermes_cli/test_kanban_effects.py
@@ -18,6 +18,9 @@ observer, and uses a plain integer fake clock so no test sleeps.
 """
 from __future__ import annotations
 
+import ast
+import json
+import sqlite3
 import threading
 from pathlib import Path
 
@@ -692,3 +695,345 @@ def test_reconcile_never_holds_txn_during_observation(kanban_home: Path) -> None
         r = kfx.reconcile_effect(conn, eff_id, _AssertObserver(), now=now)
         assert r.status == "reconciled"
         assert observed["in_txn"] is False  # no DB txn held during observation
+
+
+# ---------------------------------------------------------------------------
+# PR #72496 review-blocker remediation regressions
+# ---------------------------------------------------------------------------
+
+
+# --- Blocker 1: REVIEW_CARD_ASSIGNEE must be the valid "review" profile ------
+
+
+def test_review_card_assignee_is_review_profile(kanban_home: Path) -> None:
+    assert kfx.REVIEW_CARD_ASSIGNEE == "review"
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now), now=now)
+        assert kb.get_task(conn, r.review_task_id).assignee == "review"
+
+
+# --- Blocker 2: a new head must not spawn a parallel review while an ---------
+#     existing old-head review is still active/draining (running/done/
+#     review/blocked); leave the lane unchanged.
+
+
+@pytest.mark.parametrize("drain_status", ["running", "done", "review", "blocked"])
+def test_new_head_does_not_spawn_parallel_review_while_active(
+    kanban_home: Path, drain_status: str
+) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        # First effect at VALID_HEAD reconciles → authoritative review card.
+        eff_id = _emit(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now), now=now)
+        old_review = r.review_task_id
+        lane_id = kfx.get_effect(conn, eff_id).lane_id
+
+        # A new implementation handoff moves the PR to a NEW head.
+        tid = _ready_task(conn)
+        kb.complete_task(
+            conn, tid, summary="s", review_required=_payload(head_sha=OTHER_HEAD)
+        )
+        new_eff = next(
+            e.effect_id for e in kfx.list_effects(conn) if e.effect_id != eff_id
+        )
+        _make_all_due(conn)
+        # Put the old-head review into the draining state *after* completion so
+        # the completion's recompute_ready() sweep can't auto-promote a
+        # non-sticky ``blocked`` card back to ``ready`` before the reconcile.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status=? WHERE id=?", (drain_status, old_review)
+            )
+        obs = _observer(now, head_sha=OTHER_HEAD)
+        r2 = kfx.reconcile_effect(conn, new_eff, obs, now=now)
+
+        assert r2.code == kfx.DRAINING_ACTIVE_REVIEW
+        assert r2.created_review is False
+        assert r2.review_task_id is None
+        # Lane left completely unchanged — still bound to the old head + card.
+        lane = kfx.get_lane(conn, lane_id)
+        assert lane.review_task_id == old_review
+        assert lane.head_sha == VALID_HEAD
+        # No second authoritative review card was minted.
+        minted = conn.execute(
+            "SELECT COUNT(*) c FROM task_events WHERE kind='review_card_minted'"
+        ).fetchone()["c"]
+        assert minted == 1
+        # The draining effect is retried, not terminally done.
+        assert kfx.get_effect(conn, new_eff).state == kfx.STATE_PENDING
+
+
+# --- Blocker 3: non-null target on terminal (done) effects + one leased ------
+#     effect per lane, both enforced in SQLite.
+
+
+def test_done_effect_requires_nonnull_target(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        with pytest.raises(sqlite3.IntegrityError):
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE kanban_effects SET state='done', target_task_id=NULL "
+                    "WHERE effect_id=?",
+                    (eff_id,),
+                )
+
+
+def test_only_one_leased_effect_per_lane(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        # Two distinct-payload effects on the SAME lane.
+        t1 = _ready_task(conn)
+        kb.complete_task(conn, t1, summary="s", review_required=_payload(required_checks=["ci"]))
+        t2 = _ready_task(conn)
+        kb.complete_task(conn, t2, summary="s", review_required=_payload(required_checks=["ci", "lint"]))
+        effs = kfx.list_effects(conn)
+        assert len({e.lane_id for e in effs}) == 1
+        _make_all_due(conn)
+        first = kfx.lease_effect(conn, effs[0].effect_id, owner="w1", now=now)
+        assert first is not None
+        # A second active lease on the same lane must be refused at the DB layer.
+        second = kfx.lease_effect(conn, effs[1].effect_id, owner="w2", now=now)
+        assert second is None
+
+
+def test_installer_migrates_legacy_effects_table(kanban_home: Path) -> None:
+    # A pre-remediation table (no CHECK, no partial unique index) must be
+    # upgraded in place by the installer without losing rows.
+    with kb.connect_closing() as conn:
+        conn.executescript(
+            """
+            CREATE TABLE kanban_effect_lanes (
+                lane_id TEXT PRIMARY KEY, repo TEXT NOT NULL, pr_number INTEGER NOT NULL,
+                kind TEXT NOT NULL, revision INTEGER NOT NULL DEFAULT 0,
+                review_task_id TEXT, head_sha TEXT,
+                created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+                UNIQUE (repo, pr_number, kind));
+            CREATE TABLE kanban_effects (
+                effect_id TEXT PRIMARY KEY, lane_id TEXT NOT NULL,
+                source_task_id TEXT NOT NULL, source_transition TEXT NOT NULL,
+                kind TEXT NOT NULL, payload_json TEXT NOT NULL, payload_hash TEXT NOT NULL,
+                revision INTEGER NOT NULL DEFAULT 0, state TEXT NOT NULL,
+                attempts INTEGER NOT NULL DEFAULT 0, max_attempts INTEGER NOT NULL DEFAULT 5,
+                lease_owner TEXT, lease_expires_at INTEGER,
+                next_attempt_at INTEGER NOT NULL DEFAULT 0,
+                last_code TEXT, last_error TEXT, target_task_id TEXT,
+                created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+                UNIQUE (source_task_id, lane_id, payload_hash));
+            CREATE TABLE kanban_effect_outbox (
+                effect_id TEXT PRIMARY KEY, lane_id TEXT NOT NULL, kind TEXT NOT NULL,
+                payload_hash TEXT NOT NULL, created_at INTEGER NOT NULL);
+            INSERT INTO kanban_effects
+                (effect_id, lane_id, source_task_id, source_transition, kind,
+                 payload_json, payload_hash, revision, state, attempts, max_attempts,
+                 next_attempt_at, created_at, updated_at)
+            VALUES ('eff_legacy','lane_legacy','src','complete','review_required',
+                    '{}','h',0,'pending',0,5,0,0,0);
+            """
+        )
+        # Legacy DB accepts a done effect with a NULL target (no CHECK yet).
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE kanban_effects SET state='done', target_task_id=NULL "
+                "WHERE effect_id='eff_legacy'"
+            )
+        # Reset so the migration's own integrity check can pass, then migrate.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE kanban_effects SET state='pending' WHERE effect_id='eff_legacy'"
+            )
+        kfx.install_effects_schema(conn)
+        assert kfx.effects_installed(conn)
+        # Row preserved.
+        assert kfx.get_effect(conn, "eff_legacy") is not None
+        # New CHECK now enforced.
+        with pytest.raises(sqlite3.IntegrityError):
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE kanban_effects SET state='done', target_task_id=NULL "
+                    "WHERE effect_id='eff_legacy'"
+                )
+
+
+# --- Blocker 4: detect manual/unbound parentless review cards for the same ---
+#     repo/PR before minting; generated card carries a discoverable, reverse
+#     typed effect identity.
+
+
+def test_manual_unbound_review_blocks_minting(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        # A human hand-creates a parentless review card for the same PR.
+        manual = kb.create_task(
+            conn, title="Review acme/widget#42 by hand", assignee="review"
+        )
+        eff_id = _emit(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now), now=now)
+        assert r.code == kfx.CONFLICT_MANUAL_REVIEW_UNBOUND
+        assert r.created_review is False
+        # No authoritative card was minted; the lane is untouched.
+        lane = kfx.get_lane(conn, kfx.get_effect(conn, eff_id).lane_id)
+        assert lane.review_task_id is None
+        # The finding points at the offending manual card.
+        assert r.detail and manual in r.detail
+        # The manual card was NOT adopted/parented.
+        assert kb.parent_ids(conn, manual) == []
+
+
+def test_generated_card_has_discoverable_effect_identity(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now), now=now)
+        ident = kfx.effect_identity_of_card(conn, r.review_task_id)
+        assert ident is not None
+        assert ident.effect_id == eff_id
+        assert ident.lane_id == kfx.get_effect(conn, eff_id).lane_id
+        assert ident.head_sha == VALID_HEAD
+        # Body carries the machine-readable marker too.
+        assert kfx.EFFECT_CARD_BODY_MARKER in (kb.get_task(conn, r.review_task_id).body or "")
+        # The effect-generated card is never mistaken for a manual/unbound one.
+        conflicts = kfx.find_unbound_review_cards(
+            conn, "acme/widget", 42, lane_review_task_id=r.review_task_id
+        )
+        assert conflicts == []
+
+
+# --- Blocker 5: explicit, default-off scanner/harness CLI entrypoint ---------
+#     (not dispatcher-wired) with a scan action + disposition outcome.
+
+
+def test_scanner_cli_scan_emits_dispositions(
+    kanban_home: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+
+    obs_file = tmp_path / "obs.json"
+    obs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "repo": "acme/widget",
+                    "pr_number": 42,
+                    "head_sha": VALID_HEAD,
+                    "is_open": True,
+                    "has_conflicts": False,
+                    "checks": {"ci": "success"},
+                    "required_check_policy": ["ci"],
+                    "observed_at": now,
+                }
+            ]
+        )
+    )
+    rc = kfx.main(["scan", "--now", str(now), "--observations", str(obs_file)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["action"] == "scan"
+    assert payload["scanned"] == 1
+    disp = payload["dispositions"][0]
+    assert disp["effect_id"] == eff_id
+    assert disp["status"] == "reconciled"
+    assert disp["code"] == kfx.READY
+
+    with kb.connect_closing() as conn:
+        assert kfx.get_effect(conn, eff_id).state == kfx.STATE_DONE
+
+
+def test_scanner_cli_scan_without_observations_reports_stale(
+    kanban_home: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        _emit(conn)
+    rc = kfx.main(["scan", "--now", str(now)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    # No observation injected → a typed OBSERVATION_STALE disposition, no card.
+    assert payload["dispositions"][0]["code"] == kfx.OBSERVATION_STALE
+
+
+def test_scanner_cli_refuses_uninstalled_db(
+    kanban_home: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Default-off: on a normal board with no effect tables the scanner fails
+    # loudly rather than silently reading an empty world.
+    rc = kfx.main(["scan", "--now", "1000"])
+    assert rc != 0
+
+
+# --- Blocker 6: freshness defaults to 60s; in-lock predicate recheck uses ----
+#     the injected observation (no network under lock); no assert on stale
+#     input.
+
+
+def test_freshness_default_is_60_seconds(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        # 61s old → stale under the new 60s default (would have passed at 900s).
+        obs = kfx.InMemoryGithubObserver()
+        obs.set(_observation(now, observed_at=now - 61))
+        r = kfx.reconcile_effect(conn, eff_id, obs, now=now)
+        assert r.code == kfx.OBSERVATION_STALE
+        # A not-ready attempt scheduled a backoff; make it due again.
+        _make_all_due(conn)
+        # Exactly 60s old is still fresh → reconciles.
+        obs2 = kfx.InMemoryGithubObserver()
+        obs2.set(_observation(now, observed_at=now - 60))
+        r2 = kfx.reconcile_effect(conn, eff_id, obs2, now=now)
+        assert r2.status == "reconciled"
+
+
+def test_reconcile_impl_uses_no_assert_statements() -> None:
+    # "Ensure no assert used for stale input": the reconcile/readiness path
+    # must gate with real control flow, not assertions (which -O strips).
+    import inspect
+
+    src = inspect.getsource(kfx)
+    tree = ast.parse(src)
+    guarded = {
+        "_reconcile_effect_impl",
+        "reconcile_effect",
+        "evaluate_readiness",
+        "_recheck_ready_locked",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name in guarded:
+            for inner in ast.walk(node):
+                assert not isinstance(inner, ast.Assert), (
+                    f"{node.name} must not use assert for control flow"
+                )
+
+
+def test_inlock_recheck_reobserves_predicate_not_network(kanban_home: Path) -> None:
+    # The in-lock recheck must reuse the already-injected observation and must
+    # NOT call the observer again (no network under lock).
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+
+        calls = {"n": 0}
+
+        class _CountingObserver:
+            def observe(self, repo, pr_number):
+                calls["n"] += 1
+                return _observation(now)
+
+        r = kfx.reconcile_effect(conn, eff_id, _CountingObserver(), now=now)
+        assert r.status == "reconciled"
+        assert calls["n"] == 1  # observed exactly once, before the write txn

--- a/tests/hermes_cli/test_kanban_effects.py
+++ b/tests/hermes_cli/test_kanban_effects.py
@@ -1,0 +1,694 @@
+"""Tests for the repository-only, default-off review-required effect candidate.
+
+Covers the R01–R21 intent documented in :mod:`hermes_cli.kanban_effects`:
+
+* Producer validation + absence compatibility (R01–R03).
+* Explicit installer / default-init leaves no tables (R04, R05).
+* Deterministic canonical identities + dedup (R06–R08).
+* Lane CAS, lease/expiry, fake-clock retry backoff and DLQ (R09–R12).
+* Required-check policy missing, stale head, closed/conflict PR (R13–R15).
+* Reconcile creates/reuses exactly one parentless exact-head review card and
+  binds downstream QA/Release cards (R16, R17).
+* Downstream containment, unbound-review conflict, stale running review,
+  legacy untyped text (R18–R21).
+* Concurrency (20 workers) exactly-once, and the no-nested-BEGIN regression.
+
+Everything runs against a fresh temp DB and an in-memory (network-free) GitHub
+observer, and uses a plain integer fake clock so no test sleeps.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_effects as kfx
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+VALID_HEAD = "a" * 40
+OTHER_HEAD = "b" * 40
+
+
+def _payload(**over) -> dict:
+    base = {
+        "kind": "review_required",
+        "repo": "acme/widget",
+        "pr_number": 42,
+        "head_sha": VALID_HEAD,
+        "required_checks": ["ci"],
+    }
+    base.update(over)
+    return base
+
+
+def _ready_task(conn, title="t", assignee="worker") -> str:
+    """Create a task; with no parents it lands in ``ready`` and is directly
+    completable/blockable."""
+    return kb.create_task(conn, title=title, assignee=assignee)
+
+
+def _install(conn) -> None:
+    kfx.install_effects_schema(conn)
+
+
+def _make_all_due(conn) -> None:
+    """Zero every effect's ``next_attempt_at`` so it is immediately due under
+    the integer fake clock (the producer path stamps real wall-clock time)."""
+    with kb.write_txn(conn):
+        conn.execute("UPDATE kanban_effects SET next_attempt_at = 0")
+
+
+def _observation(now: int, **over) -> kfx.GithubObservation:
+    base = dict(
+        repo="acme/widget",
+        pr_number=42,
+        head_sha=VALID_HEAD,
+        is_open=True,
+        has_conflicts=False,
+        checks={"ci": "success"},
+        required_check_policy=("ci",),
+        observed_at=now,
+    )
+    base.update(over)
+    return kfx.GithubObservation(**base)
+
+
+def _observer(now: int, **over) -> kfx.InMemoryGithubObserver:
+    obs = kfx.InMemoryGithubObserver()
+    obs.set(_observation(now, **over))
+    return obs
+
+
+# ---------------------------------------------------------------------------
+# R04 / R05 — installer only; default init has no tables
+# ---------------------------------------------------------------------------
+
+
+def test_default_db_has_no_effect_tables(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        assert not kfx.effects_installed(conn)
+        # The tables genuinely do not exist.
+        import sqlite3
+
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("SELECT * FROM kanban_effects").fetchall()
+        # Readback helpers refuse to operate on an un-installed DB.
+        with pytest.raises(kfx.EffectsNotInstalledError):
+            kfx.list_effects(conn)
+
+
+def test_installer_creates_tables_idempotently(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        _install(conn)
+        assert kfx.effects_installed(conn)
+        # Idempotent: a second install does not raise or duplicate.
+        _install(conn)
+        assert kfx.effects_installed(conn)
+        assert kfx.list_effects(conn) == []
+
+
+def test_reinit_db_does_not_create_effect_tables(kanban_home: Path) -> None:
+    # init_db re-runs migrations; it must never add the effect tables.
+    kb.init_db()
+    with kb.connect_closing() as conn:
+        assert not kfx.effects_installed(conn)
+
+
+# ---------------------------------------------------------------------------
+# R06 / R07 — canonical identities
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_lane_id_deterministic() -> None:
+    a = kfx.canonical_lane_id("acme/widget", 42)
+    b = kfx.canonical_lane_id("acme/widget", 42)
+    c = kfx.canonical_lane_id("acme/widget", 43)
+    assert a == b
+    assert a != c
+    assert a.startswith("lane_")
+
+
+def test_canonical_payload_hash_key_order_independent() -> None:
+    p1 = kfx.validate_review_required(
+        {"kind": "review_required", "repo": "acme/widget", "pr_number": 42,
+         "head_sha": VALID_HEAD, "required_checks": ["ci", "lint"]}
+    )
+    p2 = kfx.validate_review_required(
+        {"required_checks": ["lint", "ci"], "head_sha": VALID_HEAD,
+         "pr_number": 42, "repo": "acme/widget", "kind": "review_required"}
+    )
+    assert kfx.canonical_payload_hash(p1) == kfx.canonical_payload_hash(p2)
+    # A different head is a different payload identity.
+    p3 = kfx.validate_review_required(_payload(head_sha=OTHER_HEAD))
+    assert kfx.canonical_payload_hash(p1) != kfx.canonical_payload_hash(p3)
+    # downstream_task_ids are NOT part of payload identity (binding hint only).
+    p4 = kfx.validate_review_required(_payload(downstream_task_ids=["t_x"]))
+    p5 = kfx.validate_review_required(_payload(downstream_task_ids=["t_y"]))
+    assert kfx.canonical_payload_hash(p4) == kfx.canonical_payload_hash(p5)
+
+
+# ---------------------------------------------------------------------------
+# R03 — producer validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad, code",
+    [
+        ({"repo": "acme/widget", "pr_number": 1, "head_sha": VALID_HEAD}, "MISSING_KIND"),
+        (_payload(kind="deploy"), "BAD_KIND"),
+        (_payload(repo=""), "MISSING_REPO"),
+        (_payload(repo="not-a-repo"), "BAD_REPO"),
+        ({"kind": "review_required", "repo": "a/b", "head_sha": VALID_HEAD}, "MISSING_PR"),
+        (_payload(pr_number=0), "BAD_PR"),
+        (_payload(pr_number="x"), "BAD_PR"),
+        ({"kind": "review_required", "repo": "a/b", "pr_number": 1}, "MISSING_HEAD"),
+        (_payload(head_sha="abc"), "BAD_HEAD"),
+        (_payload(head_sha="g" * 40), "BAD_HEAD"),
+        (_payload(required_checks=[""]), "BAD_REQUIRED_CHECKS"),
+    ],
+)
+def test_validate_review_required_rejects(bad, code) -> None:
+    with pytest.raises(kfx.EffectValidationError) as ei:
+        kfx.validate_review_required(bad)
+    assert ei.value.code == code
+
+
+def test_validate_normalizes_head_and_downstream() -> None:
+    p = kfx.validate_review_required(
+        _payload(head_sha=VALID_HEAD.upper(), downstream_task_ids=["t_a", "t_a", " t_b "])
+    )
+    assert p.head_sha == VALID_HEAD  # lowercased
+    assert p.downstream_task_ids == ("t_a", "t_b")  # deduped + stripped
+
+
+# ---------------------------------------------------------------------------
+# R01 / R02 — producer records effect in the transition txn; absence unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_complete_absent_payload_unchanged(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        _install(conn)
+        tid = _ready_task(conn)
+        assert kb.complete_task(conn, tid, summary="done") is True
+        assert kb.get_task(conn, tid).status == "done"
+        # No effect emitted when the payload is absent.
+        assert kfx.list_effects(conn) == []
+
+
+def test_complete_records_effect_in_same_txn(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        _install(conn)
+        tid = _ready_task(conn)
+        assert kb.complete_task(
+            conn, tid, summary="done", review_required=_payload()
+        ) is True
+        assert kb.get_task(conn, tid).status == "done"
+        effects = kfx.list_effects(conn)
+        assert len(effects) == 1
+        eff = effects[0]
+        assert eff.state == kfx.STATE_PENDING
+        assert eff.source_transition == kfx.TRANSITION_COMPLETE
+        assert eff.source_task_id == tid
+        assert eff.repo == "acme/widget" and eff.pr_number == 42
+        # Lane + outbox rows exist and share the canonical identity.
+        lane = kfx.get_lane(conn, eff.lane_id)
+        assert lane is not None and lane.repo == "acme/widget"
+        outbox = conn.execute("SELECT * FROM kanban_effect_outbox").fetchall()
+        assert len(outbox) == 1 and outbox[0]["effect_id"] == eff.effect_id
+
+
+def test_block_records_effect_in_same_txn(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        _install(conn)
+        tid = _ready_task(conn)
+        assert kb.block_task(
+            conn, tid, reason="needs review", kind="needs_input",
+            review_required=_payload(),
+        ) is True
+        assert kb.get_task(conn, tid).status == "blocked"
+        effects = kfx.list_effects(conn)
+        assert len(effects) == 1
+        assert effects[0].source_transition == kfx.TRANSITION_BLOCK
+
+
+def test_complete_invalid_payload_rejected_no_state_change(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        _install(conn)
+        tid = _ready_task(conn)
+        with pytest.raises(kfx.EffectValidationError):
+            kb.complete_task(conn, tid, summary="x", review_required=_payload(head_sha="bad"))
+        # Task untouched, no effect written.
+        assert kb.get_task(conn, tid).status == "ready"
+        assert kfx.list_effects(conn) == []
+
+
+def test_producer_noop_when_schema_not_installed(kanban_home: Path) -> None:
+    # Default-off: a valid payload against a normal DB validates but records
+    # nothing and never crashes the completion.
+    with kb.connect_closing() as conn:
+        assert not kfx.effects_installed(conn)
+        tid = _ready_task(conn)
+        assert kb.complete_task(conn, tid, summary="done", review_required=_payload()) is True
+        assert kb.get_task(conn, tid).status == "done"
+        assert not kfx.effects_installed(conn)  # still no tables
+
+
+# ---------------------------------------------------------------------------
+# R08 — dedup
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_emissions_from_same_source_dedupe_to_one_effect(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        _install(conn)
+        payload = kfx.validate_review_required(_payload())
+        with kb.write_txn(conn):
+            first = kfx.record_effect_locked(
+                conn, source_task_id="src_1", source_transition=kfx.TRANSITION_COMPLETE,
+                payload=payload, now=1,
+            )
+            replay = kfx.record_effect_locked(
+                conn, source_task_id="src_1", source_transition=kfx.TRANSITION_COMPLETE,
+                payload=payload, now=2,
+            )
+        assert first == replay
+        assert len(kfx.list_effects(conn)) == 1
+
+
+def test_distinct_sources_keep_distinct_effect_provenance(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        _install(conn)
+        payload = kfx.validate_review_required(_payload())
+        with kb.write_txn(conn):
+            first = kfx.record_effect_locked(
+                conn, source_task_id="src_1", source_transition=kfx.TRANSITION_COMPLETE,
+                payload=payload, now=1,
+            )
+            second = kfx.record_effect_locked(
+                conn, source_task_id="src_2", source_transition=kfx.TRANSITION_COMPLETE,
+                payload=payload, now=1,
+            )
+        assert first != second
+        assert {effect.source_task_id for effect in kfx.list_effects(conn)} == {"src_1", "src_2"}
+
+
+# ---------------------------------------------------------------------------
+# R13 / R14 / R15 — readiness gates
+# ---------------------------------------------------------------------------
+
+
+def _emit(conn, **over) -> str:
+    """Emit an effect via the real producer path, then normalize its
+    ``next_attempt_at`` to 0 so it is immediately due under the integer fake
+    clock the reconcile tests use (the producer stamps real wall-clock time)."""
+    tid = _ready_task(conn)
+    kb.complete_task(conn, tid, summary="s", review_required=_payload(**over))
+    eff_id = kfx.list_effects(conn)[0].effect_id
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE kanban_effects SET next_attempt_at = 0, created_at = 0, updated_at = 0 "
+            "WHERE effect_id = ?",
+            (eff_id,),
+        )
+    return eff_id
+
+
+def test_required_check_policy_missing(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        observer = _observer(now, required_check_policy=None)
+        r = kfx.reconcile_effect(conn, eff_id, observer, now=now)
+        assert r.status == "not_ready"
+        assert r.code == kfx.REQUIRED_CHECK_POLICY_MISSING
+        eff = kfx.get_effect(conn, eff_id)
+        assert eff.state == kfx.STATE_PENDING and eff.attempts == 1
+        assert eff.target_task_id is None
+        # No review card was created.
+        assert kfx.get_lane(conn, eff.lane_id).review_task_id is None
+
+
+def test_stale_head_no_card(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        observer = _observer(now, head_sha=OTHER_HEAD)
+        r = kfx.reconcile_effect(conn, eff_id, observer, now=now)
+        assert r.code == kfx.STALE_HEAD and r.status == "not_ready"
+        assert kfx.get_lane(conn, kfx.get_effect(conn, eff_id).lane_id).review_task_id is None
+
+
+def test_closed_and_conflicting_pr_not_ready(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now, is_open=False), now=now)
+        assert r.code == kfx.PR_CLOSED
+        # advance clock past backoff, then present a conflicting observation
+        now2 = kfx.get_effect(conn, eff_id).next_attempt_at
+        r2 = kfx.reconcile_effect(conn, eff_id, _observer(now2, has_conflicts=True), now=now2)
+        assert r2.code == kfx.HEAD_CONFLICT
+
+
+def test_checks_incomplete_and_failed(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now, checks={"ci": "pending"}), now=now)
+        assert r.code == kfx.CHECKS_INCOMPLETE
+        now2 = kfx.get_effect(conn, eff_id).next_attempt_at
+        r2 = kfx.reconcile_effect(conn, eff_id, _observer(now2, checks={"ci": "failure"}), now=now2)
+        assert r2.code == kfx.CHECKS_FAILED
+
+
+# ---------------------------------------------------------------------------
+# R16 / R17 — reconcile creates/reuses one review card + binds downstream
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_creates_one_parentless_review_card(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now), now=now)
+        assert r.status == "reconciled" and r.created_review
+        review = kb.get_task(conn, r.review_task_id)
+        assert review is not None
+        assert review.status == "ready"
+        assert kb.parent_ids(conn, r.review_task_id) == []  # parentless
+        eff = kfx.get_effect(conn, eff_id)
+        assert eff.state == kfx.STATE_DONE and eff.target_task_id == r.review_task_id
+        lane = kfx.get_lane(conn, eff.lane_id)
+        assert lane.review_task_id == r.review_task_id
+        assert lane.head_sha == VALID_HEAD
+
+
+def test_reconcile_reuses_review_card_for_same_head(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        # Two effects for the same lane + head but different required_checks →
+        # distinct payloads, same lane.
+        t1 = _ready_task(conn)
+        kb.complete_task(conn, t1, summary="s", review_required=_payload(required_checks=["ci"]))
+        t2 = _ready_task(conn)
+        kb.complete_task(conn, t2, summary="s", review_required=_payload(required_checks=["ci", "lint"]))
+        effs = kfx.list_effects(conn)
+        assert len(effs) == 2
+        _make_all_due(conn)
+        observer = _observer(now, checks={"ci": "success", "lint": "success"},
+                             required_check_policy=("ci", "lint"))
+        r1 = kfx.reconcile_effect(conn, effs[0].effect_id, observer, now=now)
+        r2 = kfx.reconcile_effect(conn, effs[1].effect_id, observer, now=now)
+        assert r1.review_task_id == r2.review_task_id
+        assert r1.created_review is True and r2.created_review is False
+        # Exactly one review card exists for the lane.
+        cards = conn.execute(
+            "SELECT COUNT(*) c FROM task_events WHERE kind='review_effect_reconciled'"
+        ).fetchone()["c"]
+        assert cards == 2  # two effects reconciled, one shared card
+
+
+def test_reconcile_binds_and_demotes_downstream(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        qa = _ready_task(conn, title="qa", assignee="qa")
+        rel = _ready_task(conn, title="release", assignee="release")
+        assert kb.get_task(conn, qa).status == "ready"
+        tid = _ready_task(conn)
+        kb.complete_task(
+            conn, tid, summary="s",
+            review_required=_payload(downstream_task_ids=[qa, rel]),
+        )
+        eff_id = kfx.list_effects(conn)[0].effect_id
+        _make_all_due(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now), now=now)
+        assert r.status == "reconciled"
+        # Review card is the parent of both downstream cards, both demoted.
+        assert r.review_task_id in kb.parent_ids(conn, qa)
+        assert r.review_task_id in kb.parent_ids(conn, rel)
+        assert kb.get_task(conn, qa).status == "todo"
+        assert kb.get_task(conn, rel).status == "todo"
+
+
+# ---------------------------------------------------------------------------
+# R18 / R19 / R20 — containment (alert only)
+# ---------------------------------------------------------------------------
+
+
+def test_downstream_containment_without_exact_head_approve(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        qa = _ready_task(conn, title="qa", assignee="qa")
+        tid = _ready_task(conn)
+        kb.complete_task(conn, tid, summary="s",
+                         review_required=_payload(downstream_task_ids=[qa]))
+        eff_id = kfx.list_effects(conn)[0].effect_id
+        _make_all_due(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now), now=now)
+        lane_id = kfx.get_effect(conn, eff_id).lane_id
+        # Downstream card advanced to running with no approval for the head.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='running' WHERE id=?", (qa,))
+        findings = kfx.scan_downstream_containment(
+            conn, lane_id, observation=_observation(now), approved_head_shas=[]
+        )
+        assert any(f.code == kfx.CONTAINMENT_DOWNSTREAM_UNAPPROVED for f in findings)
+        # With an exact-head approval, no containment finding.
+        ok = kfx.scan_downstream_containment(
+            conn, lane_id, observation=_observation(now), approved_head_shas=[VALID_HEAD]
+        )
+        assert not any(f.code == kfx.CONTAINMENT_DOWNSTREAM_UNAPPROVED for f in ok)
+
+
+def test_unbound_review_conflict_alert(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        kfx.reconcile_effect(conn, eff_id, _observer(now), now=now)
+        lane_id = kfx.get_effect(conn, eff_id).lane_id
+        findings = kfx.scan_unbound_review_conflict(conn, lane_id, ["t_manual"])
+        assert findings and findings[0].code == kfx.CONTAINMENT_UNBOUND_REVIEW_CONFLICT
+
+
+def test_stale_running_review_no_parallel(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        r = kfx.reconcile_effect(conn, eff_id, _observer(now), now=now)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='running' WHERE id=?", (r.review_task_id,))
+        lane_id = kfx.get_effect(conn, eff_id).lane_id
+        # Head has moved on; the running review is stale.
+        findings = kfx.scan_downstream_containment(
+            conn, lane_id, observation=_observation(now, head_sha=OTHER_HEAD)
+        )
+        assert any(f.code == kfx.CONTAINMENT_STALE_RUNNING_REVIEW for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# R21 — legacy untyped text is alert-only
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_review_text_alert_only(kanban_home: Path) -> None:
+    alert = kfx.detect_legacy_review_text("Please review this before merge")
+    assert alert.matched and alert.hint
+    assert kfx.detect_legacy_review_text("nothing to see") .matched is False
+    # Purely a text scan — creates nothing, so a fresh DB stays empty.
+    with kb.connect_closing() as conn:
+        _install(conn)
+        assert kfx.list_effects(conn) == []
+
+
+# ---------------------------------------------------------------------------
+# R10 / R11 / R12 — lease, retry backoff, DLQ (fake clock)
+# ---------------------------------------------------------------------------
+
+
+def test_lease_and_expiry(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+        leased = kfx.lease_effect(conn, eff_id, owner="w1", now=now, lease_ttl_seconds=100)
+        assert leased is not None and leased.state == kfx.STATE_LEASED
+        # A second lease before expiry loses.
+        assert kfx.lease_effect(conn, eff_id, owner="w2", now=now, lease_ttl_seconds=100) is None
+        # After the lease expires it can be re-acquired.
+        assert kfx.lease_effect(conn, eff_id, owner="w2", now=now + 101) is not None
+
+
+def test_retry_backoff_and_dlq_fake_clock(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        # Emit directly with a small max_attempts for a fast DLQ.
+        tid = _ready_task(conn)
+        payload = kfx.validate_review_required(_payload())
+        with kb.write_txn(conn):
+            eff_id = kfx.record_effect_locked(
+                conn, source_task_id=tid, source_transition=kfx.TRANSITION_COMPLETE,
+                payload=payload, now=now, max_attempts=3,
+            )
+        prev_next = -1
+        state = None
+        for _ in range(10):
+            observer = _observer(now, required_check_policy=None)  # always not ready
+            kfx.reconcile_effect(conn, eff_id, observer, now=now)
+            eff = kfx.get_effect(conn, eff_id)
+            state = eff.state
+            if state == kfx.STATE_DLQ:
+                break
+            # Backoff strictly advances the next attempt time.
+            assert eff.next_attempt_at > now
+            assert eff.next_attempt_at > prev_next
+            prev_next = eff.next_attempt_at
+            now = eff.next_attempt_at
+        assert state == kfx.STATE_DLQ
+        assert kfx.get_effect(conn, eff_id).attempts == 3
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — 20 workers, exactly once (R08 / R09 / R16 under load)
+# ---------------------------------------------------------------------------
+
+
+def test_20_concurrent_producers_one_effect(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        _install(conn)
+    payload = kfx.validate_review_required(_payload())
+
+    def worker(i: int) -> None:
+        with kb.connect_closing() as c:
+            with kb.write_txn(c):
+                kfx.record_effect_locked(
+                    c, source_task_id="shared-source",
+                    source_transition=kfx.TRANSITION_COMPLETE, payload=payload,
+                )
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    with kb.connect_closing() as conn:
+        assert len(kfx.list_effects(conn)) == 1
+
+
+def test_20_concurrent_reconcilers_one_review_card(kanban_home: Path) -> None:
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+
+    results: list[kfx.ReconcileResult] = []
+    lock = threading.Lock()
+
+    def worker(i: int) -> None:
+        observer = _observer(now)
+        with kb.connect_closing() as c:
+            r = kfx.reconcile_effect(c, eff_id, observer, now=now, owner=f"w{i}")
+        with lock:
+            results.append(r)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    reconciled = [r for r in results if r.status == "reconciled"]
+    assert len(reconciled) == 1
+    with kb.connect_closing() as conn:
+        eff = kfx.get_effect(conn, eff_id)
+        assert eff.state == kfx.STATE_DONE
+        # Exactly one review card was ever created for the lane.
+        cards = conn.execute(
+            "SELECT COUNT(*) c FROM task_events WHERE kind='review_effect_reconciled'"
+        ).fetchone()["c"]
+        assert cards == 1
+
+
+# ---------------------------------------------------------------------------
+# No-nested-BEGIN regression — locked helpers compose in an outer txn
+# ---------------------------------------------------------------------------
+
+
+def test_locked_helpers_compose_without_nested_begin(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        # Public wrappers still behave as before.
+        parent = kb.create_task(conn, title="p", assignee="worker")
+        child = kb.create_task(conn, title="c", assignee="worker")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        assert parent in kb.parent_ids(conn, child)
+
+        # The transaction-internal helpers compose inside ONE outer write txn
+        # with no "cannot start a transaction within a transaction" error.
+        with kb.write_txn(conn):
+            new_id = kb._new_task_id()
+            kb._create_task_locked(
+                conn, task_id=new_id, now=1234, title="inner", body=None,
+                assignee="worker", priority=0, created_by="test",
+                workspace_kind="scratch", workspace_path=None, branch_name=None,
+                project_id=None, project_obj=None, project_repo=None, tenant=None,
+                idempotency_key=None, max_runtime_seconds=None, skills_list=None,
+                max_retries=None, model_override=None, provider_override=None,
+                goal_mode=False, goal_max_turns=None, session_id=None,
+                parents=(), triage=False, initial_status="running",
+            )
+            kb._link_tasks_locked(conn, parent_id=parent, child_id=new_id)
+        assert kb.get_task(conn, new_id) is not None
+        assert parent in kb.parent_ids(conn, new_id)
+
+
+def test_reconcile_never_holds_txn_during_observation(kanban_home: Path) -> None:
+    """The observer is consulted strictly before the reconcile write txn.
+
+    We assert this by having the observer verify that no write transaction is
+    in progress on the connection at observe() time.
+    """
+    now = 1000
+    with kb.connect_closing() as conn:
+        _install(conn)
+        eff_id = _emit(conn)
+
+        observed = {"in_txn": None}
+
+        class _AssertObserver:
+            def observe(self, repo, pr_number):
+                observed["in_txn"] = conn.in_transaction
+                return _observation(now)
+
+        r = kfx.reconcile_effect(conn, eff_id, _AssertObserver(), now=now)
+        assert r.status == "reconciled"
+        assert observed["in_txn"] is False  # no DB txn held during observation

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -672,6 +672,7 @@ def _handle_complete(args: dict, **kw) -> str:
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
                     expected_run_id=_worker_run_id(tid),
+                    review_required=args.get("review_required"),
                 )
             except kb.ArtifactPreservationError as artifact_err:
                 return tool_error(
@@ -771,6 +772,7 @@ def _handle_block(args: dict, **kw) -> str:
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id(tid),
+                review_required=args.get("review_required"),
             )
             if not ok:
                 return tool_error(
@@ -1464,6 +1466,64 @@ def _board_schema_prop() -> dict[str, str]:
     """
     return {"type": "string", "description": _DESC_BOARD}
 
+
+def _review_required_schema_prop() -> dict[str, Any]:
+    """Schema fragment for the optional ``review_required`` effect payload.
+
+    Repository-only / default-off candidate (see
+    :mod:`hermes_cli.kanban_effects`). Absent → behavior is unchanged. When
+    present it is schema-validated; an invalid payload is rejected with a typed
+    error and no state change. On a normal board (no effect tables installed)
+    a valid payload is validated but recorded as a no-op — the feature is not
+    live.
+    """
+    return {
+        "type": "object",
+        "description": (
+            "Optional, experimental (repository-only, default-off) "
+            "review-required effect. Declares that a GitHub PR must pass "
+            "review at an exact head before downstream QA/Release work "
+            "proceeds. Omit unless a board has explicitly opted into the "
+            "effect harness — otherwise it is validated and ignored."
+        ),
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": ["review_required"],
+                "description": "Effect kind. Must be 'review_required'.",
+            },
+            "repo": {
+                "type": "string",
+                "description": "GitHub repo as 'owner/name'.",
+            },
+            "pr_number": {
+                "type": "integer",
+                "description": "Positive PR number.",
+            },
+            "head_sha": {
+                "type": "string",
+                "description": "Exact 40-character hex commit sha of the PR head.",
+            },
+            "required_checks": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional required-check policy names that must all "
+                    "conclude successfully."
+                ),
+            },
+            "downstream_task_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional pre-created QA/Release card ids to re-parent "
+                    "under the authoritative review card when it is created."
+                ),
+            },
+        },
+        "required": ["kind", "repo", "pr_number", "head_sha"],
+    }
+
 KANBAN_SHOW_SCHEMA = {
     "name": "kanban_show",
     "description": (
@@ -1621,6 +1681,7 @@ KANBAN_COMPLETE_SCHEMA = {
                     "task in-flight so you can fix the path and retry."
                 ),
             },
+            "review_required": _review_required_schema_prop(),
             "board": _board_schema_prop(),
         },
         "required": [],
@@ -1665,6 +1726,7 @@ KANBAN_BLOCK_SCHEMA = {
                     "Omit only if none apply."
                 ),
             },
+            "review_required": _review_required_schema_prop(),
             "board": _board_schema_prop(),
         },
         "required": ["reason"],


### PR DESCRIPTION
Summary: Add a repository-only default-off typed review_required producer for Kanban complete/block transitions; add installer-only effect/outbox/lane schema, injected GitHub observation, atomic parentless Review reconciliation, downstream containment readback, and fresh-DB coverage. Safety: not live or applied; no dispatcher, cron, gateway, plugin, config, migration, normal init/connect, production-board wiring, merge, deploy, live schema/board mutation, secrets, production data, or force-push. Verification: focused Python Kanban suites 566 passed; Ruff, py_compile, and diff check passed. npm run check was attempted but fails on missing pre-existing workspace dependencies/types unrelated to this Python-only PR; hosted CI must be evaluated at this head. Review focus: schema-init isolation, transition atomicity/no nested BEGIN, effect/lane uniqueness, exact-head/policy fail-closed behavior, source provenance, and downstream containment.