### PR TITLE
fix(gateway): deliver restart acknowledgement

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17515,6 +17515,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # we must inspect the result before claiming success — otherwise
             # the log line is misleading and hides real delivery failures.
             if result is not None and getattr(result, "success", True) is False:
+                # Telegram deliberately rejects normal adapter sends until the
+                # first getUpdates round-trip proves that polling is healthy.
+                # On a fresh gateway boot that round-trip is normally an idle
+                # long poll, so the restart acknowledgement was guaranteed to
+                # be rejected here even though the Bot API send path was ready.
+                # Use the plugin's one-shot REST sender for this lifecycle
+                # message.  It has an independent HTTP client and is already
+                # the supported fallback for out-of-process Telegram delivery.
+                if (
+                    platform is Platform.TELEGRAM
+                    and getattr(result, "error", None) == "send_path_degraded"
+                ):
+                    try:
+                        from plugins.platforms.telegram.adapter import _standalone_send
+
+                        fallback = await _standalone_send(
+                            platform_cfg,
+                            str(chat_id),
+                            "♻ Gateway restarted successfully. Your session continues.",
+                            thread_id=thread_id,
+                        )
+                        if isinstance(fallback, dict) and fallback.get("success"):
+                            logger.info(
+                                "Sent restart notification to %s:%s via standalone Telegram delivery",
+                                platform_str,
+                                chat_id,
+                            )
+                            return (
+                                str(platform_str),
+                                str(chat_id),
+                                str(thread_id) if thread_id else None,
+                            )
+                        logger.warning(
+                            "Restart notification fallback to %s:%s was not delivered: %s",
+                            platform_str,
+                            chat_id,
+                            (fallback or {}).get("error", "standalone sender returned no success"),
+                        )
+                        return None
+                    except Exception as fallback_error:
+                        logger.warning(
+                            "Restart notification fallback to %s:%s failed: %s",
+                            platform_str,
+                            chat_id,
+                            fallback_error,
+                        )
+                        return None
                 logger.warning(
                     "Restart notification to %s:%s was not delivered: %s",
                     platform_str,

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -705,6 +705,38 @@ async def test_send_restart_notification_logs_warning_on_sendresult_failure(
 
 
 @pytest.mark.asyncio
+async def test_send_restart_notification_uses_standalone_telegram_fallback(
+    tmp_path, monkeypatch
+):
+    """A fresh Telegram polling generation must still acknowledge /restart."""
+    from plugins.platforms.telegram import adapter as telegram_adapter
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / ".restart_notify.json").write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=False, error="send_path_degraded"),
+    )
+    standalone_send = AsyncMock(return_value={"success": True, "message_id": "2"})
+    monkeypatch.setattr(telegram_adapter, "_standalone_send", standalone_send)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    standalone_send.assert_awaited_once_with(
+        runner.config.platforms[Platform.TELEGRAM],
+        "42",
+        "♻ Gateway restarted successfully. Your session continues.",
+        thread_id=None,
+    )
+    assert not (tmp_path / ".restart_notify.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_send_home_channel_startup_notification_skipped_when_flag_disabled(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Cherry-picks the local gateway restart acknowledgement fix onto current upstream main.

Validation: 209 restart-related tests passed. One unrelated macOS /tmp versus /private/tmp failure reproduces on clean upstream; one startup race test passed on automatic retry after a timeout.