### PR TITLE
feat(security): add HERMES_DISABLE_REQUEST_DUMPS opt-out for request dumps

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1707,7 +1707,16 @@ def dump_api_request_debug(
     Captures the request body from api_kwargs (excluding transport-only keys
     like timeout). Intended for debugging provider-side 4xx failures where
     retries are not useful.
+
+    Set ``HERMES_DISABLE_REQUEST_DUMPS=1`` to skip these dumps entirely. The
+    redaction below only recognizes credentials by value pattern or by
+    sensitive-looking key name, so a secret the user pasted into the
+    conversation still reaches disk in cleartext: it sits in ordinary message
+    text, under no sensitive key, in a shape no pattern covers. Opting out is
+    the only way to guarantee no request body is persisted.
     """
+    if env_var_enabled("HERMES_DISABLE_REQUEST_DUMPS"):
+        return None
     try:
         body = copy.deepcopy(api_kwargs)
         body.pop("timeout", None)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2895,6 +2895,49 @@ def test_run_conversation_codex_continues_after_ack_for_directory_listing_prompt
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
 
 
+def test_dump_api_request_debug_disabled_writes_nothing(monkeypatch, tmp_path):
+    """HERMES_DISABLE_REQUEST_DUMPS=1 suppresses the dump and touches no disk."""
+    monkeypatch.setenv("HERMES_DISABLE_REQUEST_DUMPS", "1")
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    dump_file = agent._dump_api_request_debug(_codex_request_kwargs(), reason="preflight")
+
+    assert dump_file is None
+    assert list(tmp_path.glob("request_dump_*.json")) == []
+
+
+def test_dump_api_request_debug_disabled_also_suppresses_error_dumps(monkeypatch, tmp_path):
+    """The opt-out covers the error paths, which otherwise dump unconditionally."""
+    monkeypatch.setenv("HERMES_DISABLE_REQUEST_DUMPS", "true")
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    dump_file = agent._dump_api_request_debug(
+        _codex_request_kwargs(),
+        reason="max_retries_exhausted",
+        error=RuntimeError("boom"),
+    )
+
+    assert dump_file is None
+    assert list(tmp_path.glob("request_dump_*.json")) == []
+
+
+def test_dump_api_request_debug_enabled_by_default(monkeypatch, tmp_path):
+    """Without the opt-out the dump still lands, so the default is unchanged."""
+    monkeypatch.delenv("HERMES_DISABLE_REQUEST_DUMPS", raising=False)
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    dump_file = agent._dump_api_request_debug(_codex_request_kwargs(), reason="preflight")
+
+    assert dump_file is not None
+    assert dump_file.exists()
+
+
 def test_dump_api_request_debug_uses_responses_url(monkeypatch, tmp_path):
     """Debug dumps should show /responses URL when in codex_responses mode."""
     import json

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -123,6 +123,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |
 | `HERMES_NOUS_TIMEOUT_SECONDS` | HTTP timeout for Nous credential / token flows |
 | `HERMES_DUMP_REQUESTS` | Dump API request payloads to log files (`true`/`false`) |
+| `HERMES_DISABLE_REQUEST_DUMPS` | Never write `request_dump_*.json`, including the error paths that dump unconditionally (`true`/`false`) |
 | `HERMES_PREFILL_MESSAGES_FILE` | Path to a JSON file of ephemeral prefill messages injected at API-call time |
 | `HERMES_TIMEZONE` | IANA timezone override (for example `America/New_York`) |
 
@@ -777,6 +778,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_OPTIONAL_SKILLS` | Comma-separated list of optional-skill names to auto-install on first run. |
 | `HERMES_DEBUG_INTERRUPT` | Set to `1` to log detailed interrupt/cancel tracing to `agent.log`. |
 | `HERMES_DUMP_REQUESTS` | Dump API request payloads to log files (`true`/`false`) |
+| `HERMES_DISABLE_REQUEST_DUMPS` | Never write `request_dump_*.json`, including the error paths that dump unconditionally (`true`/`false`) |
 | `HERMES_DUMP_REQUEST_STDOUT` | Dump API request payloads to stdout instead of log files. |
 | `HERMES_OAUTH_TRACE` | Set to `1` to log OAuth token exchange and refresh attempts. Includes redacted timing info. |
 | `HERMES_OAUTH_FILE` | Override the path used for OAuth credential storage (default: `~/.hermes/auth.json`). |


### PR DESCRIPTION
## What does this PR do?

Adds `HERMES_DISABLE_REQUEST_DUMPS` so an operator can stop `request_dump_*.json` from ever being written.

Today `dump_api_request_debug()` fires unconditionally on two error paths — `non_retryable_client_error` and `max_retries_exhausted` (`agent/conversation_loop.py`). `HERMES_DUMP_REQUESTS` only gates the *preflight* path, so there is currently no way to turn the error-path dumps off.

**Why an opt-out rather than more redaction.** Existing redaction (#18750, and the structural pass in #52905) recognizes credentials either by value pattern or by sensitive-looking key name. Neither shape catches a secret the user pasted into the conversation: it lands in ordinary message text, under no sensitive key, in whatever form the user typed it. On one real install a Telegram bot token and a Brave API key reached disk in cleartext this way, in dumps that were otherwise correctly redacted.

Redaction and an opt-out solve different halves of the problem, and this PR does not touch the redaction path:

- redaction keeps dumps useful for debugging
- the opt-out lets an operator guarantee no request body is persisted at all

Default behavior is unchanged — dumps still fire unless the variable is set.

## Related Issue

No existing issue. Searched open and closed issues/PRs for `request dump`, `request_dump`, and `disable request dumps`: #18750, #51049, and #52905 all address *redaction*; none proposes an opt-out.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `agent/agent_runtime_helpers.py` — early return in `dump_api_request_debug()` when `HERMES_DISABLE_REQUEST_DUMPS` is enabled, plus a docstring note on why redaction alone cannot be exhaustive
- `tests/run_agent/test_run_agent_codex_responses.py` — 3 regression tests: opt-out on the preflight path, opt-out on an error path, and default-on behavior
- `website/docs/reference/environment-variables.md` — document the variable in both reference tables

## How to Test

1. `HERMES_DISABLE_REQUEST_DUMPS=1`, then trigger a non-retryable provider error — no `request_dump_*.json` appears in the logs dir
2. Unset it, repeat — the dump is written as before
3. `pytest tests/run_agent/test_run_agent_codex_responses.py -k dump_api_request_debug`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — `feat(security): …`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature — single commit, 3 files, +54 −0
- [ ] I've run `pytest tests/ -q` and all tests pass — **see "Test results" below; deliberately left unchecked**
- [x] I've added tests for my changes — 3 regression tests
- [x] I've tested on my platform: macOS 26.5.2 (Darwin 25.5.0), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/reference/environment-variables.md` (both reference tables) + the function docstring
- [x] N/A — `cli-config.yaml.example`: this adds an env var, not a config key. Its sibling `HERMES_DUMP_REQUESTS` is not in that file either.
- [x] N/A — `CONTRIBUTING.md` / `AGENTS.md`: no architecture or workflow change
- [x] N/A — cross-platform: the change is a single `env_var_enabled()` read, no platform-specific code paths
- [x] N/A — tool descriptions/schemas: no tool behavior changed

## Test results

Being explicit rather than checking a box I can't stand behind.

**Targeted — all green:**

| Scope | Result |
|---|---|
| `tests/run_agent/test_run_agent_codex_responses.py` | 110 passed |
| `-k dump_api_request_debug` (3 new + 4 existing) | 6 passed |
| `ruff check` on both changed source files | all checks passed |

**Full `tests/run_agent/ tests/agent/` — 190 pre-existing failures, unrelated to this PR:**

| Tree | Result |
|---|---|
| this branch | 190 failed, 9138 passed |
| `upstream/main` @ `3bd2574`, patch absent | 190 failed, 9171 passed |

Same failure count with and without the change. The failing suites (`test_usage_pricing`, `test_verification_stop`, `test_codex_app_server_session`, `test_unsupported_temperature_retry`) never touch `dump_api_request_debug`, and each of them passes 101/101 in isolation — identically on both trees. I could not run a clean `uv sync --group dev` in my sandbox and instead injected an existing venv's `site-packages` via `PYTHONPATH`, so I attribute these to my environment rather than to the tree; I'm flagging them rather than hiding them. Happy to re-run under a proper dev install if that's useful.

The collected-test delta (9372 here vs 9405 on main) is just branch age: this branch forks at `0a2c245`, 44 commits behind, which added 36 tests.

**Merge state:** `git merge-tree --write-tree upstream/main HEAD` → clean. No upstream commit has touched any of the three files since the fork point.
