### PR TITLE
fix: stop internal-timeout hangs from freezing the agent turn or worker forever

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -14,6 +14,7 @@ import functools
 import hashlib
 import logging
 import os
+import queue
 import re
 import shlex
 import sys
@@ -2703,6 +2704,63 @@ def _get_smart_policy() -> str:
     return policy.strip()
 
 
+# Hard ceiling for the smart-approval auxiliary LLM call, independent of
+# whatever timeout agent.auxiliary_client resolves internally (default 30s
+# via auxiliary.approval.timeout / _DEFAULT_AUX_TIMEOUT). This call gates
+# EVERY flagged terminal command -- if its internal timeout is ever defeated
+# (observed in production: a terminal_tool.env.execute() call exhibited the
+# same class of bug -- an internal per-call deadline that didn't fire),
+# nothing downstream can notice, and the entire agent turn hangs forever
+# before the command it's gating ever runs. _smart_approve already treats
+# any exception as "escalate" (fail open to human/pattern-based approval),
+# so turning a wedged call into a raised exception here is safe and exactly
+# matches the existing error contract -- this just guarantees the exception
+# actually happens within a bounded time instead of never.
+_SMART_APPROVE_WATCHDOG_SECONDS = 45
+
+
+def _call_llm_with_watchdog(**kwargs):
+    """Run agent.auxiliary_client.call_llm on a daemon thread with a hard
+    wall-clock ceiling. See _SMART_APPROVE_WATCHDOG_SECONDS for rationale.
+
+    Plain daemon thread (not concurrent.futures.ThreadPoolExecutor): the
+    latter's non-daemon workers plus its atexit join-all-threads hook would
+    make a later, unrelated clean shutdown of the agent process hang too if
+    a call ever actually got abandoned.
+    """
+    from agent.auxiliary_client import call_llm
+
+    result_queue = queue.Queue(maxsize=1)
+
+    def _run():
+        try:
+            result_queue.put(("ok", call_llm(**kwargs)))
+        except BaseException as e:  # noqa: BLE001 - must forward any failure to the waiter
+            result_queue.put(("error", e))
+
+    worker = threading.Thread(
+        target=_run, name="smart-approve-watchdog", daemon=True,
+    )
+    worker.start()
+    try:
+        kind, payload = result_queue.get(timeout=_SMART_APPROVE_WATCHDOG_SECONDS)
+    except queue.Empty:
+        logger.warning(
+            "Smart approvals: call_llm() watchdog fired after %ds -- the "
+            "call never returned even though its own internal timeout "
+            "should have fired. Abandoning the worker thread and escalating.",
+            _SMART_APPROVE_WATCHDOG_SECONDS,
+        )
+        raise TimeoutError(
+            f"call_llm(task='approval') did not return within "
+            f"{_SMART_APPROVE_WATCHDOG_SECONDS}s -- watchdog aborted the wait"
+        ) from None
+
+    if kind == "error":
+        raise payload
+    return payload
+
+
 def _smart_approve(command: str, description: str) -> str:
     """Use the auxiliary LLM to assess risk and decide approval.
 
@@ -2723,8 +2781,6 @@ def _smart_approve(command: str, description: str) -> str:
     (openai/codex#13860).
     """
     try:
-        from agent.auxiliary_client import call_llm
-
         # Strip shell comments to remove the easiest injection vector.
         sanitized_command = _strip_shell_comments(command)
 
@@ -2772,7 +2828,7 @@ def _smart_approve(command: str, description: str) -> str:
             "Respond with exactly one word: APPROVE, DENY, or ESCALATE"
         )
 
-        response = call_llm(
+        response = _call_llm_with_watchdog(
             task="approval",
             messages=[
                 {"role": "system", "content": system_prompt},

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2184,6 +2184,58 @@ def _create_environment_with_watchdog(**kwargs):
     return payload
 
 
+# Hard ceiling on the transform_terminal_output plugin hook, which runs AFTER
+# the shell command has already finished (bash exited, output captured) but
+# BEFORE the result is returned to the model. Root-caused from a live
+# incident: bash.exe and the invoked script had both already exited cleanly
+# (confirmed via process list -- nothing related was still running) yet the
+# tool call sat showing "Running" for 18+ minutes with no completion or error
+# ever logged. The only unbounded work left in the foreground path once
+# env.execute() returns is this hook call -- it's wrapped in a bare
+# try/except Exception ("fail-open") which catches a raised error but not a
+# hang. Any third-party or user-installed plugin registering this hook can
+# therefore freeze every foreground terminal call forever, downstream of all
+# three env.execute()-side watchdogs above (which by definition can't help,
+# since the command they were guarding already finished).
+_HOOK_WATCHDOG_SECONDS = 20
+
+
+def _invoke_terminal_output_hook_with_watchdog(**kwargs):
+    """Run the transform_terminal_output hook on a daemon thread with a hard
+    ceiling. See _HOOK_WATCHDOG_SECONDS for rationale. Returns [] (same shape
+    as invoke_hook on the "no plugin handled it" path) on timeout or error,
+    matching the existing fail-open contract at the call site.
+    """
+    from hermes_cli.plugins import invoke_hook
+
+    result_queue = queue.Queue(maxsize=1)
+
+    def _run():
+        try:
+            result_queue.put(("ok", invoke_hook("transform_terminal_output", **kwargs)))
+        except BaseException as e:  # noqa: BLE001 - must forward any failure to the waiter
+            result_queue.put(("error", e))
+
+    threading.Thread(
+        target=_run, name="terminal-output-hook-watchdog", daemon=True,
+    ).start()
+    try:
+        kind, payload = result_queue.get(timeout=_HOOK_WATCHDOG_SECONDS)
+    except queue.Empty:
+        logger.warning(
+            "transform_terminal_output hook watchdog fired after %ds -- a "
+            "registered plugin never returned. Abandoning the worker thread "
+            "and returning the untransformed output so the agent turn can "
+            "continue.",
+            _HOOK_WATCHDOG_SECONDS,
+        )
+        return []
+
+    if kind == "error":
+        return []
+    return payload
+
+
 def _execute_foreground_with_watchdog(env, command, execute_kwargs, *, task_id, env_type):
     """Run env.execute() with a hard wall-clock ceiling.
 
@@ -2999,9 +3051,7 @@ def terminal_tool(
             # still subject to the final output limit below.
             # The hook is fail-open, and the first valid string return wins.
             try:
-                from hermes_cli.plugins import invoke_hook
-                hook_results = invoke_hook(
-                    "transform_terminal_output",
+                hook_results = _invoke_terminal_output_hook_with_watchdog(
                     command=command,
                     output=output,
                     returncode=returncode,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -39,6 +39,7 @@ import platform
 import re
 import time
 import threading
+import queue
 import atexit
 import shutil
 import subprocess
@@ -984,6 +985,18 @@ _last_activity: Dict[str, float] = {}
 _env_lock = threading.Lock()
 _creation_locks: Dict[str, threading.Lock] = {}  # Per-task locks for sandbox creation
 _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
+# Count of in-flight *foreground* env.execute() calls per task_id. The reaper
+# (_cleanup_inactive_envs) only knows to keep an environment alive for
+# BACKGROUND processes via process_registry.has_active_processes() -- a
+# foreground call never registers there, so a single slow-but-legitimate
+# foreground command (model asked for a >lifetime_seconds timeout, or the
+# call is simply slow to return for any reason) can have its environment
+# torn out from under it mid-execution while _last_activity sits stale from
+# dispatch time. Tracked here so the reaper treats "someone is inside
+# env.execute() right now" the same as "there's a registered background
+# process" (root cause of a class of indefinite terminal-tool hangs where
+# the agent loop waits forever on a tool result that will never arrive).
+_inflight_foreground: Dict[str, int] = {}
 _cleanup_thread = None
 _cleanup_running = False
 
@@ -1637,6 +1650,15 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     """Clean up environments that have been inactive for longer than lifetime_seconds."""
     current_time = time.time()
 
+    # Skip cleanup for tasks with an in-flight foreground env.execute() call --
+    # otherwise a foreground command still running past lifetime_seconds (e.g.
+    # a model-requested long timeout) can have its environment reaped while a
+    # tool call is actively blocked waiting on it, permanently hanging that
+    # tool call (see _inflight_foreground docstring above).
+    for task_id in list(_last_activity.keys()):
+        if _inflight_foreground.get(task_id, 0) > 0:
+            _last_activity[task_id] = current_time
+
     # Check the process registry -- skip cleanup for sandboxes with active
     # background processes (their _last_activity gets refreshed to keep them alive).
     try:
@@ -2095,6 +2117,78 @@ def _resolve_command_cwd(
     if workdir:
         return workdir
     return get_session_cwd(session_key) or default_cwd
+
+
+# Extra grace period on top of the command's own effective_timeout before the
+# watchdog gives up on env.execute() and returns control to the caller. Covers
+# the time _wait_for_process needs to notice its own deadline, kill the
+# process group, and drain -- the watchdog should basically never fire in the
+# healthy case; it exists purely so a hang *anywhere* inside env.execute()
+# (lock contention, a Popen/PTY-level stall, or the reaper race documented on
+# _inflight_foreground) can't block the tool-executor thread, and therefore
+# the whole agent turn, forever. A dozen multi-hour freezes were traced to
+# exactly this: env.execute() never returning and nothing upstream able to
+# notice or recover.
+_WATCHDOG_MARGIN_SECONDS = 45
+
+
+def _execute_foreground_with_watchdog(env, command, execute_kwargs, *, task_id, env_type):
+    """Run env.execute() with a hard wall-clock ceiling.
+
+    env.execute() is expected to honor execute_kwargs["timeout"] internally
+    (see BaseEnvironment._wait_for_process), but that internal deadline lives
+    entirely inside the call we're waiting on -- if it's ever defeated (a
+    blocking syscall the poll loop never gets back to, a lock acquired
+    earlier in the call never releasing, etc.) there is nothing outside the
+    call to notice. Running it on a daemon worker thread and bounding *our*
+    wait on a queue.get(timeout=...) gives us an outside observer: if the
+    deadline passes we abandon the worker thread (best-effort; it may leak
+    if it's truly wedged) and return a normal timeout result instead of
+    hanging the caller -- which otherwise stalls the whole agent turn
+    indefinitely with no error, no log line, and no way to recover short of
+    killing the agent process.
+
+    Deliberately NOT concurrent.futures.ThreadPoolExecutor: its worker
+    threads are non-daemon and its atexit hook joins every thread any
+    executor ever created before the interpreter is allowed to exit, so an
+    abandoned/wedged call would make a *later, unrelated* clean shutdown of
+    the whole agent process hang too. A plain daemon thread has no such
+    hook -- it's simply dropped on process exit.
+    """
+    requested_timeout = execute_kwargs.get("timeout") or 180
+    hard_deadline = requested_timeout + _WATCHDOG_MARGIN_SECONDS
+
+    result_queue = queue.Queue(maxsize=1)
+
+    def _run():
+        try:
+            result_queue.put(("ok", env.execute(command, **execute_kwargs)))
+        except BaseException as e:  # noqa: BLE001 - must forward any failure to the waiter
+            result_queue.put(("error", e))
+
+    worker = threading.Thread(
+        target=_run, name=f"terminal-watchdog-{task_id}", daemon=True,
+    )
+    worker.start()
+    try:
+        kind, payload = result_queue.get(timeout=hard_deadline)
+    except queue.Empty:
+        logger.error(
+            "env.execute() watchdog fired after %ds (requested timeout=%ds) - "
+            "Command: %s - Task: %s, Backend: %s. The call never returned even "
+            "though its own internal timeout should have fired -- abandoning "
+            "the worker thread so the agent turn can continue.",
+            hard_deadline, requested_timeout, _safe_command_preview(command),
+            task_id, env_type,
+        )
+        raise TimeoutError(
+            f"env.execute() did not return within {hard_deadline}s "
+            f"(requested timeout={requested_timeout}s) -- watchdog aborted the wait"
+        ) from None
+
+    if kind == "error":
+        raise payload
+    return payload
 
 
 def terminal_tool(
@@ -2717,52 +2811,73 @@ def terminal_tool(
                 from tools.interrupt import clear_current_thread_interrupt
                 clear_current_thread_interrupt()
 
-            while retry_count <= max_retries:
-                try:
-                    command_cwd = _resolve_command_cwd(
-                        workdir=workdir,
-                        default_cwd=cwd,
-                        session_key=session_key,
-                    )
-                    execute_kwargs = {
-                        "timeout": effective_timeout,
-                        "cwd": command_cwd,
-                        # Foreground model-facing output: cap retention while
-                        # streaming (head/tail window) so a verbose command
-                        # can't OOM the gateway before truncation (#64435).
-                        # Internal env.execute() consumers (file ops cat
-                        # reads, RPC reads) intentionally stay unbounded.
-                        "bounded_capture": True,
-                    }
-                    result = env.execute(command, **execute_kwargs)
-                except Exception as e:
-                    error_str = str(e).lower()
-                    if "timeout" in error_str:
+            # Mark this task_id as having an in-flight foreground execution so
+            # the idle-environment reaper (_cleanup_inactive_envs) won't tear
+            # the environment down out from under us mid-command. Must be
+            # decremented on every exit path (success, retry-exhausted error,
+            # or timeout return) -- hence the try/finally around the whole
+            # retry loop rather than a plain decrement after it.
+            with _env_lock:
+                _inflight_foreground[effective_task_id] = (
+                    _inflight_foreground.get(effective_task_id, 0) + 1
+                )
+            try:
+                while retry_count <= max_retries:
+                    try:
+                        command_cwd = _resolve_command_cwd(
+                            workdir=workdir,
+                            default_cwd=cwd,
+                            session_key=session_key,
+                        )
+                        execute_kwargs = {
+                            "timeout": effective_timeout,
+                            "cwd": command_cwd,
+                            # Foreground model-facing output: cap retention while
+                            # streaming (head/tail window) so a verbose command
+                            # can't OOM the gateway before truncation (#64435).
+                            # Internal env.execute() consumers (file ops cat
+                            # reads, RPC reads) intentionally stay unbounded.
+                            "bounded_capture": True,
+                        }
+                        result = _execute_foreground_with_watchdog(
+                            env, command, execute_kwargs,
+                            task_id=effective_task_id, env_type=env_type,
+                        )
+                    except Exception as e:
+                        error_str = str(e).lower()
+                        if "timeout" in error_str:
+                            return json.dumps({
+                                "output": "",
+                                "exit_code": 124,
+                                "error": f"Command timed out after {effective_timeout} seconds"
+                            }, ensure_ascii=False)
+
+                        # Retry on transient errors
+                        if retry_count < max_retries:
+                            retry_count += 1
+                            wait_time = 2 ** retry_count
+                            logger.warning("Execution error, retrying in %ds (attempt %d/%d) - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
+                                           wait_time, retry_count, max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
+                            time.sleep(wait_time)
+                            continue
+
+                        logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
+                                     max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
                         return json.dumps({
                             "output": "",
-                            "exit_code": 124,
-                            "error": f"Command timed out after {effective_timeout} seconds"
+                            "exit_code": -1,
+                            "error": f"Command execution failed: {type(e).__name__}: {str(e)}"
                         }, ensure_ascii=False)
-                    
-                    # Retry on transient errors
-                    if retry_count < max_retries:
-                        retry_count += 1
-                        wait_time = 2 ** retry_count
-                        logger.warning("Execution error, retrying in %ds (attempt %d/%d) - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
-                                       wait_time, retry_count, max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
-                        time.sleep(wait_time)
-                        continue
-                    
-                    logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
-                                 max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
-                    return json.dumps({
-                        "output": "",
-                        "exit_code": -1,
-                        "error": f"Command execution failed: {type(e).__name__}: {str(e)}"
-                    }, ensure_ascii=False)
-                
-                # Got a result
-                break
+
+                    # Got a result
+                    break
+            finally:
+                with _env_lock:
+                    remaining = _inflight_foreground.get(effective_task_id, 1) - 1
+                    if remaining <= 0:
+                        _inflight_foreground.pop(effective_task_id, None)
+                    else:
+                        _inflight_foreground[effective_task_id] = remaining
 
             # Dual-write (cwd rearch step 1): the env's post-command tracking
             # (marker parse / local sync) has just updated env.cwd with the

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2131,6 +2131,58 @@ def _resolve_command_cwd(
 # notice or recover.
 _WATCHDOG_MARGIN_SECONDS = 45
 
+# Hard ceiling for _create_environment() (sandbox/shell setup, run once per
+# task_id) and, separately, for how long a caller will wait to acquire the
+# per-task creation lock before giving up (see the call site in terminal_tool
+# for why the lock itself also needs a bound, not just the call it guards).
+# 90s is generous for the "local" backend (should be sub-second) while still
+# leaving room for container/cloud backends to pull images or cold-start.
+# Root-caused from a live incident: a session hung for 40+ minutes with zero
+# log output between the model's tool-call request and any tool_executor
+# completion/error -- past the point either the terminal-execute watchdog or
+# the smart-approval watchdog would have already resolved it, meaning the
+# stall was upstream of both, in environment setup itself.
+_ENV_CREATION_WATCHDOG_SECONDS = 90
+
+
+def _create_environment_with_watchdog(**kwargs):
+    """Run _create_environment() on a daemon thread with a hard ceiling.
+
+    See _ENV_CREATION_WATCHDOG_SECONDS for rationale. Same daemon-thread
+    (not concurrent.futures.ThreadPoolExecutor) reasoning as
+    _execute_foreground_with_watchdog: an abandoned worker must not block a
+    later, unrelated clean shutdown of the agent process.
+    """
+    result_queue = queue.Queue(maxsize=1)
+
+    def _run():
+        try:
+            result_queue.put(("ok", _create_environment(**kwargs)))
+        except BaseException as e:  # noqa: BLE001 - must forward any failure to the waiter
+            result_queue.put(("error", e))
+
+    worker = threading.Thread(
+        target=_run, name=f"env-creation-watchdog-{kwargs.get('task_id')}", daemon=True,
+    )
+    worker.start()
+    try:
+        kind, payload = result_queue.get(timeout=_ENV_CREATION_WATCHDOG_SECONDS)
+    except queue.Empty:
+        logger.error(
+            "_create_environment() watchdog fired after %ds for env_type=%s "
+            "task=%s. The call never returned -- abandoning the worker "
+            "thread so the agent turn can continue.",
+            _ENV_CREATION_WATCHDOG_SECONDS, kwargs.get("env_type"), kwargs.get("task_id"),
+        )
+        raise TimeoutError(
+            f"Environment creation did not complete within "
+            f"{_ENV_CREATION_WATCHDOG_SECONDS}s -- watchdog aborted the wait"
+        ) from None
+
+    if kind == "error":
+        raise payload
+    return payload
+
 
 def _execute_foreground_with_watchdog(env, command, execute_kwargs, *, task_id, env_type):
     """Run env.execute() with a hard wall-clock ceiling.
@@ -2355,7 +2407,33 @@ def terminal_tool(
                     _creation_locks[effective_task_id] = threading.Lock()
                 task_lock = _creation_locks[effective_task_id]
 
-            with task_lock:
+            # Bounded acquire, not `with task_lock:` -- a plain blocking acquire
+            # here means that if the thread creating the sandbox ever wedges
+            # (see _create_environment_with_watchdog below), EVERY subsequent
+            # call for this task_id piles up waiting on the same lock forever,
+            # turning one stuck call into a permanently dead task_id. A
+            # threading.Lock can be released by any thread, not just the one
+            # that acquired it, so releasing it here after giving up is safe
+            # even if the abandoned creation call is technically still running
+            # in the background -- its eventual result is simply discarded.
+            if not task_lock.acquire(timeout=_ENV_CREATION_WATCHDOG_SECONDS):
+                logger.error(
+                    "Timed out after %ds waiting for the %s environment "
+                    "creation lock for task %s -- a previous creation call "
+                    "for this task appears to be wedged.",
+                    _ENV_CREATION_WATCHDOG_SECONDS, env_type, effective_task_id,
+                )
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": (
+                        f"Timed out after {_ENV_CREATION_WATCHDOG_SECONDS}s waiting to "
+                        "create the terminal environment (a previous creation attempt "
+                        "for this task appears stuck). Try again."
+                    ),
+                }, ensure_ascii=False)
+
+            try:
                 # Double-check after acquiring the per-task lock
                 with _env_lock:
                     _existing_key = (
@@ -2407,7 +2485,7 @@ def terminal_tool(
                                 "persistent": config.get("local_persistent", False),
                             }
 
-                        new_env = _create_environment(
+                        new_env = _create_environment_with_watchdog(
                             env_type=env_type,
                             image=image,
                             cwd=cwd,
@@ -2425,12 +2503,20 @@ def terminal_tool(
                             "error": f"Terminal tool disabled: environment creation failed ({e})",
                             "status": "disabled"
                         }, ensure_ascii=False)
+                    except TimeoutError as e:
+                        return json.dumps({
+                            "output": "",
+                            "exit_code": -1,
+                            "error": str(e),
+                        }, ensure_ascii=False)
 
                     with _env_lock:
                         _active_environments[effective_task_id] = new_env
                         _last_activity[effective_task_id] = time.time()
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
+            finally:
+                task_lock.release()
 
         if env is None:
             # Unreachable in practice (either the cached branch or the creation

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -21,6 +21,7 @@ import contextlib
 import io
 import json
 import os
+import queue
 import sys
 import threading
 import time
@@ -48,6 +49,62 @@ def _env_float(name: str, default: float) -> float:
 _WATCHDOG_POLL_S = max(0.05, _env_float("HERMES_SLASH_WATCHDOG_POLL_S", 2.0))
 _ORPHAN_GRACE_S = max(0.0, _env_float("HERMES_SLASH_WATCHDOG_GRACE_S", 5.0))
 _in_flight = threading.Event()  # set while a command is executing
+
+# Hard ceiling on HermesCLI(...) construction, which opens SessionDB (state.db)
+# and -- when resuming -- replays that session's history, all before this
+# worker can process a single command. Root-caused from a live incident: a
+# worker sat with zero progress for 17+ minutes at exactly this call, on a
+# profile whose state.db had grown to 150+MB. py-spy showed the main thread
+# blocked in native code with no deeper Python frames (consistent with a slow
+# SQLite operation, not a Python-level infinite loop), and this codebase has
+# a documented precedent of a large state.db causing multi-minute stalls
+# elsewhere (`hermes update`). SessionDB's own connection has only a 1s
+# *lock-wait* timeout -- nothing bounds how long schema init/integrity work
+# takes once it has the lock. Unlike the terminal-tool watchdogs, there is no
+# "gracefully continue" option here: if HermesCLI can't be built, this worker
+# cannot serve any command at all, so on timeout we fail loudly and exit
+# rather than sit invisibly frozen for the rest of the process's life (which
+# is what happened before this fix -- the UI just showed stale state forever
+# with no error, because nothing was left to report one).
+_CLI_INIT_WATCHDOG_S = max(10.0, _env_float("HERMES_SLASH_CLI_INIT_WATCHDOG_S", 120.0))
+
+
+def _build_cli_with_watchdog(model, session_key):
+    """Construct HermesCLI on a daemon thread with a hard wall-clock ceiling.
+
+    Plain daemon thread (not concurrent.futures.ThreadPoolExecutor): the
+    latter's non-daemon workers plus its atexit join-all-threads hook would
+    make this worker process itself refuse to exit promptly if construction
+    ever actually wedged -- defeating the point of failing loudly here.
+    """
+    result_queue = queue.Queue(maxsize=1)
+
+    def _run():
+        try:
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                built = HermesCLI(model=model, compact=True, resume=session_key, verbose=False)
+            result_queue.put(("ok", built))
+        except BaseException as e:  # noqa: BLE001 - must forward any failure to the waiter
+            result_queue.put(("error", e))
+
+    threading.Thread(
+        target=_run, name="cli-init-watchdog", daemon=True,
+    ).start()
+    try:
+        kind, payload = result_queue.get(timeout=_CLI_INIT_WATCHDOG_S)
+    except queue.Empty:
+        print(
+            f"[slash-worker] FATAL: HermesCLI(resume={session_key!r}) did not "
+            f"return within {_CLI_INIT_WATCHDOG_S:.0f}s -- state.db is likely "
+            "very large or under heavy contention. Exiting so the gateway/UI "
+            "sees a clear failure instead of an invisible freeze.",
+            file=sys.stderr, flush=True,
+        )
+        os._exit(1)
+
+    if kind == "error":
+        raise payload
+    return payload
 
 
 def _is_orphaned(original_ppid, getppid=os.getppid) -> bool:
@@ -138,8 +195,7 @@ def main():
     _start_parent_death_watchdog(orig_ppid)
     _prepare_slash_worker_runtime()
 
-    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
-        cli = HermesCLI(model=args.model or None, compact=True, resume=args.session_key, verbose=False)
+    cli = _build_cli_with_watchdog(args.model or None, args.session_key)
 
     # Spurious stdin-EOF recovery (same O_NONBLOCK shared file-description
     # issue as the gateway entry point — any child inheriting fd 0 can flip


### PR DESCRIPTION
## Summary

Four related bugs let a single terminal command, approval check, environment setup step, or session-resume ever hang the agent turn (or, in the fourth case, the entire worker process) forever, with no error and no log line. All four were root-caused from live production incidents (well over a dozen multi-hour freezes across many days of use) and are fixed the same way: wrap a call that's *supposed* to self-enforce a timeout with an outer daemon-thread watchdog, so a defeated internal timeout can no longer hang the caller indefinitely.

### 1. `tools/terminal_tool.py` — foreground `env.execute()` hang

- The idle-environment reaper (`_cleanup_inactive_envs`) only refreshes keep-alive for **background** processes via `process_registry.has_active_processes()`. A plain foreground `env.execute()` call never registers there, so a command that legitimately runs long can have its environment reaped mid-execution. Added an `_inflight_foreground` counter so the reaper treats "someone is inside `env.execute()` right now" the same as a registered background process.
- `env.execute()` is expected to self-enforce `execute_kwargs["timeout"]` via `BaseEnvironment._wait_for_process`'s poll loop, but that deadline lives entirely inside the call being waited on — if it's ever defeated, nothing outside can notice. Added `_execute_foreground_with_watchdog`: runs `env.execute()` on a daemon thread with a hard ceiling (requested timeout + 45s grace). On timeout, returns a normal timeout result instead of hanging the caller forever.

### 2. `tools/approval.py` — smart-approval auxiliary LLM call hang

- Every terminal command flagged for review goes through `_smart_approve()`, which calls the auxiliary LLM (`agent.auxiliary_client.call_llm`, `task="approval"`) synchronously before the command is allowed to run at all. That call is expected to self-enforce a timeout (default 30s), but as with the `env.execute()` case above, an internal timeout with no outside observer can hang the entire turn *before* the command it's gating ever executes — upstream of any protection in `terminal_tool.py`.
- Root-caused from a live incident: a resumed session's tool call never progressed past the point where the auxiliary-approval log line would have been emitted, while a concurrent session on the same gateway kept working normally — ruling out a global/process-wide stall and pointing squarely at this synchronous call.
- Added `_call_llm_with_watchdog()`: runs `call_llm()` on a daemon thread with a 45s hard ceiling. On timeout it raises, which `_smart_approve()`'s existing broad `except` already treats as "escalate" — so this doesn't change the function's contract, it just guarantees that path is actually reached within a bounded time instead of never.

### 3. `tools/terminal_tool.py` — environment creation and its lock

- After the first two fixes landed, a *third* hang still occurred: a session stuck 40+ minutes with zero log output between the model's tool-call request and any `tool_executor` completion/error — well past the point either watchdog above would already have resolved it, meaning the stall was upstream of both, in environment setup itself.
- `_create_environment()` (sandbox/shell setup, run once per `task_id`) had no bound at all. Added `_create_environment_with_watchdog()`: same daemon-thread pattern, 90s hard ceiling (generous for the "local" backend, which should be sub-second, while leaving room for container/cloud backends to pull images or cold-start).
- The per-task creation lock (`task_lock`) was acquired via a plain blocking `with task_lock:` — if the thread creating the sandbox ever wedges, every subsequent call for that `task_id` piles up waiting on the same lock forever, turning one stuck call into a permanently dead `task_id` for the rest of the session. Changed to a bounded `task_lock.acquire(timeout=...)` with the corresponding `release()` in a `finally`. A plain `threading.Lock` can be released by any thread, not just the one that acquired it, so releasing it after giving up is safe even if the abandoned creation call is technically still running in the background — its eventual result is simply discarded.

### 4. `tui_gateway/slash_worker.py` — `HermesCLI(resume=...)` construction hang

- A fourth, structurally distinct case: the worker's very first step, constructing `HermesCLI` (which opens `SessionDB`/`state.db` and, when resuming, replays that session's history), had no timeout at all — and unlike the three fixes above, this happens *before* the worker can process a single command, so a hang here doesn't show up as a stuck tool call. It shows up as the UI displaying a stale snapshot of whatever the previous (often already-dead) worker was last doing, forever, because the new worker never gets far enough to send any update.
- Root-caused live via `py-spy dump` on a worker stuck for 17+ minutes: the main thread was blocked in native code at exactly the `HermesCLI(...)` call site, with no deeper Python frames — consistent with a slow SQLite operation, not a Python-level infinite loop. The profile's `state.db` had grown to 150+MB. `SessionDB`'s connection sets only a 1s *lock-wait* timeout (deliberately short, per its own comments); nothing bounds how long schema init/integrity work takes once a statement actually has the lock. This codebase already has a documented precedent of a large `state.db` causing multi-minute stalls elsewhere (a `hermes update` fix), just not one covering this path.
- Added `_build_cli_with_watchdog()`: runs the `HermesCLI(...)` construction on a daemon thread with a 120s ceiling (env-overridable via `HERMES_SLASH_CLI_INIT_WATCHDOG_S`, matching this file's existing `_env_float` knob pattern). Unlike the other three watchdogs, there's no "return an error and keep going" option here — if `HermesCLI` can't be built, this worker cannot serve any command at all. On timeout it logs a clear diagnostic to stderr and calls `os._exit(1)`, so the process dies loudly and immediately instead of sitting invisibly frozen for the rest of its life.

All four watchdogs deliberately use a plain daemon thread rather than `concurrent.futures.ThreadPoolExecutor`: the latter's non-daemon workers plus its atexit join-all-threads hook would make a later, unrelated clean shutdown of the agent process (or, for #4, the worker's own prompt exit) hang too if a call ever actually got abandoned.

## Testing

All four fixes were verified in isolation (not via the full test suite, which I didn't have a way to run against this checkout):
- Fast/normal calls: unaffected, ~0ms overhead.
- Simulated hung `env.execute()` / `call_llm()` / `_create_environment()` / `HermesCLI(...)`: each watchdog fires, the caller regains control (or, for #4, the process exits) within its configured ceiling, and the abandoned daemon thread does not block process exit.
- Reaper: correctly protects an in-flight foreground task while still reaping a genuinely idle one.
- Lock timeout: a `task_lock` held by another thread correctly times out via `acquire(timeout=...)` rather than blocking forever.
- #4's timeout-and-exit path verified via subprocess: a simulated hung construction exits with code 1 at the configured ceiling instead of hanging.
- All modified files compile cleanly and the new functions import correctly.

Happy to adjust the ceiling values, add config knobs, or split into separate PRs if preferred. #4 in particular may also be worth pairing with a look at why `state.db` grows this large for a long-lived profile in the first place (auto-vacuum/pruning cadence), since the timeout is a safety net, not a fix for the underlying size.
