### PR TITLE
fix(gateway): fire processing hooks for runner-drained queued follow-ups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2180,6 +2180,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     merge_pending_message_event,
@@ -2619,6 +2620,36 @@ def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
     to a placeholder string.
     """
     return adapter.get_pending_message(session_key)
+
+
+async def _run_followup_processing_hook(
+    adapter,
+    event: MessageEvent | None,
+    hook_name: str,
+    *args,
+) -> None:
+    """Fire a platform processing-lifecycle hook for a runner-drained follow-up.
+
+    A message that arrives mid-turn is parked in the adapter's pending slot and
+    drained in-band by ``_run_agent``, never by
+    ``BasePlatformAdapter._process_message_background`` — which owns the only
+    other call site for these hooks.  Without firing them here, the read-receipt
+    reaction every adapter renders from ``on_processing_start`` is silently
+    skipped for queued, interrupting, and steer-demoted messages.
+
+    No-ops unless there is a real inbound platform message to acknowledge:
+    interrupt text and leftover ``/steer`` carry no event at all, and synthetic
+    drains (``/goal`` continuations, wake-ups, CLI hand-offs) carry no
+    ``message_id`` — the same field every adapter's own hook already gates on.
+    """
+    if event is None or adapter is None:
+        return
+    if not getattr(event, "message_id", None):
+        return
+    run_hook = getattr(adapter, "_run_processing_hook", None)
+    if not callable(run_hook):
+        return
+    await run_hook(hook_name, event, *args)
 
 
 _INTERRUPT_REASON_STOP = "Stop requested"
@@ -23525,6 +23556,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except Exception:
                         pass
 
+                # Acknowledge the follow-up the way an idle-session message is
+                # already acknowledged.  This in-band drain is the only place a
+                # queued/interrupting message ever runs — base.py's
+                # _process_message_background, which owns the sole other call
+                # site for the processing hooks, is never entered for it — so
+                # without this every platform that renders a read receipt from
+                # on_processing_start silently skips mid-turn messages.
+                # Resolve the adapter from the follow-up's OWN source: a
+                # multiplexed gateway can route it to a different profile's
+                # adapter than the turn we are completing, and only that
+                # instance holds the per-message reaction state.  Fired here
+                # rather than below so the cache re-baseline stays adjacent to
+                # the recursive call it exists to protect.
+                _hook_adapter = (
+                    self._adapter_for_source(next_source)
+                    if pending_event is not None
+                    else None
+                )
+                await _run_followup_processing_hook(
+                    _hook_adapter, pending_event, "on_processing_start",
+                )
+
                 # Re-baseline the cached agent's message_count snapshot before
                 # recursing into the in-band queued (/queue) follow-up turn.
                 # The first turn has completed and flushed its own user +
@@ -23541,17 +23594,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # what the follow-up's guard will consult.  Fail-safe in helper.
                 await self._refresh_agent_cache_message_count(session_key, session_id)
 
-                followup_result = await self._run_agent(
-                    message=next_message,
-                    context_prompt=context_prompt,
-                    history=updated_history,
-                    source=next_source,
-                    session_id=session_id,
-                    session_key=next_session_key,
-                    run_generation=run_generation,
-                    _interrupt_depth=_interrupt_depth + 1,
-                    event_message_id=next_message_id,
-                    channel_prompt=next_channel_prompt,
+                try:
+                    followup_result = await self._run_agent(
+                        message=next_message,
+                        context_prompt=context_prompt,
+                        history=updated_history,
+                        source=next_source,
+                        session_id=session_id,
+                        session_key=next_session_key,
+                        run_generation=run_generation,
+                        _interrupt_depth=_interrupt_depth + 1,
+                        event_message_id=next_message_id,
+                        channel_prompt=next_channel_prompt,
+                    )
+                except asyncio.CancelledError:
+                    # Matches _process_message_background: a cancelled turn is
+                    # not a failure, and adapters that special-case CANCELLED
+                    # (Telegram clears the marker, Signal leaves it) rely on the
+                    # distinction.  Best-effort — a re-delivered cancellation
+                    # can pre-empt the await, exactly as it can in base.py.
+                    await _run_followup_processing_hook(
+                        _hook_adapter, pending_event, "on_processing_complete",
+                        ProcessingOutcome.CANCELLED,
+                    )
+                    raise
+                except BaseException:
+                    await _run_followup_processing_hook(
+                        _hook_adapter, pending_event, "on_processing_complete",
+                        ProcessingOutcome.FAILURE,
+                    )
+                    raise
+                await _run_followup_processing_hook(
+                    _hook_adapter, pending_event, "on_processing_complete",
+                    ProcessingOutcome.SUCCESS,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2622,6 +2622,59 @@ def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
     return adapter.get_pending_message(session_key)
 
 
+def _followup_processing_hooks_apply(adapter, event: MessageEvent | None) -> bool:
+    """Whether a runner-drained follow-up should be bracketed by the hooks.
+
+    Two conditions, both necessary:
+
+    * **A real inbound platform message to acknowledge.** Adapters key their
+      in-progress marker either off ``message_id`` (Slack, Telegram, Feishu,
+      Matrix, Photon) or off the raw envelope — Signal reads
+      ``raw_message["sender"]``/``["timestamp_ms"]`` and never sets
+      ``message_id`` at all, Discord reads ``raw_message`` — so either field
+      means there is something to react to.  Synthetic drains (``/goal``
+      continuations, wake-ups, CLI hand-offs, startup auto-resume) carry
+      neither and must stay silent.
+    * **The adapter overrides ``on_processing_start``.** We *bracket*, so both
+      halves have to belong to us.  An adapter that implements only
+      ``on_processing_complete`` — Google Chat reaps its typing card there,
+      webhook ends its per-delivery session — would otherwise be handed a
+      completion for a turn whose reply has not been delivered yet, because
+      delivery happens after the whole drain chain unwinds back into
+      ``_process_message_background``.
+    """
+    if adapter is None or event is None:
+        return False
+    if not (getattr(event, "message_id", None) or getattr(event, "raw_message", None)):
+        return False
+    start_hook = getattr(type(adapter), "on_processing_start", None)
+    return start_hook is not None and start_hook is not BasePlatformAdapter.on_processing_start
+
+
+def _followup_cancel_outcome(adapter) -> ProcessingOutcome:
+    """Classify a cancelled follow-up exactly as ``_process_message_background``
+    does: only cancels the adapter itself routed (``/stop``, ``/new``,
+    ``/reset``, adapter cleanup) count as CANCELLED; anything else is a failure.
+
+    The distinction is load-bearing rather than cosmetic — Signal and Matrix
+    deliberately leave the in-progress marker in place on CANCELLED, so
+    reporting an *unexpected* cancellation as CANCELLED would strand it.
+    """
+    expected = getattr(adapter, "_expected_cancelled_tasks", None)
+    if expected is None:
+        return ProcessingOutcome.FAILURE
+    try:
+        current = asyncio.current_task()
+    except RuntimeError:
+        current = None
+    if current is None:
+        return ProcessingOutcome.FAILURE
+    try:
+        return ProcessingOutcome.CANCELLED if current in expected else ProcessingOutcome.FAILURE
+    except TypeError:
+        return ProcessingOutcome.FAILURE
+
+
 async def _run_followup_processing_hook(
     adapter,
     event: MessageEvent | None,
@@ -2634,17 +2687,12 @@ async def _run_followup_processing_hook(
     drained in-band by ``_run_agent``, never by
     ``BasePlatformAdapter._process_message_background`` — which owns the only
     other call site for these hooks.  Without firing them here, the read-receipt
-    reaction every adapter renders from ``on_processing_start`` is silently
-    skipped for queued, interrupting, and steer-demoted messages.
+    reaction adapters render from ``on_processing_start`` is silently skipped
+    for queued, interrupting, and steer-demoted messages.
 
-    No-ops unless there is a real inbound platform message to acknowledge:
-    interrupt text and leftover ``/steer`` carry no event at all, and synthetic
-    drains (``/goal`` continuations, wake-ups, CLI hand-offs) carry no
-    ``message_id`` — the same field every adapter's own hook already gates on.
+    See ``_followup_processing_hooks_apply`` for when this is a no-op.
     """
-    if event is None or adapter is None:
-        return
-    if not getattr(event, "message_id", None):
+    if not _followup_processing_hooks_apply(adapter, event):
         return
     run_hook = getattr(adapter, "_run_processing_hook", None)
     if not callable(run_hook):
@@ -23561,7 +23609,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # queued/interrupting message ever runs — base.py's
                 # _process_message_background, which owns the sole other call
                 # site for the processing hooks, is never entered for it — so
-                # without this every platform that renders a read receipt from
+                # without this every adapter that renders a read receipt from
                 # on_processing_start silently skips mid-turn messages.
                 # Resolve the adapter from the follow-up's OWN source: a
                 # multiplexed gateway can route it to a different profile's
@@ -23578,23 +23626,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _hook_adapter, pending_event, "on_processing_start",
                 )
 
-                # Re-baseline the cached agent's message_count snapshot before
-                # recursing into the in-band queued (/queue) follow-up turn.
-                # The first turn has completed and flushed its own user +
-                # assistant rows to the SessionDB, so the cross-process
-                # coherence guard (#45966) — which this recursive _run_agent
-                # call re-enters — would otherwise see the grown on-disk count
-                # against the stale build-time snapshot and rebuild the agent
-                # on THIS process's OWN writes, destroying the prompt-cache
-                # prefix #46237 was merged to preserve.  The existing
-                # re-baseline in _handle_message_with_agent only runs after the
-                # whole _run_agent chain unwinds — too late for the in-band
-                # follow-up.  Use the same (session_key, session_id) the
-                # recursive call runs under so the snapshot matches exactly
-                # what the follow-up's guard will consult.  Fail-safe in helper.
-                await self._refresh_agent_cache_message_count(session_key, session_id)
-
+                # Everything from here to the recursion runs inside the try, so
+                # that once the marker is on the message every exit closes it —
+                # including a /stop landing on the re-baseline's DB await, which
+                # would otherwise strand the marker (that helper guards its own
+                # I/O with `except Exception`, which does not catch cancellation).
                 try:
+                    # Re-baseline the cached agent's message_count snapshot
+                    # before recursing into the in-band queued (/queue) follow-up
+                    # turn.  The first turn has completed and flushed its own
+                    # user + assistant rows to the SessionDB, so the
+                    # cross-process coherence guard (#45966) — which this
+                    # recursive _run_agent call re-enters — would otherwise see
+                    # the grown on-disk count against the stale build-time
+                    # snapshot and rebuild the agent on THIS process's OWN
+                    # writes, destroying the prompt-cache prefix #46237 was
+                    # merged to preserve.  The existing re-baseline in
+                    # _handle_message_with_agent only runs after the whole
+                    # _run_agent chain unwinds — too late for the in-band
+                    # follow-up.  Use the same (session_key, session_id) the
+                    # recursive call runs under so the snapshot matches exactly
+                    # what the follow-up's guard will consult.  Fail-safe in
+                    # helper.
+                    await self._refresh_agent_cache_message_count(session_key, session_id)
+
                     followup_result = await self._run_agent(
                         message=next_message,
                         context_prompt=context_prompt,
@@ -23608,14 +23663,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         channel_prompt=next_channel_prompt,
                     )
                 except asyncio.CancelledError:
-                    # Matches _process_message_background: a cancelled turn is
-                    # not a failure, and adapters that special-case CANCELLED
-                    # (Telegram clears the marker, Signal leaves it) rely on the
-                    # distinction.  Best-effort — a re-delivered cancellation
-                    # can pre-empt the await, exactly as it can in base.py.
+                    # Classified the same way _process_message_background does:
+                    # an *expected* cancel (/stop, /new, /reset, cleanup) is
+                    # CANCELLED, anything else is a failure.  Signal and Matrix
+                    # deliberately leave the marker in place on CANCELLED, so
+                    # misclassifying here would strand it.  Best-effort — a
+                    # re-delivered cancellation can pre-empt the await, exactly
+                    # as it can in base.py.
                     await _run_followup_processing_hook(
                         _hook_adapter, pending_event, "on_processing_complete",
-                        ProcessingOutcome.CANCELLED,
+                        _followup_cancel_outcome(_hook_adapter),
                     )
                     raise
                 except BaseException:

--- a/tests/gateway/test_queued_followup_processing_hooks.py
+++ b/tests/gateway/test_queued_followup_processing_hooks.py
@@ -239,3 +239,75 @@ async def test_synthetic_followup_is_not_acknowledged(monkeypatch, tmp_path):
 
     assert adapter.started == []
     assert adapter.completed == []
+
+
+@pytest.mark.asyncio
+async def test_raw_envelope_only_followup_is_acknowledged(monkeypatch, tmp_path):
+    """Signal never sets message_id — its hook keys off the raw envelope
+    (sender + timestamp_ms) — and Discord's reads raw_message. An event
+    carrying only a raw envelope is still a real inbound message."""
+    _TwoTurnAgent.calls = []
+    _install_fake_agent(monkeypatch, tmp_path, _TwoTurnAgent)
+
+    adapter = HookRecordingAdapter()
+    runner = _make_runner(adapter)
+
+    adapter._pending_messages[SESSION_KEY] = MessageEvent(
+        text="signal-shaped follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id=None,
+        raw_message={"sender": "+15550100", "timestamp_ms": 1700000000000},
+    )
+
+    await runner._run_agent(
+        message="the first turn",
+        context_prompt="",
+        history=[],
+        source=_source(),
+        session_id="sess-hooks-raw",
+        session_key=SESSION_KEY,
+    )
+
+    assert adapter.started == [None]
+    assert adapter.completed == [(None, ProcessingOutcome.SUCCESS)]
+
+
+class CompleteOnlyAdapter(HookRecordingAdapter):
+    """Google Chat and webhook implement on_processing_complete WITHOUT
+    on_processing_start; theirs is end-of-cycle teardown (reap the typing
+    card / end the delivery session), not a reaction."""
+
+    on_processing_start = BasePlatformAdapter.on_processing_start
+
+
+@pytest.mark.asyncio
+async def test_complete_only_adapter_is_left_alone(monkeypatch, tmp_path):
+    """We bracket, so both halves must belong to us. An adapter that only
+    implements the completion half must not be handed a completion here: at
+    this point the follow-up's reply has not been delivered yet, so its
+    teardown would fire against a live turn."""
+    _TwoTurnAgent.calls = []
+    _install_fake_agent(monkeypatch, tmp_path, _TwoTurnAgent)
+
+    adapter = CompleteOnlyAdapter()
+    runner = _make_runner(adapter)
+
+    adapter._pending_messages[SESSION_KEY] = MessageEvent(
+        text="the follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="queued-3",
+    )
+
+    result = await runner._run_agent(
+        message="the first turn",
+        context_prompt="",
+        history=[],
+        source=_source(),
+        session_id="sess-hooks-complete-only",
+        session_key=SESSION_KEY,
+    )
+
+    assert result["final_response"] == "done-2"
+    assert adapter.completed == []

--- a/tests/gateway/test_queued_followup_processing_hooks.py
+++ b/tests/gateway/test_queued_followup_processing_hooks.py
@@ -1,0 +1,241 @@
+"""Processing-hook parity for queued follow-up turns.
+
+A message that arrives while a turn is already running is parked in the
+adapter's ``_pending_messages`` slot and drained *in-band* by
+``GatewayRunner._run_agent`` rather than by
+``BasePlatformAdapter._process_message_background``.  The runner-side drain
+must still fire the ``on_processing_start`` / ``on_processing_complete``
+lifecycle hooks, otherwise every platform that renders a read-receipt
+reaction from those hooks (Slack 👀, Discord, Telegram, Feishu, Matrix,
+Signal, ...) silently skips the acknowledgement for mid-turn messages.
+"""
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+)
+from gateway.session import SessionSource
+
+
+class HookRecordingAdapter(BasePlatformAdapter):
+    """Adapter that records the processing-hook lifecycle it is driven through."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.started: list = []
+        self.completed: list = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="sent-1")
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        self.started.append(getattr(event, "message_id", None))
+
+    async def on_processing_complete(self, event, outcome) -> None:
+        self.completed.append((getattr(event, "message_id", None), outcome))
+
+
+class _TwoTurnAgent:
+    calls: list = []
+
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls.append(message)
+        return {
+            "final_response": f"done-{len(type(self).calls)}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class _RaisingSecondTurnAgent:
+    calls: list = []
+
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls.append(message)
+        if len(type(self).calls) >= 2:
+            raise RuntimeError("boom in the queued follow-up turn")
+        return {
+            "final_response": "done-1",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    return runner
+
+
+def _install_fake_agent(monkeypatch, tmp_path, agent_cls):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+
+SESSION_KEY = "agent:main:telegram:dm:4242"
+
+
+def _source():
+    return SessionSource(platform=Platform.TELEGRAM, chat_id="4242", chat_type="dm")
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_fires_processing_hooks(monkeypatch, tmp_path):
+    """The runner-drained follow-up gets the same start/complete hooks as a
+    message that arrives while the session is idle."""
+    _TwoTurnAgent.calls = []
+    _install_fake_agent(monkeypatch, tmp_path, _TwoTurnAgent)
+
+    adapter = HookRecordingAdapter()
+    runner = _make_runner(adapter)
+
+    adapter._pending_messages[SESSION_KEY] = MessageEvent(
+        text="the follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="queued-1",
+    )
+
+    result = await runner._run_agent(
+        message="the first turn",
+        context_prompt="",
+        history=[],
+        source=_source(),
+        session_id="sess-hooks",
+        session_key=SESSION_KEY,
+    )
+
+    # The follow-up really did run in-band.
+    assert result["final_response"] == "done-2"
+    assert _TwoTurnAgent.calls == ["the first turn", "the follow-up"]
+
+    # ...and it was acknowledged through the lifecycle hooks.
+    assert adapter.started == ["queued-1"]
+    assert adapter.completed == [("queued-1", ProcessingOutcome.SUCCESS)]
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_failure_completes_the_hook(monkeypatch, tmp_path):
+    """A follow-up turn that blows up still closes its hook, so a platform
+    never strands a 'still working' marker on the user's message."""
+    _RaisingSecondTurnAgent.calls = []
+    _install_fake_agent(monkeypatch, tmp_path, _RaisingSecondTurnAgent)
+
+    adapter = HookRecordingAdapter()
+    runner = _make_runner(adapter)
+
+    adapter._pending_messages[SESSION_KEY] = MessageEvent(
+        text="the doomed follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="queued-2",
+    )
+
+    with pytest.raises(RuntimeError):
+        await runner._run_agent(
+            message="the first turn",
+            context_prompt="",
+            history=[],
+            source=_source(),
+            session_id="sess-hooks-failure",
+            session_key=SESSION_KEY,
+        )
+
+    assert adapter.started == ["queued-2"]
+    assert adapter.completed == [("queued-2", ProcessingOutcome.FAILURE)]
+
+
+@pytest.mark.asyncio
+async def test_synthetic_followup_is_not_acknowledged(monkeypatch, tmp_path):
+    """Drains with no inbound platform message — /goal continuations, wake-ups,
+    CLI hand-offs — carry no message_id and must stay silent: there is nothing
+    on the platform to react to."""
+    _TwoTurnAgent.calls = []
+    _install_fake_agent(monkeypatch, tmp_path, _TwoTurnAgent)
+
+    adapter = HookRecordingAdapter()
+    runner = _make_runner(adapter)
+
+    adapter._pending_messages[SESSION_KEY] = MessageEvent(
+        text="synthetic continuation",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="the first turn",
+        context_prompt="",
+        history=[],
+        source=_source(),
+        session_id="sess-hooks-synthetic",
+        session_key=SESSION_KEY,
+    )
+
+    # It still ran — we only suppressed the acknowledgement, not the turn.
+    assert result["final_response"] == "done-2"
+    assert _TwoTurnAgent.calls == ["the first turn", "synthetic continuation"]
+
+    assert adapter.started == []
+    assert adapter.completed == []


### PR DESCRIPTION
Fixes #72502.

## The bug

A message that arrives while a turn is already running never gets the processing-start
acknowledgement — the 👀 read receipt on Slack, and the equivalent in-progress reaction on Discord,
Telegram, Feishu, Matrix, Signal, Photon and the relay adapter. It is not added-then-removed; the
hook is never called.

## Mechanism

`_run_processing_hook("on_processing_start", …)` has exactly one call site in the tree, inside
`BasePlatformAdapter._process_message_background` (`gateway/platforms/base.py:5403`). The busy path
never reaches it:

1. `handle_message` hits `if session_key in self._active_sessions:` (`base.py:5165`) — a turn is in
   flight.
2. It parks the event (`_queue_text_debounce` / `merge_pending_message_event`, `base.py:5302`/`5310`)
   and **returns at `base.py:5316`**.
3. `_start_session_processing` (`base.py:5325`) — the only spawner of
   `_process_message_background` *reachable from `handle_message`*, and therefore the only thing
   that would fire the hook for this event — sits *below* that return. (The other two spawn sites,
   `base.py:5847` and `base.py:5972`, are the adapter's own drains, which run after the runner has
   already popped the slot.)

The parked event is then drained **in-band by the runner**, not by the adapter:
`_dequeue_pending_event` at `gateway/run.py:23277`, replayed through a recursive `_run_agent` at
`run.py:23544`, and that branch touches no adapter hooks. Because `get_pending_message` is a pop
(`base.py:6087`), the adapter's own drain (`base.py:5823`) — the one path that *would* fire the hook
— finds an empty slot. The gap is structural rather than a race for any message parked *before*
the runner's pop; a message that lands in the narrow window *after* it is still served by the
adapter drains and does get its hooks.

So it is one bug class, not a Slack bug: every `busy_input_mode` (`queue`, `interrupt`,
steer-demoted-to-queue), plus `/queue`, photo-burst and text-debounce flushes, and voice drains, all
funnel through that single `_dequeue_pending_event` site, and every adapter that implements the hooks hangs off the single call site upstream of it (**eight** implement `on_processing_start`: slack, discord, telegram, feishu, matrix, signal, photon, and `gateway/relay/adapter.py:1537`).

Discord is affected in a second, non-cosmetic way: its `on_processing_start` also writes durable
recovery state (`_record_discord_processing_start`, `discord/adapter.py:2460`), so a queued Discord
message never leaves `status='seen'` in the recovery DB and stays eligible for missed-message
backfill even though it was answered.

## The fix

Fire the existing hook pair around the recursive call, through one shared site. No new hook, no new
interface, no new config key, no new `HERMES_*` env var. `gateway/run.py` is +159/-27 across two
commits, of which ~27 lines are the existing recursive call re-indented into the `try` and well over
half the remainder is comment explaining the placement constraints below.

Placement was the whole design problem, so to save a reviewer the trace:

- **After** the depth-cap requeue (`run.py:23372`) and after every discard and early return in the
  block — the slash-command discard, the `_draining` discard, the stale-goal-continuation return,
  and the `next_message is None` return. From that point control either reaches the recursion or
  raises, and both close the hook, so no path can strand an in-progress marker on a user's message.
  Firing at dequeue time instead would strand one on all five of those paths.
- **Before** `_refresh_agent_cache_message_count`, so that re-baseline stays adjacent to the
  recursive call it exists to protect. Inserting a reaction round-trip between them would widen the
  window in which the cross-process coherence guard (#45966) trips on this process's own writes and
  rebuilds the agent — destroying the prompt-cache prefix #46237 was merged to preserve. **This is
  the prompt-caching-sensitive part of the change and the reason the hook is not simply fired
  immediately before `_run_agent`.**
- The hook adapter is resolved from the **follow-up's own source**, not the completing turn's. A
  multiplexed gateway can route the follow-up to a different profile's adapter
  (`_adapter_for_source`, `gateway/authz_mixin.py:101`), and only that instance holds the
  per-message reaction state — using the outer `source` would silently no-op on Slack and hit the
  wrong workspace client.
- Gated on a real inbound platform message — a truthy `message_id` **or** `raw_message`. Most
  adapters key their marker off `message_id` (Slack `3753`, Telegram `9646`, Matrix `3324`, Feishu
  `3192`, Photon `1368`), but Signal never sets it at all (`signal.py:749`) and keys off
  `raw_message["sender"]`/`["timestamp_ms"]`, and Discord's start hook reads `raw_message` too.
  Synthetic drains —
  `/goal` continuations (`run.py:15457`, explicit `message_id=None`), wake-ups, CLI hand-offs,
  startup auto-resume — carry neither and stay silent. `interrupt_message` and leftover `/steer`
  carry no event at all and are excluded too.
- **Gated on the adapter overriding `on_processing_start`.** We bracket, so both halves have to be
  ours. Google Chat (`google_chat/adapter.py:2766`) and webhook (`webhook.py:901`) implement
  `on_processing_complete` *only*, and theirs is end-of-cycle teardown rather than a reaction —
  Google Chat reaps its typing card, patching it to `(no reply)`. Since delivery happens after the
  whole drain chain unwinds, handing them a completion here would tombstone a live card. They are
  left exactly as they are today.
- Cancellation is classified exactly as `_process_message_background` does (`base.py:5862-5868`):
  `CANCELLED` only for a task in `_expected_cancelled_tasks` (`/stop`, `/new`, `/reset`, adapter
  cleanup), `FAILURE` otherwise. The distinction is load-bearing in both directions — Telegram
  clears the marker on `CANCELLED` while Signal and Matrix deliberately leave it, so reporting an
  unexpected cancellation as `CANCELLED` would strand the very marker this PR exists to clear. Like
  `base.py:5866` this is best-effort: a re-delivered cancellation can pre-empt the await.
- Hooks go through `adapter._run_processing_hook`, never the hook method directly, so a failing
  reactions API cannot break the drain — it already swallows `Exception` and logs at WARNING.

**Invariants:** nothing here touches history, message construction, tool schemas or the system
prompt — `updated_history` is a pure read at `run.py:23477` and role alternation is decided inside
`run_conversation`. Prompt caching is addressed by the placement above.

## Deliberately not changed

Outcome is `SUCCESS` unless the recursion raises, even when the follow-up returns `failed: True`.
That mirrors the existing non-queued contract: `_process_message_background` derives its outcome
from *delivery* (`processing_ok = delivery_succeeded if delivery_attempted else not bool(response)`,
`base.py:5810`), and a run returning `failed: True` still delivers a diagnostic message and reports
`SUCCESS` today. Making the outcome track agent failure is a real improvement but it should apply to
both paths at once, so it belongs in its own PR rather than being smuggled in as a queued-path-only
asymmetry.

One consequence worth stating plainly: because the bracket closes when the recursive turn returns
and delivery happens after the chain unwinds, a follow-up whose reply then *fails to send* still
shows the success marker. Reporting on delivery would require plumbing the outcome back down from
`_process_message_background`, which is a larger change than this bug warrants.

## Known remaining gap (not fixed here, by design)

`busy_input_mode: steer` where the steer *succeeds* consumes the user's message without ever
creating a pending event — the text is injected into the running turn (`run.py:6375` only queues
`if not steered and not redirected`). There is no follow-up turn to bracket, so there is nothing for
this fix to hook. Acknowledging a successful steer needs a different mechanism and a decision about
what the reaction would even mean; it is out of scope here.

## Tests

`tests/gateway/test_queued_followup_processing_hooks.py` — behaviour tests, no source-text reads, no
snapshots. They drive the real `GatewayRunner._run_agent` against a real `BasePlatformAdapter`
subclass with a pre-seeded pending slot, in the shape of the existing
`tests/gateway/test_queued_native_image_session_key.py`:

1. `test_queued_followup_fires_processing_hooks` — the drained follow-up gets
   `start(queued-1)` → `complete(queued-1, SUCCESS)`, and the follow-up still runs.
2. `test_queued_followup_failure_completes_the_hook` — a follow-up turn that raises still closes its
   hook with `FAILURE`, so no platform strands a "still working" marker.
3. `test_synthetic_followup_is_not_acknowledged` — a drain with no inbound platform message stays
   silent while still running the turn (the `/goal`-continuation class).
4. `test_raw_envelope_only_followup_is_acknowledged` — an event with only a raw envelope and no
   `message_id` IS acknowledged (the Signal shape).
5. `test_complete_only_adapter_is_left_alone` — an adapter implementing only
   `on_processing_complete` gets nothing (the Google Chat / webhook shape).

Against unmodified `main`, 1 and 2 fail (`assert [] == ['queued-1']`) and 3 passes vacuously since
nothing fires at all. Against the first commit of this PR, 4 and 5 fail — they are the regression
guards for the two defects the second commit fixes. All five pass on the branch tip.

```
# before (gateway/run.py at upstream main, test file applied)
=== Summary: 1 files, 1 tests passed, 2 failed (100% complete) in 11.8s ===
  FAILED ...::test_queued_followup_fires_processing_hooks
  FAILED ...::test_queued_followup_failure_completes_the_hook

# after
=== Summary: 1 files, 5 tests passed, 0 failed (100% complete) in 7.1s ===
```

Full gateway suite via `scripts/run_tests.sh tests/gateway/`: **550 files, 11,346 tests passed, 8 failed** (`in 180.2s`).

All 8 failures are pre-existing and environment/timing-related — none touch the queued drain. The
same suite on pristine `main` @ `0a2c245cd` in an identical worktree fails **9** files, a strict
superset:

| file | pristine `main` | this branch |
|---|---|---|
| `test_background_command.py` | fail | fail |
| `test_api_server.py` | fail | fail |
| `test_readiness.py` | fail | fail |
| `test_feishu.py` | fail | fail |
| `test_shutdown_forensics.py` | fail | fail |
| `test_session_hygiene.py` | fail | fail |
| `test_systemd_notify.py` | fail | fail |
| `test_startup_restart_race.py` | fail | fail |
| `test_memory_monitor.py` | fail | pass |

(`test_memory_monitor.py` failed on the baseline run and passed on the branch run; it flips between
runs like the rest.)

Baseline: `549 files, 11340 tests passed, 9 failed in 142.3s`. The branch's +6 passing tests are the
five new ones plus one flake that flipped. No test that passes on `main` fails
on this branch. (Locally these are asyncio-timeout flakes on a loaded runner; they are not
deterministic in either direction.)
