### PR TITLE
fix(tui): use content majority for mixed bidi lines

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/bidi.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/bidi.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { reorderBidi } from './bidi.js'
+
+type BidiCharacter = Parameters<typeof reorderBidi>[0][number]
+
+const charactersFrom = (text: string): BidiCharacter[] =>
+  Array.from(text, value => ({
+    value,
+    width: 1,
+    styleId: 0,
+    hyperlink: undefined
+  }))
+
+const textFrom = (characters: BidiCharacter[]) => characters.map(character => character.value).join('')
+
+const importBidiWithSoftwareReordering = async () => {
+  vi.resetModules()
+  vi.stubEnv('TERM_PROGRAM', 'vscode')
+
+  return import('./bidi.js')
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('reorderBidi', () => {
+  it('leaves pure LTR text unchanged', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('hello /help gpt-5')
+    const output = reorderBidi(input)
+
+    expect(output).toBe(input)
+    expect(textFrom(output)).toBe('hello /help gpt-5')
+  })
+
+  it('detects Arabic text through the RTL reorder path', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('مرحبا')
+    const output = reorderBidi(input)
+
+    expect(output).not.toBe(input)
+    expect(textFrom(output)).toBe('ابحرم')
+  })
+
+  it('keeps an English technical token readable in mixed Arabic text', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('مرحبا gpt-5')
+    const output = reorderBidi(input)
+
+    expect(textFrom(output)).toBe('gpt-5 ابحرم')
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/bidi.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/bidi.test.ts
@@ -52,4 +52,44 @@ describe('reorderBidi', () => {
 
     expect(textFrom(output)).toBe('gpt-5 ابحرم')
   })
+
+  it('uses an RTL base for English-first Persian-majority technical prose', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('React یک کتابخانه جاوااسکریپت بسیار محبوب است.')
+    const output = reorderBidi(input)
+
+    expect(textFrom(output)).toBe('.تسا بوبحم رایسب تپیرکسااواج هناخباتک کی React')
+  })
+
+  it('keeps an LTR base when English remains the strong-character majority', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('React is a popular library: محبوب')
+    const output = reorderBidi(input)
+
+    expect(textFrom(output)).toBe('React is a popular library: بوبحم')
+  })
+
+  it('uses an LTR base for RTL-first, LTR-majority technical prose', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('محبوب React is a popular library.')
+    const output = reorderBidi(input)
+
+    expect(textFrom(output)).toBe('بوبحم React is a popular library.')
+  })
+
+  it('falls back to first-strong behavior for an LTR-first tie', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('Aب.')
+    const output = reorderBidi(input)
+
+    expect(textFrom(output)).toBe('Aب.')
+  })
+
+  it('falls back to first-strong behavior for an RTL-first tie', async () => {
+    const { reorderBidi } = await importBidiWithSoftwareReordering()
+    const input = charactersFrom('بA.')
+    const output = reorderBidi(input)
+
+    expect(textFrom(output)).toBe('.Aب')
+  })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/bidi.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/bidi.ts
@@ -60,13 +60,20 @@ export function reorderBidi(characters: ClusteredChar[]): ClusteredChar[] {
   // Build a plain string from the clustered chars to run through bidi
   const plainText = characters.map(c => c.value).join('')
 
-  // Check if there are any RTL characters — skip bidi if pure LTR
-  if (!hasRTLCharacters(plainText)) {
+  // Preserve the common terminal fast path without initializing bidi-js.
+  if (isAscii(plainText)) {
     return characters
   }
 
   const bidi = getBidi()
-  const { levels } = bidi.getEmbeddingLevels(plainText, 'auto')
+  const { baseDirection, hasRtl } = contentMajorityBaseDirection(plainText, bidi)
+
+  // Check if there are any RTL characters — skip bidi if pure LTR
+  if (!hasRtl) {
+    return characters
+  }
+
+  const { levels } = bidi.getEmbeddingLevels(plainText, baseDirection)
 
   // Map bidi levels back to ClusteredChar indices.
   // Each ClusteredChar may be multiple code units in the joined string.
@@ -110,6 +117,16 @@ export function reorderBidi(characters: ClusteredChar[]): ClusteredChar[] {
   return reordered
 }
 
+function isAscii(text: string): boolean {
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) > 0x7f) {
+      return false
+    }
+  }
+
+  return true
+}
+
 function reverseRange<T>(arr: T[], start: number, end: number): void {
   while (start < end) {
     const temp = arr[start]!
@@ -131,15 +148,30 @@ function reverseRangeNumbers(arr: number[], start: number, end: number): void {
 }
 
 /**
- * Quick check for RTL characters (Hebrew, Arabic, and related scripts).
- * Avoids running the full bidi algorithm on pure-LTR text.
+ * Select the paragraph base from all bidi-strong characters instead of only
+ * the first one. This keeps English-first, RTL-majority technical prose on an
+ * RTL base while preserving LTR-majority lines and UAX#9 first-strong behavior
+ * for ties.
  */
-function hasRTLCharacters(text: string): boolean {
-  // Hebrew: U+0590-U+05FF, U+FB1D-U+FB4F
-  // Arabic: U+0600-U+06FF, U+0750-U+077F, U+08A0-U+08FF, U+FB50-U+FDFF, U+FE70-U+FEFF
-  // Thaana: U+0780-U+07BF
-  // Syriac: U+0700-U+074F
-  return /[\u0590-\u05FF\uFB1D-\uFB4F\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF\u0780-\u07BF\u0700-\u074F]/u.test(
-    text
-  )
+function contentMajorityBaseDirection(
+  text: string,
+  bidi: ReturnType<typeof bidiFactory>
+): { baseDirection: 'auto' | 'ltr' | 'rtl'; hasRtl: boolean } {
+  let ltr = 0
+  let rtl = 0
+
+  for (const character of text) {
+    const bidiClass = bidi.getBidiCharTypeName(character)
+
+    if (bidiClass === 'L') {
+      ltr++
+    } else if (bidiClass === 'R' || bidiClass === 'AL') {
+      rtl++
+    }
+  }
+
+  return {
+    baseDirection: rtl === ltr ? 'auto' : rtl > ltr ? 'rtl' : 'ltr',
+    hasRtl: rtl > 0
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Hermes already applies `bidi-js` before Ink places terminal cells on Windows, Windows Terminal, WSL, and VS Code. The current call uses the Unicode first-strong (`auto`) paragraph base, so an English technical token at the start can force a Persian/Arabic-majority line onto the wrong base:

```text
React یک کتابخانه جاوااسکریپت بسیار محبوب است.
```

This patch selects the base from all strong characters in the rendered line:

- more `R`/`AL` characters -> RTL
- more `L` characters -> LTR
- a tie -> existing first-strong behavior

It uses Hermes's existing `bidi-js` dependency and adds no runtime dependency. Pure ASCII lines return the original array before `bidi-js` is initialized, preserving the common LTR fast path.

Maintainer disclosure: I maintain the MIT-licensed [BidiLens](https://github.com/CodeinScrubs/BidiLens) project. Its mixed-direction failure model and English-first/Persian-majority corpus case motivated this focused host patch. BidiLens is not added as a dependency because this implementation can use Hermes's existing renderer dependency and retain Hermes's current Node.js compatibility.

## Related Issue

Advances the TUI work in #41454. The same first-strong failure class is reported for other Hermes surfaces in #51318 and #71613.

This PR also incorporates the regression-test commit from #15238 with its original author metadata, then adds the implementation and broader direction-policy tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/bidi.ts`
  - select the paragraph base by strong-character majority
  - retain first-strong semantics for ties
  - preserve a zero-allocation return for lines with no RTL content
  - add an ASCII fast path before initializing/scanning with `bidi-js`
- `ui-tui/packages/hermes-ink/src/ink/bidi.test.ts`
  - cover pure LTR identity/no-op behavior
  - cover Arabic and mixed Arabic/English rendering
  - cover English-first Persian-majority and RTL-first English-majority cases
  - cover both LTR-first and RTL-first ties

## How to Test

1. `npm ci --workspace ui-tui --include-workspace-root`
2. `npm test --workspace ui-tui -- packages/hermes-ink/src/ink/bidi.test.ts`
3. `npm run typecheck --workspace ui-tui`
4. `npm run build:ink --workspace ui-tui`
5. `npm exec --workspace ui-tui -- eslint packages/hermes-ink/src/ink/bidi.ts packages/hermes-ink/src/ink/bidi.test.ts`
6. `npx prettier --check ui-tui/packages/hermes-ink/src/ink/bidi.ts ui-tui/packages/hermes-ink/src/ink/bidi.test.ts`

Fresh local results:

- focused suite: 8/8 tests passed
- TypeScript typecheck: passed
- Ink build: passed
- touched-file ESLint: passed
- Prettier and `git diff --check`: passed

I also ran `npm run check --workspace ui-tui`. Build and typecheck passed, and 1,385 tests passed. Eight unrelated Windows/environment-sensitive tests failed in `terminalSetup.test.ts`, `terminalParity.test.ts`, and `editor.test.ts`; the command registry setup also reports the local Python environment missing `yaml`. I am not claiming the complete local suite is green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; this patch only changes the TypeScript TUI renderer, and the relevant TUI checks are listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and constraints are documented inline and in tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

For the English-first Persian-majority fixture, the current first-strong path produces this visual-cell order:

```text
React تسا بوبحم رایسب تپیرکسااواج هناخباتک کی.
```

The content-majority RTL base produces:

```text
.تسا بوبحم رایسب تپیرکسااواج هناخباتک کی React
```

The patch remains intentionally scoped to Hermes's current software-bidi path and the scripts handled by its existing `bidi-js` version. Terminal font shaping and supplementary-plane limitations in that dependency are outside this PR.
