### PR TITLE
fix(desktop): hide stale context usage during active turns

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
@@ -1,0 +1,175 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { StatusbarItem } from '@/app/shell/statusbar-controls'
+import { group } from '@/components/pane-shell/tree/model'
+import { $layoutTree, noteActiveTreeGroup } from '@/components/pane-shell/tree/store'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { setActiveSessionId, setBusy, setCurrentUsage, setSelectedStoredSessionId } from '@/store/session'
+import { $sessionTiles, clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+import { useStatusbarItems } from './use-statusbar-items'
+
+const SESSION_ID = 'session-1'
+const TILE_RUNTIME_ID = 'tile-runtime-1'
+const TILE_STORED_ID = 'tile-stored-1'
+
+let statusbarItems: readonly StatusbarItem[] = []
+
+const noop = () => {}
+
+const requestGateway = <T = unknown,>() => new Promise<T>(() => {})
+
+function Harness() {
+  const items = useStatusbarItems({
+    agentsOpen: false,
+    chatOpen: true,
+    commandCenterOpen: false,
+    extraLeftItems: [],
+    extraRightItems: [],
+    freshDraftReady: true,
+    gatewayState: 'open',
+    inferenceStatus: null,
+    openAgents: noop,
+    openCommandCenterSection: noop,
+    requestGateway,
+    statusSnapshot: null,
+    toggleCommandCenter: noop
+  })
+
+  statusbarItems = items.statusbarItems
+
+  return null
+}
+
+function contextUsageItem(): StatusbarItem {
+  const item = statusbarItems.find(candidate => candidate.id === 'context-usage')
+
+  if (!item) {
+    throw new Error('context usage statusbar item was not registered')
+  }
+
+  return item
+}
+
+afterEach(() => {
+  cleanup()
+  statusbarItems = []
+  setActiveSessionId(null)
+  setSelectedStoredSessionId(null)
+  setBusy(false)
+  setCurrentUsage({ calls: 0, input: 0, output: 0, total: 0 })
+  clearAllSessionStates()
+  $sessionTiles.set([])
+  $layoutTree.set(null)
+  noteActiveTreeGroup(null)
+  vi.restoreAllMocks()
+})
+
+describe('context usage statusbar freshness', () => {
+  it('replaces the last completed occupancy with unknown while the focused turn is running', () => {
+    setActiveSessionId(SESSION_ID)
+    setBusy(false)
+    setCurrentUsage({
+      calls: 1,
+      context_max: 272_000,
+      context_percent: 100,
+      context_used: 371_176,
+      input: 371_176,
+      output: 0,
+      total: 371_176
+    })
+
+    render(<Harness />)
+
+    expect(contextUsageItem()).toMatchObject({
+      detail: '[██████████] 100%',
+      label: '371.2k/272k'
+    })
+
+    act(() => setBusy(true))
+
+    expect(contextUsageItem()).toMatchObject({
+      detail: 'unknown',
+      label: 'Context usage'
+    })
+
+    act(() => {
+      setCurrentUsage({
+        calls: 2,
+        context_max: 272_000,
+        context_percent: 59,
+        context_used: 159_956,
+        input: 159_956,
+        output: 0,
+        total: 159_956
+      })
+      setBusy(false)
+    })
+
+    expect(contextUsageItem()).toMatchObject({
+      detail: '[██████░░░░] 59%',
+      label: '160k/272k'
+    })
+  })
+
+  it('uses the focused tile busy state instead of leaking the idle primary usage', () => {
+    setActiveSessionId(SESSION_ID)
+    setSelectedStoredSessionId(SESSION_ID)
+    setBusy(false)
+    setCurrentUsage({
+      calls: 1,
+      context_max: 272_000,
+      context_percent: 25,
+      context_used: 68_000,
+      input: 68_000,
+      output: 0,
+      total: 68_000
+    })
+
+    $sessionTiles.set([{ runtimeId: TILE_RUNTIME_ID, storedSessionId: TILE_STORED_ID }])
+    $layoutTree.set(group([`session-tile:${TILE_STORED_ID}`], { id: 'tile-group' }))
+    noteActiveTreeGroup('tile-group')
+    publishSessionState(TILE_RUNTIME_ID, {
+      ...createClientSessionState(TILE_STORED_ID),
+      busy: true,
+      usage: {
+        calls: 1,
+        context_max: 272_000,
+        context_percent: 100,
+        context_used: 371_176,
+        input: 371_176,
+        output: 0,
+        total: 371_176
+      }
+    })
+
+    render(<Harness />)
+
+    expect(contextUsageItem()).toMatchObject({
+      detail: 'unknown',
+      label: 'Context usage'
+    })
+
+    act(() =>
+      publishSessionState(TILE_RUNTIME_ID, {
+        ...createClientSessionState(TILE_STORED_ID),
+        busy: false,
+        usage: {
+          calls: 2,
+          context_max: 272_000,
+          context_percent: 59,
+          context_used: 159_956,
+          input: 159_956,
+          output: 0,
+          total: 159_956
+        }
+      })
+    )
+
+    expect(contextUsageItem()).toMatchObject({
+      detail: '[██████░░░░] 59%',
+      label: '160k/272k'
+    })
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -171,8 +171,15 @@ export function useStatusbarItems({
       ? focusedRowStartedAt * 1000
       : null
 
-  const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
-  const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
+  const contextUsage = useMemo(
+    () => (busy ? copy.contextUsage : usageContextLabel(currentUsage)),
+    [busy, copy.contextUsage, currentUsage]
+  )
+
+  const contextBar = useMemo(
+    () => (busy ? copy.unknown : contextBarLabel(currentUsage)),
+    [busy, copy.unknown, currentUsage]
+  )
 
   const publishContextUsage = useCallback(
     (snapshot: Pick<UsageStats, 'context_max' | 'context_percent' | 'context_used'>) => {


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop context gauge showing the previous completed turn's occupancy while a new focused turn is still running.

The root cause was that `message.start` correctly preserved the last authoritative usage snapshot while marking the session busy, but the statusbar rendered that cached snapshot without a freshness qualifier. The statusbar now shows the existing localized `Context usage` / `unknown` labels while the focused session is busy. It keeps the cached backend value intact and resumes showing numeric occupancy when the turn completes with fresh usage.

## Related Issue

Fixes #72453

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx` to hide stale numeric occupancy while the focused primary or tile session is busy.
- Added `apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx` with primary-session and focused-tile regression coverage.
- Verified the cached usage is not cleared and that fresh completion usage becomes visible again.

## How to Test

1. Enable the context-usage statusbar item and finish a turn with a known context snapshot.
2. Start another turn in either the primary chat or a focused session tile; confirm the item reads `Context usage` / `unknown` instead of the previous snapshot.
3. Complete the turn with fresh usage; confirm the new numeric occupancy and percentage are displayed.

Automated checks:

```bash
NODE_OPTIONS=--localstorage-file=/tmp/hermes-desktop-vitest.json \
  npm --workspace apps/desktop run test:ui -- --maxWorkers=1 --fileParallelism=false
npm --workspace apps/desktop run test:desktop:platforms
npm --workspace apps/desktop run typecheck
npm --workspace apps/desktop run build
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0 arm64, Electron

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Desktop UI: 2,523 passed, 1 skipped.
- Electron/platform: 794 passed, 2 skipped.
- TypeScript typecheck and production build passed.
- Manual Electron verification, for both the primary chat and a focused tile: `371.2k/272k (100%)` → `Context usage / unknown` while running → `160k/272k (59%)` after completion.
- Repository-wide `scripts/run_tests.sh` was not fully green on this macOS host: 48,288 tests passed, 68 failed in 26 untouched Python/platform files, and one unrelated file timed out. No failure involved the Desktop files changed here.
