### PR TITLE
fix(tui_gateway): plugin commands silently shadowed by hardcoded slash redirects

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -464,6 +464,77 @@ def test_slash_exec_rejects_skill_commands(server):
     assert "skill command" in resp["error"]["message"]
 
 
+def test_slash_exec_plugin_overrides_live_direct_redirect(server):
+    """A plugin command with the same name as a live-direct redirect (e.g.
+    /models, /rename) should dispatch to the plugin, not the redirect text.
+
+    Regression for the silent-shadow bug: _live_slash_command_output() has
+    hardcoded redirects that short-circuit with an early return. If the plugin
+    check sits after that return, the redirect silently wins and the plugin
+    handler is never reached.
+    """
+    sid = "test-session"
+
+    class Worker:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, cmd):
+            self.calls.append(cmd)
+            return f"worker:{cmd}"
+
+    worker = Worker()
+    server._sessions[sid] = {"session_key": sid, "agent": None, "slash_worker": worker}
+
+    # /models is one of the _LIVE_SESSION_DIRECT_COMMANDS redirects
+    # ("Use /model to view or switch the current model"). Patch the plugin
+    # handler so a plugin has registered /models.
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: (lambda arg: f"plugin-models:{arg}") if name == "models" else None,
+    ):
+        resp = server.handle_request({
+            "id": "r-plugin-redirect-override",
+            "method": "slash.exec",
+            "params": {"command": "models", "session_id": sid},
+        })
+
+    assert "error" not in resp
+    assert resp["result"] == {"output": "plugin-models:"}
+    assert worker.calls == []
+
+
+def test_slash_exec_no_plugin_falls_back_to_live_direct_redirect(server):
+    """When no plugin registers a colliding name, the redirect still works."""
+    sid = "test-session"
+
+    class Worker:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, cmd):
+            self.calls.append(cmd)
+            return f"worker:{cmd}"
+
+    worker = Worker()
+    server._sessions[sid] = {"session_key": sid, "agent": None, "slash_worker": worker}
+
+    # No plugin registers /models → the redirect should fire
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: None,
+    ):
+        resp = server.handle_request({
+            "id": "r-no-plugin-redirect",
+            "method": "slash.exec",
+            "params": {"command": "models", "session_id": sid},
+        })
+
+    assert "error" not in resp
+    assert resp["result"] == {"output": "Use /model to view or switch the current model; desktop users can also open the model picker."}
+    assert worker.calls == []
+
+
 def test_command_dispatch_queue_sends_message(server):
     """command.dispatch /queue returns {type: 'send', message: ...} for the TUI."""
     sid = "test-session"

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1090,6 +1090,38 @@ def _(rid, params: dict) -> dict:
     _cmd_base = (_cmd_parts[0] if _cmd_parts else "").lower()
     _cmd_arg = _cmd_parts[1] if len(_cmd_parts) > 1 else ""
 
+    # Plugin commands are checked here, before _live_slash_command_output()
+    # below. That function has hardcoded redirects for a few convenience
+    # aliases (e.g. /models → "Use /model", /rename → "Use /title") that
+    # short-circuit with an early return. If a plugin registers a command
+    # with a name that collides with one of these redirects, placing the
+    # plugin check after them means the redirect silently wins and the
+    # plugin handler is never reached — no error, just the redirect text.
+    # Checking plugins first lets a plugin override a redirect when the
+    # user has explicitly installed one for that name. The CLI already
+    # does this: its process_command() checks plugins before prefix
+    # matching, so this keeps the TUI gateway consistent.
+    plugin_handler = None
+    resolve_plugin_command_result = None
+    if _cmd_base:
+        try:
+            from hermes_cli.plugins import (
+                get_plugin_command_handler,
+                resolve_plugin_command_result,
+            )
+
+            plugin_handler = get_plugin_command_handler(_cmd_base)
+        except Exception:
+            plugin_handler = None
+            resolve_plugin_command_result = None
+
+    if plugin_handler and resolve_plugin_command_result:
+        try:
+            result = resolve_plugin_command_result(plugin_handler(_cmd_arg))
+            return _ok(rid, {"output": str(result or "(no output)")})
+        except Exception as e:
+            return _ok(rid, {"output": f"Plugin command error: {e}"})
+
     live_output = _live_slash_command_output(
         params.get("session_id", ""), session, _cmd_base, _cmd_arg
     )
@@ -1149,27 +1181,6 @@ def _(rid, params: dict) -> dict:
             )
     except Exception:
         pass
-
-    plugin_handler = None
-    resolve_plugin_command_result = None
-    if _cmd_base:
-        try:
-            from hermes_cli.plugins import (
-                get_plugin_command_handler,
-                resolve_plugin_command_result,
-            )
-
-            plugin_handler = get_plugin_command_handler(_cmd_base)
-        except Exception:
-            plugin_handler = None
-            resolve_plugin_command_result = None
-
-    if plugin_handler and resolve_plugin_command_result:
-        try:
-            result = resolve_plugin_command_result(plugin_handler(_cmd_arg))
-            return _ok(rid, {"output": str(result or "(no output)")})
-        except Exception as e:
-            return _ok(rid, {"output": f"Plugin command error: {e}"})
 
     worker = session.get("slash_worker")
     if not worker:


### PR DESCRIPTION
## Problem

The `slash.exec` handler in the TUI gateway (desktop app / dashboard) checks `_live_slash_command_output()` **before** plugin command dispatch. `_live_slash_command_output()` has hardcoded redirects for convenience aliases (e.g. `/models` → `"Use /model"`, `/rename` → `"Use /title"`) that short-circuit with an early return:

```python
live_output = _live_slash_command_output(...)
if live_output is not None:
    return _ok(rid, {"output": live_output})  # ← short-circuits here
# ...plugin dispatch never reached for colliding names
```

When a plugin registers a command with a name that collides with one of these redirects, the redirect silently wins and the plugin handler is never reached — no error, no warning, just the redirect text instead of the plugin output. The plugin works in the CLI but silently fails in the desktop app.

## Fix

Move the plugin dispatch block above `_live_slash_command_output()`. Same code, different execution order. The duplicate plugin dispatch block that was further down (now unreachable for redirected commands) is removed.

The CLI's `process_command()` already checks plugin commands before prefix matching, so this makes the TUI gateway consistent with the CLI.

## Testing

`tests/tui_gateway/test_protocol.py` — 95 passed, 0 failed. The three existing plugin dispatch tests all pass:
- `test_slash_exec_handles_plugin_commands_in_live_gateway`
- `test_slash_exec_plugin_lookup_failure_falls_back_to_worker`
- `test_slash_exec_plugin_handler_error_returns_output`

## Question for maintainers

The redirects in `_live_slash_command_output()` are clearly intentional (convenience aliases for common typos). If these are meant as reserved names that plugins should not override, then the right fix is different (e.g. reject plugin registration for colliding names with a warning). This PR assumes plugins should be able to override redirects when the user has explicitly installed one — but I'm happy to adjust if the intent is different.