### PR TITLE
fix(desktop): keep pinned sidebar rows in user order

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -205,7 +205,15 @@ export function SidebarSessionsSection({
   // The flat recents/pinned list is the only place sessions reorder by hand;
   // grouped/tree views always sort by creation date and never drag.
   const sessionsDraggable = sortable && !!onReorderSessions
-  const displayEntries = useMemo(() => flattenSessionsWithBranches(sessions), [sessions])
+  // Pinned and manual-drag lists pass sessions already in the caller's order.
+  // Default recents stay dateGrouped and still re-sort roots by group recency
+  // so partition buckets stay truthful — but NEVER for pins, where a turn
+  // finishing was floating background tasks over the user's fixed ranking.
+  const preserveInputOrder = pinned || (sessionsDraggable && !dateGrouped)
+  const displayEntries = useMemo(
+    () => flattenSessionsWithBranches(sessions, { preserveOrder: preserveInputOrder }),
+    [sessions, preserveInputOrder]
+  )
 
   const renderRow = (session: SessionInfo, draggable: boolean, branchStem?: string) => {
     const rowProps = {

--- a/apps/desktop/src/lib/session-branch-tree.test.ts
+++ b/apps/desktop/src/lib/session-branch-tree.test.ts
@@ -50,4 +50,34 @@ describe('flattenSessionsWithBranches', () => {
 
     expect(flattenSessionsWithBranches([branch])).toEqual([{ session: branch }])
   })
+
+  it('re-sorts roots by group recency by default (pinned-style jumps without preserveOrder)', () => {
+    // Stale important chat first in the caller's array; a recently-active
+    // background task second. Default path must lift the fresher root — that
+    // is what was scrambling the Pinned section before preserveOrder.
+    const important = session('important', { last_active: 10 })
+    const background = session('background', { last_active: 99 })
+
+    expect(flattenSessionsWithBranches([important, background]).map(e => e.session.id)).toEqual([
+      'background',
+      'important'
+    ])
+  })
+
+  it("preserveOrder keeps the caller's root order even when activity is newer lower down", () => {
+    const important = session('important', { last_active: 10 })
+    const background = session('background', { last_active: 99 })
+    const branch = session('branch', { last_active: 50, parent_session_id: 'important' })
+
+    expect(
+      flattenSessionsWithBranches([important, background, branch], { preserveOrder: true }).map(e => ({
+        id: e.session.id,
+        stem: e.branchStem
+      }))
+    ).toEqual([
+      { id: 'important', stem: undefined },
+      { id: 'branch', stem: '└─ ' },
+      { id: 'background', stem: undefined }
+    ])
+  })
 })

--- a/apps/desktop/src/lib/session-branch-tree.ts
+++ b/apps/desktop/src/lib/session-branch-tree.ts
@@ -5,10 +5,23 @@ export interface SidebarSessionEntry {
   session: SessionInfo
 }
 
+export interface FlattenSessionsOptions {
+  /**
+   * Keep the input root order instead of re-sorting by group recency.
+   * Use for hand-ordered surfaces (pinned ids, manual recents drag) so a
+   * turn completing can't float a row. Branch children still nest under
+   * their parent; sibling branches stay ordered by their own recency.
+   */
+  preserveOrder?: boolean
+}
+
 const recency = (session: SessionInfo): number => session.last_active || session.started_at || 0
 
 /** Flat list with branch/fork sessions nested visually under their parent. */
-export function flattenSessionsWithBranches(sessions: readonly SessionInfo[]): SidebarSessionEntry[] {
+export function flattenSessionsWithBranches(
+  sessions: readonly SessionInfo[],
+  options: FlattenSessionsOptions = {}
+): SidebarSessionEntry[] {
   if (sessions.length < 2) {
     return sessions.map(session => ({ session }))
   }
@@ -53,6 +66,7 @@ export function flattenSessionsWithBranches(sessions: readonly SessionInfo[]): S
   // A group sorts by its freshest member, so activity on any branch lifts the
   // whole parent→branches cluster together instead of stranding the parent at
   // its own stale timestamp. Memoized — each subtree is folded at most once.
+  // Skipped when preserveOrder is set: the caller already chose positions.
   const groupRecencyMemo = new Map<string, number>()
 
   const groupRecency = (session: SessionInfo): number => {
@@ -92,11 +106,15 @@ export function flattenSessionsWithBranches(sessions: readonly SessionInfo[]): S
     children?.forEach((child, index) => emit(child, index === children.length - 1 ? '└─ ' : '├─ '))
   }
 
-  sessions
+  const roots = sessions
     .filter(session => !nestedIds.has(session.id))
     .map((session, index) => ({ index, session }))
-    .sort((a, b) => groupRecency(b.session) - groupRecency(a.session) || a.index - b.index)
-    .forEach(({ session }) => emit(session))
+
+  if (!options.preserveOrder) {
+    roots.sort((a, b) => groupRecency(b.session) - groupRecency(a.session) || a.index - b.index)
+  }
+
+  roots.forEach(({ session }) => emit(session))
 
   for (const session of sessions) {
     if (!seen.has(session.id)) {


### PR DESCRIPTION
## Summary
- Pinned sidebar rows were jumping to most-recent-completion order even after drag-reorder, because `flattenSessionsWithBranches` re-sorted roots by `last_active` on every paint.
- Add `preserveOrder` so pins (and other non-date-grouped manual lists) keep the caller's order; default recents still sort by recency so date buckets stay honest.
- Cover the "important chat above hot background task" case in unit tests.

## Test plan
- [x] `npm test -- --run src/lib/session-branch-tree.test.ts` (5/5)
- [x] Drag pins into a fixed ranking, complete a turn on a lower pin, confirm order stays put
- [x] Unpin / re-pin still appends at the end of the pin list
- [x] Default Recents still bubble by activity under date dividers