### PR TITLE
fix(agent): use provider-default temperature for title generation (#72351)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -143,11 +143,16 @@ def generate_title(
     ]
 
     try:
+        # Use the provider's default temperature instead of forcing 0.3.
+        # Some models (e.g. GPT-5.6) only accept their server-side default
+        # and reject explicit temperature values, causing the daemon title
+        # thread to fail with "Unsupported value: 'temperature'".
+        # See: #72351, #51083, #51157
         response = call_llm(
             task="title_generation",
             messages=messages,
             max_tokens=500,
-            temperature=0.3,
+            temperature=None,
             timeout=timeout,
             main_runtime=main_runtime,
         )


### PR DESCRIPTION
## Summary
Fixes #72351.

Title generation hardcoded `temperature=0.3` in its `call_llm()` call. Models like GPT-5.6 only accept their server-side default temperature and reject explicit values. While `call_llm()` has a retry that strips temperature on error, the daemon thread races with session cleanup in short-lived CLI sessions, causing the retry to fail.

## Changes
- `agent/title_generator.py`: Change `temperature=0.3` to `temperature=None` so the provider uses its own default. This avoids the unsupported-temperature error entirely.

## Testing
- `py_compile`: OK
- `ruff check`: All checks passed
- The change is safe: title generation is a simple summarization task that works fine with any temperature.
