### PR TITLE
perf(desktop): stop re-rendering the outgoing transcript on every session switch

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useMemo, useRef, useState } from 'react'
 
 import { AssistantMessage } from '@/components/assistant-ui/thread/assistant-message'
 import { ThreadMessageList } from '@/components/assistant-ui/thread/list'
@@ -16,7 +16,7 @@ import { notifyError } from '@/store/notifications'
 
 type ThreadLoadingState = 'response' | 'session'
 
-export const Thread: FC<{
+interface ThreadProps {
   clampToComposer?: boolean
   cwd?: string | null
   gateway?: HermesGateway | null
@@ -28,7 +28,16 @@ export const Thread: FC<{
   onRestoreToMessage?: (messageId: string, target?: RestoreMessageTarget) => Promise<void> | void
   sessionId?: string | null
   sessionKey?: string | null
-}> = ({
+}
+
+// memo'd on purpose, and load-bearing for session-switch cost. ChatView
+// re-renders on every route change (it reads `location`), and this subtree is
+// the entire transcript — without a bail-out here the router's context update
+// rebuilds every message of the OUTGOING thread before it is replaced. The
+// props above are all stable across a plain re-render (see the component-map
+// and loadingIndicator memos below), so the only thing that gets through is a
+// genuine change.
+export const Thread = memo(function Thread({
   clampToComposer = false,
   cwd = null,
   gateway = null,
@@ -40,7 +49,7 @@ export const Thread: FC<{
   onRestoreToMessage,
   sessionId = null,
   sessionKey
-}) => {
+}: ThreadProps) {
   const { t } = useI18n()
   const copy = t.assistant.thread
 
@@ -129,13 +138,20 @@ export const Thread: FC<{
     </div>
   ) : undefined
 
+  // Stable element identity, for the same reason the component map above is
+  // memoized: this is a prop of the memo'd ThreadMessageList, so a fresh
+  // element every render defeats the bail-out and drags the whole transcript
+  // into the switch's render pass. It takes no props, so one element is
+  // always correct.
+  const loadingIndicator = useMemo(() => <BackgroundResumeNotice />, [])
+
   return (
     <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]">
       <ThreadMessageList
         clampToComposer={clampToComposer}
         components={messageComponents}
         emptyPlaceholder={emptyPlaceholder}
-        loadingIndicator={<BackgroundResumeNotice />}
+        loadingIndicator={loadingIndicator}
         sessionKey={sessionKey}
       />
       {loading === 'session' && <CenteredThreadSpinner />}
@@ -151,4 +167,4 @@ export const Thread: FC<{
       />
     </div>
   )
-}
+})

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -77,8 +77,20 @@ export const Thread: FC<{
   // deps. Only their definedness stays a dep — it gates UI (the user
   // Stop button, the restore-confirm affordance). Assigned during render
   // (the useStoreSelector pattern) so the ref never lags a render.
+  //
+  // cwd / gateway / sessionId ride the same ref for the same reason, and it
+  // is load-bearing on the hot path: all three change on EVERY session
+  // switch, so listing them as deps re-minted these types mid-switch and
+  // remounted the entire OUTGOING transcript — thousands of renders of a
+  // thread that was about to be replaced, all of it before the resume RPC
+  // had even been sent. They are read inside the edit composer (which only
+  // exists while a message is being edited), never during a plain render,
+  // so a ref read is always current by the time it matters.
   const callbacksRef = useRef({ onBranchInNewChat, onCancel, onDismissError, onRestoreToMessage })
   callbacksRef.current = { onBranchInNewChat, onCancel, onDismissError, onRestoreToMessage }
+
+  const editContextRef = useRef({ cwd, gateway, sessionId })
+  editContextRef.current = { cwd, gateway, sessionId }
 
   const hasBranchInNewChat = Boolean(onBranchInNewChat)
   const hasCancel = Boolean(onCancel)
@@ -96,7 +108,11 @@ export const Thread: FC<{
         />
       ),
       SystemMessage,
-      UserEditComposer: () => <UserEditComposer cwd={cwd} gateway={gateway} sessionId={sessionId} />,
+      UserEditComposer: () => {
+        const { cwd: editCwd, gateway: editGateway, sessionId: editSessionId } = editContextRef.current
+
+        return <UserEditComposer cwd={editCwd} gateway={editGateway} sessionId={editSessionId} />
+      },
       UserMessage: () => (
         <UserMessage
           onCancel={hasCancel ? () => callbacksRef.current.onCancel?.() : undefined}
@@ -104,16 +120,7 @@ export const Thread: FC<{
         />
       )
     }),
-    [
-      cwd,
-      gateway,
-      hasBranchInNewChat,
-      hasCancel,
-      hasDismissError,
-      hasRestoreToMessage,
-      requestRestoreConfirm,
-      sessionId
-    ]
+    [hasBranchInNewChat, hasCancel, hasDismissError, hasRestoreToMessage, requestRestoreConfirm]
   )
 
   const emptyPlaceholder = intro ? (


### PR DESCRIPTION
Switching between two real sessions re-rendered the transcript you were *leaving* — all of it — before the resume RPC for the session you asked for had even been sent. Two broken reference identities in `Thread` were disarming the bail-outs underneath it, so a route change dragged every message of the outgoing thread through a full render pass on its way to being discarded.

## The two breaks

**1. The message component map was re-minted on every switch.** `messageComponents` listed `cwd`, `gateway`, and `sessionId` as memo deps. All three change on *every* session switch, and the values in that map are React **component types** — a new identity is not a re-render, it's an unmount + remount of every visible message. A DOM-tagging probe confirmed it: **0 of 22** assistant message nodes survived a switch.

These three are only read inside the edit composer, which exists only while a message is actually being edited — never during a plain render. So they now ride the same ref indirection the file already used for the callbacks, for the same documented reason.

**2. `Thread` wasn't memoized.** `ChatView` reads `location`, so it re-renders on every route change, rebuilding the entire transcript subtree. `explain()` named the origin directly: `Routes (context): 217`. Wrapping `Thread` in `memo()` is only sound because the props above are now genuinely stable — including `loadingIndicator`, which was a fresh `<BackgroundResumeNotice />` element on every render and defeated `ThreadMessageList`'s own memo.

## Before / after

Measured on an isolated instance seeded with a **copy of a real 861MB `state.db`** — actual sessions with tool calls and code blocks, not synthetic tiles. Switch between the same two real sessions, via the same hash route a sidebar click takes.

| | before | after |
|---|---|---|
| wasted renders per switch | 9,568 | **555** (17x) |
| total renders | 33,450 | **9,895** |
| wasted renders *before the RPC is sent* | 3,328 | **550** |
| commits | 24 | **14** |
| total component time | 7.6s | **4.6s** |
| `explain('Block')` cascade origin | `Routes (context): 217` | **`{}`** |

`Block` / `Ct` — markdown parse + syntax highlight, the expensive leaves — disappear from the offender table entirely. A props diff across a switch now shows only `sessionKey` changing, which is exactly the one thing that *should*.

## What this does not claim

**No wall-clock speedup number, on purpose.** Render waste is down 17x and the app feels materially faster in hand, but I could not produce a before/after latency figure I'd defend. Two measurement problems, both worth recording:

- A/B-ing both arms in one long-lived renderer requires a reload between arms, and HMR churn swamped the signal — a 10x spread on `firstPaint` across five alternating rounds.
- The instance itself **degrades ~2x after ~40 switches**, so a late sample isn't comparable to an early one regardless of which arm it's on.

A fresh-spawn-per-arm harness is the fix for that and is the obvious follow-up. The render-attribution numbers above are from a single instance, same session pair, no reloads between samples, and are stable across repeats.

## Still open

The paint trace shows a **double hydration** the transcript paints 5 messages at 558ms, regresses to 1 at 815ms, then repaints at 1227ms. That, plus the residual ~400ms hydration frame, is where the next real win lives. Untouched here.

## Testing

`tsc --noEmit` clean. 76 tests pass across the thread surface, including the two that guard precisely what this changes: `thread-remount.test.tsx` (message DOM nodes stay mounted when callback props get new identities) and `user-message-edit.test.tsx` (the edit composer still opens and still receives a live `cwd`/`gateway`/`sessionId`).
