### PR TITLE
fix(cli): add timeout to state.db health probe in hermes doctor (#72441)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1496,7 +1496,26 @@ def run_doctor(args):
             # repaired in place with --fix).
             from hermes_state import _db_opens_cleanly, repair_state_db_schema
 
-            _write_reason = _db_opens_cleanly(state_db_path)
+            # _db_opens_cleanly runs PRAGMA integrity_check which can take
+            # minutes on large databases (2000+ sessions).  Wrap in a thread
+            # with a timeout so hermes doctor doesn't hang indefinitely.
+            # See: #72441
+            import concurrent.futures
+            _probe_timeout = 30.0  # seconds
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _ex:
+                _fut = _ex.submit(_db_opens_cleanly, state_db_path)
+                try:
+                    _write_reason = _fut.result(timeout=_probe_timeout)
+                except concurrent.futures.TimeoutError:
+                    _write_reason = None
+                    check_warn(
+                        f"{_DHH}/state.db write-health probe timed out",
+                        f"(>{_probe_timeout:.0f}s — database may be locked or very large)",
+                    )
+                    issues.append(
+                        "state.db health probe timed out — close other Hermes "
+                        "instances and retry, or run 'hermes sessions repair'"
+                    )
             if _write_reason is not None:
                 check_warn(
                     f"{_DHH}/state.db fails a write-health probe (FTS index may be corrupt)",


### PR DESCRIPTION
## Summary
Fixes #72441.

`hermes doctor` runs `_db_opens_cleanly()` which executes `PRAGMA integrity_check` on the state.db database. On profiles with 2000+ sessions, this can take minutes, making the doctor command appear to hang indefinitely.

## Changes
- `hermes_cli/doctor.py`: Wrap `_db_opens_cleanly` in a `ThreadPoolExecutor` with a 30-second timeout. On timeout, emit a warning with actionable suggestions.

## Testing
- `py_compile`: OK
- `ruff check`: All checks passed
- The timeout is generous (30s) to avoid false positives on slow but healthy databases.
