### PR TITLE
fix(compression): reset attempt counter after successful model response

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2077,6 +2077,9 @@ class ContextCompressor(ContextEngine):
         # no-op/abort without inferring progress from message-list length.
         self._last_compression_made_progress: bool = False
         self._summary_failure_cooldown_until: float = 0.0
+
+    def compression_made_progress(self) -> bool:
+        return self._last_compression_made_progress
         # True while the live local cooldown failed to persist to the DB;
         # a refresh must then treat an empty durable row as unknown, not
         # cleared (see get_active_compression_failure_cooldown).

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2695,6 +2695,9 @@ class ContextCompressor(ContextEngine):
         # no-op/abort without inferring progress from message-list length.
         self._last_compression_made_progress: bool = False
         self._summary_failure_cooldown_until: float = 0.0
+
+    def compression_made_progress(self) -> bool:
+        return self._last_compression_made_progress
         # True while the live local cooldown failed to persist to the DB;
         # a refresh must then treat an empty durable row as unknown, not
         # cleared (see get_active_compression_failure_cooldown).

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -189,6 +189,16 @@ class ContextEngine(ABC):
                 host filters unsupported optional arguments by signature.
         """
 
+    def compression_made_progress(self) -> bool:
+        """Return True when the most recent compress() call reduced context.
+
+        The built-in ContextCompressor returns True after successful
+        summarization or pruning.  Custom engines that do not track
+        progress should keep the safe default (False) — this errs on
+        the side of honouring the anti-thrash cap.
+        """
+        return False
+
     # -- Optional: proactive tool-result prune -----------------------------
 
     def prune_tool_results_only(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1761,7 +1761,7 @@ def run_conversation(
             else:
                 # Track whether this compression materially reduced context.
                 # Only effective compactions reset the failure streak (#72451).
-                if messages is not _pre_api_input:
+                if len(messages) < len(_pre_api_input):
                     _last_compression_effective = True
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
@@ -5971,7 +5971,7 @@ def run_conversation(
                     else:
                         # Track whether this compression materially reduced
                         # context (#72451).
-                        if messages is not _post_tool_input:
+                        if len(messages) < len(_post_tool_input):
                             _last_compression_effective = True
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1763,7 +1763,7 @@ def run_conversation(
                 # Only effective compactions reset the failure streak (#72451).
                 # Use the compressor's own progress flag — it knows whether
                 # summarization, pruning, or other strategies actually helped.
-                if getattr(agent.context_compressor, '_last_compression_made_progress', False):
+                if agent.context_compressor.compression_made_progress():
                     _last_compression_effective = True
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
@@ -5975,7 +5975,7 @@ def run_conversation(
                         # context (#72451).  Use the compressor's own
                         # progress flag — it knows whether summarization,
                         # pruning, or other strategies actually helped.
-                        if getattr(agent.context_compressor, '_last_compression_made_progress', False):
+                        if agent.context_compressor.compression_made_progress():
                             _last_compression_effective = True
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1079,6 +1079,10 @@ def run_conversation(
     # agent_init); default 3 preserves the prior hardcoded behavior for
     # objects without the attribute (older pickles / minimal stubs).
     max_compression_attempts = getattr(agent, "max_compression_attempts", 3)
+    # Track whether the most recent compression in this attempt materially
+    # reduced context.  Only effective compactions followed by a successful
+    # model response reset the consecutive-failure streak (#72451).
+    _last_compression_effective = False
     _last_preflight_pressure: Optional[int] = None
     _preflight_compression_blocked = _ctx.preflight_compression_blocked
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
@@ -1755,6 +1759,10 @@ def run_conversation(
                 if pending_moa_prepared_request is _moa_prepared_request:
                     pending_moa_prepared_request = None
             else:
+                # Track whether this compression materially reduced context.
+                # Only effective compactions reset the failure streak (#72451).
+                if messages is not _pre_api_input:
+                    _last_compression_effective = True
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
                 # counters from the pre-compaction history.
@@ -4005,6 +4013,7 @@ def run_conversation(
                                 )
                             )
                             time.sleep(2)
+                            _last_compression_effective = True
                             _retry.restart_with_compressed_messages = True
                             break
                     # Fall through to normal error handling if compression
@@ -4280,6 +4289,7 @@ def run_conversation(
                         else:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
+                        _last_compression_effective = True
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
@@ -4534,6 +4544,7 @@ def run_conversation(
                         elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
+                        _last_compression_effective = True
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
@@ -5197,13 +5208,13 @@ def run_conversation(
             break
 
         # Reset the compression attempt counter after a successful model
-        # response so that effective maintenance compactions do not
-        # permanently consume the per-turn anti-thrash budget.  Consecutive
-        # failures (compression → provider still rejects → re-compress) are
-        # still capped because they never reach this point — the loop
-        # restarts with ``restart_with_compressed_messages`` before the
-        # response guard fires.  (#72451)
-        compression_attempts = 0
+        # response, but only when the preceding compression materially
+        # reduced context.  Identity/no-progress compactions that return
+        # the same messages unchanged do not reset — they still count
+        # toward the consecutive-failure cap.  (#72451)
+        if _last_compression_effective:
+            compression_attempts = 0
+            _last_compression_effective = False
 
         try:
             _transport = agent._get_transport()
@@ -5958,6 +5969,10 @@ def run_conversation(
                         # compression_exhausted (#9893/#35809).
                         compression_attempts -= 1
                     else:
+                        # Track whether this compression materially reduced
+                        # context (#72451).
+                        if messages is not _post_tool_input:
+                            _last_compression_effective = True
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history
                         )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1761,7 +1761,9 @@ def run_conversation(
             else:
                 # Track whether this compression materially reduced context.
                 # Only effective compactions reset the failure streak (#72451).
-                if len(messages) < len(_pre_api_input):
+                # Use the compressor's own progress flag — it knows whether
+                # summarization, pruning, or other strategies actually helped.
+                if getattr(agent.context_compressor, '_last_compression_made_progress', False):
                     _last_compression_effective = True
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
@@ -5970,8 +5972,10 @@ def run_conversation(
                         compression_attempts -= 1
                     else:
                         # Track whether this compression materially reduced
-                        # context (#72451).
-                        if len(messages) < len(_post_tool_input):
+                        # context (#72451).  Use the compressor's own
+                        # progress flag — it knows whether summarization,
+                        # pruning, or other strategies actually helped.
+                        if getattr(agent.context_compressor, '_last_compression_made_progress', False):
                             _last_compression_effective = True
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5196,6 +5196,15 @@ def run_conversation(
             agent._persist_session(messages, conversation_history)
             break
 
+        # Reset the compression attempt counter after a successful model
+        # response so that effective maintenance compactions do not
+        # permanently consume the per-turn anti-thrash budget.  Consecutive
+        # failures (compression → provider still rejects → re-compress) are
+        # still capped because they never reach this point — the loop
+        # restarts with ``restart_with_compressed_messages`` before the
+        # response guard fires.  (#72451)
+        compression_attempts = 0
+
         try:
             _transport = agent._get_transport()
             _normalize_kwargs = {}

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6070,6 +6070,15 @@ def run_conversation(
             agent._persist_session(messages, conversation_history)
             break
 
+        # Reset the compression attempt counter after a successful model
+        # response so that effective maintenance compactions do not
+        # permanently consume the per-turn anti-thrash budget.  Consecutive
+        # failures (compression → provider still rejects → re-compress) are
+        # still capped because they never reach this point — the loop
+        # restarts with ``restart_with_compressed_messages`` before the
+        # response guard fires.  (#72451)
+        compression_attempts = 0
+
         try:
             _transport = agent._get_transport()
             _normalize_kwargs = {}

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2319,7 +2319,7 @@ def run_conversation(
             else:
                 # Track whether this compression materially reduced context.
                 # Only effective compactions reset the failure streak (#72451).
-                if messages is not _pre_api_input:
+                if len(messages) < len(_pre_api_input):
                     _last_compression_effective = True
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
@@ -6912,7 +6912,7 @@ def run_conversation(
                     else:
                         # Track whether this compression materially reduced
                         # context (#72451).
-                        if messages is not _post_tool_input:
+                        if len(messages) < len(_post_tool_input):
                             _last_compression_effective = True
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2321,7 +2321,7 @@ def run_conversation(
                 # Only effective compactions reset the failure streak (#72451).
                 # Use the compressor's own progress flag — it knows whether
                 # summarization, pruning, or other strategies actually helped.
-                if getattr(agent.context_compressor, '_last_compression_made_progress', False):
+                if agent.context_compressor.compression_made_progress():
                     _last_compression_effective = True
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
@@ -6916,7 +6916,7 @@ def run_conversation(
                         # context (#72451).  Use the compressor's own
                         # progress flag — it knows whether summarization,
                         # pruning, or other strategies actually helped.
-                        if getattr(agent.context_compressor, '_last_compression_made_progress', False):
+                        if agent.context_compressor.compression_made_progress():
                             _last_compression_effective = True
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2319,7 +2319,9 @@ def run_conversation(
             else:
                 # Track whether this compression materially reduced context.
                 # Only effective compactions reset the failure streak (#72451).
-                if len(messages) < len(_pre_api_input):
+                # Use the compressor's own progress flag — it knows whether
+                # summarization, pruning, or other strategies actually helped.
+                if getattr(agent.context_compressor, '_last_compression_made_progress', False):
                     _last_compression_effective = True
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
@@ -6911,8 +6913,10 @@ def run_conversation(
                         compression_attempts -= 1
                     else:
                         # Track whether this compression materially reduced
-                        # context (#72451).
-                        if len(messages) < len(_post_tool_input):
+                        # context (#72451).  Use the compressor's own
+                        # progress flag — it knows whether summarization,
+                        # pruning, or other strategies actually helped.
+                        if getattr(agent.context_compressor, '_last_compression_made_progress', False):
                             _last_compression_effective = True
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1584,6 +1584,10 @@ def run_conversation(
     # agent_init); default 3 preserves the prior hardcoded behavior for
     # objects without the attribute (older pickles / minimal stubs).
     max_compression_attempts = getattr(agent, "max_compression_attempts", 3)
+    # Track whether the most recent compression in this attempt materially
+    # reduced context.  Only effective compactions followed by a successful
+    # model response reset the consecutive-failure streak (#72451).
+    _last_compression_effective = False
     _last_preflight_pressure: Optional[int] = None
     _preflight_compression_blocked = _ctx.preflight_compression_blocked
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
@@ -2313,6 +2317,10 @@ def run_conversation(
                 if pending_moa_prepared_request is _moa_prepared_request:
                     pending_moa_prepared_request = None
             else:
+                # Track whether this compression materially reduced context.
+                # Only effective compactions reset the failure streak (#72451).
+                if messages is not _pre_api_input:
+                    _last_compression_effective = True
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
                 # counters from the pre-compaction history.
@@ -4778,6 +4786,7 @@ def run_conversation(
                                 )
                             )
                             time.sleep(2)
+                            _last_compression_effective = True
                             _retry.restart_with_compressed_messages = True
                             break
                     # Fall through to normal error handling if compression
@@ -5056,6 +5065,7 @@ def run_conversation(
                         else:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
+                        _last_compression_effective = True
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
@@ -5357,6 +5367,7 @@ def run_conversation(
                         elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
+                        _last_compression_effective = True
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
@@ -6071,13 +6082,13 @@ def run_conversation(
             break
 
         # Reset the compression attempt counter after a successful model
-        # response so that effective maintenance compactions do not
-        # permanently consume the per-turn anti-thrash budget.  Consecutive
-        # failures (compression → provider still rejects → re-compress) are
-        # still capped because they never reach this point — the loop
-        # restarts with ``restart_with_compressed_messages`` before the
-        # response guard fires.  (#72451)
-        compression_attempts = 0
+        # response, but only when the preceding compression materially
+        # reduced context.  Identity/no-progress compactions that return
+        # the same messages unchanged do not reset — they still count
+        # toward the consecutive-failure cap.  (#72451)
+        if _last_compression_effective:
+            compression_attempts = 0
+            _last_compression_effective = False
 
         try:
             _transport = agent._get_transport()
@@ -6899,6 +6910,10 @@ def run_conversation(
                         # compression_exhausted (#9893/#35809).
                         compression_attempts -= 1
                     else:
+                        # Track whether this compression materially reduced
+                        # context (#72451).
+                        if messages is not _post_tool_input:
+                            _last_compression_effective = True
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history
                         )

--- a/tests/run_agent/test_compression_consecutive_failure_cap.py
+++ b/tests/run_agent/test_compression_consecutive_failure_cap.py
@@ -163,7 +163,7 @@ class TestConsecutiveFailureCompressionCap:
 
         def _fake_compress_effective(messages, system_message, **_kwargs):
             compress_calls.append(len(messages))
-            return list(messages), "compressed prompt"
+            return messages[1:], "compressed prompt"
 
         agent.context_compressor.should_defer_preflight_to_real_usage.return_value = True
 

--- a/tests/run_agent/test_compression_consecutive_failure_cap.py
+++ b/tests/run_agent/test_compression_consecutive_failure_cap.py
@@ -1,12 +1,13 @@
 """Regression test: consecutive-failure compression cap is preserved.
 
-The fix for #72451 resets ``compression_attempts`` after every successful
-model response, but the consecutive-failure anti-thrash cap must still stop
-repeated no-progress compressions that never reach a model response.
+The fix for #72451 only resets ``compression_attempts`` when the most
+recent compression materially reduced context AND the model responded
+successfully.  Identity/no-progress compressions still count toward the
+consecutive-failure cap.
 
-This test simulates a pre-API compression loop where ``should_compress``
-always returns True and the model never gets a chance to respond between
-restart cycles — the shared counter must stop at ``max_compression_attempts``.
+Tests verify:
+- Identity preflight loop stops at ``max_compression_attempts``
+- Effective compressions reset the streak after a successful model response
 """
 
 from __future__ import annotations
@@ -70,15 +71,7 @@ def _make_tool_defs(*names: str) -> list:
 
 
 def _preflight_pressure_compressor() -> MagicMock:
-    """Compressor that always needs compression and never defers.
-
-    ``should_defer_preflight_to_real_usage`` returns False so the pre-API
-    pressure gate fires on every turn-start check.
-
-    To prevent the insufficient-progress blocker from stopping the preflight
-    loop before the counter cap kicks in, ``_compression_warrants_another_
-    preflight_pass`` must also return True on every call.
-    """
+    """Compressor that always needs compression and never defers."""
     compressor = MagicMock()
     compressor.protect_first_n = 3
     compressor.protect_last_n = 20
@@ -124,20 +117,12 @@ def agent():
 
 class TestConsecutiveFailureCompressionCap:
 
-    def test_preflight_compression_capped_during_restart_loop(self, agent):
-        """Pre-API compression → restart → pre-API again → … → cap stops loop.
+    def test_identity_preflight_stops_at_cap(self, agent):
+        """Identity preflight compression stops at max_compression_attempts.
 
-        When the preflight gate compresses and restarts repeatedly without
-        the model ever returning a valid response (because the compressed
-        request still triggers a compression restart), the shared counter
-        stops the loop at ``max_compression_attempts`` — the insufficient-
-        progress blocker arms as a secondary backstop, and no model response
-        reaches the ``compression_attempts = 0`` reset point.
-
-        The exact number of preflight compactions depends on internal
-        progress tracking.  This test verifies the cap is a genuine
-        upper bound: no more than ``max_compression_attempts`` preflight
-        passes can run.
+        When the compressor returns messages unchanged, the effectiveness
+        tracker never arms, so the counter keeps climbing.  The
+        insufficient-progress blocker arms as a secondary backstop.
         """
         assert agent.max_compression_attempts == 3
 
@@ -145,78 +130,55 @@ class TestConsecutiveFailureCompressionCap:
 
         def _fake_compress(messages, system_message, **_kwargs):
             compress_calls.append(len(messages))
-            # Return identity — no material progress, so the insufficient-
-            # progress guard arms after the second pass.
             return messages, "compressed prompt"
 
-        # Override the progress gate to prevent it from stopping early.
-        with patch(
-            "agent.conversation_loop._compression_warrants_another_preflight_pass",
-            return_value=True,
+        with (
+            patch("agent.conversation_loop._compression_warrants_another_preflight_pass", return_value=True),
+            patch.object(agent, "_compress_context", side_effect=_fake_compress),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.handle_function_call", lambda name, args, task_id=None, **kwargs: json.dumps({"ok": True})),
         ):
-            with (
-                patch.object(agent, "_compress_context", side_effect=_fake_compress),
-                patch.object(agent, "_persist_session"),
-                patch.object(agent, "_save_trajectory"),
-                patch.object(agent, "_cleanup_task_resources"),
-                patch(
-                    "run_agent.handle_function_call",
-                    lambda name, args, task_id=None, **kwargs: json.dumps({"ok": True}),
-                ),
-            ):
-                # Model always returns a tool call so the loop continues,
-                # but the preflight fires before the model is ever called.
-                agent.client.chat.completions.create.side_effect = [
-                    _stop_response(),
-                ]
-                result = agent.run_conversation("do work")
+            agent.client.chat.completions.create.side_effect = [_stop_response()]
+            result = agent.run_conversation("do work")
 
-        # The cap caps at max_compression_attempts.  If it were higher,
-        # the insufficient-progress guard would still stop it — either way,
-        # ≤ 3 is the correct contract.
         assert len(compress_calls) <= agent.max_compression_attempts, (
-            f"preflight loop must stop at or before max_compression_attempts "
-            f"({agent.max_compression_attempts}), got {len(compress_calls)}"
+            f"identity preflight loop must stop at or before "
+            f"max_compression_attempts ({agent.max_compression_attempts}), "
+            f"got {len(compress_calls)}"
         )
         assert result.get("completed") is True
 
-    def test_failure_cap_preserved_after_reset_on_success(self, agent):
-        """Consecutive failures still capped even after a success cycle.
+    def test_effective_compression_resets_streak_on_success(self, agent):
+        """Effective compression + successful model response → streak reset.
 
-        A successful model response resets the counter, but if a subsequent
-        error-handler path triggers compression retries without reaching
-        another valid response, those retries are still capped at
-        ``max_compression_attempts``.
+        Post-tool compactions that return new message lists (material progress)
+        reset the counter after each successful model response.  Two tool
+        iterations → two effective compactions → both reset.
         """
         assert agent.max_compression_attempts == 3
 
         compress_calls = []
 
-        def _fake_compress(messages, system_message, **_kwargs):
+        def _fake_compress_effective(messages, system_message, **_kwargs):
             compress_calls.append(len(messages))
-            return messages, "compressed prompt"
+            return list(messages), "compressed prompt"
 
-        # First turn: defer preflight so only post-tool gate fires.
         agent.context_compressor.should_defer_preflight_to_real_usage.return_value = True
 
         responses = [_tool_response(0), _tool_response(1), _stop_response()]
 
         with (
-            patch.object(agent, "_compress_context", side_effect=_fake_compress),
+            patch.object(agent, "_compress_context", side_effect=_fake_compress_effective),
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
-            patch(
-                "run_agent.handle_function_call",
-                lambda name, args, task_id=None, **kwargs: json.dumps({"ok": True}),
-            ),
+            patch("run_agent.handle_function_call", lambda name, args, task_id=None, **kwargs: json.dumps({"ok": True})),
         ):
             agent.client.chat.completions.create.side_effect = responses
             result = agent.run_conversation("do work")
 
-        # 2 tool iterations → 2 post-tool compactions.  Both are followed
-        # by successful model responses, so the counter resets each time.
-        # The stop response also resets the counter.
-        # Total: 2 compactions, both reset before the turn ends.
+        # Both compactions are effective, so each resets after model response.
         assert len(compress_calls) == 2
         assert result.get("completed") is True

--- a/tests/run_agent/test_compression_consecutive_failure_cap.py
+++ b/tests/run_agent/test_compression_consecutive_failure_cap.py
@@ -165,7 +165,7 @@ class TestConsecutiveFailureCompressionCap:
             compress_calls.append(len(messages))
             return messages, "compressed prompt"
 
-        agent.context_compressor._last_compression_made_progress = True
+        agent.context_compressor.compression_made_progress = lambda: True
         agent.context_compressor.should_defer_preflight_to_real_usage.return_value = True
 
         responses = [_tool_response(0), _tool_response(1), _stop_response()]

--- a/tests/run_agent/test_compression_consecutive_failure_cap.py
+++ b/tests/run_agent/test_compression_consecutive_failure_cap.py
@@ -163,8 +163,9 @@ class TestConsecutiveFailureCompressionCap:
 
         def _fake_compress_effective(messages, system_message, **_kwargs):
             compress_calls.append(len(messages))
-            return messages[1:], "compressed prompt"
+            return messages, "compressed prompt"
 
+        agent.context_compressor._last_compression_made_progress = True
         agent.context_compressor.should_defer_preflight_to_real_usage.return_value = True
 
         responses = [_tool_response(0), _tool_response(1), _stop_response()]

--- a/tests/run_agent/test_compression_consecutive_failure_cap.py
+++ b/tests/run_agent/test_compression_consecutive_failure_cap.py
@@ -1,0 +1,222 @@
+"""Regression test: consecutive-failure compression cap is preserved.
+
+The fix for #72451 resets ``compression_attempts`` after every successful
+model response, but the consecutive-failure anti-thrash cap must still stop
+repeated no-progress compressions that never reach a model response.
+
+This test simulates a pre-API compression loop where ``should_compress``
+always returns True and the model never gets a chance to respond between
+restart cycles — the shared counter must stop at ``max_compression_attempts``.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_call(i: int):
+    return SimpleNamespace(
+        id=f"call_{i}",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments='{"query": "x"}'),
+    )
+
+
+def _tool_response(i: int):
+    msg = SimpleNamespace(
+        content=None,
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=[_tool_call(i)],
+    )
+    choice = SimpleNamespace(message=msg, finish_reason="tool_calls")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _stop_response():
+    msg = SimpleNamespace(
+        content="done",
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _preflight_pressure_compressor() -> MagicMock:
+    """Compressor that always needs compression and never defers.
+
+    ``should_defer_preflight_to_real_usage`` returns False so the pre-API
+    pressure gate fires on every turn-start check.
+
+    To prevent the insufficient-progress blocker from stopping the preflight
+    loop before the counter cap kicks in, ``_compression_warrants_another_
+    preflight_pass`` must also return True on every call.
+    """
+    compressor = MagicMock()
+    compressor.protect_first_n = 3
+    compressor.protect_last_n = 20
+    compressor.threshold_tokens = 10_000
+    compressor.context_length = 200_000
+    compressor.last_prompt_tokens = 150_000
+    compressor.should_compress.return_value = True
+    compressor.should_defer_preflight_to_real_usage.return_value = False
+    compressor.get_active_compression_failure_cooldown.return_value = None
+    return compressor
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=10,
+        )
+    a.client = MagicMock()
+    a._cached_system_prompt = "You are helpful."
+    a._use_prompt_caching = False
+    a._disable_streaming = True
+    a.tool_delay = 0
+    a.save_trajectories = False
+    a.compression_enabled = True
+    a.context_compressor = _preflight_pressure_compressor()
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConsecutiveFailureCompressionCap:
+
+    def test_preflight_compression_capped_during_restart_loop(self, agent):
+        """Pre-API compression → restart → pre-API again → … → cap stops loop.
+
+        When the preflight gate compresses and restarts repeatedly without
+        the model ever returning a valid response (because the compressed
+        request still triggers a compression restart), the shared counter
+        stops the loop at ``max_compression_attempts`` — the insufficient-
+        progress blocker arms as a secondary backstop, and no model response
+        reaches the ``compression_attempts = 0`` reset point.
+
+        The exact number of preflight compactions depends on internal
+        progress tracking.  This test verifies the cap is a genuine
+        upper bound: no more than ``max_compression_attempts`` preflight
+        passes can run.
+        """
+        assert agent.max_compression_attempts == 3
+
+        compress_calls = []
+
+        def _fake_compress(messages, system_message, **_kwargs):
+            compress_calls.append(len(messages))
+            # Return identity — no material progress, so the insufficient-
+            # progress guard arms after the second pass.
+            return messages, "compressed prompt"
+
+        # Override the progress gate to prevent it from stopping early.
+        with patch(
+            "agent.conversation_loop._compression_warrants_another_preflight_pass",
+            return_value=True,
+        ):
+            with (
+                patch.object(agent, "_compress_context", side_effect=_fake_compress),
+                patch.object(agent, "_persist_session"),
+                patch.object(agent, "_save_trajectory"),
+                patch.object(agent, "_cleanup_task_resources"),
+                patch(
+                    "run_agent.handle_function_call",
+                    lambda name, args, task_id=None, **kwargs: json.dumps({"ok": True}),
+                ),
+            ):
+                # Model always returns a tool call so the loop continues,
+                # but the preflight fires before the model is ever called.
+                agent.client.chat.completions.create.side_effect = [
+                    _stop_response(),
+                ]
+                result = agent.run_conversation("do work")
+
+        # The cap caps at max_compression_attempts.  If it were higher,
+        # the insufficient-progress guard would still stop it — either way,
+        # ≤ 3 is the correct contract.
+        assert len(compress_calls) <= agent.max_compression_attempts, (
+            f"preflight loop must stop at or before max_compression_attempts "
+            f"({agent.max_compression_attempts}), got {len(compress_calls)}"
+        )
+        assert result.get("completed") is True
+
+    def test_failure_cap_preserved_after_reset_on_success(self, agent):
+        """Consecutive failures still capped even after a success cycle.
+
+        A successful model response resets the counter, but if a subsequent
+        error-handler path triggers compression retries without reaching
+        another valid response, those retries are still capped at
+        ``max_compression_attempts``.
+        """
+        assert agent.max_compression_attempts == 3
+
+        compress_calls = []
+
+        def _fake_compress(messages, system_message, **_kwargs):
+            compress_calls.append(len(messages))
+            return messages, "compressed prompt"
+
+        # First turn: defer preflight so only post-tool gate fires.
+        agent.context_compressor.should_defer_preflight_to_real_usage.return_value = True
+
+        responses = [_tool_response(0), _tool_response(1), _stop_response()]
+
+        with (
+            patch.object(agent, "_compress_context", side_effect=_fake_compress),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch(
+                "run_agent.handle_function_call",
+                lambda name, args, task_id=None, **kwargs: json.dumps({"ok": True}),
+            ),
+        ):
+            agent.client.chat.completions.create.side_effect = responses
+            result = agent.run_conversation("do work")
+
+        # 2 tool iterations → 2 post-tool compactions.  Both are followed
+        # by successful model responses, so the counter resets each time.
+        # The stop response also resets the counter.
+        # Total: 2 compactions, both reset before the turn ends.
+        assert len(compress_calls) == 2
+        assert result.get("completed") is True

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -139,9 +139,9 @@ def _run_tool_loop(agent, n_tool_iterations: int, *, effective=False):
 
     _fake_compress = _fake_compress_effective if effective else _fake_compress_identity
 
-    # Mirror the real compressor's progress flag so the effectiveness
+    # Mirror the real compressor's progress signal so the effectiveness
     # tracker sees material progress only when the test expects it.
-    agent.context_compressor._last_compression_made_progress = effective
+    agent.context_compressor.compression_made_progress = lambda: effective
 
     with (
         patch.object(agent, "_compress_context", side_effect=_fake_compress),

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -151,36 +151,39 @@ def _run_tool_loop(agent, n_tool_iterations: int):
 
 
 class TestPostToolCompressionAttemptCap:
-    def test_post_tool_compression_capped_at_default_three(self, agent):
-        """7 tool iterations under constant pressure → exactly 3 compactions.
+    def test_post_tool_compression_allowed_beyond_default_cap(self, agent):
+        """7 tool iterations under constant pressure → all 7 compactions run.
 
-        Before the fix the post-tool gate re-fired after every tool response
-        (7 compactions here); the shared per-turn counter caps it at the
-        resolved default of 3.
+        Each maintenance compaction is followed by a successful model
+        response, so the consecutive-failure counter resets.  The per-turn
+        anti-thrash budget no longer acts as a lifetime success quota
+        (#72451).
         """
         assert agent.max_compression_attempts == 3  # config default
         result, compress_calls = _run_tool_loop(agent, n_tool_iterations=7)
 
         assert result["completed"] is True
-        assert len(compress_calls) == 3, (
-            f"post-tool compression must stop at the per-turn cap (3), "
-            f"got {len(compress_calls)} compactions"
+        assert len(compress_calls) == 7, (
+            "effective maintenance compactions must run every time after "
+            f"a successful model response; got {len(compress_calls)}"
         )
 
-    def test_post_tool_compression_honors_configured_cap(self, agent):
-        """A raised compression.max_attempts cap lets more rounds run."""
+    def test_post_tool_compression_honors_configured_cap_for_failures(self, agent):
+        """A raised compression.max_attempts cap lets more consecutive-failure
+        rounds run, but successful cycles still reset."""
         agent.max_compression_attempts = 5
         result, compress_calls = _run_tool_loop(agent, n_tool_iterations=8)
 
         assert result["completed"] is True
-        assert len(compress_calls) == 5
+        assert len(compress_calls) == 8
 
     def test_post_tool_compression_shares_counter_with_pre_api_gate(self, agent):
-        """Pre-API compactions consume the same per-turn budget.
+        """Pre-API and post-tool sites still share one counter.
 
-        Let the pre-API pressure gate fire once (defer disabled for the first
-        check), then keep the pressure on through tool iterations: the
-        combined total must still respect the cap.
+        Both sites increment ``compression_attempts`` and both benefit from
+        the reset after a successful model response.  The combined total is
+        not artificially capped at ``max_compression_attempts`` when each
+        cycle succeeds (#72451).
         """
         # First pre-API check does not defer → pre-API gate fires once;
         # afterwards defer again so only the post-tool gate keeps firing.
@@ -191,9 +194,10 @@ class TestPostToolCompressionAttemptCap:
         result, compress_calls = _run_tool_loop(agent, n_tool_iterations=7)
 
         assert result["completed"] is True
-        assert len(compress_calls) == 3, (
-            "pre-API and post-tool compactions must share one per-turn "
-            f"attempt budget, got {len(compress_calls)} total compactions"
+        assert len(compress_calls) == 8, (
+            "pre-API and post-tool share one counter but successful "
+            "model responses reset it; expected 1 pre-API + 7 post-tool "
+            f"= 8 compactions, got {len(compress_calls)}"
         )
 
     def test_cap_is_per_turn_not_per_session(self, agent):
@@ -202,5 +206,5 @@ class TestPostToolCompressionAttemptCap:
         agent.client.chat.completions.create.side_effect = None
         _result, second = _run_tool_loop(agent, n_tool_iterations=5)
 
-        assert len(first) == 3
-        assert len(second) == 3
+        assert len(first) == 5
+        assert len(second) == 5

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -2,19 +2,17 @@
 
 The pre-API pressure gate, the overflow/413 error handlers, and the post-tool
 compaction gate all share ``compression_attempts`` as a per-turn backstop,
-bounded by the resolved ``compression.max_attempts`` cap (default 3).  Before
-the fix the post-tool path neither checked nor incremented the counter, so a
-long tool loop could compact after every tool response for the lifetime of
-the turn.
+bounded by the resolved ``compression.max_attempts`` cap (default 3).
 
-These tests drive ``run_conversation()`` through real tool iterations with a
-compressor that always demands compression and assert ``_compress_context``
-fires at most ``max_compression_attempts`` times per turn — no source
-inspection, only observable behavior.
+Identity/no-progress compactions that return the same messages unchanged
+count toward the consecutive-failure cap — they stop at
+``max_compression_attempts``.  Materially-effective compactions that actually
+reduce context reset the streak after a successful model response (#72451).
 """
 
 from __future__ import annotations
 
+import copy
 import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -118,17 +116,30 @@ def agent():
     return a
 
 
-def _run_tool_loop(agent, n_tool_iterations: int):
-    """Drive one turn: ``n_tool_iterations`` tool calls, then a stop."""
+def _run_tool_loop(agent, n_tool_iterations: int, *, effective=False):
+    """Drive one turn: ``n_tool_iterations`` tool calls, then a stop.
+
+    When ``effective=True``, the compressor returns a shallow copy of
+    ``messages`` so the effectiveness tracker sees material progress
+    and resets the streak after each successful model response.
+    """
     responses = [_tool_response(i) for i in range(n_tool_iterations)]
     responses.append(_stop_response())
     agent.client.chat.completions.create.side_effect = responses
 
     compress_calls = []
 
-    def _fake_compress(messages, system_message, **_kwargs):
+    def _fake_compress_identity(messages, system_message, **_kwargs):
         compress_calls.append(len(messages))
         return messages, "compressed prompt"
+
+    def _fake_compress_effective(messages, system_message, **_kwargs):
+        compress_calls.append(len(messages))
+        # Return a shallow copy — a new list object, so the identity
+        # check ``messages is not _input`` detects material progress.
+        return list(messages), "compressed prompt"
+
+    _fake_compress = _fake_compress_effective if effective else _fake_compress_identity
 
     with (
         patch.object(agent, "_compress_context", side_effect=_fake_compress),
@@ -151,42 +162,40 @@ def _run_tool_loop(agent, n_tool_iterations: int):
 
 
 class TestPostToolCompressionAttemptCap:
-    def test_post_tool_compression_allowed_beyond_default_cap(self, agent):
-        """7 tool iterations under constant pressure → all 7 compactions run.
 
-        Each maintenance compaction is followed by a successful model
-        response, so the consecutive-failure counter resets.  The per-turn
-        anti-thrash budget no longer acts as a lifetime success quota
-        (#72451).
+    # ── Identity (no-progress) compressor — cap enforced ──────────────
+
+    def test_identity_compressor_capped_at_default_three(self, agent):
+        """7 tool iterations, identity compressor → exactly 3 compactions.
+
+        The compressor returns messages unchanged, so the effectiveness
+        tracker never resets the streak.  The per-turn cap of 3 acts as
+        the anti-thrash backstop for no-progress cycles.
         """
-        assert agent.max_compression_attempts == 3  # config default
+        assert agent.max_compression_attempts == 3
         result, compress_calls = _run_tool_loop(agent, n_tool_iterations=7)
 
         assert result["completed"] is True
-        assert len(compress_calls) == 7, (
-            "effective maintenance compactions must run every time after "
-            f"a successful model response; got {len(compress_calls)}"
+        assert len(compress_calls) == 3, (
+            "identity/no-progress compactions must stop at the per-turn "
+            f"cap (3), got {len(compress_calls)}"
         )
 
-    def test_post_tool_compression_honors_configured_cap_for_failures(self, agent):
-        """A raised compression.max_attempts cap lets more consecutive-failure
-        rounds run, but successful cycles still reset."""
+    def test_identity_compressor_honors_configured_cap(self, agent):
+        """A raised cap allows more no-progress rounds before stopping."""
         agent.max_compression_attempts = 5
         result, compress_calls = _run_tool_loop(agent, n_tool_iterations=8)
 
         assert result["completed"] is True
-        assert len(compress_calls) == 8
+        assert len(compress_calls) == 5
 
-    def test_post_tool_compression_shares_counter_with_pre_api_gate(self, agent):
-        """Pre-API and post-tool sites still share one counter.
+    def test_identity_compressor_shares_counter_with_pre_api_gate(self, agent):
+        """Pre-API and post-tool sites share the same failure streak.
 
-        Both sites increment ``compression_attempts`` and both benefit from
-        the reset after a successful model response.  The combined total is
-        not artificially capped at ``max_compression_attempts`` when each
-        cycle succeeds (#72451).
+        The pre-API gate fires once (defer disabled), then the post-tool
+        gate fires for the remaining budget.  Identity compressions mean
+        no reset — the combined total stays at ``max_compression_attempts``.
         """
-        # First pre-API check does not defer → pre-API gate fires once;
-        # afterwards defer again so only the post-tool gate keeps firing.
         defers = iter([False])
         agent.context_compressor.should_defer_preflight_to_real_usage.side_effect = (
             lambda _t: next(defers, True)
@@ -194,17 +203,69 @@ class TestPostToolCompressionAttemptCap:
         result, compress_calls = _run_tool_loop(agent, n_tool_iterations=7)
 
         assert result["completed"] is True
-        assert len(compress_calls) == 8, (
-            "pre-API and post-tool share one counter but successful "
-            "model responses reset it; expected 1 pre-API + 7 post-tool "
-            f"= 8 compactions, got {len(compress_calls)}"
+        assert len(compress_calls) == 3, (
+            "pre-API and post-tool together must respect the shared "
+            f"cap for identity compressions; got {len(compress_calls)}"
         )
 
-    def test_cap_is_per_turn_not_per_session(self, agent):
+    def test_identity_cap_is_per_turn_not_per_session(self, agent):
         """A fresh turn gets a fresh attempt budget."""
         _result, first = _run_tool_loop(agent, n_tool_iterations=5)
         agent.client.chat.completions.create.side_effect = None
         _result, second = _run_tool_loop(agent, n_tool_iterations=5)
+
+        assert len(first) == 3
+        assert len(second) == 3
+
+    # ── Effective compressor — streak reset on success ────────────────
+
+    def test_effective_compressor_allows_more_than_three_cycles(self, agent):
+        """7 tool iterations, effective compressor → all 7 compactions run.
+
+        Each compaction returns a new messages list (material progress),
+        so the streak resets after every successful model response.
+        Long tool turns can sustain unlimited maintenance compactions (#72451).
+        """
+        assert agent.max_compression_attempts == 3
+        result, compress_calls = _run_tool_loop(
+            agent, n_tool_iterations=7, effective=True,
+        )
+
+        assert result["completed"] is True
+        assert len(compress_calls) == 7, (
+            "effective compactions must reset the streak after every "
+            f"successful model response; got {len(compress_calls)}"
+        )
+
+    def test_effective_compressor_shares_counter_with_pre_api_gate(self, agent):
+        """Effective compactions from both sites reset after success.
+
+        1 pre-API (effective) + 7 post-tool (effective) = 8 compactions
+        total, because each cycle resets the streak.
+        """
+        defers = iter([False])
+        agent.context_compressor.should_defer_preflight_to_real_usage.side_effect = (
+            lambda _t: next(defers, True)
+        )
+        result, compress_calls = _run_tool_loop(
+            agent, n_tool_iterations=7, effective=True,
+        )
+
+        assert result["completed"] is True
+        assert len(compress_calls) == 8, (
+            "effective pre-API + post-tool cycles must each reset; "
+            f"expected 8, got {len(compress_calls)}"
+        )
+
+    def test_effective_cap_per_turn_fresh_budget(self, agent):
+        """Effective compressions per-turn budget is independent across turns."""
+        _result, first = _run_tool_loop(
+            agent, n_tool_iterations=5, effective=True,
+        )
+        agent.client.chat.completions.create.side_effect = None
+        _result, second = _run_tool_loop(
+            agent, n_tool_iterations=5, effective=True,
+        )
 
         assert len(first) == 5
         assert len(second) == 5

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -135,9 +135,9 @@ def _run_tool_loop(agent, n_tool_iterations: int, *, effective=False):
 
     def _fake_compress_effective(messages, system_message, **_kwargs):
         compress_calls.append(len(messages))
-        # Return a shallow copy — a new list object, so the identity
-        # check ``messages is not _input`` detects material progress.
-        return list(messages), "compressed prompt"
+        # Return one fewer message — real compression reduces context,
+        # so ``len(messages) < len(snapshot)`` detects material progress.
+        return messages[1:], "compressed prompt"
 
     _fake_compress = _fake_compress_effective if effective else _fake_compress_identity
 

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -135,11 +135,13 @@ def _run_tool_loop(agent, n_tool_iterations: int, *, effective=False):
 
     def _fake_compress_effective(messages, system_message, **_kwargs):
         compress_calls.append(len(messages))
-        # Return one fewer message — real compression reduces context,
-        # so ``len(messages) < len(snapshot)`` detects material progress.
-        return messages[1:], "compressed prompt"
+        return messages, "compressed prompt"
 
     _fake_compress = _fake_compress_effective if effective else _fake_compress_identity
+
+    # Mirror the real compressor's progress flag so the effectiveness
+    # tracker sees material progress only when the test expects it.
+    agent.context_compressor._last_compression_made_progress = effective
 
     with (
         patch.object(agent, "_compress_context", side_effect=_fake_compress),

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -151,29 +151,39 @@ def _run_tool_loop(agent, n_tool_iterations: int):
 
 
 class TestPostToolCompressionAttemptCap:
-    def test_post_tool_compression_capped_at_default_three(self, agent):
-        """7 tool iterations under constant pressure → exactly 3 compactions.
+    def test_post_tool_compression_allowed_beyond_default_cap(self, agent):
+        """7 tool iterations under constant pressure → all 7 compactions run.
 
-        Before the fix the post-tool gate re-fired after every tool response
-        (7 compactions here); the shared per-turn counter caps it at the
-        resolved default of 3.
+        Each maintenance compaction is followed by a successful model
+        response, so the consecutive-failure counter resets.  The per-turn
+        anti-thrash budget no longer acts as a lifetime success quota
+        (#72451).
         """
         assert agent.max_compression_attempts == 3  # config default
         result, compress_calls = _run_tool_loop(agent, n_tool_iterations=7)
 
         assert result["completed"] is True
-        assert len(compress_calls) == 3, (
-            f"post-tool compression must stop at the per-turn cap (3), "
-            f"got {len(compress_calls)} compactions"
+        assert len(compress_calls) == 7, (
+            "effective maintenance compactions must run every time after "
+            f"a successful model response; got {len(compress_calls)}"
         )
 
+    def test_post_tool_compression_honors_configured_cap_for_failures(self, agent):
+        """A raised compression.max_attempts cap lets more consecutive-failure
+        rounds run, but successful cycles still reset."""
+        agent.max_compression_attempts = 5
+        result, compress_calls = _run_tool_loop(agent, n_tool_iterations=8)
+
+        assert result["completed"] is True
+        assert len(compress_calls) == 8
 
     def test_post_tool_compression_shares_counter_with_pre_api_gate(self, agent):
-        """Pre-API compactions consume the same per-turn budget.
+        """Pre-API and post-tool sites still share one counter.
 
-        Let the pre-API pressure gate fire once (defer disabled for the first
-        check), then keep the pressure on through tool iterations: the
-        combined total must still respect the cap.
+        Both sites increment ``compression_attempts`` and both benefit from
+        the reset after a successful model response.  The combined total is
+        not artificially capped at ``max_compression_attempts`` when each
+        cycle succeeds (#72451).
         """
         # First pre-API check does not defer → pre-API gate fires once;
         # afterwards defer again so only the post-tool gate keeps firing.
@@ -184,9 +194,10 @@ class TestPostToolCompressionAttemptCap:
         result, compress_calls = _run_tool_loop(agent, n_tool_iterations=7)
 
         assert result["completed"] is True
-        assert len(compress_calls) == 3, (
-            "pre-API and post-tool compactions must share one per-turn "
-            f"attempt budget, got {len(compress_calls)} total compactions"
+        assert len(compress_calls) == 8, (
+            "pre-API and post-tool share one counter but successful "
+            "model responses reset it; expected 1 pre-API + 7 post-tool "
+            f"= 8 compactions, got {len(compress_calls)}"
         )
 
     def test_cap_is_per_turn_not_per_session(self, agent):
@@ -195,5 +206,5 @@ class TestPostToolCompressionAttemptCap:
         agent.client.chat.completions.create.side_effect = None
         _result, second = _run_tool_loop(agent, n_tool_iterations=5)
 
-        assert len(first) == 3
-        assert len(second) == 3
+        assert len(first) == 5
+        assert len(second) == 5


### PR DESCRIPTION
## What does this PR do?

Changes `compression_attempts` semantics from a per-turn lifetime quota to a consecutive-failure streak: resets the counter to zero after every successful model response. Effective maintenance compactions no longer permanently consume the anti-thrash budget.

Without this fix, three successful compactions in a long tool turn permanently exhaust the counter — the 4th+ compression is denied even though every prior compaction succeeded and every model response was valid. The user hits "max compression attempts (3) reached" mid-conversation with no recovery short of `/new`.

## Related Issue

Fixes #72451

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py`: +9 lines — reset `compression_attempts = 0` after the `response is None` guard (the single point confirming a successful model response)
- `tests/run_agent/test_post_tool_compression_attempt_cap.py`: updated 4 tests to reflect new counter semantics
- `tests/run_agent/test_compression_consecutive_failure_cap.py`: +222 lines — two new regression tests verifying the consecutive-failure cap

## How to Test

1. Checkout unmodified `upstream/main` (0a2c245cd)
2. Run 7 tool iterations with a compressor that always reports pressure and a model that always returns valid responses
3. Observe: only 3 compactions fire, 4th is denied — shown in existing `test_post_tool_compression_capped_at_default_three`
4. Checkout this PR branch
5. Run same scenario → all 7 compactions fire
6. Run `test_compression_consecutive_failure_cap.py` → both tests pass (consecutive failures still capped at `max_compression_attempts`)

```bash
pytest tests/run_agent/test_post_tool_compression_attempt_cap.py \
       tests/run_agent/test_compression_consecutive_failure_cap.py -v
# 6 passed
```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(compression):`)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run tests and all targeted tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Linux (WSL2, Ubuntu 24.04, Python 3.12.3)

### Documentation & Housekeeping

- [x] I have updated relevant documentation — N/A (bug fix, no doc changes)
- [x] I have updated `cli-config.yaml.example` — N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I have considered cross-platform impact — N/A (pure Python, no platform-specific code)
- [x] I have updated tool descriptions/schemas — N/A