### PR TITLE
fix(desktop): keep cold gateway config off the event loop

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3031,6 +3031,20 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
     return {"profiles": profile_names, "gateway_mode": mode, "gateways": gateways}
 
 
+def _load_configured_gateway_platforms() -> set[str]:
+    """Load connected platform names away from the asyncio event loop.
+
+    The first ``load_gateway_config()`` call performs platform discovery and
+    can take longer than Desktop's WebSocket connect timeout on Windows.  This
+    helper is synchronous by design; ``get_status`` runs it in Starlette's
+    worker pool so a concurrent ``/api/ws`` handshake can still complete.
+    """
+    from gateway.config import load_gateway_config
+
+    gateway_config = load_gateway_config()
+    return {platform.value for platform in gateway_config.get_connected_platforms()}
+
+
 @app.get("/api/ssh/ownership")
 async def get_ssh_ownership(request: Request):
     _require_token(request)
@@ -3132,12 +3146,9 @@ async def get_status(profile: Optional[str] = None):
         gateway_updated_at = None
         configured_gateway_platforms: set[str] | None = None
         try:
-            from gateway.config import load_gateway_config
-
-            gateway_config = load_gateway_config()
-            configured_gateway_platforms = {
-                platform.value for platform in gateway_config.get_connected_platforms()
-            }
+            configured_gateway_platforms = await run_in_threadpool(
+                _load_configured_gateway_platforms
+            )
         except Exception:
             configured_gateway_platforms = None
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -268,6 +268,39 @@ class TestWebServerEndpoints:
         assert "active_sessions" in data
         assert data["can_update_hermes"] is True
 
+    def test_get_status_loads_gateway_config_off_event_loop(self, monkeypatch):
+        """Cold gateway config loading must not block the WebSocket loop.
+
+        On Windows the first ``load_gateway_config()`` call imports and
+        discovers platform adapters and can take longer than Desktop's 15s
+        WebSocket timeout.  Running it inline makes a concurrent /api/ws
+        handshake time out before ``gateway.ready`` can be sent.
+        """
+        import gateway.config as gateway_config
+        import hermes_cli.web_server as web_server
+
+        seen = {}
+
+        class _Config:
+            @staticmethod
+            def get_connected_platforms():
+                return []
+
+        def _load():
+            seen["thread"] = threading.get_ident()
+            return _Config()
+
+        monkeypatch.setattr(gateway_config, "load_gateway_config", _load)
+
+        async def _run():
+            event_loop_thread = threading.get_ident()
+            await web_server.get_status()
+            return event_loop_thread
+
+        event_loop_thread = asyncio.run(_run())
+
+        assert seen["thread"] != event_loop_thread
+
     def test_status_active_session_count_uses_read_only_db(self, monkeypatch, tmp_path):
         import hermes_cli.web_server as web_server
         import hermes_state


### PR DESCRIPTION
## Summary
On Windows, the first `gateway.config.load_gateway_config()` call performs platform-adapter discovery and can take longer than the Desktop frontend's 15s WebSocket connect timeout. The `/api/status` handler used to run that cold call inline on the asyncio event loop, so the concurrent `/api/ws` handshake would time out before `gateway.ready` could be sent, leaving the UI stuck on "Could not connect to Hermes gateway".

Offload the cold load to Starlette's worker pool via a dedicated synchronous helper, and add a regression test that asserts `load_gateway_config()` is not invoked on the event-loop thread.

## Repro (Windows 11, v0.19.0)
- Cold `load_gateway_config()` first call: ~14.06s (subsequent ~0.07s).
- Measured event-loop stalls before fix: 18.6s, 21.0s, 34.6s, 25.3s, 23.5s.
- Symptom: Desktop `ws ready frame send failed` followed by "Could not connect to Hermes gateway".
- Isolated `hermes serve` repro returned `gateway.ready` in 0.125s, confirming the runtime is healthy.

## After fix
- 150s startup monitor with fresh Desktop PID: no new `event loop stalled` and no new `ws ready frame send failed`.
- `/api/status` regression test asserts the loader runs off the event-loop thread (3 passed).
- `ruff check`, `python -m py_compile`, and `git diff --check` all pass.

## Test plan
- `pytest tests/hermes_cli/test_web_server.py -k 'test_get_status and (gateway_config_off_event_loop or active_session_count)'` -> 3 passed.
- Manual Windows Desktop boot: connection remains stable past 14:32 local time.

## Risks / scope
- Behavior is unchanged on the warm path (subsequent loads stay ~0.07s).
- No schema, env, or contract changes; only routing the cold call off the asyncio event loop.
