### PR TITLE
fix(desktop): handle response body errors in OAuth session fetch

### DIFF
--- a/apps/desktop/electron/fetch-json-oauth-session.test.ts
+++ b/apps/desktop/electron/fetch-json-oauth-session.test.ts
@@ -1,0 +1,106 @@
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it } from 'vitest'
+
+import { type OauthResponseLike, wireOauthSessionResponse } from './oauth-session-response'
+
+/**
+ * Behavior regression for #72530: body stream errors emitted AFTER the
+ * `response` event (e.g. net::ERR_CONTENT_LENGTH_MISMATCH when the body is
+ * truncated after headers) must reject the promise. These errors arrive on the
+ * IncomingMessage, not the ClientRequest — fetchJson/fetchPublicJson already
+ * handle this and fetchJsonViaOauthSession must too.
+ *
+ * We drive the exact response-handling unit main.ts wires into
+ * request.on('response', ...) with a fake IncomingMessage, so no real socket
+ * or electron module is needed and we assert observable behavior (resolve vs
+ * reject) rather than source text.
+ */
+function makeFakeResponse(statusCode: number, headers: Record<string, string> = {}): EventEmitter & OauthResponseLike {
+  const res = new EventEmitter() as EventEmitter & OauthResponseLike
+
+  ;(res as { statusCode?: number }).statusCode = statusCode
+  ;(res as { headers: Record<string, string> }).headers = headers
+
+  return res
+}
+
+function wire(res: EventEmitter & OauthResponseLike) {
+  let resolved: unknown
+  let rejected: Error | undefined
+  let cleared = 0
+
+  wireOauthSessionResponse(res, {
+    url: 'https://gw.example.com/api',
+    isTimedOut: () => false,
+    clearTimer: () => {
+      cleared += 1
+    },
+    resolve: value => {
+      resolved = value
+    },
+    reject: error => {
+      rejected = error
+    },
+  })
+
+  return {
+    get resolved() {
+      return resolved
+    },
+    get rejected() {
+      return rejected
+    },
+    get cleared() {
+      return cleared
+    },
+  }
+}
+
+describe('wireOauthSessionResponse body error handling (#72530)', () => {
+  it('rejects when the response emits an error after data (truncated body)', () => {
+    const res = makeFakeResponse(200, { 'content-type': 'application/json' })
+    const state = wire(res)
+
+    res.emit('data', Buffer.from('{"partial":'))
+    const err = new Error('net::ERR_CONTENT_LENGTH_MISMATCH')
+    res.emit('error', err)
+
+    expect(state.rejected).toBe(err)
+    expect(state.resolved).toBeUndefined()
+    expect(state.cleared).toBe(1)
+  })
+
+  it('resolves parsed JSON on a clean end', () => {
+    const res = makeFakeResponse(200, { 'content-type': 'application/json' })
+    const state = wire(res)
+
+    res.emit('data', Buffer.from('{"ok":true}'))
+    res.emit('end')
+
+    expect(state.rejected).toBeUndefined()
+    expect(state.resolved).toEqual({ ok: true })
+  })
+
+  it('rejects with statusCode on HTTP errors', () => {
+    const res = makeFakeResponse(503, {})
+    const state = wire(res)
+
+    res.emit('data', Buffer.from('unavailable'))
+    res.emit('end')
+
+    expect(state.resolved).toBeUndefined()
+    expect((state.rejected as Error & { statusCode?: number }).statusCode).toBe(503)
+  })
+
+  it('rejects HTML bodies as non-JSON', () => {
+    const res = makeFakeResponse(200, { 'content-type': 'text/html' })
+    const state = wire(res)
+
+    res.emit('data', Buffer.from('<!doctype html><html></html>'))
+    res.emit('end')
+
+    expect(state.resolved).toBeUndefined()
+    expect(state.rejected?.message).toMatch(/got HTML/)
+  })
+})

--- a/apps/desktop/electron/fetch-json-oauth-session.test.ts
+++ b/apps/desktop/electron/fetch-json-oauth-session.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import path from 'node:path'
-import { describe, it } from 'node:test'
+import { describe, it } from 'vitest'
 import { fileURLToPath } from 'node:url'
 
 /**

--- a/apps/desktop/electron/fetch-json-oauth-session.test.ts
+++ b/apps/desktop/electron/fetch-json-oauth-session.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import path from 'node:path'
-import { describe, it } from 'vitest'
 import { fileURLToPath } from 'node:url'
+
+import { describe, it } from 'vitest'
 
 /**
  * Regression for #72530: body stream errors after `response` (e.g.

--- a/apps/desktop/electron/fetch-json-oauth-session.test.ts
+++ b/apps/desktop/electron/fetch-json-oauth-session.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Regression for #72530: body stream errors after `response` (e.g.
+ * net::ERR_CONTENT_LENGTH_MISMATCH) must be handled on the IncomingMessage.
+ * fetchJson/fetchPublicJson already do this; fetchJsonViaOauthSession must too.
+ */
+describe('fetchJsonViaOauthSession body error handling', () => {
+  it('attaches res.on("error") inside the electronNet response handler', () => {
+    const here = path.dirname(fileURLToPath(import.meta.url))
+    const src = fs.readFileSync(path.join(here, 'main.ts'), 'utf8')
+    const start = src.indexOf('function fetchJsonViaOauthSession')
+    assert.ok(start >= 0, 'fetchJsonViaOauthSession not found')
+    const end = src.indexOf('\nfunction ', start + 1)
+    const fn = src.slice(start, end > start ? end : start + 2500)
+    assert.match(
+      fn,
+      /request\.on\(\s*['"]response['"][\s\S]*?res\.on\(\s*['"]error['"]/,
+      'response IncomingMessage must listen for error (#72530)'
+    )
+  })
+})

--- a/apps/desktop/electron/fetch-json-oauth-session.test.ts
+++ b/apps/desktop/electron/fetch-json-oauth-session.test.ts
@@ -1,27 +1,106 @@
-import assert from 'node:assert/strict'
-import fs from 'node:fs'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { EventEmitter } from 'node:events'
 
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
+
+import { type OauthResponseLike, wireOauthSessionResponse } from './oauth-session-response'
 
 /**
- * Regression for #72530: body stream errors after `response` (e.g.
- * net::ERR_CONTENT_LENGTH_MISMATCH) must be handled on the IncomingMessage.
- * fetchJson/fetchPublicJson already do this; fetchJsonViaOauthSession must too.
+ * Behavior regression for #72530: body stream errors emitted AFTER the
+ * `response` event (e.g. net::ERR_CONTENT_LENGTH_MISMATCH when the body is
+ * truncated after headers) must reject the promise. These errors arrive on the
+ * IncomingMessage, not the ClientRequest — fetchJson/fetchPublicJson already
+ * handle this and fetchJsonViaOauthSession must too.
+ *
+ * We drive the exact response-handling unit main.ts wires into
+ * request.on('response', ...) with a fake IncomingMessage, so no real socket
+ * or electron module is needed and we assert observable behavior (resolve vs
+ * reject) rather than source text.
  */
-describe('fetchJsonViaOauthSession body error handling', () => {
-  it('attaches res.on("error") inside the electronNet response handler', () => {
-    const here = path.dirname(fileURLToPath(import.meta.url))
-    const src = fs.readFileSync(path.join(here, 'main.ts'), 'utf8')
-    const start = src.indexOf('function fetchJsonViaOauthSession')
-    assert.ok(start >= 0, 'fetchJsonViaOauthSession not found')
-    const end = src.indexOf('\nfunction ', start + 1)
-    const fn = src.slice(start, end > start ? end : start + 2500)
-    assert.match(
-      fn,
-      /request\.on\(\s*['"]response['"][\s\S]*?res\.on\(\s*['"]error['"]/,
-      'response IncomingMessage must listen for error (#72530)'
-    )
+function makeFakeResponse(statusCode: number, headers: Record<string, string> = {}): EventEmitter & OauthResponseLike {
+  const res = new EventEmitter() as EventEmitter & OauthResponseLike
+
+  ;(res as { statusCode?: number }).statusCode = statusCode
+  ;(res as { headers: Record<string, string> }).headers = headers
+
+  return res
+}
+
+function wire(res: EventEmitter & OauthResponseLike) {
+  let resolved: unknown
+  let rejected: Error | undefined
+  let cleared = 0
+
+  wireOauthSessionResponse(res, {
+    url: 'https://gw.example.com/api',
+    isTimedOut: () => false,
+    clearTimer: () => {
+      cleared += 1
+    },
+    resolve: value => {
+      resolved = value
+    },
+    reject: error => {
+      rejected = error
+    },
+  })
+
+  return {
+    get resolved() {
+      return resolved
+    },
+    get rejected() {
+      return rejected
+    },
+    get cleared() {
+      return cleared
+    },
+  }
+}
+
+describe('wireOauthSessionResponse body error handling (#72530)', () => {
+  it('rejects when the response emits an error after data (truncated body)', () => {
+    const res = makeFakeResponse(200, { 'content-type': 'application/json' })
+    const state = wire(res)
+
+    res.emit('data', Buffer.from('{"partial":'))
+    const err = new Error('net::ERR_CONTENT_LENGTH_MISMATCH')
+    res.emit('error', err)
+
+    expect(state.rejected).toBe(err)
+    expect(state.resolved).toBeUndefined()
+    expect(state.cleared).toBe(1)
+  })
+
+  it('resolves parsed JSON on a clean end', () => {
+    const res = makeFakeResponse(200, { 'content-type': 'application/json' })
+    const state = wire(res)
+
+    res.emit('data', Buffer.from('{"ok":true}'))
+    res.emit('end')
+
+    expect(state.rejected).toBeUndefined()
+    expect(state.resolved).toEqual({ ok: true })
+  })
+
+  it('rejects with statusCode on HTTP errors', () => {
+    const res = makeFakeResponse(503, {})
+    const state = wire(res)
+
+    res.emit('data', Buffer.from('unavailable'))
+    res.emit('end')
+
+    expect(state.resolved).toBeUndefined()
+    expect((state.rejected as Error & { statusCode?: number }).statusCode).toBe(503)
+  })
+
+  it('rejects HTML bodies as non-JSON', () => {
+    const res = makeFakeResponse(200, { 'content-type': 'text/html' })
+    const state = wire(res)
+
+    res.emit('data', Buffer.from('<!doctype html><html></html>'))
+    res.emit('end')
+
+    expect(state.resolved).toBeUndefined()
+    expect(state.rejected?.message).toMatch(/got HTML/)
   })
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5912,6 +5912,17 @@ function fetchJsonViaOauthSession(url, options: any = {}) {
     request.on('response', res => {
       const chunks = []
       res.on('data', chunk => chunks.push(Buffer.from(chunk)))
+      // Post-response loader errors (e.g. net::ERR_CONTENT_LENGTH_MISMATCH when
+      // the body is truncated after headers) are emitted on the IncomingMessage,
+      // not on the ClientRequest. Mirror fetchJson/fetchPublicJson. (#72530)
+      res.on('error', error => {
+        if (timedOut) {
+          return
+        }
+
+        clearTimeout(timer)
+        reject(error)
+      })
       res.on('end', () => {
         if (timedOut) {
           return

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -138,6 +138,7 @@ import {
 } from './native-oauth'
 import { runNativeLogin } from './native-oauth-login'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { wireOauthSessionResponse } from './oauth-session-response'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
@@ -5910,56 +5911,12 @@ function fetchJsonViaOauthSession(url, options: any = {}) {
     }, timeoutMs)
 
     request.on('response', res => {
-      const chunks = []
-      res.on('data', chunk => chunks.push(Buffer.from(chunk)))
-      // Post-response loader errors (e.g. net::ERR_CONTENT_LENGTH_MISMATCH when
-      // the body is truncated after headers) are emitted on the IncomingMessage,
-      // not on the ClientRequest. Mirror fetchJson/fetchPublicJson. (#72530)
-      res.on('error', error => {
-        if (timedOut) {
-          return
-        }
-
-        clearTimeout(timer)
-        reject(error)
-      })
-      res.on('end', () => {
-        if (timedOut) {
-          return
-        }
-
-        clearTimeout(timer)
-        const text = Buffer.concat(chunks).toString('utf8')
-        const statusCode = res.statusCode || 500
-
-        if (statusCode >= 400) {
-          const err = new Error(`${statusCode}: ${text || ''}`) as any
-          err.statusCode = statusCode
-          reject(err)
-
-          return
-        }
-
-        if (!text) {
-          resolve(null)
-
-          return
-        }
-
-        const looksHtml = /^\s*<(?:!doctype|html)/i.test(text)
-        const contentType = String(res.headers['content-type'] || res.headers['Content-Type'] || '')
-
-        if (looksHtml || contentType.includes('text/html')) {
-          reject(new Error(`Expected JSON from ${url} but got HTML (status ${statusCode}).`))
-
-          return
-        }
-
-        try {
-          resolve(JSON.parse(text))
-        } catch {
-          reject(new Error(`Invalid JSON from ${url} (status ${statusCode}): ${text.slice(0, 200)}`))
-        }
+      wireOauthSessionResponse(res as any, {
+        url,
+        isTimedOut: () => timedOut,
+        clearTimer: () => clearTimeout(timer),
+        resolve,
+        reject,
       })
     })
     request.on('error', error => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -206,6 +206,7 @@ import {
 import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { wireOauthSessionResponse } from './oauth-session-response'
 import {
   createParentStartMarkerResolver,
   electronProcessStartMarker,
@@ -7148,45 +7149,12 @@ function fetchJsonViaOauthSession(url, options: any = {}) {
     }, timeoutMs)
 
     request.on('response', res => {
-      const chunks = []
-      res.on('data', chunk => chunks.push(Buffer.from(chunk)))
-      res.on('end', () => {
-        if (timedOut) {
-          return
-        }
-
-        clearTimeout(timer)
-        const text = Buffer.concat(chunks).toString('utf8')
-        const statusCode = res.statusCode || 500
-
-        if (statusCode >= 400) {
-          const err = new Error(`${statusCode}: ${text || ''}`) as any
-          err.statusCode = statusCode
-          reject(err)
-
-          return
-        }
-
-        if (!text) {
-          resolve(null)
-
-          return
-        }
-
-        const looksHtml = /^\s*<(?:!doctype|html)/i.test(text)
-        const contentType = String(res.headers['content-type'] || res.headers['Content-Type'] || '')
-
-        if (looksHtml || contentType.includes('text/html')) {
-          reject(new Error(`Expected JSON from ${url} but got HTML (status ${statusCode}).`))
-
-          return
-        }
-
-        try {
-          resolve(JSON.parse(text))
-        } catch {
-          reject(new Error(`Invalid JSON from ${url} (status ${statusCode}): ${text.slice(0, 200)}`))
-        }
+      wireOauthSessionResponse(res as any, {
+        url,
+        isTimedOut: () => timedOut,
+        clearTimer: () => clearTimeout(timer),
+        resolve,
+        reject,
       })
     })
     request.on('error', error => {

--- a/apps/desktop/electron/oauth-session-response.ts
+++ b/apps/desktop/electron/oauth-session-response.ts
@@ -1,0 +1,84 @@
+/**
+ * Response-stream handling for fetchJsonViaOauthSession (#72530).
+ *
+ * Extracted from main.ts as a pure, injectable unit so the body-error path can
+ * be behavior-tested without importing the electron main module or opening a
+ * real socket. The key invariant: post-response loader errors (e.g.
+ * net::ERR_CONTENT_LENGTH_MISMATCH when the body is truncated after headers)
+ * are emitted on the IncomingMessage, not on the ClientRequest — so we must
+ * listen for `error` on the response, mirroring fetchJson/fetchPublicJson.
+ */
+
+export interface OauthResponseLike {
+  on(event: 'data', cb: (chunk: unknown) => void): void
+  on(event: 'error', cb: (error: Error) => void): void
+  on(event: 'end', cb: () => void): void
+  statusCode?: number
+  headers: Record<string, string | string[] | undefined>
+}
+
+export interface WireOauthResponseOptions {
+  url: string
+  isTimedOut: () => boolean
+  clearTimer: () => void
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+}
+
+export function wireOauthSessionResponse(res: OauthResponseLike, opts: WireOauthResponseOptions): void {
+  const { url, isTimedOut, clearTimer, resolve, reject } = opts
+  const chunks: Buffer[] = []
+
+  res.on('data', chunk => chunks.push(Buffer.from(chunk as never)))
+
+  // Post-response loader errors (e.g. net::ERR_CONTENT_LENGTH_MISMATCH when the
+  // body is truncated after headers) are emitted on the IncomingMessage, not on
+  // the ClientRequest. Mirror fetchJson/fetchPublicJson. (#72530)
+  res.on('error', error => {
+    if (isTimedOut()) {
+      return
+    }
+
+    clearTimer()
+    reject(error)
+  })
+
+  res.on('end', () => {
+    if (isTimedOut()) {
+      return
+    }
+
+    clearTimer()
+    const text = Buffer.concat(chunks).toString('utf8')
+    const statusCode = res.statusCode || 500
+
+    if (statusCode >= 400) {
+      const err = new Error(`${statusCode}: ${text || ''}`) as Error & { statusCode?: number }
+      err.statusCode = statusCode
+      reject(err)
+
+      return
+    }
+
+    if (!text) {
+      resolve(null)
+
+      return
+    }
+
+    const looksHtml = /^\s*<(?:!doctype|html)/i.test(text)
+    const contentType = String(res.headers['content-type'] || res.headers['Content-Type'] || '')
+
+    if (looksHtml || contentType.includes('text/html')) {
+      reject(new Error(`Expected JSON from ${url} but got HTML (status ${statusCode}).`))
+
+      return
+    }
+
+    try {
+      resolve(JSON.parse(text))
+    } catch {
+      reject(new Error(`Invalid JSON from ${url} (status ${statusCode}): ${text.slice(0, 200)}`))
+    }
+  })
+}


### PR DESCRIPTION
## Summary
Closes #72530. `fetchJsonViaOauthSession` now listens for `res.on('error')` so mid-body net errors (e.g. `ERR_CONTENT_LENGTH_MISMATCH`) reject instead of raising uncaught Electron modals.

## Motivation
Post-response loader errors emit on IncomingMessage, not ClientRequest. `fetchJson`/`fetchPublicJson` already handled this; the OAuth session path did not.

## Verification
- `node --test apps/desktop/electron/fetch-json-oauth-session.test.ts`