### PR TITLE
fix(agent): replace assert with runtime guard in secret_sources command parser

### DIFF
--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -113,7 +113,8 @@ def parse_secret_output(stdout: str, wanted_key: str) -> Optional[str]:
     ]
     for line in dotenv_lines:
         m = _ENV_LINE.match(line)
-        assert m is not None  # filtered above
+        if m is None:
+            continue  # pragma: no cover — filtered above, defensive guard
         if m.group(1) == wanted_key:
             value = unquote_dotenv_value(m.group(2))
             # Whitespace-only (e.g. a quoted `K="  "` placeholder) is "no


### PR DESCRIPTION
## Summary

Replace `assert m is not None` with a defensive `if m is None: continue` guard in `agent/secret_sources/command.py:116`.

## Problem

The `assert` statement at `agent/secret_sources/command.py:116` is stripped by `python -O` (optimized mode), silently removing the invariant check. While the regex match is logically guaranteed by the upstream filter in the list comprehension, relying on `assert` for production code is a well-known anti-pattern:

- Under `python -O`, the assert is removed entirely
- If the invariant were ever violated (e.g. regex engine change), the subsequent `m.group(1)` would raise an unhelpful `AttributeError: 'NoneType' object has no attribute 'group'`

## Fix

Replace:
```python
assert m is not None  # filtered above
```

With:
```python
if m is None:
    continue  # pragma: no cover — filtered above, defensive guard
```

This is a no-op in the normal case (the regex always matches lines that already passed the filter) but provides a graceful degradation path instead of an AssertionError crash.

## Test Plan

- [x] Syntax check passes (`ast.parse()`)
- [x] Existing tests pass
- [ ] `python -O -c "import agent.secret_sources.command"` — no AssertionError

## Notes

This assert was not covered by prior assert-fixing PRs (#56866, #62659, #64818). The `agent/secret_sources/` module was recently added and was not included in the earlier assert sweeps.