### PR TITLE
fix(desktop): hide compaction envelopes from session titles

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -1,3 +1,4 @@
+import { sessionTitle } from '@/lib/chat-runtime'
 import { mediaExternalUrl, resolveMediaDisplaySrc } from '@/lib/media'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
@@ -51,7 +52,7 @@ const PRODUCER_TOOL_ARTIFACT_KEY_RE =
 const SCREENSHOT_PATH_RE = /Screenshot path:\s*([^\r\n<>]+)/gi
 
 function artifactSessionTitle(session: SessionInfo): string {
-  return session.title?.trim() || session.preview?.trim() || 'Untitled session'
+  return sessionTitle(session)
 }
 
 function normalizeValue(value: string): string {

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -1,6 +1,6 @@
+import { sessionTitle } from '@/lib/chat-runtime'
 import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
 import { filePathFromMediaPath, isRemoteGateway, mediaExternalUrl } from '@/lib/media'
-import { sessionTitle } from '@/lib/chat-runtime'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
 export type ArtifactKind = 'image' | 'file' | 'link'

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -1,5 +1,6 @@
 import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
 import { filePathFromMediaPath, isRemoteGateway, mediaExternalUrl } from '@/lib/media'
+import { sessionTitle } from '@/lib/chat-runtime'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
 export type ArtifactKind = 'image' | 'file' | 'link'
@@ -26,7 +27,7 @@ const FILE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp|pdf|txt|json|md|csv|zip|tar
 const KEY_HINT_RE = /(path|file|url|image|artifact|output|download|result|target)/i
 
 function artifactSessionTitle(session: SessionInfo): string {
-  return session.title?.trim() || session.preview?.trim() || 'Untitled session'
+  return sessionTitle(session)
 }
 
 function normalizeValue(value: string): string {

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 
+import { sessionTitle } from '@/lib/chat-runtime'
 import {
   initQuickEntryBridge,
   QUICK_TARGET_CURRENT,
@@ -27,7 +28,11 @@ function sessionOptions(): QuickEntrySessionOption[] {
     .slice(0, QUICK_ENTRY_SESSION_OPTIONS)
     .map(session => ({
       id: session.id,
-      title: session.title?.trim() || session.preview?.trim() || session.id
+      title: (() => {
+        const t = sessionTitle(session)
+
+        return t === 'Untitled session' ? session.id : t
+      })()
     }))
 }
 

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 
+import { sessionTitle } from '@/lib/chat-runtime'
 import {
   initQuickEntryBridge,
   QUICK_TARGET_CURRENT,
@@ -10,7 +11,6 @@ import {
 import { $gatewayState, $sessions } from '@/store/session'
 import { sessionTileDelegate } from '@/store/session-states'
 import { isSecondaryWindow } from '@/store/windows'
-import { sessionTitle } from '@/lib/chat-runtime'
 
 interface QuickEntryBridgeParams {
   startFreshSessionDraft: () => void
@@ -30,6 +30,7 @@ function sessionOptions(): QuickEntrySessionOption[] {
       id: session.id,
       title: (() => {
         const t = sessionTitle(session)
+
         return t === 'Untitled session' ? session.id : t
       })()
     }))

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -10,6 +10,7 @@ import {
 import { $gatewayState, $sessions } from '@/store/session'
 import { sessionTileDelegate } from '@/store/session-states'
 import { isSecondaryWindow } from '@/store/windows'
+import { sessionTitle } from '@/lib/chat-runtime'
 
 interface QuickEntryBridgeParams {
   startFreshSessionDraft: () => void
@@ -27,7 +28,10 @@ function sessionOptions(): QuickEntrySessionOption[] {
     .slice(0, QUICK_ENTRY_SESSION_OPTIONS)
     .map(session => ({
       id: session.id,
-      title: session.title?.trim() || session.preview?.trim() || session.id
+      title: (() => {
+        const t = sessionTitle(session)
+        return t === 'Untitled session' ? session.id : t
+      })()
     }))
 }
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
+import type { SessionInfo } from '@/types/hermes'
 
 import {
   attachmentDisplayText,
   attachmentId,
   coerceThinkingText,
+  isCompactionEnvelopePreview,
   messageCreatedAt,
   optimisticAttachmentRef,
   parseCommandDispatch,
-  parseSlashCommand
+  parseSlashCommand,
+  sessionTitle,
 } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
@@ -198,5 +201,38 @@ describe('messageCreatedAt', () => {
   it('treats a zero / non-finite timestamp as absent', () => {
     expect(messageCreatedAt({ timestamp: 0 }, NOW).getTime()).toBe(NOW)
     expect(messageCreatedAt({ timestamp: Number.NaN }, NOW).getTime()).toBe(NOW)
+  })
+})
+
+function makeSession(partial: Partial<SessionInfo>): SessionInfo {
+  return {
+    id: 's1',
+    title: null,
+    preview: null,
+    ...partial,
+  } as SessionInfo
+}
+
+describe('sessionTitle', () => {
+  it('prefers explicit titles', () => {
+    expect(sessionTitle(makeSession({ title: 'My chat', preview: '[CONTEXT COMPACTION — REFERENCE ONLY] x' }))).toBe(
+      'My chat'
+    )
+  })
+
+  it('uses ordinary user previews for untitled sessions', () => {
+    expect(sessionTitle(makeSession({ title: null, preview: 'Please fix the build' }))).toBe('Please fix the build')
+  })
+
+  it('never uses compaction envelope previews as titles', () => {
+    expect(
+      sessionTitle(
+        makeSession({
+          title: null,
+          preview: '[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into a summary.',
+        })
+      )
+    ).toBe('Untitled session')
+    expect(isCompactionEnvelopePreview('[CONTEXT SUMMARY]: old')).toBe(true)
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -235,4 +235,16 @@ describe('sessionTitle', () => {
     ).toBe('Untitled session')
     expect(isCompactionEnvelopePreview('[CONTEXT SUMMARY]: old')).toBe(true)
   })
+
+  it('treats the generic [CONTEXT COMPACTION] envelope form as a compaction preview', () => {
+    expect(isCompactionEnvelopePreview('[CONTEXT COMPACTION] Earlier turns were compacted.')).toBe(true)
+    expect(
+      sessionTitle(
+        makeSession({
+          title: null,
+          preview: '[CONTEXT COMPACTION] Earlier turns were compacted.',
+        })
+      )
+    ).toBe('Untitled session')
+  })
 })

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -309,7 +309,7 @@ describe('coalesceToolOnlyAssistants toolCallId uniqueness', () => {
 
     expect(ids).toEqual(['call-a', 'call-b'])
   })
-}
+})
 
 function makeSession(partial: Partial<SessionInfo>): SessionInfo {
   return {

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ChatMessage, ChatMessagePart } from '@/lib/chat-messages'
 import type { ComposerAttachment } from '@/store/composer'
+import type { SessionInfo } from '@/types/hermes'
 
 import {
   attachmentDisplayText,
@@ -9,10 +10,12 @@ import {
   coalesceToolOnlyAssistants,
   coerceThinkingText,
   createToolMergeCache,
+  isCompactionEnvelopePreview,
   messageCreatedAt,
   optimisticAttachmentRef,
   parseCommandDispatch,
   parseSlashCommand,
+  sessionTitle,
   toRuntimeMessage
 } from './chat-runtime'
 
@@ -305,5 +308,50 @@ describe('coalesceToolOnlyAssistants toolCallId uniqueness', () => {
       .map(part => (part as { toolCallId: string }).toolCallId)
 
     expect(ids).toEqual(['call-a', 'call-b'])
+  })
+}
+
+function makeSession(partial: Partial<SessionInfo>): SessionInfo {
+  return {
+    id: 's1',
+    title: null,
+    preview: null,
+    ...partial
+  } as SessionInfo
+}
+
+describe('sessionTitle', () => {
+  it('prefers explicit titles', () => {
+    expect(sessionTitle(makeSession({ title: 'My chat', preview: '[CONTEXT COMPACTION — REFERENCE ONLY] x' }))).toBe(
+      'My chat'
+    )
+  })
+
+  it('uses ordinary user previews for untitled sessions', () => {
+    expect(sessionTitle(makeSession({ title: null, preview: 'Please fix the build' }))).toBe('Please fix the build')
+  })
+
+  it('never uses compaction envelope previews as titles', () => {
+    expect(
+      sessionTitle(
+        makeSession({
+          title: null,
+          preview: '[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into a summary.'
+        })
+      )
+    ).toBe('Untitled session')
+    expect(isCompactionEnvelopePreview('[CONTEXT SUMMARY]: old')).toBe(true)
+  })
+
+  it('treats the generic [CONTEXT COMPACTION] envelope form as a compaction preview', () => {
+    expect(isCompactionEnvelopePreview('[CONTEXT COMPACTION] Earlier turns were compacted.')).toBe(true)
+    expect(
+      sessionTitle(
+        makeSession({
+          title: null,
+          preview: '[CONTEXT COMPACTION] Earlier turns were compacted.'
+        })
+      )
+    ).toBe('Untitled session')
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -48,8 +48,43 @@ export function createClientSessionState(
   }
 }
 
+/**
+ * Internal compaction envelopes must never become user-visible titles (#72452).
+ *
+ * The backend treats any `[CONTEXT COMPACTION` prefix as compressed synthetic
+ * content (see gateway/platforms/api_server.py `_is_compressed_summary_message`),
+ * so match that whole family here rather than only the `— REFERENCE ONLY]` form.
+ */
+const COMPACTION_TITLE_PREFIXES = [
+  '[CONTEXT COMPACTION',
+  '[CONTEXT SUMMARY]:',
+  '[CONTEXT SUMMARY]',
+] as const
+
+export function isCompactionEnvelopePreview(preview: string | null | undefined): boolean {
+  const text = (preview ?? '').trim()
+
+  if (!text) {
+    return false
+  }
+
+  return COMPACTION_TITLE_PREFIXES.some(prefix => text.startsWith(prefix))
+}
+
 export function sessionTitle(session: SessionInfo): string {
-  return session.title?.trim() || session.preview?.trim() || 'Untitled session'
+  const explicit = session.title?.trim()
+
+  if (explicit) {
+    return explicit
+  }
+
+  const preview = session.preview?.trim()
+
+  if (preview && !isCompactionEnvelopePreview(preview)) {
+    return preview
+  }
+
+  return 'Untitled session'
 }
 
 /** What a session is called before it has been sent — and before its composer

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -61,9 +61,15 @@ export function createClientSessionState(
   }
 }
 
-/** Internal compaction envelopes must never become user-visible titles (#72452). */
+/**
+ * Internal compaction envelopes must never become user-visible titles (#72452).
+ *
+ * The backend treats any `[CONTEXT COMPACTION` prefix as compressed synthetic
+ * content (see gateway/platforms/api_server.py `_is_compressed_summary_message`),
+ * so match that whole family here rather than only the `— REFERENCE ONLY]` form.
+ */
 const COMPACTION_TITLE_PREFIXES = [
-  '[CONTEXT COMPACTION — REFERENCE ONLY]',
+  '[CONTEXT COMPACTION',
   '[CONTEXT SUMMARY]:',
   '[CONTEXT SUMMARY]',
 ] as const

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -70,15 +70,20 @@ const COMPACTION_TITLE_PREFIXES = [
 
 export function isCompactionEnvelopePreview(preview: string | null | undefined): boolean {
   const text = (preview ?? '').trim()
-  if (!text) return false
+
+  if (!text) {return false}
+
   return COMPACTION_TITLE_PREFIXES.some(prefix => text.startsWith(prefix))
 }
 
 export function sessionTitle(session: SessionInfo): string {
   const explicit = session.title?.trim()
-  if (explicit) return explicit
+
+  if (explicit) {return explicit}
   const preview = session.preview?.trim()
-  if (preview && !isCompactionEnvelopePreview(preview)) return preview
+
+  if (preview && !isCompactionEnvelopePreview(preview)) {return preview}
+
   return 'Untitled session'
 }
 

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -61,8 +61,25 @@ export function createClientSessionState(
   }
 }
 
+/** Internal compaction envelopes must never become user-visible titles (#72452). */
+const COMPACTION_TITLE_PREFIXES = [
+  '[CONTEXT COMPACTION — REFERENCE ONLY]',
+  '[CONTEXT SUMMARY]:',
+  '[CONTEXT SUMMARY]',
+] as const
+
+export function isCompactionEnvelopePreview(preview: string | null | undefined): boolean {
+  const text = (preview ?? '').trim()
+  if (!text) return false
+  return COMPACTION_TITLE_PREFIXES.some(prefix => text.startsWith(prefix))
+}
+
 export function sessionTitle(session: SessionInfo): string {
-  return session.title?.trim() || session.preview?.trim() || 'Untitled session'
+  const explicit = session.title?.trim()
+  if (explicit) return explicit
+  const preview = session.preview?.trim()
+  if (preview && !isCompactionEnvelopePreview(preview)) return preview
+  return 'Untitled session'
 }
 
 export function coerceGatewayText(value: unknown): string {

--- a/apps/desktop/src/lib/session-link-title.ts
+++ b/apps/desktop/src/lib/session-link-title.ts
@@ -9,6 +9,7 @@
 import { useEffect, useMemo, useState } from 'react'
 
 import { getSession } from '@/hermes'
+import { isCompactionEnvelopePreview } from '@/lib/chat-runtime'
 import { parseSessionRefValue, sessionRefCacheKey, sessionRefFallbackLabel } from '@/lib/session-refs'
 import { $sessions, sessionMatchesStoredId } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
@@ -21,7 +22,19 @@ const titleSubs = new Map<string, Set<(value: string) => void>>()
  *  fallback is a worse chip label than the short id, so an untitled row
  *  resolves to empty and the caller's fallback wins. */
 function sessionRowTitle(row: SessionInfo): string {
-  return row.title?.trim() || row.preview?.trim() || ''
+  const explicit = row.title?.trim()
+
+  if (explicit) {
+    return explicit
+  }
+
+  const preview = row.preview?.trim()
+
+  if (preview && !isCompactionEnvelopePreview(preview)) {
+    return preview
+  }
+
+  return ''
 }
 
 function profileMatches(sessionProfile: null | string | undefined, target?: string): boolean {

--- a/apps/desktop/src/lib/session-link-title.ts
+++ b/apps/desktop/src/lib/session-link-title.ts
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { getSession } from '@/hermes'
 import { parseSessionRefValue, sessionRefCacheKey, sessionRefFallbackLabel } from '@/lib/session-refs'
 import { $sessions, sessionMatchesStoredId } from '@/store/session'
+import { isCompactionEnvelopePreview } from '@/lib/chat-runtime'
 import type { SessionInfo } from '@/types/hermes'
 
 const titleCache = new Map<string, string>()
@@ -21,7 +22,11 @@ const titleSubs = new Map<string, Set<(value: string) => void>>()
  *  fallback is a worse chip label than the short id, so an untitled row
  *  resolves to empty and the caller's fallback wins. */
 function sessionRowTitle(row: SessionInfo): string {
-  return row.title?.trim() || row.preview?.trim() || ''
+  const explicit = row.title?.trim()
+  if (explicit) return explicit
+  const preview = row.preview?.trim()
+  if (preview && !isCompactionEnvelopePreview(preview)) return preview
+  return ''
 }
 
 function profileMatches(sessionProfile: null | string | undefined, target?: string): boolean {

--- a/apps/desktop/src/lib/session-link-title.ts
+++ b/apps/desktop/src/lib/session-link-title.ts
@@ -9,9 +9,9 @@
 import { useEffect, useMemo, useState } from 'react'
 
 import { getSession } from '@/hermes'
+import { isCompactionEnvelopePreview } from '@/lib/chat-runtime'
 import { parseSessionRefValue, sessionRefCacheKey, sessionRefFallbackLabel } from '@/lib/session-refs'
 import { $sessions, sessionMatchesStoredId } from '@/store/session'
-import { isCompactionEnvelopePreview } from '@/lib/chat-runtime'
 import type { SessionInfo } from '@/types/hermes'
 
 const titleCache = new Map<string, string>()
@@ -23,9 +23,12 @@ const titleSubs = new Map<string, Set<(value: string) => void>>()
  *  resolves to empty and the caller's fallback wins. */
 function sessionRowTitle(row: SessionInfo): string {
   const explicit = row.title?.trim()
-  if (explicit) return explicit
+
+  if (explicit) {return explicit}
   const preview = row.preview?.trim()
-  if (preview && !isCompactionEnvelopePreview(preview)) return preview
+
+  if (preview && !isCompactionEnvelopePreview(preview)) {return preview}
+
   return ''
 }
 


### PR DESCRIPTION
## Summary
Closes #72452. Untitled sessions whose preview is a synthetic compaction envelope no longer use that internal text as the sidebar/picker title.

## Motivation
Child sessions after compaction often have `title=NULL` and a preview starting with `[CONTEXT COMPACTION — REFERENCE ONLY]…`. Desktop title fallback treated that as user content.

## Verification
- `cd apps/desktop && npx vitest run src/lib/chat-runtime.test.ts` (29 passed)