### PR TITLE
feat(gateway): increase hook context payload limits for cross-platform mirroring

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14002,7 +14002,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "thread_id": str(getattr(source, "thread_id", None)) if getattr(source, "thread_id", None) else "",
                 "chat_type": getattr(source, "chat_type", "") or "",
                 "session_id": session_entry.session_id,
-                "message": message_text[:500],
+                "message": message_text[:1000],
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
@@ -14248,9 +14248,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 response = f"{response}\n\n{_footer_line}"
 
             # Emit agent:end hook
+            # NOTE: truncated to 4000 chars (not 500) to support telegram-mirror
+            # hook which forwards the full response to Telegram (4096 char limit).
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
-                "response": (response or "")[:500],
+                "response": (response or "")[:4000],
             })
             
             # Check for pending process watchers (check_interval on background processes)


### PR DESCRIPTION
## Summary

The `agent:start` and `agent:end` hook events currently truncate their context payloads to **500 characters** — the inbound message preview (`agent:start`) and the agent response text (`agent:end`). This is too short for hooks that forward content to platforms with larger limits (e.g. Telegram's 4096-char message boundary).

## Changes

| Event | Field | Before | After |
|-------|-------|--------|-------|
| `agent:start` | `message` | `message_text[:500]` | `message_text[:1000]` |
| `agent:end` | `response` | `response[:500]` | `response[:4000]` |

## Rationale

A common hook pattern is **cross-platform mirroring**: forward Desktop/cli agent activity to a messaging platform (Telegram, Discord, Slack) so the user can monitor progress remotely. With the 500-char cap, responses are cut to a snippet that is often useless for follow-up decisions.

The 4000-char cap for `agent:end` responses leaves headroom under Telegram's 4096-char limit and is well within Discord/Slack limits. The 1000-char cap for `agent:start` message previews gives enough context to identify the task without flooding.

## Use case

A `telegram-mirror` hook installed in `~/.hermes/hooks/telegram-mirror/`:

- `agent:start` → sends `🔄 Desktop — bắt đầu xử lý: <message preview>` to Telegram
- `agent:end` → sends `✅ Desktop — phản hồi: <full response>` to Telegram
- Skips when the originating platform is already Telegram (no double-send)
- Mirrors the response into the Telegram session transcript for context continuity

## Compatibility

**No breaking change.** Hooks that only read the first 500 chars are unaffected by the larger cap — strings in Python are subscript-safe. Any downstream code relying on `len(context["response"]) <= 500` would be affected, but this is an internal context dict, not a public API.

## Test plan

- [x] Gateway starts with the patch, hooks load successfully
- [x] `agent:start` fires with message > 500 chars → hook receives full 1000-char preview
- [x] `agent:end` fires with response > 500 chars → hook receives full 4000-char response
- [x] Telegram mirror hook sends near-complete response (not truncated snippet)
- [x] Hooks on platforms with short responses (< 500 chars) behave identically