### PR TITLE
fix(gateway): exclude current-turn media from dedup

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3237,10 +3237,10 @@ class BasePlatformAdapter(ABC):
     def _history_media_paths_for_session(self, session_key: str) -> Optional[set]:
         """Return media paths already delivered in prior turns of this session.
 
-        Loads the persisted transcript, drops the most recent assistant entry
-        (which belongs to the current response), and scans the remaining history
-        for MEDIA: tags and image_generate JSON payloads.  Used to prevent the
-        model from re-delivering the same file when it echoes an old MEDIA tag.
+        Loads the persisted transcript, drops the current turn, and scans the
+        remaining history for MEDIA: tags and image_generate JSON payloads.
+        Used to prevent the model from re-delivering the same file when it
+        echoes an old MEDIA tag.
         """
         store = getattr(self, "_session_store", None)
         if not store:
@@ -3258,14 +3258,13 @@ class BasePlatformAdapter(ABC):
             return None
         if not transcript:
             return None
-        # Exclude the current turn's assistant message, which has already been
-        # persisted by the time we reach delivery but must not be treated as
-        # "history" for dedup purposes.
+        # The full current turn has already been persisted by delivery time.
+        # Remove it at the last user-message boundary so its tool output is not
+        # mistaken for media delivered in a prior turn.
         history = list(transcript)
-        for msg in reversed(history):
-            if msg.get("role") == "assistant":
-                history.remove(msg)
-                break
+        while history and history[-1].get("role") != "user":
+            history.pop()
+        history = history[:-1]
         if not history:
             return None
         # Avoid circular import: gateway.run already imports this module.

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -11,8 +11,10 @@ make_image tool several turns earlier must not leak onto a later
 text-only reply, even when the path-based dedup set fails to capture it.
 """
 
-import pytest
 import re
+from unittest.mock import MagicMock
+
+import pytest
 
 
 def extract_media_tags_fixed(result_messages, history_len):
@@ -289,6 +291,35 @@ caption
         paths = _collect_history_media_paths(history)
         assert "/tmp/gen/cat.png" in paths  # JSON-payload path (the bug)
         assert "/tmp/voice/note.ogg" in paths  # MEDIA: text path (already worked)
+
+    def test_non_streaming_dedup_excludes_current_turn_tool_output(self):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        old_path = "/tmp/gen/old.png"
+        current_path = "/tmp/gen/current.png"
+        transcript = [
+            {"role": "user", "content": "make the old image"},
+            {"role": "assistant", "content": f"MEDIA:{old_path}"},
+            {"role": "user", "content": "make a new image"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "current", "function": {"name": "image_generate"}}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "current",
+                "content": f'{{"success": true, "image": "{current_path}"}}',
+            },
+            {"role": "assistant", "content": f"MEDIA:{current_path}"},
+        ]
+        adapter = MagicMock()
+        adapter._session_store.peek_session_id.return_value = "session-id"
+        adapter._session_store.load_transcript.return_value = transcript
+
+        paths = BasePlatformAdapter._history_media_paths_for_session(
+            adapter, "session-key"
+        )
+        assert paths == {old_path}
 
     def test_image_generate_not_reemitted_after_compression(self):
         """End-to-end of the #46627 fix: collect history paths, then the

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -321,6 +321,45 @@ caption
         )
         assert paths == {old_path}
 
+    @pytest.mark.parametrize(
+        "current_path",
+        ["/tmp/tts/current.ogg", "/tmp/tts/already-delivered.ogg"],
+    )
+    def test_non_streaming_dedup_scopes_tts_paths_to_prior_turns(
+        self, current_path
+    ):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        old_path = "/tmp/tts/already-delivered.ogg"
+        transcript = [
+            {"role": "user", "content": "say the old message"},
+            {"role": "assistant", "content": f"MEDIA:{old_path}"},
+            {"role": "user", "content": "say the current message"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "tts", "function": {"name": "text_to_speech"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "tts",
+                "content": f"[[audio_as_voice]]\\nMEDIA:{current_path}",
+            },
+            {
+                "role": "assistant",
+                "content": f"[[audio_as_voice]]\\nMEDIA:{current_path}",
+            },
+        ]
+        adapter = MagicMock()
+        adapter._session_store.peek_session_id.return_value = "session-id"
+        adapter._session_store.load_transcript.return_value = transcript
+
+        paths = BasePlatformAdapter._history_media_paths_for_session(
+            adapter, "session-key"
+        )
+        assert paths == {old_path}
+
     def test_image_generate_not_reemitted_after_compression(self):
         """End-to-end of the #46627 fix: collect history paths, then the
         compression-fallback rescan (history_offset stale) must dedup the


### PR DESCRIPTION
## What does this PR do?

Prevents non-streaming gateway adapters from treating a newly generated image as media that was already delivered in an earlier turn.

The persisted transcript contains the complete current turn by delivery time. Removing only its final assistant message left the current `image_generate` tool result in the history scan, so the new path was filtered before Signal or another adapter could send it. This change cuts the transcript at the last user-message boundary instead.

## Related Issue

Fixes #72536

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: exclude the entire current turn from prior-turn media deduplication.
- `tests/gateway/test_media_extraction.py`: cover a prior delivered image followed by a current-turn `image_generate` result.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_media_extraction.py -q`.
2. Run `scripts/run_tests.sh tests/gateway/test_media_spaced_paths_and_history_dedupe.py -q`.
3. Ask a non-streaming gateway platform to generate an image and confirm the current image is sent once.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 arm64, Python 3.12.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused validation:

- `tests/gateway/test_media_extraction.py`: 16 passed
- `tests/gateway/test_media_spaced_paths_and_history_dedupe.py`: 13 passed
- `ruff check gateway/platforms/base.py tests/gateway/test_media_extraction.py`: passed
- `scripts/check-windows-footguns.py`: no Windows footguns found
