### PR TITLE
fix(desktop): tolerate slow local gateway startup

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -223,9 +223,9 @@ export class HermesGateway extends JsonRpcGatewayClient {
   constructor() {
     super({
       closedErrorMessage: 'Hermes gateway connection closed',
-      // Local backend startup can briefly hold the Python GIL while Desktop
-      // initializes plugins and scheduled work. Keep the shared/web default
-      // strict, but allow this native client to survive a slow local boot.
+      // A Desktop dial can race a local or remote backend that is still doing
+      // synchronous startup work. Prefer slower dead-endpoint detection over a
+      // false boot/reconnect failure; shared/web callers keep the 15s default.
       connectTimeoutMs: 60_000,
       connectErrorMessage: 'Could not connect to Hermes gateway',
       createRequestId: nextId => nextId,

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -223,6 +223,10 @@ export class HermesGateway extends JsonRpcGatewayClient {
   constructor() {
     super({
       closedErrorMessage: 'Hermes gateway connection closed',
+      // Local backend startup can briefly hold the Python GIL while Desktop
+      // initializes plugins and scheduled work. Keep the shared/web default
+      // strict, but allow this native client to survive a slow local boot.
+      connectTimeoutMs: 60_000,
       connectErrorMessage: 'Could not connect to Hermes gateway',
       createRequestId: nextId => nextId,
       notConnectedErrorMessage: 'Hermes gateway is not connected',

--- a/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
@@ -4,6 +4,8 @@
 import { JsonRpcGatewayClient } from '@hermes/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { HermesGateway } from '@/hermes'
+
 class FakeSocket {
   static OPEN = 1
   readyState = 0
@@ -20,6 +22,22 @@ class FakeSocket {
   send = vi.fn()
 }
 
+class SlowFakeSocket {
+  static OPEN = 1
+  readyState = 0
+  addEventListener = vi.fn((type: string, handler: () => void) => {
+    if (type === 'open') {
+      setTimeout(() => {
+        this.readyState = SlowFakeSocket.OPEN
+        handler()
+      }, 20_000)
+    }
+  })
+  removeEventListener = vi.fn()
+  close = vi.fn()
+  send = vi.fn()
+}
+
 describe('JsonRpcGatewayClient connect() URL guard', () => {
   beforeEach(() => {
     vi.stubGlobal('WebSocket', FakeSocket) // jsdom has none; class reads WebSocket.OPEN
@@ -27,6 +45,7 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.useRealTimers()
   })
 
   it('rejects a non-string IPC result object', async () => {
@@ -61,5 +80,17 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
       await client.connect(url)
       expect(client.connectionState).toBe('open')
     }
+  })
+
+  it('allows Desktop to survive a slow local backend boot', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', SlowFakeSocket)
+
+    const client = new HermesGateway()
+    const connected = client.connect('ws://127.0.0.1:1234/api/ws?token=t')
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    await expect(connected).resolves.toBeUndefined()
+    expect(client.connectionState).toBe('open')
   })
 })

--- a/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
@@ -38,7 +38,16 @@ class SlowFakeSocket {
   send = vi.fn()
 }
 
-describe('JsonRpcGatewayClient connect() URL guard', () => {
+class NeverOpenSocket {
+  static OPEN = 1
+  readyState = 0
+  addEventListener = vi.fn()
+  removeEventListener = vi.fn()
+  close = vi.fn()
+  send = vi.fn()
+}
+
+describe('JsonRpcGatewayClient connect()', () => {
   beforeEach(() => {
     vi.stubGlobal('WebSocket', FakeSocket) // jsdom has none; class reads WebSocket.OPEN
   })
@@ -92,5 +101,34 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
     await vi.advanceTimersByTimeAsync(20_000)
     await expect(connected).resolves.toBeUndefined()
     expect(client.connectionState).toBe('open')
+  })
+
+  it('keeps the shared gateway client connect timeout at 15 seconds', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', SlowFakeSocket)
+
+    const client = new JsonRpcGatewayClient()
+    const connected = expect(client.connect('ws://127.0.0.1:1234/api/ws?token=t')).rejects.toThrow(
+      'WebSocket connection failed'
+    )
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    await connected
+    expect(client.connectionState).toBe('error')
+  })
+
+  it('still fails a Desktop dial that never opens within 60 seconds', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', NeverOpenSocket)
+
+    const client = new HermesGateway()
+    const connected = client.connect('ws://127.0.0.1:1234/api/ws?token=t').then(
+      () => null,
+      error => error
+    )
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    await expect(connected).resolves.toEqual(new Error('Could not connect to Hermes gateway'))
+    expect(client.connectionState).toBe('error')
   })
 })


### PR DESCRIPTION
## Summary

- give the Electron Desktop gateway client a 60-second connection timeout
- keep the shared JSON-RPC gateway default at 15 seconds for other callers
- cover the Desktop-specific override with a delayed-WebSocket regression test

## Root cause

The Desktop backend can announce `HERMES_BACKEND_READY` before its Python event loop is able to accept the renderer's shared WebSocket connection. Under startup GIL pressure, observed local Windows launches took 13–26 seconds to accept that socket.

The renderer still used the shared 15-second connection deadline, so it could report `Could not connect to Hermes gateway` and close the socket immediately before the backend accepted it. Desktop startup then failed even though the backend itself was healthy.

This change gives only the local Desktop transport additional startup tolerance. Web and other shared gateway callers retain the existing 15-second default.

The longer deadline applies to every Desktop WebSocket dial, including reconnects and secondary profiles. That intentionally favors avoiding false failures while a Desktop-managed backend is still starting over detecting a dead endpoint within 15 seconds; the existing reconnect backoff still applies after the handshake deadline.

## Validation

- `npm.cmd test -- --run src/lib/json-rpc-gateway-url-guard.test.ts` — 8 passed
- `npm.cmd --workspace apps/desktop run typecheck` — passed
- `npm.cmd --workspace apps/desktop run lint` — passed with existing warnings and no errors
- packaged Windows Desktop startup verified against a backend that previously exceeded the old deadline
