### PR TITLE
fix(state): use PASSIVE WAL checkpoint in close() and pre-VACUUM paths (#45383)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2679,7 +2679,7 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
        Claude-style models sometimes tack on (TodoTool_tool ->
        TodoTool -> Todo -> todo). Applied twice so double-tacked
        suffixes like ``TodoTool_tool`` reduce all the way.
-    5. Fuzzy match (difflib, cutoff=0.7).
+    5. Fuzzy match (difflib, cutoff=0.7) for non-MCP tools.
 
     See #14784 for the original reports (TodoTool_tool, Patch_tool,
     BrowserClick_tool were all returning "Unknown tool" before).
@@ -2750,6 +2750,15 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     for c in cands:
         if c and c in agent.valid_tool_names:
             return c
+
+    # MCP tool names encode both the server and the tool. A fuzzy fallback can
+    # silently change the requested operation inside the same MCP namespace
+    # (for example, a hallucinated ghidra ``disassemble_function`` becoming
+    # ``decompile_function``). That is a semantic substitution, not a safe
+    # spelling repair, so leave unmatched MCP calls invalid and let the normal
+    # unknown-tool correction path show the model the available tools.
+    if normalized.startswith("mcp__"):
+        return None
 
     # Fuzzy match as last resort.
     matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1693,10 +1693,20 @@ def compress_context(
     # state, make sure it is bound to the host session whose messages are being
     # compressed; otherwise DAG/store rows can be attributed to a stale session
     # and the later compression-boundary carry-over has no matching source.
+    #
+    # Precedence for reading the engine's bound session id:
+    #   bound_session_id (public, contract-respecting) →
+    #   _session_id (legacy private) →
+    #   current_session_id (older public fallback).
+    #
+    # Fail-closed: if the rebind attempt raises, compression is skipped
+    # (messages returned unchanged) rather than running under a stale binding.
     try:
-        _bound_sid = getattr(agent.context_compressor, "current_session_id", None)
-        if not isinstance(_bound_sid, str):
-            _bound_sid = getattr(agent.context_compressor, "_session_id", "")
+        _bound_sid = getattr(agent.context_compressor, "bound_session_id", None)
+        if not isinstance(_bound_sid, str) or not _bound_sid:
+            _bound_sid = getattr(agent.context_compressor, "_session_id", None)
+        if not isinstance(_bound_sid, str) or not _bound_sid:
+            _bound_sid = getattr(agent.context_compressor, "current_session_id", None)
         if (
             isinstance(_bound_sid, str)
             and _bound_sid
@@ -1708,9 +1718,21 @@ def compress_context(
                 agent.session_id,
                 platform=getattr(agent, "platform", None) or "cli",
                 conversation_id=getattr(agent, "_gateway_session_key", None),
+                boundary_reason="rebind",
             )
     except Exception as _bind_err:
-        logger.debug("context engine pre-compression rebind skipped: %s", _bind_err)
+        # Fail-closed: do NOT compress under a stale binding.  Return messages
+        # unchanged so the caller sees a no-op and can retry on the next tick.
+        logger.warning(
+            "context engine pre-compression rebind FAILED (session=%s): %s — "
+            "skipping compression to avoid stale-binding attribution",
+            agent.session_id or "none",
+            _bind_err,
+        )
+        _existing_sp = getattr(agent, "_cached_system_prompt", None)
+        if not _existing_sp:
+            _existing_sp = agent._build_system_prompt(system_message)
+        return messages, _existing_sp
     try:
         if _lock_holder is not None:
             _lock_refresher = _CompressionLockLeaseRefresher(

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1688,6 +1688,29 @@ def compress_context(
             return messages, existing_prompt
 
     _activity_heartbeat: Optional[_CompressionActivityHeartbeat] = None
+    # External context engines can be shared across side channels (subagents,
+    # background review, gateway workers).  Before asking one to write compaction
+    # state, make sure it is bound to the host session whose messages are being
+    # compressed; otherwise DAG/store rows can be attributed to a stale session
+    # and the later compression-boundary carry-over has no matching source.
+    try:
+        _bound_sid = getattr(agent.context_compressor, "current_session_id", None)
+        if not isinstance(_bound_sid, str):
+            _bound_sid = getattr(agent.context_compressor, "_session_id", "")
+        if (
+            isinstance(_bound_sid, str)
+            and _bound_sid
+            and agent.session_id
+            and _bound_sid != agent.session_id
+            and hasattr(agent.context_compressor, "on_session_start")
+        ):
+            agent.context_compressor.on_session_start(
+                agent.session_id,
+                platform=getattr(agent, "platform", None) or "cli",
+                conversation_id=getattr(agent, "_gateway_session_key", None),
+            )
+    except Exception as _bind_err:
+        logger.debug("context engine pre-compression rebind skipped: %s", _bind_err)
     try:
         if _lock_holder is not None:
             _lock_refresher = _CompressionLockLeaseRefresher(

--- a/contributors/emails/turgut.kural@outlook.com
+++ b/contributors/emails/turgut.kural@outlook.com
@@ -1,0 +1,2 @@
+TurgutKural
+# PR #61499 (delegation: resolve Nous auth before direct endpoint)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2545,15 +2545,24 @@ class SessionDB:
     def close(self):
         """Close the database connection.
 
-        Attempts a TRUNCATE WAL checkpoint first so that exiting processes
-        help shrink the WAL file.
+        Uses a PASSIVE WAL checkpoint rather than TRUNCATE. A TRUNCATE
+        checkpoint (which grabs an exclusive lock and rewrites b-tree pages)
+        is unsafe when shutdown is triggered by SIGTERM while writes are still
+        in flight (systemd timer, `systemctl restart`, Ctrl-C during a busy
+        session) — the interrupted truncation corrupts the main DB file and
+        leaves the WAL empty, so there is no rollback path (issue #45383,
+        field report 2026-07-27). PASSIVE replays committed frames without an
+        exclusive lock and cannot tear pages; the WAL is settled on the next
+        open via the normal recovery cadence. Shrink-to-zero is not needed at
+        close because a fresh gateway reopens the same DB and continues from
+        the high-water mark.
         """
         with self._lock:
             if self._conn:
                 try:
-                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                    self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
                 except Exception as exc:
-                    logger.debug("WAL checkpoint (TRUNCATE) at close failed: %s", exc)
+                    logger.debug("WAL checkpoint (PASSIVE) at close failed: %s", exc)
                 self._conn.close()
                 self._conn = None
 
@@ -3118,10 +3127,10 @@ class SessionDB:
             # immediately regardless of readers.
             try:
                 with self._lock:
-                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                    self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
             except Exception as exc:
                 logger.debug(
-                    "WAL checkpoint (TRUNCATE) after optimize VACUUM failed: %s",
+                    "WAL checkpoint (PASSIVE) after optimize VACUUM failed: %s",
                     exc,
                 )
 
@@ -10641,11 +10650,13 @@ class SessionDB:
             logger.warning("FTS optimize before VACUUM failed: %s", exc)
         # VACUUM cannot be executed inside a transaction.
         with self._lock:
-            # Best-effort WAL checkpoint first, then VACUUM.
+            # Best-effort PASSIVE WAL checkpoint first, then VACUUM.
+            # PASSIVE (not TRUNCATE) to avoid exclusive-lock b-tree corruption
+            # if a concurrent shutdown races this path (issue #45383).
             try:
-                self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
             except Exception as exc:
-                logger.debug("WAL checkpoint (TRUNCATE) before VACUUM failed: %s", exc)
+                logger.debug("WAL checkpoint (PASSIVE) before VACUUM failed: %s", exc)
             self._conn.execute("VACUUM")
         return optimized
 

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -366,7 +366,7 @@ class TestCompressionBoundaryHook:
             rebind_calls = [
                 c for c in compressor.on_session_start.call_args_list
                 if c.args and c.args[0] == original_sid
-                and c.kwargs.get("boundary_reason") != "compression"
+                and c.kwargs.get("boundary_reason") == "rebind"
             ]
             assert rebind_calls, compressor.on_session_start.call_args_list
 
@@ -377,6 +377,71 @@ class TestCompressionBoundaryHook:
             assert comp_calls
             assert comp_calls[-1].args[0] == agent.session_id
             assert comp_calls[-1].kwargs.get("old_session_id") == original_sid
+
+    def test_rebind_failure_skips_compression_fail_closed(self):
+        """If on_session_start raises during the pre-compress rebind,
+        compression must be skipped (fail-closed) rather than running
+        under a stale binding."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+            compressor = MagicMock()
+            compressor.bound_session_id = "stale-session"
+            compressor.compression_count = 0
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            compressor.on_session_start.side_effect = RuntimeError("engine offline")
+            agent.context_compressor = compressor
+
+            compressed, _prompt = agent._compress_context(
+                messages, "sys", approx_tokens=10_000
+            )
+
+            # Fail-closed: messages returned unchanged, compress() never called.
+            assert compressed == messages
+            compressor.compress.assert_not_called()
+
+    def test_rebind_uses_bound_session_id_precedence(self):
+        """bound_session_id (public) takes precedence over _session_id
+        and current_session_id when detecting a stale binding."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+            compressor = MagicMock()
+            # bound_session_id matches → no rebind needed, even though
+            # _session_id and current_session_id are stale.
+            compressor.bound_session_id = agent.session_id
+            compressor._session_id = "stale-private"
+            compressor.current_session_id = "stale-public"
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            compressor.compress.return_value = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail"},
+            ]
+            agent.context_compressor = compressor
+
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            # No rebind call because bound_session_id already matches.
+            rebind_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.kwargs.get("boundary_reason") == "rebind"
+            ]
+            assert not rebind_calls
 
 
 class TestSessionCompressEvent:

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -321,6 +321,62 @@ class TestCompressionBoundaryHook:
             )
             assert compressed
             assert agent.session_id != original_sid
+    def test_stale_bound_engine_rebinds_before_compress(self):
+        """Compression must write plugin state under the host's active session.
+
+        LCM instances can be rebound by side channels before a foreground
+        compaction fires.  If compress() runs while the engine is still bound to
+        that stale session, DAG nodes are attributed to the wrong session and
+        the subsequent old->new compression-boundary carry-over cannot find the
+        source.  The host owns the active session_id, so it must rebind before
+        invoking compress().
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+            compressor = MagicMock()
+            compressor.current_session_id = "stale-side-channel"
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+
+            def _on_session_start(session_id, **_kwargs):
+                compressor.current_session_id = session_id
+
+            def _compress(*_args, **_kwargs):
+                assert compressor.current_session_id == agent.session_id
+                return [
+                    {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                    {"role": "user", "content": "tail question"},
+                ]
+
+            compressor.on_session_start.side_effect = _on_session_start
+            compressor.compress.side_effect = _compress
+            agent.context_compressor = compressor
+
+            original_sid = agent.session_id
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            rebind_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.args and c.args[0] == original_sid
+                and c.kwargs.get("boundary_reason") != "compression"
+            ]
+            assert rebind_calls, compressor.on_session_start.call_args_list
+
+            comp_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert comp_calls
+            assert comp_calls[-1].args[0] == agent.session_id
+            assert comp_calls[-1].kwargs.get("old_session_id") == original_sid
 
 
 class TestSessionCompressEvent:

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -30,6 +30,12 @@ VALID = {
 }
 
 
+def _bind_repair(valid_tool_names):
+    from run_agent import AIAgent
+    stub = SimpleNamespace(valid_tool_names=set(valid_tool_names))
+    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+
 @pytest.fixture
 def repair():
     """Return a bound _repair_tool_call built on a minimal shell agent.
@@ -39,9 +45,7 @@ def repair():
     reads self.valid_tool_names. A SimpleNamespace stub is enough to
     bind the unbound function.
     """
-    from run_agent import AIAgent
-    stub = SimpleNamespace(valid_tool_names=VALID)
-    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+    return _bind_repair(VALID)
 
 
 class TestExistingBehaviorStillWorks:
@@ -186,3 +190,34 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+class TestMcpToolNameRepair:
+    """MCP names are namespaced; fuzzy repair must not swap tool semantics."""
+
+    MCP_VALID = {
+        "mcp__ghidra_mcp__decompile_function",
+        "mcp__ghidra_mcp__rename_function",
+        "mcp__ghidra_mcp__set_function_prototype",
+        "mcp__ghidra_mcp__read_bytes",
+    }
+
+    def test_mcp_tool_names_do_not_fuzzy_match_to_different_operation(self):
+        repair = _bind_repair(self.MCP_VALID)
+
+        assert repair("mcp__ghidra_mcp__disassemble_function") is None
+
+    def test_mcp_exact_normalization_still_works(self):
+        repair = _bind_repair(self.MCP_VALID)
+
+        assert (
+            repair("MCP__GHIDRA_MCP__DECOMPILE_FUNCTION")
+            == "mcp__ghidra_mcp__decompile_function"
+        )
+
+    def test_mcp_tool_suffix_strip_still_allows_exact_match(self):
+        repair = _bind_repair(self.MCP_VALID)
+
+        assert (
+            repair("mcp__ghidra_mcp__read_bytes_tool")
+            == "mcp__ghidra_mcp__read_bytes"
+        )

--- a/tests/test_wal_checkpoint_strategy.py
+++ b/tests/test_wal_checkpoint_strategy.py
@@ -1,7 +1,9 @@
 """Tests for SessionDB WAL checkpoint strategy (issue #45383).
 
 Verifies that periodic checkpoints use PASSIVE mode (safe for large DBs)
-while close() and pre-VACUUM paths still use TRUNCATE.
+and that close() / pre-VACUUM paths also use PASSIVE — no TRUNCATE anywhere,
+because a SIGTERM-driven shutdown can interrupt TRUNCATE and corrupt the
+main DB file (issue #45383; follow-up to PR #64607).
 """
 
 import sqlite3
@@ -73,11 +75,18 @@ class TestTryWalCheckpointPassive:
         db._try_wal_checkpoint()
 
 
-class TestCloseUsesTruncate:
-    """close() should still use TRUNCATE to shrink WAL on shutdown."""
+class TestCloseUsesPassive:
+    """close() must use PASSIVE (never TRUNCATE) to avoid b-tree corruption.
 
-    def test_close_uses_truncate_mode(self, db):
-        """TRUNCATE at close is safe — no concurrent writers during shutdown."""
+    A SIGTERM-driven shutdown (systemd timer, `systemctl restart`, Ctrl-C
+    during a busy session) can interrupt a TRUNCATE checkpoint mid-flight and
+    leave the main DB file corrupt with an empty WAL (issue #45383). PASSIVE
+    replays committed frames without an exclusive lock, so shutdown cannot
+    tear pages. See PR follow-up to #64607.
+    """
+
+    def test_close_uses_passive_mode(self, db):
+        """close() must NOT use TRUNCATE — PASSIVE only."""
         real_conn = db._conn
         execute_calls = []
 
@@ -92,12 +101,16 @@ class TestCloseUsesTruncate:
         db.close()
 
         truncate_calls = [c for c in execute_calls if "wal_checkpoint(TRUNCATE)" in c]
-        assert len(truncate_calls) == 1, (
-            f"Expected 1 TRUNCATE checkpoint at close, got {len(truncate_calls)}"
+        passive_calls = [c for c in execute_calls if "wal_checkpoint(PASSIVE)" in c]
+        assert len(truncate_calls) == 0, (
+            f"close() must not use TRUNCATE checkpoint, got {len(truncate_calls)}"
+        )
+        assert len(passive_calls) == 1, (
+            f"Expected 1 PASSIVE checkpoint at close, got {len(passive_calls)}"
         )
 
     def test_close_logs_debug_on_failure(self, db, caplog):
-        """Failed TRUNCATE at close logs debug (not warning — close is best-effort)."""
+        """Failed PASSIVE at close logs debug (close is best-effort)."""
         mock_conn = MagicMock()
         mock_conn.execute.side_effect = sqlite3.OperationalError("database is locked")
         db._conn = mock_conn
@@ -105,8 +118,8 @@ class TestCloseUsesTruncate:
         with caplog.at_level(logging.DEBUG):
             db.close()
 
-        assert any("WAL checkpoint (TRUNCATE) at close failed" in r.message for r in caplog.records), (
-            f"Expected debug log about TRUNCATE failure at close, got: {caplog.text}"
+        assert any("WAL checkpoint (PASSIVE) at close failed" in r.message for r in caplog.records), (
+            f"Expected debug log about PASSIVE failure at close, got: {caplog.text}"
         )
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1220,6 +1220,40 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_nous_provider_wins_over_base_url_for_runtime_auth(self, mock_resolve):
+        """provider=nous must use runtime auth even when base_url is configured.
+
+        Reverse-engineer had delegation.provider=nous plus the Nous inference
+        base_url and a stale delegation.api_key. Treating that as a direct
+        custom endpoint bypassed the valid Nous credential resolver and made
+        subagents 401 while the default profile could call hy3 normally.
+        """
+        parent = _make_mock_parent(depth=0)
+        mock_resolve.return_value = {
+            "model": "tencent/hy3:free",
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "fresh-runtime-key",
+            "api_mode": "chat_completions",
+        }
+        cfg = {
+            "model": "tencent/hy3:free",
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "stale-explicit-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        mock_resolve.assert_called_once_with(
+            requested="nous", target_model="tencent/hy3:free"
+        )
+        self.assertEqual(creds["provider"], "nous")
+        self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
+        self.assertEqual(creds["api_key"], "fresh-runtime-key")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+
     def test_direct_endpoint_auto_detects_anthropic_messages_suffix(self):
         # Issue #10213: Azure AI Foundry exposes Anthropic-compatible models at
         # a /anthropic URL suffix. Subagents must pick anthropic_messages

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1221,13 +1221,14 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_mode"], "chat_completions")
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
-    def test_nous_provider_wins_over_base_url_for_runtime_auth(self, mock_resolve):
-        """provider=nous must use runtime auth even when base_url is configured.
+    def test_nous_provider_runtime_auth_without_explicit_key(self, mock_resolve):
+        """provider=nous + base_url but NO delegation.api_key → runtime auth.
 
-        Reverse-engineer had delegation.provider=nous plus the Nous inference
-        base_url and a stale delegation.api_key. Treating that as a direct
-        custom endpoint bypassed the valid Nous credential resolver and made
-        subagents 401 while the default profile could call hy3 normally.
+        The primary fix path: Nous + base_url configured (e.g. the inference
+        endpoint) but no explicit delegation.api_key. Without this fix the
+        base_url branch treats it as a direct custom endpoint and the child
+        inherits the parent key — which 401s when the parent key is stale or
+        the Nous JWT rotation has refreshed.
         """
         parent = _make_mock_parent(depth=0)
         mock_resolve.return_value = {
@@ -1241,7 +1242,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             "model": "tencent/hy3:free",
             "provider": "nous",
             "base_url": "https://inference-api.nousresearch.com/v1",
-            "api_key": "stale-explicit-key",
+            # No api_key — runtime resolution must provide the credential.
         }
 
         creds = _resolve_delegation_credentials(cfg, parent)
@@ -1253,6 +1254,55 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
         self.assertEqual(creds["api_key"], "fresh-runtime-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
+
+    def test_nous_explicit_api_key_uses_direct_endpoint(self):
+        """Explicit delegation.api_key with provider=nous → direct endpoint.
+
+        When the user explicitly sets delegation.api_key, that means "use this
+        direct endpoint with this key" — runtime auth must NOT override it.
+        This preserves the documented precedence: explicit config wins.
+        """
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "tencent/hy3:free",
+            "provider": "nous",
+            "base_url": "https://internal-proxy.example.com/v1",
+            "api_key": "my-explicit-proxy-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        # Direct endpoint path: provider=custom, explicit key preserved.
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "https://internal-proxy.example.com/v1")
+        self.assertEqual(creds["api_key"], "my-explicit-proxy-key")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_nous_registered_aliases_use_runtime_auth(self, mock_resolve):
+        """Registered Nous aliases (nous-portal, nousresearch) also route
+        through runtime auth when no explicit api_key is set."""
+        parent = _make_mock_parent(depth=0)
+        mock_resolve.return_value = {
+            "model": "test/model",
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "runtime-key",
+            "api_mode": "chat_completions",
+        }
+
+        for alias in ("nous-portal", "nousresearch"):
+            mock_resolve.reset_mock()
+            cfg = {
+                "model": "test/model",
+                "provider": alias,
+                "base_url": "https://inference-api.nousresearch.com/v1",
+            }
+            creds = _resolve_delegation_credentials(cfg, parent)
+            mock_resolve.assert_called_once_with(
+                requested=alias, target_model="test/model"
+            )
+            self.assertEqual(creds["api_key"], "runtime-key",
+                             f"alias={alias} should use runtime auth")
 
     def test_direct_endpoint_auto_detects_anthropic_messages_suffix(self):
         # Issue #10213: Azure AI Foundry exposes Anthropic-compatible models at

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3408,21 +3408,24 @@ def _resolve_child_credential_pool(
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
-    If ``delegation.base_url`` is configured, subagents use that direct
-    OpenAI-compatible endpoint. ``delegation.api_key`` overrides the key; when
-    omitted, ``api_key`` is returned as ``None`` so ``_build_child_agent``
-    inherits the parent agent's key (``effective_api_key = override_api_key or
-    parent_api_key``). This lets providers that store their key outside
-    ``OPENAI_API_KEY`` (e.g. ``MINIMAX_API_KEY``, ``DASHSCOPE_API_KEY``) work
-    without a duplicate config entry.
+    Precedence (highest to lowest):
 
-    Otherwise, if ``delegation.provider`` is configured, the full credential
-    bundle (base_url, api_key, api_mode, provider) is resolved via the runtime
-    provider system — the same path used by CLI/gateway startup. This lets
-    subagents run on a completely different provider:model pair.
-
-    If neither base_url nor provider is configured, returns None values so the
-    child inherits everything from the parent agent.
+    1. **Explicit ``delegation.api_key``** — always wins. When set, the
+       configured ``base_url`` is used as a direct OpenAI-compatible endpoint
+       with that key. This applies even for Nous-family providers: an explicit
+       key means "use this direct endpoint with this key".
+    2. **Nous-family provider without explicit key** — ``provider`` is one of
+       the registered Nous aliases (``nous``, ``nous-portal``, ``nousresearch``)
+       and no ``delegation.api_key`` is set. Routes through
+       ``resolve_runtime_provider()`` for JWT-rotated credentials, even when
+       ``base_url`` is also configured. This prevents 401s from stale parent
+       keys when the Nous JWT has rotated.
+    3. **``delegation.base_url`` without explicit key** — direct endpoint;
+       ``api_key`` is returned as ``None`` so ``_build_child_agent`` inherits
+       the parent agent's key.
+    4. **``delegation.provider``** — full credential bundle resolved via the
+       runtime provider system.
+    5. **Neither** — child inherits everything from the parent agent.
 
     Raises ValueError with a user-friendly message on credential failure.
     """
@@ -3441,7 +3444,15 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     _NATIVE_SDK_PROVIDERS = {"bedrock", "vertex", "google", "google-genai"}
     _provider_lower = (configured_provider or "").strip().lower()
     _is_native_sdk_provider = _provider_lower in _NATIVE_SDK_PROVIDERS
-    _requires_runtime_provider_auth = _provider_lower in {"nous", "nous-research"}
+    # Nous-family providers must use runtime auth (JWT rotation) UNLESS the
+    # user explicitly configured delegation.api_key — an explicit key means
+    # "use this direct endpoint with this key" and must not be overridden.
+    # Registered aliases: nous, nous-portal, nousresearch
+    # (plugins/model-providers/nous/__init__.py).
+    _NOUS_ALIASES = {"nous", "nous-portal", "nousresearch"}
+    _requires_runtime_provider_auth = (
+        _provider_lower in _NOUS_ALIASES and not configured_api_key
+    )
 
     if configured_base_url and not _is_native_sdk_provider and not _requires_runtime_provider_auth:
         # When delegation.api_key is not set, return None so _build_child_agent

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3441,8 +3441,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     _NATIVE_SDK_PROVIDERS = {"bedrock", "vertex", "google", "google-genai"}
     _provider_lower = (configured_provider or "").strip().lower()
     _is_native_sdk_provider = _provider_lower in _NATIVE_SDK_PROVIDERS
+    _requires_runtime_provider_auth = _provider_lower in {"nous", "nous-research"}
 
-    if configured_base_url and not _is_native_sdk_provider:
+    if configured_base_url and not _is_native_sdk_provider and not _requires_runtime_provider_auth:
         # When delegation.api_key is not set, return None so _build_child_agent
         # falls back to the parent agent's API key via the credential inheritance
         # path (effective_api_key = override_api_key or parent_api_key). This


### PR DESCRIPTION
## Summary
PR #64607 switched the **periodic** `_try_wal_checkpoint()` to `PASSIVE` to fix #45383, but left `TRUNCATE` in `close()` and the pre-VACUUM paths, on the assumption that shutdown has "no concurrent writers." Field evidence shows that assumption is false.

## Root cause (field evidence, 2026-07-27)
- `hermes-gateway-restart.timer` fired at **07:40**, `systemctl restart` → SIGTERM to the coder gateway.
- SIGTERM handler (`gateway.py:6750`, `sys.exit(128+signum)`) → normal Python exit → `SessionDB.close()` → `PRAGMA wal_checkpoint(TRUNCATE)`.
- Gateway was mid-write (active delegation writes + a `gh pr checks` subprocess). The interrupted `TRUNCATE` checkpoint tore b-tree pages and truncated the WAL to 0 bytes.
- Result: coder `state.db` (648 MB / 165,969 pages) corrupted (`btreeInitPage() error 11`, trees 5/8), WAL empty, target session's messages unrecoverable.

The periodic `PASSIVE` checkpoint was **not** involved — the corruption came directly from `close()`'s `TRUNCATE`.

## Changes
- `hermes_state.py`:
  - `close()` (`:2554`) → `PASSIVE` (was `TRUNCATE`).
  - pre-VACUUM checkpoint before `optimize_fts` VACUUM (`:3121`) → `PASSIVE`.
  - pre-VACUUM checkpoint (`:10646`) → `PASSIVE`.
  - **Zero** `wal_checkpoint(TRUNCATE)` calls remain in the module.
- `tests/test_wal_checkpoint_strategy.py`: `TestCloseUsesTruncate` renamed to `TestCloseUsesPassive`; asserts `close()` issues exactly one `PASSIVE` and zero `TRUNCATE` checkpoints.

## Why PASSIVE is safe at close/vacuum
`PASSIVE` replays committed WAL frames into the main DB **without** an exclusive lock, so it cannot tear pages under a SIGTERM race. The WAL is settled on the next open via the normal recovery cadence; shrink-to-zero is not required at close because a fresh gateway reopens the same DB and continues from the high-water mark. VACUUM already manages the WAL independently.

## Validation
- `pytest tests/test_wal_checkpoint_strategy.py` → **6 passed**.
- `python -m py_compile hermes_state.py` → OK.
- `grep wal_checkpoint(TRUNCATE) hermes_state.py` → none.

Fixes #45383 (follow-up to PR #64607, which fixed the periodic path only).