### PR TITLE
fix(desktop): guard destroyed mainWindow in getWindowState/getWindowButtonPosition

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -182,9 +182,12 @@ import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-market
 import {
   computeWindowOptions,
   debounce,
+  isWindowLive,
   sanitizeWindowState,
   MIN_HEIGHT as WINDOW_MIN_HEIGHT,
-  MIN_WIDTH as WINDOW_MIN_WIDTH
+  MIN_WIDTH as WINDOW_MIN_WIDTH,
+  windowButtonPosition,
+  windowChromeState
 } from './window-state'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 import {
@@ -4929,18 +4932,23 @@ function getWindowButtonPosition() {
     return null
   }
 
-  return mainWindow?.getWindowButtonPosition?.() || WINDOW_BUTTON_POSITION
+  // `mainWindow?.` is not enough: mainWindow is only cleared on 'closed', which
+  // fires after destroy(), so the wrapper stays truthy for a window whose native
+  // side is already gone and calling through it throws.
+  return windowButtonPosition(mainWindow, WINDOW_BUTTON_POSITION)
 }
 
 function getNativeOverlayWidth() {
   return computeNativeOverlayWidth({ isWindows: IS_WINDOWS, isWsl: IS_WSL, isMac: IS_MAC })
 }
 
+// Spread into the ready/IPC payloads the renderer boots on, so a throw here is
+// what surfaces as "Desktop boot failed: Object has been destroyed" (#38468).
+// windowChromeState() reports the same three booleans a live window always
+// reported, and all-false for one that is absent or already destroyed.
 function getWindowState(win = mainWindow) {
   return {
-    isFullscreen: Boolean(win?.isFullScreen?.()),
-    isMinimized: Boolean(win?.isMinimized?.()),
-    isVisible: Boolean(win?.isVisible?.()),
+    ...windowChromeState(win),
     nativeOverlayWidth: getNativeOverlayWidth(),
     windowButtonPosition: getWindowButtonPosition()
   }
@@ -9574,7 +9582,13 @@ ipcMain.handle('hermes:profile:set', async (_event, name) => {
   // new HERMES_HOME. Pool backends keep their own homes, so only the primary
   // is torn down.
   await teardownPrimaryBackendAndWait()
-  mainWindow?.reload()
+
+  // Same destroyed-window hazard as getWindowState(): the teardown is awaited,
+  // so the window can be gone by the time we get here and `?.` would still call
+  // reload() on the dead wrapper.
+  if (isWindowLive(mainWindow)) {
+    mainWindow.reload()
+  }
 
   return { profile: next }
 })

--- a/apps/desktop/electron/window-state.test.ts
+++ b/apps/desktop/electron/window-state.test.ts
@@ -1,7 +1,9 @@
 /**
- * Unit tests for the pure window-state geometry helpers. These cover the logic
- * that protects the user: garbage rejection, off-screen fallback, oversized
- * clamping, and the debounce that collapses mid-drag write storms.
+ * Unit tests for the pure window-state helpers. These cover the logic that
+ * protects the user: garbage rejection, off-screen fallback, oversized
+ * clamping, the debounce that collapses mid-drag write storms, and the
+ * destroyed-window guards that keep a window torn down mid-boot from throwing
+ * out of the ready payload.
  */
 
 import assert from 'node:assert/strict'
@@ -13,10 +15,13 @@ import {
   debounce,
   DEFAULT_HEIGHT,
   DEFAULT_WIDTH,
+  isWindowLive,
   MIN_HEIGHT,
   MIN_WIDTH,
   onScreen,
-  sanitizeWindowState
+  sanitizeWindowState,
+  windowButtonPosition,
+  windowChromeState
 } from './window-state'
 
 // A single 1920×1080 monitor (work area trimmed for the taskbar).
@@ -154,4 +159,90 @@ test('debounce.flush runs now and cancels the pending timer', () => {
   assert.equal(calls, 1)
 
   vi.useRealTimers()
+})
+
+// ─── destroyed-window guards ───────────────────────────────────────────────
+
+const FALLBACK_BUTTON_POSITION = { x: 24, y: 10 }
+
+// A window that is up: every accessor answers normally.
+const liveWindow = () => ({
+  isDestroyed: () => false,
+  isFullScreen: () => true,
+  isMinimized: () => false,
+  isVisible: () => true,
+  getWindowButtonPosition: () => ({ x: 12, y: 6 })
+})
+
+// What Electron actually hands back after destroy(): the JS wrapper survives and
+// still exposes every method, but the native binding behind each one throws.
+// This is the shape that produced #38468 — `win?.isFullScreen?.()` finds the
+// method, invokes it, and the TypeError escapes getWindowState().
+const destroyedWindow = () => {
+  const destroyed = () => {
+    throw new TypeError('Object has been destroyed')
+  }
+
+  return {
+    isDestroyed: () => true,
+    isFullScreen: destroyed,
+    isMinimized: destroyed,
+    isVisible: destroyed,
+    getWindowButtonPosition: destroyed
+  }
+}
+
+test('isWindowLive is true only for a window that answers isDestroyed() false', () => {
+  assert.equal(isWindowLive(liveWindow()), true)
+  assert.equal(isWindowLive(destroyedWindow()), false)
+  assert.equal(isWindowLive(undefined), false)
+  assert.equal(isWindowLive(null), false)
+  // No isDestroyed() to probe (a plain stand-in) — treat as not live rather than
+  // assuming the rest of the surface is safe to call.
+  assert.equal(isWindowLive({}), false)
+})
+
+test('windowChromeState passes a live window through unchanged', () => {
+  assert.deepEqual(windowChromeState(liveWindow()), {
+    isFullscreen: true,
+    isMinimized: false,
+    isVisible: true
+  })
+})
+
+test('windowChromeState reports all-false for an absent or partial window', () => {
+  const allFalse = { isFullscreen: false, isMinimized: false, isVisible: false }
+
+  assert.deepEqual(windowChromeState(undefined), allFalse)
+  assert.deepEqual(windowChromeState(null), allFalse)
+  assert.deepEqual(windowChromeState({}), allFalse)
+})
+
+test('windowChromeState reports all-false for a destroyed window instead of throwing', () => {
+  // Regression for #38468: "Desktop boot failed: Object has been destroyed at
+  // getWindowState()". A destroyed window must degrade, not crash the boot
+  // payload it is spread into.
+  assert.deepEqual(windowChromeState(destroyedWindow()), {
+    isFullscreen: false,
+    isMinimized: false,
+    isVisible: false
+  })
+})
+
+test('windowButtonPosition passes a live window through unchanged', () => {
+  assert.deepEqual(windowButtonPosition(liveWindow(), FALLBACK_BUTTON_POSITION), { x: 12, y: 6 })
+})
+
+test('windowButtonPosition falls back for absent, partial, and destroyed windows', () => {
+  assert.equal(windowButtonPosition(undefined, FALLBACK_BUTTON_POSITION), FALLBACK_BUTTON_POSITION)
+  assert.equal(windowButtonPosition(null, FALLBACK_BUTTON_POSITION), FALLBACK_BUTTON_POSITION)
+  assert.equal(windowButtonPosition({}, FALLBACK_BUTTON_POSITION), FALLBACK_BUTTON_POSITION)
+  assert.equal(windowButtonPosition(destroyedWindow(), FALLBACK_BUTTON_POSITION), FALLBACK_BUTTON_POSITION)
+})
+
+test('windowButtonPosition keeps the pre-guard fallback for a live window with no position', () => {
+  // Preserves the old `|| WINDOW_BUTTON_POSITION` behaviour on platforms where
+  // the window has no traffic lights to report.
+  const noPosition = { ...liveWindow(), getWindowButtonPosition: () => undefined }
+  assert.equal(windowButtonPosition(noPosition, FALLBACK_BUTTON_POSITION), FALLBACK_BUTTON_POSITION)
 })

--- a/apps/desktop/electron/window-state.ts
+++ b/apps/desktop/electron/window-state.ts
@@ -3,7 +3,9 @@
  * size, position, and maximized flag across launches. Side-effect-free so the
  * part that actually matters (rejecting garbage + off-screen bounds) is
  * unit-testable without booting Electron; main.ts owns the file I/O and the
- * live `screen` displays.
+ * live `screen` displays. Also home to the destroyed-window liveness guards
+ * main.ts reads chrome state through, for the same reason: they are pure, and
+ * the failure they prevent is only reproducible against a fake window.
  */
 
 // Defaults mirror the historical hardcoded BrowserWindow size; MIN_* mirror its
@@ -112,6 +114,64 @@ function computeWindowOptions(state, displays): WindowOptions {
   return opts
 }
 
+// Structural shape of the bits of a BrowserWindow these guards touch. Every
+// method is optional so plain stand-ins (and a window mid-teardown) are handled
+// by probing rather than by trusting the type.
+interface LiveWindow {
+  isDestroyed?: () => boolean
+  isFullScreen?: () => boolean
+  isMinimized?: () => boolean
+  isVisible?: () => boolean
+  getWindowButtonPosition?: () => WindowButtonPosition
+}
+
+interface WindowButtonPosition {
+  x: number
+  y: number
+}
+
+interface WindowChromeState {
+  isFullscreen: boolean
+  isMinimized: boolean
+  isVisible: boolean
+}
+
+// Electron keeps a BrowserWindow's JS wrapper alive after destroy(), so optional
+// chaining is NOT a destroyed-window guard: `win?.isVisible?.()` still finds the
+// method and invokes it, and the native binding throws
+// `TypeError: Object has been destroyed`. Anything reading a window's live state
+// has to ask isDestroyed() first. isDestroyed is itself probed because callers
+// legitimately pass undefined (no window yet) or a plain object stand-in.
+function isWindowLive(win?: LiveWindow): boolean {
+  return Boolean(win) && typeof win.isDestroyed === 'function' && !win.isDestroyed()
+}
+
+// The fullscreen/minimized/visible triple main.ts reports to the renderer. A
+// live window reports exactly what it reported before this guard existed; an
+// absent or destroyed one reports all-false instead of throwing.
+function windowChromeState(win?: LiveWindow): WindowChromeState {
+  if (!isWindowLive(win)) {
+    return { isFullscreen: false, isMinimized: false, isVisible: false }
+  }
+
+  return {
+    isFullscreen: Boolean(win.isFullScreen?.()),
+    isMinimized: Boolean(win.isMinimized?.()),
+    isVisible: Boolean(win.isVisible?.())
+  }
+}
+
+// macOS traffic-light origin for a window, falling back to `fallback` for an
+// absent or destroyed one — the same value the previous
+// `|| WINDOW_BUTTON_POSITION` produced, minus the throw.
+function windowButtonPosition(win: LiveWindow | undefined, fallback: WindowButtonPosition): WindowButtonPosition {
+  if (!isWindowLive(win)) {
+    return fallback
+  }
+
+  return win.getWindowButtonPosition?.() || fallback
+}
+
 // Trailing debounce: collapse a burst of resize/move events (Linux fires many
 // mid-drag) into a single run `delayMs` after the last. `.flush()` runs now and
 // cancels the pending timer — used on close, before the window is gone.
@@ -140,9 +200,12 @@ export {
   debounce,
   DEFAULT_HEIGHT,
   DEFAULT_WIDTH,
+  isWindowLive,
   MIN_HEIGHT,
   MIN_VISIBLE,
   MIN_WIDTH,
   onScreen,
-  sanitizeWindowState
+  sanitizeWindowState,
+  windowButtonPosition,
+  windowChromeState
 }


### PR DESCRIPTION
## What does this PR do?

Stops the Desktop app crashing on boot with `TypeError: Object has been destroyed` when the main window is torn down while `getWindowState()` is being read.

Electron keeps a `BrowserWindow`'s JS wrapper alive after `destroy()`, and `main.ts` only clears `mainWindow` on the `'closed'` event — which fires *after* the native side is gone (there is an explicit comment on that handler: *"the closed wrapper remains truthy"*). Optional chaining is therefore not a guard here: `win?.isFullScreen?.()` finds the method, **invokes** it, and the native binding throws.

`getWindowState()` is spread into the ready/IPC payloads the renderer boots on (`main.ts:7851`, `:7953`, `:8090`, `:8285`), so that throw is what the user sees as **"Desktop boot failed"**.

The fix adds pure liveness helpers to `apps/desktop/electron/window-state.ts` and reads through them. Behaviour for a live window is unchanged — this is a guard, not a semantics change; a destroyed or absent window now degrades to the same defaults the absent-window path already produced (`false` for the three booleans, `WINDOW_BUTTON_POSITION` for the traffic-light origin).

## Related Issue

Fixes #38468

### Supersedes

- **Supersedes #38589** (@xxxigm) — patches `apps/desktop/electron/main.cjs`, which `39d09453f95e` renamed to `apps/desktop/electron/main.ts`. The file it edits no longer exists on `main`, so it cannot apply. The review on it asked for the TypeScript port; no port was pushed.
- **Supersedes #45990** (@tonychuang738-lang) — same problem, and the inline review on `main.cjs:3278` said so directly:

  > Current main no longer ships this CJS entrypoint: `39d09453f95e…` renamed it to `apps/desktop/electron/main.ts`, which the bundler uses. Please port this guard to the corresponding TypeScript helper.

  No port was pushed there either. This PR is that port.

Neither PR is closed by this one — that's for their authors / maintainers to decide.

### Superset of the previous attempts

#45990 is `+4/-2` and guards **only** `isFullScreen()`, leaving `isMinimized()` and `isVisible()` free to throw from the same payload. This PR covers **all four** throwing accessors:

| Site | Guarded before | Guarded here |
| --- | --- | --- |
| `getWindowState` → `isFullScreen()` | only in #45990 | ✅ |
| `getWindowState` → `isMinimized()` | ✗ | ✅ |
| `getWindowState` → `isVisible()` | ✗ | ✅ |
| `getWindowButtonPosition()` | ✗ | ✅ |
| `hermes:profile:set` → `mainWindow?.reload()` | ✗ | ✅ |

The fifth is the same construct found by grepping `main.ts` for optional-chained window calls: it runs after an awaited `teardownPrimaryBackendAndWait()`, so the window can be gone by the time it fires. The only other hit, `applyTitleBarOverlay`'s `win?.setTitleBarOverlay?.(options)`, is already inside a `try/catch` and is deliberately left alone.

### Consistent with the file's own idiom

`main.ts` already uses `isDestroyed()` in 65 places — including `sendBackendExit()`, nine lines below `getWindowState()`:

```ts
if (!mainWindow || mainWindow.isDestroyed()) {
  return
}
```

These two functions were the stragglers. The helpers live in `window-state.ts` because they are side-effect-free and the failure is only reproducible against a fake window, which is exactly that module's stated contract (*"Side-effect-free so the part that actually matters is unit-testable without booting Electron"*). No existing export in that file is renamed or changed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/window-state.ts` — add three pure helpers and export them:
  - `isWindowLive(win)` — `Boolean(win) && typeof win.isDestroyed === 'function' && !win.isDestroyed()`. `isDestroyed` is itself probed, because callers legitimately pass `undefined` (no window yet) or a plain object stand-in.
  - `windowChromeState(win)` — the `isFullscreen` / `isMinimized` / `isVisible` triple, all-`false` for an absent or destroyed window.
  - `windowButtonPosition(win, fallback)` — traffic-light origin, falling back exactly as the old `|| WINDOW_BUTTON_POSITION` did.
- `apps/desktop/electron/main.ts` — `getWindowState()` spreads `windowChromeState(win)` (same keys, same order, same values for a live window); `getWindowButtonPosition()` returns `windowButtonPosition(mainWindow, WINDOW_BUTTON_POSITION)` and keeps its `IS_MAC` early-return first; `hermes:profile:set` gates its `reload()` on `isWindowLive`.
- `apps/desktop/electron/window-state.test.ts` — 8 tests for the guards, including the regression that encodes this issue.

## How to Test

1. `cd apps/desktop && npm run test:desktop:platforms` → `Test Files 68 passed | 1 skipped (69)`, `Tests 801 passed | 2 skipped (803)`.
2. Confirm the tests actually cover the fix: neutralise the two `if (!isWindowLive(win))` guards in `window-state.ts` and re-run — **3 tests fail** with `TypeError: Object has been destroyed`, thrown from the fake window's accessors through `windowChromeState` and `windowButtonPosition`. Restore them and it is green again.
3. `npm run typecheck` — `tsc -p tsconfig.electron.json --noEmit` and `tsc -p tsconfig.e2e.json --noEmit` both clean. (`tsc -p .` reports 4 pre-existing errors in `src/debug/render-counter.ts` about a missing `bippy` module; identical on a clean checkout of `main`, unrelated to this change.)
4. `npm run lint` — 0 errors.

The regression test builds the shape Electron actually hands back after `destroy()`: a wrapper that still exposes every method, where each one throws.

```ts
const destroyedWindow = () => {
  const destroyed = () => {
    throw new TypeError('Object has been destroyed')
  }

  return {
    isDestroyed: () => true,
    isFullScreen: destroyed,
    isMinimized: destroyed,
    isVisible: destroyed,
    getWindowButtonPosition: destroyed
  }
}
```

Also covered: a live window passes through unchanged (the byte-identical-behaviour guarantee), `undefined` / `null` behave as they did under `?.`, an object with no `isDestroyed` is treated as not-live rather than probed further, and a live window with no traffic-light position still gets the fallback.

`apps/desktop/package.json` needs no change — `vitest.config.ts` collects `electron/**/*.test.ts` into the `electron` project.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is Electron/TypeScript only; ran the desktop vitest suite instead (see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the `window-state.ts` module docstring now mentions the liveness guards
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the guards are platform-independent; `getWindowButtonPosition()` keeps its `IS_MAC` early return, so Windows/Linux still get `null`. The reported crash is macOS remote-gateway, but the race is not macOS-specific.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
