### PR TITLE
fix(model-normalize): strip matching aggregator prefix so provider-as-prefix names resolve

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -410,7 +410,17 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     # --- Aggregators: need vendor/model format ---
     if provider in _AGGREGATOR_PROVIDERS:
-        return _prepend_vendor(name)
+        # A name whose ``/`` prefix is the aggregator itself (e.g.
+        # ``openrouter/deepseek-v4-pro``) is not a real ``vendor/model`` slug
+        # — the prefix is the provider, not a vendor.  ``_prepend_vendor``
+        # treats any slash-bearing name as already resolved and passes it
+        # through unchanged, so the aggregator rejects it with HTTP 400 "not a
+        # valid model ID".  Strip the matching provider prefix first so
+        # ``_prepend_vendor`` re-attaches the correct vendor
+        # (``deepseek/deepseek-v4-pro``).  A genuine ``vendor/model`` slug like
+        # ``anthropic/claude-sonnet-4.6`` is untouched because its prefix does
+        # not match the provider.  See issue #72418.
+        return _prepend_vendor(_strip_matching_provider_prefix(name, provider))
 
     # --- OpenCode Zen / OpenCode Go: flat-namespace resellers.
     #     Their /v1/models API returns bare IDs only (no vendor prefix), and

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -164,6 +164,50 @@ class TestAggregatorProviders:
         assert result == "anthropic/claude-sonnet-4.6"
 
 
+# ── Aggregator provider-prefix repair (issue #72418) ───────────────────
+
+class TestIssue72418AggregatorProviderPrefix:
+    """Aggregators must repair a ``provider/`` prefix that matches themselves.
+
+    A name like ``openrouter/deepseek-v4-pro`` carries the *aggregator* as its
+    prefix, not a real vendor.  ``_prepend_vendor`` used to treat any
+    slash-bearing name as already-resolved and pass it through, so the
+    aggregator API received ``openrouter/deepseek-v4-pro`` and rejected it with
+    HTTP 400 "not a valid model ID".  The matching provider prefix must be
+    stripped so the correct vendor is re-attached.
+    """
+
+    @pytest.mark.parametrize("model,provider,expected", [
+        # The reported bug: provider-as-prefix on a bare model name.
+        ("openrouter/deepseek-v4-pro", "openrouter", "deepseek/deepseek-v4-pro"),
+        ("openrouter/gpt-5.4", "openrouter", "openai/gpt-5.4"),
+        ("openrouter/claude-sonnet-4.6", "openrouter", "anthropic/claude-sonnet-4.6"),
+        # Same class of bug on the other aggregators.
+        ("nous/deepseek-v4-pro", "nous", "deepseek/deepseek-v4-pro"),
+        ("kilocode/glm-5.2", "kilocode", "z-ai/glm-5.2"),
+        # Case-insensitive provider prefix.
+        ("OpenRouter/deepseek-v4-pro", "openrouter", "deepseek/deepseek-v4-pro"),
+    ])
+    def test_matching_provider_prefix_is_stripped(self, model, provider, expected):
+        assert normalize_model_for_provider(model, provider) == expected
+
+    @pytest.mark.parametrize("model,provider,expected", [
+        # A genuine vendor/model slug must survive untouched.
+        ("anthropic/claude-sonnet-4.6", "openrouter", "anthropic/claude-sonnet-4.6"),
+        ("deepseek/deepseek-v4-pro", "openrouter", "deepseek/deepseek-v4-pro"),
+        ("moonshotai/kimi-k2.5", "openrouter", "moonshotai/kimi-k2.5"),
+        # A non-matching provider prefix is left for the API to handle.
+        ("anthropic/claude-sonnet-4.6", "nous", "anthropic/claude-sonnet-4.6"),
+    ])
+    def test_real_vendor_prefix_is_preserved(self, model, provider, expected):
+        assert normalize_model_for_provider(model, provider) == expected
+
+    def test_bare_name_still_prepends_vendor(self):
+        """No prefix at all still gets the vendor prepended (unchanged behavior)."""
+        assert normalize_model_for_provider("claude-sonnet-4.6", "openrouter") == "anthropic/claude-sonnet-4.6"
+        assert normalize_model_for_provider("gpt-5.4", "nous") == "openai/gpt-5.4"
+
+
 class TestIssue6211NativeProviderPrefixNormalization:
     @pytest.mark.parametrize("model,target_provider,expected", [
         ("zai/glm-5.1", "zai", "glm-5.1"),


### PR DESCRIPTION
## Summary

Fixes #72418.

When a model name carries the **aggregator itself** as its ``/`` prefix (e.g. ``openrouter/deepseek-v4-pro`` instead of ``deepseek/deepseek-v4-pro``), ``normalize_model_for_provider`` passed it through unchanged. ``_prepend_vendor`` treats any slash-bearing name as already-resolved, so the request reached OpenRouter as ``openrouter/deepseek-v4-pro`` and was rejected with HTTP 400 "not a valid model ID".

This is easy to hit: typing ``/model openrouter/<name>`` (or a model picker sending the wrong prefix) stores the bad override, and every subsequent call fails until the override is cleared.

## Root cause

`hermes_cli/model_normalize.py`, aggregator branch:

```python
if provider in _AGGREGATOR_PROVIDERS:
    return _prepend_vendor(name)   # any name with "/" is returned as-is
```

``_prepend_vendor`` short-circuits on any ``/``, so a name whose prefix is the **provider** (not a real vendor) survives untouched.

## Fix

For aggregator providers (openrouter, nous, kilocode), strip a matching provider prefix first — reusing the existing ``_strip_matching_provider_prefix`` helper — so ``_prepend_vendor`` re-attaches the correct vendor:

```python
if provider in _AGGREGATOR_PROVIDERS:
    return _prepend_vendor(_strip_matching_provider_prefix(name, provider))
```

- ``openrouter/deepseek-v4-pro`` → ``deepseek/deepseek-v4-pro`` ✅ (was: unchanged → HTTP 400)
- ``openrouter/gpt-5.4`` → ``openai/gpt-5.4``
- ``nous/claude-opus-4.6`` → ``anthropic/claude-opus-4.6``
- ``OpenRouter/deepseek-v4-pro`` → ``deepseek/deepseek-v4-pro`` (case-insensitive prefix)
- Genuine ``vendor/model`` slugs like ``anthropic/claude-sonnet-4.6`` are **untouched** (prefix ≠ provider).
- Bare names like ``claude-sonnet-4.6`` still get the vendor prepended as before.

``_strip_matching_provider_prefix`` only strips when the prefix resolves to the same canonical provider id, so a real vendor prefix (``anthropic/``, ``deepseek/``, ``moonshotai/``) is never mangled.

## Testing

- New ``TestIssue72418AggregatorProviderPrefix`` in ``tests/hermes_cli/test_model_normalize.py``: covers the reported case, all three aggregators, case-insensitive prefixes, preserved real-vendor prefixes, and the unchanged bare-name path.
- Verified the 6 prefix-stripping cases **fail** with the fix reverted and **pass** with it applied (real regression coverage, not change-detectors).
- ``tests/hermes_cli/test_model_normalize.py``: 96 passed.
- Ran the adjacent model-switch / provider-resolution suites (17 files). All pass in isolation; a pre-existing set of 7 test-ordering failures in ``tests/agent/test_auxiliary_main_first.py`` reproduce **with and without** this change (they use the ``custom`` provider, which this fix does not touch) and pass when that file runs alone — i.e. unrelated module-global pollution, not introduced here.
- ``ruff check`` on both changed files: clean.

Co-Authored-By: Clark Code <noreply@clarkchat.com>