### PR TITLE
Fix Langfuse trace finalization for gateway turns

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -101,6 +101,16 @@ def _debug(message: str) -> None:
         logger.info("Langfuse tracing: %s", message)
 
 
+def _debug_exception(action: str, exc: Exception) -> None:
+    """Record a diagnostic without leaking exception-controlled payloads.
+
+    SDK and transport exceptions may embed request bodies, credentials, trace
+    IDs, or provider responses.  Finalization diagnostics therefore expose the
+    actionable exception class while deliberately redacting the message.
+    """
+    _debug(f"{action} failed: {type(exc).__name__}: <redacted>")
+
+
 # Sentinel: "_get_langfuse() has tried and failed". Lets us short-circuit
 # every subsequent hook call without re-checking env vars or re-attempting
 # SDK init. Tests clear this by reloading the module via
@@ -221,7 +231,10 @@ def _get_langfuse() -> Optional[Langfuse]:
     try:
         _LANGFUSE_CLIENT = Langfuse(**kwargs)
     except Exception as exc:  # pragma: no cover - fail-open
-        logger.warning("Could not initialize Langfuse client: %s", exc)
+        logger.warning(
+            "Could not initialize Langfuse client: %s: <redacted>",
+            type(exc).__name__,
+        )
         _LANGFUSE_CLIENT = _INIT_FAILED
         return None
 
@@ -595,7 +608,7 @@ def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, 
             except Exception:
                 cost_details["total"] = float(cost.amount_usd)
     except Exception as exc:  # pragma: no cover - fail-open
-        _debug(f"usage normalization failed: {exc}")
+        _debug_exception("usage normalization", exc)
 
     return usage_details, cost_details
 
@@ -603,7 +616,15 @@ def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, 
 def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform: str, provider: str, model: str,
                       api_mode: str, messages: Any, client: Langfuse,
                       turn_id: str = "", api_request_id: str = "") -> TraceState:
-    trace_id = client.create_trace_id(seed=f"{session_id or 'sessionless'}::{task_id or task_key}")
+    # ``create_trace_id(seed=...)`` is deterministic.  A seed scoped only to
+    # session/task made every turn in a long-lived gateway conversation reuse
+    # one Langfuse trace ID, so later turns updated the original trace instead
+    # of creating the expected per-turn trace.  Prefer the unique turn ID;
+    # request ID is the compatibility fallback for request-scoped callers.
+    trace_scope = turn_id or api_request_id or task_key
+    trace_id = client.create_trace_id(
+        seed=f"{session_id or 'sessionless'}::{task_id or task_key}::{trace_scope}"
+    )
     trace_input = _extract_last_user_message(messages)
     metadata = {
         "source": "hermes",
@@ -663,7 +684,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
     except Exception:
         pass
 
-    _debug(f"started trace {trace_id} for {task_key}")
+    _debug("started root trace")
     return TraceState(trace_id=trace_id, root_ctx=root_ctx, root_span=root_span)
 
 
@@ -698,7 +719,7 @@ def _end_observation(observation: Any, *, output: Any = None, metadata: Optional
             observation.update(**update_kwargs)
         observation.end()
     except Exception as exc:  # pragma: no cover - fail-open
-        _debug(f"end observation failed: {exc}")
+        _debug_exception("end observation", exc)
 
 
 def _merge_trace_output(output: Any, state: TraceState) -> Any:
@@ -731,19 +752,23 @@ def _evict_stale_locked() -> None:
         try:
             state.root_span.end()
         except Exception as exc:  # pragma: no cover - fail-open
-            _debug(f"evict stale trace failed: {exc}")
+            _debug_exception("evict stale trace", exc)
 
 
 def _finish_trace(task_key: str, *, output: Any = None) -> None:
+    _debug("finish trace entered")
     client = _get_langfuse()
     if client is None:
+        _debug("finish trace skipped: client unavailable")
         return
 
     with _STATE_LOCK:
         state = _TRACE_STATE.pop(task_key, None)
     if state is None:
+        _debug("finish trace state not found")
         return
 
+    _debug("finish trace state found")
     try:
         for observation in state.generations.values():
             _end_observation(observation)
@@ -754,16 +779,31 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
                 _end_observation(observation)
         final_output = _merge_trace_output(output, state)
         if final_output is not None:
-            state.root_span.set_trace_io(output=final_output)
-            state.root_span.update(output=final_output)
-        state.root_span.end()
+            try:
+                state.root_span.set_trace_io(output=final_output)
+                state.root_span.update(output=final_output)
+            except Exception as exc:  # pragma: no cover - fail-open
+                _debug_exception("finish trace root output update", exc)
+        try:
+            state.root_span.end()
+            _debug("finish trace root span ended")
+        except Exception as exc:  # pragma: no cover - fail-open
+            _debug_exception("finish trace root span end", exc)
     except Exception as exc:  # pragma: no cover - fail-open
-        _debug(f"finish trace failed: {exc}")
+        _debug_exception("finish trace finalization", exc)
     finally:
         try:
+            if state.root_ctx is not None:
+                state.root_ctx.__exit__(None, None, None)
+                _debug("finish trace root context exited")
+        except Exception as exc:  # pragma: no cover - fail-open
+            _debug_exception("finish trace root context exit", exc)
+        try:
+            _debug("finish trace flush invoked")
             client.flush()
-        except Exception:
-            pass
+            _debug("finish trace flush completed")
+        except Exception as exc:  # pragma: no cover - fail-open
+            _debug_exception("finish trace flush", exc)
 
 
 def _assistant_has_tool_calls(message: Any) -> bool:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -356,8 +356,9 @@ class TestTurnTraceIsolation:
 
         # Turn 2 finalized and was popped by _finish_trace; only turn 1's
         # (non-finalizing) state lingers.  Assert the surviving key is turn 1's
-        # and that turn 2 never merged into it — `all(...)` over an empty set
+        # turn 2 never merged into it — `all(...)` over an empty set
         # would pass vacuously, so pin the exact surviving key instead.
+        assert len(set(started)) == 2
         keys = list(mod._TRACE_STATE.keys())
         assert len(keys) == 1
         assert "turn1" in keys[0]
@@ -413,6 +414,129 @@ class TestTurnTraceIsolation:
         assert tk("", "s") == "session:s"
         # turn_id wins over api_request_id when both are present.
         assert tk("t", "s", turn_id="u", api_request_id="r") == "task:t:turn:u"
+
+
+class TestTraceFinalization:
+    """Finalization must close the root lifecycle and never break Hermes."""
+
+    LOGGER_NAME = "plugins.observability.langfuse"
+
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    @staticmethod
+    def _state(mod, *, fail_end=False):
+        events = []
+
+        class _RootSpan:
+            def set_trace_io(self, **kwargs):
+                events.append("set_trace_io")
+
+            def update(self, **kwargs):
+                events.append("update")
+
+            def end(self):
+                events.append("root_end")
+                if fail_end:
+                    raise RuntimeError("sk-lf-secret prompt payload")
+
+        class _RootContext:
+            def __exit__(self, exc_type, exc, tb):
+                events.append("root_context_exit")
+                return False
+
+        return mod.TraceState(
+            trace_id="test-trace-id",
+            root_ctx=_RootContext(),
+            root_span=_RootSpan(),
+        ), events
+
+    def test_finish_trace_ends_root_exits_context_and_flushes(self, monkeypatch):
+        mod = self._fresh_plugin()
+        state, events = self._state(mod)
+        task_key = "task-finalize"
+        flushes = []
+
+        class _Client:
+            def flush(self):
+                flushes.append(True)
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _Client())
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        mod._finish_trace(task_key, output={"content": "synthetic"})
+
+        assert "root_end" in events
+        assert "root_context_exit" in events
+        assert events.index("root_end") < events.index("root_context_exit")
+        assert flushes == [True]
+        assert task_key not in mod._TRACE_STATE
+
+    def test_finish_trace_flush_failure_is_debug_sanitized_and_fail_open(self, monkeypatch, caplog):
+        mod = self._fresh_plugin()
+        state, events = self._state(mod, fail_end=True)
+        task_key = "task-finalize"
+
+        class _Client:
+            def flush(self):
+                raise RuntimeError("sk-lf-secret prompt payload")
+
+        monkeypatch.setenv("HERMES_LANGFUSE_DEBUG", "true")
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _Client())
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            mod._finish_trace(task_key, output={"content": "synthetic"})
+
+        assert task_key not in mod._TRACE_STATE
+        assert "root_end" in events
+        assert "root_context_exit" in events
+        assert "sk-lf-secret" not in caplog.text
+        assert "prompt payload" not in caplog.text
+        assert "RuntimeError: <redacted>" in caplog.text
+        assert "flush invoked" in caplog.text
+
+    def test_finish_trace_child_finalization_error_is_debug_sanitized(self, monkeypatch, caplog):
+        mod = self._fresh_plugin()
+        state, _ = self._state(mod)
+
+        class _FailingChild:
+            def end(self):
+                raise RuntimeError("sk-lf-secret prompt payload")
+
+        class _Client:
+            def flush(self):
+                pass
+
+        state.generations["1"] = _FailingChild()
+        monkeypatch.setenv("HERMES_LANGFUSE_DEBUG", "true")
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _Client())
+        monkeypatch.setitem(mod._TRACE_STATE, "task-finalize", state)
+
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            mod._finish_trace("task-finalize")
+
+        assert "sk-lf-secret" not in caplog.text
+        assert "prompt payload" not in caplog.text
+        assert "end observation failed: RuntimeError: <redacted>" in caplog.text
+
+    def test_finish_trace_diagnostics_are_disabled_by_default(self, monkeypatch, caplog):
+        mod = self._fresh_plugin()
+        state, _ = self._state(mod)
+
+        class _Client:
+            def flush(self):
+                raise RuntimeError("sk-lf-secret prompt payload")
+
+        monkeypatch.delenv("HERMES_LANGFUSE_DEBUG", raising=False)
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _Client())
+        monkeypatch.setitem(mod._TRACE_STATE, "task-finalize", state)
+
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            mod._finish_trace("task-finalize")
+
+        assert caplog.records == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

- The plugin can create the root observation for a live gateway turn but never persist the trace.
- The finalization lifecycle does not deterministically scope and close the root span context by gateway turn before flushing.
- Flush/finalization failures are silently swallowed, making the failure operationally invisible.

## Fix

- Scope trace state deterministically by gateway turn.
- Correctly end and exit the root span context before calling `client.flush()`.
- Add debug-gated diagnostics for finalization and flush lifecycle.
- Emit only sanitized state and exception classes.
- Preserve fail-open behavior so observability failures never break the agent loop.

Fixes #32005.

## Validation

- focused Langfuse tests: 52/52 passed;
- full Hermes plugin suite: 1,985/1,985 passed;
- live gateway trace persisted with debug enabled;
- live tool-call trace persisted with a TOOL observation;
- live gateway trace persisted with debug disabled;
- gateway remained healthy with zero automatic restarts.