### PR TITLE
fix(hindsight): preserve shared observation scopes

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -19,7 +19,7 @@ Config via environment variables:
   HINDSIGHT_IDLE_TIMEOUT           — embedded daemon idle timeout seconds; 0 disables shutdown (default: 300)
   HINDSIGHT_EMBED_PORT_HEALTH_GRACE_TIMEOUT — seconds to wait for a slow embedded daemon /health before treating it as stale (default: 30; set via config.json port_health_grace_timeout)
   HINDSIGHT_RETAIN_TAGS            — comma-separated tags attached to retained memories
-  HINDSIGHT_RETAIN_OBSERVATION_SCOPES — observation scoping for retained memories: per_tag/combined/all_combinations, or a JSON list of tag-lists for custom scopes
+  HINDSIGHT_RETAIN_OBSERVATION_SCOPES — observation scoping for retained memories: per_tag/combined/all_combinations/shared, or a JSON list of tag-lists for custom scopes
   HINDSIGHT_RETAIN_SOURCE          — metadata source value attached to retained memories
   HINDSIGHT_RETAIN_USER_PREFIX     — label used before user turns in retained transcripts
   HINDSIGHT_RETAIN_ASSISTANT_PREFIX — label used before assistant turns in retained transcripts
@@ -441,7 +441,7 @@ def _normalize_retain_tags(value: Any) -> List[str]:
     return normalized
 
 
-_OBSERVATION_SCOPE_KEYWORDS = {"per_tag", "combined", "all_combinations"}
+_OBSERVATION_SCOPE_KEYWORDS = {"per_tag", "combined", "all_combinations", "shared"}
 
 
 def _normalize_observation_scopes(value: Any) -> Any:
@@ -449,7 +449,8 @@ def _normalize_observation_scopes(value: Any) -> Any:
 
     Returns one of:
       * ``None`` — nothing configured; Hindsight applies its ``combined`` default.
-      * a keyword string — ``"per_tag"`` / ``"combined"`` / ``"all_combinations"``.
+      * a keyword string — ``"per_tag"`` / ``"combined"`` /
+        ``"all_combinations"`` / ``"shared"``.
       * ``list[list[str]]`` — custom scopes, one inner list per consolidation pass.
 
     Accepts a keyword string, a JSON-encoded list, a flat list of tags (treated as
@@ -1076,7 +1077,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
             {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
             {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
-            {"key": "observation_scopes", "description": "How observations are scoped during consolidation: 'combined' (default — one pass over all tags), 'per_tag' (one isolated observation per tag), 'all_combinations' (every tag subset — expensive), or a JSON list of tag-lists for explicit custom scopes. Empty uses Hindsight's 'combined' default.", "default": ""},
+            {"key": "observation_scopes", "description": "How observations are scoped during consolidation: 'combined' (default — one pass over all tags), 'shared' (one global untagged scope across volatile session tags), 'per_tag' (one isolated observation per tag), 'all_combinations' (every tag subset — expensive), or a JSON list of tag-lists for explicit custom scopes. Empty uses Hindsight's 'combined' default.", "default": ""},
             {"key": "retain_source", "description": "Metadata source value attached to retained memories", "default": ""},
             {"key": "retain_user_prefix", "description": "Label used before user turns in retained transcripts", "default": "User"},
             {"key": "retain_assistant_prefix", "description": "Label used before assistant turns in retained transcripts", "default": "Assistant"},

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -276,9 +276,10 @@ class TestConfig:
         assert provider._recall_types == ["observation"]
 
 
-    def test_observation_scopes_keyword_config(self, provider_with_config):
-        p = provider_with_config(observation_scopes="per_tag")
-        assert p._observation_scopes == "per_tag"
+    @pytest.mark.parametrize("scope", ["per_tag", "shared"])
+    def test_observation_scopes_keyword_config(self, provider_with_config, scope):
+        p = provider_with_config(observation_scopes=scope)
+        assert p._observation_scopes == scope
 
 
     def test_custom_config_values(self, provider_with_config):


### PR DESCRIPTION
## Summary
- preserve the Hindsight API's `shared` observation scope instead of normalizing it away
- document `shared` in the Hindsight provider configuration
- cover provider initialization and `hindsight_retain` request forwarding for the scope

`shared` consolidates source facts across volatile provenance/session tags while retaining those tags on the source facts.

## Testing
- `pytest -q -n 0 tests/plugins/memory/test_hindsight_provider.py::test_normalize_observation_scopes_keywords_pass_through tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_observation_scopes_keyword_config tests/plugins/memory/test_hindsight_provider.py::TestToolHandlers::test_retain_passes_observation_scopes`
- `ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
