### PR TITLE
fix(agent): enforce delegate task spawn cap

### DIFF
--- a/agent/delegation_validation.py
+++ b/agent/delegation_validation.py
@@ -1,0 +1,58 @@
+"""Import-safe delegate_task argument normalization and validation."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Optional
+
+
+def recover_tasks_from_json_string(
+    tasks: Any,
+) -> tuple[Optional[list[dict[str, Any]]], Optional[str]]:
+    """Recover a model-emitted JSON string containing a task batch."""
+    if not isinstance(tasks, str):
+        return None, None
+    raw = tasks.strip()
+    if not raw:
+        return None, "Provide either 'goal' (single task) or 'tasks' (batch)."
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, (
+            "tasks must be a JSON array of task objects; received a string "
+            f"that could not be parsed as JSON ({exc.msg})."
+        )
+    if not isinstance(parsed, list):
+        return None, (
+            f"tasks must be a JSON array of task objects; parsed "
+            f"{type(parsed).__name__} instead."
+        )
+    return parsed, None
+
+
+def build_delegate_task_list(
+    *,
+    goal: Any,
+    context: Any,
+    role: Any,
+    tasks: Any,
+) -> tuple[Optional[list[dict[str, Any]]], Optional[str]]:
+    """Select single/batch mode and validate every task's goal."""
+    if tasks and isinstance(tasks, list):
+        task_list = tasks
+    elif goal and isinstance(goal, str) and goal.strip():
+        task_list = [{"goal": goal, "context": context, "role": role}]
+    else:
+        return None, "Provide either 'goal' (single task) or 'tasks' (batch)."
+
+    if not task_list:
+        return None, "No tasks provided."
+
+    for i, task in enumerate(task_list):
+        if not isinstance(task, Mapping):
+            return None, f"Task {i} must be an object, got {type(task).__name__}."
+        task_goal = task.get("goal")
+        if not isinstance(task_goal, str) or not task_goal.strip():
+            return None, f"Task {i} is missing a 'goal'."
+
+    return task_list, None

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -13,8 +13,12 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
-from utils import safe_json_loads
+from agent.delegation_validation import (
+    build_delegate_task_list,
+    recover_tasks_from_json_string,
+)
 from agent.tool_result_classification import file_mutation_result_landed
+from utils import safe_json_loads
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -287,6 +291,7 @@ class ToolCallGuardrailController:
         # single agent loop rather than accumulating across the session.
         self._turn_web_search_count = 0
         self._turn_subagent_count = 0
+        self._subagent_reservations: dict[ToolCallSignature, list[int]] = {}
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
@@ -299,8 +304,8 @@ class ToolCallGuardrailController:
         # These are hard ceilings on how many times a runaway-prone tool may
         # be called within a single agent loop (turn). They apply regardless
         # of hard_stop_enabled (which only governs the per-turn loop detector).
-        # We block BEFORE the call runs once the count is already at the cap,
-        # then increment for an allowed call so the (cap+1)-th is refused.
+        # We reserve each allowed call before execution and block when its
+        # projected total would cross the configured ceiling.
         cap_block = self._check_loop_cap(tool_name, _coerce_args(args), signature)
         if cap_block is not None:
             return cap_block
@@ -357,6 +362,8 @@ class ToolCallGuardrailController:
     ) -> ToolGuardrailDecision:
         args = _coerce_args(args)
         signature = ToolCallSignature.from_call(tool_name, args)
+        if tool_name == "delegate_task":
+            self._settle_subagent_reservation(signature, result)
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
 
@@ -485,13 +492,15 @@ class ToolCallGuardrailController:
             if not cap:
                 return None
             spawn_count = _subagent_spawn_count(args)
-            if self._turn_subagent_count >= cap:
+            projected_count = self._turn_subagent_count + spawn_count
+            if projected_count > cap:
                 decision = ToolGuardrailDecision(
                     action="block",
                     code="loop_subagent_cap",
                     message=(
-                        f"Blocked delegate_task: this turn has already spawned "
-                        f"{self._turn_subagent_count} subagents (limit {cap}). "
+                        f"Blocked delegate_task: this turn has already spawned or "
+                        f"reserved {self._turn_subagent_count} subagents, and this "
+                        f"call would add {spawn_count} (limit {cap}). "
                         "This looks like a runaway delegation loop. Finish the "
                         "work with the results you have and answer the user."
                     ),
@@ -502,9 +511,38 @@ class ToolCallGuardrailController:
                 self._halt_decision = decision
                 return decision
             self._turn_subagent_count += spawn_count
+            if spawn_count:
+                self._subagent_reservations.setdefault(signature, []).append(spawn_count)
             return None
 
         return None
+
+    def _settle_subagent_reservation(
+        self,
+        signature: ToolCallSignature,
+        result: str | None,
+    ) -> None:
+        """Replace a delegate call's reservation with its actual spawn count.
+
+        ``before_call`` must reserve the whole request so multiple calls cannot
+        race past the cap. The delegate result then tells us whether children
+        were actually created: synchronous results contain one entry per child,
+        while accepted background batches return a structured ``count``. Normal
+        preflight rejections return ``{"error": ...}`` and therefore release the
+        reservation. Unknown result shapes keep the reservation conservatively.
+        """
+        reservations = self._subagent_reservations.get(signature)
+        if not reservations:
+            return
+        reserved = reservations.pop(0)
+        if not reservations:
+            self._subagent_reservations.pop(signature, None)
+
+        actual = _subagent_result_spawn_count(result, fallback=reserved)
+        self._turn_subagent_count = max(
+            0,
+            self._turn_subagent_count - reserved + actual,
+        )
 
 
 def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
@@ -611,17 +649,48 @@ def _non_negative_int(value: Any, default: int) -> int:
 
 
 def _subagent_spawn_count(args: Mapping[str, Any]) -> int:
-    """How many subagents a single delegate_task call spawns.
+    """How many subagents a structurally valid delegate_task call requests.
 
     delegate_task runs in one of two modes: a batch (``tasks`` is a non-empty
-    list, one child per item) or a single task (``goal``). Count the batch size
-    when present, otherwise 1, so the session subagent cap reflects real spawns
-    rather than delegate_task invocations.
+    list, one child per item) or a single task (``goal``). Models may encode the
+    tasks array as a JSON string, which the delegate tool recovers before
+    spawning. Mirror that normalization here and return zero for malformed task
+    requests that the tool will reject before constructing a child.
     """
     tasks = args.get("tasks") if isinstance(args, Mapping) else None
-    if isinstance(tasks, list) and tasks:
-        return len(tasks)
-    return 1
+    recovered_tasks, tasks_error = recover_tasks_from_json_string(tasks)
+    if tasks_error:
+        return 0
+    if recovered_tasks is not None:
+        tasks = recovered_tasks
+
+    task_list, task_error = build_delegate_task_list(
+        goal=args.get("goal"),
+        context=args.get("context"),
+        role=args.get("role"),
+        tasks=tasks,
+    )
+    return len(task_list) if task_error is None and task_list is not None else 0
+
+
+def _subagent_result_spawn_count(result: str | None, *, fallback: int) -> int:
+    """Extract actual child construction count from a delegate_task result."""
+    parsed = safe_json_loads(result or "")
+    if not isinstance(parsed, Mapping):
+        return fallback
+
+    results = parsed.get("results")
+    if isinstance(results, list):
+        return len(results)
+
+    if parsed.get("status") == "dispatched":
+        count = parsed.get("count")
+        if isinstance(count, int) and not isinstance(count, bool) and count >= 0:
+            return count
+
+    if parsed.get("error"):
+        return 0
+    return fallback
 
 
 def _sha256(value: str) -> str:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -359,6 +359,101 @@ def test_subagent_cap_counts_batch_task_spawns():
     assert decision.code == "loop_subagent_cap"
 
 
+def test_subagent_cap_blocks_batch_that_crosses_remaining_budget():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_subagents=3))
+    )
+    assert controller.before_call("delegate_task", {"goal": "first"}).action == "allow"
+
+    decision = controller.before_call(
+        "delegate_task",
+        {"tasks": [{"goal": "a"}, {"goal": "b"}, {"goal": "c"}]},
+    )
+
+    assert decision.action == "block"
+    assert decision.code == "loop_subagent_cap"
+    assert controller._turn_subagent_count == 1
+
+
+def test_subagent_cap_counts_json_string_batch_like_native_list():
+    tasks = [{"goal": "a"}, {"goal": "b"}, {"goal": "c"}]
+    decisions = []
+    for tasks_arg in (tasks, json.dumps(tasks)):
+        controller = ToolCallGuardrailController(
+            ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_subagents=2))
+        )
+        decisions.append(controller.before_call("delegate_task", {"tasks": tasks_arg}))
+        assert controller._turn_subagent_count == 0
+
+    assert [decision.action for decision in decisions] == ["block", "block"]
+    assert {decision.code for decision in decisions} == {"loop_subagent_cap"}
+
+
+def test_rejected_delegate_batch_releases_reserved_spawn_budget():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_subagents=5))
+    )
+    args = {"tasks": [{"goal": str(i)} for i in range(4)]}
+    assert controller.before_call("delegate_task", args).action == "allow"
+    assert controller._turn_subagent_count == 4
+
+    controller.after_call(
+        "delegate_task",
+        args,
+        json.dumps({"error": "Too many tasks: max_concurrent_children is 3."}),
+        failed=True,
+    )
+
+    assert controller._turn_subagent_count == 0
+    assert controller.before_call("delegate_task", {"goal": "valid"}).action == "allow"
+
+
+def test_invalid_delegate_arguments_do_not_consume_spawn_budget():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_subagents=1))
+    )
+    invalid_calls = (
+        {"tasks": '[{"goal": "broken"}'},
+        {"tasks": ""},
+        {"tasks": [{"context": "missing goal"}]},
+        {},
+    )
+    for args in invalid_calls:
+        assert controller.before_call("delegate_task", args).action == "allow"
+        controller.after_call(
+            "delegate_task",
+            args,
+            json.dumps({"error": "invalid delegation request"}),
+            failed=True,
+        )
+
+    assert controller._turn_subagent_count == 0
+    assert controller.before_call("delegate_task", {"goal": "valid"}).action == "allow"
+
+
+def test_failed_child_result_still_consumes_spawn_budget():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_subagents=1))
+    )
+    args = {"goal": "child fails"}
+    assert controller.before_call("delegate_task", args).action == "allow"
+    controller.after_call(
+        "delegate_task",
+        args,
+        json.dumps(
+            {
+                "results": [
+                    {"task_index": 0, "status": "error", "error": "child failed"}
+                ]
+            }
+        ),
+        failed=True,
+    )
+
+    assert controller._turn_subagent_count == 1
+    assert controller.before_call("delegate_task", {"goal": "next"}).action == "block"
+
+
 def test_subagent_cap_resets_each_turn():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_subagents=1))

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -184,6 +184,46 @@ def test_same_tool_failure_warning_tells_model_to_recover_with_tools():
     assert "different tool" in content
 
 
+def test_delegate_cap_releases_rejected_call_but_counts_failed_child_spawn():
+    agent = _make_agent(
+        "delegate_task",
+        config={
+            "tool_loop_guardrails": {
+                "loop_caps": {"max_subagents": 1},
+            }
+        },
+    )
+    messages = []
+
+    def run(args: dict, call_id: str) -> None:
+        msg = SimpleNamespace(
+            content="",
+            tool_calls=[_mock_tool_call("delegate_task", json.dumps(args), call_id)],
+        )
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    def fake_dispatch(args: dict) -> str:
+        if not args.get("goal"):
+            return json.dumps({"error": "Provide either goal or tasks."})
+        return json.dumps(
+            {
+                "results": [
+                    {"task_index": 0, "status": "error", "error": "child failed"}
+                ]
+            }
+        )
+
+    with patch.object(agent, "_dispatch_delegate_task", side_effect=fake_dispatch) as dispatch:
+        run({}, "invalid")
+        run({"goal": "spawned but failed"}, "spawned")
+        run({"goal": "must be blocked"}, "blocked")
+
+    assert dispatch.call_count == 2
+    assert "Provide either goal or tasks" in messages[0]["content"]
+    assert "child failed" in messages[1]["content"]
+    assert "loop_subagent_cap" in messages[2]["content"]
+
+
 def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_and_preserves_result_order():
     agent = _make_agent("web_search", config=_hard_stop_config())
     blocked_args = {"query": "blocked"}

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -32,6 +32,10 @@ from concurrent.futures import (
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
+from agent.delegation_validation import (
+    build_delegate_task_list,
+    recover_tasks_from_json_string as _recover_tasks_from_json_string,
+)
 from toolsets import TOOLSETS
 
 # Sentinel value used by the runtime provider system for providers that are
@@ -2720,29 +2724,6 @@ def _run_child_lifecycle(
     return result
 
 
-def _recover_tasks_from_json_string(
-    tasks: Any,
-) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
-    if not isinstance(tasks, str):
-        return None, None
-    raw = tasks.strip()
-    if not raw:
-        return None, "Provide either 'goal' (single task) or 'tasks' (batch)."
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        return None, (
-            "tasks must be a JSON array of task objects; received a string "
-            f"that could not be parsed as JSON ({exc.msg})."
-        )
-    if not isinstance(parsed, list):
-        return None, (
-            f"tasks must be a JSON array of task objects; parsed "
-            f"{type(parsed).__name__} instead."
-        )
-    return parsed, None
-
-
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -2841,32 +2822,23 @@ def delegate_task(
     if recovered_tasks is not None:
         tasks = recovered_tasks
 
-    if tasks and isinstance(tasks, list):
-        if len(tasks) > max_children:
-            return tool_error(
-                f"Too many tasks: {len(tasks)} provided, but "
-                f"max_concurrent_children is {max_children}. "
-                f"Either reduce the task count, split into multiple "
-                f"delegate_task calls, or increase "
-                f"delegation.max_concurrent_children in config.yaml."
-            )
-        task_list = tasks
-    elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "role": top_role}]
-    else:
-        return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
+    if tasks and isinstance(tasks, list) and len(tasks) > max_children:
+        return tool_error(
+            f"Too many tasks: {len(tasks)} provided, but "
+            f"max_concurrent_children is {max_children}. "
+            f"Either reduce the task count, split into multiple "
+            f"delegate_task calls, or increase "
+            f"delegation.max_concurrent_children in config.yaml."
+        )
 
-    if not task_list:
-        return tool_error("No tasks provided.")
-
-    # Validate each task has a goal
-    for i, task in enumerate(task_list):
-        if not isinstance(task, dict):
-            return tool_error(
-                f"Task {i} must be an object, got {type(task).__name__}."
-            )
-        if not task.get("goal", "").strip():
-            return tool_error(f"Task {i} is missing a 'goal'.")
+    task_list, task_error = build_delegate_task_list(
+        goal=goal,
+        context=context,
+        role=top_role,
+        tasks=tasks,
+    )
+    if task_error:
+        return tool_error(task_error)
 
     overall_start = time.monotonic()
     results = []


### PR DESCRIPTION
## What does this PR do?

Fixes the `delegate_task` per-turn loop cap so it tracks subagents that can actually be spawned without allowing a batch to cross the configured ceiling.

The old guardrail checked only whether the existing count had reached the cap, then charged the raw request before `delegate_task` normalized or validated it. As a result, native batches could cross the remaining budget, JSON-string batches were counted as one, and executor-rejected calls could consume budget without creating a child.

This change uses a reservation/reconciliation model:

- normalize and structurally validate single and batch arguments through one import-safe helper shared by the guardrail and `delegate_task`;
- reject a call before execution when `current + requested > max_subagents`;
- reserve allowed requests so multiple calls cannot pass the same remaining budget;
- reconcile from structured results, releasing preflight rejections while retaining children that were created but later failed;
- conservatively retain the reservation for unknown result shapes.

Unlike a defer-only commit that truncates the counter after execution, this preserves the cap as a ceiling on actual child creation rather than only on the recorded count.

## Related Issue

Fixes #72550

Related prior work: #56447 established the projected-count boundary rule. 

Alternative implementation: #72561. This PR differs by reserving the full normalized request before execution; a three-child batch at a cap of two is rejected instead of spawning three children and recording only two.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added `agent/delegation_validation.py` for shared JSON recovery and task validation.
- Updated `ToolCallGuardrailController` to check projected spawn totals and reconcile reservations after execution.
- Reused the shared normalization path in `tools/delegate_tool.py` to prevent validation drift.
- Added unit and runtime coverage for cap crossings, JSON batches, rejected requests, invalid arguments, turn resets, and failed child execution.

## How to Test

1. Configure `LoopCapConfig(max_subagents=2)`.
2. Call `before_call("delegate_task", ...)` with either a native or JSON-string three-task batch.
3. Verify both calls are blocked before execution and the counter remains zero.
4. Reserve a batch that passes the loop cap but is rejected by `max_concurrent_children`, feed its structured error to `after_call()`, and verify a subsequent valid call is allowed.
5. Feed a result containing a failed child and verify that child still consumes one unit.

```text
Pre-fix probe on d71033a4077a:
- list batch at cap=2: allow, counter=3
- JSON batch at cap=2: allow, counter=1
- oversized batch: allow, counter=60; next valid call blocked

Post-fix probe:
- list batch at cap=2: block, counter=0
- JSON batch at cap=2: block, counter=0
- oversized batch: block without charging; next valid call allowed
```

```bash
scripts/run_tests.sh tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/tools/test_delegate.py
```

Result: 197 passed, 0 failed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and documented the overlap above.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repository test wrapper and all 197 targeted tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on macOS 26.5.2 with Python 3.11.15.

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior and fallback semantics are documented in code.
- [x] `cli-config.yaml.example` is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A; no workflow changed.
- [x] Cross-platform impact considered: the changed paths are pure Python data handling with no OS-specific I/O.
- [x] Tool schema updates are N/A; the model-facing schema is unchanged.

## Remaining Risk

The full repository suite was not run. Validation covers the complete existing `tests/tools/test_delegate.py` file plus the focused guardrail unit and runtime suites.
