### PR TITLE
fix(dashboard): remove deleted custom env keys

### DIFF
--- a/web/src/lib/env-state.test.ts
+++ b/web/src/lib/env-state.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import type { EnvVarInfo } from "./api";
+import { removeDeletedEnvVarFromState } from "./env-state";
+
+function envVar(overrides: Partial<EnvVarInfo> = {}): EnvVarInfo {
+  return {
+    is_set: true,
+    redacted_value: "secr...alue",
+    description: "",
+    url: null,
+    category: "provider",
+    is_password: true,
+    tools: [],
+    advanced: false,
+    ...overrides,
+  };
+}
+
+describe("removeDeletedEnvVarFromState", () => {
+  it("removes a deleted custom key from dashboard state", () => {
+    const vars = {
+      WHATSAPP_DEBUG: envVar({ category: "custom", custom: true }),
+      OPENAI_API_KEY: envVar(),
+    };
+
+    const updated = removeDeletedEnvVarFromState(vars, "WHATSAPP_DEBUG");
+
+    expect(updated).not.toHaveProperty("WHATSAPP_DEBUG");
+    expect(updated?.OPENAI_API_KEY).toBe(vars.OPENAI_API_KEY);
+  });
+
+  it("keeps a catalog key available while marking it unset", () => {
+    const vars = { OPENAI_API_KEY: envVar() };
+
+    const updated = removeDeletedEnvVarFromState(vars, "OPENAI_API_KEY");
+
+    expect(updated?.OPENAI_API_KEY).toEqual({
+      ...vars.OPENAI_API_KEY,
+      is_set: false,
+      redacted_value: null,
+    });
+  });
+});

--- a/web/src/lib/env-state.ts
+++ b/web/src/lib/env-state.ts
@@ -1,0 +1,21 @@
+import type { EnvVarInfo } from "./api";
+
+/** Reconcile a successful DELETE /api/env response with the Keys page state. */
+export function removeDeletedEnvVarFromState(
+  vars: Record<string, EnvVarInfo> | null,
+  key: string,
+): Record<string, EnvVarInfo> | null {
+  const info = vars?.[key];
+  if (!vars || !info) return vars;
+
+  if (info.custom) {
+    const updated = { ...vars };
+    delete updated[key];
+    return updated;
+  }
+
+  return {
+    ...vars,
+    [key]: { ...info, is_set: false, redacted_value: null },
+  };
+}

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import type { EnvVarInfo } from "@/lib/api";
+import { removeDeletedEnvVarFromState } from "@/lib/env-state";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
@@ -722,14 +723,7 @@ export default function EnvPage() {
         setSaving(key);
         try {
           await api.deleteEnvVar(key);
-          setVars((prev) =>
-            prev
-              ? {
-                  ...prev,
-                  [key]: { ...prev[key], is_set: false, redacted_value: null },
-                }
-              : prev,
-          );
+          setVars((prev) => removeDeletedEnvVarFromState(prev, key));
           setEdits((prev) => {
             const n = { ...prev };
             delete n[key];


### PR DESCRIPTION
## What does this PR do?

Removes arbitrary custom environment-variable rows from the dashboard immediately after `DELETE /api/env` succeeds, while preserving catalogued variables as unset rows so users can configure them again.

The backend already removes the assignment from `.env`. The bug was in the Keys page's optimistic state update: it converted every deleted key to `is_set: false`, which is correct for catalogued keys but leaves deleted custom keys as ghost rows until refresh.

## Related Issue

Fixes #72552

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `removeDeletedEnvVarFromState` to distinguish custom and catalogued key deletion state.
- Use the helper after a successful Keys-page delete.
- Add regression tests proving custom keys disappear and catalogued keys remain available as unset.

## How to Test

1. Run `cd web && pnpm run test`.
2. Run `pnpm run typecheck` and `pnpm run build` from `web/`.
3. In the dashboard Keys page, add a custom key, clear it, and confirm its row disappears without refreshing; clear a catalogued key and confirm it remains available to set again.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite was run, but the macOS baseline has unrelated failures; relevant env tests pass (16/16)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior now matches existing documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — frontend-only state transition
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

After rebasing onto current `main`, automated regression coverage exercises both custom-key removal and catalogued-key reset behavior. Web verification: 158 tests passed, TypeScript typecheck passed, changed-file ESLint passed, full web ESLint completed with 0 errors (26 warnings outside this diff), and the production build completed successfully.

Relevant backend env tests passed (16/16). The full Python suite completed with 33 failures across 15 platform/integration test files unrelated to this frontend-only diff; this PR changes only TypeScript dashboard code.
