### PR TITLE
fix(termux): prebuild psutil compatibility shim in setup-hermes.sh

### DIFF
--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -194,6 +194,20 @@ if is_termux; then
     export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk 2>/dev/null || printf '%s' "${ANDROID_API_LEVEL:-}")"
     echo -e "${CYAN}→${NC} Termux detected — installing the tested Android bundle"
     "$SETUP_PYTHON" -m pip install --upgrade pip setuptools wheel
+
+    # On Android, psutil's setup.py rejects sys.platform == 'android' before
+    # it ever invokes the C build, so the pip install below would fail at
+    # "platform android is not supported".  Prebuild psutil from the official
+    # sdist with a one-line marker patch (Linux source path is fine on
+    # Android).  Stopgap until psutil#2762 ships upstream.
+    if "$SETUP_PYTHON" -c 'import sys; raise SystemExit(0 if sys.platform == "android" else 1)' 2>/dev/null; then
+        echo -e "${CYAN}→${NC} Android Python detected: prebuilding psutil compatibility shim..."
+        if ! "$SETUP_PYTHON" "$SCRIPT_DIR/scripts/install_psutil_android.py" --pip "$SETUP_PYTHON -m pip"; then
+            echo -e "${YELLOW}⚠${NC} psutil Android prebuild failed — package install will likely fail next."
+            echo -e "${CYAN}→${NC} Workaround: manually rerun 'python scripts/install_psutil_android.py' once your toolchain is set up."
+        fi
+    fi
+
     if [ -f "constraints-termux.txt" ]; then
         "$SETUP_PYTHON" -m pip install -e ".[termux]" -c constraints-termux.txt || {
             echo -e "${YELLOW}⚠${NC} Termux bundle install failed, falling back to base install..."


### PR DESCRIPTION
## What does this PR do?

Fixes `setup-hermes.sh` (the manual dev quick-setup script) so it doesn't silently produce a broken install on Termux/Android.

On Termux, `setup-hermes.sh` currently jumps straight from creating the venv to `pip install -e ".[termux]" -c constraints-termux.txt`. Because upstream `psutil`'s `setup.py` rejects `sys.platform == "android"` before the build even starts, that install fails on `psutil` with `platform android is not supported` — the exact symptom in #31415. The script's own `-e` (`set -e`) *doesn't* catch this because the pip call is chained with `||` into a fallback that also fails, and the overall script still exits 0, leaving a venv containing only `pip`/`wheel`/`setuptools` and no actual `hermes` command.

`scripts/install.sh` (the one-line `curl | bash` installer) already works around this: it prebuilds `psutil` via the repo's own `scripts/install_psutil_android.py` shim before the `[termux]` install. `setup-hermes.sh` never got the equivalent step, so anyone following "Quick setup for developers who cloned the repo manually" on Termux hits this.

## Related Issue

Fixes #31415

Note: #44390 (open) already fixes the *documented* manual step-by-step guide in `website/docs/getting-started/termux.md` to include the psutil shim step. That guide never mentions `setup-hermes.sh`, so this PR is a separate, non-overlapping fix for the convenience script itself — confirmed no open PR currently touches `setup-hermes.sh`'s Termux branch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `setup-hermes.sh`: on Termux, detect `sys.platform == "android"` and run `scripts/install_psutil_android.py` (mirroring `install.sh`'s existing guard and warning message) before the `[termux]` pip install.

## How to Test

1. On a fresh Termux checkout of this branch: `rm -rf venv && ./setup-hermes.sh`
2. Without this fix, the install log shows `ERROR: Failed to build 'psutil' when getting requirements to build wheel` and the script still exits 0 with `venv/bin/` containing no `hermes` entry point.
3. With this fix, `Android Python detected: prebuilding psutil compatibility shim...` prints before the `[termux]` install, `pip install -e ".[termux]"` succeeds, and `hermes --version` / `hermes doctor` work afterward.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see note above re: #44390 / #67163 — neither touches `setup-hermes.sh`)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: Termux on Android (aarch64)

### Documentation & Housekeeping

- [x] N/A — no config keys, architecture, or tool schema changes; `website/docs/getting-started/termux.md` doesn't reference `setup-hermes.sh` so no doc update needed here