### PR TITLE
[AI] fix(gateway): use timezone-aware UTC timestamp for BlueBubbles tempGuid

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -15,7 +15,7 @@ import os
 import re
 import uuid
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -485,7 +485,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -541,7 +541,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:


### PR DESCRIPTION
## Summary

Fixes an incorrect timestamp in the BlueBubbles (iMessage) platform adapter when generating message tempGuid values.

gateway/platforms/bluebubbles.py used datetime.utcnow().timestamp(). Since utcnow() returns a naive datetime, .timestamp() interprets it in the local timezone, producing an epoch value offset by the local UTC offset (e.g. 8 hours off for UTC+8). datetime.utcnow() is also deprecated since Python 3.12 (this project supports >=3.11,<3.14).

Changed both occurrences to datetime.now(timezone.utc).timestamp(), which is the pattern already used elsewhere in this repo, and updated the import accordingly.

## Test Plan

- python -m pytest on the gateway tests: 60 passed.
- Repo-wide grep confirms no remaining datetime.utcnow() usages in this file.