### PR TITLE
fix(gateway): avoid re-import of hermes_cli.main in code_skew._fingerprint() (#72543)

### DIFF
--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -27,10 +27,22 @@ def _fingerprint() -> str | None:
     """Current checkout fingerprint, reusing the CLI's git-rev reader.
 
     ``hermes_cli.main`` is always already imported in a gateway process (it's
-    the entry point), so this import is free and avoids duplicating the
+    the entry point), so normally this import is free and avoids duplicating the
     worktree-aware ref resolution.
+
+    However, when launched via ``python -m hermes_cli.main`` the module is
+    first loaded as ``__main__``, not as ``hermes_cli.main``.  Re-importing
+    it via a ``from hermes_cli.main import ...`` would re-execute its
+    module-level code, including ``_apply_profile_override()`` — which would
+    strip ``--profile`` from argv again and then fall back to the sticky
+    active_profile, silently hijacking HERMES_HOME.  We therefore check
+    ``__main__`` first, which covers the ``-m`` case without a second import.
     """
     try:
+        __main_mod = __import__("__main__")
+        if hasattr(__main_mod, "_read_git_revision_fingerprint"):
+            return __main_mod._read_git_revision_fingerprint(_PROJECT_ROOT)
+
         from hermes_cli.main import _read_git_revision_fingerprint
 
         return _read_git_revision_fingerprint(_PROJECT_ROOT)


### PR DESCRIPTION
## Summary

When the gateway is launched via `python -m hermes_cli.main gateway run` (the exact ExecStart of the generated systemd user unit), the module is loaded as `__main__`, not as `hermes_cli.main`. The lazy import in `code_skew._fingerprint()` — `from hermes_cli.main import _read_git_revision_fingerprint` — therefore re-executes the entire module, including `_apply_profile_override()`.

The second execution of `_apply_profile_override()` finds no `--profile` flag left in argv (the first pass already consumed and stripped it), falls back to the sticky `~/.hermes/active_profile`, and overwrites `HERMES_HOME` to that profile's directory. The gateway's duplicate-PID guard then finds the already-running profile gateway and exits with status 1, causing a systemd restart loop.

## Fix

Check `__main__` first in `code_skew._fingerprint()`. When launched via `python -m`, `__main__` IS the `hermes_cli.main` module and already has `_read_git_revision_fingerprint` loaded. This avoids a second import entirely.

## Tests

- ✅ 12/12 `test_apply_profile_override.py` pass
- ✅ 10/10 `test_code_skew.py` pass
- ✅ 4/4 `test_read_git_revision_fingerprint` tests pass
- ✅ Syntax check passes

Closes #72543