### PR TITLE
fix(tools): recognise WeCom targets in _parse_target_ref

### DIFF
--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -55,6 +55,41 @@ def test_whatsapp_friendly_name_still_uses_directory_resolution() -> None:
     assert _parse_target_ref("whatsapp", "general")[2] is False
 
 
+def test_wecom_external_userid_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "wecom", "woGyl0EAAAF904oOQcB4CAMZr5piFDxQ"
+    )
+
+    assert chat_id == "woGyl0EAAAF904oOQcB4CAMZr5piFDxQ"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_wecom_corp_scoped_userid_is_explicit() -> None:
+    # The callback adapter emits ``corp_id:user_id`` chat IDs and splits on the
+    # first ``:`` to recover ``touser`` — a scoped reply target must round-trip.
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "wecom", "wwabc123:woGyl0EAAAF904oOQcB4CAMZr5piFDxQ"
+    )
+
+    assert chat_id == "wwabc123:woGyl0EAAAF904oOQcB4CAMZr5piFDxQ"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_wecom_userid_prefix_only_matches_wecom() -> None:
+    # The ``wo``-prefixed token must not be treated as explicit on other
+    # platforms, which have their own target grammars.
+    assert _parse_target_ref("telegram", "woGyl0EAAAF904oOQcB4CAMZr5piFDxQ")[2] is False
+    assert _parse_target_ref("weixin", "woGyl0EAAAF904oOQcB4CAMZr5piFDxQ")[2] is False
+
+
+def test_wecom_friendly_name_still_uses_directory_resolution() -> None:
+    # A human-friendly channel name lacks the ``wo`` prefix, so it falls through
+    # to channel-directory resolution rather than being sent verbatim.
+    assert _parse_target_ref("wecom", "sales-team")[2] is False
+
+
 def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
     whatsapp_cfg = SimpleNamespace(enabled=True, token=None, extra={"api_url": "http://bridge"})
     config = SimpleNamespace(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -34,6 +34,11 @@ _SLACK_MENTION_RE = re.compile(r"^\s*<@(U[A-Z0-9]{8,})(?:\|[^>]+)?>\s*$")
 # Session-derived Slack thread targets use "<conversation_id>:<thread_ts>".
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
+# WeCom external-contact user IDs are ``wo``-prefixed base64url tokens
+# (e.g. ``woGyl0EAAAF904oOQcB4CAMZr5piFDxQ``). The callback adapter also scopes
+# incoming chat IDs as ``corp_id:user_id`` (it splits on the first ``:`` to
+# recover ``touser``), so accept an optional corp prefix here too.
+_WECOM_TARGET_RE = re.compile(r"^\s*((?:[A-Za-z0-9._-]+:)?wo[A-Za-z0-9_-]+)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
@@ -568,6 +573,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             return trimmed[:split_idx], trimmed[split_idx + 1 :], True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
+    if platform_name == "wecom":
+        match = _WECOM_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
     if platform_name == "yuanbao":


### PR DESCRIPTION
## What does this PR do?

`hermes send -t wecom:<userid>` failed on v0.19.0 with `Could not resolve '<userid>' on wecom`.

`_parse_target_ref()` in `tools/send_message_tool.py` has a dedicated handler for every messaging platform — telegram, feishu, discord, slack, matrix, weixin, yuanbao, ntfy, email, whatsapp, signal, the E.164 phone platforms, and xmpp — but **WeCom was missing**. A WeCom external-contact user ID is not numeric and contains no `@`, so it fell through to the final `return None, None, False`, was treated as a non-explicit name, and was rejected by channel-directory resolution.

The fix mirrors the existing Weixin handler: a precompiled `_WECOM_TARGET_RE` plus a `platform_name == "wecom"` branch. WeCom external-contact IDs are `wo`-prefixed base64url tokens (e.g. `woGyl0EAAAF904oOQcB4CAMZr5piFDxQ`). The callback adapter also scopes incoming chat IDs as `corp_id:user_id` (it splits on the first `:` to recover `touser` — `plugins/platforms/wecom/callback_adapter.py:211`), so an optional `corp_id:` prefix is accepted to let scoped reply targets round-trip.

## Related Issue

Fixes #72566

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py` — add `_WECOM_TARGET_RE` constant and a `wecom` branch in `_parse_target_ref`, alongside the existing Weixin handler.
- `tests/tools/test_send_message_target_parse.py` — 4 parser tests: bare `wo…` ID explicit, `corp_id:wo…` scoped ID explicit, prefix rejected on other platforms (telegram/weixin), friendly name still falls through to directory resolution.

## How to Test

1. `hermes send -t wecom:woGyl0EAAAF904oOQcB4CAMZr5piFDxQ -m "test"` now resolves the target instead of erroring.
2. `uv run python -m pytest tests/tools/test_send_message_target_parse.py -q` → 11 passed.
3. The two positive assertions fail on `main` without the source change (verified by stashing the fix), confirming the tests actually gate the regression.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14

### Documentation & Housekeeping

- [x] No config keys added — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: pure-Python regex parsing, no platform-specific behavior
- [x] Tool behavior unchanged for every other platform — N/A for schema updates