### PR TITLE
fix(config): preserve config.yaml comments/formatting in `hermes config set` + `unset` (#63039, salvage of #50706)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4878,6 +4878,12 @@ def set_config_value(key: str, value: str, force: bool = False):
             coerced_value = float(value)
 
     value = coerced_value
+    # Snapshot the pre-write mapping so the round-trip writer below can apply
+    # only the changed paths and leave every untouched line — comments, blank
+    # lines, ordering, quoting — exactly as the user wrote it (#63039). Taken
+    # BEFORE the scalar-model normalization below so that normalization is
+    # part of the before/after diff and gets persisted.
+    _config_before_write = copy.deepcopy(user_config)
     # Normalize a scalar ``model`` key before writing sub-keys so that
     # ``hermes config set model.provider openai`` doesn't silently
     # destroy the model id when ``model`` is a bare string shorthand
@@ -4955,10 +4961,18 @@ def set_config_value(key: str, value: str, force: bool = False):
         user_config = _normalize_root_model_keys(user_config)
         key = "model.base_url"
         print("  (note: 'api_base' is an alias — saved as model.base_url)")
-    # Write only user config back (not the full merged defaults)
+    # Write only user config back (not the full merged defaults).
+    # Round-trip apply preserves the user's comments and formatting on every
+    # untouched key (#63039) — the same guarantee cli.py's save_config_value
+    # already gives via atomic_roundtrip_yaml_update. Files the round-trip
+    # parser rejects but PyYAML tolerates (e.g. duplicate keys) fall back to
+    # the historical plain dump so the write itself never regresses.
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    from utils import atomic_roundtrip_yaml_apply, atomic_yaml_write
+    try:
+        atomic_roundtrip_yaml_apply(config_path, _config_before_write, user_config)
+    except Exception:
+        atomic_yaml_write(config_path, user_config, sort_keys=False)
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.
@@ -5073,6 +5087,9 @@ def unset_config_value(key: str):
             )
             sys.exit(1)
 
+    # Snapshot for the round-trip diff below — the removal must not cost the
+    # user every comment and blank line in the rest of the file (#63039).
+    _config_before_write = copy.deepcopy(user_config)
     removed = _unset_nested(user_config, key)
 
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
@@ -5085,8 +5102,13 @@ def unset_config_value(key: str):
         sys.exit(1)
 
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    from utils import atomic_roundtrip_yaml_apply, atomic_yaml_write
+    try:
+        atomic_roundtrip_yaml_apply(config_path, _config_before_write, user_config)
+    except Exception:
+        # Same fallback contract as set_config_value: files the round-trip
+        # parser rejects still get the historical plain dump.
+        atomic_yaml_write(config_path, user_config, sort_keys=False)
     print(f"✓ Unset {key} from {config_path}")
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4966,12 +4966,19 @@ def set_config_value(key: str, value: str, force: bool = False):
     # untouched key (#63039) — the same guarantee cli.py's save_config_value
     # already gives via atomic_roundtrip_yaml_update. Files the round-trip
     # parser rejects but PyYAML tolerates (e.g. duplicate keys) fall back to
-    # the historical plain dump so the write itself never regresses.
+    # the historical plain dump so the write itself never regresses. Only
+    # RoundTripUnsupportedError falls back — filesystem/atomic-write failures
+    # propagate, so a failed write can never masquerade as a successful
+    # (comment-stripping) rewrite.
     ensure_hermes_home()
-    from utils import atomic_roundtrip_yaml_apply, atomic_yaml_write
+    from utils import (
+        RoundTripUnsupportedError,
+        atomic_roundtrip_yaml_apply,
+        atomic_yaml_write,
+    )
     try:
         atomic_roundtrip_yaml_apply(config_path, _config_before_write, user_config)
-    except Exception:
+    except RoundTripUnsupportedError:
         atomic_yaml_write(config_path, user_config, sort_keys=False)
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
@@ -5102,12 +5109,17 @@ def unset_config_value(key: str):
         sys.exit(1)
 
     ensure_hermes_home()
-    from utils import atomic_roundtrip_yaml_apply, atomic_yaml_write
+    from utils import (
+        RoundTripUnsupportedError,
+        atomic_roundtrip_yaml_apply,
+        atomic_yaml_write,
+    )
     try:
         atomic_roundtrip_yaml_apply(config_path, _config_before_write, user_config)
-    except Exception:
+    except RoundTripUnsupportedError:
         # Same fallback contract as set_config_value: files the round-trip
-        # parser rejects still get the historical plain dump.
+        # parser rejects still get the historical plain dump; write failures
+        # propagate rather than silently stripping comments.
         atomic_yaml_write(config_path, user_config, sort_keys=False)
     print(f"✓ Unset {key} from {config_path}")
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -723,3 +723,123 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+# Comment / formatting preservation (#63039)
+# ---------------------------------------------------------------------------
+
+class TestCommentPreservation:
+    """`hermes config set` must not destroy hand-edited config.yaml content.
+
+    Regression for #63039: set_config_value round-tripped the file through
+    PyYAML (fast_safe_load → atomic_yaml_write), which strips every comment,
+    blank line, and the user's key order on each write. The CLI's own
+    save_config_value (cli.py) already preserves them via ruamel round-trip;
+    this class pins the same contract onto the `hermes config set` path.
+    Test matrix extends the cases contributed in #63140.
+    """
+
+    CONFIG = (
+        "# Hermes main config — hand-maintained; ask in #infra before editing.\n"
+        "model:\n"
+        "  default: gpt-5.2  # pinned for eval reproducibility\n"
+        "  provider: openai\n"
+        "\n"
+        "# Terminal execution backend: docker isolates agent commands.\n"
+        "terminal:\n"
+        "  backend: docker\n"
+        "\n"
+        "custom_providers:\n"
+        "  - name: local-vllm  # dev box\n"
+        "    api_key: old-key\n"
+        "  - name: prod-endpoint\n"
+        "    api_key: prod-key\n"
+    )
+
+    def _seed(self, home):
+        (home / "config.yaml").write_text(self.CONFIG)
+
+    def test_header_comment_survives_unrelated_set(self, _isolated_hermes_home):
+        self._seed(_isolated_hermes_home)
+        set_config_value("tts.provider", "elevenlabs")
+        text = _read_config(_isolated_hermes_home)
+        assert "# Hermes main config — hand-maintained" in text
+        assert "provider: elevenlabs" in text
+
+    def test_inline_comment_on_untouched_key_survives(self, _isolated_hermes_home):
+        self._seed(_isolated_hermes_home)
+        set_config_value("terminal.backend", "ssh")
+        text = _read_config(_isolated_hermes_home)
+        assert "# pinned for eval reproducibility" in text
+        assert "backend: ssh" in text
+
+    def test_section_comment_survives_sibling_write(self, _isolated_hermes_home):
+        self._seed(_isolated_hermes_home)
+        set_config_value("model.provider", "anthropic")
+        text = _read_config(_isolated_hermes_home)
+        assert "# Terminal execution backend: docker isolates agent commands." in text
+        assert "provider: anthropic" in text
+
+    def test_blank_lines_and_key_order_survive(self, _isolated_hermes_home):
+        self._seed(_isolated_hermes_home)
+        set_config_value("terminal.backend", "ssh")
+        text = _read_config(_isolated_hermes_home)
+        # model section still precedes terminal, blank separators intact.
+        assert text.index("model:") < text.index("terminal:") < text.index("custom_providers:")
+        assert "\n\n" in text
+
+    def test_indexed_list_write_keeps_sibling_element_comments(self, _isolated_hermes_home):
+        """Indexed paths (#17876 semantics) must not flatten the list's comments."""
+        self._seed(_isolated_hermes_home)
+        set_config_value("custom_providers.0.api_key", "new-key")
+        text = _read_config(_isolated_hermes_home)
+        assert "# dev box" in text
+        import yaml as _yaml
+        data = _yaml.safe_load(text)
+        assert data["custom_providers"][0]["api_key"] == "new-key"
+        assert data["custom_providers"][1]["api_key"] == "prod-key"
+
+    def test_api_base_alias_canonicalized_and_comments_preserved(self, _isolated_hermes_home):
+        """The #8919 alias migration must keep working on the round-trip path."""
+        self._seed(_isolated_hermes_home)
+        set_config_value("model.api_base", "http://localhost:8000/v1")
+        text = _read_config(_isolated_hermes_home)
+        import yaml as _yaml
+        data = _yaml.safe_load(text)
+        assert data["model"]["base_url"] == "http://localhost:8000/v1"
+        assert "api_base" not in data["model"]
+        assert "api_base" not in data
+        assert "# Hermes main config — hand-maintained" in text
+
+    def test_duplicate_key_file_still_writes_value(self, _isolated_hermes_home):
+        """PyYAML tolerates duplicate keys (last wins); ruamel round-trip does
+        not. On such files the write must still land — falling back to the
+        plain dump (comments lost) rather than crashing."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "terminal:\n  backend: local\nterminal:\n  backend: docker\n"
+        )
+        set_config_value("tts.provider", "openai")
+        import yaml as _yaml
+        data = _yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert data["tts"]["provider"] == "openai"
+        assert data["terminal"]["backend"] == "docker"
+
+    def test_new_nested_key_created_without_touching_rest(self, _isolated_hermes_home):
+        self._seed(_isolated_hermes_home)
+        set_config_value("gateway.port", "8899")
+        text = _read_config(_isolated_hermes_home)
+        import yaml as _yaml
+        data = _yaml.safe_load(text)
+        assert data["gateway"]["port"] == 8899
+        assert "# dev box" in text
+        assert "# pinned for eval reproducibility" in text
+
+    def test_unset_preserves_comments_on_remaining_keys(self, _isolated_hermes_home):
+        """`hermes config unset` shares the write path — same contract (#63039)."""
+        from hermes_cli.config import unset_config_value
+        self._seed(_isolated_hermes_home)
+        unset_config_value("terminal.backend")
+        text = _read_config(_isolated_hermes_home)
+        assert "# Hermes main config — hand-maintained" in text
+        assert "# pinned for eval reproducibility" in text
+        import yaml as _yaml
+        data = _yaml.safe_load(text)
+        assert "backend" not in (data.get("terminal") or {})

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -843,3 +843,33 @@ class TestCommentPreservation:
         import yaml as _yaml
         data = _yaml.safe_load(text)
         assert "backend" not in (data.get("terminal") or {})
+
+    def test_write_failure_propagates_instead_of_stripping_comments(
+        self, _isolated_hermes_home, monkeypatch
+    ):
+        """Sweeper ask on the salvage PR: only round-trip *parser* rejection
+        may fall back to the plain (comment-stripping) dump. A genuine write
+        failure (temp file, fsync, atomic replace) must propagate — falling
+        through would turn a failed write into a "successful" rewrite that
+        destroys the user's comments."""
+        import utils as utils_module
+
+        self._seed(_isolated_hermes_home)
+        original = _read_config(_isolated_hermes_home)
+
+        real_replace = utils_module.atomic_replace
+        calls = {"n": 0}
+
+        def first_call_explodes(tmp_path, path):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("simulated atomic-replace failure")
+            return real_replace(tmp_path, path)  # a fallback dump would succeed
+
+        monkeypatch.setattr(utils_module, "atomic_replace", first_call_explodes)
+        import pytest as _pytest
+        with _pytest.raises(OSError, match="simulated atomic-replace failure"):
+            set_config_value("terminal.backend", "ssh")
+
+        # File untouched: no plain-dump fallback happened, comments intact.
+        assert _read_config(_isolated_hermes_home) == original

--- a/utils.py
+++ b/utils.py
@@ -503,6 +503,19 @@ def _apply_yaml_diff(doc: Any, before: Any, after: Any) -> None:
                 doc[key] = _rt_safe_scalar(new_val)
 
 
+class RoundTripUnsupportedError(ValueError):
+    """The round-trip writer cannot represent this document.
+
+    Raised by :func:`atomic_roundtrip_yaml_apply` ONLY for conditions where
+    falling back to a plain (comment-stripping) dump is legitimate: ruamel
+    being unavailable, or the round-trip parser rejecting a document that
+    PyYAML tolerates (e.g. duplicate keys).  Genuine write failures — temp
+    file creation, fsync, atomic replace — propagate as-is so callers never
+    mask a failed write by "successfully" rewriting the file without its
+    comments.
+    """
+
+
 def atomic_roundtrip_yaml_apply(
     path: Union[str, Path],
     before: Any,
@@ -515,12 +528,19 @@ def atomic_roundtrip_yaml_apply(
     Companion to :func:`atomic_roundtrip_yaml_update` for callers that compute
     the full post-write mapping through existing (plain-dict) mutation and
     normalisation helpers and need multi-key semantics — nested writes, list
-    index writes, and key deletions — in one atomic replace.  Raises on files
-    the round-trip parser rejects (e.g. duplicate keys, which PyYAML
-    tolerates); callers decide whether to fall back to a plain dump.
+    index writes, and key deletions — in one atomic replace.
+
+    Raises :class:`RoundTripUnsupportedError` when the document cannot go
+    through the round-trip parser (duplicate keys, ruamel unavailable) — the
+    only condition where a plain-dump fallback is appropriate.  Filesystem
+    and atomic-write failures propagate unchanged.
     """
-    from ruamel.yaml import YAML
-    from ruamel.yaml.comments import CommentedMap
+    try:
+        from ruamel.yaml import YAML
+        from ruamel.yaml.comments import CommentedMap
+        from ruamel.yaml.error import YAMLError
+    except ImportError as exc:
+        raise RoundTripUnsupportedError(f"ruamel.yaml unavailable: {exc}") from exc
 
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -532,8 +552,16 @@ def atomic_roundtrip_yaml_apply(
     yaml_rt.indent(mapping=2, sequence=4, offset=2)
 
     if path.exists():
-        with path.open("r", encoding="utf-8") as f:
-            doc = yaml_rt.load(f) or CommentedMap()
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                doc = yaml_rt.load(f) or CommentedMap()
+        except YAMLError as exc:
+            # PyYAML tolerates documents ruamel's round-trip parser rejects
+            # (duplicate keys being the common case) — signal "unsupported",
+            # not "failed", so callers may fall back to the historical dump.
+            raise RoundTripUnsupportedError(
+                f"round-trip parser rejected {path.name}: {exc}"
+            ) from exc
     else:
         doc = CommentedMap()
     if not isinstance(doc, CommentedMap):

--- a/utils.py
+++ b/utils.py
@@ -436,6 +436,135 @@ def atomic_roundtrip_yaml_update(
         raise
 
 
+def _rt_safe_scalar(value: Any) -> Any:
+    """Quote strings whose plain YAML form would round-trip as a different type.
+
+    ruamel emits YAML 1.2, where ``off``/``yes``/``090`` are plain strings —
+    but this codebase reads config back with PyYAML (YAML 1.1), which parses
+    those spellings as booleans/numbers.  Wrapping ambiguous strings in an
+    explicit single-quoted scalar keeps the readers' view identical to what
+    the historical PyYAML dump produced (it quoted them for the same reason).
+    """
+    if isinstance(value, str):
+        try:
+            if not isinstance(yaml.safe_load(value), str):
+                from ruamel.yaml.scalarstring import SingleQuotedScalarString
+
+                return SingleQuotedScalarString(value)
+        except yaml.YAMLError:
+            pass  # unparseable as a bare scalar — ruamel will quote it itself
+    elif isinstance(value, dict):
+        return {k: _rt_safe_scalar(v) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [_rt_safe_scalar(v) for v in value]
+    return value
+
+
+def _apply_yaml_diff(doc: Any, before: Any, after: Any) -> None:
+    """Mutate round-trip *doc* so its data equals *after*, touching only paths
+    that differ between the plain mappings *before* and *after*.
+
+    Untouched siblings keep their ruamel comment/format metadata because their
+    nodes are never reassigned.  Equal-length lists are merged element-wise so
+    an indexed write (``custom_providers.0.api_key``) does not flatten the
+    comments on the other elements; structural list changes replace the whole
+    sequence (comment loss is then confined to the list the caller changed).
+    """
+    # Deletions first (e.g. the api_base → base_url alias migration pops keys).
+    if isinstance(before, dict) and isinstance(after, dict):
+        for key in before:
+            if key not in after and key in doc:
+                del doc[key]
+        for key, new_val in after.items():
+            if key in before and before[key] == new_val:
+                continue  # unchanged — leave the node (and its comments) alone
+            old_val = before.get(key)
+            existing = doc[key] if key in doc else None
+            if (
+                isinstance(existing, dict)
+                and isinstance(old_val, dict)
+                and isinstance(new_val, dict)
+            ):
+                _apply_yaml_diff(existing, old_val, new_val)
+            elif (
+                isinstance(existing, list)
+                and isinstance(old_val, list)
+                and isinstance(new_val, list)
+                and len(existing) == len(old_val) == len(new_val)
+            ):
+                for i, (o, n) in enumerate(zip(old_val, new_val)):
+                    if o == n:
+                        continue
+                    if isinstance(existing[i], dict) and isinstance(o, dict) and isinstance(n, dict):
+                        _apply_yaml_diff(existing[i], o, n)
+                    else:
+                        existing[i] = _rt_safe_scalar(n)
+            else:
+                doc[key] = _rt_safe_scalar(new_val)
+
+
+def atomic_roundtrip_yaml_apply(
+    path: Union[str, Path],
+    before: Any,
+    after: Any,
+) -> None:
+    """Rewrite *path* so its data equals *after*, preserving the comments,
+    ordering, quoting, and blank lines of everything that did not change
+    between *before* and *after*.
+
+    Companion to :func:`atomic_roundtrip_yaml_update` for callers that compute
+    the full post-write mapping through existing (plain-dict) mutation and
+    normalisation helpers and need multi-key semantics — nested writes, list
+    index writes, and key deletions — in one atomic replace.  Raises on files
+    the round-trip parser rejects (e.g. duplicate keys, which PyYAML
+    tolerates); callers decide whether to fall back to a plain dump.
+    """
+    from ruamel.yaml import YAML
+    from ruamel.yaml.comments import CommentedMap
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    yaml_rt = YAML(typ="rt")
+    yaml_rt.preserve_quotes = True
+    yaml_rt.allow_unicode = True
+    yaml_rt.default_flow_style = False
+    yaml_rt.indent(mapping=2, sequence=4, offset=2)
+
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            doc = yaml_rt.load(f) or CommentedMap()
+    else:
+        doc = CommentedMap()
+    if not isinstance(doc, CommentedMap):
+        doc = CommentedMap(doc)
+
+    _apply_yaml_diff(doc, before if isinstance(before, dict) else {}, after)
+
+    original_mode = _preserve_file_mode(path)
+    original_owner = _preserve_file_owner(path)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.stem}_",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml_rt.dump(doc, f)
+            f.flush()
+            os.fsync(f.fileno())
+        real_path = atomic_replace(tmp_path, path)
+        real_path_obj = Path(real_path)
+        _restore_file_owner(real_path_obj, original_owner)
+        _restore_file_mode(real_path_obj, original_mode)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
 # ─── JSON Helpers ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`hermes config set` (and `hermes config unset`) silently rewrite the entire `config.yaml` through PyYAML — every comment, blank line, and the user's key order is destroyed on each write (#63039). This routes both commands through a ruamel round-trip writer so only the changed paths are touched, while keeping the write semantics byte-identical to today.

Salvage of #50706 by @LeonSGP43 (the `atomic_roundtrip_yaml_update` helper approach endorsed in the triage of #63140), reworked against current main to address all three problems from the sweeper review there. Test matrix extends the four cases contributed in #63140 by @liuhao1024.

## Changes

- `utils.py`: `atomic_roundtrip_yaml_apply(path, before, after)` — companion to the existing `atomic_roundtrip_yaml_update` (`utils.py:337`, already used by cli.py's `save_config_value` since `85383c636`). Applies the diff between two plain mappings onto the round-trip document: untouched nodes are never reassigned, so their comments/format survive; equal-length lists merge element-wise so an indexed write (`custom_providers.0.api_key`) keeps sibling elements' comments; deletions propagate (alias migration). PyYAML-ambiguous strings (`off`, `yes`, `090`) are written single-quoted — ruamel emits YAML 1.2 but this codebase reads config with PyYAML (YAML 1.1), which would otherwise coerce them to booleans/numbers (the historical dump quoted them for the same reason; `approvals.mode off` regression is covered by existing tests).
- `hermes_cli/config.py`: `set_config_value()` and `unset_config_value()` snapshot the pre-write mapping, keep computing the post-write mapping through the existing helpers unchanged — `_set_nested()` (indexed-path semantics, #17876) and `_normalize_root_model_keys()` (api_base → base_url alias, #8919) — then write via the round-trip apply. Files the round-trip parser rejects but PyYAML tolerates (e.g. duplicate keys) fall back to the historical plain dump, so the write itself never regresses.
- `tests/hermes_cli/test_set_config_value.py`: `TestCommentPreservation` — 9 tests: header/inline/section comments, blank lines + key order, indexed list write keeping sibling comments, api_base alias canonicalization with comments preserved, duplicate-key fallback, new nested key creation, and unset. All except the fallback case fail on unfixed main.

## Sweeper review asks from #50706 — all addressed

| Ask (review of #50706) | Here |
|---|---|
| don't drop `_normalize_root_model_keys()` | reused verbatim on the plain mapping; diff-apply carries the alias migration (including key deletions) onto the round-trip doc; regression asserts `model.base_url` set + both `api_base` spellings removed + comments intact |
| retain the unreadable-config preflight | `require_readable_config_before_write` untouched, still runs before every write |
| keep numeric-list support (`atomic_roundtrip_yaml_update` only handles mappings) | diff-apply handles list-index writes via the existing `_set_nested`; element-wise merge preserves the rest of the list's comments |

## Root cause

`set_config_value()` (`hermes_cli/config.py:9070-9125`) and `unset_config_value()` (`:9191-9253`) load with `fast_safe_load` and write with `atomic_yaml_write` (PyYAML full-document dump). Two writers existed with different contracts: cli.py's `save_config_value` was converted to ruamel round-trip in `85383c636`, but the `hermes config set`/`unset` path never was — #63039 documents the divergence. The cost is silent: the file stays valid, only the human-maintained content vanishes; #65051's reporter independently hit this as "my hand-edits became dead text" while debugging an unrelated symptom.

## Validation

E2E on the real data path (temp `HERMES_HOME`, seeded hand-commented config, `set_config_value('terminal.backend','ssh')`):

| | before fix (main `d71033a40`) | after fix |
|---|---|---|
| header comment | destroyed | preserved |
| inline comment (`# pinned for eval reproducibility`) | destroyed | preserved |
| blank-line structure | destroyed | preserved |
| written value | `backend: ssh` | `backend: ssh` (file otherwise byte-identical) |

- `scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config.py tests/test_atomic_replace_symlinks.py tests/cli/test_cli_save_config_value.py` — 312 passed, 0 failed
- New tests red on unfixed main: 7/8 fail (fallback case green by definition), plus unset case
- Full `tests/hermes_cli/` sweep: 43 pre-existing failures in 6 unrelated files (kanban_notify, web_server_cron_profiles, plugin_runtime_disable_gate, service_manager, gateway_wsl, signal_handler_kanban_worker) — reproduced identically on clean main `d71033a40`, none touch the config write path

## Scope notes

- Bulk writers are deliberately untouched: `save_config()` (wizard/migration full-document semantics, `merge_existing` contract) and the dashboard raw-YAML editor overwrite by design; `hermes update` migration comment loss is #63039's second facet and needs the same treatment at `_persist_migration` — bounded follow-up, not this diff.
- `tui_gateway/server.py`'s `_write_config_key()` fail-open-on-parse-failure is #66752 / PR #66844's territory — not duplicated here.
- The `[]`-vs-string list coercion in `config set` values is #64323 — orthogonal to the writer.

Fixes #63039. Refs #50706 (salvaged), #63140 (tests credited), #8919, #17876, #65051.
