### PR TITLE
test(gateway): isolate detailed health readiness

### DIFF
--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1069,7 +1069,10 @@ class TestHealthDetailedEndpoint:
             "active_agents": 2,
             "exit_reason": None,
             "updated_at": "2026-04-14T00:00:00Z",
-        }), patch("gateway.run._resolve_gateway_model", return_value="test/model"):
+        }), patch("gateway.run._resolve_gateway_model", return_value="test/model"), patch(
+            "gateway.platforms.api_server.collect_runtime_readiness",
+            return_value={"status": "ok", "checks": {}},
+        ):
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.get("/health/detailed")
                 assert resp.status == 200


### PR DESCRIPTION
## Summary
- make the detailed-health payload test independent of host disk pressure
- keep readiness integration covered by the adjacent dedicated readiness test
- avoid a deterministic false failure whenever the checkout volume is at or above the 90% degradation threshold

## Reproduction
On the unmodified base with the APFS volume at 95% usage, `TestHealthDetailedEndpoint::test_health_detailed_returns_ok` returned `degraded` even though the fixture intends to exercise an all-OK response. The endpoint correctly included the real disk probe; the test had not isolated it.

## Validation
- parent: 1 failed, 7 passed in the focused health class
- fixed: 8 passed in the focused health class
- robustness pack: 298 passed across API auth, profile isolation, credential permissions, environment-home isolation, cross-profile guards, and snapshot redaction/injection tests

This is a test-harness reliability correction only; production readiness behavior is unchanged.