### PR TITLE
fix(gateway): harden restart and delivery fault handling

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -9,6 +9,7 @@ import asyncio
 import inspect
 import ipaddress
 import logging
+import math
 import os
 import random
 import re
@@ -4564,7 +4565,23 @@ class BasePlatformAdapter(ABC):
         if not error:
             return False
         lowered = error.lower()
+        # Connection/pool acquisition timeouts happen before a request is sent
+        # and are safe to retry.  Only read/write/unspecified delivery timeouts
+        # are ambiguous.
+        if "connecttimeout" in lowered or "connect timeout" in lowered:
+            return False
+        if "pooltimeout" in lowered or "pool timeout" in lowered:
+            return False
         return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
+
+    @staticmethod
+    def _valid_retry_after(value: Any) -> Optional[float]:
+        """Return a safe server delay, or None for malformed/non-positive data."""
+        try:
+            delay = float(value)
+        except (TypeError, ValueError):
+            return None
+        return delay if math.isfinite(delay) and delay > 0 else None
 
     def _unwrap_ephemeral(self, response: Any) -> Tuple[Optional[str], int]:
         """Unwrap a handler response into (text, ttl_seconds).
@@ -4645,18 +4662,18 @@ class BasePlatformAdapter(ABC):
             return result
 
         error_str = result.error or ""
-        is_network = result.retryable or self._is_retryable_error(error_str)
-
         # Timeout errors are not safe to retry (message may have been
-        # delivered) and not formatting errors — return the failure as-is.
-        if not is_network and self._is_timeout_error(error_str):
+        # delivered) and not formatting errors.  This safety classification
+        # outranks an adapter's retryable hint.
+        if self._is_timeout_error(error_str):
             return result
+        is_network = result.retryable or self._is_retryable_error(error_str)
 
         if is_network:
             # Retry with exponential backoff for transient errors.
             # Honor server-requested retry_after (e.g. Telegram FloodWait)
             # when present — it is authoritative over our backoff schedule.
-            server_retry_after = result.retry_after
+            server_retry_after = self._valid_retry_after(result.retry_after)
             for attempt in range(1, max_retries + 1):
                 if server_retry_after is not None:
                     delay = server_retry_after + random.uniform(0, 1)
@@ -4678,8 +4695,9 @@ class BasePlatformAdapter(ABC):
                     logger.info("[%s] Send succeeded on retry %d", self.name, attempt)
                     return result
                 error_str = result.error or ""
-                if result.retry_after is not None:
-                    server_retry_after = result.retry_after
+                if self._is_timeout_error(error_str):
+                    return result
+                server_retry_after = self._valid_retry_after(result.retry_after)
                 if not (result.retryable or self._is_retryable_error(error_str)):
                     break  # error switched to non-transient — fall through to plain-text fallback
             else:

--- a/gateway/restart_loop_guard.py
+++ b/gateway/restart_loop_guard.py
@@ -31,10 +31,12 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from typing import List, Optional
 
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 
 logger = logging.getLogger("gateway.run")
 
@@ -52,19 +54,32 @@ def _load_boots() -> List[float]:
     try:
         raw = _state_path().read_text(encoding="utf-8")
         data = json.loads(raw)
+        if not isinstance(data, dict):
+            return []
         boots = data.get("boots", [])
-        return [float(t) for t in boots if isinstance(t, (int, float))]
-    except (OSError, ValueError, TypeError):
+        if not isinstance(boots, list):
+            return []
+        return [
+            float(t)
+            for t in boots
+            if isinstance(t, (int, float)) and math.isfinite(float(t))
+        ]
+    except (OSError, ValueError, TypeError, AttributeError):
         return []
 
 
 def _save_boots(boots: List[float]) -> None:
     try:
         path = _state_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({"boots": boots}), encoding="utf-8")
-    except OSError:
+        atomic_json_write(path, {"boots": boots}, indent=None)
+    except (OSError, TypeError, ValueError):
         pass
+
+
+def _recent_boots(boots: List[float], ts: float, window_seconds: int) -> List[float]:
+    """Return finite observations inside the past window, never the future."""
+    cutoff = ts - max(1, window_seconds)
+    return [t for t in boots if math.isfinite(t) and cutoff <= t <= ts]
 
 
 def record_restart_interrupted_boot(
@@ -79,8 +94,7 @@ def record_restart_interrupted_boot(
     persistence failure returns the in-memory list without raising.
     """
     ts = time.time() if now is None else now
-    cutoff = ts - max(1, window_seconds)
-    boots = [t for t in _load_boots() if t >= cutoff]
+    boots = _recent_boots(_load_boots(), ts, window_seconds)
     boots.append(ts)
     _save_boots(boots)
     return boots
@@ -103,9 +117,8 @@ def is_restart_loop_tripped(
     if max_restarts <= 0:
         return False
     ts = time.time() if now is None else now
-    cutoff = ts - max(1, window_seconds)
     try:
-        recent = [t for t in _load_boots() if t >= cutoff]
+        recent = _recent_boots(_load_boots(), ts, window_seconds)
     except Exception:  # pragma: no cover — _load_boots already guards
         return False
     return len(recent) >= max_restarts

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -14,19 +14,22 @@ concurrently under distinct configurations).
 import hashlib
 import json
 import logging
+import math
 import os
 import shlex
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from dataclasses import dataclass
 from pathlib import Path
 from hermes_constants import get_hermes_home, _get_platform_default_hermes_home
 from typing import Any, Callable, NamedTuple, Optional
-from utils import atomic_json_write
+from utils import atomic_json_write, atomic_replace
 
 if sys.platform == "win32":
     import msvcrt
@@ -47,6 +50,7 @@ _WINDOWS_LOCK_OFFSET = 1024 * 1024
 _GATEWAY_RUNNING_PID_CACHE_TTL_SECONDS = 1.0
 _gateway_running_pid_cache_lock = threading.Lock()
 _gateway_running_pid_cache: dict[tuple[str, bool, bool], tuple[float, tuple[Any, ...], Optional[int]]] = {}
+_starts_log_thread_lock = threading.RLock()
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +71,54 @@ def _get_starts_log_path() -> Path:
     return get_hermes_home() / "gateway-starts.log"
 
 
+@contextmanager
+def _locked_starts_log(path: Path):
+    """Serialize the start-ledger read/modify/write across threads/processes."""
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with _starts_log_thread_lock:
+        handle = open(lock_path, "a+b")
+        try:
+            if _IS_WINDOWS:
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"\0")
+                    handle.flush()
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                if _IS_WINDOWS:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            finally:
+                handle.close()
+
+
+def _atomic_write_start_times(path: Path, timestamps: list[float]) -> None:
+    """Atomically persist the line-oriented ledger using a unique temp file."""
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.stem}_", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(repr(ts) for ts in timestamps) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        atomic_replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
 def record_start_and_check_storm(
     max_starts: int = 5, window_s: float = 120.0, *, backoff_cap_s: float = 300.0
 ) -> Optional[StormInfo]:
@@ -85,34 +137,34 @@ def record_start_and_check_storm(
         path = _get_starts_log_path()
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        now = datetime.now(timezone.utc).timestamp()
+        with _locked_starts_log(path):
+            now = datetime.now(timezone.utc).timestamp()
 
-        existing: list[float] = []
-        if path.exists():
-            for line in path.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    existing.append(float(line))
-                except ValueError:
-                    continue
+            existing: list[float] = []
+            if path.exists():
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        timestamp = float(line)
+                    except ValueError:
+                        continue
+                    # A future or non-finite value can otherwise stay in every
+                    # window forever and manufacture the maximum backoff.
+                    if math.isfinite(timestamp) and timestamp <= now:
+                        existing.append(timestamp)
 
-        existing.append(now)
+            existing.append(now)
 
-        # Keep only starts within the sliding window for the storm decision.
-        recent = [ts for ts in existing if now - ts <= window_s]
+            # Keep only starts within the sliding window for the storm decision.
+            recent = [ts for ts in existing if 0 <= now - ts <= window_s]
 
-        # Ring-buffer what we persist so the file stays bounded even if the
-        # window is wide or starts are frequent.
-        keep = max(max_starts * 4, 40)
-        to_write = existing[-keep:]
-
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(
-            "\n".join(repr(ts) for ts in to_write) + "\n", encoding="utf-8"
-        )
-        os.replace(tmp, path)
+            # Ring-buffer what we persist so the file stays bounded even if the
+            # window is wide or starts are frequent.
+            keep = max(max_starts * 4, 40)
+            to_write = existing[-keep:]
+            _atomic_write_start_times(path, to_write)
 
         if len(recent) > max_starts:
             backoff = min(

--- a/tests/gateway/test_stress_fault_invariants.py
+++ b/tests/gateway/test_stress_fault_invariants.py
@@ -1,0 +1,210 @@
+"""Fault-injection contracts for gateway restart and delivery bookkeeping."""
+
+from __future__ import annotations
+
+import json
+import math
+import multiprocessing
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway import restart_loop_guard, status
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, Platform, SendResult
+
+
+class _RetryAdapter(BasePlatformAdapter):
+    def __init__(self) -> None:
+        super().__init__(PlatformConfig(), Platform.TELEGRAM)
+        self.results: list[SendResult] = []
+        self.calls = 0
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None, **kwargs):
+        self.calls += 1
+        return self.results.pop(0)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"chat_id": chat_id}
+
+
+def _record_start_in_process(home: str, gate, max_starts: int) -> None:
+    os.environ["HERMES_HOME"] = home
+    gate.wait()
+    status.record_start_and_check_storm(max_starts=max_starts, window_s=120)
+
+
+def test_respawn_start_ledger_keeps_every_concurrent_writer(tmp_path, monkeypatch):
+    """Concurrent supervisors must not erase sibling start observations."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    workers = 32
+    barrier = threading.Barrier(workers)
+
+    def record() -> None:
+        barrier.wait()
+        status.record_start_and_check_storm(max_starts=workers + 1, window_s=120)
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        list(pool.map(lambda _index: record(), range(workers)))
+
+    lines = status._get_starts_log_path().read_text(encoding="utf-8").splitlines()
+    assert len(lines) == workers
+
+
+def test_respawn_start_ledger_keeps_every_process_writer(tmp_path):
+    """The adjacent lock must protect independent supervisor processes too."""
+    workers = 8
+    context = multiprocessing.get_context("spawn")
+    gate = context.Event()
+    processes = [
+        context.Process(
+            target=_record_start_in_process,
+            args=(str(tmp_path), gate, workers + 1),
+        )
+        for _ in range(workers)
+    ]
+    try:
+        for process in processes:
+            process.start()
+        gate.set()
+        for process in processes:
+            process.join(timeout=20)
+        assert [process.exitcode for process in processes] == [0] * workers
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+
+    path = tmp_path / "gateway-starts.log"
+    assert len(path.read_text(encoding="utf-8").splitlines()) == workers
+
+
+@pytest.mark.parametrize("seed", [float("inf"), time.time() + 86_400])
+def test_respawn_start_ledger_ignores_impossible_timestamps(
+    tmp_path, monkeypatch, seed
+):
+    """Corrupt/future history must not manufacture a five-minute backoff."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = status._get_starts_log_path()
+    path.write_text("\n".join([repr(seed)] * 6) + "\n", encoding="utf-8")
+
+    result = status.record_start_and_check_storm(max_starts=5, window_s=120)
+
+    assert result is None
+
+
+def test_restart_loop_torn_write_preserves_last_good_history(tmp_path, monkeypatch):
+    """An interrupted persistence attempt must not destroy the prior breaker."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = restart_loop_guard._state_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"boots": [1000.0, 1001.0]}), encoding="utf-8")
+    original_write_text = Path.write_text
+
+    def torn_write(self, data, *args, **kwargs):
+        if self == path:
+            original_write_text(self, '{"boots":[1000.0', encoding="utf-8")
+            raise OSError("synthetic power loss")
+        return original_write_text(self, data, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", torn_write)
+    restart_loop_guard.record_restart_interrupted_boot(60, now=1002.0)
+
+    assert restart_loop_guard.is_restart_loop_tripped(3, 60, now=1003.0)
+
+
+def test_restart_loop_malformed_root_fails_open_and_self_heals(tmp_path, monkeypatch):
+    """A non-object state document must not escape the breaker's fail-open API."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = restart_loop_guard._state_path()
+    path.parent.mkdir(parents=True)
+    path.write_text("[]", encoding="utf-8")
+
+    assert restart_loop_guard.check_and_record(3, 60, now=1000.0) is False
+    assert json.loads(path.read_text(encoding="utf-8")) == {"boots": [1000.0]}
+
+
+@pytest.mark.parametrize("seed", [float("inf"), 1_000_000_000_000.0])
+def test_restart_loop_ignores_nonfinite_and_future_boots(tmp_path, monkeypatch, seed):
+    """Impossible persisted boot times must never permanently trip recovery."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = restart_loop_guard._state_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"boots": [seed]}), encoding="utf-8")
+
+    assert restart_loop_guard.is_restart_loop_tripped(1, 60, now=1000.0) is False
+
+
+@pytest.mark.asyncio
+async def test_retryable_flag_cannot_override_ambiguous_timeout():
+    """Read/write timeouts stay non-retriable even if an adapter misflags one."""
+    adapter = _RetryAdapter()
+    adapter.results = [
+        SendResult(success=False, error="ReadTimeout: request may have landed", retryable=True),
+        SendResult(success=True, message_id="duplicate"),
+    ]
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._send_with_retry("chat", "hello", base_delay=0)
+
+    assert result.success is False
+    assert adapter.calls == 1
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retry_transition_to_timeout_never_sends_plaintext_duplicate():
+    """A timeout after a safe connect retry must stop without fallback resend."""
+    adapter = _RetryAdapter()
+    adapter.results = [
+        SendResult(success=False, error="ConnectError: refused", retryable=True),
+        SendResult(success=False, error="WriteTimeout: request may have landed"),
+        SendResult(success=True, message_id="duplicate-fallback"),
+    ]
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        result = await adapter._send_with_retry("chat", "hello", base_delay=0)
+
+    assert result.success is False
+    assert adapter.calls == 2
+
+
+@pytest.mark.parametrize("retry_after", [-10.0, float("nan"), float("inf"), "bad"])
+@pytest.mark.asyncio
+async def test_invalid_retry_after_falls_back_to_bounded_local_backoff(retry_after):
+    """Malformed server delay values cannot hot-loop, crash, or sleep forever."""
+    adapter = _RetryAdapter()
+    adapter.results = [
+        SendResult(
+            success=False,
+            error="rate limited",
+            retryable=True,
+            retry_after=retry_after,
+        ),
+        SendResult(success=True, message_id="ok"),
+    ]
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._send_with_retry(
+            "chat", "hello", max_retries=1, base_delay=1.0
+        )
+
+    assert result.success is True
+    delay = sleep.await_args.args[0]
+    assert math.isfinite(delay)
+    assert 1.0 <= delay < 3.0


### PR DESCRIPTION
## Summary

Hardens ordinary gateway reliability under concurrent supervisors, corrupt/torn state, ambiguous delivery timeouts, and malformed rate-limit metadata.

- serialize the gateway start ledger across threads and processes, persist it atomically, and reject non-finite/future timestamps
- atomically persist restart-loop state, fail open on malformed roots, and ignore impossible boot times
- give ambiguous read/write timeout safety precedence over adapter retry hints, stop retry-to-timeout fallback duplicates, and bound retry-after input

## Defects reproduced and fixed

- S11-01: concurrent start-ledger writers lost observations
- S11-02: non-finite/future start entries manufactured maximum storm backoff
- S11-03: interrupted restart-loop writes destroyed the last good breaker history
- S11-04: a non-object restart-loop JSON root escaped the documented fail-open contract
- S11-05: non-finite/future boot timestamps permanently tripped recovery
- S11-06: retryable=true overrode an ambiguous ReadTimeout and duplicated delivery
- S11-07: a safe connection retry transitioning to WriteTimeout fell through to a duplicate plaintext send
- S11-08: negative, NaN, infinite, or non-numeric retry-after values could hot-loop, sleep forever, or raise

## Verification

Parent commit 825069004a09023452a50c649f79e9a39bef40b5: 13/13 fault-injection assertions failed.

Current branch after rebase onto d71033a4077a6dfdcdb42c9e9eeab4c41e4a7012:

- scripts/run_tests.sh tests/gateway/test_stress_fault_invariants.py tests/gateway/test_send_retry.py tests/gateway/test_status.py tests/hermes_cli/test_gateway_restart_loop.py -q
- 251 passed, 0 failed
- isolated local gateway on 127.0.0.1:18711: 100/100 concurrent authenticated detailed-health probes returned 200
- SIGINT shutdown released port 18711 and left no lane process

## Integration notes

PR #52899 also touches the nearby timeout classifier; rebase/merge sequencing should preserve this PRs explicit ConnectTimeout/PoolTimeout exclusions and ambiguous-timeout precedence. Telegram first-send/edit-fallback races observed during the audit match already tracked Slack sibling defects and are intentionally not duplicated here. No API, configuration, or agent-boundary changes are included.