### PR TITLE
fix(tui): make crash recovery state durable

### DIFF
--- a/tests/tui_gateway/test_state_recovery_lane12.py
+++ b/tests/tui_gateway/test_state_recovery_lane12.py
@@ -6,6 +6,7 @@ import json
 import math
 import multiprocessing
 import os
+import stat
 import sys
 import threading
 import time
@@ -125,6 +126,25 @@ def test_marker_entry_cap_includes_the_new_turn(tmp_path, monkeypatch):
     entries = json.loads(path.read_text(encoding="utf-8"))
     assert len(entries) == 32
     assert "new" in entries
+
+
+@pytest.mark.skipif(os.name == "nt", reason="directory fsync is POSIX durability")
+def test_marker_replace_fsyncs_payload_and_parent_directory(tmp_path, monkeypatch):
+    from tui_gateway import turn_marker
+
+    synced_modes: list[int] = []
+    real_fsync = turn_marker.os.fsync
+
+    def tracking_fsync(fd: int):
+        synced_modes.append(os.fstat(fd).st_mode)
+        return real_fsync(fd)
+
+    monkeypatch.setattr(turn_marker.os, "fsync", tracking_fsync)
+
+    record_turn_start(tmp_path, "session", "durable prompt")
+
+    assert any(stat.S_ISREG(mode) for mode in synced_modes)
+    assert any(stat.S_ISDIR(mode) for mode in synced_modes)
 
 
 def _concurrent_marker_writer(home: str, key: str, barrier) -> None:

--- a/tests/tui_gateway/test_state_recovery_lane12.py
+++ b/tests/tui_gateway/test_state_recovery_lane12.py
@@ -1,0 +1,389 @@
+"""Crash/restart recovery contracts found by the lane-12 E2E campaign."""
+
+from __future__ import annotations
+
+import json
+import math
+import multiprocessing
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from tui_gateway import host_supervisor as host_mod
+from tui_gateway import server
+from tui_gateway.host_supervisor import HostSupervisor
+from tui_gateway.turn_marker import read_turn_marker, record_turn_start
+
+
+def _marker_path(home: Path) -> Path:
+    return home / "desktop" / "interrupted_turns.json"
+
+
+def test_malformed_sibling_marker_does_not_block_new_turn_record(tmp_path):
+    path = _marker_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "damaged": {
+                    "attempts": 0,
+                    "prompt": "old",
+                    "started_at": "not-a-timestamp",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    record_turn_start(tmp_path, "current", "finish the current task")
+
+    assert read_turn_marker(tmp_path, "current") is not None
+    assert read_turn_marker(tmp_path, "damaged") is None
+
+
+@pytest.mark.parametrize("started_at", [math.nan, math.inf, -math.inf])
+def test_nonfinite_marker_timestamp_is_never_recovered(tmp_path, started_at):
+    path = _marker_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "session": {
+                    "attempts": 0,
+                    "prompt": "stale operation",
+                    "started_at": started_at,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert read_turn_marker(tmp_path, "session") is None
+
+
+def test_far_future_marker_is_not_auto_continued(tmp_path, monkeypatch):
+    path = _marker_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "session": {
+                    "attempts": 0,
+                    "prompt": "repeat an old side effect",
+                    "started_at": time.time() + 24 * 3600,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    started: list[str] = []
+
+    class RecordingThread:
+        def __init__(self, **_kwargs):
+            pass
+
+        def start(self):
+            started.append("thread")
+
+    monkeypatch.setattr(server.threading, "Thread", RecordingThread)
+    session = {
+        "profile_home": str(tmp_path),
+        "history_lock": threading.Lock(),
+        "running": False,
+    }
+
+    assert server._maybe_schedule_auto_continue("sid", session, "session") is None
+    assert started == []
+
+
+def test_marker_entry_cap_includes_the_new_turn(tmp_path, monkeypatch):
+    now = time.time()
+    path = _marker_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                f"old-{i}": {
+                    "attempts": 0,
+                    "prompt": f"prompt {i}",
+                    "started_at": now - i,
+                }
+                for i in range(32)
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tui_gateway.turn_marker.time.time", lambda: now)
+
+    record_turn_start(tmp_path, "new", "new prompt")
+
+    entries = json.loads(path.read_text(encoding="utf-8"))
+    assert len(entries) == 32
+    assert "new" in entries
+
+
+def _concurrent_marker_writer(home: str, key: str, barrier) -> None:
+    """Force two processes through the same pre-write snapshot on old code."""
+    from tui_gateway import turn_marker
+
+    original_load = turn_marker._load
+
+    def synchronized_load(path):
+        value = original_load(path)
+        try:
+            barrier.wait(timeout=0.25)
+        except threading.BrokenBarrierError:
+            pass
+        return value
+
+    turn_marker._load = synchronized_load
+    turn_marker.record_turn_start(home, key, f"prompt {key}")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fork-only deterministic race harness")
+def test_marker_updates_are_serialized_across_processes(tmp_path):
+    ctx = multiprocessing.get_context("fork")
+    barrier = ctx.Barrier(2)
+    workers = [
+        ctx.Process(target=_concurrent_marker_writer, args=(str(tmp_path), key, barrier))
+        for key in ("one", "two")
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=5)
+        assert worker.exitcode == 0
+
+    assert read_turn_marker(tmp_path, "one") is not None
+    assert read_turn_marker(tmp_path, "two") is not None
+
+
+def _write_fake_host(path: Path, *, build_sha: str = "expected", control: str = "ack") -> None:
+    path.write_text(
+        f"""
+import json, os, sys, time
+print(json.dumps({{'type':'hello','host_pid':os.getpid(),'boot_id':'boot','build_sha':{build_sha!r},'hermes_home':os.environ.get('HERMES_HOME','')}}), flush=True)
+for raw in sys.stdin:
+    frame=json.loads(raw)
+    if frame.get('type') == 'shutdown':
+        print(json.dumps({{'type':'shutdown.ack','request_id':frame.get('request_id')}}), flush=True)
+        break
+    if frame.get('type') == 'control':
+        if {control!r} == 'crash':
+            os._exit(9)
+        if {control!r} == 'hang':
+            time.sleep(60)
+        print(json.dumps({{'type':'control.ack','request_id':frame.get('request_id')}}), flush=True)
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def _wait_dead(pid: int, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not host_mod._pid_alive(pid):
+            return True
+        time.sleep(0.02)
+    return not host_mod._pid_alive(pid)
+
+
+def test_invalid_hello_cleans_up_spawned_child(tmp_path):
+    script = tmp_path / "wrong_host.py"
+    _write_fake_host(script, build_sha="wrong")
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "registry.json",
+        argv=[sys.executable, str(script)],
+        expected_build_sha="expected",
+        autostart=False,
+    )
+    spawned: list[int] = []
+    original_validate = supervisor._validate_hello
+
+    def validate():
+        spawned.append(supervisor.pid)
+        original_validate()
+
+    supervisor._validate_hello = validate
+
+    with pytest.raises(RuntimeError, match="build mismatch"):
+        supervisor.start()
+
+    assert spawned and spawned[0] > 0
+    assert _wait_dead(spawned[0]), "hello-rejected child survived startup failure"
+
+
+def test_registry_persistence_failure_cleans_up_spawned_child(tmp_path, monkeypatch):
+    script = tmp_path / "host.py"
+    _write_fake_host(script)
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "registry.json",
+        argv=[sys.executable, str(script)],
+        expected_build_sha="expected",
+        autostart=False,
+    )
+    spawned: list[int] = []
+
+    def fail_registry():
+        spawned.append(supervisor.pid)
+        raise OSError("disk full")
+
+    monkeypatch.setattr(supervisor, "_persist_registry", fail_registry)
+
+    with pytest.raises(OSError, match="disk full"):
+        supervisor.start()
+
+    assert spawned and spawned[0] > 0
+    assert _wait_dead(spawned[0]), "unregistered child survived registry failure"
+
+
+def test_compute_host_crash_resolves_pending_control_waiter(tmp_path):
+    script = tmp_path / "crash_host.py"
+    _write_fake_host(script, control="crash")
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "registry.json",
+        argv=[sys.executable, str(script)],
+        expected_build_sha="expected",
+        respawn_max=0,
+        autostart=False,
+    )
+    result: list[object] = []
+    supervisor.start()
+
+    def call_control():
+        try:
+            result.append(
+                supervisor.control(
+                    "sid", route_name="session.save", timeout=5.0
+                )
+            )
+        except Exception as exc:  # old behavior strands the waiter to timeout
+            result.append(exc)
+
+    worker = threading.Thread(target=call_control)
+    worker.start()
+    worker.join(timeout=1.5)
+    try:
+        assert not worker.is_alive(), "control waiter remained stranded after crash"
+        assert isinstance(result[0], dict)
+        assert result[0]["type"] == "control.error"
+        assert result[0]["reason"] == "crash"
+    finally:
+        supervisor.shutdown()
+
+
+def test_control_send_failure_does_not_leak_waiter(tmp_path, monkeypatch):
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "registry.json", autostart=False
+    )
+    monkeypatch.setattr(supervisor, "start", lambda: None)
+    monkeypatch.setattr(
+        supervisor,
+        "_send_frame",
+        lambda _frame: (_ for _ in ()).throw(BrokenPipeError("closed")),
+    )
+
+    with pytest.raises(BrokenPipeError):
+        supervisor.control("sid", route_name="session.save", timeout=0.1)
+
+    assert supervisor._pending_controls == {}
+
+
+def test_stale_exit_cannot_remove_replacement_registry(tmp_path, monkeypatch):
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({"host_pid": 222}), encoding="utf-8")
+    supervisor = HostSupervisor(registry_path=registry, autostart=False)
+    old_proc = type("OldProc", (), {"pid": 111, "wait": lambda self: 9})()
+    supervisor._proc = old_proc
+    monkeypatch.setattr(supervisor, "_maybe_respawn_after_crash", lambda: None)
+
+    supervisor._wait_for_exit(old_proc)
+
+    assert json.loads(registry.read_text(encoding="utf-8"))["host_pid"] == 222
+
+
+def test_failed_orphan_termination_blocks_duplicate_start(tmp_path, monkeypatch):
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({"host_pid": 111}), encoding="utf-8")
+    supervisor = HostSupervisor(registry_path=registry, autostart=False)
+    monkeypatch.setattr(host_mod, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(supervisor, "_pid_matches_compute_host", lambda _pid: True)
+    monkeypatch.setattr(supervisor, "_terminate_pid", lambda *_a, **_kw: False)
+    spawned: list[str] = []
+    monkeypatch.setattr(
+        supervisor, "_spawn_locked", lambda *, reason: spawned.append(reason)
+    )
+
+    with pytest.raises(RuntimeError, match="could not terminate"):
+        supervisor.start()
+
+    assert spawned == []
+    assert registry.exists()
+
+
+def test_shutdown_resolves_pending_control_waiter(tmp_path, monkeypatch):
+    script = tmp_path / "hang_host.py"
+    _write_fake_host(script, control="hang")
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "registry.json",
+        argv=[sys.executable, str(script)],
+        expected_build_sha="expected",
+        autostart=False,
+    )
+    monkeypatch.setattr(host_mod, "_SHUTDOWN_TIMEOUT_SECS", 0.1)
+    result: list[object] = []
+    supervisor.start()
+
+    def call_control():
+        try:
+            result.append(
+                supervisor.control("sid", route_name="session.save", timeout=5.0)
+            )
+        except Exception as exc:
+            result.append(exc)
+
+    worker = threading.Thread(target=call_control)
+    worker.start()
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline and not supervisor._pending_controls:
+        time.sleep(0.01)
+    supervisor.shutdown()
+    worker.join(timeout=1)
+
+    assert not worker.is_alive(), "control waiter remained stranded during shutdown"
+    assert isinstance(result[0], dict)
+    assert result[0]["type"] == "control.error"
+    assert result[0]["reason"] == "shutdown"
+
+
+def test_transient_respawn_failure_is_retried(tmp_path, monkeypatch):
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "registry.json", respawn_max=3, autostart=False
+    )
+    calls: list[str] = []
+
+    def spawn(*, reason: str):
+        calls.append(reason)
+        if len(calls) == 1:
+            raise OSError("temporary fork failure")
+        supervisor._proc = object()  # only proves the retry path was invoked
+
+    class InlineThread:
+        def __init__(self, target=None, **_kwargs):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(supervisor, "_spawn_locked", spawn)
+    monkeypatch.setattr(host_mod, "_Thread", InlineThread)
+    monkeypatch.setattr(host_mod.time, "sleep", lambda _delay: None)
+
+    supervisor._maybe_respawn_after_crash()
+
+    assert calls == ["crash", "crash"]

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -191,7 +191,12 @@ class HostSupervisor:
             if self.is_running():
                 return
             self._closing = False
-            self.reconcile_startup_orphan()
+            reconciliation = self.reconcile_startup_orphan()
+            if reconciliation == "termination-failed":
+                raise RuntimeError(
+                    "could not terminate the registered compute host; "
+                    "refusing to start a duplicate"
+                )
             self._spawn_locked(reason="startup")
 
     def shutdown(self) -> None:
@@ -199,6 +204,9 @@ class HostSupervisor:
             self._closing = True
             proc = self._proc
         if proc is None:
+            self._fail_pending_controls(
+                reason="shutdown", message="compute host supervisor shut down"
+            )
             return
         try:
             if proc.poll() is None and proc.stdin is not None:
@@ -207,7 +215,16 @@ class HostSupervisor:
         except Exception:
             self._terminate_process(proc)
         finally:
-            self._remove_registry()
+            with self._lock:
+                if self._proc is proc:
+                    self._proc = None
+            self._fail_pending_turns(
+                reason="shutdown", message="compute host supervisor shut down"
+            )
+            self._fail_pending_controls(
+                reason="shutdown", message="compute host supervisor shut down"
+            )
+            self._remove_registry(expected_pid=int(proc.pid or 0))
 
     def reconcile_startup_orphan(self) -> str:
         """Terminate a stale registered host, guarding against PID reuse."""
@@ -216,7 +233,7 @@ class HostSupervisor:
         except FileNotFoundError:
             return "none"
         except Exception:
-            self._remove_registry()
+            self._remove_registry(force=True)
             return "invalid-registry"
 
         try:
@@ -224,15 +241,19 @@ class HostSupervisor:
         except Exception:
             pid = 0
         if pid <= 0 or not _pid_alive(pid):
-            self._remove_registry()
+            self._remove_registry(force=True)
             return "not-running"
         if not self._pid_matches_compute_host(pid):
             # PID was reused by another process. Never signal it.
-            self._remove_registry()
+            self._remove_registry(force=True)
             return "pid-reuse-ignored"
 
-        self._terminate_pid(pid, timeout=_SHUTDOWN_TIMEOUT_SECS)
-        self._remove_registry()
+        if not self._terminate_pid(pid, timeout=_SHUTDOWN_TIMEOUT_SECS):
+            # Keep the registry as the durable owner record.  Removing it and
+            # spawning anyway would create two live compute hosts after a
+            # permission error or a process that ignored both signals.
+            return "termination-failed"
+        self._remove_registry(expected_pid=pid)
         return "terminated"
 
     def submit_turn(
@@ -301,7 +322,13 @@ class HostSupervisor:
             q = queue.Queue(maxsize=1)
             with self._lock:
                 self._pending_controls[request_id] = q
-        self._send_frame(frame)
+        try:
+            self._send_frame(frame)
+        except Exception:
+            if wait:
+                with self._lock:
+                    self._pending_controls.pop(request_id, None)
+            raise
         if not wait or q is None:
             return {"status": "sent", "request_id": request_id}
         try:
@@ -346,11 +373,23 @@ class HostSupervisor:
         self._stdout_thread.start()
         self._stderr_thread.start()
         self._wait_thread.start()
-        if not self._hello_event.wait(timeout=10.0):
+        try:
+            if not self._hello_event.wait(timeout=10.0):
+                raise RuntimeError(
+                    f"compute host did not send hello; stderr={self._stderr_tail[-5:]}"
+                )
+            self._validate_hello()
+            self._persist_registry()
+        except Exception:
+            # Once Popen succeeds every later startup gate owns cleanup.  A
+            # rejected hello or failed registry write previously leaked a live
+            # unregistered child; its wait thread could then respawn it too.
+            with self._lock:
+                if self._proc is proc:
+                    self._proc = None
             self._terminate_process(proc)
-            raise RuntimeError(f"compute host did not send hello; stderr={self._stderr_tail[-5:]}")
-        self._validate_hello()
-        self._persist_registry()
+            self._remove_registry(expected_pid=int(proc.pid or 0))
+            raise
         logger.info("compute host started pid=%s reason=%s", proc.pid, reason)
 
     def _validate_hello(self) -> None:
@@ -377,13 +416,35 @@ class HostSupervisor:
         tmp.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
         tmp.replace(self.registry_path)
 
-    def _remove_registry(self) -> None:
+    def _remove_registry(
+        self, *, expected_pid: int | None = None, force: bool = False
+    ) -> bool:
+        """Remove only the registry owned by the exiting child.
+
+        An old wait thread can run after a replacement has already published
+        its registry.  A blind unlink in that window erases the replacement's
+        durable identity and makes the next backend spawn another host.
+        """
         try:
+            if not force and expected_pid is not None:
+                try:
+                    data = json.loads(self.registry_path.read_text(encoding="utf-8"))
+                    registered_pid = int(data.get("host_pid") or 0)
+                except FileNotFoundError:
+                    return False
+                except Exception:
+                    # An unreadable registry cannot be proven to belong to this
+                    # child.  Startup reconciliation owns forced cleanup.
+                    return False
+                if registered_pid != int(expected_pid):
+                    return False
             self.registry_path.unlink()
+            return True
         except FileNotFoundError:
-            pass
+            return False
         except Exception:
             logger.debug("failed to remove compute host registry", exc_info=True)
+            return False
 
     def _send_frame(self, frame: dict[str, Any]) -> None:
         with self._lock:
@@ -471,8 +532,11 @@ class HostSupervisor:
             if self._proc is not proc:
                 return
             self._proc = None
-        self._remove_registry()
+        self._remove_registry(expected_pid=int(proc.pid or 0))
         self._fail_pending_turns(reason="crash", message=f"compute host exited with code {code}")
+        self._fail_pending_controls(
+            reason="crash", message=f"compute host exited with code {code}"
+        )
         self._maybe_respawn_after_crash()
 
     def _fail_pending_turns(self, *, reason: str, message: str) -> None:
@@ -504,6 +568,23 @@ class HostSupervisor:
                 except Exception:
                     logger.exception("compute host error callback failed")
 
+    def _fail_pending_controls(self, *, reason: str, message: str) -> None:
+        """Wake every synchronous control caller when its host disappears."""
+        with self._lock:
+            pending = self._pending_controls
+            self._pending_controls = {}
+        for request_id, waiter in pending.items():
+            frame = {
+                "type": "control.error",
+                "request_id": request_id,
+                "reason": reason,
+                "message": message,
+            }
+            try:
+                waiter.put_nowait(frame)
+            except queue.Full:
+                pass
+
     def _maybe_respawn_after_crash(self) -> None:
         now = time.monotonic()
         self._restart_times = [t for t in self._restart_times if now - t <= _RESPAWN_WINDOW_SECS]
@@ -524,31 +605,44 @@ class HostSupervisor:
                     self._spawn_locked(reason="crash")
                 except Exception:
                     logger.exception("compute host respawn failed")
+                    # A transient fork/import/registry failure must not make a
+                    # single crash permanently disable turn isolation.  Feed
+                    # it back through the same bounded crash-loop budget.
+                    self._maybe_respawn_after_crash()
 
         _Thread(target=_respawn, name="compute-host-respawn", daemon=True).start()
 
     def _pid_matches_compute_host(self, pid: int) -> bool:
         return is_compute_host_identity(pid)
 
-    def _terminate_pid(self, pid: int, *, timeout: float = _SHUTDOWN_TIMEOUT_SECS) -> None:
+    def _terminate_pid(
+        self, pid: int, *, timeout: float = _SHUTDOWN_TIMEOUT_SECS
+    ) -> bool:
         try:
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:
-            return
+            return True
         except Exception:
             logger.debug("failed to SIGTERM compute host pid=%s", pid, exc_info=True)
-            return
+            return False
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if not _pid_alive(pid):
-                return
+                return True
             time.sleep(0.05)
         try:
             os.kill(pid, signal.SIGKILL)
         except ProcessLookupError:
-            return
+            return True
         except Exception:
             logger.debug("failed to SIGKILL compute host pid=%s", pid, exc_info=True)
+            return False
+        deadline = time.monotonic() + min(2.0, max(0.1, timeout))
+        while time.monotonic() < deadline:
+            if not _pid_alive(pid):
+                return True
+            time.sleep(0.05)
+        return not _pid_alive(pid)
 
     def _terminate_process(self, proc: subprocess.Popen[str]) -> None:
         if proc.poll() is not None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -35,6 +35,7 @@ from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from tui_gateway import git_probe
 from tui_gateway.turn_marker import (
+    _MAX_FUTURE_SKEW_SECS,
     clear_turn_marker,
     read_turn_marker,
     record_turn_start,
@@ -6531,7 +6532,12 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
         return None
     enabled, freshness_secs, max_attempts = _auto_continue_config()
     age = time.time() - marker["started_at"]
-    if not enabled or age > freshness_secs or marker["attempts"] >= max_attempts:
+    if (
+        not enabled
+        or age < -_MAX_FUTURE_SKEW_SECS
+        or age > freshness_secs
+        or marker["attempts"] >= max_attempts
+    ):
         # Stale, disabled, or crash-looping: stop trying. The journal/partial
         # transcript still shows what happened; a manual message continues it.
         clear_turn_marker(home, session_key)

--- a/tui_gateway/turn_marker.py
+++ b/tui_gateway/turn_marker.py
@@ -22,12 +22,14 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import tempfile
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -38,12 +40,91 @@ _MAX_ENTRIES = 32
 # Enough to re-submit any realistic prompt; guards the sidecar against a
 # pathological multi-megabyte paste being journaled on every turn.
 _MAX_PROMPT_CHARS = 64_000
+# A small backwards clock adjustment is harmless.  A marker hours or days in
+# the future is not evidence of a current interrupted turn, though, and must
+# not crowd real entries out of the bounded journal or trigger replay.
+_MAX_FUTURE_SKEW_SECS = 5 * 60
 
 _lock = threading.Lock()
+_lock_warning_paths: set[str] = set()
 
 
 def _marker_path(home: Path | str) -> Path:
     return Path(home) / _MARKER_DIR / _MARKER_FILE
+
+
+def _marker_lock_path(home: Path | str) -> Path:
+    return Path(home) / _MARKER_DIR / ".interrupted_turns.lock"
+
+
+@contextmanager
+def _process_lock(home: Path | str) -> Iterator[None]:
+    """Serialize marker read-modify-write transactions across backends.
+
+    A dashboard restart can briefly overlap the old backend while it drains.
+    The process-local lock alone lets those processes both read the same file
+    and then atomically replace it with different snapshots, losing one turn.
+    Keep the advisory lock on a stable adjacent inode (never the replaced JSON
+    inode) so it remains authoritative throughout the transaction.
+    """
+    path = _marker_lock_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = open(path, "a+b")
+    locked = False
+    try:
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                # Windows byte-range locks require the byte to exist.
+                if not handle.read(1):
+                    handle.seek(0)
+                    handle.write(b"0")
+                    handle.flush()
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            locked = True
+        except (ImportError, OSError):
+            # Keep the historical best-effort marker behavior on exotic
+            # filesystems/platforms that do not offer advisory locks.
+            path_key = str(path)
+            if path_key not in _lock_warning_paths:
+                _lock_warning_paths.add(path_key)
+                logger.warning(
+                    "turn-marker cross-process lock unavailable at %s; "
+                    "using process-local serialization",
+                    path,
+                    exc_info=True,
+                )
+        yield
+    finally:
+        try:
+            if locked and os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            elif locked:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
+
+
+def _started_at(entry: dict) -> float | None:
+    try:
+        value = float(entry.get("started_at") or 0)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(value) or value <= 0:
+        return None
+    return value
 
 
 def _load(path: Path) -> dict[str, dict]:
@@ -61,16 +142,19 @@ def _load(path: Path) -> dict[str, dict]:
 
 
 def _prune(entries: dict[str, dict], now: float) -> dict[str, dict]:
-    fresh = {
-        key: entry
-        for key, entry in entries.items()
-        if now - float(entry.get("started_at") or 0) <= _MAX_AGE_SECS
-    }
+    fresh: dict[str, dict] = {}
+    for key, entry in entries.items():
+        started_at = _started_at(entry)
+        if started_at is None:
+            continue
+        age = now - started_at
+        if -_MAX_FUTURE_SKEW_SECS <= age <= _MAX_AGE_SECS:
+            fresh[key] = entry
     if len(fresh) <= _MAX_ENTRIES:
         return fresh
     newest = sorted(
         fresh.items(),
-        key=lambda item: float(item[1].get("started_at") or 0),
+        key=lambda item: _started_at(item[1]) or 0,
         reverse=True,
     )[:_MAX_ENTRIES]
     return dict(newest)
@@ -85,7 +169,25 @@ def _store(path: Path, entries: dict[str, dict]) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(entries, f)
+            f.flush()
+            os.fsync(f.fileno())
         os.replace(tmp, path)
+        # The file fsync above makes the payload durable; persisting the
+        # containing directory makes the replacement name durable too.  On a
+        # sudden machine reset, omitting this step can resurrect the old name
+        # or lose the marker entirely even though the temp file was synced.
+        if os.name != "nt":
+            try:
+                dir_fd = os.open(path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+            except OSError:
+                # Some network filesystems reject directory fsync.  The
+                # atomic replacement already succeeded; preserve that useful
+                # state instead of treating bookkeeping as a failed write.
+                logger.debug("directory fsync unavailable for %s", path.parent)
     except Exception:
         try:
             os.unlink(tmp)
@@ -113,10 +215,13 @@ def record_turn_start(
     }
     try:
         with _lock:
-            path = _marker_path(home)
-            entries = _prune(_load(path), now)
-            entries[session_key] = entry
-            _store(path, entries)
+            with _process_lock(home):
+                path = _marker_path(home)
+                entries = _prune(_load(path), now)
+                entries[session_key] = entry
+                # Apply the bound after insertion too.  Pruning only the old
+                # snapshot allowed every successful write to hold 33 entries.
+                _store(path, _prune(entries, now))
     except Exception:
         logger.debug("failed to record turn marker for %s", session_key, exc_info=True)
 
@@ -127,12 +232,13 @@ def clear_turn_marker(home: Path | str, session_key: str) -> None:
         return
     try:
         with _lock:
-            path = _marker_path(home)
-            entries = _load(path)
-            if session_key not in entries:
-                return
-            del entries[session_key]
-            _store(path, entries)
+            with _process_lock(home):
+                path = _marker_path(home)
+                entries = _load(path)
+                if session_key not in entries:
+                    return
+                del entries[session_key]
+                _store(path, entries)
     except Exception:
         logger.debug("failed to clear turn marker for %s", session_key, exc_info=True)
 
@@ -152,8 +258,10 @@ def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | Non
     if not prompt.strip():
         return None
     try:
-        started_at = float(entry.get("started_at") or 0)
+        started_at = _started_at(entry)
+        if started_at is None:
+            return None
         attempts = max(0, int(entry.get("attempts") or 0))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
     return {"attempts": attempts, "prompt": prompt, "started_at": started_at}


### PR DESCRIPTION
## Summary

Hardens the Desktop/TUI interrupted-turn journal and compute-host supervisor against ordinary crash/restart races.

- validates and bounds persisted turn markers, rejects implausible clock-skewed recovery, serializes sidecar updates across processes, and fsyncs both payload and directory entry
- cleans up compute children after post-spawn startup failures
- resolves pending control waiters on crash/shutdown and removes send-failure leaks
- prevents stale exits from deleting replacement registries and refuses duplicate startup when an orphan cannot be terminated
- retries transient compute-host respawn failures within the existing bounded crash-loop budget

No external systems, credentials, protocol schemas, prompt caching, or evaluation ground truth are changed.

## Reproduction

Detached current-main parent plus the regression file: **15/15 failed** (one parametrized timestamp contract produces three cases). The POSIX durability assertion also failed independently because neither the payload nor directory was fsynced.

## Validation

- `scripts/run_tests.sh -j 1 tests/tui_gateway/test_state_recovery_lane12.py -q`: **16 passed**
- `scripts/run_tests.sh -j 4 tests/tui_gateway/ -q`: **517 passed**
- Ruff: all changed files pass
- `git diff --check`: pass
- isolated API gateway on port 18712: 25/25 concurrent health probes returned 200; clean SIGTERM restart and SIGKILL restart both returned to healthy 200

## Open-PR coordination

PR #71276 also edits the interrupted-turn files to persist auto-continue attempt claims. This PR does not replace that behavior; if #71276 lands first, retain its compare-and-set attempt claim while resolving the small `turn_marker.py` / `server.py` overlap.