### PR TITLE
fix: handle list-type content in extract_content_or_reasoning (#72417)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8255,7 +8255,24 @@ def extract_content_or_reasoning(response) -> str:
     import re
 
     msg = response.choices[0].message
-    content = (msg.content or "").strip()
+    raw_content = msg.content
+    # Multimodal responses may return content as a list of typed parts
+    # (e.g. [{"type": "text", "text": "..."}, {"type": "image_url", ...}]).
+    # Flatten to a plain string so downstream regex/string ops don't crash
+    # with "expected string or bytes-like object, got 'list'".
+    if isinstance(raw_content, list):
+        text_bits: list[str] = []
+        for part in raw_content:
+            if isinstance(part, str):
+                text_bits.append(part)
+            elif isinstance(part, dict):
+                if part.get("type") == "text":
+                    text_bits.append(part.get("text", ""))
+                elif part.get("type") == "image_url":
+                    text_bits.append("[image]")
+            # Skip unknown part types silently
+        raw_content = "\n".join(text_bits) if text_bits else ""
+    content = (raw_content or "").strip()
 
     if content:
         # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)


### PR DESCRIPTION
## Summary

`extract_content_or_reasoning()` in `agent/auxiliary_client.py` crashes when `message.content` is a list (multimodal response parts) instead of a string, producing:

```
Error during OpenAI-compatible API call #59: expected string or bytes-like object, got 'list'
```

This happens when certain providers return content as a list of typed parts (e.g. `[{"type": "text", "text": "..."}, {"type": "image_url", ...}]`) instead of a plain string. The function passed this list directly to `str.strip()` and `re.sub()`, both of which expect string arguments.

## Fix

Flatten list-type `msg.content` to a plain string before processing:
- `str` parts joined directly
- `text`-type dict parts extracted via `.get("text")`
- `image_url` parts replaced with `[image]` marker
- Unknown part types skipped silently

## Test Plan

- [x] All 22 existing tests in `tests/tools/test_llm_content_none_guard.py` pass
- [x] Syntax check passes
- [ ] Regression test with list-type content (manual verification)

Fixes #72417