### PR TITLE
[AI] fix(whatsapp): group messages silently dropped when LID sender has no lid-mapping file

### DIFF
--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -86,3 +86,22 @@ export function matchesAllowedUser(senderId, allowedUsers, sessionDir) {
 
   return false;
 }
+
+// Baileys v7 delivers group senders in LID form (``key.participant``) and
+// carries the matching phone number in ``key.participantAlt`` (DMs:
+// ``remoteJidAlt``). When the session has no lid-mapping-*.json file for
+// that LID yet (e.g. a fresh bot number without history sync),
+// expandWhatsAppIdentifiers cannot bridge the two forms, so a phone-number
+// allowlist silently rejects every group participant (#72529). Fall back to
+// the alt identifier so whichever form the operator configured still matches.
+export function matchesAllowedSenderWithAlt(senderId, senderAltId, allowedUsers, sessionDir) {
+  if (matchesAllowedUser(senderId, allowedUsers, sessionDir)) {
+    return true;
+  }
+  const alt = normalizeWhatsAppIdentifier(senderAltId);
+  if (alt && alt !== normalizeWhatsAppIdentifier(senderId)) {
+    return matchesAllowedUser(alt, allowedUsers, sessionDir);
+  }
+  return false;
+}
+

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -6,6 +6,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 
 import {
   expandWhatsAppIdentifiers,
+  matchesAllowedSenderWithAlt,
   matchesAllowedUser,
   normalizeWhatsAppIdentifier,
   parseAllowedUsers,
@@ -74,6 +75,52 @@ test('matchesAllowedUser rejects everyone when allowlist is empty (#8389)', () =
     // Null/undefined allowlist (defensive) also rejects.
     assert.equal(matchesAllowedUser('19175395595@s.whatsapp.net', null, sessionDir), false);
     assert.equal(matchesAllowedUser('19175395595@s.whatsapp.net', undefined, sessionDir), false);
+  } finally {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+});
+
+test('matchesAllowedSenderWithAlt falls back to participantAlt when no lid mapping exists (#72529)', () => {
+  // Baileys v7 group messages arrive with key.participant in LID form and
+  // the phone number only in key.participantAlt. A fresh bot session has no
+  // lid-mapping-*.json files, so the LID alone can never match a phone
+  // allowlist — the alt identifier must be consulted as a fallback.
+  const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
+
+  try {
+    const allowedUsers = parseAllowedUsers('+19175395595');
+
+    // No mapping file: LID by itself is rejected today (the #72529 drop)…
+    assert.equal(matchesAllowedUser('267383306489914@lid', allowedUsers, sessionDir), false);
+    // …but the alt phone identifier rescues the match.
+    assert.equal(
+      matchesAllowedSenderWithAlt('267383306489914@lid', '19175395595@s.whatsapp.net', allowedUsers, sessionDir),
+      true
+    );
+
+    // A stranger's LID with a non-allowlisted alt stays rejected.
+    assert.equal(
+      matchesAllowedSenderWithAlt('188012763865257@lid', '15550001111@s.whatsapp.net', allowedUsers, sessionDir),
+      false
+    );
+
+    // Missing / empty alt keeps the existing behaviour.
+    assert.equal(matchesAllowedSenderWithAlt('267383306489914@lid', '', allowedUsers, sessionDir), false);
+    assert.equal(matchesAllowedSenderWithAlt('267383306489914@lid', undefined, allowedUsers, sessionDir), false);
+  } finally {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+});
+
+test('matchesAllowedSenderWithAlt still resolves via lid-mapping files without an alt', () => {
+  const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
+
+  try {
+    writeFileSync(path.join(sessionDir, 'lid-mapping-19175395595.json'), JSON.stringify('267383306489914'));
+    writeFileSync(path.join(sessionDir, 'lid-mapping-267383306489914_reverse.json'), JSON.stringify('19175395595'));
+
+    const allowedUsers = parseAllowedUsers('+19175395595');
+    assert.equal(matchesAllowedSenderWithAlt('267383306489914@lid', '', allowedUsers, sessionDir), true);
   } finally {
     rmSync(sessionDir, { recursive: true, force: true });
   }

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,7 +30,7 @@ import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { matchesAllowedSenderWithAlt, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -532,6 +532,12 @@ async function startSocket() {
 
       const chatId = msg.key.remoteJid;
       const senderId = msg.key.participant || chatId;
+      // Baileys v7 sends the phone-number twin of a LID sender here: group
+      // messages carry key.participantAlt, DMs carry key.remoteJidAlt. Keep
+      // it for allowlist fallback when no lid-mapping file exists (#72529).
+      const senderAltId = normalizeWhatsAppId(
+        msg.key.participant ? (msg.key.participantAlt || '') : (msg.key.remoteJidAlt || '')
+      );
       const isGroup = chatId.endsWith('@g.us');
       const senderNumber = senderId.replace(/@.*/, '');
       emitDebugEvent({
@@ -634,13 +640,14 @@ async function startSocket() {
           } catch {}
           continue;
         }
-        if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedSenderWithAlt(senderId, senderAltId, ALLOWED_USERS, SESSION_DIR)) {
           try {
             console.log(JSON.stringify({
               event: 'ignored',
               reason: 'allowlist_mismatch',
               chatId,
               senderId,
+              senderAltId,
             }));
           } catch {}
           continue;


### PR DESCRIPTION
Fixes #72529

## Root cause

In bot mode, group messages never reach the gateway while DMs work fine. The drop happens in the bridge, before the Python gateway ever sees the message:

1. Baileys 7.0.0-rc13 delivers group senders in LID form: `msg.key.participant = <id>@lid`.
2. The bridge allowlist gate (`bridge.js`, messages.upsert) matches that LID against `WHATSAPP_ALLOWED_USERS` (usually phone numbers) via `matchesAllowedUser`, which can only bridge LID and phone forms through `lid-mapping-*.json` session files.
3. Those mapping files are frequently absent for group participants: Baileys rc13 only stores an envelope LID/PN mapping when the decryption sender is a PN and the alt is a LID (see `src/Utils/decode-wa-message.ts` in WhiskeySockets/Baileys, storeLIDPNMappings call) - the exact opposite of the group-LID case. A fresh bot number without history sync has none of these files.
4. The gate then drops the message with `reason: allowlist_mismatch`, logged only to bridge stdout - which hosted deployments do not surface. Gateway logs show nothing, matching the report.

Baileys rc13 already ships the fix material: for LID-addressed stanzas it sets `key.participantAlt` (groups) / `key.remoteJidAlt` (DMs) to the phone-number twin of the sender (and the LID twin when addressing is PN). The bridge currently never reads these fields.

## Change

- `allowlist.js`: add `matchesAllowedSenderWithAlt(senderId, senderAltId, ...)` - tries the existing match first, then falls back to the alt identifier when it differs. Empty-allowlist / wildcard semantics unchanged.
- `bridge.js`: derive `senderAltId` from `participantAlt`/`remoteJidAlt` in messages.upsert, use the new matcher at the allowlist gate, and include `senderAltId` in the ignored-event log line for easier diagnosis.
- `allowlist.test.mjs`: regression tests for the #72529 scenario (LID sender, no mapping files, phone allowlist), stranger rejection, empty-alt fallback, and mapping-file resolution still working without an alt.

## Verification and limitations

- `node --test allowlist.test.mjs`: 7/7 pass (5 existing + 2 new).
- Simulated the patched gate against the four rc13 addressing shapes (group/DM x LID/PN addressing, plus device-suffixed alt and missing alt) taken from the rc13 decode-wa-message source: allowlisted senders pass, strangers and no-alt LID senders are still rejected.
- I could not reproduce the issue end to end (no live WhatsApp bot environment; the issue is still marked needs-repro). The analysis above is from source only, so a confirmation from someone who can reproduce #72529 would be valuable.

Behavior notes: the fallback only widens matching for senders whose alt identifier is explicitly allowlisted - unlisted senders keep getting dropped, and the empty-allowlist secure default (#8389) is untouched.