### PR TITLE
feat(gateway): add owner-only YouTube probe boundary

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -19,6 +19,7 @@ from enum import Enum
 from hermes_cli.config import get_hermes_home
 from agent.secret_scope import current_secret_scope, get_secret as _get_secret
 from utils import is_truthy_value
+from gateway.owner_commands import OwnerConfig, _load_owner_config
 
 logger = logging.getLogger(__name__)
 
@@ -900,6 +901,10 @@ class GatewayConfig:
     # dict with: name, platform, profile, and optional guild_id/chat_id/thread_id.
     profile_routes: list = field(default_factory=list)
 
+    # Dedicated owner identity set. It is secret-scoped, bounded, and omitted
+    # from to_dict() so owner IDs are never returned through config surfaces.
+    owner_config: OwnerConfig = field(default_factory=OwnerConfig, repr=False)
+
     def __post_init__(self) -> None:
         self.systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
             self.systemd_watchdog_seconds
@@ -1152,6 +1157,7 @@ class GatewayConfig:
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
             profile_routes=profile_routes,
+            owner_config=_load_owner_config(_getenv("HERMES_OWNER_PRINCIPALS")),
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:

--- a/gateway/owner_commands.py
+++ b/gateway/owner_commands.py
@@ -1,0 +1,410 @@
+"""Private owner-principal and pre-model owner-command boundary.
+
+Owner identity is intentionally separate from gateway authorization.  The
+configured set is read from the secret-scoped ``HERMES_OWNER_PRINCIPALS`` value
+as comma-separated ``platform:user-id`` entries, is bounded, and is never
+serialized or logged by this module.
+
+Request/session bindings are opaque HMACs tied to this process epoch.  They are
+not durable replay keys; a future host integration must provide durable replay
+protection.  The callback contract is deliberately synchronous and may return
+only ``"accepted"`` or ``"duplicate"``.
+
+Hermes plugins and all other Python loaded into the gateway process are trusted
+in-process code.  The private provenance machinery prevents accidental/public
+API forgery and detects mutation between adapter intake and interception; it is
+not a sandbox or isolation boundary against a malicious plugin with arbitrary
+Python access.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import inspect
+import json
+import re
+import secrets
+from dataclasses import dataclass, field
+from typing import Any, Callable, FrozenSet, Optional
+from urllib.parse import urlsplit
+
+
+_MAX_OWNERS = 16
+_MAX_OWNER_ENTRY_LENGTH = 320
+_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+_WATCH_QUERY_RE = re.compile(r"^v=([A-Za-z0-9_-]{11})$")
+_COMMAND_PREFIX = "/youtube-probe"
+_PROCESS_EPOCH_KEY = secrets.token_bytes(32)
+
+
+@dataclass(frozen=True, slots=True)
+class OwnerConfig:
+    """Bounded owner set with no public identifier-bearing representation."""
+
+    _principals: FrozenSet[str] = field(default_factory=frozenset, repr=False)
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._principals)
+
+    @property
+    def count(self) -> int:
+        return len(self._principals)
+
+    def __repr__(self) -> str:
+        return f"OwnerConfig(enabled={self.enabled}, count={self.count})"
+
+
+@dataclass(frozen=True, slots=True)
+class _OwnerPrincipal:
+    platform: str
+    request_binding: str = field(repr=False)
+    session_binding: str = field(repr=False)
+
+    def __repr__(self) -> str:
+        return f"_OwnerPrincipal(platform={self.platform!r}, bindings=<redacted>)"
+
+
+@dataclass(frozen=True, slots=True)
+class _OwnerCommandRequest:
+    principal: _OwnerPrincipal = field(repr=False)
+    video_url: str = field(repr=False)
+    request_binding: str = field(repr=False)
+    session_binding: str = field(repr=False)
+
+    def __repr__(self) -> str:
+        return "_OwnerCommandRequest(<redacted>)"
+
+
+@dataclass(frozen=True, slots=True)
+class _InboundOwnerProvenance:
+    _digest: str = field(repr=False)
+    _owner_command_candidate: bool = field(repr=False)
+
+    def __repr__(self) -> str:
+        return "_InboundOwnerProvenance(<redacted>)"
+
+
+def _load_owner_config(raw: Optional[str]) -> OwnerConfig:
+    """Parse the secret-scoped owner set without exposing rejected values."""
+    if not isinstance(raw, str) or not raw.strip():
+        return OwnerConfig()
+    parsed: set[str] = set()
+    entries = raw.split(",")
+    if len(entries) > _MAX_OWNERS:
+        return OwnerConfig()
+    for entry in entries:
+        value = entry.strip()
+        if not value or len(value) > _MAX_OWNER_ENTRY_LENGTH or ":" not in value:
+            return OwnerConfig()
+        platform, user_id = value.split(":", 1)
+        platform = platform.strip().lower()
+        user_id = user_id.strip()
+        if (
+            not platform
+            or not user_id
+            or platform in {"api_server", "webhook", "relay", "local"}
+            or "*" in user_id
+            or any(ch.isspace() for ch in platform)
+        ):
+            return OwnerConfig()
+        parsed.add(_owner_fingerprint(platform, user_id))
+    if len(parsed) > _MAX_OWNERS:
+        return OwnerConfig()
+    return OwnerConfig(frozenset(parsed))
+
+
+def _opaque_binding(kind: str, *parts: object) -> str:
+    payload = "\x1f".join([kind, *(str(part or "") for part in parts)])
+    return hmac.new(
+        _PROCESS_EPOCH_KEY, payload.encode("utf-8"), hashlib.sha256
+    ).hexdigest()[:32]
+
+
+def _owner_fingerprint(platform: str, user_id: str) -> str:
+    return _opaque_binding("owner", platform, user_id)
+
+
+def _canonical_youtube_url(text: str) -> Optional[str]:
+    if (
+        not isinstance(text, str)
+        or not text.startswith("https://")
+        or any(ch.isspace() for ch in text)
+    ):
+        return None
+    try:
+        parsed = urlsplit(text)
+    except ValueError:
+        return None
+    if (
+        parsed.scheme != "https"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port is not None
+        or parsed.fragment
+    ):
+        return None
+    if parsed.netloc == "www.youtube.com":
+        if parsed.path != "/watch":
+            return None
+        query_match = _WATCH_QUERY_RE.fullmatch(parsed.query)
+        if query_match is None:
+            return None
+        video_id = query_match.group(1)
+        canonical = f"https://www.youtube.com/watch?v={video_id}"
+        return canonical if text == canonical else None
+    if parsed.netloc == "youtu.be":
+        if parsed.query or not parsed.path.startswith("/"):
+            return None
+        video_id = parsed.path[1:]
+        if "/" in video_id or not _VIDEO_ID_RE.fullmatch(video_id):
+            return None
+        canonical = f"https://youtu.be/{video_id}"
+        return canonical if text == canonical else None
+    return None
+
+
+def _is_owner_command_candidate(text: object) -> bool:
+    return isinstance(text, str) and (
+        text == _COMMAND_PREFIX
+        or (
+            text.startswith(_COMMAND_PREFIX)
+            and len(text) > len(_COMMAND_PREFIX)
+            and text[len(_COMMAND_PREFIX)].isspace()
+        )
+    )
+
+
+def _normalized_name(value: object) -> str:
+    raw = getattr(value, "name", None)
+    if raw is None:
+        raw = getattr(value, "value", value)
+    return str(raw or "").lower()
+
+
+def _provenance_facts(event: Any) -> Optional[tuple[object, ...]]:
+    """Return validated transport facts, or ``None`` when provenance is unsafe."""
+    source = getattr(event, "source", None)
+    raw = getattr(event, "raw_message", None)
+    platform = getattr(getattr(source, "platform", None), "value", "")
+    if (
+        source is None
+        or raw is None
+        or getattr(source, "chat_type", None) != "dm"
+        or not getattr(source, "user_id", None)
+        or getattr(source, "is_bot", False) is True
+        or getattr(event, "reply_to_message_id", None)
+        or getattr(event, "reply_to_text", None)
+    ):
+        return None
+
+    if platform == "telegram":
+        author = getattr(raw, "from_user", None)
+        chat = getattr(raw, "chat", None)
+        author_id = str(getattr(author, "id", ""))
+        raw_message_id = str(getattr(raw, "message_id", ""))
+        chat_id = str(getattr(chat, "id", ""))
+        chat_type = _normalized_name(getattr(chat, "type", None))
+        if not (
+            author is not None
+            and chat is not None
+            and bool(author_id and raw_message_id and chat_id)
+            and author_id == str(source.user_id)
+            and raw_message_id == str(getattr(event, "message_id", ""))
+            and chat_id == str(source.chat_id)
+            and chat_id == author_id
+            and chat_type in {"private", "chattype.private"}
+            and getattr(author, "is_bot", False) is False
+            and getattr(raw, "forward_origin", None) is None
+            and getattr(raw, "forward_date", None) is None
+            and getattr(raw, "sender_chat", None) is None
+            and getattr(raw, "via_bot", None) is None
+            and getattr(raw, "is_automatic_forward", False) is False
+            and getattr(raw, "reply_to_message", None) is None
+        ):
+            return None
+        raw_facts: tuple[object, ...] = (
+            author_id,
+            raw_message_id,
+            chat_id,
+            chat_type,
+            False,  # author is not a bot
+            False,  # not forwarded/automatic/via-bot/sender-chat
+            False,  # not a reply
+        )
+    elif platform == "discord":
+        author = getattr(raw, "author", None)
+        channel = getattr(raw, "channel", None)
+        author_id = str(getattr(author, "id", ""))
+        raw_message_id = str(getattr(raw, "id", ""))
+        channel_id = str(getattr(channel, "id", ""))
+        msg_type = getattr(raw, "type", None)
+        msg_type_name = _normalized_name(msg_type)
+        channel_type = _normalized_name(getattr(channel, "type", None))
+        channel_class = type(channel).__name__.lower() if channel is not None else ""
+        is_private_channel = channel_class == "dmchannel" or channel_type in {
+            "private",
+            "dm",
+            "channeltype.private",
+        }
+        if not (
+            author is not None
+            and channel is not None
+            and bool(author_id and raw_message_id and channel_id)
+            and author_id == str(source.user_id)
+            and raw_message_id == str(getattr(event, "message_id", ""))
+            and channel_id == str(source.chat_id)
+            and getattr(author, "bot", False) is False
+            and getattr(raw, "guild", None) is None
+            and getattr(channel, "guild", None) is None
+            and is_private_channel
+            and getattr(raw, "webhook_id", None) is None
+            and getattr(raw, "reference", None) is None
+            and not (getattr(raw, "message_snapshots", None) or [])
+            and msg_type_name in {"default", "messagetype.default"}
+        ):
+            return None
+        raw_facts = (
+            author_id,
+            raw_message_id,
+            channel_id,
+            channel_type,
+            channel_class,
+            msg_type_name,
+            False,  # author is not a bot
+            False,  # no webhook/reference/forward snapshot/guild
+        )
+    else:
+        return None
+
+    return (
+        platform,
+        str(source.user_id),
+        str(source.chat_id),
+        str(getattr(event, "message_id", "")),
+        getattr(event, "text", None),
+        getattr(source, "chat_type", None),
+        getattr(source, "is_bot", False) is True,
+        getattr(source, "delivered_via_upstream_relay", False) is True,
+        getattr(event, "internal", False) is True,
+        bool(getattr(event, "reply_to_message_id", None)),
+        bool(getattr(event, "reply_to_text", None)),
+        bool(getattr(event, "media_urls", None)),
+        bool(getattr(event, "channel_context", None)),
+        raw_facts,
+    )
+
+
+def _provenance_digest(event: Any) -> Optional[str]:
+    facts = _provenance_facts(event)
+    if facts is None:
+        return None
+    encoded = json.dumps(facts, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return hmac.new(
+        _PROCESS_EPOCH_KEY, b"provenance\0" + encoded, hashlib.sha256
+    ).hexdigest()
+
+
+def _stamp_direct_human_event(event: Any) -> None:
+    """Privately bind an intake event once to its exact validated provenance."""
+    if getattr(event, "_owner_provenance", None) is not None:
+        return
+    digest = _provenance_digest(event)
+    if digest is not None:
+        event._owner_provenance = _InboundOwnerProvenance(
+            digest,
+            _is_owner_command_candidate(getattr(event, "text", None)),
+        )
+
+
+def _has_valid_provenance(event: Any) -> bool:
+    provenance = getattr(event, "_owner_provenance", None)
+    if not isinstance(provenance, _InboundOwnerProvenance):
+        return False
+    current = _provenance_digest(event)
+    return current is not None and hmac.compare_digest(provenance._digest, current)
+
+
+def _handle_owner_command(
+    event: Any,
+    config: OwnerConfig,
+    callback: Optional[Callable[[_OwnerCommandRequest], object]],
+    *,
+    session_key: str,
+    rewritten: bool = False,
+) -> tuple[bool, Optional[str]]:
+    """Synchronously decide and consume an owner command before model dispatch."""
+    text = getattr(event, "text", None)
+    provenance = getattr(event, "_owner_provenance", None)
+    if provenance is not None and not _has_valid_provenance(event):
+        if _is_owner_command_candidate(text) or (
+            isinstance(provenance, _InboundOwnerProvenance)
+            and provenance._owner_command_candidate
+        ):
+            return True, "Owner command unavailable."
+        return False, None
+    if not _is_owner_command_candidate(text):
+        return False, None
+
+    parts = text.split(" ") if isinstance(text, str) else []
+    if len(parts) != 2 or not parts[1] or any(not part for part in parts):
+        return True, "Usage: /youtube-probe <HTTPS YouTube video URL>"
+    video_url = _canonical_youtube_url(parts[1])
+    if video_url is None:
+        return True, "Usage: /youtube-probe <HTTPS YouTube video URL>"
+
+    source = getattr(event, "source", None)
+    platform = getattr(getattr(source, "platform", None), "value", "")
+    user_id = getattr(source, "user_id", None)
+    eligible = bool(
+        config.enabled
+        and not rewritten
+        and source is not None
+        and getattr(event, "internal", False) is False
+        and _has_valid_provenance(event)
+        and getattr(source, "chat_type", None) == "dm"
+        and getattr(source, "is_bot", False) is False
+        and getattr(source, "delivered_via_upstream_relay", False) is False
+        and not getattr(event, "media_urls", None)
+        and not getattr(event, "channel_context", None)
+        and _owner_fingerprint(platform, str(user_id or "")) in config._principals
+    )
+    if not eligible:
+        return True, "Owner command unavailable."
+
+    request_binding = _opaque_binding(
+        "request", platform, user_id, getattr(event, "message_id", None), video_url
+    )
+    session_binding = _opaque_binding("session", platform, user_id, session_key)
+    principal = _OwnerPrincipal(
+        platform=platform,
+        request_binding=request_binding,
+        session_binding=session_binding,
+    )
+    if callback is None:
+        return True, "Owner command service unavailable."
+
+    try:
+        result = callback(
+            _OwnerCommandRequest(
+                principal=principal,
+                video_url=video_url,
+                request_binding=request_binding,
+                session_binding=session_binding,
+            )
+        )
+        if inspect.isawaitable(result):
+            if inspect.iscoroutine(result):
+                result.close()
+            return True, "Owner command service unavailable."
+    except Exception:
+        return True, "Owner command service unavailable."
+
+    if result == "accepted":
+        return True, "YouTube probe accepted."
+    if result == "duplicate":
+        return True, "YouTube probe already accepted."
+    return True, "Owner command service unavailable."

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1819,6 +1819,11 @@ class MessageEvent:
     # particular key existing.
     metadata: Dict[str, Any] = field(default_factory=dict)
 
+    # Private, process-local HMAC provenance envelope used only by the owner-
+    # command boundary. ``init=False`` prevents callers from supplying it via
+    # the public constructor; it is also absent from persistence.
+    _owner_provenance: object = field(default=None, init=False, repr=False, compare=False)
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10004,6 +10004,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
         # (e.g. customer handover ingest) without triggering the pairing flow.
         if not is_internal:
+            _owner_input_rewritten = False
             try:
                 from hermes_cli.plugins import invoke_hook as _invoke_hook
                 _hook_results = _invoke_hook(
@@ -10033,11 +10034,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if isinstance(_new_text, str):
                         event = dataclasses.replace(event, text=_new_text)
                         source = event.source
+                        _owner_input_rewritten = True
                     break
                 if _action == "allow":
                     break
 
         if is_internal:
+            _owner_input_rewritten = False
             pass
         elif source.user_id is None:
             # Messages with no user identity (Telegram service messages,
@@ -10090,6 +10093,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
+
+        # Owner commands are consumed only after ordinary authorization and
+        # before any session/model dispatch. Authorization exists only in the
+        # immutable request passed directly to the synchronous callback.
+        from gateway.owner_commands import OwnerConfig, _handle_owner_command
+        _owner_handled, _owner_response = _handle_owner_command(
+            event,
+            getattr(self.config, "owner_config", None) or OwnerConfig(),
+            getattr(self, "_owner_command_callback", None),
+            session_key=self._session_key_for_source(source),
+            rewritten=_owner_input_rewritten,
+        )
+        if _owner_handled:
+            return _owner_response
         
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4265,6 +4265,14 @@ OPTIONAL_ENV_VARS = {
     },
 
     # ── Messaging platforms ──
+    "HERMES_OWNER_PRINCIPALS": {
+        "description": "Private comma-separated owner principals (platform:user-id) for owner-only gateway commands",
+        "prompt": "Owner principals",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
+    },
     "TELEGRAM_BOT_TOKEN": {
         "description": "Complete Telegram bot token created by @BotFather (numeric bot ID followed by a colon and secret)",
         "prompt": "Telegram bot token",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7530,6 +7530,8 @@ class DiscordAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
         )
+        from gateway.owner_commands import _stamp_direct_human_event
+        _stamp_direct_human_event(event)
 
         # Track thread participation so the bot won't require @mention for
         # follow-up messages in threads it has already engaged in.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9086,7 +9086,7 @@ class TelegramAdapter(BasePlatformAdapter):
             _chat_id_str if thread_id_str else None,
         )
 
-        return MessageEvent(
+        event = MessageEvent(
             text=message.text or "",
             message_type=msg_type,
             source=source,
@@ -9099,6 +9099,9 @@ class TelegramAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
             timestamp=message.date,
         )
+        from gateway.owner_commands import _stamp_direct_human_event
+        _stamp_direct_human_event(event)
+        return event
 
     # ── Message reactions (processing lifecycle) ──────────────────────────
 

--- a/tests/gateway/test_owner_commands.py
+++ b/tests/gateway/test_owner_commands.py
@@ -1,0 +1,493 @@
+"""Security contract for the explicit gateway owner-command boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway import owner_commands
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.owner_commands import (
+    _canonical_youtube_url,
+    _handle_owner_command,
+    _load_owner_config,
+    _stamp_direct_human_event,
+)
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+VIDEO_ID = "dQw4w9WgXcQ"
+WATCH_URL = f"https://www.youtube.com/watch?v={VIDEO_ID}"
+SHORT_URL = f"https://youtu.be/{VIDEO_ID}"
+
+
+def _telegram_event(
+    text: str = f"/youtube-probe {WATCH_URL}",
+    *,
+    user_id: str = "owner-1",
+    chat_type: str = "dm",
+    reply: bool = False,
+    forwarded: bool = False,
+    bot: bool = False,
+) -> MessageEvent:
+    author = SimpleNamespace(id=user_id, is_bot=bot)
+    raw = SimpleNamespace(
+        from_user=author,
+        chat=SimpleNamespace(id=user_id, type=SimpleNamespace(name="private")),
+        message_id="message-1",
+        forward_origin=object() if forwarded else None,
+        forward_date=None,
+        sender_chat=None,
+        via_bot=None,
+        is_automatic_forward=False,
+        reply_to_message=object() if reply else None,
+    )
+    event = MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=user_id,
+            chat_type=chat_type,
+            user_id=user_id,
+            is_bot=bot,
+        ),
+        raw_message=raw,
+        message_id="message-1",
+        reply_to_message_id="prior" if reply else None,
+    )
+    _stamp_direct_human_event(event)
+    return event
+
+
+def _decision(event, config=None, callback=lambda request: "accepted", **kwargs):
+    return _handle_owner_command(
+        event,
+        config or _load_owner_config("telegram:owner-1"),
+        callback,
+        session_key="opaque-input-session",
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "canonical"),
+    [(WATCH_URL, WATCH_URL), (SHORT_URL, SHORT_URL)],
+)
+def test_exact_canonical_url_grammar_accepts_only_supported_forms(url, canonical):
+    assert _canonical_youtube_url(url) == canonical
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        f"http://www.youtube.com/watch?v={VIDEO_ID}",
+        f"https://youtube.com/watch?v={VIDEO_ID}",
+        f"https://www.youtube.com/watch?v={VIDEO_ID}&list=abc",
+        f"https://www.youtube.com/watch?v={VIDEO_ID}#fragment",
+        "https://www.youtube.com/watch?",
+        "https://www.youtube.com/watch#",
+        f"https://www.youtube.com/watch?v={VIDEO_ID}?",
+        f"https://www.youtube.com/watch?v={VIDEO_ID}#",
+        f"https://WWW.YOUTUBE.COM/watch?v={VIDEO_ID}",
+        "https://www.youtube.com/watch?v=%64Qw4w9WgXcQ",
+        f"https://youtu.be/{VIDEO_ID}?feature=share",
+        f"https://youtu.be/{VIDEO_ID}?",
+        f"https://youtu.be/{VIDEO_ID}#",
+        "https://youtu.be/not-eleven",
+        "https://example.invalid/watch?v=dQw4w9WgXcQ",
+    ],
+)
+def test_exact_canonical_url_grammar_rejects_variants(url):
+    assert _canonical_youtube_url(url) is None
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "/youtube-probe",
+        f"/youtube-probe  {WATCH_URL}",
+        f"/youtube-probe {WATCH_URL} extra",
+        f"/youtube-probe\t{WATCH_URL}",
+        f"/youtube-probe\n{WATCH_URL}",
+    ],
+)
+def test_malformed_command_is_consumed_without_callback(text):
+    callback = MagicMock(return_value="accepted")
+    handled, response = _decision(_telegram_event(text), callback=callback)
+    assert handled is True
+    assert response.startswith("Usage:")
+    callback.assert_not_called()
+
+
+def test_command_prefix_collision_is_not_consumed():
+    callback = MagicMock(return_value="accepted")
+    handled, response = _decision(
+        _telegram_event(f"/youtube-probe-extra {WATCH_URL}"), callback=callback
+    )
+    assert handled is False
+    assert response is None
+    callback.assert_not_called()
+
+
+def test_owner_config_is_bounded_disabled_by_default_and_not_serialized():
+    assert _load_owner_config(None).enabled is False
+    assert _load_owner_config("telegram:*").enabled is False
+    oversized = ",".join(f"telegram:user-{i}" for i in range(17))
+    assert _load_owner_config(oversized).enabled is False
+
+    cfg = GatewayConfig(owner_config=_load_owner_config("telegram:private-owner"))
+    rendered = cfg.to_dict()
+    assert "owner_config" not in rendered
+    assert "private-owner" not in repr(cfg)
+    assert "private-owner" not in repr(cfg.owner_config)
+
+
+@pytest.mark.parametrize(
+    "event,config,rewritten",
+    [
+        (
+            _telegram_event(user_id="ordinary"),
+            _load_owner_config("telegram:owner-1"),
+            False,
+        ),
+        (
+            _telegram_event(chat_type="group"),
+            _load_owner_config("telegram:owner-1"),
+            False,
+        ),
+        (_telegram_event(reply=True), _load_owner_config("telegram:owner-1"), False),
+        (
+            _telegram_event(forwarded=True),
+            _load_owner_config("telegram:owner-1"),
+            False,
+        ),
+        (_telegram_event(bot=True), _load_owner_config("telegram:owner-1"), False),
+        (_telegram_event(), _load_owner_config("telegram:owner-1"), True),
+    ],
+)
+def test_auth_and_provenance_matrix_fails_closed(event, config, rewritten):
+    callback = MagicMock(return_value="accepted")
+    handled, response = _decision(
+        event, config=config, callback=callback, rewritten=rewritten
+    )
+    assert handled is True
+    assert response == "Owner command unavailable."
+    callback.assert_not_called()
+
+
+def test_api_bearer_relay_pairing_role_and_allow_all_cannot_imply_owner():
+    for platform in (Platform.API_SERVER, Platform.WEBHOOK, Platform.RELAY):
+        event = MessageEvent(
+            text=f"/youtube-probe {WATCH_URL}",
+            source=SessionSource(
+                platform=platform,
+                chat_id="private",
+                chat_type="dm",
+                user_id="owner-1",
+                role_authorized=True,
+                delivered_via_upstream_relay=platform == Platform.RELAY,
+            ),
+            raw_message=SimpleNamespace(),
+        )
+        callback = MagicMock(return_value="accepted")
+        handled, response = _decision(event, callback=callback)
+        assert handled is True
+        assert response == "Owner command unavailable."
+        callback.assert_not_called()
+
+
+def test_direct_discord_human_can_be_proven_but_forward_snapshot_cannot():
+    def make_event(snapshots):
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="private-discord-chat",
+            chat_type="dm",
+            user_id="discord-owner",
+        )
+        raw = SimpleNamespace(
+            author=SimpleNamespace(id="discord-owner", bot=False),
+            id="discord-message",
+            channel=SimpleNamespace(
+                id="private-discord-chat",
+                type=SimpleNamespace(name="private"),
+                guild=None,
+            ),
+            guild=None,
+            webhook_id=None,
+            reference=None,
+            message_snapshots=snapshots,
+            type=SimpleNamespace(name="default"),
+        )
+        event = MessageEvent(
+            text=f"/youtube-probe {WATCH_URL}",
+            source=source,
+            raw_message=raw,
+            message_id="discord-message",
+        )
+        _stamp_direct_human_event(event)
+        return event
+
+    config = _load_owner_config("discord:discord-owner")
+    assert _decision(make_event([]), config=config) == (
+        True,
+        "YouTube probe accepted.",
+    )
+    callback = MagicMock(return_value="accepted")
+    assert _decision(make_event([object()]), config=config, callback=callback) == (
+        True,
+        "Owner command unavailable.",
+    )
+    callback.assert_not_called()
+
+
+def test_unstamped_direct_local_and_public_constructor_fail_closed():
+    event = MessageEvent(
+        text=f"/youtube-probe {WATCH_URL}",
+        source=SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="local",
+            chat_type="dm",
+            user_id="owner-1",
+        ),
+    )
+    handled, response = _decision(event, config=_load_owner_config("local:owner-1"))
+    assert handled is True
+    assert response == "Owner command unavailable."
+
+
+def test_callback_request_is_immutable_opaque_and_repr_redacted():
+    observed = {}
+
+    def callback(request):
+        observed["request"] = request
+        return "accepted"
+
+    handled, response = _decision(_telegram_event(), callback=callback)
+    assert (handled, response) == (True, "YouTube probe accepted.")
+    principal = observed["request"].principal
+    assert observed["request"].request_binding == principal.request_binding
+    assert len(observed["request"].request_binding) == 32
+    assert len(observed["request"].session_binding) == 32
+    assert "owner-1" not in repr(observed["request"])
+    assert WATCH_URL not in repr(observed["request"])
+    assert observed["request"].request_binding not in repr(observed["request"])
+    assert observed["request"].session_binding not in repr(observed["request"])
+    assert observed["request"].request_binding not in repr(principal)
+    assert observed["request"].session_binding not in repr(principal)
+    with pytest.raises((AttributeError, TypeError)):
+        principal.platform = "forged"
+
+
+@pytest.mark.asyncio
+async def test_child_task_created_inside_callback_has_no_ambient_owner_authority():
+    tasks = []
+
+    async def inspect_ambient_state():
+        return hasattr(owner_commands, "_current_owner_principal")
+
+    def callback(request):
+        tasks.append(asyncio.create_task(inspect_ambient_state()))
+        return "accepted"
+
+    assert _decision(_telegram_event(), callback=callback) == (
+        True,
+        "YouTube probe accepted.",
+    )
+    assert await tasks[0] is False
+
+
+@pytest.mark.parametrize("field", ["text", "source", "message_id", "raw"])
+def test_in_place_event_and_source_mutation_invalidates_provenance(field):
+    event = _telegram_event()
+    if field == "text":
+        event.text = f"/youtube-probe {SHORT_URL}"
+    elif field == "source":
+        event.source.user_id = "owner-2"
+    elif field == "message_id":
+        event.message_id = "message-2"
+    else:
+        event.raw_message.forward_origin = object()
+
+    callback = MagicMock(return_value="accepted")
+    config = _load_owner_config("telegram:owner-1,telegram:owner-2")
+    assert _decision(event, config=config, callback=callback) == (
+        True,
+        "Owner command unavailable.",
+    )
+    callback.assert_not_called()
+
+
+def test_mutated_event_cannot_be_restamped_over_existing_provenance():
+    event = _telegram_event()
+    original_provenance = event._owner_provenance
+    event.text = f"/youtube-probe {SHORT_URL}"
+    _stamp_direct_human_event(event)
+    assert event._owner_provenance is original_provenance
+    assert _decision(event) == (True, "Owner command unavailable.")
+
+
+@pytest.mark.parametrize(
+    ("callback", "expected"),
+    [
+        (None, "Owner command service unavailable."),
+        (
+            lambda request: (_ for _ in ()).throw(RuntimeError("private failure")),
+            "Owner command service unavailable.",
+        ),
+        (lambda request: "unexpected", "Owner command service unavailable."),
+        (lambda request: "duplicate", "YouTube probe already accepted."),
+    ],
+)
+def test_callback_absent_failure_duplicate_are_consumed(callback, expected):
+    handled, response = _decision(_telegram_event(), callback=callback)
+    assert handled is True
+    assert response == expected
+
+
+@pytest.mark.asyncio
+async def test_async_callback_is_rejected_not_fire_and_forget():
+    called = False
+
+    async def callback(request):
+        nonlocal called
+        called = True
+        return "accepted"
+
+    handled, response = _decision(_telegram_event(), callback=callback)
+    await asyncio.sleep(0)
+    assert handled is True
+    assert response == "Owner command service unavailable."
+    assert called is False
+
+
+def test_no_owner_ids_or_command_text_are_logged(caplog):
+    caplog.set_level(logging.DEBUG)
+    secret_id = "private-owner-id"
+    secret_url = f"https://youtu.be/{VIDEO_ID}"
+    event = _telegram_event(f"/youtube-probe {secret_url}", user_id=secret_id)
+    handled, _ = _decision(
+        event,
+        config=_load_owner_config(f"telegram:{secret_id}"),
+        callback=lambda request: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    assert handled is True
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert secret_id not in rendered
+    assert secret_url not in rendered
+
+    captured = {}
+    event = _telegram_event(user_id=secret_id)
+    _decision(
+        event,
+        config=_load_owner_config(f"telegram:{secret_id}"),
+        callback=lambda request: captured.setdefault("request", request) and "accepted",
+    )
+    request_repr = repr(captured["request"])
+    assert secret_id not in request_repr
+    assert WATCH_URL not in request_repr
+    assert captured["request"].request_binding not in request_repr
+    provenance_repr = repr(event._owner_provenance)
+    assert secret_id not in provenance_repr
+    assert WATCH_URL not in provenance_repr
+    assert event._owner_provenance._digest not in provenance_repr
+
+
+def test_normal_message_regression_is_not_consumed():
+    callback = MagicMock(return_value="accepted")
+    handled, response = _decision(
+        _telegram_event("please inspect this video"), callback=callback
+    )
+    assert (handled, response) == (False, None)
+    callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_canonical_gateway_runs_owner_hook_after_authorization(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner-1")
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)},
+        owner_config=_load_owner_config("telegram:owner-1"),
+    )
+    runner.adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._update_prompt_pending = {}
+    runner._startup_restore_in_progress = False
+    runner._scale_to_zero_note_real_inbound = MagicMock()
+    runner._owner_command_callback = MagicMock(return_value="accepted")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+
+    response = await runner._handle_message(_telegram_event())
+
+    assert response == "YouTube probe accepted."
+    runner._owner_command_callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_pairing_only_authorization_does_not_imply_owner(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)},
+        owner_config=_load_owner_config("telegram:different-owner"),
+    )
+    runner.adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._update_prompt_pending = {}
+    runner._startup_restore_in_progress = False
+    runner._scale_to_zero_note_real_inbound = MagicMock()
+    runner._owner_command_callback = MagicMock(return_value="accepted")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+
+    response = await runner._handle_message(_telegram_event(user_id="paired-user"))
+
+    assert response == "Owner command unavailable."
+    runner._owner_command_callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_global_allow_all_authorization_does_not_imply_owner(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)},
+        owner_config=_load_owner_config("telegram:different-owner"),
+    )
+    runner.adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._update_prompt_pending = {}
+    runner._startup_restore_in_progress = False
+    runner._scale_to_zero_note_real_inbound = MagicMock()
+    runner._owner_command_callback = MagicMock(return_value="accepted")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+
+    response = await runner._handle_message(_telegram_event(user_id="allow-all-user"))
+
+    assert response == "Owner command unavailable."
+    runner._owner_command_callback.assert_not_called()


### PR DESCRIPTION
## Summary
- add a bounded owner-principal configuration separate from gateway authorization
- bind Telegram and Discord DM provenance before model dispatch
- add a synchronous fail-closed callback boundary for canonical YouTube URLs
- avoid logging or serializing owner identifiers and request bindings

## Verification
- 50 focused gateway security tests passed
- Ruff checks passed
- git diff --check passed

This PR provides only the authorization boundary. Network execution remains unavailable until a durable replay ledger and constrained egress integration are reviewed separately.