### PR TITLE
fix(runtime): clean up remote backend probes

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1006,6 +1006,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
         _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
 
+    env = None
     try:
         config = _get_env_config()
         # Build the environment the same way tools/terminal_tool.py does for a
@@ -1039,7 +1040,10 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "container_cpu": config.get("container_cpu", 1),
                 "container_memory": config.get("container_memory", 5120),
                 "container_disk": config.get("container_disk", 51200),
-                "container_persistent": config.get("container_persistent", True),
+                # This is a one-command introspection probe, not a user
+                # workspace. It must never inherit the long-lived default
+                # container contract or survive as a bridge-network sleeper.
+                "container_persistent": False,
                 "modal_mode": config.get("modal_mode", "auto"),
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
@@ -1047,8 +1051,8 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "docker_env": config.get("docker_env", {}),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_extra_args": config.get("docker_extra_args", []),
-                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
-                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+                "docker_persist_across_processes": False,
+                "docker_orphan_reaper": False,
             }
 
         env = _create_environment(
@@ -1082,6 +1086,17 @@ def _probe_remote_backend(env_type: str) -> str | None:
         logger.debug("Backend probe failed: %s", e)
         _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
+    finally:
+        if env is not None:
+            try:
+                cleanup = getattr(env, "cleanup", None)
+                if callable(cleanup):
+                    cleanup()
+            except Exception as e:
+                # Prompt construction must remain best-effort. The ephemeral
+                # config above is the primary lifecycle guarantee; cleanup
+                # failures are diagnostics, not prompt failures.
+                logger.debug("Backend probe cleanup failed: %s", e)
 
     # Parse key=value lines back into a tidy summary.
     parsed: dict[str, str] = {}

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -28,6 +28,21 @@ _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
 # AGENTS.md as authoritative project context. Context discovery must never
 # resolve here.
 _PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona"})
+
+
+def _cwd_is_backend_local() -> bool:
+    """True when configured paths belong to a remote/container filesystem."""
+    backend = os.environ.get("TERMINAL_ENV", "").strip().lower()
+    return backend in _CONTAINER_BACKENDS
+
+
+def _warn_missing_cwd(label: str, value: str) -> None:
+    # `/workspace` and similar paths are valid inside container backends but
+    # intentionally absent on the host gateway. Warn only when the configured
+    # path is expected to name a host directory.
+    if not _cwd_is_backend_local():
+        logger.warning("%s does not exist: %s", label, value)
 
 
 def _is_install_tree(p: Path) -> bool:
@@ -63,13 +78,13 @@ def resolve_agent_cwd() -> Path:
         p = Path(override).expanduser()
         if p.is_dir():
             return p
-        logger.warning("configured working directory does not exist: %s", override)
+        _warn_missing_cwd("configured working directory", override)
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
         if p.is_dir():
             return p
-        logger.warning("TERMINAL_CWD does not exist: %s", raw)
+        _warn_missing_cwd("TERMINAL_CWD", raw)
     return Path(os.getcwd())
 
 
@@ -86,7 +101,7 @@ def resolve_context_cwd() -> Path | None:
     if override:
         p = Path(override).expanduser()
         if not p.is_dir():
-            logger.warning("configured working directory does not exist: %s", override)
+            _warn_missing_cwd("configured working directory", override)
         else:
             return p
         return None
@@ -94,7 +109,7 @@ def resolve_context_cwd() -> Path | None:
     if raw:
         p = Path(raw).expanduser()
         if not p.is_dir():
-            logger.warning("TERMINAL_CWD does not exist: %s", raw)
+            _warn_missing_cwd("TERMINAL_CWD", raw)
         else:
             return p
     return None

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1330,6 +1330,8 @@ class TestEnvironmentHints:
         _pb._clear_backend_probe_cache()
 
         class _FakeEnv:
+            cleaned = False
+
             def execute(self, cmd, timeout=None):
                 return {
                     "returncode": 0,
@@ -1339,11 +1341,16 @@ class TestEnvironmentHints:
                     ),
                 }
 
+            def cleanup(self):
+                self.cleaned = True
+
         created = {}
 
         def _fake_create_environment(*, env_type, **kwargs):
             created["env_type"] = env_type
-            return _FakeEnv()
+            created["container_config"] = kwargs["container_config"]
+            created["env"] = _FakeEnv()
+            return created["env"]
 
         # Patch the REAL factory in tools.terminal_tool — the probe imports it
         # locally, so the import itself must succeed (the bug was here).
@@ -1355,6 +1362,36 @@ class TestEnvironmentHints:
         assert line is not None
         assert "Linux 6.8.0" in line
         assert "root" in line
+        assert created["container_config"]["container_persistent"] is False
+        assert created["container_config"]["docker_persist_across_processes"] is False
+        assert created["container_config"]["docker_orphan_reaper"] is False
+        assert created["env"].cleaned is True
+
+    def test_probe_remote_backend_cleans_up_after_execute_failure(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import tools.terminal_tool as _tt
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        _pb._clear_backend_probe_cache()
+
+        class _FailingEnv:
+            cleaned = False
+
+            def execute(self, cmd, timeout=None):
+                raise TimeoutError("probe timed out")
+
+            def cleanup(self):
+                self.cleaned = True
+
+        env = _FailingEnv()
+        monkeypatch.setattr(
+            _tt,
+            "_create_environment",
+            lambda **kwargs: env,
+        )
+
+        assert _pb._probe_remote_backend("docker") is None
+        assert env.cleaned is True
 
     def test_remote_backend_list_covers_known_sandboxes(self):
         """Regression guard: if someone adds a remote backend, they must list it here."""
@@ -1704,5 +1741,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -35,6 +35,24 @@ class TestResolveAgentCwd:
         monkeypatch.chdir(tmp_path)
         assert resolve_agent_cwd() == tmp_path
 
+    def test_container_cwd_missing_on_host_is_silent(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", "/workspace")
+        monkeypatch.chdir(tmp_path)
+
+        assert resolve_agent_cwd() == tmp_path
+        assert "TERMINAL_CWD does not exist" not in caplog.text
+
+    def test_local_cwd_missing_on_host_still_warns(self, monkeypatch, tmp_path, caplog):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "gone"))
+        monkeypatch.chdir(tmp_path)
+
+        assert resolve_agent_cwd() == tmp_path
+        assert "TERMINAL_CWD does not exist" in caplog.text
+
     def test_expands_leading_tilde(self, monkeypatch):
         monkeypatch.setenv("TERMINAL_CWD", "~")
         assert resolve_agent_cwd() == Path(os.path.expanduser("~"))
@@ -73,6 +91,13 @@ class TestResolveContextCwd:
         missing = tmp_path / "gone"
         monkeypatch.setenv("TERMINAL_CWD", str(missing))
         assert resolve_context_cwd() is None
+
+    def test_container_context_cwd_missing_on_host_is_silent(self, monkeypatch, caplog):
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", "/workspace")
+
+        assert resolve_context_cwd() is None
+        assert "TERMINAL_CWD does not exist" not in caplog.text
 
     def test_returns_install_tree_when_explicitly_configured(self, monkeypatch):
         # An EXPLICITLY configured install-tree cwd is honored verbatim — the


### PR DESCRIPTION
## Summary
- force prompt-time backend probes to use ephemeral container lifecycle settings
- clean up probe environments on success and failure
- suppress host-only missing-cwd warnings for container backends while preserving local warnings

## Verification
- 186 focused tests passed
- Ruff checks passed
- git diff --check passed