### PR TITLE
fix(agent): enforce secret-source fetch timeout with a daemon thread so a stalled fetch cannot hang the CLI

### DIFF
--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -27,9 +27,9 @@ third-party backends ship as standalone plugin repos implementing
 
 from __future__ import annotations
 
-import concurrent.futures
 import logging
 import os
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -205,33 +205,57 @@ def _fetch_with_timeout(
     result is discarded.  The thread itself may linger until process
     exit — acceptable for a startup-only path, and strictly better than
     an unbounded hang on every ``hermes`` invocation.
+
+    The worker is an explicit ``threading.Thread(daemon=True)`` and NOT a
+    ``concurrent.futures.ThreadPoolExecutor`` on purpose: executor workers
+    are non-daemon threads that ``concurrent.futures.thread`` joins at
+    interpreter shutdown via its atexit hook, and ``shutdown(wait=False)``
+    does not detach them.  With an executor, a fetch stuck in a hung
+    download or subprocess kept the whole process alive at exit — the
+    TIMEOUT result was returned, the command printed its output, and then
+    the CLI hung forever anyway (#72071: ``hermes gateway status`` never
+    returning with a misconfigured Bitwarden source).  A daemon thread
+    cannot block interpreter shutdown, which is the entire point of this
+    budget.
     """
     timeout = source.fetch_timeout_seconds(cfg)
-    executor = concurrent.futures.ThreadPoolExecutor(
-        max_workers=1, thread_name_prefix=f"secret-src-{source.name}"
-    )
-    try:
-        future = executor.submit(source.fetch, cfg, home_path)
-        try:
-            result = future.result(timeout=timeout)
-        except concurrent.futures.TimeoutError:
-            future.cancel()
-            res = FetchResult()
-            res.error = (
-                f"fetch exceeded {timeout:.0f}s budget — startup continued "
-                "without this source (raise secrets."
-                f"{source.name}.timeout_seconds if the backend is just slow)"
-            )
-            res.error_kind = ErrorKind.TIMEOUT
-            return res
-        except Exception as exc:  # noqa: BLE001 — contract violation, contain it
-            res = FetchResult()
-            res.error = f"fetch raised {type(exc).__name__}: {exc}"
-            res.error_kind = ErrorKind.INTERNAL
-            return res
-    finally:
-        executor.shutdown(wait=False)
 
+    outcome: Dict[str, object] = {}
+    done = threading.Event()
+
+    def _worker() -> None:
+        try:
+            outcome["result"] = source.fetch(cfg, home_path)
+        except Exception as exc:  # noqa: BLE001 — contract violation, contain it
+            outcome["exception"] = exc
+        finally:
+            done.set()
+
+    worker = threading.Thread(
+        target=_worker,
+        name=f"secret-src-{source.name}",
+        daemon=True,
+    )
+    worker.start()
+
+    if not done.wait(timeout):
+        res = FetchResult()
+        res.error = (
+            f"fetch exceeded {timeout:.0f}s budget — startup continued "
+            "without this source (raise secrets."
+            f"{source.name}.timeout_seconds if the backend is just slow)"
+        )
+        res.error_kind = ErrorKind.TIMEOUT
+        return res
+
+    exc = outcome.get("exception")
+    if exc is not None:
+        res = FetchResult()
+        res.error = f"fetch raised {type(exc).__name__}: {exc}"
+        res.error_kind = ErrorKind.INTERNAL
+        return res
+
+    result = outcome.get("result")
     if not isinstance(result, FetchResult):
         res = FetchResult()
         res.error = (

--- a/tests/test_secret_source_fetch_timeout.py
+++ b/tests/test_secret_source_fetch_timeout.py
@@ -1,0 +1,122 @@
+"""Regression tests for #72071 — a stalled secret-source fetch must never
+hang the CLI.
+
+``agent.secret_sources.registry._fetch_with_timeout`` enforces the
+per-source wall-clock budget that protects every CLI entrypoint (e.g.
+``hermes gateway status``) from a secrets backend that blocks.  Two
+properties matter:
+
+* the budget actually returns a ``TIMEOUT`` FetchResult promptly, and
+* the fetch runs on a *daemon* thread, so a fetch stuck in a hung
+  download/subprocess cannot block interpreter shutdown.  (The previous
+  ThreadPoolExecutor-based implementation used non-daemon workers that
+  ``concurrent.futures.thread`` joins at exit, so the process hung
+  forever even after the timeout fired.)
+"""
+
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from agent.secret_sources.base import ErrorKind, FetchResult, SecretSource
+from agent.secret_sources.registry import _fetch_with_timeout
+
+
+class _StallingSource(SecretSource):
+    """Simulates a fetch stuck in an unresponsive download/subprocess."""
+
+    name = "stalling"
+    label = "Stalling Source"
+    shape = "bulk"
+
+    def __init__(self, release: threading.Event):
+        self._release = release
+        self.thread: Optional[threading.Thread] = None
+
+    def fetch(self, cfg: dict, home_path: Path) -> FetchResult:
+        self.thread = threading.current_thread()
+        # Outlive the 0.2s budget by a wide margin unless released.
+        self._release.wait(30)
+        return FetchResult()
+
+    def fetch_timeout_seconds(self, cfg: dict) -> float:
+        return 0.2
+
+
+class _FastSource(SecretSource):
+    name = "fast"
+    label = "Fast Source"
+    shape = "bulk"
+
+    def fetch(self, cfg: dict, home_path: Path) -> FetchResult:
+        result = FetchResult()
+        result.secrets = {"FAST_TOKEN": "value"}
+        return result
+
+
+class _RaisingSource(SecretSource):
+    name = "raising"
+    label = "Raising Source"
+    shape = "bulk"
+
+    def fetch(self, cfg: dict, home_path: Path) -> FetchResult:
+        raise RuntimeError("boom")
+
+
+class _WrongTypeSource(SecretSource):
+    name = "wrongtype"
+    label = "Wrong Type Source"
+    shape = "bulk"
+
+    def fetch(self, cfg: dict, home_path: Path):  # type: ignore[override]
+        return {"not": "a FetchResult"}
+
+
+def test_timeout_returns_promptly_without_waiting_for_fetch(tmp_path):
+    release = threading.Event()
+    source = _StallingSource(release)
+    try:
+        start = time.monotonic()
+        result = _fetch_with_timeout(source, {}, tmp_path)
+        elapsed = time.monotonic() - start
+
+        assert result.error_kind == ErrorKind.TIMEOUT
+        assert "budget" in (result.error or "")
+        # Must come back around the 0.2s budget, not the 30s stall.
+        assert elapsed < 5
+    finally:
+        release.set()
+
+
+def test_stalled_fetch_runs_on_daemon_thread(tmp_path):
+    """The worker must be a daemon so a stuck fetch can't block exit (#72071)."""
+    release = threading.Event()
+    source = _StallingSource(release)
+    try:
+        _fetch_with_timeout(source, {}, tmp_path)
+        assert source.thread is not None
+        assert source.thread is not threading.main_thread()
+        assert source.thread.daemon
+    finally:
+        release.set()
+        if source.thread is not None:
+            source.thread.join(timeout=5)
+
+
+def test_fast_fetch_result_passes_through(tmp_path):
+    result = _fetch_with_timeout(_FastSource(), {}, tmp_path)
+    assert result.ok
+    assert result.secrets == {"FAST_TOKEN": "value"}
+
+
+def test_fetch_exception_contained_as_internal_error(tmp_path):
+    result = _fetch_with_timeout(_RaisingSource(), {}, tmp_path)
+    assert result.error_kind == ErrorKind.INTERNAL
+    assert "RuntimeError" in (result.error or "")
+
+
+def test_non_fetchresult_return_contained_as_internal_error(tmp_path):
+    result = _fetch_with_timeout(_WrongTypeSource(), {}, tmp_path)
+    assert result.error_kind == ErrorKind.INTERNAL
+    assert "dict" in (result.error or "")


### PR DESCRIPTION
## What does this PR do?

Fixes the mechanism behind `hermes gateway status` (and every other CLI entrypoint) hanging **indefinitely** when a secret source stalls during startup — e.g. Bitwarden enabled but misconfigured on Windows (#72071).

**Root cause.** `agent/secret_sources/registry.py::_fetch_with_timeout` runs `source.fetch()` inside a `concurrent.futures.ThreadPoolExecutor`. The docstring says the budget is enforced with a *daemon* worker thread, but executor workers are **non-daemon** threads, and `concurrent.futures.thread` registers an atexit hook (`threading._register_atexit`) that **joins all worker threads at interpreter shutdown**. `executor.shutdown(wait=False)` does not detach them.

So when a fetch stalls past its budget (hung `bws` binary download, wedged subprocess):

1. the TIMEOUT `FetchResult` is returned as designed,
2. the command finishes its work and prints output,
3. …and then the process **hangs forever at exit**, joined to the stuck worker thread.

From the outside this looks exactly like the issue report: `hermes gateway status` never returns, watchdog scripts falsely detect a dead gateway and trigger restarts. The wall-clock budget — the one safeguard that exists specifically so a secrets backend can never block startup — is defeated by its own implementation.

**Fix.** Run the fetch on an explicit `threading.Thread(daemon=True)` (what the docstring already promised). A daemon thread cannot block interpreter shutdown. Behavior is otherwise byte-for-byte equivalent:

- budget overrun → `TIMEOUT` FetchResult with the same message,
- fetch raises → `INTERNAL` ("fetch raised …"),
- fetch returns a non-`FetchResult` → `INTERNAL` ("fetch returned … instead of FetchResult"),
- good result → passed through unchanged.

## Related Issue

Fixes #72071

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `agent/secret_sources/registry.py` — `_fetch_with_timeout` now uses an explicit daemon `threading.Thread` + `threading.Event` instead of `ThreadPoolExecutor`; dropped the `concurrent.futures` import; docstring documents why an executor must not be used here.
- `tests/test_secret_source_fetch_timeout.py` — new regression tests:
  - timeout returns promptly (~budget, not the stall duration) with `ErrorKind.TIMEOUT`,
  - the stalled fetch runs on a **daemon** thread (the #72071 regression guard),
  - fast fetch result passes through unchanged,
  - raising fetch is contained as `INTERNAL`,
  - non-`FetchResult` return is contained as `INTERNAL`.

## How to Test

```bash
scripts/run_tests.sh tests/test_secret_source_fetch_timeout.py -q
```

Manual repro of the original symptom (before this patch):

1. In `~/.hermes/config.yaml` set `secrets.bitwarden.enabled: true` with a token/config that makes the fetch stall (e.g. unreachable download endpoint for the `bws` auto-install, or a wedged subprocess).
2. Run `hermes gateway status` — the status output appears, but the process never exits (stuck in the atexit join of the executor worker).
3. With this patch, the process exits normally right after printing; the stalled worker is a daemon and is dropped at shutdown.

You can also observe the mechanism in isolation: a `ThreadPoolExecutor` worker blocked in `Event().wait()` keeps a Python process alive at exit, while a `daemon=True` thread does not.

## Platforms tested

The fix is pure-stdlib threading with no platform-specific code paths. Tests are hermetic (no network, no subprocesses) and written to run on Linux/macOS/Windows. **Honest note:** this was prepared in a restricted environment where I could not execute `scripts/run_tests.sh` myself — the test file uses only pytest + stdlib and follows the repo's hermetic test conventions, but please let CI confirm.

## Checklist

### Code
- [x] Change is focused on one logical fix
- [x] No new dependencies
- [x] Follows existing code style, keeps public behavior/messages identical
- [x] Regression tests added

### Documentation & Housekeeping
- [x] Docstring updated to explain the executor pitfall
- [x] Conventional Commit message (`fix(agent): …`)
- [x] Searched open **and** merged PRs/issues for duplicates before opening (none found for this fix)