### PR TITLE
fix(gateway): keep background delegation results in parent turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19793,6 +19793,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         resolve from that profile's secret scope. Mirrors the pattern in
         ``_run_agent``.
         """
+        # /background is itself a finite, fire-and-forget session. It can run
+        # long work, but once its agent turn returns the temporary session is
+        # closed and cannot receive a second, detached completion. Mark only
+        # this asyncio task's copied context as finite so delegate_task reuses
+        # its existing synchronous fallback: child agents still fan out in
+        # parallel, while their background parent waits for the combined result
+        # before replying. The originating live-chat context is unaffected.
+        from gateway.session_context import declare_stateless_channel
+
+        declare_stateless_channel()
+
         if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
             return await self._run_background_task_inner(
                 prompt, source, task_id, event_message_id, media_urls, media_types,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2055,6 +2055,12 @@ class GatewayTurnMixin:
         media_types: Optional[List[str]] = None,
     ) -> None:
         """Profile-scoping wrapper around the background agent task (mirrors ``_run_agent``)."""
+        # This finite task has no consumer for detached completions after its
+        # parent turn closes. Reuse inline delegation aggregation only in this
+        # task's copied context; the originating live chat remains routable.
+        from gateway.session_context import declare_stateless_channel
+
+        declare_stateless_channel()
         with self._profile_scope_for_source(source):
             return await self._run_background_task_inner(
                 prompt, source, task_id, event_message_id, media_urls, media_types,

--- a/tests/gateway/test_multiplex_background_task_scope.py
+++ b/tests/gateway/test_multiplex_background_task_scope.py
@@ -46,4 +46,31 @@ class TestBackgroundTaskProfileScope:
         scope.assert_called_once_with(Path("/fake/profile"))
         inner.assert_awaited_once()
 
+    def test_marks_background_runtime_as_unable_to_receive_late_completions(self):
+        """The copied /background context is finite; the live chat stays routable."""
+        from gateway.session_context import (
+            async_delivery_supported,
+            reset_session_vars,
+        )
+
+        runner = _make_runner(multiplex=False)
+        observed = []
+
+        async def observe_delivery_capability(*args):
+            observed.append(async_delivery_supported())
+
+        inner = mock.AsyncMock(side_effect=observe_delivery_capability)
+        runner._run_background_task_inner = inner
+        reset_session_vars()
+        assert async_delivery_supported() is True
+
+        asyncio.run(
+            runner._run_background_task(
+                prompt="test", source=mock.MagicMock(), task_id="bg_test"
+            )
+        )
+
+        assert observed == [False]
+        assert async_delivery_supported() is True
+
 

--- a/tests/gateway/test_multiplex_background_task_scope.py
+++ b/tests/gateway/test_multiplex_background_task_scope.py
@@ -46,4 +46,39 @@ class TestBackgroundTaskProfileScope:
         scope.assert_called_once_with(Path("/fake/profile"))
         inner.assert_awaited_once()
 
+    def test_marks_background_runtime_as_unable_to_receive_late_completions(self):
+        """The finite /background turn waits; the live chat stays routable."""
+        from gateway.session_context import (
+            async_delivery_supported,
+            reset_session_vars,
+        )
+
+        runner = _make_runner(multiplex=False)
+        observed = []
+
+        async def observe_delivery_capability(*args):
+            observed.append(async_delivery_supported())
+
+        runner._run_background_task_inner = mock.AsyncMock(
+            side_effect=observe_delivery_capability
+        )
+
+        async def run_scenario():
+            reset_session_vars()
+            assert async_delivery_supported() is True
+            task = asyncio.create_task(
+                runner._run_background_task(
+                    prompt="test", source=mock.MagicMock(), task_id="bg_test"
+                )
+            )
+            await task
+            # ContextVar writes in the spawned task must not disable async
+            # delivery in the live-chat task that created it.
+            assert async_delivery_supported() is True
+
+        asyncio.run(run_scenario())
+
+        assert observed == [False]
+        assert async_delivery_supported() is True
+
 


### PR DESCRIPTION
## Bug description

A gateway `/background` task could call `delegate_task`, return an interim response, and close its temporary `bg_*` session before the delegated batch finished. The children later completed, but their result could not re-enter the permanently closed parent session.

## Root cause

The temporary `/background` task inherited the originating live chat's async-delivery capability. That capability is valid for the persistent live chat, but not for the finite background agent turn: once the turn returns and its agent closes, it has no durable consumer for a detached completion.

## Fix

- mark only the copied `/background` asyncio task context as unable to receive late async completions
- reuse the existing finite-session `delegate_task` fallback so the aggregate returns while the background parent is active
- preserve concurrent child fan-out
- preserve ordinary live-chat asynchronous delegation because the originating context is unchanged
- add regression coverage for copied-task and caller-context isolation

## Verification on current `main`

- focused and adjacent background/delegation suites: 32 passed
- independent review: approved; no security, concurrency, or context-isolation blockers
- Ruff: passed
- Python compilation: passed
- `git diff --check`: passed

## Risk

Low. The change sets an existing `ContextVar` capability only inside the asyncio task created specifically for `/background`; it reuses established finite-session behavior rather than adding a new delivery path.
