### PR TITLE
fix(tools): add WeCom handler to _parse_target_ref (#72566)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -34,6 +34,10 @@ _SLACK_MENTION_RE = re.compile(r"^\s*<@(U[A-Z0-9]{8,})(?:\|[^>]+)?>\s*$")
 # Session-derived Slack thread targets use "<conversation_id>:<thread_ts>".
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
+# WeCom user IDs: external contacts start with "wo", internal users are
+# alphanumeric.  Multi-corp deployments use "corp_id:user_id" to avoid
+# cross-corp collisions (see plugins/platforms/wecom/callback_adapter.py).
+_WECOM_TARGET_RE = re.compile(r"^\s*(wo[A-Za-z0-9_-]+|[A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)?)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
@@ -568,6 +572,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             return trimmed[:split_idx], trimmed[split_idx + 1 :], True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
+    if platform_name == "wecom":
+        match = _WECOM_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
     if platform_name == "yuanbao":


### PR DESCRIPTION
## Summary
Fixes #72566.

v0.19.0 regression: `hermes send -t wecom:<userid>` fails with "Could not resolve '<userid>' on wecom" because the WeCom branch was missing from `_parse_target_ref()`.

## Changes
- `tools/send_message_tool.py`: Add `_WECOM_TARGET_RE` regex matching:
  - External contact IDs (`wo...`)
  - Internal user IDs (alphanumeric)
  - Multi-corp `corp_id:user_id` format
- Add WeCom handler block in `_parse_target_ref` after the weixin handler.

## Testing
- `py_compile`: OK
- `ruff check`: All checks passed
- Regex tested against `woGyl0EAAAF904oOQcB4CAMZr5piFDxQ`, `corp:user`, bare user IDs
