### PR TITLE
fix(cli): explain that the parent hermes CLI session trips the `sessions recover` fingerprint check

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -333,7 +333,14 @@ def _snapshot_and_inspect(
         if before != after:
             raise SessionRecoverySafetyError(
                 "The source database bundle changed while it was being copied. "
-                "Stop every Hermes process using this profile and retry."
+                "Stop every Hermes process using this profile and retry. "
+                "That includes the interactive `hermes` CLI session this "
+                "command may have been launched from: it writes session "
+                "bookkeeping to the database in the background, so stopping "
+                "the gateway alone is not enough. Run `hermes sessions "
+                "recover` from a fresh shell with no Hermes CLI running, or "
+                "point --source at a stable snapshot taken with SQLite's "
+                "backup API (sqlite3.Connection.backup())."
             )
 
         conn = sqlite3.connect(

--- a/tests/hermes_cli/test_session_recovery_fingerprint_message.py
+++ b/tests/hermes_cli/test_session_recovery_fingerprint_message.py
@@ -1,0 +1,65 @@
+"""Regression test for #72291 — the source-fingerprint error must tell the
+user that the parent interactive ``hermes`` CLI session counts as one of the
+"Hermes processes" writing to the database.
+
+Users who hit this error stop the gateway, retry, and fail again, because
+their own interactive CLI session keeps writing session bookkeeping to
+``state.db`` in the background. The check itself is correct; the guidance
+needs to name the culprit and the two working escapes (fresh shell, or a
+SQLite backup-API snapshot as ``--source``).
+"""
+
+import sqlite3
+
+import pytest
+
+from hermes_cli import session_recovery
+
+
+def _make_source_db(path):
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE placeholder (x INTEGER)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_fingerprint_error_names_parent_cli_session(tmp_path, monkeypatch):
+    source = tmp_path / "state.db"
+    _make_source_db(source)
+
+    real_copy = session_recovery._copy_source_bundle
+
+    def copy_then_mutate(src, snapshot_dir):
+        result = real_copy(src, snapshot_dir)
+        # Simulate a background bookkeeping write from the parent CLI
+        # session landing while the bundle was being copied.
+        with open(src, "ab") as handle:
+            handle.write(b"\x00")
+        return result
+
+    monkeypatch.setattr(session_recovery, "_copy_source_bundle", copy_then_mutate)
+
+    with pytest.raises(session_recovery.SessionRecoverySafetyError) as excinfo:
+        session_recovery.inspect_session_database(source, work_dir=tmp_path)
+
+    message = str(excinfo.value)
+    # Original guidance is preserved…
+    assert "changed while it was being copied" in message
+    assert "Stop every Hermes process" in message
+    # …and the new guidance names the parent CLI session and both escapes.
+    assert "interactive `hermes` CLI session" in message
+    assert "fresh shell" in message
+    assert "backup" in message
+
+
+def test_unchanged_source_does_not_trip_the_fingerprint_guard(tmp_path):
+    source = tmp_path / "state.db"
+    _make_source_db(source)
+
+    # No writer touches the source: inspection must complete without raising
+    # the safety error (the placeholder DB is simply not recoverable).
+    report = session_recovery.inspect_session_database(source, work_dir=tmp_path)
+    assert report["operation"] == "inspect"
+    assert report["source_unchanged"] is True


### PR DESCRIPTION
## What does this PR do?

Implements Option A (minimal, message-only) from #72291.

When `hermes sessions recover` is run from inside an interactive `hermes` CLI session, the source-fingerprint safety check in `hermes_cli/session_recovery.py::_snapshot_and_inspect` fails with:

> The source database bundle changed while it was being copied. Stop every Hermes process using this profile and retry.

The check is **correct** — it catches a real race. But the guidance is practically misleading: the user stops the gateway (the only process they can see), retries, and fails again, because the **parent CLI session itself** keeps writing session bookkeeping (compression tick, context tracking) to `state.db` on a background thread. Nothing in the message says so.

This PR keeps the check untouched and only extends the error message to:

- name the parent interactive `hermes` CLI session as one of the "Hermes processes",
- suggest running `hermes sessions recover` from a fresh shell, and
- mention pointing `--source` at a stable snapshot taken with SQLite's concurrent-writer-safe backup API (`sqlite3.Connection.backup()`), which is the workaround the issue reporter validated on a 3.17 GB database.

The original first two sentences are preserved verbatim, so anything grepping for the existing text keeps matching. Option B from the issue (`--self-snapshot` flag) is a behavior change and is deliberately left out of this minimal fix.

## Related Issue

Fixes #72291

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `hermes_cli/session_recovery.py` — extended the `SessionRecoverySafetyError` message in `_snapshot_and_inspect` (message text only; no logic change anywhere).
- `tests/hermes_cli/test_session_recovery_fingerprint_message.py` — new regression tests:
  - a source mutated mid-copy (simulated background bookkeeping write) raises the safety error, and the message names the parent CLI session, the fresh-shell escape, and the backup-API snapshot escape;
  - an untouched source does not trip the fingerprint guard.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_session_recovery_fingerprint_message.py -q
```

Manual repro (from the issue): inside an active `hermes` CLI session, run `hermes gateway stop`, then `hermes sessions recover --source ~/.hermes/state.db --output /tmp/recovered.db`. Before: the error tells you to stop "every Hermes process" with no hint that your own shell is the writer. After: the message names the parent CLI session and gives two working escapes.

## Platforms tested

Message-string-only change with no platform-specific behavior; the new tests are hermetic (stdlib `sqlite3` + pytest `tmp_path`/`monkeypatch`, no network). **Honest note:** prepared in a restricted environment where I could not execute `scripts/run_tests.sh` myself — please let CI confirm.

## Checklist

### Code
- [x] Change is focused on one logical fix (message text only)
- [x] No new dependencies
- [x] Existing error-message prefix preserved verbatim
- [x] Regression tests added

### Documentation & Housekeeping
- [x] Conventional Commit message (`fix(cli): …`)
- [x] Searched open **and** merged PRs/issues for duplicates before opening (adjacent merged work: #71629, #71770 — neither touches this message; no competing PR for #72291)