### PR TITLE
fix(tools): reject empty web_search queries before backend dispatch

### DIFF
--- a/tests/tools/test_web_search_empty_query.py
+++ b/tests/tools/test_web_search_empty_query.py
@@ -1,0 +1,71 @@
+"""Regression tests for #72270 — an empty web_search query must be rejected
+before it reaches any backend.
+
+Models (especially small local ones) occasionally call web_search with
+query=''. Without a guard the empty string is forwarded verbatim: SearXNG
+receives ``/search?q=`` and answers HTTP 400, so the model only sees an
+opaque "SearXNG returned HTTP 400" and tends to retry the same empty call.
+The tool must fail fast with actionable guidance instead, for every backend,
+without any plugin discovery or network dispatch.
+"""
+
+import json
+
+import pytest
+
+from tools import web_tools
+
+
+def _forbid_backend_dispatch(monkeypatch):
+    def _boom():
+        raise AssertionError(
+            "backend dispatch must not happen for an empty web_search query"
+        )
+
+    # _ensure_web_plugins_loaded is the first step of backend dispatch inside
+    # web_search_tool, so reaching it means the guard did not fire.
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", _boom)
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["", "   ", "\n\t ", None, 5],
+    ids=["empty", "spaces", "other-whitespace", "none", "non-string"],
+)
+def test_blank_or_invalid_query_is_rejected_before_dispatch(monkeypatch, query):
+    _forbid_backend_dispatch(monkeypatch)
+
+    payload = json.loads(web_tools.web_search_tool(query))
+
+    assert payload["success"] is False
+    assert "query" in payload["error"]
+
+
+def test_valid_query_is_stripped_and_still_dispatched(monkeypatch):
+    import agent.web_search_registry as web_search_registry
+
+    seen = {}
+
+    class _FakeProvider:
+        name = "fake-backend"
+
+        def supports_search(self):
+            return True
+
+        def search(self, query, limit):
+            seen["query"] = query
+            seen["limit"] = limit
+            return {"success": True, "data": {"web": []}}
+
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "fake-backend")
+    monkeypatch.setattr(
+        web_search_registry, "get_provider", lambda name: _FakeProvider()
+    )
+
+    payload = json.loads(
+        web_tools.web_search_tool("  python packaging \n", limit=3)
+    )
+
+    assert payload["success"] is True
+    assert seen == {"query": "python packaging", "limit": 3}

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -650,6 +650,19 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     Raises:
         Exception: If search fails or API key is not set
     """
+    if not isinstance(query, str) or not query.strip():
+        # Guard against model-issued empty queries. Without this, the empty
+        # string reaches the backend as-is — SearXNG receives /search?q= and
+        # answers HTTP 400 (#72270) — and the model only sees an opaque
+        # "SearXNG returned HTTP 400". Fail fast with actionable guidance
+        # instead, for every backend, before any plugin/network dispatch.
+        return tool_error(
+            "web_search requires a non-empty 'query' string. Retry the call "
+            "with the actual search terms in the 'query' argument.",
+            success=False,
+        )
+    query = query.strip()
+
     try:
         limit = int(limit)
     except (TypeError, ValueError):


### PR DESCRIPTION
## What does this PR do?

Fixes the failure mode reported in #72270. The reporter's log shows what actually happens:

```
tools.web_tools: WEB_SEARCH ENTRY query='' limit=5
plugins.web.searxng.provider: SearXNG HTTP error: Client error '400 Bad Request' for url 'http://10.10.2.135:8888/search?q=&format=json&pageno=1'
agent.tool_executor: Tool web_search returned error (0.01s): { "success": false, "error": "SearXNG returned HTTP 400" }
```

The model (a small local Ollama model in this case) occasionally calls `web_search` with `query=''`. Nothing in `web_search_tool` validates the query, so the empty string is forwarded verbatim to the configured backend; SearXNG receives `/search?q=` and answers HTTP 400. The model then only sees an opaque "SearXNG returned HTTP 400" — which looks like a broken SearXNG setup — and tends to retry the same empty call.

This PR adds a fail-fast guard in `web_search_tool`: non-string or blank queries are rejected **before any plugin discovery or network dispatch**, with an error message the model can act on ("retry with the actual search terms in the 'query' argument"). Valid queries are stripped of surrounding whitespace. The guard protects every backend (searxng, brave-free, ddgs, exa, parallel, tavily, firecrawl), not just SearXNG.

Note: why a given model emits an empty query in the first place is a model-quality issue outside this repo's control — but the tool contract (`"required": ["query"]` with a meaningful string) should be enforced at the tool boundary, and the error the model gets back should point at the real problem instead of the backend's HTTP status.

## Related Issue

Fixes #72270

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `tools/web_tools.py` — added an empty/invalid-query guard at the top of `web_search_tool` (returns `{"error": ..., "success": false}` via the existing `tool_error` helper, matching the `tool_error("Interrupted", success=False)` shape already used in this function); valid queries are `.strip()`-ed before dispatch.
- `tests/tools/test_web_search_empty_query.py` — new regression tests:
  - parametrized: `''`, whitespace-only, `None`, and non-string queries are rejected and provably never reach backend dispatch (`_ensure_web_plugins_loaded` is monkeypatched to fail the test if called);
  - a valid query is stripped and still dispatched to the provider with the right limit.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_web_search_empty_query.py -q
```

Manual repro (from the issue): configure SearXNG as the search backend and call `web_search` with an empty query. Before: opaque `SearXNG returned HTTP 400` after a wasted network round-trip. After: immediate, actionable error with no request sent.

## Platforms tested

Pure-Python logic change with no platform-specific behavior; the new tests are hermetic (pytest `monkeypatch`, no network). **Honest note:** prepared in a restricted environment where I could not execute `scripts/run_tests.sh` myself — please let CI confirm.

## Checklist

### Code
- [x] One logical change (input validation at the tool boundary)
- [x] No new dependencies
- [x] No behavior change for valid queries (other than whitespace stripping)
- [x] Regression tests added

### Documentation & Housekeeping
- [x] Conventional Commit message (`fix(tools): …`)
- [x] Searched open **and** merged PRs/issues for duplicates before opening (adjacent merged work: #49800 fixed the MCP kwargs-envelope path that produced the same symptom; no guard at the tool boundary existed, and no competing PR for #72270)