### PR TITLE
fix: warn when jsonschema missing instead of silent debug skip (#72400)

### DIFF
--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -474,8 +474,12 @@ def _parse_structured_text(
             import jsonschema  # type: ignore[import-untyped]
             jsonschema.validate(parsed, json_schema)
         except ImportError:
-            # jsonschema is optional; skip strict validation when absent.
-            logger.debug("jsonschema unavailable; skipping schema validation")
+            # jsonschema is optional; skip strict validation when absent
+            # but warn so callers know their schema was NOT validated.
+            logger.warning(
+                "jsonschema package not installed; "
+                "skipping schema validation for structured output"
+            )
         except jsonschema.ValidationError as exc:  # type: ignore[attr-defined]
             raise ValueError(
                 f"Plugin LLM structured output did not match schema: {exc.message}"

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -447,6 +447,30 @@ class TestJsonParsing:
         assert parsed == {"language": "French"}
         assert ct == "json"
 
+    def test_schema_validation_warns_when_jsonschema_missing(self):
+        """When jsonschema is absent, validation is skipped and a warning is logged."""
+        import unittest.mock as mock
+
+        schema = {
+            "type": "object",
+            "properties": {"language": {"type": "string"}},
+            "required": ["language"],
+        }
+        # Simulate jsonschema not being installed
+        with mock.patch.dict("sys.modules", {"jsonschema": None}):
+            with mock.patch("agent.plugin_llm.logger") as mock_logger:
+                parsed, ct = _parse_structured_text(
+                    text='{"unrelated": "field"}',
+                    json_mode=False,
+                    json_schema=schema,
+                )
+        # The non-conforming data is returned without error
+        assert parsed == {"unrelated": "field"}
+        assert ct == "json"
+        # A warning was logged (not just debug)
+        mock_logger.warning.assert_called_once()
+        assert "jsonschema" in mock_logger.warning.call_args[0][0]
+
 
 # ---------------------------------------------------------------------------
 # End-to-end facade


### PR DESCRIPTION
## Summary

When a caller passes `json_schema=` to `complete_structured()` but the `jsonschema` package is not installed, validation was silently skipped with only a `debug`-level log message. Plugins believe their output is schema-validated when nothing actually validated it.

The existing tests that would catch this use `pytest.importorskip("jsonschema")` — so they skip on exactly the machines where the bug is live.

## Changes

- **`agent/plugin_llm.py`**: Upgrade the log level from `debug` to `warning` when jsonschema is absent but a schema was requested, so callers can observe that validation was skipped.
- **`tests/agent/test_plugin_llm.py`**: Add `test_schema_validation_warns_when_jsonschema_missing` that explicitly simulates missing jsonschema (via `mock.patch.dict("sys.modules", ...)`) and verifies:
  - Non-conforming data is returned without error (degraded behavior)
  - A warning is logged (not just debug)
  - The existing `importorskip`-guarded tests remain unchanged since they test the validation-*passing* path which requires the real package.

## Test Plan

- `pytest tests/agent/test_plugin_llm.py -xvs -k schema` — all 5 schema tests pass
- New test runs even when jsonschema is installed (mocks the missing import)

Fixes #72400