### PR TITLE
feat(cli): add profile-scoped contact route registry

### DIFF
--- a/hermes_cli/contacts_cmd.py
+++ b/hermes_cli/contacts_cmd.py
@@ -42,8 +42,7 @@ def directory_path() -> Path:
 
 
 def _norm(value: Any) -> str:
-    normalized = unicodedata.normalize("NFKC", str(value).casefold())
-    return "".join(character for character in normalized if character.isalnum())
+    return unicodedata.normalize("NFKC", str(value)).casefold().strip()
 
 
 def _string_list(value: Any, field: str) -> list[str]:

--- a/hermes_cli/contacts_cmd.py
+++ b/hermes_cli/contacts_cmd.py
@@ -1,0 +1,459 @@
+"""Profile-scoped contact and outbound-route registry CLI.
+
+This module deliberately resolves routes without sending.  Reachability,
+authorization, and a user's route preference are separate concerns; callers
+must perform an authority check and the actual send through the existing
+messaging surface.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import tempfile
+import unicodedata
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+from hermes_constants import get_hermes_home
+
+SCHEMA_VERSION = 1
+_ROUTE_STATES = {"verified", "unverified", "stale"}
+_LIVE_DIRECTORY_PLATFORMS = {"discord", "telegram", "slack", "whatsapp", "signal"}
+
+
+class ContactRegistryError(ValueError):
+    """Raised when a contact registry does not satisfy the v1 contract."""
+
+
+def registry_path() -> Path:
+    """Return the active profile's contact-registry path."""
+    return get_hermes_home() / "contacts.yaml"
+
+
+def directory_path() -> Path:
+    """Return the active profile's generated channel-directory path."""
+    return get_hermes_home() / "channel_directory.json"
+
+
+def _norm(value: Any) -> str:
+    normalized = unicodedata.normalize("NFKC", str(value).casefold())
+    return "".join(character for character in normalized if character.isalnum())
+
+
+def _string_list(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ContactRegistryError(f"{field} must be a list of strings")
+    return value
+
+
+def _contact_names(contact: dict[str, Any]) -> Iterable[str]:
+    yield str(contact.get("id", ""))
+    yield str(contact.get("display_name", ""))
+    yield from _string_list(contact.get("aliases"), "contact.aliases")
+
+
+def validate_registry(data: Any) -> dict[str, Any]:
+    """Validate and return a v1 registry.
+
+    Validation intentionally permits extra fields so people can keep provenance,
+    notes, identity evidence, and platform-specific constraints without forcing a
+    migration for every extension.
+    """
+    if not isinstance(data, dict):
+        raise ContactRegistryError("registry root must be a mapping")
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise ContactRegistryError(
+            f"schema_version must be {SCHEMA_VERSION}; got {data.get('schema_version')!r}"
+        )
+    contacts = data.get("contacts")
+    if not isinstance(contacts, list):
+        raise ContactRegistryError("contacts must be a list")
+
+    contact_ids: set[str] = set()
+    name_owners: dict[str, str] = {}
+    for index, contact in enumerate(contacts):
+        prefix = f"contacts[{index}]"
+        if not isinstance(contact, dict):
+            raise ContactRegistryError(f"{prefix} must be a mapping")
+        contact_id = contact.get("id")
+        display_name = contact.get("display_name")
+        if not isinstance(contact_id, str) or not contact_id.strip():
+            raise ContactRegistryError(f"{prefix}.id must be a non-empty string")
+        if not isinstance(display_name, str) or not display_name.strip():
+            raise ContactRegistryError(f"{prefix}.display_name must be a non-empty string")
+        if contact_id in contact_ids:
+            raise ContactRegistryError(f"duplicate contact id: {contact_id}")
+        contact_ids.add(contact_id)
+
+        for name in _contact_names(contact):
+            normalized = _norm(name)
+            if not normalized:
+                raise ContactRegistryError(f"{prefix} contains an empty name or alias")
+            owner = name_owners.get(normalized)
+            if owner and owner != contact_id:
+                raise ContactRegistryError(
+                    f"ambiguous contact name or alias {name!r}: {owner} and {contact_id}"
+                )
+            name_owners[normalized] = contact_id
+
+        routes = contact.get("routes", [])
+        if not isinstance(routes, list):
+            raise ContactRegistryError(f"{prefix}.routes must be a list")
+        route_keys: set[str] = set()
+        for route_index, route in enumerate(routes):
+            route_prefix = f"{prefix}.routes[{route_index}]"
+            if not isinstance(route, dict):
+                raise ContactRegistryError(f"{route_prefix} must be a mapping")
+            key = route.get("key")
+            platform = route.get("platform")
+            destination = route.get("destination")
+            status = route.get("status", "unverified")
+            if not isinstance(key, str) or not key.strip():
+                raise ContactRegistryError(f"{route_prefix}.key must be a non-empty string")
+            if key in route_keys:
+                raise ContactRegistryError(f"duplicate route key for {contact_id}: {key}")
+            route_keys.add(key)
+            if not isinstance(platform, str) or not platform.strip():
+                raise ContactRegistryError(f"{route_prefix}.platform must be a non-empty string")
+            if not isinstance(destination, str) or not destination.strip():
+                raise ContactRegistryError(f"{route_prefix}.destination must be a non-empty string")
+            if status not in _ROUTE_STATES:
+                raise ContactRegistryError(
+                    f"{route_prefix}.status must be one of {sorted(_ROUTE_STATES)}"
+                )
+            _string_list(route.get("preferred_for"), f"{route_prefix}.preferred_for")
+            _string_list(route.get("constraints"), f"{route_prefix}.constraints")
+
+    policy = data.get("policy", {})
+    if policy is not None and not isinstance(policy, dict):
+        raise ContactRegistryError("policy must be a mapping")
+    return data
+
+
+def load_registry(path: Path | None = None) -> dict[str, Any]:
+    target = path or registry_path()
+    if not target.exists():
+        raise ContactRegistryError(
+            f"contact registry not found: {target}; run `hermes contacts init`"
+        )
+    if os.name != "nt" and stat.S_IMODE(target.stat().st_mode) & 0o077:
+        raise ContactRegistryError(
+            f"contact registry permissions are too broad: {target}; run `chmod 600 {target}`"
+        )
+    try:
+        raw = yaml.safe_load(target.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise ContactRegistryError(f"could not read contact registry {target}: {exc}") from exc
+    return validate_registry(raw)
+
+
+def _safe_write_yaml(path: Path, data: dict[str, Any]) -> None:
+    """Atomically write a registry and enforce owner-only permissions on POSIX."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        if os.name != "nt":
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        if os.name != "nt":
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def init_registry(path: Path | None = None) -> Path:
+    target = path or registry_path()
+    if target.exists():
+        raise ContactRegistryError(f"contact registry already exists: {target}")
+    data = {
+        "schema_version": SCHEMA_VERSION,
+        "policy": {
+            "default_send": "deny",
+        },
+        "contacts": [],
+    }
+    _safe_write_yaml(target, data)
+    return target
+
+
+def find_contact(contacts: list[dict[str, Any]], query: str) -> tuple[str, dict[str, Any] | None]:
+    normalized = _norm(query)
+    matches = [
+        contact
+        for contact in contacts
+        if normalized and normalized in {_norm(name) for name in _contact_names(contact)}
+    ]
+    if not matches:
+        return "unknown_contact", None
+    if len(matches) > 1:
+        return "ambiguous_contact", None
+    return "ok", matches[0]
+
+
+def choose_route(
+    contact: dict[str, Any], *, purpose: str | None = None, route_key: str | None = None
+) -> tuple[str, dict[str, Any] | None]:
+    routes = contact.get("routes") or []
+    if route_key:
+        matches = [route for route in routes if route.get("key") == route_key]
+    elif purpose:
+        matches = [
+            route for route in routes if purpose in (route.get("preferred_for") or [])
+        ]
+    else:
+        return "route_selector_required", None
+    if not matches:
+        return "no_preferred_route", None
+    if len(matches) > 1:
+        return "ambiguous_route", None
+    return "ok", matches[0]
+
+
+def load_directory(path: Path | None = None) -> dict[str, Any]:
+    target = path or directory_path()
+    if not target.exists():
+        return {}
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def directory_has(directory: dict[str, Any], platform: str, destination: str) -> bool:
+    entries = (directory.get("platforms") or {}).get(platform) or []
+    if not isinstance(entries, list):
+        return False
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_id = str(entry.get("id", ""))
+        if entry_id == destination:
+            return True
+        # Some adapters expose a stable chat_id separately from a composite id.
+        if str(entry.get("chat_id", "")) == destination:
+            return True
+    return False
+
+
+def resolve_contact(
+    data: dict[str, Any],
+    query: str,
+    *,
+    purpose: str | None = None,
+    route_key: str | None = None,
+    directory: dict[str, Any] | None = None,
+    show_destination: bool = False,
+) -> tuple[int, dict[str, Any]]:
+    """Resolve a route without sending or claiming authorization."""
+    status, contact = find_contact(data["contacts"], query)
+    if status != "ok" or contact is None:
+        return 2, {"status": status, "query": query, "send_performed": False}
+
+    status, route = choose_route(contact, purpose=purpose, route_key=route_key)
+    result: dict[str, Any] = {
+        "contact_id": contact.get("id"),
+        "display_name": contact.get("display_name"),
+        "purpose": purpose,
+        "send_performed": False,
+        "authorization_check": "required",
+    }
+    if status != "ok" or route is None:
+        return 3, {**result, "status": status}
+
+    route_status = str(route.get("status", "unverified"))
+    result.update(
+        {
+            "route_key": route.get("key"),
+            "platform": route.get("platform"),
+            "destination_type": route.get("destination_type"),
+            "route_status": route_status,
+            "last_verified": route.get("last_verified"),
+            "constraints": route.get("constraints") or [],
+        }
+    )
+    if show_destination:
+        result["destination"] = route.get("destination")
+        if route.get("mention"):
+            result["mention"] = route.get("mention")
+
+    if route_status == "stale":
+        return 4, {**result, "status": "stale_destination"}
+    if route_status != "verified":
+        return 4, {**result, "status": "unverified_destination"}
+    if route.get("sendable") is False:
+        return 4, {**result, "status": "not_sendable"}
+
+    platform = str(route.get("platform", "")).casefold()
+    destination = str(route.get("destination", ""))
+    if platform in _LIVE_DIRECTORY_PLATFORMS:
+        if directory is None or not directory_has(directory, platform, destination):
+            return 4, {
+                **result,
+                "status": "destination_not_in_live_directory",
+                "live_check": "failed",
+            }
+        result["live_check"] = "directory_match"
+    else:
+        # Email and other providers require an adapter/account-specific check.
+        # Return the selected route but do not report a send-ready resolution.
+        return 4, {
+            **result,
+            "status": "live_check_unavailable",
+            "live_check": "unsupported_for_platform",
+        }
+
+    return 0, {**result, "status": "ok"}
+
+
+def _json_print(payload: dict[str, Any] | list[dict[str, Any]]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True, default=str))
+
+
+def _redacted_contact(contact: dict[str, Any], *, show_destinations: bool = False) -> dict[str, Any]:
+    result = {
+        "id": contact.get("id"),
+        "display_name": contact.get("display_name"),
+        "aliases": contact.get("aliases") or [],
+        "routes": [],
+    }
+    for route in contact.get("routes") or []:
+        item = {
+            "key": route.get("key"),
+            "platform": route.get("platform"),
+            "preferred_for": route.get("preferred_for") or [],
+            "status": route.get("status", "unverified"),
+            "last_verified": route.get("last_verified"),
+        }
+        if show_destinations:
+            item["destination"] = route.get("destination")
+        result["routes"].append(item)
+    return result
+
+
+def contacts_command(args: Any) -> int:
+    action = getattr(args, "contacts_action", None)
+    path = Path(args.file).expanduser() if getattr(args, "file", None) else registry_path()
+    try:
+        if action == "path":
+            print(path)
+            return 0
+        if action == "init":
+            created = init_registry(path)
+            _json_print({"status": "created", "path": str(created)})
+            return 0
+
+        data = load_registry(path)
+        if action == "validate":
+            _json_print(
+                {
+                    "status": "ok",
+                    "path": str(path),
+                    "schema_version": data["schema_version"],
+                    "contact_count": len(data["contacts"]),
+                }
+            )
+            return 0
+        if action in ("list", "ls"):
+            _json_print(
+                [
+                    _redacted_contact(contact, show_destinations=bool(args.show_destinations))
+                    for contact in data["contacts"]
+                ]
+            )
+            return 0
+        if action == "show":
+            status, contact = find_contact(data["contacts"], args.contact)
+            if status != "ok" or contact is None:
+                _json_print({"status": status, "query": args.contact})
+                return 2
+            _json_print(
+                _redacted_contact(contact, show_destinations=bool(args.show_destinations))
+            )
+            return 0
+        if action == "resolve":
+            directory = load_directory(
+                Path(args.directory).expanduser() if args.directory else directory_path()
+            )
+            code, result = resolve_contact(
+                data,
+                args.contact,
+                purpose=args.purpose,
+                route_key=args.route,
+                directory=directory,
+                show_destination=bool(args.show_destination),
+            )
+            _json_print(result)
+            return code
+
+        args._contacts_parser.print_help()
+        return 0
+    except ContactRegistryError as exc:
+        _json_print({"status": "registry_error", "detail": str(exc), "send_performed": False})
+        return 5
+
+
+def build_parser(subparsers: Any) -> Any:
+    parser = subparsers.add_parser(
+        "contacts",
+        help="Manage the profile-scoped contact and outbound-route registry",
+        description=(
+            "Manage a user-owned contact registry under $HERMES_HOME. "
+            "Resolution is non-sending and does not grant messaging authority."
+        ),
+    )
+    parser.add_argument(
+        "--file",
+        help="Registry path (default: $HERMES_HOME/contacts.yaml)",
+    )
+    actions = parser.add_subparsers(dest="contacts_action")
+
+    actions.add_parser("init", help="Create an empty owner-readable registry")
+    actions.add_parser("path", help="Print the active registry path")
+    actions.add_parser("validate", help="Validate schema and identity/route uniqueness")
+
+    list_parser = actions.add_parser("list", aliases=["ls"], help="List contacts without destinations")
+    list_parser.add_argument(
+        "--show-destinations",
+        action="store_true",
+        help="Include endpoint values in output",
+    )
+
+    show = actions.add_parser("show", help="Show one contact without destinations")
+    show.add_argument("contact")
+    show.add_argument("--show-destinations", action="store_true")
+
+    resolve = actions.add_parser("resolve", help="Resolve one route without sending")
+    resolve.add_argument("contact")
+    selector = resolve.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--purpose", help="Purpose-specific preferred route")
+    selector.add_argument("--route", help="Explicit route key")
+    resolve.add_argument(
+        "--directory",
+        help="Generated channel directory (default: $HERMES_HOME/channel_directory.json)",
+    )
+    resolve.add_argument(
+        "--show-destination",
+        action="store_true",
+        help="Include the endpoint value in output",
+    )
+
+    parser.set_defaults(func=contacts_command, _contacts_parser=parser)
+    return parser

--- a/hermes_cli/contacts_cmd.py
+++ b/hermes_cli/contacts_cmd.py
@@ -13,6 +13,7 @@ import os
 import stat
 import tempfile
 import unicodedata
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -22,7 +23,8 @@ from hermes_constants import get_hermes_home
 
 SCHEMA_VERSION = 1
 _ROUTE_STATES = {"verified", "unverified", "stale"}
-_LIVE_DIRECTORY_PLATFORMS = {"discord", "telegram", "slack", "whatsapp", "signal"}
+_DIRECTORY_MAX_AGE_SECONDS = 10 * 60
+_NON_DIRECTORY_PLATFORMS = {"email"}
 
 
 class ContactRegistryError(ValueError):
@@ -127,6 +129,8 @@ def validate_registry(data: Any) -> dict[str, Any]:
                 raise ContactRegistryError(
                     f"{route_prefix}.status must be one of {sorted(_ROUTE_STATES)}"
                 )
+            if "sendable" in route and not isinstance(route["sendable"], bool):
+                raise ContactRegistryError(f"{route_prefix}.sendable must be a boolean")
             _string_list(route.get("preferred_for"), f"{route_prefix}.preferred_for")
             _string_list(route.get("constraints"), f"{route_prefix}.constraints")
 
@@ -253,6 +257,26 @@ def directory_has(directory: dict[str, Any], platform: str, destination: str) ->
     return False
 
 
+def directory_is_fresh(directory: dict[str, Any]) -> bool:
+    """Return whether the generated directory is recent enough to use.
+
+    The gateway refreshes this cache every five minutes. A ten-minute ceiling
+    tolerates one missed refresh while preventing a stopped or reconfigured
+    gateway from leaving indefinitely trusted reachability evidence.
+    """
+    updated_at = directory.get("updated_at")
+    if not isinstance(updated_at, str) or not updated_at.strip():
+        return False
+    try:
+        timestamp = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.astimezone()
+        age_seconds = (datetime.now(timestamp.tzinfo) - timestamp).total_seconds()
+    except (TypeError, ValueError, OSError):
+        return False
+    return -60 <= age_seconds <= _DIRECTORY_MAX_AGE_SECONDS
+
+
 def resolve_contact(
     data: dict[str, Any],
     query: str,
@@ -303,22 +327,27 @@ def resolve_contact(
 
     platform = str(route.get("platform", "")).casefold()
     destination = str(route.get("destination", ""))
-    if platform in _LIVE_DIRECTORY_PLATFORMS:
-        if directory is None or not directory_has(directory, platform, destination):
-            return 4, {
-                **result,
-                "status": "destination_not_in_live_directory",
-                "live_check": "failed",
-            }
-        result["live_check"] = "directory_match"
-    else:
-        # Email and other providers require an adapter/account-specific check.
+    if platform in _NON_DIRECTORY_PLATFORMS:
+        # Email requires an account-specific check outside the gateway directory.
         # Return the selected route but do not report a send-ready resolution.
         return 4, {
             **result,
             "status": "live_check_unavailable",
             "live_check": "unsupported_for_platform",
         }
+    if directory is None or not directory_is_fresh(directory):
+        return 4, {
+            **result,
+            "status": "stale_channel_directory",
+            "live_check": "directory_missing_or_stale",
+        }
+    if not directory_has(directory, platform, destination):
+        return 4, {
+            **result,
+            "status": "destination_not_in_live_directory",
+            "live_check": "failed",
+        }
+    result["live_check"] = "fresh_directory_match"
 
     return 0, {**result, "status": "ok"}
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11362,6 +11362,13 @@ def main():
     project_parser.set_defaults(func=cmd_project)
 
     # =========================================================================
+    # contacts command — profile-scoped identity and route registry
+    # =========================================================================
+    from hermes_cli.contacts_cmd import build_parser as _build_contacts_parser
+
+    _build_contacts_parser(subparsers)
+
+    # =========================================================================
     # hooks command — shell-hook inspection and management
     # =========================================================================
     # hooks command  (parser built in hermes_cli/subcommands/hooks.py)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10460,7 +10460,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
     {
         "acp", "approvals", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
-        "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
+        "config", "console", "contacts", "cron", "curator", "dashboard", "serve", "debug", "doctor",
         "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",

--- a/skills/productivity/contact-routing/SKILL.md
+++ b/skills/productivity/contact-routing/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: contact-routing
+description: "Resolve a person to a verified, purpose-specific outbound route before messaging; use when the user asks to contact, notify, DM, email, or hand off to someone by name."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [contacts, messaging, routing, safety]
+---
+
+# Contact Routing
+
+Use Hermes's profile-scoped contact registry to distinguish four separate facts:
+
+1. **Identity** — who the person is.
+2. **Reachability** — whether a configured gateway currently exposes the destination.
+3. **Route preference** — which route the user designated for this purpose.
+4. **Authorization** — whether the requested communication may be sent.
+
+Never infer one from another. A generated channel-directory entry or platform allowlist is not a preferred route.
+
+## When to Use
+
+- The user asks to contact, notify, DM, email, or hand off to a person by name.
+- Several platform identities or destinations could refer to the same person.
+- The communication purpose determines which route should be used.
+- A discovered or allowlisted destination must not be mistaken for route preference.
+
+## Prerequisites
+
+- Initialize `$HERMES_HOME/contacts.yaml` with `hermes contacts init`.
+- Record only source-backed identity and route information.
+- Configure the relevant messaging/mail adapter separately; the registry stores no credentials.
+
+## Procedure
+
+1. Identify the communication purpose explicitly, such as `internal`, `external_work`, or `urgent`.
+2. Resolve without sending:
+
+   ```bash
+   hermes contacts resolve "Person" --purpose purpose_name
+   ```
+
+   Use `--route route-key` only when the user or durable workflow selected that exact route.
+3. Stop on any status other than `ok`, including unknown/ambiguous contacts, missing routes, stale endpoints, or live-directory mismatches.
+4. A successful resolution still reports `authorization_check: required`. Confirm the user authorized the communication and that no platform-specific identity check remains.
+5. Re-run with `--show-destination` only when preparing the authorized delivery.
+6. Send through the existing messaging or mailbox tool; the resolver never sends.
+7. Read back the destination, sender identity, message ID, and content when the platform supports it.
+
+## Registry maintenance
+
+Initialize and inspect the active profile's registry:
+
+```bash
+hermes contacts init
+hermes contacts validate
+hermes contacts list
+hermes contacts show "Person"
+```
+
+The registry lives at `$HERMES_HOME/contacts.yaml`. Keep it owner-readable, source identities and route preferences, mark stale/unverified routes honestly, and avoid storing credentials or message history in it.
+
+## Pitfalls
+
+Do not automatically merge contacts based on similar names or endpoints. Do not promote every discovered destination into the registry. Ask for clarification when identity, purpose, preferred route, or authority is materially ambiguous.
+
+## Verification
+
+- `hermes contacts validate` reports `status: ok`.
+- Resolution reports the expected contact ID, route key, and live-check state.
+- Resolution output always reports `send_performed: false` and `authorization_check: required`.
+- After an authorized send, the platform readback matches the resolved destination and expected sender identity.

--- a/skills/productivity/contact-routing/SKILL.md
+++ b/skills/productivity/contact-routing/SKILL.md
@@ -43,7 +43,7 @@ Never infer one from another. A generated channel-directory entry or platform al
    ```
 
    Use `--route route-key` only when the user or durable workflow selected that exact route.
-3. Stop on any status other than `ok`, including unknown/ambiguous contacts, missing routes, stale endpoints, or live-directory mismatches.
+3. Stop on any status other than `ok`, including unknown/ambiguous contacts, missing routes, stale endpoints, stale directory caches, or directory mismatches.
 4. A successful resolution still reports `authorization_check: required`. Confirm the user authorized the communication and that no platform-specific identity check remains.
 5. Re-run with `--show-destination` only when preparing the authorized delivery.
 6. Send through the existing messaging or mailbox tool; the resolver never sends.
@@ -69,6 +69,6 @@ Do not automatically merge contacts based on similar names or endpoints. Do not 
 ## Verification
 
 - `hermes contacts validate` reports `status: ok`.
-- Resolution reports the expected contact ID, route key, and live-check state.
+- Resolution reports the expected contact ID, route key, and live-check state. A directory match is accepted only when the generated cache is at most ten minutes old.
 - Resolution output always reports `send_performed: false` and `authorization_check: required`.
 - After an authorized send, the platform readback matches the resolved destination and expected sender identity.

--- a/skills/productivity/contact-routing/SKILL.md
+++ b/skills/productivity/contact-routing/SKILL.md
@@ -1,24 +1,17 @@
 ---
 name: contact-routing
-description: "Resolve a person to a verified, purpose-specific outbound route before messaging; use when the user asks to contact, notify, DM, email, or hand off to someone by name."
+description: Resolve verified contact routes before authorized messaging.
 version: 1.0.0
-author: Hermes Agent
+author: Julian Albou (@julianships), with Hermes Agent
 license: MIT
 metadata:
   hermes:
     tags: [contacts, messaging, routing, safety]
 ---
 
-# Contact Routing
+# Contact Routing Skill
 
-Use Hermes's profile-scoped contact registry to distinguish four separate facts:
-
-1. **Identity** — who the person is.
-2. **Reachability** — whether a configured gateway currently exposes the destination.
-3. **Route preference** — which route the user designated for this purpose.
-4. **Authorization** — whether the requested communication may be sent.
-
-Never infer one from another. A generated channel-directory entry or platform allowlist is not a preferred route.
+Resolve a named person to a profile-scoped, purpose-specific outbound route without sending. This skill keeps identity, reachability, route preference, and messaging authorization separate so one fact is never inferred from another.
 
 ## When to Use
 
@@ -31,44 +24,53 @@ Never infer one from another. A generated channel-directory entry or platform al
 
 - Initialize `$HERMES_HOME/contacts.yaml` with `hermes contacts init`.
 - Record only source-backed identity and route information.
-- Configure the relevant messaging/mail adapter separately; the registry stores no credentials.
+- Configure the relevant messaging or mail adapter separately; the registry stores no credentials.
 
-## Procedure
+## How to Run
 
-1. Identify the communication purpose explicitly, such as `internal`, `external_work`, or `urgent`.
-2. Resolve without sending:
+Resolve without sending:
 
-   ```bash
-   hermes contacts resolve "Person" --purpose purpose_name
-   ```
+```bash
+hermes contacts resolve "Person" --purpose purpose_name
+```
 
-   Use `--route route-key` only when the user or durable workflow selected that exact route.
-3. Stop on any status other than `ok`, including unknown/ambiguous contacts, missing routes, stale endpoints, stale directory caches, or directory mismatches.
-4. A successful resolution still reports `authorization_check: required`. Confirm the user authorized the communication and that no platform-specific identity check remains.
-5. Re-run with `--show-destination` only when preparing the authorized delivery.
-6. Send through the existing messaging or mailbox tool; the resolver never sends.
-7. Read back the destination, sender identity, message ID, and content when the platform supports it.
+Use `--route route-key` only when the user or a durable workflow selected that exact route. Add `--show-destination` only when preparing an authorized delivery.
 
-## Registry maintenance
-
-Initialize and inspect the active profile's registry:
+## Quick Reference
 
 ```bash
 hermes contacts init
 hermes contacts validate
 hermes contacts list
 hermes contacts show "Person"
+hermes contacts resolve "Person" --purpose internal
 ```
 
-The registry lives at `$HERMES_HOME/contacts.yaml`. Keep it owner-readable, source identities and route preferences, mark stale/unverified routes honestly, and avoid storing credentials or message history in it.
+The registry lives at `$HERMES_HOME/contacts.yaml`. Keep it owner-readable, source identities and route preferences, mark stale or unverified routes honestly, and avoid storing credentials or message history in it.
+
+## Procedure
+
+1. Identify the communication purpose explicitly, such as `internal`, `external_work`, or `urgent`.
+2. Run `hermes contacts resolve` with the person's exact ID, display name, or alias. Matching is case-insensitive and Unicode-normalized but preserves punctuation and word boundaries.
+3. Stop on any status other than `ok`, including unknown or ambiguous contacts, missing routes, stale endpoints, stale directory caches, or directory mismatches.
+4. Treat a successful resolution as reachability evidence only. It still reports `authorization_check: required`.
+5. Confirm the user authorized the communication and that no platform-specific identity check remains.
+6. Re-run with `--show-destination` only when preparing the authorized delivery.
+7. Send through the existing messaging or mailbox tool; the resolver never sends.
+8. Read back the destination, sender identity, message ID, and content when the platform supports it.
 
 ## Pitfalls
 
-Do not automatically merge contacts based on similar names or endpoints. Do not promote every discovered destination into the registry. Ask for clarification when identity, purpose, preferred route, or authority is materially ambiguous.
+- Do not automatically merge contacts based on similar names or endpoints.
+- Do not remove punctuation or whitespace to force a match.
+- Do not promote every discovered destination into the registry.
+- Do not treat a directory match or route preference as authorization.
+- Ask for clarification when identity, purpose, preferred route, or authority is materially ambiguous.
 
 ## Verification
 
 - `hermes contacts validate` reports `status: ok`.
-- Resolution reports the expected contact ID, route key, and live-check state. A directory match is accepted only when the generated cache is at most ten minutes old.
+- Resolution reports the expected contact ID, route key, and live-check state.
+- A directory match is accepted only when the generated cache is at most ten minutes old.
 - Resolution output always reports `send_performed: false` and `authorization_check: required`.
 - After an authorized send, the platform readback matches the resolved destination and expected sender identity.

--- a/tests/hermes_cli/test_contacts_cmd.py
+++ b/tests/hermes_cli/test_contacts_cmd.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import pytest
+
+from hermes_cli.contacts_cmd import (
+    ContactRegistryError,
+    build_parser,
+    find_contact,
+    init_registry,
+    load_registry,
+    resolve_contact,
+    validate_registry,
+)
+
+
+def _registry(*contacts):
+    return validate_registry(
+        {
+            "schema_version": 1,
+            "policy": {
+                "default_send": "deny",
+            },
+            "contacts": list(contacts),
+        }
+    )
+
+
+def _contact(*, status="verified", preferred_for=None, destination="123"):
+    return {
+        "id": "alice-example",
+        "display_name": "Alice Example",
+        "aliases": ["Alice"],
+        "routes": [
+            {
+                "key": "discord-dm",
+                "platform": "discord",
+                "destination_type": "dm",
+                "destination": destination,
+                "preferred_for": preferred_for or ["internal"],
+                "status": status,
+                "last_verified": "2026-01-02",
+                "constraints": ["Check messaging authority before sending."],
+            }
+        ],
+    }
+
+
+def _directory(destination="123"):
+    return {"platforms": {"discord": [{"id": destination, "name": "alice"}]}}
+
+
+def test_init_creates_empty_profile_registry_with_owner_only_mode(tmp_path):
+    target = tmp_path / "contacts.yaml"
+
+    assert init_registry(target) == target
+    data = load_registry(target)
+
+    assert data["schema_version"] == 1
+    assert data["policy"]["default_send"] == "deny"
+    assert data["contacts"] == []
+    if os.name != "nt":
+        assert target.stat().st_mode & 0o777 == 0o600
+
+
+def test_init_refuses_to_replace_existing_registry_without_force(tmp_path):
+    target = tmp_path / "contacts.yaml"
+    init_registry(target)
+
+    with pytest.raises(ContactRegistryError, match="already exists"):
+        init_registry(target)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are not available")
+def test_load_fails_closed_when_registry_is_group_or_world_readable(tmp_path):
+    target = tmp_path / "contacts.yaml"
+    init_registry(target)
+    target.chmod(0o644)
+
+    with pytest.raises(ContactRegistryError, match="permissions are too broad"):
+        load_registry(target)
+
+
+def test_registry_rejects_ambiguous_names_across_contacts():
+    first = _contact()
+    second = {
+        "id": "another-person",
+        "display_name": "Another Person",
+        "aliases": ["Alice"],
+        "routes": [],
+    }
+
+    with pytest.raises(ContactRegistryError, match="ambiguous contact name"):
+        _registry(first, second)
+
+
+def test_registry_rejects_duplicate_route_keys():
+    contact = _contact()
+    contact["routes"].append(dict(contact["routes"][0]))
+
+    with pytest.raises(ContactRegistryError, match="duplicate route key"):
+        _registry(contact)
+
+
+def test_find_contact_matches_id_display_name_or_alias_exactly():
+    data = _registry(_contact())
+
+    assert find_contact(data["contacts"], "alice")[0] == "ok"
+    assert find_contact(data["contacts"], "Alice Example")[0] == "ok"
+    assert find_contact(data["contacts"], "alice-example")[0] == "ok"
+    assert find_contact(data["contacts"], "ali")[0] == "unknown_contact"
+
+
+def test_find_contact_supports_unicode_names():
+    contact = _contact()
+    contact.update({"id": "zoe", "display_name": "Zoë", "aliases": ["佐伊"]})
+    data = _registry(contact)
+
+    assert find_contact(data["contacts"], "ZOË")[0] == "ok"
+    assert find_contact(data["contacts"], "佐伊")[0] == "ok"
+
+
+def test_valid_resolution_is_non_sending_and_redacts_destination_by_default():
+    code, result = resolve_contact(
+        _registry(_contact()),
+        "Alice",
+        purpose="internal",
+        directory=_directory(),
+    )
+
+    assert code == 0
+    assert result["status"] == "ok"
+    assert result["live_check"] == "directory_match"
+    assert result["send_performed"] is False
+    assert result["authorization_check"] == "required"
+    assert "destination" not in result
+
+
+def test_resolution_can_explicitly_show_destination():
+    code, result = resolve_contact(
+        _registry(_contact()),
+        "Alice",
+        route_key="discord-dm",
+        directory=_directory(),
+        show_destination=True,
+    )
+
+    assert code == 0
+    assert result["destination"] == "123"
+
+
+def test_unknown_contact_fails_closed():
+    code, result = resolve_contact(
+        _registry(_contact()),
+        "Bob",
+        purpose="internal",
+        directory=_directory(),
+    )
+
+    assert code == 2
+    assert result == {
+        "status": "unknown_contact",
+        "query": "Bob",
+        "send_performed": False,
+    }
+
+
+def test_contact_without_matching_preferred_route_fails_closed():
+    code, result = resolve_contact(
+        _registry(_contact(preferred_for=["internal"])),
+        "Alice",
+        purpose="external",
+        directory=_directory(),
+    )
+
+    assert code == 3
+    assert result["status"] == "no_preferred_route"
+    assert result["send_performed"] is False
+
+
+def test_stale_route_fails_before_directory_match():
+    code, result = resolve_contact(
+        _registry(_contact(status="stale")),
+        "Alice",
+        purpose="internal",
+        directory=_directory(),
+    )
+
+    assert code == 4
+    assert result["status"] == "stale_destination"
+
+
+def test_live_directory_mismatch_fails_closed():
+    code, result = resolve_contact(
+        _registry(_contact()),
+        "Alice",
+        purpose="internal",
+        directory=_directory("different"),
+    )
+
+    assert code == 4
+    assert result["status"] == "destination_not_in_live_directory"
+    assert result["live_check"] == "failed"
+
+
+def test_email_resolution_fails_until_external_live_check_and_never_sends():
+    contact = _contact()
+    route = contact["routes"][0]
+    route.update(
+        {
+            "key": "email",
+            "platform": "email",
+            "destination_type": "address",
+            "destination": "alice@example.invalid",
+        }
+    )
+
+    code, result = resolve_contact(
+        _registry(contact),
+        "Alice",
+        purpose="internal",
+        directory={},
+    )
+
+    assert code == 4
+    assert result["status"] == "live_check_unavailable"
+    assert result["live_check"] == "unsupported_for_platform"
+    assert result["authorization_check"] == "required"
+    assert result["send_performed"] is False
+
+
+def test_cli_parser_initializes_and_validates_selected_file(tmp_path, capsys):
+    target = tmp_path / "contacts.yaml"
+    parser = argparse.ArgumentParser()
+    build_parser(parser.add_subparsers(dest="command"))
+
+    initialized_args = parser.parse_args(
+        ["contacts", "--file", str(target), "init"]
+    )
+    assert initialized_args.func(initialized_args) == 0
+    initialized = json.loads(capsys.readouterr().out)
+
+    validated_args = parser.parse_args(
+        ["contacts", "--file", str(target), "validate"]
+    )
+    assert validated_args.func(validated_args) == 0
+    validated = json.loads(capsys.readouterr().out)
+
+    assert initialized["path"] == str(target)
+    assert validated["contact_count"] == 0
+    if os.name != "nt":
+        assert target.stat().st_mode & 0o777 == 0o600

--- a/tests/hermes_cli/test_contacts_cmd.py
+++ b/tests/hermes_cli/test_contacts_cmd.py
@@ -127,6 +127,13 @@ def test_find_contact_matches_id_display_name_or_alias_exactly():
     assert find_contact(data["contacts"], "ali")[0] == "unknown_contact"
 
 
+@pytest.mark.parametrize("query", ["Alice?", "a-l-i-c-e", "AliceExample"])
+def test_find_contact_preserves_punctuation_and_word_boundaries(query):
+    data = _registry(_contact())
+
+    assert find_contact(data["contacts"], query)[0] == "unknown_contact"
+
+
 def test_find_contact_supports_unicode_names():
     contact = _contact()
     contact.update({"id": "zoe", "display_name": "Zoë", "aliases": ["佐伊"]})

--- a/tests/hermes_cli/test_contacts_cmd.py
+++ b/tests/hermes_cli/test_contacts_cmd.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -50,7 +51,10 @@ def _contact(*, status="verified", preferred_for=None, destination="123"):
 
 
 def _directory(destination="123"):
-    return {"platforms": {"discord": [{"id": destination, "name": "alice"}]}}
+    return {
+        "updated_at": datetime.now().astimezone().isoformat(),
+        "platforms": {"discord": [{"id": destination, "name": "alice"}]},
+    }
 
 
 def test_init_creates_empty_profile_registry_with_owner_only_mode(tmp_path):
@@ -105,6 +109,15 @@ def test_registry_rejects_duplicate_route_keys():
         _registry(contact)
 
 
+@pytest.mark.parametrize("value", [0, "false", None])
+def test_registry_rejects_non_boolean_sendable(value):
+    contact = _contact()
+    contact["routes"][0]["sendable"] = value
+
+    with pytest.raises(ContactRegistryError, match="sendable must be a boolean"):
+        _registry(contact)
+
+
 def test_find_contact_matches_id_display_name_or_alias_exactly():
     data = _registry(_contact())
 
@@ -133,7 +146,7 @@ def test_valid_resolution_is_non_sending_and_redacts_destination_by_default():
 
     assert code == 0
     assert result["status"] == "ok"
-    assert result["live_check"] == "directory_match"
+    assert result["live_check"] == "fresh_directory_match"
     assert result["send_performed"] is False
     assert result["authorization_check"] == "required"
     assert "destination" not in result
@@ -204,6 +217,44 @@ def test_live_directory_mismatch_fails_closed():
     assert code == 4
     assert result["status"] == "destination_not_in_live_directory"
     assert result["live_check"] == "failed"
+
+
+def test_stale_channel_directory_fails_closed_even_when_destination_matches():
+    directory = _directory()
+    directory["updated_at"] = (
+        datetime.now().astimezone() - timedelta(minutes=11)
+    ).isoformat()
+
+    code, result = resolve_contact(
+        _registry(_contact()),
+        "Alice",
+        purpose="internal",
+        directory=directory,
+    )
+
+    assert code == 4
+    assert result["status"] == "stale_channel_directory"
+    assert result["live_check"] == "directory_missing_or_stale"
+
+
+def test_plugin_platform_can_use_fresh_directory_membership():
+    contact = _contact()
+    contact["routes"][0]["platform"] = "matrix"
+    directory = {
+        "updated_at": datetime.now().astimezone().isoformat(),
+        "platforms": {"matrix": [{"id": "123", "name": "alice"}]},
+    }
+
+    code, result = resolve_contact(
+        _registry(contact),
+        "Alice",
+        purpose="internal",
+        directory=directory,
+    )
+
+    assert code == 0
+    assert result["status"] == "ok"
+    assert result["live_check"] == "fresh_directory_match"
 
 
 def test_email_resolution_fails_until_external_live_check_and_never_sends():

--- a/tests/hermes_cli/test_startup_plugin_gating.py
+++ b/tests/hermes_cli/test_startup_plugin_gating.py
@@ -74,6 +74,11 @@ def _live_subcommand_names() -> set[str]:
 # ── _plugin_cli_discovery_needed ───────────────────────────────────────────
 
 
+def test_contacts_skips_plugin_discovery():
+    with patch.object(sys, "argv", ["hermes", "contacts", "list"]):
+        assert _plugin_cli_discovery_needed() is False
+
+
 # ── _BUILTIN_SUBCOMMANDS ↔ argparse registration parity ────────────────────
 
 

--- a/tests/skills/test_contact_routing_skill.py
+++ b/tests/skills/test_contact_routing_skill.py
@@ -1,0 +1,47 @@
+"""Contract tests for the bundled contact-routing skill."""
+
+from pathlib import Path
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "productivity"
+    / "contact-routing"
+    / "SKILL.md"
+)
+
+
+def _frontmatter_value(text: str, key: str) -> str:
+    prefix = f"{key}:"
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return line.removeprefix(prefix).strip().strip('"')
+    raise AssertionError(f"missing {key!r} frontmatter in {SKILL_PATH}")
+
+
+def test_contact_routing_skill_meets_metadata_contract():
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    description = _frontmatter_value(text, "description")
+    author = _frontmatter_value(text, "author")
+
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert author.startswith("Julian Albou (@julianships)")
+
+
+def test_contact_routing_skill_uses_modern_section_order():
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    headings = [
+        "# Contact Routing Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+
+    positions = [text.index(heading) for heading in headings]
+    assert positions == sorted(positions)

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -58,6 +58,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes cron` | Inspect and tick the cron scheduler. |
 | `hermes kanban` | Multi-profile collaboration board (tasks, links, dispatcher). |
 | `hermes project` | Manage named, multi-folder workspaces (projects). Anchors desktop session grouping and, when bound to a kanban board, gives tasks a deterministic worktree + branch convention. State is per-profile. |
+| `hermes contacts` | Manage the profile-scoped contact and purpose-specific outbound-route registry. Resolution is non-sending and does not grant messaging authority. |
 | `hermes webhook` | Manage dynamic webhook subscriptions for event-driven activation. |
 | `hermes hooks` | Inspect, approve, or remove shell-script hooks declared in `config.yaml`. |
 | `hermes doctor` | Diagnose config and dependency issues. |
@@ -730,6 +731,27 @@ Projects are human-named workspaces that can span multiple folders / repos. They
 | `archive` | Archive a project (recoverable). |
 | `restore` | Restore an archived project. |
 | `bind-board` | Bind a kanban board to this project. |
+
+## `hermes contacts`
+
+```bash
+hermes contacts <init|path|validate|list|show|resolve>
+```
+
+Manage the active profile's owner-readable contact and outbound-route registry at `$HERMES_HOME/contacts.yaml`. Contact identity, generated channel reachability, platform authorization, and route preference remain separate concerns.
+
+| Subcommand | Description |
+|------------|-------------|
+| `init` | Create an empty v1 registry with deny-by-default policy (`0600` on POSIX). Never overwrites an existing registry. |
+| `path` | Print the active registry path. |
+| `validate` | Validate schema, contact/name uniqueness, route keys, and route states. |
+| `list` (alias `ls`) | List contacts and route metadata without endpoint values. Add `--show-destinations` to reveal them. |
+| `show <contact>` | Show one exact ID, display-name, or alias match. Endpoint values remain hidden unless requested. |
+| `resolve <contact>` | Resolve one `--purpose` or explicit `--route` without sending. Add `--show-destination` only when preparing an authorized action. |
+
+The resolver reports explicit failure states for unknown or ambiguous contacts, missing or ambiguous routes, stale/unverified endpoints, and live-directory mismatches. Every result records `send_performed: false`; successful resolution still records `authorization_check: required`.
+
+See [Contact Route Registry](../user-guide/messaging/contact-route-registry.md) for the schema and safety model.
 
 ## `hermes webhook`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -744,12 +744,12 @@ Manage the active profile's owner-readable contact and outbound-route registry a
 |------------|-------------|
 | `init` | Create an empty v1 registry with deny-by-default policy (`0600` on POSIX). Never overwrites an existing registry. |
 | `path` | Print the active registry path. |
-| `validate` | Validate schema, contact/name uniqueness, route keys, and route states. |
+| `validate` | Validate schema, contact/name uniqueness, route keys, route states, and boolean sendability flags. |
 | `list` (alias `ls`) | List contacts and route metadata without endpoint values. Add `--show-destinations` to reveal them. |
 | `show <contact>` | Show one exact ID, display-name, or alias match. Endpoint values remain hidden unless requested. |
 | `resolve <contact>` | Resolve one `--purpose` or explicit `--route` without sending. Add `--show-destination` only when preparing an authorized action. |
 
-The resolver reports explicit failure states for unknown or ambiguous contacts, missing or ambiguous routes, stale/unverified endpoints, and live-directory mismatches. Every result records `send_performed: false`; successful resolution still records `authorization_check: required`.
+The resolver reports explicit failure states for unknown or ambiguous contacts, missing or ambiguous routes, stale/unverified endpoints, stale channel-directory caches, and directory mismatches. Any gateway or plugin platform present in the generated directory is supported dynamically; email requires a separate account-specific check. Every result records `send_performed: false`; successful resolution still records `authorization_check: required`.
 
 See [Contact Route Registry](../user-guide/messaging/contact-route-registry.md) for the schema and safety model.
 

--- a/website/docs/user-guide/messaging/contact-route-registry.md
+++ b/website/docs/user-guide/messaging/contact-route-registry.md
@@ -60,6 +60,7 @@ contacts:
         destination: "123456789012345678"
         preferred_for: [internal]
         status: verified
+        sendable: true
         last_verified: 2026-01-02
         constraints:
           - Verify messaging authority before sending.
@@ -72,7 +73,7 @@ Hermes rejects:
 - duplicate contact IDs;
 - an alias/name that maps to multiple contacts;
 - duplicate route keys within one contact;
-- malformed route fields;
+- malformed route fields, including a non-boolean `sendable` value;
 - unsupported route states.
 
 Supported route states are `verified`, `unverified`, and `stale`.
@@ -117,10 +118,13 @@ The resolver fails closed for cases such as:
 - `stale_destination`
 - `unverified_destination`
 - `not_sendable`
+- `stale_channel_directory`
 - `destination_not_in_live_directory`
 - `live_check_unavailable`
 
-For gateway-backed platforms such as Discord and Telegram, the selected destination must also appear in the active profile's generated channel directory. Platforms such as email require their own account/mailbox verification. Until a caller performs that check, the resolver returns `live_check_unavailable` rather than silently reporting a send-ready result.
+For any gateway or plugin platform represented in `channel_directory.json`, the selected destination must appear in a directory refreshed within the last ten minutes. The gateway normally refreshes it every five minutes; an older or malformed cache returns `stale_channel_directory` even if the destination still appears in the file. This cache check is reachability evidence, not proof that a gateway remains active, so the actual send path must still revalidate its adapter.
+
+Platforms such as email require their own account/mailbox verification and are excluded from directory checks. Until a caller performs that check, the resolver returns `live_check_unavailable` rather than silently reporting a send-ready result.
 
 ## Before sending
 

--- a/website/docs/user-guide/messaging/contact-route-registry.md
+++ b/website/docs/user-guide/messaging/contact-route-registry.md
@@ -57,7 +57,7 @@ contacts:
       - key: discord-dm
         platform: discord
         destination_type: dm
-        destination: "123456789012345678"
+        destination: "discord-user-id"
         preferred_for: [internal]
         status: verified
         sendable: true

--- a/website/docs/user-guide/messaging/contact-route-registry.md
+++ b/website/docs/user-guide/messaging/contact-route-registry.md
@@ -1,0 +1,134 @@
+---
+sidebar_position: 14
+title: "Contact Route Registry"
+description: "Resolve people to purpose-specific outbound routes without conflating identity, reachability, or authorization"
+---
+
+# Contact Route Registry
+
+Hermes can discover reachable messaging destinations in `channel_directory.json`, and each gateway has its own authorization controls. Neither answers a different question: **which verified route should Hermes use to contact a particular person for a particular purpose?**
+
+The profile-scoped contact registry provides that missing user-owned layer:
+
+```text
+person → purpose-specific preferred route → current destination
+```
+
+Route resolution never sends a message and never grants messaging authority.
+
+## Keep the layers separate
+
+| Layer | Meaning |
+|---|---|
+| `contacts.yaml` | Durable identity evidence and the user's route preferences |
+| `channel_directory.json` | Generated cache of destinations currently reachable by configured gateways |
+| Platform allowlists | Authorization to receive from or interact with particular users/chats |
+| Session history | Prior conversation evidence |
+
+A destination appearing in the generated directory does not prove who owns it or that it is preferred. An allowlist entry grants access; it is not an address book. A resolved route still requires a separate authority check before sending.
+
+## Initialize the registry
+
+```bash
+hermes contacts init
+hermes contacts path
+```
+
+The default path is:
+
+```text
+$HERMES_HOME/contacts.yaml
+```
+
+On POSIX systems, Hermes creates the file with owner-only `0600` permissions. `init` never overwrites an existing registry.
+
+## Registry format
+
+```yaml
+schema_version: 1
+policy:
+  default_send: deny
+
+contacts:
+  - id: alice-example
+    display_name: Alice Example
+    aliases: [Alice]
+    routes:
+      - key: discord-dm
+        platform: discord
+        destination_type: dm
+        destination: "123456789012345678"
+        preferred_for: [internal]
+        status: verified
+        last_verified: 2026-01-02
+        constraints:
+          - Verify messaging authority before sending.
+```
+
+Extra fields are permitted so a registry can retain provenance, identity evidence, and platform-specific notes. Required identifiers, aliases, route keys, route status, and purpose lists are validated.
+
+Hermes rejects:
+
+- duplicate contact IDs;
+- an alias/name that maps to multiple contacts;
+- duplicate route keys within one contact;
+- malformed route fields;
+- unsupported route states.
+
+Supported route states are `verified`, `unverified`, and `stale`.
+
+## Validate and inspect
+
+```bash
+hermes contacts validate
+hermes contacts list
+hermes contacts show "Alice"
+```
+
+Endpoint values are hidden from `list` and `show` by default. Include them only when needed:
+
+```bash
+hermes contacts show "Alice" --show-destinations
+```
+
+## Resolve without sending
+
+Resolve by purpose:
+
+```bash
+hermes contacts resolve "Alice" --purpose internal
+```
+
+Or select a known route key explicitly:
+
+```bash
+hermes contacts resolve "Alice" --route discord-dm
+```
+
+Destination values remain hidden unless `--show-destination` is passed. Machine-readable output includes `send_performed: false` and `authorization_check: required`.
+
+The resolver fails closed for cases such as:
+
+- `unknown_contact`
+- `ambiguous_contact`
+- `route_selector_required`
+- `no_preferred_route`
+- `ambiguous_route`
+- `stale_destination`
+- `unverified_destination`
+- `not_sendable`
+- `destination_not_in_live_directory`
+- `live_check_unavailable`
+
+For gateway-backed platforms such as Discord and Telegram, the selected destination must also appear in the active profile's generated channel directory. Platforms such as email require their own account/mailbox verification. Until a caller performs that check, the resolver returns `live_check_unavailable` rather than silently reporting a send-ready result.
+
+## Before sending
+
+A successful resolution means only that one source-backed route matched. Before any outbound action:
+
+1. Confirm the communication itself is authorized.
+2. Perform any platform-specific live identity or membership check not covered by the generated directory.
+3. Send through Hermes's existing messaging or mailbox surface.
+4. Read back the actual destination, sender identity, message ID, and content when the platform permits.
+
+Do not automatically merge identities from similar display names, promote every discovered endpoint into the registry, or infer a preferred route merely because a destination exists.


### PR DESCRIPTION
## What does this PR do?

Adds a profile-scoped, user-owned contact and outbound-route registry at `$HERMES_HOME/contacts.yaml`, plus a non-sending resolver exposed through `hermes contacts`.

The feature fills the gap between four concepts that Hermes currently has to keep separate:

- **identity** — who the person is;
- **reachability** — which destinations currently appear in `channel_directory.json`;
- **authorization** — whether communication is allowed by the relevant platform/workflow;
- **route preference** — which verified destination the owner prefers for a particular purpose.

The resolver performs no send, redacts endpoint values by default, requires exact identity and route matches, fails on stale/unverified/live-directory-missing destinations, and always reports that a separate authorization check is required.

This is intentionally a narrow v1: no automatic identity merging, communication-history ingestion, contact discovery, CRM behavior, or proactive messaging.

## Related Issue

Related to (does not close):

- #35234 — shared user identity layer
- #12323 — unified People DB / message ingestion
- #48303 — stale generated channel-directory contact resolution

This PR is narrower than those proposals: it adds an explicit, profile-local third-party contact-routing primitive without conflating it with the Hermes user's own identity or generated communication history.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/contacts_cmd.py`
  - Adds `init`, `path`, `validate`, `list`, `show`, and `resolve` commands.
  - Writes atomically and enforces owner-only `0600` registry permissions on POSIX.
  - Validates schema version, Unicode names/aliases, contact uniqueness, route-key uniqueness, route state, and list fields.
  - Resolves by purpose or explicit route key without sending or claiming authorization.
  - Revalidates gateway-backed destinations against the active profile's generated channel directory.
  - Hides endpoints unless explicitly requested.
- `hermes_cli/main.py`
  - Registers the `hermes contacts` command family.
- `skills/productivity/contact-routing/SKILL.md`
  - Adds the agent-side workflow and safety boundaries while reusing the CLI and existing messaging/mail surfaces.
- `tests/hermes_cli/test_contacts_cmd.py`
  - Covers secure initialization, permission rejection, schema ambiguity, Unicode names, boolean sendability validation, valid resolution, endpoint redaction, unknown/missing/stale/unverified routes, stale directory caches, dynamic plugin platforms, unsupported live checks, and CLI parser dispatch.
- Documentation
  - Adds the registry schema, resolver statuses, CLI reference, and pre/post-send safety model.

## How to Test

```bash
PYTHONPATH=. python -m pytest \
  tests/hermes_cli/test_contacts_cmd.py \
  tests/hermes_cli/test_main_model_custom_provider_normalization.py \
  -q -o 'addopts='
```

Expected: `23 passed`.

```bash
python scripts/check-windows-footguns.py --all
ruff check hermes_cli/contacts_cmd.py tests/hermes_cli/test_contacts_cmd.py
git diff --check origin/main...HEAD
```

Expected: no Windows footguns, no ruff findings, and no whitespace errors.

Manual smoke test:

```bash
export HERMES_HOME="$(mktemp -d)"
python -m hermes_cli.main contacts init
python -m hermes_cli.main contacts validate
python -m hermes_cli.main contacts list
```

Expected: an empty v1 registry, `status: ok`, and mode `0600` on POSIX.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 12.7.6, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — POSIX permissions are guarded and the Windows footgun check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool added or changed

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — safe person-to-route resolution applies across messaging platforms
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (uses the new Hermes CLI plus existing messaging surfaces)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the contact-routing skill to resolve a sample contact"`

## Screenshots / Logs

```text
23 passed in 1.86s
All checks passed!                         # ruff
✓ No Windows footguns found (831 files scanned)
sensitive/public-diff scan: 0 private identifiers or credential-pattern hits
```

This is opened as a draft to get maintainer feedback on the v1 schema and whether the bundled skill + CLI placement is the preferred upstream surface before adding any send-path integration.
