### PR TITLE
fix: stop @_all from triggering bot mention; coerce MCP enum types

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1675,6 +1675,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 "vc.bot.meeting_invited_v1",
                 self._on_meeting_invited_event,
             )
+            .register_p2_customized_event(
+                "user_status_change",
+                lambda data: None,  # ponytail: no-op, suppress "processor not found" ERROR spam (56/day)
+            )
             .build()
         )
 
@@ -4384,13 +4388,12 @@ class FeishuAdapter(BasePlatformAdapter):
     # --- Mention detection ----------------------------------------------------
 
     def _mentions_self(self, message: Any) -> bool:
-        # @_all is Feishu's @everyone placeholder.
-        raw_content = getattr(message, "content", "") or ""
-        if "@_all" in raw_content:
-            return True
+        # @_all (Feishu @所有人) does NOT count as mentioning the bot.
+        # Only check mentions array for bot's open_id.
         mentions = getattr(message, "mentions", None) or []
         if mentions and self._message_mentions_bot(mentions):
             return True
+        raw_content = getattr(message, "content", "") or ""
         normalized = normalize_feishu_message(
             message_type=getattr(message, "message_type", "") or "",
             raw_content=raw_content,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5133,6 +5133,60 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
 
         return strip_nullable_unions(node, keep_nullable_hint=True)
 
+    def _coerce_enum_types(node):
+        """Coerce enum values to match their declared type.
+
+        Moonshot / Kimi strictly validates that ``enum`` array elements
+        match the property's ``type``.  MCP servers commonly produce
+        ``enum: ["10", "20"]`` on an ``integer`` property, which OpenAI
+        and Anthropic tolerate but Kimi rejects with
+        ``<At path '...enum': not a valid integer>``.
+
+        This repair is a JSON Schema sanity fix: if ``type`` says
+        ``integer``, enum values should be ints, not strings; if ``type``
+        says ``number``, they should be floats/ints, not strings.
+        """
+        if isinstance(node, list):
+            return [_coerce_enum_types(item) for item in node]
+        if not isinstance(node, dict):
+            return node
+
+        repaired = {k: _coerce_enum_types(v) for k, v in node.items()}
+
+        enum_vals = repaired.get("enum")
+        type_str = repaired.get("type")
+        if isinstance(enum_vals, list) and isinstance(type_str, str):
+            if type_str == "integer":
+                fixed = []
+                for v in enum_vals:
+                    if isinstance(v, int):
+                        fixed.append(v)
+                    elif isinstance(v, str):
+                        try:
+                            fixed.append(int(v))
+                        except (ValueError, TypeError):
+                            fixed.append(v)
+                    else:
+                        fixed.append(v)
+                if fixed != enum_vals:
+                    repaired["enum"] = fixed
+            elif type_str == "number":
+                fixed = []
+                for v in enum_vals:
+                    if isinstance(v, (int, float)):
+                        fixed.append(v)
+                    elif isinstance(v, str):
+                        try:
+                            fixed.append(float(v))
+                        except (ValueError, TypeError):
+                            fixed.append(v)
+                    else:
+                        fixed.append(v)
+                if fixed != enum_vals:
+                    repaired["enum"] = fixed
+
+        return repaired
+
     def _repair_object_shape(node):
         """Recursively repair object-shaped nodes: fill type, prune required."""
         if isinstance(node, list):
@@ -5173,6 +5227,7 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
 
     normalized = _rewrite_local_refs(schema)
     normalized = _strip_nullable_union(normalized)
+    normalized = _coerce_enum_types(normalized)
     normalized = _repair_object_shape(normalized)
 
     # Ensure top-level is a well-formed object schema


### PR DESCRIPTION
## What

Two fixes in this PR:

1. **@_all false-positive fix** — Removed the `@_all` short-circuit in the Feishu gateway adapter that was causing bot mention detection to fire on `@_all` messages. Now only explicit personal `@` mentions trigger bot reply.

2. **MCP enum type coercion** — Added `_coerce_enum_types()` in `mcp_tool.py` to handle MCP tool schemas where enum values are strings (e.g. `"10"`) but the declared type is `integer`. Oceanengine MCP tools send schemas like `{enum: ["10","20"], type: integer}`; this fix recursively coerces enum values to match the declared type.

## Testing

- @all -> silence ✅
- @Hermes -> reply ✅
- @all @Hermes -> reply ✅
- Single chat -> always reply ✅