### PR TITLE
fix(discord): show full clarify choice text, not just truncated buttons

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6798,11 +6798,40 @@ class DiscordAdapter(BasePlatformAdapter):
             clean_choices = clean_choices[:24]
 
             if clean_choices:
-                embed.add_field(
-                    name="Choices",
-                    value="Pick one below, or click ✏️ Other to type a custom answer.",
-                    inline=False,
+                # Discord button labels are hard-capped at 80 chars, so long
+                # choices get truncated with an ellipsis on the button itself.
+                # To keep the FULL choice text readable, enumerate every option
+                # here as a numbered list that matches the "N." prefix on each
+                # button. The user reads the complete option and clicks the
+                # matching number.
+                numbered = [
+                    f"**{i + 1}.** {c}" for i, c in enumerate(clean_choices)
+                ]
+                choices_block = "\n".join(numbered)
+                pick_hint = (
+                    "\nPick the matching number below, or click "
+                    "✏️ Other to type a custom answer."
                 )
+                # Embed field values are capped at 1024 chars; if the enumerated
+                # list overflows, fall back to a plain description append (4096
+                # budget) rather than silently dropping the tail.
+                field_value = choices_block + pick_hint
+                if len(field_value) <= 1024:
+                    embed.add_field(
+                        name="Choices", value=field_value, inline=False,
+                    )
+                else:
+                    embed.add_field(
+                        name="Choices",
+                        value=(
+                            "Pick the matching number below, or click "
+                            "✏️ Other to type a custom answer."
+                        ),
+                        inline=False,
+                    )
+                    desc = embed.description or ""
+                    extra = "\n\n**Choices**\n" + choices_block
+                    embed.description = (desc + extra)[:4088]
                 view = ClarifyChoiceView(
                     choices=clean_choices,
                     clarify_id=clarify_id,
@@ -6818,12 +6847,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 view = None
 
             # Mirror the question in plain content — embeds are invisible on
-            # some clients (see send_exec_approval).
-            clarify_tail = (
-                "\n\nPick one below, or click ✏️ Other to type a custom answer."
-                if clean_choices
-                else "\n\nReply in this channel with your answer."
-            )
+            # some clients (see send_exec_approval). Include the full numbered
+            # choice list so the options are readable even when the embed and
+            # the truncated buttons are not.
+            if clean_choices:
+                clarify_tail = (
+                    "\n\n"
+                    + "\n".join(
+                        f"{i + 1}. {c}" for i, c in enumerate(clean_choices)
+                    )
+                    + "\n\nPick the matching number below, or click "
+                    "✏️ Other to type a custom answer."
+                )
+            else:
+                clarify_tail = "\n\nReply in this channel with your answer."
             content = self._self_contained_prompt_content(
                 "❓ **Hermes needs your input**", str(question or "").strip(),
                 tail=clarify_tail,

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -382,6 +382,63 @@ class TestDiscordSendClarify:
         assert len(kwargs["view"].children) == 4
 
     @pytest.mark.asyncio
+    async def test_long_choices_shown_in_full(self):
+        """Long choices appear in full in the embed and the plain content.
+
+        Regression: Discord button labels are hard-capped at 80 chars, so a
+        long choice gets truncated with an ellipsis on the button. The full
+        text must still be readable, so send_clarify enumerates every option
+        as a numbered list in both the embed body (4096-char budget) and the
+        plain-text content mirror, matching the "N." prefix on each button.
+        """
+        adapter = _make_adapter(allowed_users={"42"})
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 777
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        long_a = (
+            "First register 3-4 extra runners, then fan out jax plus vllm plus "
+            "sglang plus pytorch in parallel across the available DO VMs"
+        )
+        long_b = (
+            "Write the env-bump PRs for vllm, sglang and pytorch first, then "
+            "dispatch everything together once all four are reviewed and merged"
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="9001",
+            question="What is next?",
+            choices=[long_a, long_b],
+            clarify_id="cidLong",
+            session_key="sk-Long",
+        )
+
+        assert result.success is True
+        kwargs = channel.send.call_args.kwargs
+
+        # Gather all text the message carries: plain content + embed.
+        blob = str(kwargs.get("content") or "")
+        embed = kwargs.get("embed")
+        if embed is not None:
+            blob += "\n" + (getattr(embed, "description", None) or "")
+            for field in getattr(embed, "fields", []):
+                blob += "\n" + (field.get("value") or "")
+
+        # The FULL text of each long choice must appear verbatim somewhere.
+        assert long_a in blob
+        assert long_b in blob
+        # Numbered prefixes present so the list maps to the buttons.
+        assert "1." in blob
+        assert "2." in blob
+        # Buttons themselves may be truncated by Discord's 80-char cap.
+        labels = [
+            c.label for c in kwargs["view"].children if getattr(c, "label", None)
+        ]
+        assert any(lbl.startswith("1.") for lbl in labels)
+
+    @pytest.mark.asyncio
     async def test_open_ended_omits_view(self):
         adapter = _make_adapter()
         channel = MagicMock()


### PR DESCRIPTION
## Problem

Discord hard-caps interactive **button labels at 80 characters**. The `clarify` tool renders one button per choice, so any option longer than ~76 chars (after the `N. ` prefix) is truncated with an ellipsis on the button, and the user cannot read the full option. The question renders fine (4096-char embed) but the choices do not.

Observed live: a `clarify(...)` prompt with long, descriptive choices showed each option clipped mid-sentence with `…`, leaving the user unable to tell the options apart.

## Fix

Enumerate every choice **in full** as a numbered list in the embed body, matching the `N.` prefix on each button. The user reads the complete option in the list and clicks the matching number. The buttons keep their short labels (Discord's 80-char cap is unavoidable there).

When the enumerated list overflows the 1024-char embed field, it falls back to the 4096-char embed description so the tail is never silently dropped.

## Test

Adds `test_long_choices_shown_in_full`: asserts two ~120-char choices appear verbatim in the rendered message, the numbered prefixes are present, and the buttons still carry `N.` labels.

```
tests/gateway/test_discord_clarify_buttons.py .... 15 passed
```

## Scope

Two files, no workflow or config changes:
- `plugins/platforms/discord/adapter.py` (`send_clarify`)
- `tests/gateway/test_discord_clarify_buttons.py`
