### PR TITLE
fix(gateway): exclude full current turn from media dedup history (#72536)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3258,14 +3258,27 @@ class BasePlatformAdapter(ABC):
             return None
         if not transcript:
             return None
-        # Exclude the current turn's assistant message, which has already been
-        # persisted by the time we reach delivery but must not be treated as
-        # "history" for dedup purposes.
+        # Exclude the current turn entirely.  The current turn starts after
+        # the last user message and may contain multiple entries (tool calls,
+        # tool results, and the final assistant response).  Removing only the
+        # last assistant message leaves tool-call/result entries that carry
+        # the same MEDIA: path, causing the collector to mark newly generated
+        # images as "already delivered".  See #72536.
         history = list(transcript)
-        for msg in reversed(history):
-            if msg.get("role") == "assistant":
-                history.remove(msg)
+        last_user_idx = None
+        for idx in range(len(history) - 1, -1, -1):
+            if history[idx].get("role") == "user":
+                last_user_idx = idx
                 break
+        if last_user_idx is not None:
+            history = history[:last_user_idx]
+        else:
+            # No user message found — drop the last assistant entry as a
+            # best-effort fallback (original behaviour).
+            for msg in reversed(history):
+                if msg.get("role") == "assistant":
+                    history.remove(msg)
+                    break
         if not history:
             return None
         # Avoid circular import: gateway.run already imports this module.


### PR DESCRIPTION
## Summary
Fixes #72536.

`_history_media_paths_for_session()` removed only the last assistant message before scanning for MEDIA: tags. But the current turn may contain multiple entries (tool calls, tool results, final assistant response). The tool result JSON carrying the generated image path was still present in the "history", so `_collect_history_media_paths` marked it as "already delivered" and the non-streaming dispatch filter dropped the image.

## Changes
- `gateway/platforms/base.py`: Slice the transcript at the last user message boundary so the entire current turn is excluded from history. Falls back to original single-assistant-message removal when no user message exists.

## Testing
- `py_compile`: OK
- `ruff check`: All checks passed
- `test_media_extraction`: All passed
- `test_media_spaced_paths_and_history_dedupe`: All passed
