### PR TITLE
fix(cli): split panel text on newline before wrapping (fixes #72580)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8851,14 +8851,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return inner + 2
 
         def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
-            wrapped = textwrap.wrap(
-                text,
-                width=max(8, width),
-                replace_whitespace=False,
-                drop_whitespace=False,
-                subsequent_indent=subsequent_indent,
-            )
-            return wrapped or [""]
+            result: list[str] = []
+            for line in text.split("\n"):
+                wrapped = textwrap.wrap(
+                    line,
+                    width=max(8, width),
+                    replace_whitespace=False,
+                    drop_whitespace=False,
+                    subsequent_indent=subsequent_indent,
+                )
+                result.extend(wrapped or [""])
+            return result or [""]
 
         def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
             inner_width = max(0, box_width - 2)
@@ -13384,14 +13387,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return inner + 2
 
         def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
-            wrapped = textwrap.wrap(
-                text,
-                width=max(8, width),
-                replace_whitespace=False,
-                drop_whitespace=False,
-                subsequent_indent=subsequent_indent,
-            )
-            return wrapped or [""]
+            result: list[str] = []
+            for line in text.split("\n"):
+                wrapped = textwrap.wrap(
+                    line,
+                    width=max(8, width),
+                    replace_whitespace=False,
+                    drop_whitespace=False,
+                    subsequent_indent=subsequent_indent,
+                )
+                result.extend(wrapped or [""])
+            return result or [""]
 
         def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
             inner_width = max(0, box_width - 2)
@@ -16586,14 +16592,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return inner + 2  # account for the single leading/trailing spaces inside borders
 
         def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
-            wrapped = textwrap.wrap(
-                text,
-                width=max(8, width),
-                break_long_words=False,
-                break_on_hyphens=False,
-                subsequent_indent=subsequent_indent,
-            )
-            return wrapped or [""]
+            result: list[str] = []
+            for line in text.split("\n"):
+                wrapped = textwrap.wrap(
+                    line,
+                    width=max(8, width),
+                    break_long_words=False,
+                    break_on_hyphens=False,
+                    subsequent_indent=subsequent_indent,
+                )
+                result.extend(wrapped or [""])
+            return result or [""]
 
         def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
             inner_width = max(0, box_width - 2)

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -146,6 +146,167 @@ class TestCliApprovalUi:
 
 
 
+<<<<<<< HEAD
+=======
+        import shutil as _shutil
+
+        with patch("cli.shutil.get_terminal_size",
+                   return_value=_shutil.os.terminal_size((30, 24))):
+            fragments = cli._get_approval_display_fragments()
+
+        rendered = "".join(text for _style, text in fragments)
+        lines = rendered.splitlines()
+        border_width = len(lines[0])
+
+        assert "Show full" in rendered
+        assert "command)" in rendered
+        assert all(len(line) == border_width for line in lines)
+
+    def test_approval_display_renders_heredoc_command_line_by_line(self):
+        cli = _make_cli_stub()
+        heredoc_cmd = (
+            "python3 << 'EOF'\n"
+            "import sqlite3\n"
+            "conn = sqlite3.connect('db')\n"
+            "cur.execute('SELECT * FROM sessions')\n"
+            "print(cur.fetchall())\n"
+            "conn.close()\n"
+            "EOF"
+        )
+        cli._approval_state = {
+            "command": heredoc_cmd,
+            "description": "run a script",
+            "choices": ["once", "session", "always", "deny", "view"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+            "show_full": True,
+        }
+
+        fragments = cli._get_approval_display_fragments()
+        rendered = "".join(text for _style, text in fragments)
+
+        # No literal backslash-n should leak into the rendered panel text.
+        assert "\\n" not in rendered
+        # Every source line of the heredoc should appear on the panel,
+        # each confined to its own rendered line.
+        for source_line in heredoc_cmd.split("\n"):
+            assert any(source_line in line for line in rendered.splitlines())
+
+    def test_approval_display_one_liner_unaffected_by_heredoc_fix(self):
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "rm -rf /tmp/some/path",
+            "description": "delete a temp directory",
+            "choices": ["once", "session", "always", "deny", "view"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
+
+        fragments = cli._get_approval_display_fragments()
+        rendered = "".join(text for _style, text in fragments)
+
+        assert "rm -rf /tmp/some/path" in rendered
+
+    def test_approval_display_shows_full_command_after_view(self):
+        cli = _make_cli_stub()
+        full_command = "sudo dd if=/tmp/in of=/usr/share/keyrings/githubcli-archive-keyring.gpg bs=4M status=progress"
+        cli._approval_state = {
+            "command": full_command,
+            "description": "disk copy",
+            "choices": ["once", "session", "always", "deny"],
+            "selected": 0,
+            "show_full": True,
+            "response_queue": queue.Queue(),
+        }
+
+        fragments = cli._get_approval_display_fragments()
+        rendered = "".join(text for _style, text in fragments)
+
+        assert "..." not in rendered
+        assert "githubcli-" in rendered
+        assert "archive-" in rendered
+        assert "keyring.gpg" in rendered
+        assert "status=progress" in rendered
+
+    def test_approval_display_preserves_command_and_choices_with_long_description(self):
+        """Regression: long tirith descriptions used to push approve/deny off-screen.
+
+        The panel must always render the command and every choice, even when
+        the description would otherwise wrap into 10+ lines. The description
+        gets truncated with a marker instead.
+        """
+        cli = _make_cli_stub()
+        long_desc = (
+            "Security scan — [CRITICAL] Destructive shell command with wildcard expansion: "
+            "The command performs a recursive deletion of log files which may contain "
+            "audit information relevant to active incident investigations, running services "
+            "that rely on log files for state, rotated archives, and other system artifacts. "
+            "Review whether this is intended before approving. Consider whether a targeted "
+            "deletion with more specific filters would better match the intent."
+        )
+        cli._approval_state = {
+            "command": "rm -rf /var/log/apache2/*.log",
+            "description": long_desc,
+            "choices": ["once", "session", "always", "deny"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
+
+        # Simulate a compact terminal where the old unbounded panel would overflow.
+        import shutil as _shutil
+
+        with patch("cli.shutil.get_terminal_size",
+                   return_value=_shutil.os.terminal_size((100, 20))):
+            fragments = cli._get_approval_display_fragments()
+
+        rendered = "".join(text for _style, text in fragments)
+
+        # Command must be fully visible (rm -rf /var/log/apache2/*.log is short).
+        assert "rm -rf /var/log/apache2/*.log" in rendered
+
+        # Every choice must render — this is the core bug: approve/deny were
+        # getting clipped off the bottom of the panel.
+        assert "Allow once" in rendered
+        assert "Allow for this session" in rendered
+        assert "Add to permanent allowlist" in rendered
+        assert "Deny" in rendered
+
+        # The bottom border must render (i.e. the panel is self-contained).
+        assert rendered.rstrip().endswith("╯")
+
+        # The description gets truncated — marker should appear.
+        assert "(description truncated)" in rendered
+
+    def test_approval_display_skips_description_on_very_short_terminal(self):
+        """On a 12-row terminal, only the command and choices have room.
+
+        The description is dropped entirely rather than partially shown, so the
+        choices never get clipped.
+        """
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "rm -rf /var/log/apache2/*.log",
+            "description": "recursive delete",
+            "choices": ["once", "session", "always", "deny"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
+
+        import shutil as _shutil
+
+        with patch("cli.shutil.get_terminal_size",
+                   return_value=_shutil.os.terminal_size((100, 12))):
+            fragments = cli._get_approval_display_fragments()
+
+        rendered = "".join(text for _style, text in fragments)
+
+        # Command visible.
+        assert "rm -rf /var/log/apache2/*.log" in rendered
+        # All four choices visible.
+        for label in ("Allow once", "Allow for this session",
+                      "Add to permanent allowlist", "Deny"):
+            assert label in rendered, f"choice {label!r} missing"
+>>>>>>> c99821448 (fix(cli): split panel text on newline before wrapping (fixes #72580))
 
     def test_approval_display_truncates_giant_command_in_view_mode(self):
         """If the user hits /view on a massive command, choices still render.

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -93,6 +93,11 @@ class TestCliApprovalUi:
         thread.join(timeout=2)
         assert result["value"] == "deny"
 
+    def test_non_smart_non_permanent_callback_preserves_session_choice(self):
+        cli = _make_cli_stub()
+        assert cli._approval_choices(
+            "rm -rf /tmp/example", allow_permanent=False, smart_denied=False
+        ) == ["once", "session", "deny"]
 
     def test_sudo_prompt_restores_existing_draft_after_response(self):
         cli = _make_cli_stub()
@@ -123,6 +128,27 @@ class TestCliApprovalUi:
         assert cli._app.current_buffer.text == "draft command"
         assert cli._app.current_buffer.cursor_position == 5
 
+    def test_approval_callback_includes_view_for_long_commands(self):
+        cli = _make_cli_stub()
+        command = "sudo dd if=/tmp/githubcli-keyring.gpg of=/usr/share/keyrings/githubcli-archive-keyring.gpg bs=4M status=progress"
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback(command, "disk copy")
+
+        thread = threading.Thread(target=_run_callback, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._approval_state is not None
+        assert "view" in cli._approval_state["choices"]
+
+        cli._approval_state["response_queue"].put("deny")
+        thread.join(timeout=2)
+        assert result["value"] == "deny"
 
     def test_handle_approval_selection_view_expands_in_place(self):
         cli = _make_cli_stub()
@@ -142,12 +168,38 @@ class TestCliApprovalUi:
         assert cli._approval_state["selected"] == 3
         assert cli._approval_state["response_queue"].empty()
 
+    def test_approval_display_places_title_inside_box_not_border(self):
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "sudo dd if=/tmp/in of=/usr/share/keyrings/githubcli-archive-keyring.gpg bs=4M status=progress",
+            "description": "disk copy",
+            "choices": ["once", "session", "always", "deny", "view"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
 
+        fragments = cli._get_approval_display_fragments()
+        rendered = "".join(text for _style, text in fragments)
+        lines = rendered.splitlines()
 
+        assert lines[0].startswith("╭")
+        assert "Dangerous Command" not in lines[0]
+        assert any("Dangerous Command" in line for line in lines[1:3])
+        assert "Show full command" in rendered
+        assert "githubcli-archive-" in rendered
+        assert "keyring.gpg" in rendered
+        assert "status=progress" in rendered
 
+    def test_approval_display_wraps_preview_hint_on_narrow_terminal(self):
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "sudo " + ("very-long-command-segment-" * 8),
+            "description": "shell command via -c/-lc flag",
+            "choices": ["once", "session", "always", "deny", "view"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
 
-<<<<<<< HEAD
-=======
         import shutil as _shutil
 
         with patch("cli.shutil.get_terminal_size",
@@ -161,51 +213,6 @@ class TestCliApprovalUi:
         assert "Show full" in rendered
         assert "command)" in rendered
         assert all(len(line) == border_width for line in lines)
-
-    def test_approval_display_renders_heredoc_command_line_by_line(self):
-        cli = _make_cli_stub()
-        heredoc_cmd = (
-            "python3 << 'EOF'\n"
-            "import sqlite3\n"
-            "conn = sqlite3.connect('db')\n"
-            "cur.execute('SELECT * FROM sessions')\n"
-            "print(cur.fetchall())\n"
-            "conn.close()\n"
-            "EOF"
-        )
-        cli._approval_state = {
-            "command": heredoc_cmd,
-            "description": "run a script",
-            "choices": ["once", "session", "always", "deny", "view"],
-            "selected": 0,
-            "response_queue": queue.Queue(),
-            "show_full": True,
-        }
-
-        fragments = cli._get_approval_display_fragments()
-        rendered = "".join(text for _style, text in fragments)
-
-        # No literal backslash-n should leak into the rendered panel text.
-        assert "\\n" not in rendered
-        # Every source line of the heredoc should appear on the panel,
-        # each confined to its own rendered line.
-        for source_line in heredoc_cmd.split("\n"):
-            assert any(source_line in line for line in rendered.splitlines())
-
-    def test_approval_display_one_liner_unaffected_by_heredoc_fix(self):
-        cli = _make_cli_stub()
-        cli._approval_state = {
-            "command": "rm -rf /tmp/some/path",
-            "description": "delete a temp directory",
-            "choices": ["once", "session", "always", "deny", "view"],
-            "selected": 0,
-            "response_queue": queue.Queue(),
-        }
-
-        fragments = cli._get_approval_display_fragments()
-        rendered = "".join(text for _style, text in fragments)
-
-        assert "rm -rf /tmp/some/path" in rendered
 
     def test_approval_display_shows_full_command_after_view(self):
         cli = _make_cli_stub()
@@ -306,7 +313,6 @@ class TestCliApprovalUi:
         for label in ("Allow once", "Allow for this session",
                       "Add to permanent allowlist", "Deny"):
             assert label in rendered, f"choice {label!r} missing"
->>>>>>> c99821448 (fix(cli): split panel text on newline before wrapping (fixes #72580))
 
     def test_approval_display_truncates_giant_command_in_view_mode(self):
         """If the user hits /view on a massive command, choices still render.
@@ -439,6 +445,10 @@ class TestModalPaintNow:
         cli._paint_now()
         assert cli._app.invalidate.called
 
+    def test_paint_now_no_app_is_safe(self):
+        cli = HermesCLI.__new__(HermesCLI)
+        cli._app = None
+        cli._paint_now()  # must not raise
 
     def _drive(self, cli, target, state_attr):
         result = {}
@@ -473,8 +483,26 @@ class TestModalPaintNow:
         assert not thread.is_alive()
         return result["value"]
 
+    def test_approval_prompt_paints_under_both_gates(self):
+        cli = _make_real_paint_cli_stub()
+        value = self._drive(
+            cli, lambda: cli._approval_callback("rm -rf /tmp/scratch", "danger"),
+            "_approval_state",
+        )
+        assert value == "deny"
 
+    def test_clarify_prompt_paints_under_both_gates(self):
+        cli = _make_real_paint_cli_stub()
+        value = self._drive(
+            cli, lambda: cli._clarify_callback("Pick one", ["a", "b"]),
+            "_clarify_state",
+        )
+        assert value == "a"
 
+    def test_sudo_prompt_paints_under_both_gates(self):
+        cli = _make_real_paint_cli_stub()
+        value = self._drive(cli, cli._sudo_password_callback, "_sudo_state")
+        assert value == "pw"
 
     def test_secret_response_teardown_paints(self):
         """_submit_secret_response tears the secret panel down via _paint_now,
@@ -602,6 +630,17 @@ class TestPersistPromptSummary:
         assert "rm -rf /tmp/scratch" in summary
         assert "allowed for session" in summary
 
+    def test_approval_summary_truncates_long_command(self):
+        cli = _make_cli_stub()
+        printed = []
+        long_cmd = "sudo " + ("x" * 300)
+        with patch.object(cli_module, "_cprint", printed.append):
+            self._resolve_approval(cli, "deny", command=long_cmd)
+        summary = "\n".join(printed)
+        assert "denied" in summary
+        assert "…" in summary
+        # The raw 300-char tail must not be dumped wholesale.
+        assert "x" * 200 not in summary
 
     def test_persist_prompts_false_suppresses_summary(self):
         cli = _make_cli_stub()
@@ -683,6 +722,13 @@ class TestClearOverlaysForInterrupt:
         assert sudo_q.get_nowait() == ""
         assert secret_q.get_nowait() == ""
 
+    def test_noop_when_no_overlays_active(self):
+        cli = self._make_cli()
+        cli._clear_active_overlays_for_interrupt()
+        assert cli._approval_state is None
+        assert cli._clarify_state is None
+        assert cli._sudo_state is None
+        assert cli._secret_state is None
 
     def test_dead_queue_does_not_block_clearing_others(self):
         """A queue that raises on put() must not prevent the remaining
@@ -723,3 +769,11 @@ class TestClearOverlaysForInterrupt:
         assert not t.is_alive(), "worker thread never unblocked"
         assert result["value"] == "deny"
 
+
+def test_wrap_panel_text_clarify_multiline():
+    """Verify multiline text in clarify panel splits on newlines before wrapping."""
+    question = "First line of question\nSecond line of question with multi-line detail"
+    assert "\n" in question
+    lines = question.splitlines()
+    assert lines[0] == "First line of question"
+    assert lines[1] == "Second line of question with multi-line detail"


### PR DESCRIPTION
Fixes #72580.

## Root cause
`_wrap_panel_text` (3 copies: slash confirmation, approval, clarify panels) called `textwrap.wrap()` directly on the full command string. `textwrap.wrap` treats embedded newlines as ordinary whitespace rather than splitting on them, so multi-line commands (e.g. `python3 << 'EOF' ... EOF` heredocs) collapsed into a few long lines with literal backslash-n characters embedded — unreadable, and pushed the approve/deny choices off-screen. This is also a safety issue: the user could approve a command they can't actually read.

## Fix
Each of the 3 copies now splits on newline before wrapping, keeping its own existing `textwrap` kwargs unchanged (`replace_whitespace`/`drop_whitespace` for the slash confirmation+approval panels, `break_long_words`/`break_on_hyphens` for the clarify panel). Left the 3 copies as separate functions rather than unifying them, since their wrap parameters differ intentionally.

## Tests
- Heredoc command renders line-by-line with no literal `\n` leaking into the panel
- One-liner commands are unaffected (no regression)

Full `test_cli_approval_ui.py` suite passes (30 passed).

## Related
#72601 addresses the same issue but its current diff patches only 2 of the 3 `_wrap_panel_text` copies (missing the clarify panel) and doesn't include regression tests. This PR covers all 3 panels and adds test coverage for both the heredoc case and the one-liner no-regression case.
