### PR TITLE
fix(agent): reset compression attempt counter after successful compaction (#72451)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1775,6 +1775,13 @@ def run_conversation(
                 conversation_history = conversation_history_after_compression(
                     agent, messages, conversation_history
                 )
+                # Reset the compression attempt counter after a successful
+                # compaction.  Without this, each successful in-place
+                # compression consumes the same budget as a failed/no-progress
+                # retry, and the turn permanently loses the ability to
+                # compress once the cap is reached — even though every earlier
+                # compaction made substantial progress.  See #72451.
+                compression_attempts = 0
                 api_call_count -= 1
                 agent._api_call_count = api_call_count
                 agent.iteration_budget.refund()


### PR DESCRIPTION
## Summary
Fixes #72451.

The pre-API compression path increments `compression_attempts` before running `_compress_context`, but never resets it after a successful in-place compaction. Each successful compression consumes the same budget as a failed retry. In long tool-calling turns, the default budget of 3 is exhausted by successful compactions alone, and later context growth cannot be compressed.

## Changes
- `agent/conversation_loop.py`: Add `compression_attempts = 0` after a successful in-place compaction so the budget is only consumed by failed/no-progress attempts.

## Testing
- `py_compile`: OK
- `ruff check`: All checks passed
