### PR TITLE
fix(doctor): remove cd prefix and gate --with-deps behind sudo check

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1875,14 +1875,36 @@ def run_doctor(args):
                         )
                         if sys.platform == "win32":
                             check_info(
-                                f"Install with: cd {PROJECT_ROOT} && "
-                                "npx playwright install chromium"
+                                "Install with: npx playwright install chromium"
                             )
                         else:
-                            check_info(
-                                f"Install with: cd {PROJECT_ROOT} && "
-                                "npx playwright install --with-deps chromium"
-                            )
+                            # Gate --with-deps behind sudo availability to
+                            # avoid silent hangs when Playwright spawns
+                            # an interactive sudo prompt (#25816).
+                            _is_root = hasattr(os, "geteuid") and os.geteuid() == 0
+                            _can_sudo = False
+                            if not _is_root:
+                                import subprocess as _sp
+
+                                try:
+                                    _can_sudo = _sp.run(
+                                        ["sudo", "-n", "true"],
+                                        capture_output=True,
+                                        timeout=5,
+                                    ).returncode == 0
+                                except (OSError, _sp.TimeoutExpired):
+                                    pass
+                            if _is_root or _can_sudo:
+                                check_info(
+                                    "Install with: npx playwright install --with-deps chromium"
+                                )
+                            else:
+                                check_info(
+                                    "Install with: npx playwright install chromium"
+                                )
+                                check_info(
+                                    "Then run (once, with sudo): sudo npx playwright install-deps chromium"
+                                )
     elif _is_termux():
         check_info("Node.js not found (browser tools are optional in the tested Termux path)")
         check_info("Install Node.js on Termux with: pkg install nodejs")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -379,7 +379,7 @@ def _format_browser_timeout_error(
                 "The browser daemon may still be starting, or Chromium may be "
                 "missing system libraries. Install/repair with: "
                 "npx agent-browser install --with-deps "
-                "(or: npx playwright install --with-deps chromium)"
+                "(or: npx playwright install chromium)"
             )
     if hints:
         parts.extend(hints)
@@ -1077,7 +1077,7 @@ def _run_chrome_fallback_command(
             hint = (
                 "Chrome fallback requires Chromium, but it is missing. Install it with: "
                 "npx agent-browser install --with-deps "
-                "(or: npx playwright install --with-deps chromium)"
+                "(or: npx playwright install chromium)"
             )
         return {"success": False, "error": hint}
 
@@ -2355,7 +2355,7 @@ def _run_browser_command(
             hint = (
                 "Chromium browser is missing. Install it with: "
                 "npx agent-browser install --with-deps "
-                "(or: npx playwright install --with-deps chromium)"
+                "(or: npx playwright install chromium)"
             )
         logger.warning("browser command blocked: %s", hint)
         return {"success": False, "error": hint}
@@ -4836,7 +4836,7 @@ if __name__ == "__main__":
                 else:
                     print("     Install it with:")
                     print("       npx agent-browser install --with-deps")
-                    print("     Or:  npx playwright install --with-deps chromium")
+                    print("     Or:  npx playwright install chromium")
         except FileNotFoundError:
             print("   - agent-browser CLI not found")
             print(f"     Install: {_browser_install_hint()}")


### PR DESCRIPTION
## Summary

`hermes doctor` prints a Playwright install command that **cannot succeed as written**. This PR fixes all three independent defects identified in #72612.

## Changes

### hermes_cli/doctor.py
- **Remove `cd {PROJECT_ROOT} &&` prefix** from Playwright install command — Playwright is not a project dependency, so `npx` resolves in package context and finds nothing. The cd was carried over from the `agent-browser` line where it IS needed (`node_modules/.bin/agent-browser` exists). Playwright's cache is global (`~/.cache/ms-playwright`).
- **Gate `--with-deps` behind sudo check** — matches the existing pattern in `scripts/install.sh` (line 2197): check `id -u == 0` OR `sudo -n true`. Without this, non-sudo users get a silent hang when Playwright spawns an interactive sudo prompt hidden behind ANSI progress bars (#25816). When sudo is unavailable, suggest `npx playwright install chromium` and a separate `sudo npx playwright install-deps chromium`.

### tools/browser_tool.py (4 instances)
- Remove `--with-deps` from fallback hint strings at lines 382, 1080, 2358, 4839 — the `npx agent-browser install --with-deps` hint on the same line already covers the sudo case, and the Playwright fallback should be safe for all users.

## Fixes

Fixes #72612

## Test Plan

- [x] `python3 -c "import ast; ast.parse(...)"` passes for both files
- [x] `pytest tests/tools/test_browser_chromium_check.py` — 11/11 passed