### PR TITLE
fix(delegation): stop in-memory prune deleting results before delivery (#65853, salvage of #65955)

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -798,3 +798,97 @@ def test_ack_flips_in_memory_state_even_when_db_row_is_gone(tmp_path, monkeypatc
             and rec.get("delivery_state") != "delivered"
         ]
     assert not stuck, f"records stuck pending after acknowledgement: {stuck}"
+
+
+def _dispatch_completed_batch(n):
+    """Dispatch *n* trivially-completing delegations and wait for the workers.
+
+    Uses a real session_key/parent so durable rows exist — the
+    claim/complete/drop production paths operate on the durable row, and a
+    session-less dispatch takes the legacy no-row shortcut instead.
+    """
+    for i in range(n):
+        ad.dispatch_async_delegation(
+            goal=f"drop{i}", context=None, toolsets=None, role="leaf", model="m",
+            session_key="owner", parent_session_id="parent",
+            runner=lambda: {"status": "completed", "summary": "ok"},
+            max_async_children=n + 20,
+        )
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and ad.active_count() > 0:
+        time.sleep(0.05)
+    return ad.list_async_delegations()
+
+
+def test_dropped_deliveries_fall_to_terminal_cap(tmp_path, monkeypatch):
+    """Sweeper (blocking): `dropped` is terminal too. The gateway drops
+    completions whose owner session is permanently gone
+    (drop_completion_delivery); those records must be capped with terminal
+    history, not squat in the 1,000-item pending budget forever."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    records = _dispatch_completed_batch(ad._MAX_RETAINED_COMPLETED + 10)
+
+    for r in records:
+        did = r["delegation_id"]
+        claim = f"test:{did}"
+        assert ad.claim_completion_delivery(did, claim)
+        ad.drop_completion_delivery(did, claim)
+
+    assert len(ad.list_async_delegations()) <= ad._MAX_RETAINED_COMPLETED
+    with ad._records_lock:
+        stuck = [
+            rid for rid, rec in ad._records.items()
+            if rec.get("status") != "running"
+            and rec.get("delivery_state") not in ("delivered", "dropped")
+        ]
+    assert not stuck, f"dropped records left in the pending bucket: {stuck}"
+
+
+def test_production_claim_complete_path_converges_and_caps(tmp_path, monkeypatch):
+    """Sweeper ask: cover the production acknowledgement path — the gateway
+    claims a completion, injects it, then calls complete_completion_delivery
+    (not mark_completion_delivered). The cap must converge on that path too."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    records = _dispatch_completed_batch(ad._MAX_RETAINED_COMPLETED + 10)
+
+    for r in records:
+        did = r["delegation_id"]
+        claim = f"consumer:{did}"
+        assert ad.claim_completion_delivery(did, claim)
+        acked = ad.complete_completion_delivery(did, claim)
+        # The DURABLE row may already be gone: _prune_durable_records counts
+        # all terminal rows against the history cap regardless of delivery
+        # state (that durable-side defect is #65860's scope, not this PR's).
+        # The ack must report True whenever the row still exists — and the
+        # IN-MEMORY record must converge either way.
+        if ad.get_durable_delegation(did) is not None:
+            assert acked, f"claimed completion failed to ack with row present: {did}"
+
+    assert len(ad.list_async_delegations()) <= ad._MAX_RETAINED_COMPLETED
+    with ad._records_lock:
+        stuck = [
+            rid for rid, rec in ad._records.items()
+            if rec.get("status") != "running"
+            and rec.get("delivery_state") != "delivered"
+        ]
+    assert not stuck
+
+
+def test_exhausted_attempts_release_converges_in_memory(tmp_path, monkeypatch):
+    """The second drop path: release after the attempt budget is exhausted
+    converges the durable row to `dropped` — the in-memory record must
+    follow, or it stays `pending` forever."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(ad, "_MAX_DELIVERY_ATTEMPTS", 1)
+    records = _dispatch_completed_batch(1)
+    did = records[0]["delegation_id"]
+
+    claim = "consumer:exhausted"
+    assert ad.claim_completion_delivery(did, claim)  # attempts -> 1
+    assert ad.release_completion_delivery(did, claim)  # capped -> dropped
+
+    with ad._records_lock:
+        rec = ad._records.get(did)
+    assert rec is not None and rec.get("delivery_state") == "dropped", (
+        f"exhausted-attempt drop did not converge in memory: {rec and rec.get('delivery_state')}"
+    )

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -729,3 +729,72 @@ def test_gateway_cli_origin_event_left_unrouted():
     runner._enrich_async_delegation_routing(evt)
     assert "platform" not in evt
 
+
+def test_completed_records_pruned_to_cap():
+    # Run more than the retention cap quickly; ensure list doesn't grow forever.
+    # Delivered records are capped at _MAX_RETAINED_COMPLETED (50); pending
+    # (undelivered) records at _MAX_DURABLE_PENDING (1000).
+    N = ad._MAX_RETAINED_COMPLETED + 10  # 60
+    for i in range(N):
+        ad.dispatch_async_delegation(
+            goal=f"t{i}", context=None, toolsets=None, role="leaf", model="m",
+            session_key="", runner=lambda: {"status": "completed", "summary": "ok"},
+            max_async_children=N + 20,
+        )
+    # let workers finish
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and ad.active_count() > 0:
+        time.sleep(0.05)
+
+    # All 60 are pending (undelivered) → none pruned (60 < 1000).
+    all_records = ad.list_async_delegations()
+    assert len(all_records) == N, (
+        f"expected {N} pending records, got {len(all_records)}"
+    )
+
+    # Acknowledge every record through the public path. The acknowledgement
+    # itself must enforce the delivered cap — no completion finalizer and no
+    # direct call into the private prune helper.
+    for r in all_records:
+        ad.mark_completion_delivered(r["delegation_id"])
+
+    assert len(ad.list_async_delegations()) <= ad._MAX_RETAINED_COMPLETED
+
+
+def test_ack_flips_in_memory_state_even_when_db_row_is_gone(tmp_path, monkeypatch):
+    """In-memory delivery state must not depend on the durable row surviving.
+
+    The DB and the in-memory dict can diverge (a durable prune can drop a
+    delivered row while the in-memory record lives on). If the ack only
+    flipped in-memory state when the DB UPDATE hit a row, such records stayed
+    'pending' forever and were never eligible for the delivered cap.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    N = ad._MAX_RETAINED_COMPLETED + 10
+    for i in range(N):
+        ad.dispatch_async_delegation(
+            goal=f"g{i}", context=None, toolsets=None, role="leaf", model="m",
+            session_key="", runner=lambda: {"status": "completed", "summary": "ok"},
+            max_async_children=N + 20,
+        )
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and ad.active_count() > 0:
+        time.sleep(0.05)
+
+    records = ad.list_async_delegations()
+    # First ack normally, then ack AGAIN — the second round hits rowcount==0
+    # (row already delivered) and must still leave in-memory state delivered.
+    for r in records:
+        ad.mark_completion_delivered(r["delegation_id"])
+    for r in records:
+        ad.mark_completion_delivered(r["delegation_id"])
+
+    remaining = ad.list_async_delegations()
+    assert len(remaining) <= ad._MAX_RETAINED_COMPLETED
+    with ad._records_lock:
+        stuck = [
+            rid for rid, rec in ad._records.items()
+            if rec.get("status") != "running"
+            and rec.get("delivery_state") != "delivered"
+        ]
+    assert not stuck, f"records stuck pending after acknowledgement: {stuck}"

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -387,20 +387,29 @@ def mark_completion_delivered(delegation_id: str) -> bool:
     return acked
 
 
-def _mark_in_memory_delivered(delegation_id: str) -> None:
-    """Update the in-memory record's delivery_state so prune doesn't
-    discard an undelivered result, then enforce the delivered cap.
+def _mark_in_memory_terminal(delegation_id: str, state: str) -> None:
+    """Converge the in-memory record to a terminal delivery state
+    (``delivered`` or ``dropped``), then enforce the terminal-history cap.
 
     Pruning here (not only in the completion finalizers) means a burst that
     completed as pending cannot retain more than ``_MAX_RETAINED_COMPLETED``
-    delivered records until some later completion happens to run the prune —
-    acknowledgement itself converges the cap.
+    terminal records until some later completion happens to run the prune —
+    the acknowledgement/drop itself converges the cap.
+
+    ``delivered`` is never downgraded to ``dropped``: a drop call racing an
+    earlier successful acknowledgement (its DB UPDATE finds no pending row)
+    must not relabel a delivery that actually happened.
     """
     with _records_lock:
         record = _records.get(delegation_id)
         if record is not None:
-            record["delivery_state"] = "delivered"
+            if not (state == "dropped" and record.get("delivery_state") == "delivered"):
+                record["delivery_state"] = state
             _prune_completed_locked()
+
+
+def _mark_in_memory_delivered(delegation_id: str) -> None:
+    _mark_in_memory_terminal(delegation_id, "delivered")
 
 
 def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -459,15 +468,23 @@ def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                 "marking terminally dropped (result remains queryable).",
                 delegation_id, _MAX_DELIVERY_ATTEMPTS,
             )
-            return True
-        cur = conn.execute(
-            """UPDATE async_delegations SET delivery_claim=NULL,
-                      delivery_claimed_at=NULL, updated_at=?
-               WHERE delegation_id=? AND delivery_state='pending'
-                 AND delivery_claim=?""",
-            (now, delegation_id, claim_id),
-        )
-        return cur.rowcount == 1
+            released = None  # exhausted → terminally dropped, converge below
+        else:
+            released = conn.execute(
+                """UPDATE async_delegations SET delivery_claim=NULL,
+                          delivery_claimed_at=NULL, updated_at=?
+                   WHERE delegation_id=? AND delivery_state='pending'
+                     AND delivery_claim=?""",
+                (now, delegation_id, claim_id),
+            )
+    if released is None:
+        # The in-memory dict is what the prune reads — converge it (outside
+        # the DB transaction, matching the ack paths) so a dropped record is
+        # capped with terminal history instead of squatting in the 1,000-item
+        # pending budget forever.
+        _mark_in_memory_terminal(delegation_id, "dropped")
+        return True
+    return released.rowcount == 1
 
 
 def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -489,7 +506,16 @@ def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                  AND delivery_claim=?""",
             (now, delegation_id, claim_id),
         )
-        return cur.rowcount == 1
+        dropped = cur.rowcount == 1
+    # Unconditionally, as in the acknowledgement paths: the gateway has
+    # decided this completion can never be delivered (owner session is
+    # permanently gone). rowcount==0 means the durable row was already
+    # delivered/dropped/pruned — either way the in-memory record must leave
+    # the pending bucket so the terminal-history cap governs it. A racing
+    # earlier delivery is preserved (_mark_in_memory_terminal never
+    # downgrades delivered → dropped).
+    _mark_in_memory_terminal(delegation_id, "dropped")
+    return dropped
 
 
 def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -609,22 +635,28 @@ def _new_delegation_id() -> str:
 def _prune_completed_locked() -> None:
     """Drop the oldest completed records beyond the retention cap.
 
-    Mirrors ``_prune_durable_records``: delivered records are capped at
-    ``_MAX_RETAINED_COMPLETED`` (50), while undelivered (pending) records
-    enjoy the separate ``_MAX_DURABLE_PENDING`` (1000) cap so results are
-    never deleted before the parent agent has consumed them.
+    Mirrors ``_prune_durable_records``: terminal records (delivered or
+    dropped) are capped at ``_MAX_RETAINED_COMPLETED`` (50), while
+    undelivered (pending) records enjoy the separate ``_MAX_DURABLE_PENDING``
+    (1000) cap so results are never deleted before the parent agent has
+    consumed them.
 
     Caller must hold ``_records_lock``.
     """
-    # Step 1 — delivered records: cap at _MAX_RETAINED_COMPLETED.
-    delivered = [
+    # Step 1 — terminal records (delivered OR dropped): cap at
+    # _MAX_RETAINED_COMPLETED. Dropped is terminal too — the gateway drops
+    # completions whose owner session is permanently gone, and the
+    # exhausted-attempt branch converges undeliverable rows; neither may
+    # squat in the pending budget (sweeper review on this PR).
+    terminal = [
         (rid, r)
         for rid, r in _records.items()
-        if r.get("status") != "running" and r.get("delivery_state") == "delivered"
+        if r.get("status") != "running"
+        and r.get("delivery_state") in ("delivered", "dropped")
     ]
-    if len(delivered) > _MAX_RETAINED_COMPLETED:
-        delivered.sort(key=lambda kv: kv[1].get("completed_at") or kv[1].get("dispatched_at") or 0)
-        for rid, _ in delivered[: len(delivered) - _MAX_RETAINED_COMPLETED]:
+    if len(terminal) > _MAX_RETAINED_COMPLETED:
+        terminal.sort(key=lambda kv: kv[1].get("completed_at") or kv[1].get("dispatched_at") or 0)
+        for rid, _ in terminal[: len(terminal) - _MAX_RETAINED_COMPLETED]:
             _records.pop(rid, None)
 
     # Step 2 — pending (undelivered) records: cap at _MAX_DURABLE_PENDING so a
@@ -632,7 +664,8 @@ def _prune_completed_locked() -> None:
     pending = [
         (rid, r)
         for rid, r in _records.items()
-        if r.get("status") != "running" and r.get("delivery_state") != "delivered"
+        if r.get("status") != "running"
+        and r.get("delivery_state") not in ("delivered", "dropped")
     ]
     overflow = max(0, len(pending) - _MAX_DURABLE_PENDING)
     if overflow:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -377,7 +377,19 @@ def mark_completion_delivered(delegation_id: str) -> bool:
                WHERE delegation_id=? AND delivery_state!='delivered'""",
             (now, now, delegation_id),
         )
-        return cur.rowcount == 1
+        acked = cur.rowcount == 1
+    if acked:
+        _mark_in_memory_delivered(delegation_id)
+    return acked
+
+
+def _mark_in_memory_delivered(delegation_id: str) -> None:
+    """Update the in-memory record's delivery_state so prune doesn't
+    discard an undelivered result."""
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is not None:
+            record["delivery_state"] = "delivered"
 
 
 def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -481,7 +493,10 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                  AND delivery_claim=?""",
             (now, now, delegation_id, claim_id),
         )
-        return cur.rowcount == 1
+        acked = cur.rowcount == 1
+    if acked:
+        _mark_in_memory_delivered(delegation_id)
+    return acked
 
 
 def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
@@ -578,19 +593,36 @@ def _new_delegation_id() -> str:
 def _prune_completed_locked() -> None:
     """Drop the oldest completed records beyond the retention cap.
 
+    Mirrors ``_prune_durable_records``: delivered records are capped at
+    ``_MAX_RETAINED_COMPLETED`` (50), while undelivered (pending) records
+    enjoy the separate ``_MAX_DURABLE_PENDING`` (1000) cap so results are
+    never deleted before the parent agent has consumed them.
+
     Caller must hold ``_records_lock``.
     """
-    completed = [
+    # Step 1 — delivered records: cap at _MAX_RETAINED_COMPLETED.
+    delivered = [
         (rid, r)
         for rid, r in _records.items()
-        if r.get("status") != "running"
+        if r.get("status") != "running" and r.get("delivery_state") == "delivered"
     ]
-    if len(completed) <= _MAX_RETAINED_COMPLETED:
-        return
-    # Oldest-first by completion time (fall back to dispatch time).
-    completed.sort(key=lambda kv: kv[1].get("completed_at") or kv[1].get("dispatched_at") or 0)
-    for rid, _ in completed[: len(completed) - _MAX_RETAINED_COMPLETED]:
-        _records.pop(rid, None)
+    if len(delivered) > _MAX_RETAINED_COMPLETED:
+        delivered.sort(key=lambda kv: kv[1].get("completed_at") or kv[1].get("dispatched_at") or 0)
+        for rid, _ in delivered[: len(delivered) - _MAX_RETAINED_COMPLETED]:
+            _records.pop(rid, None)
+
+    # Step 2 — pending (undelivered) records: cap at _MAX_DURABLE_PENDING so a
+    # burst of completions doesn't delete results before the parent reads them.
+    pending = [
+        (rid, r)
+        for rid, r in _records.items()
+        if r.get("status") != "running" and r.get("delivery_state") != "delivered"
+    ]
+    overflow = max(0, len(pending) - _MAX_DURABLE_PENDING)
+    if overflow:
+        pending.sort(key=lambda kv: kv[1].get("completed_at") or kv[1].get("dispatched_at") or 0)
+        for rid, _ in pending[:overflow]:
+            _records.pop(rid, None)
 
 
 def _current_origin_session_id() -> str:
@@ -701,6 +733,7 @@ def dispatch_async_delegation(
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "delivery_state": "pending",
     }
     # Capacity check and record insert under ONE lock hold — checking
     # active_count() separately would let two concurrent dispatches (e.g.
@@ -941,6 +974,7 @@ def dispatch_async_delegation_batch(
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "delivery_state": "pending",
     }
     with _records_lock:
         running = sum(

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -378,18 +378,29 @@ def mark_completion_delivered(delegation_id: str) -> bool:
             (now, now, delegation_id),
         )
         acked = cur.rowcount == 1
-    if acked:
-        _mark_in_memory_delivered(delegation_id)
+    # Unconditionally: the in-memory dict is the state the prune reads, and it
+    # can diverge from the DB (a durable prune may have dropped the delivered
+    # row while the in-memory record survives). Gating on the DB rowcount left
+    # such records 'pending' forever — uncapped retention under the pending
+    # budget and never eligible for the delivered cap.
+    _mark_in_memory_delivered(delegation_id)
     return acked
 
 
 def _mark_in_memory_delivered(delegation_id: str) -> None:
     """Update the in-memory record's delivery_state so prune doesn't
-    discard an undelivered result."""
+    discard an undelivered result, then enforce the delivered cap.
+
+    Pruning here (not only in the completion finalizers) means a burst that
+    completed as pending cannot retain more than ``_MAX_RETAINED_COMPLETED``
+    delivered records until some later completion happens to run the prune —
+    acknowledgement itself converges the cap.
+    """
     with _records_lock:
         record = _records.get(delegation_id)
         if record is not None:
             record["delivery_state"] = "delivered"
+            _prune_completed_locked()
 
 
 def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -494,8 +505,13 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
             (now, now, delegation_id, claim_id),
         )
         acked = cur.rowcount == 1
-    if acked:
-        _mark_in_memory_delivered(delegation_id)
+    # Unconditionally, as in mark_completion_delivered: this runs only after
+    # the completion event was actually injected into the consumer's queue.
+    # rowcount==0 here means the durable row was already delivered, dropped,
+    # pruned, or claimed over — none of which change the fact that THIS
+    # consumer received the payload, so the in-memory record must not stay
+    # 'pending' (it would be retained forever and shield the delivered cap).
+    _mark_in_memory_delivered(delegation_id)
     return acked
 
 


### PR DESCRIPTION
## Summary

Async delegation's in-memory prune can delete a completed child's result before the parent has consumed it: `_prune_completed_locked()` counts ALL terminal records (delivered + pending) against the single 50-item cap, so a burst of 51+ completions evicts still-undelivered results (#65853).

**Salvage of #65955 by @webtecnica** (author inactive since Jul 19), rebased onto current main and completed: this addresses the sweeper review's two problems verbatim, plus the in-memory/DB divergence bug @dany-aspire found on the original branch (his repro — 60 dispatched, 60 acked, 9 stuck `pending`, 59 retained — is now a regression test, and his suggested unconditional flip is the implemented fix). Triage by @alt-glitch confirmed this is not a duplicate of #65860 (durable-store retention) — this PR is the in-memory mirror of that same delivered/pending split, which main already has on the DB side (`_prune_durable_records`, `tools/async_delegation.py:234-261`).

## Changes

- `tools/async_delegation.py` (salvaged, cherry-picked with authorship): split the in-memory prune — delivered records capped at `_MAX_RETAINED_COMPLETED` (50), undelivered at `_MAX_DURABLE_PENDING` (1000), mirroring `_prune_durable_records`; track `delivery_state` on in-memory records (both dispatch sites); flip it on both ack paths.
- `tools/async_delegation.py` (rework): `_mark_in_memory_delivered()` prunes under `_records_lock`, so acknowledgement itself converges the delivered cap (sweeper problem 1 — previously only the completion finalizers pruned, so an acked burst held >50 delivered records until an unrelated completion). Both ack paths now flip in-memory state **unconditionally** instead of gating on the DB `rowcount` (@dany-aspire's finding): the durable row can already be delivered/dropped/pruned while the in-memory record survives, and both acks run only after the payload was actually injected into the consumer's queue — gating left such records `pending` forever, uncapped.
- `tests/tools/test_async_delegation.py`: cap test asserts through the public acknowledgement path with no direct call into the private prune helper (sweeper problem 2); new `test_ack_flips_in_memory_state_even_when_db_row_is_gone` covers the divergence/double-ack case.

## Sweeper review asks (on #65955) — both addressed

| Ask | Here |
|---|---|
| invoke `_prune_completed_locked()` within `_mark_in_memory_delivered()` while holding `_records_lock` | done — acknowledgement enforces the delivered cap immediately |
| assert the cap after acknowledgement without calling the private prune helper | done — `test_completed_records_pruned_to_cap` uses only `mark_completion_delivered()` |

## Root cause

`tools/async_delegation.py:548-563` (current main) prunes every non-running record oldest-first against one cap, with no delivery-state check; `_finalize` invokes it on every completion (`:777`, batch `:~1020`). The durable store already distinguishes delivered from pending (`_prune_durable_records`), but the in-memory dict — the state the gateway actually serves — did not. Additionally, the original PR's in-memory flip was gated on the DB UPDATE rowcount; DB and memory diverge (durable prune can drop a delivered row while the in-memory record lives), leaving records stuck `pending` forever — the original PR's own cap test fails on its unfixed branch code (59 records retained), which is exactly what @dany-aspire reported.

## Validation

- Red on current main (`d71033a40`): `test_completed_records_pruned_to_cap` (results evicted while pending) and `test_ack_flips_in_memory_state_even_when_db_row_is_gone` both fail; green with the fix — `scripts/run_tests.sh tests/tools/test_async_delegation.py`: 41 passed, 0 failed.
- Red on the original #65955 code without the rework commit: `test_completed_records_pruned_to_cap` fails (stuck-pending divergence), confirming @dany-aspire's report.
- Full `tests/tools/` sweep: failures identical to clean main (pre-existing, unrelated subsystems — mcp/browser/image/file_tools), 22 files fail identically on clean main `d71033a40`; one additional file (`test_base_environment.py`) is a parallel-run flake that passes 3/3 standalone on this branch and does not import the changed module.

## Scope notes

- Durable-store (DB-side) retention is #65860's territory — untouched here.
- Records whose delivery converges to terminal `dropped` (attempt budget exhausted) become evictable under the delivered cap via the unconditional flip — bounded retention, results remain queryable in the durable store.

Fixes #65853. Salvage of #65955 by @webtecnica; refs #65860, credit @dany-aspire for the divergence find and the minimal-fix suggestion, @alt-glitch for the duplicate triage.
