### PR TITLE
fix(cli): heal gutted managed Node trees instead of failing npm resolution forever

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -412,13 +412,49 @@ def _heal_managed_node_windows() -> bool:
             if extracted is None or not extracted.is_dir():
                 return False
             target = home / "node"
-            if target.exists():
-                shutil.rmtree(target)
-            shutil.move(str(extracted), str(target))
+            target.mkdir(parents=True, exist_ok=True)
+            _install_extracted_node_tree(extracted, target)
     except OSError:
         return False
 
     return node_tool_runnable(str(target / "node.exe"))
+
+
+def _install_extracted_node_tree(extracted: Path, target: Path) -> None:
+    """Install *extracted* into *target* additively, never gutting the tree.
+
+    ``rmtree(target)`` + ``move`` leaves a half-deleted tree (e.g. a bare
+    ``node.exe`` with no npm) when any file is locked by a running process,
+    and that gutted tree then shadows system Node forever. Instead copy
+    file-by-file over the existing tree. A locked destination cannot be
+    overwritten on Windows but can be renamed, so it is renamed aside and
+    replaced; a file that cannot be updated at all is left as-is, keeping
+    the tree complete either way.
+    """
+    for source in sorted(extracted.rglob("*")):
+        dest = target / source.relative_to(extracted)
+        if source.is_dir():
+            dest.mkdir(parents=True, exist_ok=True)
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        staged = dest.with_name(dest.name + ".hermes-heal-new")
+        shutil.copy2(source, staged)
+        try:
+            os.replace(staged, dest)
+        except PermissionError:
+            aside = dest.with_name(dest.name + ".hermes-heal-old")
+            try:
+                if aside.exists():
+                    aside.unlink()
+                os.replace(dest, aside)
+                os.replace(staged, dest)
+            except OSError:
+                staged.unlink(missing_ok=True)
+    for stale in target.rglob("*.hermes-heal-old"):
+        try:
+            stale.unlink()
+        except OSError:
+            pass
 
 
 def heal_hermes_managed_node() -> bool:
@@ -463,18 +499,8 @@ def heal_hermes_managed_node() -> bool:
 def find_hermes_node_executable(command: str) -> str | None:
     """Return a Hermes-managed Node/npm executable path, healing broken trees."""
     names = _candidate_node_command_names(command)
-    broken_present = False
-    for directory in iter_hermes_node_dirs():
-        for name in names:
-            candidate = directory / name
-            if candidate.is_file() and (
-                sys.platform == "win32" or os.access(candidate, os.X_OK)
-            ):
-                resolved = str(candidate)
-                if node_tool_runnable(resolved):
-                    return resolved
-                broken_present = True
-    if broken_present and heal_hermes_managed_node():
+
+    def _resolve() -> str | None:
         for directory in iter_hermes_node_dirs():
             for name in names:
                 candidate = directory / name
@@ -484,6 +510,18 @@ def find_hermes_node_executable(command: str) -> str | None:
                     resolved = str(candidate)
                     if node_tool_runnable(resolved):
                         return resolved
+        return None
+
+    resolved = _resolve()
+    if resolved:
+        return resolved
+    # Heal whether the command is present-but-broken or missing entirely from
+    # the managed tree (a gutted tree with node.exe but no npm would otherwise
+    # never heal, yet still suppresses the PATH fallback in
+    # find_node_executable). heal_hermes_managed_node() itself no-ops when no
+    # managed tree exists at all.
+    if heal_hermes_managed_node():
+        return _resolve()
     return None
 
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -339,6 +339,41 @@ class TestNodeToolRunnable:
 
         assert find_node_executable("npm") is None
 
+    def test_missing_managed_npm_heals_when_node_present(self, tmp_path, monkeypatch):
+        """A gutted tree (node exists, npm missing entirely) must still heal.
+
+        Previously heal only ran when a broken npm *file* was found, so a
+        tree stripped down to just node never healed — and, because the tree
+        was still "present", find_node_executable never fell back to PATH
+        either, failing every npm resolution forever.
+        """
+        profile_home = tmp_path / "profiles" / "assistant"
+        managed_bin = profile_home / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        self._stub(managed_bin, "node", "#!/bin/sh\necho '22.0.0'\nexit 0\n")
+        heal_called = {"value": False}
+
+        system_bin = tmp_path / "system-bin"
+        system_bin.mkdir()
+        self._stub(system_bin, "npm", "#!/bin/sh\necho '11.10.0'\nexit 0\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("PATH", str(system_bin))
+        monkeypatch.setattr(hermes_constants, "_managed_node_heal_attempted", False)
+
+        def _heal():
+            heal_called["value"] = True
+            healed = managed_bin / "npm"
+            healed.write_text("#!/bin/sh\necho '22.0.0'\nexit 0\n")
+            healed.chmod(0o755)
+            return True
+
+        monkeypatch.setattr(hermes_constants, "heal_hermes_managed_node", _heal)
+
+        resolved = find_node_executable("npm")
+        assert heal_called["value"] is True
+        assert resolved == str(managed_bin / "npm")
+
     def test_healthy_managed_npm_still_preferred(self, tmp_path, monkeypatch):
         profile_home = tmp_path / "profiles" / "assistant"
         managed_bin = profile_home / "node" / "bin"
@@ -353,6 +388,63 @@ class TestNodeToolRunnable:
         monkeypatch.setenv("PATH", str(system_bin))
 
         assert find_node_executable("npm") == str(managed_npm)
+
+
+class TestInstallExtractedNodeTree:
+    """_install_extracted_node_tree() must never gut an existing tree."""
+
+    def test_additive_install_over_gutted_tree(self, tmp_path):
+        extracted = tmp_path / "extracted"
+        (extracted / "node_modules" / "npm").mkdir(parents=True)
+        (extracted / "node.exe").write_text("new-node")
+        (extracted / "npm.cmd").write_text("new-npm")
+        (extracted / "node_modules" / "npm" / "cli.js").write_text("cli")
+
+        target = tmp_path / "node"
+        target.mkdir()
+        (target / "node.exe").write_text("old-node")
+
+        hermes_constants._install_extracted_node_tree(extracted, target)
+
+        assert (target / "node.exe").read_text() == "new-node"
+        assert (target / "npm.cmd").read_text() == "new-npm"
+        assert (target / "node_modules" / "npm" / "cli.js").read_text() == "cli"
+
+    def test_locked_file_renamed_aside_and_replaced(self, tmp_path, monkeypatch):
+        """A destination that cannot be overwritten is renamed aside, not fatal."""
+        extracted = tmp_path / "extracted"
+        extracted.mkdir()
+        (extracted / "node.exe").write_text("new-node")
+        (extracted / "npm.cmd").write_text("new-npm")
+
+        target = tmp_path / "node"
+        target.mkdir()
+        locked = target / "node.exe"
+        locked.write_text("old-node")
+
+        real_replace = os.replace
+        state = {"denied": False}
+
+        def _replace(src, dst):
+            # Deny the first direct overwrite of node.exe, as Windows does
+            # for a running executable; renames of it still succeed.
+            if (
+                not state["denied"]
+                and Path(dst) == locked
+                and str(src).endswith(".hermes-heal-new")
+            ):
+                state["denied"] = True
+                raise PermissionError(13, "in use", str(dst))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(hermes_constants.os, "replace", _replace)
+
+        hermes_constants._install_extracted_node_tree(extracted, target)
+
+        assert (target / "node.exe").read_text() == "new-node"
+        assert (target / "npm.cmd").read_text() == "new-npm"
+        assert not list(target.rglob("*.hermes-heal-old"))
+        assert not list(target.rglob("*.hermes-heal-new"))
 
 
 class TestIsContainer:


### PR DESCRIPTION
## Summary

Two related bugs in `hermes_constants.py` can leave a Hermes-managed Node tree "gutted" (`node.exe` present, npm missing entirely) — and once that happens, every `hermes desktop --build-only` (and therefore every `hermes update` desktop rebuild) fails with `npm was not found on PATH`, silently and forever.

### Bug 1 — a gutted tree never heals and never falls back

`find_hermes_node_executable()` only attempted `heal_hermes_managed_node()` when a candidate executable **existed** but failed `node_tool_runnable` (`broken_present`). If npm is entirely missing from the managed tree while `node.exe` exists:

- `broken_present` stays `False`, so heal never runs, and
- `find_node_executable()` still returns `None` instead of falling back to system npm, because `hermes_managed_node_tree_present()` is still `True` (node.exe counts).

Net effect: npm resolution is permanently dead with no self-repair and no fallback.

**Fix:** attempt heal whenever no runnable candidate was found — present-but-broken *or* missing entirely. The no-managed-tree case is unchanged: `heal_hermes_managed_node()` already no-ops when `hermes_managed_node_tree_present()` is `False`, so machines without a managed tree still fall straight through to the PATH lookup.

### Bug 2 — the Windows heal itself creates gutted trees

`_heal_managed_node_windows()` did `shutil.rmtree(target)` then `shutil.move(...)`. If any file in the tree is locked by a running process (e.g. a long-lived service that was spawned from the managed `node.exe`), `rmtree` deletes everything it can, throws on the locked file, heal returns `False` — and the tree is left half-deleted (typically `node.exe` only, no npm). That is exactly the state that triggers bug 1 permanently.

**Fix:** install the extracted zip additively, file by file over the existing tree (`_install_extracted_node_tree`). Each file is staged next to its destination and swapped in with `os.replace`; a locked destination is renamed aside first (a running exe can be renamed but not overwritten on Windows) and then replaced. A file that can't be updated at all is left as-is. Either way the tree stays complete — heal can no longer make things worse than it found them.

## Observed impact (real machine)

On a Windows 11 install, the managed tree at `%LOCALAPPDATA%\hermes\node` contained only `node.exe` from ~Jul 15 to Jul 27, 2026 — a heal had run while a service spawned from the managed node held `node.exe` locked. Every `hermes update` in that window "succeeded" while the desktop rebuild step silently failed, leaving the packaged `app.asar` 12 days stale.

## Tests

- `test_missing_managed_npm_heals_when_node_present` — regression for bug 1 (POSIX-stub class, same harness as the adjacent heal tests).
- `TestInstallExtractedNodeTree` — cross-platform: additive install over a gutted tree, and locked-destination rename-aside path (lock simulated by denying the first direct `os.replace` overwrite).

Ran `tests/test_hermes_constants.py` on Windows: all previously-passing tests still pass, plus the two new cross-platform tests (the POSIX-stub test skips on Windows by class design and is exercised in CI). Also smoke-tested the bug-1 path end-to-end on Windows with `.cmd` stubs: gutted tree → heal attempted → healed npm resolved. The 6 pre-existing local failures (symlink privilege / platform-default home) fail identically on an untouched checkout of `main`.

## Notes

- Behavior change: heal no longer deletes files that exist in the tree but not in the new zip (stale leftovers survive). That seemed like the right trade against the current failure mode of destroying the tree; happy to add a post-install prune of known-stale paths if you'd prefer.
- Leftover `*.hermes-heal-old` rename-aside files are best-effort cleaned at the end of each heal (a still-locked one is retried on the next heal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
