### PR TITLE
fix(desktop): release the composer focus target when a composer unmounts

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.test.ts
+++ b/apps/desktop/src/app/chat/composer/focus.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { blurComposerInput } from './focus'
+import {
+  blurComposerInput,
+  getActiveComposer,
+  markActiveComposer,
+  onComposerFocusRequest,
+  releaseActiveComposer,
+  requestComposerFocus
+} from './focus'
 import { RICH_INPUT_SLOT } from './rich-editor'
 
 /**
@@ -46,5 +53,58 @@ describe('blurComposerInput', () => {
     blurComposerInput()
 
     expect(document.activeElement).toBe(outside)
+  })
+})
+
+/**
+ * `markActiveComposer` has four call sites and, before this, no counterpart:
+ * an unmounting composer left `activeTarget` pointing at itself, so every
+ * `'active'`-routed request was delivered to a target with no subscriber.
+ */
+describe('releaseActiveComposer', () => {
+  afterEach(() => {
+    // `activeTarget` is module-level — a case that leaves a stale claim behind
+    // would otherwise decide the next one.
+    markActiveComposer('main')
+  })
+
+  it('falls back to the main composer when the claimant releases', () => {
+    markActiveComposer('edit')
+    expect(getActiveComposer()).toBe('edit')
+
+    releaseActiveComposer('edit')
+
+    expect(getActiveComposer()).toBe('main')
+  })
+
+  it('leaves the key with the live claimant when a stale composer releases late', () => {
+    markActiveComposer('edit')
+    markActiveComposer('tile:abc')
+
+    releaseActiveComposer('edit')
+
+    expect(getActiveComposer()).toBe('tile:abc')
+  })
+
+  it('routes an active-target request to the main composer once the edit composer closes', async () => {
+    // Mirrors the per-composer filter in use-composer-draft / user-edit-composer:
+    // a composer ignores any request not addressed to its own target.
+    const mainComposerSaw: string[] = []
+
+    const off = onComposerFocusRequest(({ target }) => {
+      if (target === 'main') {
+        mainComposerSaw.push(target)
+      }
+    })
+
+    markActiveComposer('edit')
+    releaseActiveComposer('edit')
+    requestComposerFocus('active')
+
+    // `dispatch` defers to a macrotask so click/keydown handlers settle first.
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    off()
+
+    expect(mainComposerSaw).toEqual(['main'])
   })
 })

--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -82,6 +82,20 @@ export const markActiveComposer = (target: ComposerTarget) => {
   activeTarget = target
 }
 
+/** Hand the routing key back when a composer unmounts, so `'active'` can never
+ *  resolve to a composer that no longer has a subscriber — such a request is
+ *  dispatched and then dropped by every mounted composer's target filter, and
+ *  nothing re-marks the active composer on its own.
+ *
+ *  Guarded on identity: a composer unmounting AFTER another one claimed the key
+ *  (closing a background tile, a deferred edit-close cleanup) must not steal it
+ *  from the live claimant. */
+export const releaseActiveComposer = (target: ComposerTarget) => {
+  if (activeTarget === target) {
+    activeTarget = 'main'
+  }
+}
+
 /** The composer that last held focus — the target `'active'` resolves to.
  *  Used by broadcast listeners (voice, Esc-to-stop) to act on exactly one. */
 export const getActiveComposer = (): ComposerTarget => activeTarget

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { type ComposerAttachment, mainComposerScope, stashSessionDraft } from '@/store/composer'
 
 import type { QueueEditState } from '../composer-utils'
+import { type ComposerTarget, getActiveComposer, markActiveComposer } from '../focus'
+import { type ComposerScope, ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
 
 import { useComposerDraft } from './use-composer-draft'
 
@@ -126,5 +128,50 @@ describe('useComposerDraft — rehydrate diagnostic log stays redacted', () => {
       attachmentKinds: ['url'],
       scope: 'session-secret'
     })
+  })
+})
+
+describe('useComposerDraft — a closing composer hands the focus-bus key back', () => {
+  afterEach(() => {
+    cleanup()
+    mainComposerScope.clear()
+    markActiveComposer('main')
+  })
+
+  function renderScoped(target: ComposerTarget) {
+    const scope: ComposerScope = { ...MAIN_COMPOSER_SCOPE, target }
+
+    return render(
+      <ComposerScopeProvider value={scope}>
+        <ProbeHarness
+          activeQueueSessionKey="session-tile"
+          onLayoutSnapshot={() => undefined}
+          sessionId="session-tile"
+        />
+      </ComposerScopeProvider>
+    )
+  }
+
+  it('stops `active` resolving to a session tile once the tile unmounts', () => {
+    const { unmount } = renderScoped('tile:abc')
+
+    // Mounting claims the bus for this tile — the leak precondition.
+    expect(getActiveComposer()).toBe('tile:abc')
+
+    unmount()
+
+    expect(getActiveComposer()).toBe('main')
+  })
+
+  it('leaves the key alone when another composer claimed it before this one unmounted', () => {
+    const { unmount } = renderScoped('tile:abc')
+    expect(getActiveComposer()).toBe('tile:abc')
+
+    // The user clicks into a second tile, which claims the bus.
+    markActiveComposer('tile:other')
+
+    unmount()
+
+    expect(getActiveComposer()).toBe('tile:other')
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -17,7 +17,8 @@ import {
   markActiveComposer,
   onComposerFocusRequest,
   onComposerInsertRefsRequest,
-  onComposerInsertRequest
+  onComposerInsertRequest,
+  releaseActiveComposer
 } from '../focus'
 import { type InlineRefInput, insertInlineRefsIntoEditor } from '../inline-refs'
 import { composerPlainText, placeCaretEnd, REF_RE, renderComposerContents } from '../rich-editor'
@@ -152,6 +153,13 @@ export function useComposerDraft({
       focusInput()
     }
   }, [focusInput, focusKey, focusRequestId, inputDisabled])
+
+  // The mirror of the `markActiveComposer` above: give the key back when this
+  // composer goes away (a session tile closing, a pane unmounting). Covers both
+  // claim sites for this composer — `focusInput` here and ChatBar's `onFocus` —
+  // since they mark the same scope target. Without it `'active'` keeps
+  // resolving to a dead tile and every routed focus/insert request is dropped.
+  useEffect(() => () => releaseActiveComposer(target), [target])
 
   useEffect(() => {
     if (inputDisabled) {

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -19,7 +19,8 @@ import {
   focusComposerInput,
   markActiveComposer,
   onComposerFocusRequest,
-  onComposerInsertRequest
+  onComposerInsertRequest,
+  releaseActiveComposer
 } from '@/app/chat/composer/focus'
 import { useAtCompletions } from '@/app/chat/composer/hooks/use-at-completions'
 import { useComposerUndo } from '@/app/chat/composer/hooks/use-composer-undo'
@@ -110,7 +111,17 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const at = useAtCompletions({ cwd, gateway, sessionId })
   const slash = useSlashCompletions({ gateway })
 
-  useEffect(() => () => notifyThreadEditClose(), [])
+  // This is the one composer that routinely unmounts, so it is where the focus
+  // bus leaks: confirming or cancelling an edit tears the composer down while
+  // `'edit'` is still the active target. Release it alongside the thread-scroll
+  // cleanup so keyboard routing falls back to the main composer.
+  useEffect(
+    () => () => {
+      notifyThreadEditClose()
+      releaseActiveComposer('edit')
+    },
+    []
+  )
 
   const focusEditor = useCallback(() => {
     const editor = editorRef.current


### PR DESCRIPTION
## What does this PR do?

`markActiveComposer` claims the composer focus-bus routing key (`activeTarget`, `app/chat/composer/focus.ts:51`). It has **four call sites and no counterpart** — there is no release site anywhere in the repo, so a composer that unmounts leaves `activeTarget` pointing at itself forever.

| claim site | what claims the target |
|---|---|
| `app/chat/composer/hooks/use-composer-draft.ts:104` | scoped composer's `focusInput()` → `markActiveComposer(target)` |
| `app/chat/composer/index.tsx:868` | `onFocus={() => markActiveComposer(scope.target)}` |
| `components/assistant-ui/thread/user-edit-composer.tsx:124` | `focusEditor()` → `markActiveComposer('edit')` |
| `components/assistant-ui/thread/user-edit-composer.tsx:741` | `onFocus={() => markActiveComposer('edit')}` |

Release sites: **none**.

The inline edit composer is the one composer that routinely unmounts. Its only unmount cleanup is `user-edit-composer.tsx:113` (`notifyThreadEditClose()` — thread-scroll state, not focus), and nothing re-marks the main composer on edit close. So the moment the user confirms or cancels an edit, `activeTarget` is `'edit'` with **zero subscribers**, and `resolve()` (`focus.ts:53`) keeps routing every `'active'` request there — where each composer's own filter (`if (requested !== target) return`) drops it.

Every API on this bus resolves `'active'` through that one function, so all five go dead together: `requestComposerFocus` (`focus.ts:92`), `requestComposerInsert` (`:104`), `requestComposerInsertRefs` (`:120`), `requestComposerSubmit` (`:137`) and `requestVoiceToggle` (`:148`). One release site fixes all of them.

### What the user sees

1. **Typing a letter does nothing.** `app/hooks/use-keybinds.ts:278-279` calls `event.preventDefault()` **before** `requestComposerFocus('active', { typeChar })`. The keystroke is consumed and the focus request goes to a dead target — the character is lost and nothing focuses.
2. **Esc stops working exactly when it matters.** `use-composer-esc-cancel.ts:40` bails on `getActiveComposer() !== target`. Resubmitting an edited message *starts a new turn*, so Esc-to-stop is dead in the one flow that just started something to stop.
3. The `composer.focus` hotkey (`use-keybinds.ts:133`), soft `/` (`use-keybinds.ts:296-297`), preview-rail attach (`app/chat/right-rail/preview-file.tsx:505`) and the clarify late-answer path (`components/assistant-ui/clarify-tool.tsx:233`) all silently no-op.

**It does not self-heal.** The re-focus effect in `use-composer-draft.ts` is keyed on `[focusInput, focusKey, focusRequestId, inputDisabled]`, and `focusKey` changes only on session switch. The keyboard stays dead until the user clicks the input box.

### Why the release lives in the hook rather than in ChatBar

Session tiles claim scoped targets — `app/chat/session-tile.tsx:132` passes `` target: `tile:${storedSessionId}` `` — and leak identically when a tile is closed, so a fix covering only the edit composer would be a subset of the bug. Releasing from `useComposerDraft` covers **both** scoped claim sites at once, because `use-composer-draft.ts:104` and `index.tsx:868` mark the same `scope.target` value: one effect handles the main composer and every session tile, and `index.tsx` needs no change.

The identity guard (`if (activeTarget === target)`) is load-bearing: a composer unmounting *after* another one claimed the key must not steal it back. The main composer never unmounts in practice, and the guard plus the `'main'` default make releasing it a no-op anyway, so no special-casing is needed.

`use-composer-esc-cancel.ts` is deliberately left alone — it *consumes* the stale value rather than producing it, so changing it would paper over the leak instead of fixing it.

This restores two invariants the surrounding code already documents: `use-composer-esc-cancel.ts:11-13` ("only the active one's Esc cancels") and `focus.ts:85-87` ("the composer that last held focus").

## Related Issue

There is no filed issue and no superseded PR for this one — it turned up while reading the focus bus, so there is nothing to auto-close.

Related background only: **#63290** is the maintainer-labelled meta-issue for the recurring composer state-divergence bug class (the DOM / `draftRef` / AUI three-way split). This is the same family — composer state that diverges from reality and then persists — but a different piece of state (module-level focus routing), so this PR does **not** close it.

Duplicate check: no open PR touches `focus.ts`, `focus.test.ts`, `use-composer-draft.ts(x)` or `use-composer-esc-cancel.ts`, and no open PR mentions `markActiveComposer`, `getActiveComposer`, `requestComposerFocus` or `releaseActiveComposer`. The three open PRs on `user-edit-composer.tsx` (#71517, #71102, #70804) touch the attachment-upload call and the `submitting` latch, not focus, and do not overlap these hunks.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/focus.ts` — add `releaseActiveComposer(target)`, guarded on `activeTarget === target` so a late release cannot clobber a live claimant.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts` — release the scope target on unmount. Covers the main composer and every `tile:<id>` composer, and both of their claim sites.
- `apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx` — release `'edit'` from the existing unmount cleanup, alongside `notifyThreadEditClose()`.
- `apps/desktop/src/app/chat/composer/focus.test.ts` — 3 cases: release falls back to `'main'`; a stale release leaves the live claimant alone; end-to-end through the bus, a `'main'` subscriber receives an `'active'` request after the edit composer closes.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx` — 2 cases mounting the hook under a `tile:abc` scope: unmount hands the key back; unmount does not clobber a key another composer has since claimed.

## How to Test

Manual reproduction (fails on `main`, passes with this change):

1. Open a chat with at least one previous user message. Click that message to open the inline edit composer.
2. Press Esc to cancel it, or confirm the edit. **Do not click the main input.**
3. Type any letter → nothing happens, the character is swallowed. Press `/` → no slash menu. If the edit was resubmitted and a turn is running, press Esc → the turn does not stop.
4. Click the main input once — everything works again. (Same thing with a session tile: focus its composer, close the tile, then try to type in the main chat.)

Automated, from `apps/desktop/`:

```
npx vitest run --project ui src/app/chat/composer/focus.test.ts src/app/chat/composer/hooks/use-composer-draft.test.tsx
```

**Red before.** With `releaseActiveComposer`'s body emptied — which reproduces `main`, where no release site exists at all — 3 of the 5 new cases fail:

```
 ❯ |ui| src/app/chat/composer/focus.test.ts (5 tests | 2 failed)
     × falls back to the main composer when the claimant releases
     × routes an active-target request to the main composer once the edit composer closes
 ❯ |ui| src/app/chat/composer/hooks/use-composer-draft.test.tsx (4 tests | 1 failed)
     × stops `active` resolving to a session tile once the tile unmounts

 FAIL  releaseActiveComposer > falls back to the main composer when the claimant releases
 AssertionError: expected 'edit' to be 'main' // Object.is equality

 FAIL  releaseActiveComposer > routes an active-target request to the main composer once the edit composer closes
 AssertionError: expected [] to deeply equal [ 'main' ]

 FAIL  useComposerDraft — a closing composer hands the focus-bus key back > stops `active` resolving to a session tile once the tile unmounts
 AssertionError: expected 'tile:abc' to be 'main' // Object.is equality

 Test Files  2 failed (2)
      Tests  3 failed | 6 passed (9)
```

**Green after**, with the fix restored:

```
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

The other 2 new cases are guard tests — they exist to reject an unguarded `activeTarget = 'main'` implementation, so they pass in both directions by design.

Full blocking checks, from `apps/desktop/`:

- `npm run test:ui` → **296 files, 2528 passed | 1 skipped**.
- `npm run lint` → **0 errors**. The warning count is unchanged from `main`; the 2 warnings reported in `use-composer-draft.ts` are the pre-existing `stashAt` / `react-hooks/exhaustive-deps` ones (they appear on clean `origin/main` at the same effects).
- `npm run typecheck` → clean for every touched file. The only errors are 4 pre-existing ones in `src/debug/render-counter.ts`, from `bippy` (a declared devDependency) not being installed in this local `node_modules`; they reproduce identically on clean `origin/main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is desktop renderer TypeScript. Ran the project that owns these tests instead: `npm run test:ui` (2528 passed), plus `npm run lint` and `npm run typecheck`.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 (vitest + jsdom)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new export carries a doc comment next to `markActiveComposer`; no external docs describe this internal bus
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, renderer-only state with no platform-specific code paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
