### PR TITLE
fix(stream_consumer): guard message_len_fn_for_chat against hot-reload AttributeError after git pull

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -680,11 +680,16 @@ class GatewayStreamConsumer:
         # Telegram 4096); native adapters return their scalar unchanged.
         # Gate on isinstance(BasePlatformAdapter) so test MagicMocks (whose
         # auto-attributes return mock objects, not callables) fall back to len.
-        _len_fn: "Callable[[str], int]" = (
-            self.adapter.message_len_fn_for_chat(self.chat_id)
-            if isinstance(self.adapter, _BasePlatformAdapter)
-            else len
-        )
+        # Guard the call with except Exception so a hot-reload (git pull while
+        # the gateway runs) does not crash when the lazy-imported stream_consumer
+        # calls methods the in-memory adapter doesn't have yet (#72628).
+        if isinstance(self.adapter, _BasePlatformAdapter):
+            try:
+                _len_fn = self.adapter.message_len_fn_for_chat(self.chat_id)
+            except Exception:
+                _len_fn = len
+        else:
+            _len_fn = len
         # Rich-capable adapters (Telegram rich messages) raise this above the
         # legacy per-message limit so a reply that fits one rich send/draft
         # isn't fragmented at 4096 while streaming.  See _raw_message_limit.


### PR DESCRIPTION
## Summary

When `git pull` updates the code while the gateway is running, a lazy import of `stream_consumer.py` (which happens on the first message) can pick up a NEW version of the module while the adapter classes in memory (`base.py`) are still the OLD version. This causes an `AttributeError` when the new `stream_consumer.py` calls `message_len_fn_for_chat()` that didn't exist in the old adapter.

## Root Cause

1. Gateway starts → loads `gateway/platforms/base.py` eagerly at module level
2. `git pull` updates `stream_consumer.py` on disk
3. First message arrives → lazy import at `gateway/run.py:20027` loads the NEW `stream_consumer.py`
4. `GatewayStreamConsumer.run()` calls `self.adapter.message_len_fn_for_chat(self.chat_id)`
5. But the adapter object was instantiated from the OLD `base.py` (loaded at startup) → **`AttributeError`**

## Fix

**`gateway/stream_consumer.py:683-687`** — replaced the bare ternary expression with an `if/else` block wrapped in `try/except Exception`, consistent with the pattern already used at line 1368-1373 in the same file and at `run.py:21029-21036`.

## Related

Fixes #72628

Found and diagnosed by @webtecnica