### PR TITLE
feat(plugins): extend public subagent lifecycle contract

### DIFF
--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -23,7 +23,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from typing import Any, Callable, Mapping, Optional
 
 
-PUBLIC_CONTRACT_VERSION = 2
+PUBLIC_CONTRACT_VERSION = 3
 _MAX_GOAL_CHARS = 16_000
 _MAX_CONTEXT_CHARS = 32_000
 _MAX_METADATA_BYTES = 8_192
@@ -95,6 +95,27 @@ class SubagentHandle:
 
 
 @dataclasses.dataclass(frozen=True)
+class SubagentCompletionHandle:
+    """Opaque authority for one manually produced durable completion."""
+
+    contract_version: int
+    delegation_id: str
+    parent_session_id: Optional[str]
+    created_at: float
+    capability: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "SubagentCompletionHandle":
+        try:
+            return cls(**dict(value))
+        except (TypeError, ValueError) as exc:
+            raise SubagentLifecycleError("Malformed completion handle.") from exc
+
+
+@dataclasses.dataclass(frozen=True)
 class SubagentStatus:
     handle: SubagentHandle
     state: SubagentState
@@ -158,6 +179,9 @@ class _Record:
         default=None, repr=False, compare=False
     )
     last_progress_monotonic: Optional[float] = None
+    delivery_route: Mapping[str, Any] = dataclasses.field(
+        default_factory=dict, repr=False, compare=False
+    )
 
 
 class _Registry:
@@ -212,6 +236,166 @@ class SubagentLifecycleService:
     def contract_version(self) -> int:
         """Return the exact public lifecycle contract implemented by this host."""
         return PUBLIC_CONTRACT_VERSION
+
+    @staticmethod
+    def _capture_delivery_route(parent: Any) -> dict[str, Any]:
+        """Capture the current durable outbox route without retaining prompt data."""
+        parent_session_id = str(getattr(parent, "session_id", "") or "") or None
+        try:
+            from tools.approval import get_current_session_key
+
+            session_key = get_current_session_key(default="")
+        except Exception:
+            session_key = ""
+        origin_ui_session_id = ""
+        try:
+            from gateway.session_context import (
+                async_delivery_supported,
+                get_session_env,
+            )
+
+            origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "")
+            async_supported = bool(async_delivery_supported())
+        except Exception:
+            async_supported = True
+            origin_ui_session_id = ""
+        if parent_session_id:
+            session_key = parent_session_id
+        from tools.async_delegation import _current_origin_session_id
+
+        origin_session_id = _current_origin_session_id()
+        return {
+            "session_key": session_key,
+            "parent_session_id": parent_session_id,
+            "origin_ui_session_id": origin_ui_session_id,
+            "origin_session_id": origin_session_id,
+            "deliverable": async_supported or bool(origin_session_id),
+        }
+
+    def register_completion_delivery(
+        self,
+        *,
+        goal: str,
+        context: Optional[str] = None,
+        role: str = "leaf",
+        model: Optional[str] = None,
+        toolsets: Optional[tuple[str, ...]] = None,
+    ) -> SubagentCompletionHandle:
+        """Capture the current origin and register one durable manual producer.
+
+        Plugins use this for work whose real terminal is outside the child
+        runner. Completion later enters the same claim/retry/restore queue as
+        ``delegate_task`` and remains pinned to this captured origin even after
+        an unrelated conversation becomes active.
+        """
+        parent = self._parent_agent_resolver()
+        if parent is None:
+            raise SubagentLifecycleError(
+                "No active Hermes parent session is available."
+            )
+        self._validate_completion_registration(
+            goal=goal,
+            context=context,
+            role=role,
+            model=model,
+            toolsets=toolsets,
+        )
+        route = self._capture_delivery_route(parent)
+        parent_session_id = route["parent_session_id"]
+        if not route["deliverable"]:
+            raise SubagentLifecycleError(
+                "This session cannot receive a detached durable completion."
+            )
+
+        from tools.async_delegation import register_external_delegation
+
+        receipt = register_external_delegation(
+            goal=goal,
+            context=context,
+            toolsets=list(toolsets) if toolsets else None,
+            role=role,
+            model=model,
+            session_key=str(route["session_key"] or ""),
+            parent_session_id=parent_session_id,
+            origin_ui_session_id=str(route["origin_ui_session_id"] or ""),
+            origin_session_id=str(route["origin_session_id"] or ""),
+        )
+        delegation_id = str(receipt.get("delegation_id") or "")
+        if receipt.get("status") != "registered" or not delegation_id:
+            raise SubagentLifecycleError("Completion delivery registration failed.")
+        created_at = time.time()
+        return SubagentCompletionHandle(
+            contract_version=PUBLIC_CONTRACT_VERSION,
+            delegation_id=delegation_id,
+            parent_session_id=parent_session_id,
+            created_at=created_at,
+            capability=self._completion_capability(
+                delegation_id, parent_session_id, created_at
+            ),
+        )
+
+    def publish_completion(
+        self,
+        handle: SubagentCompletionHandle,
+        *,
+        status: str,
+        summary: Optional[str],
+        error: Optional[str] = None,
+        api_calls: int = 0,
+        duration_seconds: Optional[float] = None,
+        exit_reason: Optional[str] = None,
+    ) -> bool:
+        """Persist and enqueue one completion; duplicate publication is false."""
+        self._validate_completion_handle(handle)
+        if status not in {"completed", "error", "interrupted", "cancelled", "unknown"}:
+            raise SubagentLifecycleError("Unsupported completion status.")
+        for name, value in (
+            ("summary", summary),
+            ("error", error),
+            ("exit_reason", exit_reason),
+        ):
+            if value is not None and (
+                not isinstance(value, str) or len(value) > _MAX_RESULT_CHARS
+            ):
+                raise SubagentLifecycleError(
+                    f"{name} must be a string of at most {_MAX_RESULT_CHARS} characters."
+                )
+        if (
+            not isinstance(api_calls, int)
+            or isinstance(api_calls, bool)
+            or api_calls < 0
+        ):
+            raise SubagentLifecycleError("api_calls must be a non-negative integer.")
+        if duration_seconds is not None and (
+            not isinstance(duration_seconds, (int, float))
+            or isinstance(duration_seconds, bool)
+            or not math.isfinite(float(duration_seconds))
+            or duration_seconds < 0
+        ):
+            raise SubagentLifecycleError(
+                "duration_seconds must be finite and non-negative."
+            )
+
+        from tools.async_delegation import complete_external_delegation
+
+        return complete_external_delegation(
+            handle.delegation_id,
+            status=status,
+            summary=summary,
+            error=error,
+            api_calls=api_calls,
+            duration_seconds=None
+            if duration_seconds is None
+            else float(duration_seconds),
+            exit_reason=exit_reason,
+        )
+
+    def discard_completion_delivery(self, handle: SubagentCompletionHandle) -> bool:
+        """Discard a registration only while it is still uncompleted."""
+        self._validate_completion_handle(handle)
+        from tools.async_delegation import discard_external_delegation
+
+        return discard_external_delegation(handle.delegation_id)
 
     def launch(self, request: SubagentLaunchRequest) -> SubagentHandle:
         parent = self._parent_agent_resolver()
@@ -282,6 +466,7 @@ class SubagentLifecycleService:
             agent=child,
             parent_agent=parent if request.on_terminal is not None else None,
             on_terminal=request.on_terminal,
+            delivery_route=self._capture_delivery_route(parent),
         )
         # Attach only after every public handle/record field is safely constructed.
         # The value is absent from prompts, model config, metadata, and repr output.
@@ -426,6 +611,72 @@ class SubagentLifecycleService:
             return None
         return getattr(agent, _PRIVATE_CONTEXT_ATTR, None)
 
+    def publish_notification(
+        self,
+        summary: str,
+        *,
+        dedupe_key: str,
+        priority: bool = False,
+    ) -> bool:
+        """Durably enqueue one bounded child milestone pinned to its origin."""
+        if not isinstance(summary, str):
+            raise SubagentLifecycleError("Progress summary must be a string.")
+        clean = " ".join(summary.split())
+        if not clean or len(clean) > _MAX_PROGRESS_CHARS:
+            raise SubagentLifecycleError(
+                "Progress summary must contain 1 to 500 visible characters."
+            )
+        if not isinstance(dedupe_key, str) or not 1 <= len(dedupe_key) <= 200:
+            raise SubagentLifecycleError("dedupe_key must contain 1 to 200 characters.")
+        if not isinstance(priority, bool):
+            raise SubagentLifecycleError("priority must be a boolean.")
+        agent = get_active_subagent_parent()
+        subagent_id = str(getattr(agent, "_subagent_id", "") or "")
+        if not subagent_id:
+            return False
+        now = time.monotonic()
+        with _REGISTRY.lock:
+            record = _REGISTRY.records.get(subagent_id)
+            if (
+                record is None
+                or record.agent is not agent
+                or record.state not in {SubagentState.STARTING, SubagentState.RUNNING}
+            ):
+                return False
+            if (
+                not priority
+                and record.last_progress_monotonic is not None
+                and now - record.last_progress_monotonic
+                < _MIN_PROGRESS_INTERVAL_SECONDS
+            ):
+                return False
+            route = dict(record.delivery_route)
+            model = record.handle.model
+        if not route.get("deliverable"):
+            return False
+        try:
+            from tools.async_delegation import publish_external_notification
+
+            accepted = publish_external_notification(
+                summary=clean,
+                dedupe_key=dedupe_key,
+                session_key=str(route.get("session_key") or ""),
+                parent_session_id=route.get("parent_session_id"),
+                origin_ui_session_id=str(route.get("origin_ui_session_id") or ""),
+                origin_session_id=str(route.get("origin_session_id") or ""),
+                model=model,
+            )
+        except Exception:
+            logger.debug("Durable subagent notification failed", exc_info=True)
+            return False
+        if not accepted:
+            return False
+        with _REGISTRY.lock:
+            current = _REGISTRY.records.get(subagent_id)
+            if current is record:
+                current.last_progress_monotonic = now
+        return True
+
     def publish_progress(self, summary: str, *, priority: bool = False) -> bool:
         """Relay one bounded child milestone to its origin display callback.
 
@@ -465,7 +716,7 @@ class SubagentLifecycleService:
                 return False
             record.last_progress_monotonic = now
         try:
-            callback("subagent_progress", clean)
+            callback("subagent.progress", clean)
         except Exception:
             logger.debug("Subagent progress callback failed", exc_info=True)
             return False
@@ -634,6 +885,67 @@ class SubagentLifecycleService:
     ) -> str:
         value = f"{subagent_id}|{parent_session_id or ''}|{created_at:.6f}".encode()
         return hmac.new(_SECRET, value, hashlib.sha256).hexdigest()
+
+    @staticmethod
+    def _completion_capability(
+        delegation_id: str, parent_session_id: Optional[str], created_at: float
+    ) -> str:
+        value = (
+            f"completion|{delegation_id}|{parent_session_id or ''}|{created_at:.6f}"
+        ).encode()
+        return hmac.new(_SECRET, value, hashlib.sha256).hexdigest()
+
+    @classmethod
+    def _validate_completion_handle(cls, handle: SubagentCompletionHandle) -> None:
+        if (
+            not isinstance(handle, SubagentCompletionHandle)
+            or handle.contract_version != PUBLIC_CONTRACT_VERSION
+            or not isinstance(handle.delegation_id, str)
+            or not handle.delegation_id.startswith("deleg_")
+            or len(handle.delegation_id) > 120
+            or not isinstance(handle.created_at, (int, float))
+            or not math.isfinite(float(handle.created_at))
+            or not isinstance(handle.capability, str)
+        ):
+            raise SubagentLifecycleError("Malformed completion handle.")
+        expected = cls._completion_capability(
+            handle.delegation_id, handle.parent_session_id, float(handle.created_at)
+        )
+        if not hmac.compare_digest(handle.capability, expected):
+            raise SubagentLifecycleError("Invalid completion handle capability.")
+
+    @staticmethod
+    def _validate_completion_registration(
+        *,
+        goal: str,
+        context: Optional[str],
+        role: str,
+        model: Optional[str],
+        toolsets: Optional[tuple[str, ...]],
+    ) -> None:
+        if not isinstance(goal, str) or not goal.strip() or len(goal) > _MAX_GOAL_CHARS:
+            raise SubagentLifecycleError(
+                "goal must be a non-empty string of at most 16000 characters."
+            )
+        if context is not None and (
+            not isinstance(context, str) or len(context) > _MAX_CONTEXT_CHARS
+        ):
+            raise SubagentLifecycleError(
+                "context must be a string of at most 32000 characters."
+            )
+        if role not in {"leaf", "orchestrator"}:
+            raise SubagentLifecycleError("role must be 'leaf' or 'orchestrator'.")
+        if model is not None and (not isinstance(model, str) or len(model) > 500):
+            raise SubagentLifecycleError(
+                "model must be a string of at most 500 characters."
+            )
+        if toolsets is not None and (
+            not isinstance(toolsets, tuple)
+            or any(not isinstance(item, str) or not item for item in toolsets)
+        ):
+            raise SubagentLifecycleError(
+                "toolsets must be a tuple of non-empty strings."
+            )
 
     @staticmethod
     def _validate_request(request: SubagentLaunchRequest, parent: Any) -> None:

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -13,6 +13,7 @@ import enum
 import hashlib
 import hmac
 import json
+import logging
 import math
 import secrets
 import threading
@@ -22,12 +23,16 @@ from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from typing import Any, Callable, Mapping, Optional
 
 
-PUBLIC_CONTRACT_VERSION = 1
+PUBLIC_CONTRACT_VERSION = 2
 _MAX_GOAL_CHARS = 16_000
 _MAX_CONTEXT_CHARS = 32_000
 _MAX_METADATA_BYTES = 8_192
 _MAX_RESULT_CHARS = 32_000
 _TERMINAL_RETENTION_SECONDS = 3_600
+_PRIVATE_CONTEXT_ATTR = "_plugin_private_context"
+_MAX_PROGRESS_CHARS = 500
+_MIN_PROGRESS_INTERVAL_SECONDS = 5.0
+logger = logging.getLogger(__name__)
 
 
 class SubagentLifecycleError(ValueError):
@@ -59,6 +64,10 @@ class SubagentLaunchRequest:
     correlation_id: Optional[str] = None
     metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     timeout_seconds: Optional[float] = None
+    private_context: Any = dataclasses.field(default=None, repr=False, compare=False)
+    on_terminal: Optional[Callable[..., None]] = dataclasses.field(
+        default=None, repr=False, compare=False
+    )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -144,6 +153,11 @@ class _Record:
     started_at: Optional[float] = None
     completed_at: Optional[float] = None
     result: Optional[SubagentResult] = None
+    parent_agent: Any = dataclasses.field(default=None, repr=False)
+    on_terminal: Optional[Callable[..., None]] = dataclasses.field(
+        default=None, repr=False, compare=False
+    )
+    last_progress_monotonic: Optional[float] = None
 
 
 class _Registry:
@@ -194,12 +208,23 @@ class SubagentLifecycleService:
     def __init__(self, parent_agent_resolver: Callable[[], Any]) -> None:
         self._parent_agent_resolver = parent_agent_resolver
 
+    @property
+    def contract_version(self) -> int:
+        """Return the exact public lifecycle contract implemented by this host."""
+        return PUBLIC_CONTRACT_VERSION
+
     def launch(self, request: SubagentLaunchRequest) -> SubagentHandle:
         parent = self._parent_agent_resolver()
         if parent is None:
             raise SubagentLifecycleError(
                 "No active Hermes parent session is available."
             )
+        return self._launch_with_parent(request, parent)
+
+    def _launch_with_parent(
+        self, request: SubagentLaunchRequest, parent: Any
+    ) -> SubagentHandle:
+        """Launch with a host-owned parent retained only for in-process relaunch."""
         self._validate_request(request, parent)
         parent_session_id = str(getattr(parent, "session_id", "") or "") or None
         if request.parent_session_id and request.parent_session_id != parent_session_id:
@@ -250,12 +275,32 @@ class SubagentLifecycleService:
             int(getattr(child, "_delegate_depth", 1) or 1),
             self._capability(subagent_id, parent_session_id, created),
         )
-        record = _Record(handle, SubagentState.PENDING, created, agent=child)
+        record = _Record(
+            handle,
+            SubagentState.PENDING,
+            created,
+            agent=child,
+            parent_agent=parent if request.on_terminal is not None else None,
+            on_terminal=request.on_terminal,
+        )
+        # Attach only after every public handle/record field is safely constructed.
+        # The value is absent from prompts, model config, metadata, and repr output.
+        setattr(child, _PRIVATE_CONTEXT_ATTR, request.private_context)
         with _REGISTRY.lock:
             _REGISTRY.records[subagent_id] = record
             if request.correlation_id:
                 _REGISTRY.correlations[correlation_key] = subagent_id
-        record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        try:
+            record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        except Exception as exc:
+            setattr(child, _PRIVATE_CONTEXT_ATTR, None)
+            with _REGISTRY.lock:
+                _REGISTRY.records.pop(subagent_id, None)
+                if request.correlation_id:
+                    _REGISTRY.correlations.pop(correlation_key, None)
+            raise SubagentLifecycleError(
+                "Hermes failed to schedule the child."
+            ) from exc
         return handle
 
     def status(self, handle: SubagentHandle) -> SubagentStatus:
@@ -337,7 +382,101 @@ class SubagentLifecycleService:
         with _REGISTRY.lock:
             return SubagentReconnectResult(True, record.state)
 
-    def _record(self, handle: SubagentHandle) -> Optional[_Record]:
+    def relaunch(
+        self,
+        previous_handle: SubagentHandle,
+        request: SubagentLaunchRequest,
+    ) -> SubagentHandle:
+        """Launch a replacement from a terminal handle in the same host process.
+
+        The previous handle is an unforgeable process-local capability. Its retained
+        parent is never returned to plugin code and is discarded with the bounded
+        terminal record. Relaunch deliberately does not claim process-restart
+        recovery; after restart the handle remains unknown.
+        """
+        record = self._record(previous_handle, require_active_parent=False)
+        if record is None:
+            raise SubagentLifecycleError("Unknown previous subagent handle.")
+        with _REGISTRY.lock:
+            if record.result is None or record.state not in {
+                SubagentState.SUCCEEDED,
+                SubagentState.FAILED,
+                SubagentState.INTERRUPTED,
+                SubagentState.CANCELLED,
+            }:
+                raise SubagentLifecycleError(
+                    "A replacement can only follow a terminal subagent."
+                )
+            parent = record.parent_agent
+        if parent is None:
+            raise SubagentLifecycleError("The retained parent is unavailable.")
+        retained_parent_id = str(getattr(parent, "session_id", "") or "") or None
+        if retained_parent_id != previous_handle.parent_session_id:
+            raise SubagentLifecycleError("The retained parent no longer matches.")
+        return self._launch_with_parent(request, parent)
+
+    def current_private_context(self) -> Any:
+        """Return the opaque context attached to the currently executing child.
+
+        The value exists only while that child is alive and is never copied into a
+        prompt, model-callable schema, handle, status, result, or retained record.
+        """
+        agent = get_active_subagent_parent()
+        if agent is None:
+            return None
+        return getattr(agent, _PRIVATE_CONTEXT_ATTR, None)
+
+    def publish_progress(self, summary: str, *, priority: bool = False) -> bool:
+        """Relay one bounded child milestone to its origin display callback.
+
+        Routine updates are limited to one per child every five seconds. Priority
+        owner-gate, anomaly, and terminal updates may bypass that interval. The
+        caller still decides which durable events are useful enough to summarize.
+        """
+        if not isinstance(summary, str):
+            raise SubagentLifecycleError("Progress summary must be a string.")
+        clean = " ".join(summary.split())
+        if not clean or len(clean) > _MAX_PROGRESS_CHARS:
+            raise SubagentLifecycleError(
+                "Progress summary must contain 1 to 500 visible characters."
+            )
+        if not isinstance(priority, bool):
+            raise SubagentLifecycleError("priority must be a boolean.")
+        agent = get_active_subagent_parent()
+        subagent_id = str(getattr(agent, "_subagent_id", "") or "")
+        callback = getattr(agent, "tool_progress_callback", None)
+        if not subagent_id or not callable(callback):
+            return False
+        now = time.monotonic()
+        with _REGISTRY.lock:
+            record = _REGISTRY.records.get(subagent_id)
+            if (
+                record is None
+                or record.agent is not agent
+                or record.state not in {SubagentState.STARTING, SubagentState.RUNNING}
+            ):
+                return False
+            previous = record.last_progress_monotonic
+            if (
+                not priority
+                and previous is not None
+                and now - previous < _MIN_PROGRESS_INTERVAL_SECONDS
+            ):
+                return False
+            record.last_progress_monotonic = now
+        try:
+            callback("subagent_progress", clean)
+        except Exception:
+            logger.debug("Subagent progress callback failed", exc_info=True)
+            return False
+        return True
+
+    def _record(
+        self,
+        handle: SubagentHandle,
+        *,
+        require_active_parent: bool = True,
+    ) -> Optional[_Record]:
         if (
             not isinstance(handle, SubagentHandle)
             or type(handle.contract_version) is not int
@@ -372,12 +511,16 @@ class SubagentLifecycleService:
             ),
         ):
             return None
-        parent = self._parent_agent_resolver()
-        active_parent_id = str(getattr(parent, "session_id", "") or "") or None
-        if active_parent_id != handle.parent_session_id:
-            return None
+        if require_active_parent:
+            parent = self._parent_agent_resolver()
+            active_parent_id = str(getattr(parent, "session_id", "") or "") or None
+            if active_parent_id != handle.parent_session_id:
+                return None
         with _REGISTRY.lock:
-            return _REGISTRY.records.get(handle.subagent_id)
+            record = _REGISTRY.records.get(handle.subagent_id)
+            if record is None or record.handle != handle:
+                return None
+            return record
 
     @staticmethod
     def _cleanup_locked() -> None:
@@ -462,12 +605,28 @@ class SubagentLifecycleService:
                 json.dumps(payload, sort_keys=True, default=str).encode()
             ).hexdigest(),
         )
+        child = record.agent
+        if child is not None:
+            setattr(child, _PRIVATE_CONTEXT_ATTR, None)
         with _REGISTRY.lock:
             record.agent = None
             record.result = result
             record.state = result.terminal_state
             record.completed_at = result.completed_at
             record.updated_at = result.completed_at or time.time()
+            terminal_status = SubagentStatus(
+                record.handle, record.state, record.updated_at
+            )
+            on_terminal = record.on_terminal
+        if on_terminal is not None:
+            try:
+                on_terminal(record.handle, terminal_status, result)
+            except Exception:
+                logger.warning("Subagent terminal callback failed", exc_info=True)
+            finally:
+                with _REGISTRY.lock:
+                    record.on_terminal = None
+                    record.parent_agent = None
 
     @staticmethod
     def _capability(
@@ -500,6 +659,8 @@ class SubagentLifecycleService:
             raise SubagentLifecycleError(
                 "Per-launch timeout is not supported; configure delegation timeout explicitly."
             )
+        if request.on_terminal is not None and not callable(request.on_terminal):
+            raise SubagentLifecycleError("on_terminal must be callable.")
         if request.working_directory is not None:
             raise SubagentLifecycleError(
                 "working_directory is not supported because Hermes delegates use isolated task environments."
@@ -518,8 +679,10 @@ class SubagentLifecycleService:
             raise SubagentLifecycleError("metadata exceeds 8192 bytes.")
         if request.allowed_toolsets:
             from toolsets import TOOLSETS
+            from tools.registry import registry
 
-            unknown = set(request.allowed_toolsets) - set(TOOLSETS)
+            registered = set(TOOLSETS) | set(registry.get_registered_toolset_names())
+            unknown = set(request.allowed_toolsets) - registered
             if unknown:
                 raise SubagentLifecycleError(
                     f"Unknown toolsets: {', '.join(sorted(unknown))}."

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -1,5 +1,6 @@
 """Contract tests for the public plugin subagent lifecycle API."""
 
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -81,6 +82,29 @@ def test_duplicate_correlation_and_permission_validation(lifecycle):
     with pytest.raises(SubagentLifecycleError, match="working_directory"):
         lifecycle.launch(SubagentLaunchRequest(goal="x", working_directory="C:/"))
     lifecycle.wait(handle, timeout_seconds=1)
+
+
+def test_accepts_plugin_registered_toolset(lifecycle, monkeypatch):
+    from tools.registry import registry
+
+    monkeypatch.setattr(
+        registry,
+        "get_registered_toolset_names",
+        lambda: {"plugin-supervisor-control"},
+    )
+    parent = SimpleNamespace(
+        session_id="plugin-parent",
+        enabled_toolsets=["plugin-supervisor-control"],
+    )
+    service = SubagentLifecycleService(lambda: parent)
+    handle = service.launch(
+        SubagentLaunchRequest(
+            goal="x",
+            allowed_toolsets=("plugin-supervisor-control",),
+            correlation_id="plugin-toolset",
+        )
+    )
+    assert service.wait(handle, timeout_seconds=1).state is SubagentState.SUCCEEDED
 
 
 def test_cancel_is_cooperative_and_forged_handle_is_unknown(lifecycle):
@@ -172,7 +196,9 @@ def test_public_lifecycle_runs_host_aggregation(monkeypatch):
     child.session_id = "child-session"
     hook = Mock()
 
-    monkeypatch.setattr("tools.delegate_tool._build_child_agent", lambda **_kwargs: child)
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_agent", lambda **_kwargs: child
+    )
     monkeypatch.setattr(
         "tools.delegate_tool._run_single_child",
         lambda *_args, **_kwargs: {
@@ -218,7 +244,8 @@ def test_plugin_context_uses_turn_scoped_parent(monkeypatch):
 
     parent = SimpleNamespace(session_id="gateway-parent", enabled_toolsets=["file"])
     monkeypatch.setattr(
-        "tools.delegate_tool._build_child_agent", lambda **_kwargs: FakeChild("sa-gateway")
+        "tools.delegate_tool._build_child_agent",
+        lambda **_kwargs: FakeChild("sa-gateway"),
     )
     monkeypatch.setattr(
         "tools.delegate_tool._run_single_child",
@@ -254,3 +281,128 @@ def test_agent_turn_binds_and_clears_lifecycle_parent(monkeypatch):
     assert agent.run_conversation("hello") == {"final_response": "ok"}
     assert observed == [agent]
     assert get_active_subagent_parent() is None
+
+
+def test_private_context_is_hidden_available_only_in_child_and_cleared(monkeypatch):
+    parent = SimpleNamespace(session_id="parent-private", enabled_toolsets=["file"])
+    child = FakeChild("sa-private")
+    secret = {"opaque": "do-not-serialize"}
+    observed = []
+
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_agent", lambda **_kwargs: child
+    )
+
+    service = SubagentLifecycleService(lambda: parent)
+
+    def run(_index, _goal, running_child, _parent):
+        with bind_subagent_parent(running_child):
+            observed.append(service.current_private_context())
+        return {
+            "status": "completed",
+            "summary": "done",
+            "api_calls": 0,
+            "duration_seconds": 0,
+        }
+
+    monkeypatch.setattr("tools.delegate_tool._run_single_child", run)
+    request = SubagentLaunchRequest(goal="x", private_context=secret)
+    assert "do-not-serialize" not in repr(request)
+
+    handle = service.launch(request)
+    assert "do-not-serialize" not in repr(handle.to_dict())
+    assert service.wait(handle, timeout_seconds=1).state is SubagentState.SUCCEEDED
+    assert observed == [secret]
+    assert child._plugin_private_context is None
+    assert service.current_private_context() is None
+
+
+def test_publish_progress_is_bounded_rate_limited_and_priority_can_bypass(monkeypatch):
+    parent = SimpleNamespace(session_id="parent-progress", enabled_toolsets=["file"])
+    child = FakeChild("sa-progress")
+    relayed = []
+    receipts = []
+    child.tool_progress_callback = lambda *args, **kwargs: relayed.append((
+        args,
+        kwargs,
+    ))
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_agent", lambda **_kwargs: child
+    )
+    ticks = iter((10.0, 11.0, 12.0))
+    monkeypatch.setattr("agent.subagent_lifecycle.time.monotonic", lambda: next(ticks))
+
+    service = SubagentLifecycleService(lambda: parent)
+
+    def run(_index, _goal, running_child, _parent):
+        with bind_subagent_parent(running_child):
+            receipts.append(service.publish_progress("first milestone"))
+            receipts.append(service.publish_progress("too soon"))
+            receipts.append(service.publish_progress("owner gate", priority=True))
+        return {
+            "status": "completed",
+            "summary": "done",
+            "api_calls": 0,
+            "duration_seconds": 0,
+        }
+
+    monkeypatch.setattr("tools.delegate_tool._run_single_child", run)
+    handle = service.launch(SubagentLaunchRequest(goal="x"))
+    assert service.wait(handle, timeout_seconds=1).state is SubagentState.SUCCEEDED
+    assert receipts == [True, False, True]
+    assert [call[0] for call in relayed] == [
+        ("subagent_progress", "first milestone"),
+        ("subagent_progress", "owner gate"),
+    ]
+
+
+def test_terminal_callback_can_relaunch_on_same_parent_without_active_turn(monkeypatch):
+    parent = SimpleNamespace(session_id="parent-relaunch", enabled_toolsets=["file"])
+    counter = iter(range(2))
+    callback_finished = threading.Event()
+    relaunched = []
+
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_agent",
+        lambda **_kwargs: FakeChild(f"sa-relaunch-{next(counter)}"),
+    )
+    monkeypatch.setattr(
+        "tools.delegate_tool._run_single_child",
+        lambda *_args, **_kwargs: {
+            "status": "completed",
+            "summary": "generation done",
+            "api_calls": 0,
+            "duration_seconds": 0,
+        },
+    )
+
+    service = SubagentLifecycleService(lambda: parent)
+
+    def on_terminal(handle, snapshot, result):
+        assert snapshot.state is SubagentState.SUCCEEDED
+        assert result.ready
+        replacement = service.relaunch(
+            handle,
+            SubagentLaunchRequest(
+                goal="replacement",
+                correlation_id="generation-2",
+                private_context={"generation": 2},
+            ),
+        )
+        relaunched.append(replacement)
+        callback_finished.set()
+
+    first = service.launch(
+        SubagentLaunchRequest(
+            goal="first",
+            correlation_id="generation-1",
+            on_terminal=on_terminal,
+        )
+    )
+    assert service.wait(first, timeout_seconds=1).state is SubagentState.SUCCEEDED
+    assert callback_finished.wait(1)
+    assert len(relaunched) == 1
+    second = relaunched[0]
+    assert second.subagent_id != first.subagent_id
+    assert second.parent_session_id == first.parent_session_id
+    assert service.wait(second, timeout_seconds=1).state is SubagentState.SUCCEEDED

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -351,9 +351,103 @@ def test_publish_progress_is_bounded_rate_limited_and_priority_can_bypass(monkey
     assert service.wait(handle, timeout_seconds=1).state is SubagentState.SUCCEEDED
     assert receipts == [True, False, True]
     assert [call[0] for call in relayed] == [
-        ("subagent_progress", "first milestone"),
-        ("subagent_progress", "owner gate"),
+        ("subagent.progress", "first milestone"),
+        ("subagent.progress", "owner gate"),
     ]
+
+
+def test_durable_notification_is_origin_routed_idempotent_and_restorable(
+    tmp_path, monkeypatch
+):
+    from tools import async_delegation as ad
+    from tools.process_registry import process_registry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(
+        "gateway.session_context.async_delivery_supported", lambda: True
+    )
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    receipts = []
+    publish_finished = threading.Event()
+    publish_errors = []
+    original_publish = ad.publish_external_notification
+
+    def observable_publish(**kwargs):
+        try:
+            return original_publish(**kwargs)
+        except Exception as exc:
+            publish_errors.append(repr(exc))
+            raise
+
+    monkeypatch.setattr(ad, "publish_external_notification", observable_publish)
+    current_parent = {
+        "value": SimpleNamespace(
+            session_id="origin-milestone", enabled_toolsets=["file"]
+        )
+    }
+    service = SubagentLifecycleService(lambda: current_parent["value"])
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_agent",
+        lambda **_kwargs: FakeChild("sa-durable-milestone"),
+    )
+
+    def run(_index, _goal, running_child, _parent):
+        with bind_subagent_parent(running_child):
+            current_parent["value"] = SimpleNamespace(
+                session_id="unrelated-current-turn", enabled_toolsets=["file"]
+            )
+            receipts.append(
+                service.publish_notification(
+                    "safe durable milestone",
+                    dedupe_key="native-job:cursor-7",
+                    priority=True,
+                )
+            )
+            receipts.append(
+                service.publish_notification(
+                    "safe durable milestone",
+                    dedupe_key="native-job:cursor-7",
+                    priority=True,
+                )
+            )
+            current_parent["value"] = SimpleNamespace(
+                session_id="origin-milestone", enabled_toolsets=["file"]
+            )
+            publish_finished.set()
+        return {
+            "status": "completed",
+            "summary": "done",
+            "api_calls": 0,
+            "duration_seconds": 0,
+        }
+
+    monkeypatch.setattr("tools.delegate_tool._run_single_child", run)
+    try:
+        handle = service.launch(
+            SubagentLaunchRequest(goal="private child prompt sentinel")
+        )
+        assert publish_finished.wait(1)
+        assert service.wait(handle, timeout_seconds=1).state is SubagentState.SUCCEEDED
+        assert receipts == [True, True], publish_errors
+        assert ad.active_count() == 0
+        event = process_registry.completion_queue.get_nowait()
+        assert event["summary"] == "safe durable milestone"
+        assert event["parent_session_id"] == "origin-milestone"
+        assert event["session_key"] == "origin-milestone"
+        assert process_registry.completion_queue.empty()
+        durable = ad.get_durable_delegation(event["delegation_id"])
+        assert durable["state"] == "completed"
+        assert durable["delivery_state"] == "pending"
+        assert "private child prompt sentinel" not in str(durable)
+        restored = __import__("queue").Queue()
+        assert ad.restore_undelivered_completions(restored) == 1
+        assert restored.get_nowait()["delegation_id"] == event["delegation_id"]
+        assert restored.empty()
+    finally:
+        ad._reset_for_tests()
 
 
 def test_terminal_callback_can_relaunch_on_same_parent_without_active_turn(monkeypatch):
@@ -406,3 +500,119 @@ def test_terminal_callback_can_relaunch_on_same_parent_without_active_turn(monke
     assert second.subagent_id != first.subagent_id
     assert second.parent_session_id == first.parent_session_id
     assert service.wait(second, timeout_seconds=1).state is SubagentState.SUCCEEDED
+
+
+def test_manual_completion_delivery_is_durable_routed_and_exactly_once(
+    tmp_path, monkeypatch
+):
+    from tools import async_delegation as ad
+    from tools.process_registry import process_registry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    try:
+        current_parent = {
+            "value": SimpleNamespace(
+                session_id="origin-delivery", enabled_toolsets=["file"]
+            )
+        }
+        service = SubagentLifecycleService(lambda: current_parent["value"])
+        delivery = service.register_completion_delivery(
+            goal="deliver one native terminal",
+            context="bounded public context",
+            role="leaf",
+            model="test-model",
+            toolsets=("file",),
+        )
+        assert ad.active_count() == 1
+
+        # A different conversation/turn can become active before the producer ends;
+        # the terminal must retain the origin captured at registration time.
+        current_parent["value"] = SimpleNamespace(
+            session_id="unrelated-current-turn", enabled_toolsets=["file"]
+        )
+        assert (
+            service.publish_completion(
+                delivery,
+                status="completed",
+                summary="native terminal result",
+                api_calls=2,
+                duration_seconds=1.25,
+            )
+            is True
+        )
+        assert (
+            service.publish_completion(
+                delivery,
+                status="completed",
+                summary="duplicate must not enqueue",
+            )
+            is False
+        )
+        assert ad.active_count() == 0
+
+        event = process_registry.completion_queue.get_nowait()
+        assert event["summary"] == "native terminal result"
+        assert event["parent_session_id"] == "origin-delivery"
+        assert event["session_key"] == "origin-delivery"
+        assert process_registry.completion_queue.empty()
+
+        durable = ad.get_durable_delegation(delivery.delegation_id)
+        assert durable["state"] == "completed"
+        assert durable["delivery_state"] == "pending"
+
+        restored = __import__("queue").Queue()
+        assert ad.restore_undelivered_completions(restored) == 1
+        assert restored.get_nowait()["delegation_id"] == delivery.delegation_id
+        assert restored.empty()
+    finally:
+        ad._reset_for_tests()
+
+
+def test_manual_completion_delivery_discard_removes_only_running_registration(
+    tmp_path, monkeypatch
+):
+    from tools import async_delegation as ad
+    from tools.process_registry import process_registry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    try:
+        parent = SimpleNamespace(session_id="origin-discard", enabled_toolsets=["file"])
+        service = SubagentLifecycleService(lambda: parent)
+        handle = service.register_completion_delivery(goal="external work")
+        assert ad.active_count() == 1
+        assert service.discard_completion_delivery(handle) is True
+        assert service.discard_completion_delivery(handle) is False
+        assert ad.active_count() == 0
+        assert ad.get_durable_delegation(handle.delegation_id) is None
+        assert process_registry.completion_queue.empty()
+    finally:
+        ad._reset_for_tests()
+
+
+def test_manual_completion_delivery_fails_closed_without_a_routable_session(
+    tmp_path, monkeypatch
+):
+    from gateway import session_context
+    from tools import async_delegation as ad
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setattr(session_context, "async_delivery_supported", lambda: False)
+    monkeypatch.setattr(ad, "_current_origin_session_id", lambda: "")
+    ad._reset_for_tests()
+    try:
+        parent = SimpleNamespace(session_id="finite-worker", enabled_toolsets=["file"])
+        service = SubagentLifecycleService(lambda: parent)
+        with pytest.raises(
+            SubagentLifecycleError,
+            match="cannot receive a detached durable completion",
+        ):
+            service.register_completion_delivery(goal="unroutable external work")
+        assert ad.active_count() == 0
+    finally:
+        ad._reset_for_tests()

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -36,6 +36,7 @@ logic stays in one place.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import sqlite3
@@ -201,6 +202,7 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
     now = time.time()
     try:
         from gateway.status import get_process_start_time
+
         owner_started_at = get_process_start_time(__import__("os").getpid())
     except Exception:
         owner_started_at = None
@@ -211,24 +213,33 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
     }
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
-            """INSERT OR REPLACE INTO async_delegations
+            """INSERT INTO async_delegations
                (delegation_id, origin_session, origin_ui_session_id,
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
                 owner_started_at, task_json, origin_session_id)
                VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
-            (record["delegation_id"], record.get("session_key", ""),
-             record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
-             record["dispatched_at"], now, __import__("os").getpid(),
-             owner_started_at, json.dumps(task_payload),
-             record.get("origin_session_id", "")),
+            (
+                record["delegation_id"],
+                record.get("session_key", ""),
+                record.get("origin_ui_session_id", ""),
+                record.get("parent_session_id"),
+                record["dispatched_at"],
+                now,
+                __import__("os").getpid(),
+                owner_started_at,
+                json.dumps(task_payload),
+                record.get("origin_session_id", ""),
+            ),
         )
     _prune_durable_records()
 
 
 def _delete_durable_delegation(delegation_id: str) -> None:
     with _DB_LOCK, _transaction() as conn:
-        conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
+        conn.execute(
+            "DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,)
+        )
 
 
 def _prune_durable_records() -> None:
@@ -277,8 +288,14 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
             """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
                event_json=?, result_json=?, delivery_state='pending'
                WHERE delegation_id=?""",
-            (event.get("status", "completed"), event.get("completed_at", now), now,
-             json.dumps(event), json.dumps(result), event["delegation_id"]),
+            (
+                event.get("status", "completed"),
+                event.get("completed_at", now),
+                now,
+                json.dumps(event),
+                json.dumps(result),
+                event["delegation_id"],
+            ),
         )
 
 
@@ -306,8 +323,17 @@ def recover_abandoned_delegations() -> int:
                FROM async_delegations WHERE state IN ('running','finalizing')"""
         ).fetchall()
         for row in rows:
-            (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+            (
+                delegation_id,
+                session_key,
+                origin_ui,
+                parent_id,
+                dispatched_at,
+                pid,
+                started,
+                task_json,
+                origin_session_id,
+            ) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -317,18 +343,26 @@ def recover_abandoned_delegations() -> int:
                 continue
             task = json.loads(task_json or "{}")
             event = {
-                "type": "async_delegation", "delegation_id": delegation_id,
-                "session_key": session_key, "origin_ui_session_id": origin_ui,
+                "type": "async_delegation",
+                "delegation_id": delegation_id,
+                "session_key": session_key,
+                "origin_ui_session_id": origin_ui,
                 # Restore the durable wake target so completions recovered
                 # after a restart remain routable to api_server sessions.
                 "origin_session_id": origin_session_id or "",
-                "parent_session_id": parent_id, "goal": task.get("goal", ""),
-                "goals": task.get("goals"), "context": task.get("context"),
-                "toolsets": task.get("toolsets"), "role": task.get("role"),
-                "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
-                "status": "unknown", "summary": None,
+                "parent_session_id": parent_id,
+                "goal": task.get("goal", ""),
+                "goals": task.get("goals"),
+                "context": task.get("context"),
+                "toolsets": task.get("toolsets"),
+                "role": task.get("role"),
+                "model": task.get("model"),
+                "is_batch": bool(task.get("is_batch")),
+                "status": "unknown",
+                "summary": None,
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
-                "dispatched_at": dispatched_at, "completed_at": now,
+                "dispatched_at": dispatched_at,
+                "completed_at": now,
             }
             result = {"status": "unknown", "summary": None, "error": event["error"]}
             conn.execute(
@@ -434,7 +468,8 @@ def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
             logger.warning(
                 "Async delegation %s exhausted its %d delivery attempts; "
                 "marking terminally dropped (result remains queryable).",
-                delegation_id, _MAX_DELIVERY_ATTEMPTS,
+                delegation_id,
+                _MAX_DELIVERY_ATTEMPTS,
             )
             return True
         cur = conn.execute(
@@ -500,15 +535,20 @@ def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
             """SELECT origin_session, state, dispatched_at, completed_at,
                       result_json, delivery_state, delivery_attempts,
                       origin_session_id
-               FROM async_delegations WHERE delegation_id=?""", (delegation_id,),
+               FROM async_delegations WHERE delegation_id=?""",
+            (delegation_id,),
         ).fetchone()
     if row is None:
         return None
     return {
-        "delegation_id": delegation_id, "origin_session": row[0], "state": row[1],
-        "dispatched_at": row[2], "completed_at": row[3],
+        "delegation_id": delegation_id,
+        "origin_session": row[0],
+        "state": row[1],
+        "dispatched_at": row[2],
+        "completed_at": row[3],
         "result": json.loads(row[4]) if row[4] else None,
-        "delivery_state": row[5], "delivery_attempts": row[6],
+        "delivery_state": row[5],
+        "delivery_attempts": row[6],
         "origin_session_id": row[7] or "",
     }
 
@@ -536,7 +576,8 @@ def active_count() -> int:
     """Number of async delegations currently running."""
     with _records_lock:
         return sum(
-            1 for r in _records.values()
+            1
+            for r in _records.values()
             if r.get("status") in {"running", "stalling", "finalizing"}
         )
 
@@ -551,14 +592,14 @@ def _prune_completed_locked() -> None:
     Caller must hold ``_records_lock``.
     """
     completed = [
-        (rid, r)
-        for rid, r in _records.items()
-        if r.get("status") != "running"
+        (rid, r) for rid, r in _records.items() if r.get("status") != "running"
     ]
     if len(completed) <= _MAX_RETAINED_COMPLETED:
         return
     # Oldest-first by completion time (fall back to dispatch time).
-    completed.sort(key=lambda kv: kv[1].get("completed_at") or kv[1].get("dispatched_at") or 0)
+    completed.sort(
+        key=lambda kv: kv[1].get("completed_at") or kv[1].get("dispatched_at") or 0
+    )
     for rid, _ in completed[: len(completed) - _MAX_RETAINED_COMPLETED]:
         _records.pop(rid, None)
 
@@ -589,6 +630,165 @@ def _current_origin_session_id() -> str:
         return get_session_env("HERMES_SESSION_CHAT_ID", "") or ""
     except Exception:
         return ""
+
+
+def register_external_delegation(
+    *,
+    goal: str,
+    context: Optional[str],
+    toolsets: Optional[List[str]],
+    role: str,
+    model: Optional[str],
+    session_key: str,
+    parent_session_id: Optional[str] = None,
+    origin_ui_session_id: str = "",
+    origin_session_id: str = "",
+    interrupt_fn: Optional[Callable[[], None]] = None,
+    delegation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Register work owned by another host lifecycle producer.
+
+    The producer, rather than this module's executor, decides when the work is
+    terminal. Registration still occupies the official active count and writes
+    the same durable routing record used by ``delegate_task``.
+    """
+    delegation_id = delegation_id or _new_delegation_id()
+    dispatched_at = time.time()
+    record: Dict[str, Any] = {
+        "delegation_id": delegation_id,
+        "goal": goal,
+        "context": context,
+        "toolsets": list(toolsets) if toolsets else None,
+        "role": role,
+        "model": model,
+        "session_key": session_key,
+        "origin_ui_session_id": origin_ui_session_id,
+        "origin_session_id": origin_session_id,
+        "parent_session_id": parent_session_id,
+        "status": "running",
+        "dispatched_at": dispatched_at,
+        "completed_at": None,
+        "interrupt_fn": interrupt_fn,
+        "is_batch": False,
+        "progress_fn": None,
+        "_progress_token": None,
+        "_progress_ts": dispatched_at,
+        "_interrupted_at": None,
+        "external_producer": True,
+    }
+    with _records_lock:
+        _records[delegation_id] = record
+    try:
+        _persist_dispatch(record)
+    except BaseException:
+        with _records_lock:
+            _records.pop(delegation_id, None)
+        raise
+    return {"status": "registered", "delegation_id": delegation_id}
+
+
+def complete_external_delegation(
+    delegation_id: str,
+    *,
+    status: str,
+    summary: Optional[str],
+    error: Optional[str] = None,
+    api_calls: int = 0,
+    duration_seconds: Optional[float] = None,
+    exit_reason: Optional[str] = None,
+) -> bool:
+    """Durably finalize and enqueue an externally produced completion once."""
+    result: Dict[str, Any] = {
+        "status": status,
+        "summary": summary,
+        "error": error,
+        "api_calls": api_calls,
+        "exit_reason": exit_reason,
+    }
+    if duration_seconds is not None:
+        result["duration_seconds"] = duration_seconds
+    return _finalize(delegation_id, result, status)
+
+
+def publish_external_notification(
+    *,
+    summary: str,
+    dedupe_key: str,
+    session_key: str,
+    parent_session_id: Optional[str],
+    origin_ui_session_id: str,
+    origin_session_id: str,
+    model: Optional[str] = None,
+) -> bool:
+    """Transfer one idempotent milestone into the durable delivery outbox."""
+    summary_sha256 = hashlib.sha256(summary.encode("utf-8")).hexdigest()
+    identity = json.dumps(
+        [session_key, parent_session_id, dedupe_key, summary_sha256],
+        separators=(",", ":"),
+    )
+    delegation_id = (
+        f"deleg_notice_{hashlib.sha256(identity.encode('utf-8')).hexdigest()[:32]}"
+    )
+    with _records_lock:
+        existing = _records.get(delegation_id)
+        existing_state = existing.get("status") if existing is not None else None
+    if existing_state not in {None, "running", "stalling"}:
+        return True
+    if existing_state in {"running", "stalling"}:
+        return complete_external_delegation(
+            delegation_id,
+            status="completed",
+            summary=summary,
+            api_calls=0,
+            duration_seconds=0.0,
+            exit_reason="milestone",
+        )
+    try:
+        register_external_delegation(
+            goal="Background subagent milestone",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model=model,
+            session_key=session_key,
+            parent_session_id=parent_session_id,
+            origin_ui_session_id=origin_ui_session_id,
+            origin_session_id=origin_session_id,
+            delegation_id=delegation_id,
+        )
+    except sqlite3.IntegrityError:
+        durable = get_durable_delegation(delegation_id)
+        return bool(durable and durable.get("state") not in {"running", "finalizing"})
+    published = complete_external_delegation(
+        delegation_id,
+        status="completed",
+        summary=summary,
+        api_calls=0,
+        duration_seconds=0.0,
+        exit_reason="milestone",
+    )
+    if published:
+        return True
+    durable = get_durable_delegation(delegation_id)
+    return bool(durable and durable.get("state") not in {"running", "finalizing"})
+
+
+def discard_external_delegation(delegation_id: str) -> bool:
+    """Remove a registration whose producer never launched.
+
+    A completion already finalizing or terminal is immutable and cannot be
+    discarded, preventing launch-error cleanup from deleting a real result.
+    """
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is None or record.get("status") != "running":
+            return False
+        # Keep the registry lock while deleting the durable row so a concurrent
+        # finalizer cannot win after the precondition check. If deletion fails,
+        # the running record remains intact and is safely retryable.
+        _delete_durable_delegation(delegation_id)
+        _records.pop(delegation_id, None)
+    return True
 
 
 def dispatch_async_delegation(
@@ -677,8 +877,7 @@ def dispatch_async_delegation(
     # from different gateway sessions) both pass the check and exceed the cap.
     with _records_lock:
         running = sum(
-            1 for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            1 for r in _records.values() if r.get("status") in ("running", "stalling")
         )
         if running >= max_async_children:
             return {
@@ -732,20 +931,35 @@ def dispatch_async_delegation(
 
     logger.info(
         "Dispatched async delegation %s (session_key=%s): %s",
-        delegation_id, session_key or "<cli>", (goal or "")[:80],
+        delegation_id,
+        session_key or "<cli>",
+        (goal or "")[:80],
     )
     return {"status": "dispatched", "delegation_id": delegation_id}
 
 
-def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
+def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> bool:
     """Mark a record complete and push the completion event onto the queue."""
     claimed = _begin_finalization(delegation_id)
     if claimed is None:
-        return
-    event_record, _interrupt_fn = claimed
+        return False
+    event_record, interrupt_fn = claimed
 
-    _push_completion_event(event_record, result, status)
+    try:
+        _push_completion_event(event_record, result, status)
+    except BaseException:
+        # Persistence failed before a durable terminal existed. Return ownership
+        # to the producer so it can retry rather than leaving a permanent
+        # in-memory/durable ``finalizing`` limbo.
+        with _records_lock:
+            record = _records.get(delegation_id)
+            if record is not None and record.get("status") == "finalizing":
+                record["status"] = "running"
+                record["completed_at"] = None
+                record["interrupt_fn"] = interrupt_fn
+        raise
     _finish_finalization(delegation_id, status)
+    return True
 
 
 def _begin_finalization(
@@ -791,7 +1005,8 @@ def _push_completion_event(
         logger.error(
             "Async delegation %s finished but process_registry import failed; "
             "result lost: %s",
-            record.get("delegation_id"), exc,
+            record.get("delegation_id"),
+            exc,
         )
         return
 
@@ -840,9 +1055,9 @@ def _push_completion_event(
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
         logger.error(
-            "Async delegation %s: failed to enqueue completion event; "
-            "result lost: %s",
-            record.get("delegation_id"), exc,
+            "Async delegation %s: failed to enqueue completion event; result lost: %s",
+            record.get("delegation_id"),
+            exc,
         )
 
 
@@ -888,7 +1103,9 @@ def dispatch_async_delegation_batch(
     n = len(goals)
     # A combined goal label for status listings / the completion header.
     combined_goal = (
-        goals[0] if n == 1 else f"{n} parallel subagents: " + "; ".join(g[:40] for g in goals)
+        goals[0]
+        if n == 1
+        else f"{n} parallel subagents: " + "; ".join(g[:40] for g in goals)
     )
     record: Dict[str, Any] = {
         "delegation_id": delegation_id,
@@ -914,8 +1131,7 @@ def dispatch_async_delegation_batch(
     }
     with _records_lock:
         running = sum(
-            1 for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            1 for r in _records.values() if r.get("status") in ("running", "stalling")
         )
         if running >= max_async_children:
             return {
@@ -940,8 +1156,7 @@ def dispatch_async_delegation_batch(
             # Batch status: completed unless every child errored/was interrupted.
             child_results = combined.get("results") or []
             if child_results and all(
-                (r.get("status") not in ("completed", "success"))
-                for r in child_results
+                (r.get("status") not in ("completed", "success")) for r in child_results
             ):
                 status = "error"
             else:
@@ -973,14 +1188,14 @@ def dispatch_async_delegation_batch(
 
     logger.info(
         "Dispatched async delegation batch %s (%d task(s), session_key=%s)",
-        delegation_id, n, session_key or "<cli>",
+        delegation_id,
+        n,
+        session_key or "<cli>",
     )
     return {"status": "dispatched", "delegation_id": delegation_id}
 
 
-def _finalize_batch(
-    delegation_id: str, combined: Dict[str, Any], status: str
-) -> None:
+def _finalize_batch(delegation_id: str, combined: Dict[str, Any], status: str) -> None:
     """Mark a batch record complete and push ONE combined completion event."""
     claimed = _begin_finalization(delegation_id)
     if claimed is None:
@@ -1001,7 +1216,8 @@ def _push_batch_completion_event(
         logger.error(
             "Async delegation batch %s finished but process_registry import "
             "failed; result lost: %s",
-            event_record.get("delegation_id"), exc,
+            event_record.get("delegation_id"),
+            exc,
         )
         return
 
@@ -1051,7 +1267,8 @@ def _push_batch_completion_event(
         logger.error(
             "Async delegation batch %s: failed to enqueue completion event; "
             "result lost: %s",
-            event_record.get("delegation_id"), exc,
+            event_record.get("delegation_id"),
+            exc,
         )
 
 
@@ -1123,9 +1340,7 @@ def _stale_monitor_loop() -> None:
                     record["_progress_ts"] = now
                     continue
                 quiet_for = now - (record.get("_progress_ts") or now)
-                limit = (
-                    _STALE_IN_TOOL_SECONDS if in_tool else _STALE_IDLE_SECONDS
-                )
+                limit = _STALE_IN_TOOL_SECONDS if in_tool else _STALE_IDLE_SECONDS
                 if quiet_for >= limit:
                     record["status"] = "stalling"
                     record["_interrupted_at"] = now
@@ -1136,19 +1351,20 @@ def _stale_monitor_loop() -> None:
                     record["_stall_quiet_seconds"] = round(quiet_for, 2)
                     record["_stall_threshold_seconds"] = limit
                     record["_stall_in_tool"] = bool(in_tool)
-                    stalled.append(
-                        (
-                            record["delegation_id"],
-                            bool(record.get("is_batch")),
-                            quiet_for,
-                            in_tool,
-                        )
-                    )
+                    stalled.append((
+                        record["delegation_id"],
+                        bool(record.get("is_batch")),
+                        quiet_for,
+                        in_tool,
+                    ))
         for delegation_id, _is_batch, quiet_for, in_tool in stalled:
             logger.warning(
                 "Async delegation %s made no progress for %.0fs "
                 "(in_tool=%s) — interrupting; grace window %.0fs",
-                delegation_id, quiet_for, in_tool, _STALL_GRACE_SECONDS,
+                delegation_id,
+                quiet_for,
+                in_tool,
+                _STALL_GRACE_SECONDS,
             )
             with _records_lock:
                 record = _records.get(delegation_id)
@@ -1159,7 +1375,8 @@ def _stale_monitor_loop() -> None:
                 except Exception as exc:
                     logger.debug(
                         "Async delegation %s stall interrupt failed: %s",
-                        delegation_id, exc,
+                        delegation_id,
+                        exc,
                     )
         for delegation_id in expired:
             _finalize_stalled(delegation_id)
@@ -1193,7 +1410,8 @@ def _finalize_stalled(delegation_id: str) -> None:
     )
     logger.error(
         "Async delegation %s force-finalized as stalled after %.0fs",
-        delegation_id, duration,
+        delegation_id,
+        duration,
     )
     # Structured stall metadata (#51690): lets parents and UIs distinguish
     # a stall-monitor kill from other failures without parsing the error
@@ -1203,8 +1421,10 @@ def _finalize_stalled(delegation_id: str) -> None:
         "stalled_after_quiet_seconds": quiet_seconds,
         "stall_threshold_seconds": threshold_seconds,
         "stall_phase": (
-            "in_tool" if stall_in_tool
-            else "idle" if stall_in_tool is not None
+            "in_tool"
+            if stall_in_tool
+            else "idle"
+            if stall_in_tool is not None
             else None
         ),
         "stall_grace_seconds": _STALL_GRACE_SECONDS,
@@ -1289,8 +1509,7 @@ def list_async_delegations() -> List[Dict[str, Any]]:
             item = {
                 k: v
                 for k, v in r.items()
-                if k not in {"interrupt_fn", "progress_fn"}
-                and not k.startswith("_")
+                if k not in {"interrupt_fn", "progress_fn"} and not k.startswith("_")
             }
             status = r.get("status")
             if status in ("running", "stalling"):
@@ -1338,8 +1557,7 @@ def interrupt_all(reason: str = "shutdown") -> int:
     count = 0
     with _records_lock:
         targets = [
-            r for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            r for r in _records.values() if r.get("status") in ("running", "stalling")
         ]
     for r in targets:
         fn = r.get("interrupt_fn")
@@ -1350,7 +1568,8 @@ def interrupt_all(reason: str = "shutdown") -> int:
             except Exception as exc:
                 logger.debug(
                     "interrupt_all: %s interrupt failed: %s",
-                    r.get("delegation_id"), exc,
+                    r.get("delegation_id"),
+                    exc,
                 )
     if count:
         logger.info("Interrupted %d async delegation(s) (%s)", count, reason)
@@ -1386,12 +1605,19 @@ def interrupt_for_session(
     count = 0
     with _records_lock:
         targets = [
-            r for r in _records.values()
+            r
+            for r in _records.values()
             if r.get("status") in ("running", "stalling")
             and (
-                (origin_ui_session_id and str(r.get("origin_ui_session_id") or "") == origin_ui_session_id)
+                (
+                    origin_ui_session_id
+                    and str(r.get("origin_ui_session_id") or "") == origin_ui_session_id
+                )
                 or (session_key and str(r.get("session_key") or "") == session_key)
-                or (parent_session_id and str(r.get("parent_session_id") or "") == parent_session_id)
+                or (
+                    parent_session_id
+                    and str(r.get("parent_session_id") or "") == parent_session_id
+                )
             )
         ]
     for r in targets:
@@ -1403,12 +1629,14 @@ def interrupt_for_session(
             except Exception as exc:
                 logger.debug(
                     "interrupt_for_session: %s interrupt failed: %s",
-                    r.get("delegation_id"), exc,
+                    r.get("delegation_id"),
+                    exc,
                 )
     if count:
         logger.info(
             "Interrupted %d async delegation(s) for ending session (%s)",
-            count, reason,
+            count,
+            reason,
         )
     return count
 

--- a/website/docs/developer-guide/subagent-lifecycle-api.md
+++ b/website/docs/developer-guide/subagent-lifecycle-api.md
@@ -49,8 +49,9 @@ agent:
   handles, metadata, transcripts, results, and persistence, and is cleared before
   the terminal callback runs.
 - `service.publish_progress(summary, priority=False)` relays one bounded summary
-  through the child-owned host progress callback. Non-priority updates are limited
-  to one every five seconds per child; priority updates may bypass that interval.
+  through the child-owned host `subagent.progress` callback. Non-priority updates
+  are limited to one every five seconds per child; priority updates may bypass
+  that interval. This callback is display-only and is not a durable chat event.
 - `SubagentLaunchRequest(on_terminal=...)` receives `(handle, status, result)`
   once after terminal state is durable in memory. From that callback,
   `service.relaunch(handle, request)` may launch a fresh child under the same
@@ -61,6 +62,64 @@ tool arguments. Keep secrets out of public `context` and `metadata`; put only th
 minimum process-local capability in `private_context`. Callback exceptions are
 contained and do not change the terminal result. The callback and saved parent
 reference are discarded after it returns.
+
+## Contract v3: durable manual completion producers
+
+Version 3 adds a connector-agnostic way for a plugin to deliver work whose real
+terminal is outside a single child runner. Register while the origin turn is
+active, keep the opaque handle in process, and publish only after the external
+work has reached its own terminal:
+
+```python
+delivery = service.register_completion_delivery(
+    goal="Deliver terminal result for native job job-42",
+    context='{"kind":"native_job","job_id":"job-42"}',
+    role="leaf",
+    toolsets=("native_job_status", "native_job_result"),
+)
+
+# Later, from trusted plugin lifecycle code:
+published = service.publish_completion(
+    delivery,
+    status="completed",
+    summary="The native job finished successfully.",
+    exit_reason="native_job_succeeded",
+)
+
+# From a running child, transfer one bounded milestone to the same durable outbox.
+accepted = service.publish_notification(
+    "Native job job-42 reached its owner gate.",
+    dedupe_key="native-job:job-42:cursor-17",
+    priority=True,
+)
+```
+
+Registration captures the current origin session and creates an ordinary durable
+`async_delegation` running row, so it participates in the shared active count.
+`publish_completion` bounds and validates the terminal fields, persists the event
+before enqueue, removes it from the active count, and returns `False` on duplicate
+publication. The existing CLI/gateway/Desktop completion drain then creates a new
+turn in the captured origin, using the same ownership claim, retry, drop cap, and
+restart restore semantics as `delegate_task`; a subsequently active unrelated
+conversation cannot retarget it. Finite runtimes with neither an async delivery
+consumer nor an API-session wake target fail registration before any durable row
+is created. If producer launch fails before work exists,
+`discard_completion_delivery` removes only a still-running registration and cannot
+delete a terminal result.
+
+`publish_notification` is available only from the running child context. It captures
+the child's origin route at launch, persists and enqueues the bounded summary before
+returning `True`, and derives an opaque deterministic delivery identity from the
+caller-supplied `dedupe_key`. Retrying the same key and summary is therefore safe and
+does not enqueue a second event. Returning `False` means the caller must leave its
+source cursor unacknowledged and retry later. Both milestones and terminal events are
+pinned to the captured origin even if another conversation becomes active.
+
+The public goal/context and bounded terminal summary are durable because they are
+needed for restart-safe delivery. Never put prompts, raw tool inputs, secrets, or
+opaque `private_context` data in them. The completion capability is process-local
+and exactly-once for the host process; contract v3 does not reconstruct the external
+worker or a live child after host restart.
 
 `cancel(handle, reason=...)` is cooperative: it asks the child agent to
 interrupt at its next safe boundary and returns `CANCEL_REQUESTED`; it never

--- a/website/docs/developer-guide/subagent-lifecycle-api.md
+++ b/website/docs/developer-guide/subagent-lifecycle-api.md
@@ -37,6 +37,31 @@ or forged handles return `UNKNOWN`/`UNKNOWN_HANDLE` and cannot access a child.
 The stable states are `PENDING`, `STARTING`, `RUNNING`, `SUCCEEDED`, `FAILED`,
 `INTERRUPTED`, `CANCEL_REQUESTED`, `CANCELLED`, and `UNKNOWN`.
 
+## Contract v2: private context, progress, and bounded relaunch
+
+`service.contract_version` reports the exact public contract. Version 2 adds
+three process-local plugin primitives without exposing the live parent or child
+agent:
+
+- `SubagentLaunchRequest(private_context=...)` attaches an opaque object to the
+  child in memory. A plugin tool invoked by that child can read it only through
+  `service.current_private_context()`. It is excluded from request repr/equality,
+  handles, metadata, transcripts, results, and persistence, and is cleared before
+  the terminal callback runs.
+- `service.publish_progress(summary, priority=False)` relays one bounded summary
+  through the child-owned host progress callback. Non-priority updates are limited
+  to one every five seconds per child; priority updates may bypass that interval.
+- `SubagentLaunchRequest(on_terminal=...)` receives `(handle, status, result)`
+  once after terminal state is durable in memory. From that callback,
+  `service.relaunch(handle, request)` may launch a fresh child under the same
+  still-live parent. The replacement gets a new handle and correlation ID.
+
+Private context and terminal callbacks are trusted plugin-code inputs, not model
+tool arguments. Keep secrets out of public `context` and `metadata`; put only the
+minimum process-local capability in `private_context`. Callback exceptions are
+contained and do not change the terminal result. The callback and saved parent
+reference are discarded after it returns.
+
 `cancel(handle, reason=...)` is cooperative: it asks the child agent to
 interrupt at its next safe boundary and returns `CANCEL_REQUESTED`; it never
 claims completion until `wait` or `result` observes a terminal state. Terminal
@@ -51,8 +76,10 @@ synchronous `delegate_task` tool, batch delegation, or its gateway/TUI display.
 The initial implementation retains metadata and terminal results in-process for
 one hour.
 After a process restart, `reconnect` returns `RECONNECT_UNAVAILABLE` and never
-starts a replacement child. Running Python threads also cannot survive process
-exit; callers must treat those handles as interrupted by process exit.
+starts a replacement child. `relaunch` is deliberately in-process and must be
+called from the terminal callback while its bounded parent reference is live.
+Running Python threads and private contexts also cannot survive process exit;
+callers must treat those handles as interrupted by process exit.
 
 Requests are fail-closed: goal/context/metadata sizes are capped, unknown or
 parent-broadening toolsets are rejected, and per-tool blocks, working-directory


### PR DESCRIPTION
## Summary

- version the public plugin subagent lifecycle contract to v3
- preserve opaque child identity, parent/tool-use identity, bounded lifecycle timestamps and active-task counts without persisting prompts or raw payloads
- relay bounded `subagent.progress` milestones through the existing host surface
- add generic durable origin notifications and terminal completion registration using Hermes' existing async-delivery queue
- retain in-process terminal relaunch while explicitly treating process-restart loss as unknown, not recovered
- accept currently registered plugin toolsets while preserving parent permission narrowing

## Safety boundaries

- no plugin-specific or vendor-specific core tool is added
- plugins receive no live parent or child agent object
- opaque context is cleared before terminal callback delivery
- callback/rate-limit failures leave delivery retryable and cannot rewrite terminal state
- origin acceptance controls final delivery acknowledgment; restored completions deduplicate
- no process-restart execution takeover is claimed

## Validation

- `python -m pytest -q tests/agent/test_subagent_lifecycle.py tests/tools/test_async_delegation.py` — 66 passed
- Ruff check and format-check on the changed Python/tests — passed
- exact consumer composite against contract v3 — durable restore=1, terminal deduplicated, zero active supervisors/async residue, secret scan clean
- merge-tree preflight against current `origin/main` — clean

The consumer connector and any provider/live acceptance remain outside this public host PR.