### PR TITLE
Fix/pre lease compression drift adopt

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1952,8 +1952,12 @@ def init_agent(
     # parent_session_id chain, no `name #N` renumber). See #38763 and
     # agent/conversation_compression.py. Consumed by compress_context(), not the
     # compressor, so it rides on the agent.
+    # Default True must match DEFAULT_CONFIG["compression"]["in_place"]
+    # (#38763). default=False here previously flipped agents into rotation
+    # mode whenever the merged config omitted the key (partial configs,
+    # load_config failure → {}), re-arming the pre-lease drift abort.
     compression_in_place = is_truthy_value(
-        _compression_cfg.get("in_place"), default=False
+        _compression_cfg.get("in_place"), default=True
     )
     codex_app_server_auto_compaction = str(
         _compression_cfg.get("codex_app_server_auto", "native") or "native"

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1402,7 +1402,10 @@ def compress_context(
     # `name #N` renumber, no contextvar/env/logging re-sync, no memory/context-
     # engine session-switch. The conversation keeps one durable id for life,
     # eliminating the session-rotation bug cluster. Default True (2107b86024).
-    in_place = bool(getattr(agent, "compression_in_place", False))
+    # Default True matches DEFAULT_CONFIG / #38763. A missing attribute must
+    # NOT fall back to rotation mode — that re-enables the pre-lease drift
+    # path and can wedge busy sessions that never set the flag.
+    in_place = bool(getattr(agent, "compression_in_place", True))
     # Set True once the in-place DB write actually completes (the DB block can
     # raise and skip it). Surfaced to the gateway via agent._last_compaction_in_place.
     compacted_in_place = False
@@ -1712,6 +1715,13 @@ def compress_context(
         # non-destructive — pre-compaction rows are soft-archived (active=0,
         # compacted=1), stay searchable and recoverable, so snapshot/durable
         # drift cannot lose data there and must not abort compaction.
+        #
+        # When durable DID grow, ADOPT it and continue rather than aborting.
+        # Aborting returned the stale snapshot unchanged, so busy sessions
+        # (memory review / shared session_id writers) stayed permanently
+        # behind the DB: every /compress and auto-compress saw
+        # "changed before lease acquisition", surfaced as the misleading
+        # "No changes from compression", and never reclaimed tokens.
         if not in_place and _lock_db is not None and _lock_sid:
             durable_loader = getattr(
                 type(_lock_db), "get_messages_as_conversation", None
@@ -1719,16 +1729,18 @@ def compress_context(
             if callable(durable_loader):
                 durable_parent = durable_loader(_lock_db, _lock_sid)
                 if isinstance(durable_parent, list) and len(durable_parent) > len(messages):
-                    logger.warning(
-                        "compression aborted: session=%s changed before lease "
-                        "acquisition; preserving newer durable messages",
+                    logger.info(
+                        "compression: session=%s grew before lease "
+                        "(%d → %d msgs); adopting durable snapshot",
                         _lock_sid,
+                        len(messages),
+                        len(durable_parent),
                     )
-                    _release_lock()
-                    existing_prompt = getattr(agent, "_cached_system_prompt", None)
-                    if not existing_prompt:
-                        existing_prompt = agent._build_system_prompt(system_message)
-                    return messages, existing_prompt
+                    messages = durable_parent
+                    # Token estimate was for the stale snapshot; clear it so
+                    # the compressor re-derives from the adopted transcript
+                    # instead of under-counting the newly visible rows.
+                    approx_tokens = 0
 
         # Notify external memory provider before compression discards context.
         # The provider's on_pre_compress() may return a string of insights it

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -243,6 +243,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("browser", "allow_private_urls"),
         ("compression", "enabled"),
         ("compression", "threshold"),
+        ("compression", "in_place"),
         ("display", "streaming"),
         ("display", "skin"),
         ("display", "show_reasoning"),

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -340,10 +340,17 @@ def test_concurrent_compression_does_not_fork_session(tmp_path: Path) -> None:
     )
 
 
-def test_durable_message_committed_before_lease_aborts_stale_snapshot(
+def test_durable_message_committed_before_lease_is_adopted(
     tmp_path: Path,
 ) -> None:
-    """A durable row absent from the caller snapshot must survive in the parent."""
+    """A durable row absent from the caller snapshot must still be compressed.
+
+    Previously this path aborted and returned the stale snapshot unchanged,
+    which permanently wedged busy sessions: every compress attempt saw the
+    DB ahead of the in-memory list, logged "changed before lease
+    acquisition", and never called the compressor. Adopting the durable
+    transcript keeps the late-committed turn and lets compression proceed.
+    """
     db = SessionDB(db_path=tmp_path / "state.db")
     parent_sid = "PRE_LEASE_DURABLE_RACE"
     db.create_session(parent_sid, source="webui")
@@ -359,15 +366,21 @@ def test_durable_message_committed_before_lease_aborts_stale_snapshot(
         stale_snapshot, "sys", approx_tokens=120_000
     )
 
-    assert returned is stale_snapshot
-    assert agent.session_id == parent_sid
-    assert db.find_live_compression_child(parent_sid) is None
-    assert [m["content"] for m in db.get_messages_as_conversation(parent_sid)] == [
+    agent.context_compressor.compress.assert_called_once()
+    compressed_arg = agent.context_compressor.compress.call_args.args[0]
+    assert [m["content"] for m in compressed_arg] == [
         "old durable",
         "late committed before lease",
     ]
-    agent.context_compressor.compress.assert_not_called()
-
+    # Must not echo the stale snapshot — compression proceeded on the
+    # adopted durable transcript (rotation publishes a child session).
+    assert returned is not stale_snapshot
+    assert returned[0]["content"] == "[CONTEXT COMPACTION] summary"
+    assert agent.session_id != parent_sid
+    child = db.find_live_compression_child(parent_sid)
+    assert child is not None
+    child_id = child["id"] if isinstance(child, dict) else child
+    assert child_id == agent.session_id
 
 def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     """The loser of the lock race must return its input messages verbatim.


### PR DESCRIPTION
## What does this PR do?

Fixes a wedge where `/compress` and auto-compression keep reporting **"No changes from compression"** on huge busy sessions, even though the context is far over the model limit.

On rotation-mode compression (`compression.in_place: false`), if the durable session grew before the lease was acquired (memory review / shared `session_id` writers), Hermes aborted and returned the stale in-memory snapshot unchanged. Busy sessions stayed permanently behind the DB, so every compress attempt logged `changed before lease acquisition` and never reclaimed tokens.

This PR:
1. **Adopts the durable transcript** when it grew pre-lease, then continues compressing (instead of aborting as a no-op).
2. **Aligns `compression.in_place` fallbacks with `DEFAULT_CONFIG` (`True`)** so partial/failed config loads do not silently fall back into rotation mode, and surfaces `compression.in_place` in `hermes dump` overrides so a stale `false` is visible.

## Related Issue

Fixes # (Discord report: cannot compress / "No changes from compression" on latest `d71033a4`; logs show repeated `changed before lease acquisition`)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_compression.py` — on pre-lease durable growth in rotation mode, adopt durable messages and continue compress; default `getattr(..., compression_in_place)` to `True`
- `agent/agent_init.py` — `is_truthy_value(..., default=True)` for `compression.in_place` to match `DEFAULT_CONFIG`
- `hermes_cli/dump.py` — include `compression.in_place` in dump config overrides
- `tests/agent/test_compression_concurrent_fork.py` — update pre-lease race test to expect adopt + compress instead of abort/no-op

## How to Test

1. Reproduce (before fix / rotation mode): long busy session with concurrent writers, `compression.in_place: false`, run `/compress` → expect "No changes from compression" and agent.log lines `changed before lease acquisition`.
2. After fix with same setup: `/compress` should call the compressor on the adopted durable transcript and reduce message/token count (or rotate to a compacted child), not return a no-op.
3. Default path: with `compression.in_place: true` (default), confirm `/compress` / auto-compress still works unchanged.
4. `hermes dump` — if config has `compression.in_place: false`, it should appear under `config_overrides`.
5. `scripts/run_tests.sh tests/agent/test_compression_concurrent_fork.py tests/agent/test_manual_compression_feedback.py tests/run_agent/test_in_place_compaction.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (reporter on latest `0.19.0 [d71033a4]`):

```
compression aborted: session=... changed before lease acquisition; preserving newer durable messages
No changes from compression: 1708 messages
Approx request size: ~839,897 tokens (unchanged)
Context length exceeded (...). Cannot compress further.
```

After (unit coverage): pre-lease durable growth adopts the durable snapshot and invokes the compressor instead of returning the stale snapshot unchanged.
