### PR TITLE
feat(raft): report Hermes runtime identity

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -59,6 +59,9 @@ DEFAULT_ACTIVITY_QUEUE_CAP = 500
 ACTIVITY_CONTENT_CAP = 4096
 ACTIVITY_EVENT_SCHEMA = "raft-activity.v1"
 ACTIVITY_DRAIN_SCHEMA = "raft-activity-drain.v1"
+RUNTIME_INTEGRATION_SCHEMA = "slock-external-runtime-integration.v1"
+RAFT_ADAPTER_VERSION = "1.0.0"
+RAFT_ADAPTER_INSTANCE = "hermes-gateway"
 BRIDGE_TOKEN_HEADER = "x-raft-bridge-token"
 
 _CONTENT_FIELD_NAMES = {
@@ -95,6 +98,35 @@ _RAFT_CONTEXT_LOCK = threading.Lock()
 _RAFT_SESSION_IDS: set[str] = set()
 _RAFT_TURN_IDS: set[str] = set()
 _RAFT_PROMPT_TURN_IDS: set[str] = set()
+
+_RUNTIME_INTEGRATION_MANIFEST = {
+    "schema": RUNTIME_INTEGRATION_SCHEMA,
+    "runtimeId": "hermes",
+    "adapterVersion": RAFT_ADAPTER_VERSION,
+    "integrationPattern": "external-harness-plugin",
+    "commsMode": "spawn-core",
+    "commsProtocolVersion": "agent-comms-core.v1",
+    "proofSchemaVersion": "agent-proof.v1",
+    "minSlockCliVersion": "0.0.3",
+    "multiplex": False,
+    "agentIsolation": "session-scoped",
+    "bridgeLifecycle": {
+        "explicitStartOnly": True,
+        "oneShotCommandsBridgeIndependent": True,
+        "requiresBridgeFailureCodes": ["BRIDGE_NOT_RUNNING", "NO_CORE_SESSION"],
+        "autoStartDefault": False,
+    },
+    "serverApi": {
+        "mode": "interim-agent-api-events",
+        "deliveryOnly": True,
+        "cursorAuthority": "model_seen_only",
+    },
+    "wakeAdapter": {
+        "kind": "raft-channel",
+        "protocol": "raft-channel.v0",
+        "requiresInteractiveSession": True,
+    },
+}
 
 
 def check_raft_requirements() -> bool:
@@ -468,6 +500,15 @@ class RaftAdapter(BasePlatformAdapter):
     def runtime_session(self) -> str:
         return self._runtime_session
 
+    def _create_http_app(self) -> "web.Application":
+        app = web.Application(client_max_size=self._max_body_bytes)
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_get(self._path, self._handle_runtime_manifest)
+        app.router.add_post(self._path, self._handle_wake)
+        app.router.add_post("/activity", self._handle_activity)
+        app.router.add_get("/activity/drain", self._handle_activity_drain)
+        return app
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         if not self._bridge_token:
             self._bridge_token = secrets.token_hex(32)
@@ -477,11 +518,7 @@ class RaftAdapter(BasePlatformAdapter):
         # including Transfer-Encoding: chunked bodies that carry no
         # Content-Length and would otherwise bypass the header checks below
         # (mirrors gateway/platforms/webhook.py's connect()).
-        app = web.Application(client_max_size=self._max_body_bytes)
-        app.router.add_get("/health", self._handle_health)
-        app.router.add_post(self._path, self._handle_wake)
-        app.router.add_post("/activity", self._handle_activity)
-        app.router.add_get("/activity/drain", self._handle_activity_drain)
+        app = self._create_http_app()
 
         if self._port != 0:
             import socket as _socket
@@ -542,6 +579,7 @@ class RaftAdapter(BasePlatformAdapter):
             "agent", "bridge",
             "--wake-adapter", "wake-channel",
             "--wake-channel-endpoint", endpoint,
+            "--adapter-instance", RAFT_ADAPTER_INSTANCE,
         ]
         env = {**os.environ, "RAFT_CHANNEL_TOKEN": self._bridge_token}
         try:
@@ -593,6 +631,11 @@ class RaftAdapter(BasePlatformAdapter):
                 },
             }
         )
+
+    async def _handle_runtime_manifest(self, request: "web.Request") -> "web.Response":
+        if not self._validate_bridge_token(request.headers.get(BRIDGE_TOKEN_HEADER, "")):
+            return web.json_response({"ok": False, "error": "unauthorized"}, status=401)
+        return web.json_response(_RUNTIME_INTEGRATION_MANIFEST)
 
     async def _handle_wake(self, request: "web.Request") -> "web.Response":
         if not self._validate_bridge_token(request.headers.get(BRIDGE_TOKEN_HEADER, "")):

--- a/tests/gateway/test_raft_adapter.py
+++ b/tests/gateway/test_raft_adapter.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from aiohttp import web
@@ -16,6 +16,9 @@ from plugins.platforms.raft.adapter import (
     ActivityQueue,
     BRIDGE_TOKEN_HEADER,
     DEFAULT_PATH,
+    RAFT_ADAPTER_INSTANCE,
+    RAFT_ADAPTER_VERSION,
+    RUNTIME_INTEGRATION_SCHEMA,
     RaftAdapter,
     _ACTIVE_ADAPTERS,
     _ACTIVE_ADAPTERS_LOCK,
@@ -58,13 +61,7 @@ def _make_adapter(**extra):
 
 
 def _create_app(adapter: RaftAdapter) -> web.Application:
-    # Mirror connect(): client_max_size enforces the cap on chunked bodies.
-    app = web.Application(client_max_size=adapter._max_body_bytes)
-    app.router.add_get("/health", adapter._handle_health)
-    app.router.add_post(adapter._path, adapter._handle_wake)
-    app.router.add_post("/activity", adapter._handle_activity)
-    app.router.add_get("/activity/drain", adapter._handle_activity_drain)
-    return app
+    return adapter._create_http_app()
 
 
 def _activity_event(event_id: str, **overrides):
@@ -111,6 +108,30 @@ class TestRaftWakeHttp:
 
         assert body["ok"] is False
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runtime_manifest_is_authenticated_and_adapter_owned(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as client:
+            unauthorized = await client.get(DEFAULT_PATH)
+            assert unauthorized.status == 401
+
+            response = await client.get(
+                DEFAULT_PATH,
+                headers={BRIDGE_TOKEN_HEADER: "bridge-secret"},
+            )
+            assert response.status == 200
+            body = await response.json()
+
+        assert body["schema"] == RUNTIME_INTEGRATION_SCHEMA
+        assert body["runtimeId"] == "hermes"
+        assert body["adapterVersion"] == RAFT_ADAPTER_VERSION
+        assert body["wakeAdapter"]["kind"] == "raft-channel"
+        assert body["bridgeLifecycle"]["requiresBridgeFailureCodes"] == [
+            "BRIDGE_NOT_RUNNING",
+            "NO_CORE_SESSION",
+        ]
 
     @pytest.mark.asyncio
     async def test_rejects_content_bearing_payload(self):
@@ -473,6 +494,21 @@ class TestBodySize:
 
 
 class TestRaftConfig:
+    def test_spawned_bridge_binds_stable_hermes_adapter_instance(self, monkeypatch):
+        adapter = _make_adapter()
+        process = Mock(pid=123)
+        monkeypatch.setenv("RAFT_PROFILE", "hermes-profile")
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/local/bin/raft")
+
+        with patch("plugins.platforms.raft.adapter.subprocess.Popen", return_value=process) as popen:
+            adapter._spawn_bridge(49152)
+
+        command = popen.call_args.args[0]
+        assert command[-2:] == ["--adapter-instance", RAFT_ADAPTER_INSTANCE]
+        assert command[command.index("--wake-channel-endpoint") + 1] == (
+            "http://127.0.0.1:49152/wake"
+        )
+
     def test_env_enablement_auto_enables_with_raft_profile(self, monkeypatch):
         monkeypatch.setenv("RAFT_PROFILE", "my-agent")
 


### PR DESCRIPTION
## Summary
- expose an authenticated runtime integration manifest on the existing Raft wake endpoint
- report adapter-owned `runtimeId=hermes`, adapter version, and the exact comms/proof contract
- bind spawned Raft bridges to a stable `hermes-gateway` adapter instance
- centralize HTTP app construction so production and tests exercise identical routes

## Verification
- `scripts/run_tests.sh tests/gateway/test_raft_adapter.py` (22/22)
- `ruff check plugins/platforms/raft/adapter.py tests/gateway/test_raft_adapter.py`
- mutation proof: deleting the GET route fails the authenticated manifest acceptance test with 405

## Companion
- https://github.com/botiverse/slock/pull/5524
