### PR TITLE
fix(compression): attribute auxiliary failures to the actual wire route

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2907,6 +2907,9 @@ def _set_relay_auxiliary_route(
     provider: str | None,
     model: str | None,
     api_mode: str | None,
+    *,
+    route_callback: Optional[Callable[[str, Optional[str], str], None]] = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
 ) -> None:
     context = _RELAY_AUX_CALL_CONTEXT.get()
     if context is None:
@@ -2915,6 +2918,81 @@ def _set_relay_auxiliary_route(
     context["model"] = str(model or "unknown")
     context["response_model"] = None
     context["api_mode"] = str(api_mode or "chat_completions")
+    context["route_callback"] = route_callback
+    runtime = main_runtime or {}
+    context["main_runtime"] = {
+        "provider": str(runtime.get("provider") or ""),
+        "base_url": str(runtime.get("base_url") or ""),
+    }
+
+
+def _wire_provider_name(
+    provider: str | None,
+    base_url: str,
+    main_runtime: Optional[Dict[str, Any]],
+) -> str:
+    """Return the concrete provider label for one physical wire attempt."""
+    raw_provider = str(provider or "").strip()
+    wrapped = re.search(r"\(([^()]*)\)$", raw_provider)
+    if wrapped:
+        raw_provider = wrapped.group(1).strip()
+    normalized = _normalize_aux_provider(raw_provider)
+    if normalized not in {"", "auto"}:
+        return raw_provider or normalized
+
+    runtime = main_runtime or {}
+    runtime_provider = str(runtime.get("provider") or "").strip()
+    runtime_base = str(runtime.get("base_url") or "").strip()
+    if (
+        runtime_provider
+        and runtime_provider not in {"auto"}
+        and runtime_base
+        and base_url_hostname(runtime_base) == base_url_hostname(base_url)
+    ):
+        return runtime_provider
+
+    try:
+        from agent.model_metadata import _infer_provider_from_url
+
+        inferred = _infer_provider_from_url(base_url)
+        if inferred:
+            return inferred
+    except Exception:
+        pass
+
+    # An auto-selected HTTP client with an otherwise unknown endpoint is a
+    # custom route. Reporting "custom" is more actionable than preserving the
+    # config-layer "auto" label, which never went over the wire.
+    return "custom" if base_url else "auto"
+
+
+def _notify_relay_auxiliary_route(
+    client: Any,
+    kwargs: Dict[str, Any],
+    provider: str | None,
+) -> None:
+    """Publish the latest physical route without affecting request success."""
+    context = _RELAY_AUX_CALL_CONTEXT.get()
+    if context is None:
+        return
+    route_callback = context.get("route_callback")
+    if not callable(route_callback):
+        return
+
+    base_url = str(getattr(client, "base_url", "") or "")
+    try:
+        clean_base, _ = _extract_url_query_params(base_url)
+        route_callback(
+            _wire_provider_name(
+                provider or context.get("provider"),
+                clean_base,
+                context.get("main_runtime"),
+            ),
+            str(kwargs.get("model") or context.get("model") or "") or None,
+            clean_base,
+        )
+    except Exception:
+        logger.debug("route_callback error in auxiliary wire attempt", exc_info=True)
 
 
 def _relay_auxiliary_metadata(
@@ -2947,6 +3025,7 @@ def _relay_sync_completion(
     create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
     callback = create or (lambda request: client.chat.completions.create(**request))
+    _notify_relay_auxiliary_route(client, kwargs, provider)
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     # Protected compression calls isolate only the provider callback and stream
     # aggregation.  The owning thread remains free to unwind its lease/DB
@@ -2998,6 +3077,7 @@ def _relay_sync_stream(
     provider: str | None = None,
     api_mode: str | None = None,
 ) -> Any:
+    _notify_relay_auxiliary_route(client, kwargs, provider)
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
         return client.chat.completions.create(**kwargs)
@@ -8679,6 +8759,10 @@ def _call_llm_impl(
             output can stream to the user.
         stream_options: Passed through to the request when stream is True
             (e.g. {"include_usage": True}).
+        route_callback: Optional observer invoked immediately before every
+            physical sync wire attempt with the concrete provider, request
+            model, and query-stripped client endpoint. Later retries and
+            fallbacks replace the caller's previous route snapshot.
 
     Returns:
         Response object with .choices[0].message.content, OR — when stream=True —
@@ -8773,27 +8857,12 @@ def _call_llm_impl(
         resolved_provider,
         final_model,
         resolved_api_mode,
+        route_callback=route_callback,
+        main_runtime=main_runtime,
     )
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
-    # Report the route ACTUALLY used on the wire (after auto-detection,
-    # fallback chains, and client construction) so callers that need to
-    # attribute a failure point at the real endpoint, not the pre-resolution
-    # guess from _resolve_task_provider_model (#72636). The base_url is
-    # query-stripped so credentials some proxies carry as ?key=... are not
-    # leaked into user-facing diagnostics; the callback also re-strips
-    # defensively in case a future caller bypasses this path.
-    if route_callback is not None:
-        try:
-            _clean_base, _dropped_q = _extract_url_query_params(_base_info)
-            route_callback(
-                resolved_provider or "auto",
-                final_model,
-                _clean_base,
-            )
-        except Exception:
-            logger.debug("route_callback error in call_llm", exc_info=True)
     if task:
         logger.info("Auxiliary %s: using %s (%s)%s",
                      task, resolved_provider or "auto", final_model or "default",

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8683,6 +8683,7 @@ def call_llm(
             api_mode=api_mode,
             stream=stream,
             stream_options=stream_options,
+            route_callback=route_callback,
         )
         if stream and semaphore is not None:
             stream_semaphore = semaphore
@@ -8728,6 +8729,7 @@ def _call_llm_impl(
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
+    route_callback: Optional[Callable[[str, Optional[str], str], None]] = None,
 ) -> Any:
     """Centralized synchronous LLM call.
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8578,6 +8578,7 @@ def call_llm(
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
+    route_callback: Optional[Callable[[str, Optional[str], str], None]] = None,
 ) -> Any:
     """Run an auxiliary LLM request, applying the configured task limit."""
     semaphore = _acquire_sync_aux_semaphore(task)
@@ -8776,6 +8777,23 @@ def _call_llm_impl(
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
+    # Report the route ACTUALLY used on the wire (after auto-detection,
+    # fallback chains, and client construction) so callers that need to
+    # attribute a failure point at the real endpoint, not the pre-resolution
+    # guess from _resolve_task_provider_model (#72636). The base_url is
+    # query-stripped so credentials some proxies carry as ?key=... are not
+    # leaked into user-facing diagnostics; the callback also re-strips
+    # defensively in case a future caller bypasses this path.
+    if route_callback is not None:
+        try:
+            _clean_base, _dropped_q = _extract_url_query_params(_base_info)
+            route_callback(
+                resolved_provider or "auto",
+                final_model,
+                _clean_base,
+            )
+        except Exception:
+            logger.debug("route_callback error in call_llm", exc_info=True)
     if task:
         logger.info("Auxiliary %s: using %s (%s)%s",
                      task, resolved_provider or "auto", final_model or "default",

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3769,10 +3769,17 @@ def _call_fallback_candidate_sync(
     fb_client: Any, fb_model: Optional[str], fb_label: str, *, task: Optional[str], messages: list,
     temperature: Optional[float], max_tokens: Optional[int], tools: Optional[list],
     effective_timeout: float, effective_extra_body: dict, reasoning_config: Optional[dict],
+    terminal_auth_exc: Optional[list] = None,
 ) -> Optional[Any]:
     """Call one fallback candidate with stale-credential recovery: on an auth error refresh its
     credentials and retry once with a rebuilt client; if that also auth-fails, quarantine the
     provider and return None so the caller moves on. Non-auth errors raise.
+
+    When ``terminal_auth_exc`` is a list and the candidate is quarantined,
+    the terminal auth exception of THIS physical attempt is appended to it,
+    so a caller whose fallback chain exhausts can propagate the error that
+    belongs to the last physical wire attempt instead of the primary's
+    earlier ``first_err`` (#72636).
 
     ``effective_timeout`` is the task-level deadline; a configured-chain candidate with its own ``timeout``
     entry gets that instead, so a fallback tuned differently from the primary is allowed its own budget
@@ -3801,14 +3808,18 @@ def _call_fallback_candidate_sync(
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
             raise
+        terminal_exc = fb_err
         fb_provider, retry = _plan_fallback_auth_retry(destination, rebuild, async_mode=False)
         if retry is not None:
             try:
                 return _send(*retry)
             except Exception as retry_err:
+                terminal_exc = retry_err
                 if not _is_auth_error(retry_err):
                     raise
         _quarantine_fallback_candidate(task, fb_label, fb_provider, fb_err)
+        if terminal_auth_exc is not None:
+            terminal_auth_exc.append(terminal_exc)
         return None
 
 
@@ -7257,17 +7268,33 @@ def _call_llm_impl(
                     _last_transient = retry_transient
             raise _last_transient
     except Exception as first_err:
+        # Terminal auth exception of the most recent quarantined fallback
+        # candidate, if any. When the fallback chain exhausts, the route
+        # snapshot on the caller's side already identifies the LAST physical
+        # fallback attempt; the error propagated must belong to that same
+        # attempt or downstream diagnostics pair one attempt's identity with
+        # a different attempt's failure class (#72636).
+        _swallowed_auth: list = []
+
         def _perform(step: _LadderStep) -> Any:
             kind, args, kw = _ladder_step_call(step, req, retry_kwargs, candidate_kwargs)
             if kind == "call":
                 return _validate_llm_response(_relay_sync_completion(*args, **kw), task)
             if kind == "retry":
                 return _retry_same_provider_sync(**kw)
-            return _call_fallback_candidate_sync(*args, **kw)
+            return _call_fallback_candidate_sync(*args, terminal_auth_exc=_swallowed_auth, **kw)
         result = _drive_ladder(
             _start_recovery_ladder(first_err, req, retry_kwargs, task=task, async_mode=False, route_info=route_info),
             _perform)
         if result is _RERAISE_ORIGINAL:
+            if _swallowed_auth:
+                # The last physical wire attempt was a fallback candidate whose
+                # credential was dead. The route snapshot already identifies that
+                # fallback, so propagate ITS terminal auth error (chained to the
+                # primary origin for context) instead of re-raising the primary's
+                # earlier error — otherwise the compression diagnostic pairs the
+                # fallback's endpoint with the primary's failure class (#72636).
+                raise _swallowed_auth[-1] from first_err
             raise
         return result
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6945,6 +6945,7 @@ def call_llm(
     extra_headers: Optional[Dict[str, str]] = None, api_mode: str = None, stream: bool = False,
     stream_options: dict = None, route_info: Optional[Dict[str, str]] = None,
     latency_info: Optional[Dict[str, int]] = None,
+    route_callback: Optional[Callable[[str, Optional[str], str], None]] = None,
 ) -> Any:
     """Run an auxiliary LLM request, applying the configured task limit."""
     queue_started_at = time.monotonic()
@@ -6973,6 +6974,7 @@ def call_llm(
                 max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=extra_body,
                 reasoning_config=reasoning_config, extra_headers=extra_headers, api_mode=api_mode,
                 stream=stream, stream_options=stream_options, route_info=route_info,
+                route_callback=route_callback,
             )
         if stream and semaphore is not None:
             stream_semaphore = semaphore
@@ -7078,6 +7080,7 @@ def _call_llm_impl(
     timeout: float = None, extra_body: dict = None, reasoning_config: Optional[dict] = None,
     extra_headers: Optional[Dict[str, str]] = None, api_mode: str = None, stream: bool = False,
     stream_options: dict = None, route_info: Optional[Dict[str, str]] = None,
+    route_callback: Optional[Callable[[str, Optional[str], str], None]] = None,
 ) -> Any:
     """Centralized synchronous LLM call: resolve provider/model, auth, kwargs, fallbacks.
     task: aux task whose provider:model comes from config (ignored if provider set); api_mode
@@ -7092,6 +7095,23 @@ def _call_llm_impl(
         extra_headers=extra_headers, api_mode=api_mode, route_info=route_info,
     )
     client, kwargs, request_provider = req.client, req.kwargs, req.request_provider
+    # Report the route ACTUALLY used on the wire (after auto-detection,
+    # fallback chains, and client construction) so callers that need to
+    # attribute a failure point at the real endpoint, not the pre-resolution
+    # guess from _resolve_task_provider_model (#72636). The base_url is
+    # query-stripped so credentials some proxies carry as ?key=... are not
+    # leaked into user-facing diagnostics; the callback also re-strips
+    # defensively in case a future caller bypasses this path.
+    if route_callback is not None:
+        try:
+            _clean_base, _dropped_q = _extract_url_query_params(req.base_info or req.resolved_base_url)
+            route_callback(
+                request_provider or "auto",
+                kwargs.get("model"),
+                _clean_base,
+            )
+        except Exception:
+            logger.debug("route_callback error in call_llm", exc_info=True)
     # Streaming path (MoA aggregator): return the raw SDK stream, skipping validation and
     # the fallback chain (they assume a complete response); the caller owns reassembly/fallback.
     if stream:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7287,13 +7287,20 @@ def _call_llm_impl(
             _start_recovery_ladder(first_err, req, retry_kwargs, task=task, async_mode=False, route_info=route_info),
             _perform)
         if result is _RERAISE_ORIGINAL:
-            if _swallowed_auth:
+            if _swallowed_auth and (task == "compression" or route_callback is not None):
                 # The last physical wire attempt was a fallback candidate whose
                 # credential was dead. The route snapshot already identifies that
                 # fallback, so propagate ITS terminal auth error (chained to the
                 # primary origin for context) instead of re-raising the primary's
                 # earlier error — otherwise the compression diagnostic pairs the
                 # fallback's endpoint with the primary's failure class (#72636).
+                #
+                # Scoped to the attribution path only (compression, or any caller
+                # that registered a route_callback): every other auxiliary task —
+                # vision, web_extract, title generation, ... — keeps the
+                # pre-existing exception contract, where a swallowed fallback 401
+                # leaves the PRIMARY error (e.g. a 429 that upper layers key
+                # backoff decisions on) as the one callers observe.
                 raise _swallowed_auth[-1] from first_err
             raise
         return result

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2418,9 +2418,17 @@ def _set_relay_auxiliary_route(
     context["api_mode"] = str(api_mode or "chat_completions")
     context["route_callback"] = route_callback
     runtime = main_runtime or {}
+    runtime_base = str(runtime.get("base_url") or "")
+    try:
+        runtime_base, _ = _extract_url_query_params(runtime_base)
+    except Exception:
+        runtime_base = runtime_base.split("?", 1)[0]
+    # Stored query-stripped even though the only reader today compares
+    # hostnames — a future logger of this context must not be able to leak
+    # credentials some proxies carry as ?key=... (#72636).
     context["main_runtime"] = {
         "provider": str(runtime.get("provider") or ""),
-        "base_url": str(runtime.get("base_url") or ""),
+        "base_url": runtime_base,
     }
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2401,7 +2401,14 @@ def _relay_auxiliary_call_async(callback):
     return wrapped
 
 
-def _set_relay_auxiliary_route(provider: str | None, model: str | None, api_mode: str | None) -> None:
+def _set_relay_auxiliary_route(
+    provider: str | None,
+    model: str | None,
+    api_mode: str | None,
+    *,
+    route_callback: Optional[Callable[[str, Optional[str], str], None]] = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
+) -> None:
     context = _RELAY_AUX_CALL_CONTEXT.get()
     if context is None:
         return
@@ -2409,6 +2416,81 @@ def _set_relay_auxiliary_route(provider: str | None, model: str | None, api_mode
     context["model"] = str(model or "unknown")
     context["response_model"] = None
     context["api_mode"] = str(api_mode or "chat_completions")
+    context["route_callback"] = route_callback
+    runtime = main_runtime or {}
+    context["main_runtime"] = {
+        "provider": str(runtime.get("provider") or ""),
+        "base_url": str(runtime.get("base_url") or ""),
+    }
+
+
+def _wire_provider_name(
+    provider: str | None,
+    base_url: str,
+    main_runtime: Optional[Dict[str, Any]],
+) -> str:
+    """Return the concrete provider label for one physical wire attempt."""
+    raw_provider = str(provider or "").strip()
+    wrapped = re.search(r"\(([^()]*)\)$", raw_provider)
+    if wrapped:
+        raw_provider = wrapped.group(1).strip()
+    normalized = _normalize_aux_provider(raw_provider)
+    if normalized not in {"", "auto"}:
+        return raw_provider or normalized
+
+    runtime = main_runtime or {}
+    runtime_provider = str(runtime.get("provider") or "").strip()
+    runtime_base = str(runtime.get("base_url") or "").strip()
+    if (
+        runtime_provider
+        and runtime_provider not in {"auto"}
+        and runtime_base
+        and base_url_hostname(runtime_base) == base_url_hostname(base_url)
+    ):
+        return runtime_provider
+
+    try:
+        from agent.model_metadata import _infer_provider_from_url
+
+        inferred = _infer_provider_from_url(base_url)
+        if inferred:
+            return inferred
+    except Exception:
+        pass
+
+    # An auto-selected HTTP client with an otherwise unknown endpoint is a
+    # custom route. Reporting "custom" is more actionable than preserving the
+    # config-layer "auto" label, which never went over the wire.
+    return "custom" if base_url else "auto"
+
+
+def _notify_relay_auxiliary_route(
+    client: Any,
+    kwargs: Dict[str, Any],
+    provider: str | None,
+) -> None:
+    """Publish the latest physical route without affecting request success."""
+    context = _RELAY_AUX_CALL_CONTEXT.get()
+    if context is None:
+        return
+    route_callback = context.get("route_callback")
+    if not callable(route_callback):
+        return
+
+    base_url = str(getattr(client, "base_url", "") or "")
+    try:
+        clean_base, _ = _extract_url_query_params(base_url)
+        route_callback(
+            _wire_provider_name(
+                provider or context.get("provider"),
+                clean_base,
+                context.get("main_runtime"),
+            ),
+            str(kwargs.get("model") or context.get("model") or "") or None,
+            clean_base,
+        )
+    except Exception:
+        logger.debug("route_callback error in auxiliary wire attempt", exc_info=True)
 
 
 def _record_route_info(
@@ -2444,6 +2526,7 @@ def _relay_sync_completion(
     api_mode: str | None = None, create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
     callback = create or (lambda request: client.chat.completions.create(**request))
+    _notify_relay_auxiliary_route(client, kwargs, provider)
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     # Isolate only the provider callback so the owning thread can unwind its lease/DB
     # transaction on hard cancel without touching the shared client.
@@ -2477,6 +2560,7 @@ async def _relay_async_completion(
 def _relay_sync_stream(
     client: Any, kwargs: dict[str, Any], *, provider: str | None = None, api_mode: str | None = None
 ) -> Any:
+    _notify_relay_auxiliary_route(client, kwargs, provider)
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
         return client.chat.completions.create(**kwargs)
@@ -6528,6 +6612,7 @@ def _prepare_aux_request(
     timeout: Optional[float], extra_body: Optional[dict], reasoning_config: Optional[dict],
     extra_headers: Optional[Dict[str, str]], api_mode: Optional[str],
     route_info: Optional[Dict[str, str]], async_mode: bool,
+    route_callback: Optional[Callable[[str, Optional[str], str], None]] = None,
 ) -> _PreparedAuxRequest:
     """Shared head of call_llm/async_call_llm: resolve route + client, publish it, build request kwargs.
     Sync-only: compression fast lane, per-request ``extra_headers``, and ``base_info`` falling
@@ -6555,7 +6640,10 @@ def _prepare_aux_request(
             leak_guard_config=compression_config, max_tokens=max_tokens,
             extra_body=effective_extra_body,
         )
-    _set_relay_auxiliary_route(request_provider, final_model, resolved_api_mode)
+    _set_relay_auxiliary_route(
+        request_provider, final_model, resolved_api_mode,
+        route_callback=route_callback, main_runtime=main_runtime,
+    )
     _record_route_info(route_info, _fallback_provider_from_label(request_provider), final_model)
     if async_mode:
         base_info = str(getattr(client, "base_url", "") or "")
@@ -7008,6 +7096,7 @@ def _plan_aux_call(
     timeout: Optional[float], extra_body: Optional[dict], reasoning_config: Optional[dict],
     extra_headers: Optional[Dict[str, str]], api_mode: Optional[str],
     route_info: Optional[Dict[str, str]],
+    route_callback: Optional[Callable[[str, Optional[str], str], None]] = None,
 ) -> Tuple[_PreparedAuxRequest, Dict[str, Any], Dict[str, Any]]:
     """Shared head of both call impls: prepare the request and bundle the kwargs the recovery
     drivers pass to ``_retry_same_provider_*`` / ``_call_fallback_candidate_*``. One immutable
@@ -7020,6 +7109,7 @@ def _plan_aux_call(
         max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=extra_body,
         reasoning_config=reasoning_config, extra_headers=extra_headers,
         api_mode=api_mode, route_info=route_info, async_mode=async_mode,
+        route_callback=route_callback,
     )
     candidate_kwargs = dict(
         task=task, messages=messages, temperature=temperature, max_tokens=max_tokens,
@@ -7086,32 +7176,19 @@ def _call_llm_impl(
     task: aux task whose provider:model comes from config (ignored if provider set); api_mode
     overrides task config; timeout=None reads auxiliary.{task}.timeout; extra_headers override
     client defaults. stream=True returns the raw SDK stream (caller consumes/falls back)
-    instead of a validated response. RuntimeError if no provider is configured."""
+    instead of a validated response. RuntimeError if no provider is configured.
+    route_callback: optional observer invoked immediately before every physical sync
+    wire attempt with the concrete provider, request model, and query-stripped client
+    endpoint. Later retries and fallbacks replace the caller's previous route snapshot."""
     req, retry_kwargs, candidate_kwargs = _plan_aux_call(
         task, async_mode=False, provider=provider, model=model, base_url=base_url,
         api_key=api_key, main_runtime=main_runtime, messages=messages,
         temperature=temperature, max_tokens=max_tokens, tools=tools, timeout=timeout,
         extra_body=extra_body, reasoning_config=reasoning_config,
         extra_headers=extra_headers, api_mode=api_mode, route_info=route_info,
+        route_callback=route_callback,
     )
     client, kwargs, request_provider = req.client, req.kwargs, req.request_provider
-    # Report the route ACTUALLY used on the wire (after auto-detection,
-    # fallback chains, and client construction) so callers that need to
-    # attribute a failure point at the real endpoint, not the pre-resolution
-    # guess from _resolve_task_provider_model (#72636). The base_url is
-    # query-stripped so credentials some proxies carry as ?key=... are not
-    # leaked into user-facing diagnostics; the callback also re-strips
-    # defensively in case a future caller bypasses this path.
-    if route_callback is not None:
-        try:
-            _clean_base, _dropped_q = _extract_url_query_params(req.base_info or req.resolved_base_url)
-            route_callback(
-                request_provider or "auto",
-                kwargs.get("model"),
-                _clean_base,
-            )
-        except Exception:
-            logger.debug("route_callback error in call_llm", exc_info=True)
     # Streaming path (MoA aggregator): return the raw SDK stream, skipping validation and
     # the fallback chain (they assume a complete response); the caller owns reassembly/fallback.
     if stream:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3920,16 +3920,33 @@ This compaction should PRIORITISE preserving all information related to the focu
                     _aux_context = self.context_length
             except Exception:
                 pass
-            # Persist the resolved auxiliary identity (the provider/model/
-            # base_url actually used on the wire) on the instance so callers
-            # that need to attribute a failure can read the *real* auxiliary
-            # endpoint rather than the main-model identity stored on
-            # self.provider / self.summary_model / self.base_url (#72636).
-            # These differ whenever auxiliary.compression.{provider,model,
-            # base_url} is configured separately from the main runtime.
-            self._last_aux_call_provider = _aux_provider or ""
-            self._last_aux_call_model = _aux_model or ""
-            self._last_aux_call_base_url = _aux_base_url or ""
+            # Reset the wire-route snapshot at the start of each attempt; the
+            # authoritative version is written by the route_callback inside
+            # call_llm AFTER the actual client is resolved (auto-detection,
+            # fallback chains, client.base_url). _resolve_task_provider_model
+            # above returns a config-layer guess that call_llm may override,
+            # so we do NOT persist it as the wire identity (#72636).
+            self._last_aux_call_provider = ""
+            self._last_aux_call_model = ""
+            self._last_aux_call_base_url = ""
+
+            def _record_aux_route(provider, model, base_url):
+                # Invoked by call_llm once the real client is built; this is
+                # the route actually used on the wire, after auto-detection /
+                # fallback. Strip any query string defensively — some proxies
+                # carry credentials as ?key=... and this value is surfaced in
+                # user-facing diagnostics on Telegram/Discord/Slack/CLI (#72636).
+                _safe_base = ""
+                if base_url:
+                    try:
+                        from agent.auxiliary_client import _extract_url_query_params
+                        _safe_base, _ = _extract_url_query_params(str(base_url))
+                    except Exception:
+                        _safe_base = str(base_url).split("?", 1)[0]
+                self._last_aux_call_provider = provider or ""
+                self._last_aux_call_model = model or ""
+                self._last_aux_call_base_url = _safe_base or ""
+
             # Compression is atomic: protect the in-flight summary call from a
             # mid-turn gateway interrupt. Without this, an incoming user message
             # aborts the summary and compression falls back to a degraded static
@@ -3938,7 +3955,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             _aux_call_start = time.monotonic()
             try:
                 with aux_interrupt_protection():
-                    response = call_llm(**call_kwargs)
+                    response = call_llm(route_callback=_record_aux_route, **call_kwargs)
             finally:
                 self._record_aux_compression_call(
                     prompt_messages=call_kwargs["messages"],

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3902,12 +3902,11 @@ This compaction should PRIORITISE preserving all information related to the focu
                 call_kwargs["model"] = self.summary_model
             _aux_provider = ""
             _aux_model = self.summary_model or ""
-            _aux_base_url: Optional[str] = None
             _aux_context = None
             try:
                 from agent.auxiliary_client import _resolve_task_provider_model
 
-                _resolved_provider, _resolved_model, _resolved_base_url, _, _ = (
+                _resolved_provider, _resolved_model, _, _, _ = (
                     _resolve_task_provider_model(
                         "compression",
                         model=(self.summary_model or ""),
@@ -3915,27 +3914,27 @@ This compaction should PRIORITISE preserving all information related to the focu
                 )
                 _aux_provider = _resolved_provider or ""
                 _aux_model = _resolved_model or _aux_model or self.model or ""
-                _aux_base_url = _resolved_base_url
                 if _aux_model == self.model:
                     _aux_context = self.context_length
             except Exception:
                 pass
             # Reset the wire-route snapshot at the start of each attempt; the
-            # authoritative version is written by the route_callback inside
-            # call_llm AFTER the actual client is resolved (auto-detection,
-            # fallback chains, client.base_url). _resolve_task_provider_model
-            # above returns a config-layer guess that call_llm may override,
-            # so we do NOT persist it as the wire identity (#72636).
+            # authoritative version is written by call_llm's route_callback
+            # before each physical request (auto-detection, retries, fallback
+            # chains, client.base_url). _resolve_task_provider_model above
+            # returns a config-layer guess that call_llm may override, so we do
+            # NOT persist it as the wire identity (#72636).
             self._last_aux_call_provider = ""
             self._last_aux_call_model = ""
             self._last_aux_call_base_url = ""
 
             def _record_aux_route(provider, model, base_url):
-                # Invoked by call_llm once the real client is built; this is
-                # the route actually used on the wire, after auto-detection /
-                # fallback. Strip any query string defensively — some proxies
-                # carry credentials as ?key=... and this value is surfaced in
-                # user-facing diagnostics on Telegram/Discord/Slack/CLI (#72636).
+                # Invoked before every call_llm physical request; the final
+                # callback is therefore the route that terminated the call,
+                # after auto-detection / fallback. Strip any query string
+                # defensively — some proxies carry credentials as ?key=... and
+                # this value is surfaced in user-facing diagnostics on
+                # Telegram/Discord/Slack/CLI (#72636).
                 _safe_base = ""
                 if base_url:
                     try:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2479,6 +2479,13 @@ class ContextCompressor(ContextEngine):
         self._last_aux_call_provider: str = ""
         self._last_aux_call_model: str = ""
         self._last_aux_call_base_url: str = ""
+        # Per-attempt failure classification ("auth" | "network" | "other" |
+        # None). Unlike _last_summary_auth_failure / _last_summary_network_failure,
+        # which are intentionally sticky across compress() calls to preserve
+        # the cooldown guard (see compress()), this field is reset at the top
+        # of every _generate_summary attempt so the abort diagnostic reflects
+        # the CURRENT attempt's failure mode, not a stale prior one (#72636).
+        self._last_attempt_failure_class: Optional[str] = None
         self._last_compression_telemetry: Optional[Dict[str, Any]] = None
         self._active_compression_telemetry: Optional[Dict[str, Any]] = None
         self._compression_telemetry_seed: Optional[Dict[str, Any]] = None
@@ -3864,6 +3871,12 @@ FOCUS TOPIC: "{focus_topic}"
 This compaction should PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
 
         try:
+            # Per-attempt reset: this attempt's failure classification must
+            # reflect THIS attempt's outcome, not a sticky prior one (#72636).
+            # _last_summary_auth_failure / _last_summary_network_failure stay
+            # sticky for the cooldown guard (see compress()); this field is the
+            # authoritative "what went wrong this attempt" for the abort path.
+            self._last_attempt_failure_class = None
             call_kwargs = {
                 "task": "compression",
                 "main_runtime": {
@@ -4066,6 +4079,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                 # Keep the established field name for caller compatibility;
                 # it now represents the broader terminal access/quota class.
                 self._last_summary_auth_failure = True
+                self._last_attempt_failure_class = "auth"
             if _is_json_decode and not _is_model_not_found and not _is_timeout:
                 logger.error(
                     "Context compression failed: auxiliary LLM returned a "
@@ -4160,6 +4174,13 @@ This compaction should PRIORITISE preserving all information related to the focu
             # the auth-failure carve-out; independent of abort_on_summary_failure.
             if _is_streaming_closed:
                 self._last_summary_network_failure = True
+                self._last_attempt_failure_class = "network"
+            elif self._last_attempt_failure_class is None:
+                # Any other transient failure (timeout, JSON decode, 5xx, ...)
+                # that reached this branch — not auth, not a network stream
+                # close. Classified so the abort diagnostic does not inherit a
+                # stale "auth" verdict from a prior attempt (#72636).
+                self._last_attempt_failure_class = "other"
             logger.warning(
                 "Failed to generate context summary: %s. "
                 "Further summary attempts paused for %d seconds.",

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2471,6 +2471,14 @@ class ContextCompressor(ContextEngine):
         # succeeded.  Silent recovery would hide the broken config.
         self._last_aux_model_failure_error: Optional[str] = None
         self._last_aux_model_failure_model: Optional[str] = None
+        # The auxiliary identity actually used on the wire for the most
+        # recent summary call — resolved from auxiliary.compression config
+        # by _resolve_task_provider_model, distinct from the main-model
+        # identity on self.provider / self.summary_model / self.base_url.
+        # Read by the compression-abort diagnostic (#72636).
+        self._last_aux_call_provider: str = ""
+        self._last_aux_call_model: str = ""
+        self._last_aux_call_base_url: str = ""
         self._last_compression_telemetry: Optional[Dict[str, Any]] = None
         self._active_compression_telemetry: Optional[Dict[str, Any]] = None
         self._compression_telemetry_seed: Optional[Dict[str, Any]] = None
@@ -3881,20 +3889,34 @@ This compaction should PRIORITISE preserving all information related to the focu
                 call_kwargs["model"] = self.summary_model
             _aux_provider = ""
             _aux_model = self.summary_model or ""
+            _aux_base_url: Optional[str] = None
             _aux_context = None
             try:
                 from agent.auxiliary_client import _resolve_task_provider_model
 
-                _resolved_provider, _resolved_model, _, _, _ = _resolve_task_provider_model(
-                    "compression",
-                    model=(self.summary_model or ""),
+                _resolved_provider, _resolved_model, _resolved_base_url, _, _ = (
+                    _resolve_task_provider_model(
+                        "compression",
+                        model=(self.summary_model or ""),
+                    )
                 )
                 _aux_provider = _resolved_provider or ""
                 _aux_model = _resolved_model or _aux_model or self.model or ""
+                _aux_base_url = _resolved_base_url
                 if _aux_model == self.model:
                     _aux_context = self.context_length
             except Exception:
                 pass
+            # Persist the resolved auxiliary identity (the provider/model/
+            # base_url actually used on the wire) on the instance so callers
+            # that need to attribute a failure can read the *real* auxiliary
+            # endpoint rather than the main-model identity stored on
+            # self.provider / self.summary_model / self.base_url (#72636).
+            # These differ whenever auxiliary.compression.{provider,model,
+            # base_url} is configured separately from the main runtime.
+            self._last_aux_call_provider = _aux_provider or ""
+            self._last_aux_call_model = _aux_model or ""
+            self._last_aux_call_base_url = _aux_base_url or ""
             # Compression is atomic: protect the in-flight summary call from a
             # mid-turn gateway interrupt. Without this, an incoming user message
             # aborts the summary and compression falls back to a degraded static

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1836,6 +1836,13 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         self._last_aux_call_provider: str = ""
         self._last_aux_call_model: str = ""
         self._last_aux_call_base_url: str = ""
+        # Per-attempt failure classification ("auth" | "network" | "other" |
+        # None). Unlike _last_summary_auth_failure / _last_summary_network_failure,
+        # which are intentionally sticky across compress() calls to preserve
+        # the cooldown guard (see compress()), this field is reset at the top
+        # of every summary attempt so the abort diagnostic reflects the
+        # CURRENT attempt's failure mode, not a stale prior one (#72636).
+        self._last_attempt_failure_class: Optional[str] = None
         self._consecutive_timeout_failures = 0
         # Turns unrecoverably dropped by a static fallback, so callers can warn.
         self._last_summary_dropped_count = 0
@@ -3183,6 +3190,12 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         """Issue the single aux summary call; return validated content text.
         Raises RuntimeError for empty content or a length-truncated (PARTIAL) summary so the failure
         routes through main-model fallback + cooldown instead of wiping the compacted turns."""
+        # Per-attempt reset: this attempt's failure classification must
+        # reflect THIS attempt's outcome, not a sticky prior one (#72636).
+        # _last_summary_auth_failure / _last_summary_network_failure stay
+        # sticky for the cooldown guard (see compress()); this field is the
+        # authoritative "what went wrong this attempt" for the abort path.
+        self._last_attempt_failure_class = None
         # call_llm writes the route it actually selected; never pre-resolve a second, stale pair.
         _aux_route: Dict[str, str] = {}
         call_kwargs: Dict[str, Any] = {
@@ -3505,6 +3518,7 @@ Write only the summary body. Do not include any preamble or prefix."""
         if _is_summary_access_or_quota_error(e):
             # Field name kept for caller compatibility; now covers the whole access/quota class.
             self._last_summary_auth_failure = True
+            self._last_attempt_failure_class = "auth"
         if kind.json_decode and not kind.model_not_found and not kind.timeout:
             logger.error(
                 "Context compression failed: auxiliary LLM returned a non-JSON response. provider=%s "
@@ -3536,10 +3550,21 @@ Write only the summary body. Do not include any preamble or prefix."""
             # destroying the middle window for a placeholder marker — retrying once the provider recovers is
             # strictly better than dropping context (#29559, #25585, #94448).
             self._last_summary_network_failure = True
+            self._last_attempt_failure_class = "network"
         elif kind.truncated:
             self._last_summary_truncated_failure = True
+            if self._last_attempt_failure_class is None:
+                self._last_attempt_failure_class = "other"
         elif kind.empty_content:
             self._last_summary_empty_content_failure = True
+            if self._last_attempt_failure_class is None:
+                self._last_attempt_failure_class = "other"
+        elif self._last_attempt_failure_class is None:
+            # Any other transient failure (timeout, JSON decode, 5xx, ...)
+            # that reached this branch — not auth, not a network stream
+            # close. Classified so the abort diagnostic does not inherit a
+            # stale "auth" verdict from a prior attempt (#72636).
+            self._last_attempt_failure_class = "other"
         logger.warning(
             "Failed to generate context summary: %s. Further summary attempts paused for %d seconds.", e,
             _transient_cooldown,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3243,9 +3243,33 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
                 _aux_context = self.context_length
         except Exception:
             pass
-        self._last_aux_call_provider = _aux_provider or ""
-        self._last_aux_call_model = _aux_model or ""
-        self._last_aux_call_base_url = _aux_base_url or ""
+        # Reset the wire-route snapshot at the start of each attempt; the
+        # authoritative version is written by the route_callback inside
+        # call_llm AFTER the actual client is resolved (auto-detection,
+        # fallback chains, client.base_url). _resolve_task_provider_model
+        # above returns a config-layer guess that call_llm may override,
+        # so we do NOT persist it as the wire identity (#72636).
+        self._last_aux_call_provider = ""
+        self._last_aux_call_model = ""
+        self._last_aux_call_base_url = ""
+
+        def _record_aux_route(provider, model, base_url):
+            # Invoked by call_llm once the real client is built; this is
+            # the route actually used on the wire, after auto-detection /
+            # fallback. Strip any query string defensively — some proxies
+            # carry credentials as ?key=... and this value is surfaced in
+            # user-facing diagnostics on Telegram/Discord/Slack/CLI (#72636).
+            _safe_base = ""
+            if base_url:
+                try:
+                    from agent.auxiliary_client import _extract_url_query_params
+                    _safe_base, _ = _extract_url_query_params(str(base_url))
+                except Exception:
+                    _safe_base = str(base_url).split("?", 1)[0]
+            self._last_aux_call_provider = provider or ""
+            self._last_aux_call_model = model or ""
+            self._last_aux_call_base_url = _safe_base or ""
+
         # Compression is atomic: protect the in-flight summary call from a mid-turn gateway interrupt.
         # Without this, an incoming user message aborts the summary and compression falls back to a degraded
         # static marker, losing the real handoff (#23975). Re-entrant: a main-model retry (_generate_summary
@@ -3256,7 +3280,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         try:
             # Compression is atomic: shield the summary call from gateway interrupts. Re-entrant.
             with aux_interrupt_protection():
-                response = call_llm(**call_kwargs)
+                response = call_llm(route_callback=_record_aux_route, **call_kwargs)
         finally:
             route_known = bool(_aux_route.get("provider") and _aux_route.get("model"))
             _aux_model = _aux_route.get("model") or self.summary_model or self.model or ""

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1828,6 +1828,14 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         # A handoff may carry role="user" only for alternation, so role alone can't prove a human turn existed.
         self._previous_summary = self._summary_has_user_turn = self._last_summary_error = None
         self._last_aux_model_failure_error = self._last_aux_model_failure_model = None
+        # The auxiliary identity actually used on the wire for the most
+        # recent summary call — resolved from auxiliary.compression config
+        # by _resolve_task_provider_model, distinct from the main-model
+        # identity on self.provider / self.summary_model / self.base_url.
+        # Read by the compression-abort diagnostic (#72636).
+        self._last_aux_call_provider: str = ""
+        self._last_aux_call_model: str = ""
+        self._last_aux_call_base_url: str = ""
         self._consecutive_timeout_failures = 0
         # Turns unrecoverably dropped by a static fallback, so callers can warn.
         self._last_summary_dropped_count = 0
@@ -3191,6 +3199,40 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             call_kwargs["model"] = self.summary_model
         # Pinned route (stall fallback) overrides task routing so the retry leaves the stalled backend.
         call_kwargs.update(_pinned_summary_call_kwargs())
+        # Failure attribution (#72636): resolve the auxiliary identity
+        # BEFORE dispatch and persist it on the instance. Auth errors that
+        # abort the call pre-dispatch never populate ``_aux_route``, so
+        # callers attributing the failure need the resolved provider/
+        # model/base_url rather than the main-model identity stored on
+        # self.provider / self.summary_model / self.base_url. These differ
+        # whenever auxiliary.compression.{provider,model,base_url} is
+        # configured separately from the main runtime.
+        # Attribution-only: never fed back into ``call_kwargs`` — the wire
+        # route stays whatever ``call_llm`` selects and records in
+        # ``_aux_route``.
+        _aux_provider = ""
+        _aux_model = self.summary_model or ""
+        _aux_base_url: Optional[str] = None
+        _aux_context = None
+        try:
+            from agent.auxiliary_client import _resolve_task_provider_model
+
+            _resolved_provider, _resolved_model, _resolved_base_url, _, _ = (
+                _resolve_task_provider_model(
+                    "compression",
+                    model=(self.summary_model or ""),
+                )
+            )
+            _aux_provider = _resolved_provider or ""
+            _aux_model = _resolved_model or _aux_model or self.model or ""
+            _aux_base_url = _resolved_base_url
+            if _aux_model == self.model:
+                _aux_context = self.context_length
+        except Exception:
+            pass
+        self._last_aux_call_provider = _aux_provider or ""
+        self._last_aux_call_model = _aux_model or ""
+        self._last_aux_call_base_url = _aux_base_url or ""
         # Compression is atomic: protect the in-flight summary call from a mid-turn gateway interrupt.
         # Without this, an incoming user message aborts the summary and compression falls back to a degraded
         # static marker, losing the real handoff (#23975). Re-entrant: a main-model retry (_generate_summary

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1836,6 +1836,17 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         self._last_aux_call_provider: str = ""
         self._last_aux_call_model: str = ""
         self._last_aux_call_base_url: str = ""
+        # The CONFIG-layer auxiliary identity (provider/model/base_url as
+        # declared under auxiliary.compression), captured per attempt. Used
+        # only when no physical request was dispatched (e.g. an explicit
+        # provider whose API key is missing fails before the client is
+        # built) to distinguish "configured but pre-dispatch failure" from
+        # "auxiliary.compression not set at all" — the latter is the only
+        # case where the diagnostic may fall back to the main-model
+        # identity (#72636).
+        self._last_aux_config_provider: str = ""
+        self._last_aux_config_model: str = ""
+        self._last_aux_config_base_url: str = ""
         # Per-attempt failure classification ("auth" | "network" | "other" |
         # None). Unlike _last_summary_auth_failure / _last_summary_network_failure,
         # which are intentionally sticky across compress() calls to preserve
@@ -3226,10 +3237,11 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         _aux_provider = ""
         _aux_model = self.summary_model or ""
         _aux_context = None
+        _resolved_base = None
         try:
             from agent.auxiliary_client import _resolve_task_provider_model
 
-            _resolved_provider, _resolved_model, _, _, _ = (
+            _resolved_provider, _resolved_model, _resolved_base, _, _ = (
                 _resolve_task_provider_model(
                     "compression",
                     model=(self.summary_model or ""),
@@ -3250,6 +3262,28 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self._last_aux_call_provider = ""
         self._last_aux_call_model = ""
         self._last_aux_call_base_url = ""
+        # Config-layer identity: what auxiliary.compression is DECLARED to
+        # use, captured before dispatch. Populated only when an explicit
+        # provider is configured — when the task is unset the resolution
+        # returns "auto" and the summary call inherits the main-model
+        # identity. Used when no physical request was dispatched (e.g. the
+        # explicit provider's API key is missing) so the abort diagnostic
+        # reports the configured auxiliary identity as a pre-dispatch
+        # failure instead of substituting the main endpoint (#72636).
+        self._last_aux_config_provider = ""
+        self._last_aux_config_model = ""
+        self._last_aux_config_base_url = ""
+        if _aux_provider not in ("", "auto", None):
+            _cfg_base = str(_resolved_base or "")
+            if _cfg_base:
+                try:
+                    from agent.auxiliary_client import _extract_url_query_params
+                    _cfg_base, _ = _extract_url_query_params(_cfg_base)
+                except Exception:
+                    _cfg_base = _cfg_base.split("?", 1)[0]
+            self._last_aux_config_provider = str(_aux_provider)
+            self._last_aux_config_model = str(_aux_model or "")
+            self._last_aux_config_base_url = _cfg_base
 
         def _record_aux_route(provider, model, base_url):
             # Invoked before every call_llm physical request; the final

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3225,12 +3225,11 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         # ``_aux_route``.
         _aux_provider = ""
         _aux_model = self.summary_model or ""
-        _aux_base_url: Optional[str] = None
         _aux_context = None
         try:
             from agent.auxiliary_client import _resolve_task_provider_model
 
-            _resolved_provider, _resolved_model, _resolved_base_url, _, _ = (
+            _resolved_provider, _resolved_model, _, _, _ = (
                 _resolve_task_provider_model(
                     "compression",
                     model=(self.summary_model or ""),
@@ -3238,27 +3237,27 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             )
             _aux_provider = _resolved_provider or ""
             _aux_model = _resolved_model or _aux_model or self.model or ""
-            _aux_base_url = _resolved_base_url
             if _aux_model == self.model:
                 _aux_context = self.context_length
         except Exception:
             pass
         # Reset the wire-route snapshot at the start of each attempt; the
-        # authoritative version is written by the route_callback inside
-        # call_llm AFTER the actual client is resolved (auto-detection,
-        # fallback chains, client.base_url). _resolve_task_provider_model
-        # above returns a config-layer guess that call_llm may override,
-        # so we do NOT persist it as the wire identity (#72636).
+        # authoritative version is written by call_llm's route_callback
+        # before each physical request (auto-detection, retries, fallback
+        # chains, client.base_url). _resolve_task_provider_model above
+        # returns a config-layer guess that call_llm may override, so we do
+        # NOT persist it as the wire identity (#72636).
         self._last_aux_call_provider = ""
         self._last_aux_call_model = ""
         self._last_aux_call_base_url = ""
 
         def _record_aux_route(provider, model, base_url):
-            # Invoked by call_llm once the real client is built; this is
-            # the route actually used on the wire, after auto-detection /
-            # fallback. Strip any query string defensively — some proxies
-            # carry credentials as ?key=... and this value is surfaced in
-            # user-facing diagnostics on Telegram/Discord/Slack/CLI (#72636).
+            # Invoked before every call_llm physical request; the final
+            # callback is therefore the route that terminated the call,
+            # after auto-detection / fallback. Strip any query string
+            # defensively — some proxies carry credentials as ?key=... and
+            # this value is surfaced in user-facing diagnostics on
+            # Telegram/Discord/Slack/CLI (#72636).
             _safe_base = ""
             if base_url:
                 try:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2130,39 +2130,57 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     """Surface the compression auxiliary's own provider/model/endpoint when
     compression aborted on an auxiliary auth/quota failure (#72636).
 
-    The compressor records the failing identity on itself
-    (``provider`` / ``summary_model`` / ``base_url``); the surrounding
-    "Compression aborted" warning already says *that* something failed,
-    but with an auxiliary summary model the main-model identity
-    (``agent.provider`` / ``agent.model`` / ``agent.base_url``) is the
-    wrong one to chase. This companion block points the user at the
-    actual compression endpoint to fix.
+    The identity actually used on the wire for the summary call is
+    resolved from ``auxiliary.compression`` config by
+    ``_resolve_task_provider_model`` and recorded on the compressor as
+    ``_last_aux_call_provider`` / ``_last_aux_call_model`` /
+    ``_last_aux_call_base_url``. This is *not* the same as
+    ``compressor.provider`` / ``compressor.summary_model`` /
+    ``compressor.base_url`` — those carry the *main* model's identity
+    (the compressor is initialized against the main runtime), so reading
+    them here would point the user at the wrong endpoint whenever the
+    compression auxiliary is configured separately. The surrounding
+    "Compression aborted" warning says *that* something failed; this
+    companion block says *which* endpoint to fix.
 
     Called only from the compression-abort branch in
     :func:`compress_context`. The helper runs after the current
     compression attempt has completed, avoiding the pre-request and
     unrelated-main-error ordering problems that an earlier call site
-    in the main-model API-error path introduced.
+    in the main-model API-error path introduced. The identity fields
+    are populated before the summary ``call_llm`` fires, so they are
+    fresh at this call site.
 
     Silent when no compressor is attached or the abort was not an auth
-    failure (the gate is ``_last_summary_auth_failure``). Tolerates a
-    misbehaving compressor missing any of the three identity fields via
-    ``getattr`` defaults so this diagnostic can never mask the abort
-    warning itself.
+    failure (the gate is ``_last_summary_auth_failure``). Falls back to
+    the main-model identity when no separate auxiliary was resolved
+    (``auxiliary.compression`` unset / ``auto``) and says so explicitly,
+    rather than silently reporting a wrong endpoint.
     """
     _ctx_comp = getattr(agent, "context_compressor", None)
     if _ctx_comp is None or not getattr(_ctx_comp, "_last_summary_auth_failure", False):
         return
 
-    _comp_provider = getattr(_ctx_comp, "provider", "auto") or "auto"
-    _comp_model = getattr(_ctx_comp, "summary_model", "unknown") or "unknown"
-    _comp_base = getattr(_ctx_comp, "base_url", "unknown") or "unknown"
+    _aux_provider = (getattr(_ctx_comp, "_last_aux_call_provider", "") or "").strip()
+    _aux_model = (getattr(_ctx_comp, "_last_aux_call_model", "") or "").strip()
+    _aux_base = (getattr(_ctx_comp, "_last_aux_call_base_url", "") or "").strip()
+
+    # When auxiliary.compression is unset / "auto", the summary call runs
+    # against the main model — report that honestly instead of inventing a
+    # phantom auxiliary endpoint.
+    if not _aux_provider and not _aux_model and not _aux_base:
+        _aux_provider = (getattr(_ctx_comp, "provider", "") or "auto").strip() or "auto"
+        _aux_model = (getattr(_ctx_comp, "model", "") or "unknown").strip() or "unknown"
+        _aux_base = (getattr(_ctx_comp, "base_url", "") or "unknown").strip() or "unknown"
+        _note = " (auxiliary.compression is not configured — using main model)"
+    else:
+        _note = ""
 
     agent._emit_warning(
         f"⚠ Auxiliary compression model failed with an auth/permission "
         f"error — check auxiliary.compression in config.yaml. "
-        f"🔌 Provider: {_comp_provider}  Model: {_comp_model}  "
-        f"🌐 Endpoint: {_comp_base}"
+        f"🔌 Provider: {_aux_provider}  Model: {_aux_model}  "
+        f"🌐 Endpoint: {_aux_base}{_note}"
     )
 
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2131,10 +2131,10 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     compression aborted on the auxiliary summary call (#72636).
 
     The identity ACTUALLY used on the wire is recorded by
-    ``call_llm``'s ``route_callback`` — invoked after the real client is
-    built (auto-detection, fallback chains, and ``client.base_url``
-    applied), so it reflects the route the failed request really took,
-    not the config-layer pre-resolution from
+    ``call_llm``'s ``route_callback`` — invoked before every physical wire
+    attempt after the real client is built (auto-detection, fallback chains,
+    and ``client.base_url`` applied), so the final snapshot reflects the route
+    the failed request really took, not the config-layer pre-resolution from
     ``_resolve_task_provider_model`` (which ``call_llm`` may override).
     The callback writes ``_last_aux_call_provider`` /
     ``_last_aux_call_model`` / ``_last_aux_call_base_url`` on the

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2126,6 +2126,46 @@ def finalize_context_engine_compression_notification(
     return bool(pending())
 
 
+def _emit_compression_auth_hint(agent: Any) -> None:
+    """Surface the compression auxiliary's own provider/model/endpoint when
+    compression aborted on an auxiliary auth/quota failure (#72636).
+
+    The compressor records the failing identity on itself
+    (``provider`` / ``summary_model`` / ``base_url``); the surrounding
+    "Compression aborted" warning already says *that* something failed,
+    but with an auxiliary summary model the main-model identity
+    (``agent.provider`` / ``agent.model`` / ``agent.base_url``) is the
+    wrong one to chase. This companion block points the user at the
+    actual compression endpoint to fix.
+
+    Called only from the compression-abort branch in
+    :func:`compress_context`. The helper runs after the current
+    compression attempt has completed, avoiding the pre-request and
+    unrelated-main-error ordering problems that an earlier call site
+    in the main-model API-error path introduced.
+
+    Silent when no compressor is attached or the abort was not an auth
+    failure (the gate is ``_last_summary_auth_failure``). Tolerates a
+    misbehaving compressor missing any of the three identity fields via
+    ``getattr`` defaults so this diagnostic can never mask the abort
+    warning itself.
+    """
+    _ctx_comp = getattr(agent, "context_compressor", None)
+    if _ctx_comp is None or not getattr(_ctx_comp, "_last_summary_auth_failure", False):
+        return
+
+    _comp_provider = getattr(_ctx_comp, "provider", "auto") or "auto"
+    _comp_model = getattr(_ctx_comp, "summary_model", "unknown") or "unknown"
+    _comp_base = getattr(_ctx_comp, "base_url", "unknown") or "unknown"
+
+    agent._emit_warning(
+        f"⚠ Auxiliary compression model failed with an auth/permission "
+        f"error — check auxiliary.compression in config.yaml. "
+        f"🔌 Provider: {_comp_provider}  Model: {_comp_model}  "
+        f"🌐 Endpoint: {_comp_base}"
+    )
+
+
 def compress_context(
     agent: Any,
     messages: list,
@@ -2955,6 +2995,12 @@ def compress_context(
                         "No messages were dropped — conversation continues unchanged. "
                         "Run /compress to retry, or /new to start a fresh session."
                     )
+                # When the abort was caused by an auxiliary compression-model
+                # auth/quota failure, point at the *compression* endpoint —
+                # agent.provider/model/base_url are the main model's, which is
+                # the wrong thing to chase (#72636). The flag is set during
+                # summary generation, so it is fresh at this call site.
+                _emit_compression_auth_hint(agent)
                 _existing_sp = getattr(agent, "_cached_system_prompt", None)
                 if not _existing_sp:
                     _existing_sp = agent._build_system_prompt(system_message)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2130,26 +2130,27 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     """Surface the compression auxiliary's own provider/model/endpoint when
     compression aborted on the auxiliary summary call (#72636).
 
-    The identity actually used on the wire for the summary call is
-    resolved from ``auxiliary.compression`` config by
-    ``_resolve_task_provider_model`` and recorded on the compressor as
-    ``_last_aux_call_provider`` / ``_last_aux_call_model`` /
-    ``_last_aux_call_base_url``. This is *not* the same as
-    ``compressor.provider`` / ``compressor.summary_model`` /
-    ``compressor.base_url`` — those carry the *main* model's identity
-    (the compressor is initialized against the main runtime), so reading
-    them here would point the user at the wrong endpoint whenever the
-    compression auxiliary is configured separately. The surrounding
-    "Compression aborted" warning says *that* something failed; this
-    companion block says *which* endpoint to fix.
+    The identity ACTUALLY used on the wire is recorded by
+    ``call_llm``'s ``route_callback`` — invoked after the real client is
+    built (auto-detection, fallback chains, and ``client.base_url``
+    applied), so it reflects the route the failed request really took,
+    not the config-layer pre-resolution from
+    ``_resolve_task_provider_model`` (which ``call_llm`` may override).
+    The callback writes ``_last_aux_call_provider`` /
+    ``_last_aux_call_model`` / ``_last_aux_call_base_url`` on the
+    compressor, with the base_url query-stripped to avoid leaking
+    credentials that some proxies carry as ``?key=...``. This is *not*
+    the same as ``compressor.provider`` / ``compressor.summary_model`` /
+    ``compressor.base_url`` — those carry the *main* model's identity.
+
+    The surrounding "Compression aborted" warning says *that* something
+    failed; this companion block says *which* endpoint to fix.
 
     Called only from the compression-abort branch in
     :func:`compress_context`. The helper runs after the current
     compression attempt has completed, avoiding the pre-request and
     unrelated-main-error ordering problems that an earlier call site
-    in the main-model API-error path introduced. The identity fields
-    are populated before the summary ``call_llm`` fires, so they are
-    fresh at this call site.
+    in the main-model API-error path introduced.
 
     The gate is the per-attempt ``_last_attempt_failure_class`` (reset at
     the top of every ``_generate_summary`` attempt), NOT the sticky
@@ -2158,9 +2159,10 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     followed by a forced retry that fails with a 500 would otherwise be
     mis-attributed as an auth failure (#72636).
 
-    Falls back to the main-model identity when no separate auxiliary was
-    resolved (``auxiliary.compression`` unset / ``auto``) and says so
-    explicitly, rather than silently reporting a wrong endpoint.
+    When the route_callback never fired (e.g. ``call_llm`` raised "no
+    provider configured" before a client existed), the identity fields
+    stay empty and the diagnostic falls back to the main-model identity
+    with an explicit note, rather than inventing a phantom endpoint.
 
     Wording is chosen to pass the gateway noise filter
     (``_TELEGRAM_NOISY_STATUS_RE``) — it must NOT match
@@ -2179,9 +2181,13 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     _aux_model = (getattr(_ctx_comp, "_last_aux_call_model", "") or "").strip()
     _aux_base = (getattr(_ctx_comp, "_last_aux_call_base_url", "") or "").strip()
 
-    # When auxiliary.compression is unset / "auto", the summary call runs
-    # against the main model — report that honestly instead of inventing a
-    # phantom auxiliary endpoint.
+    # _last_aux_call_* is written by call_llm's route_callback after the real
+    # client is built (auto-detection / fallback applied). When the callback
+    # never fired — e.g. call_llm raised "no provider configured" before a
+    # client existed — the fields stay empty; fall back to the main-model
+    # identity and say so, rather than inventing a phantom endpoint. A non-
+    # empty "auto" provider here is a REAL auto-chain route, not a missing
+    # config, so it is reported as-is.
     if not _aux_provider and not _aux_model and not _aux_base:
         _aux_provider = (getattr(_ctx_comp, "provider", "") or "auto").strip() or "auto"
         _aux_model = (getattr(_ctx_comp, "model", "") or "unknown").strip() or "unknown"

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2128,7 +2128,7 @@ def finalize_context_engine_compression_notification(
 
 def _emit_compression_auth_hint(agent: Any) -> None:
     """Surface the compression auxiliary's own provider/model/endpoint when
-    compression aborted on an auxiliary auth/quota failure (#72636).
+    compression aborted on the auxiliary summary call (#72636).
 
     The identity actually used on the wire for the summary call is
     resolved from ``auxiliary.compression`` config by
@@ -2151,14 +2151,28 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     are populated before the summary ``call_llm`` fires, so they are
     fresh at this call site.
 
-    Silent when no compressor is attached or the abort was not an auth
-    failure (the gate is ``_last_summary_auth_failure``). Falls back to
-    the main-model identity when no separate auxiliary was resolved
-    (``auxiliary.compression`` unset / ``auto``) and says so explicitly,
-    rather than silently reporting a wrong endpoint.
+    The gate is the per-attempt ``_last_attempt_failure_class`` (reset at
+    the top of every ``_generate_summary`` attempt), NOT the sticky
+    ``_last_summary_auth_failure`` — that flag intentionally persists
+    across compress() calls to protect the cooldown guard, so a 401
+    followed by a forced retry that fails with a 500 would otherwise be
+    mis-attributed as an auth failure (#72636).
+
+    Falls back to the main-model identity when no separate auxiliary was
+    resolved (``auxiliary.compression`` unset / ``auto``) and says so
+    explicitly, rather than silently reporting a wrong endpoint.
+
+    Wording is chosen to pass the gateway noise filter
+    (``_TELEGRAM_NOISY_STATUS_RE``) — it must NOT match
+    ``auxiliary\\s+.+\\s+failed`` / ``compression\\s+summary\\s+failed``
+    patterns, otherwise messaging platforms (Telegram/Discord/Slack)
+    silently swallow the diagnostic and the user never sees it.
     """
     _ctx_comp = getattr(agent, "context_compressor", None)
-    if _ctx_comp is None or not getattr(_ctx_comp, "_last_summary_auth_failure", False):
+    if _ctx_comp is None:
+        return
+    _cls = getattr(_ctx_comp, "_last_attempt_failure_class", None)
+    if _cls not in ("auth", "network", "other"):
         return
 
     _aux_provider = (getattr(_ctx_comp, "_last_aux_call_provider", "") or "").strip()
@@ -2176,9 +2190,22 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     else:
         _note = ""
 
+    # Per-class guidance. Wording avoids the gateway noise-filter patterns
+    # (notably "auxiliary ... failed" and "compression summary failed") so
+    # the message reaches Telegram/Discord/Slack, not just local/CLI.
+    if _cls == "auth":
+        _guidance = (
+            "auth/permission error — check the credential and "
+            "auxiliary.compression in config.yaml"
+        )
+    elif _cls == "network":
+        _guidance = "network/connection error — this is usually transient"
+    else:
+        _guidance = "error — see agent.log for detail"
+
     agent._emit_warning(
-        f"⚠ Auxiliary compression model failed with an auth/permission "
-        f"error — check auxiliary.compression in config.yaml. "
+        f"⚠ Compression auxiliary endpoint could not be reached "
+        f"({_guidance}). "
         f"🔌 Provider: {_aux_provider}  Model: {_aux_model}  "
         f"🌐 Endpoint: {_aux_base}{_note}"
     )
@@ -3013,11 +3040,10 @@ def compress_context(
                         "No messages were dropped — conversation continues unchanged. "
                         "Run /compress to retry, or /new to start a fresh session."
                     )
-                # When the abort was caused by an auxiliary compression-model
-                # auth/quota failure, point at the *compression* endpoint —
-                # agent.provider/model/base_url are the main model's, which is
-                # the wrong thing to chase (#72636). The flag is set during
-                # summary generation, so it is fresh at this call site.
+                # Point at the *compression* endpoint that failed, not the
+                # main model's identity (agent.provider/model/base_url are the
+                # main model's). The helper gates on the per-attempt failure
+                # class and is silent when no useful attribution applies (#72636).
                 _emit_compression_auth_hint(agent)
                 _existing_sp = getattr(agent, "_cached_system_prompt", None)
                 if not _existing_sp:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2342,6 +2342,17 @@ def _emit_compression_auth_hint(agent: Any) -> None:
         if _pre_dispatch
         else "⚠ Compression auxiliary endpoint could not be reached "
     )
+    # Sanitize at the SINK, regardless of which producer filled _aux_base.
+    # The route_callback and config-layer captures strip the query at their
+    # sources, but the no-route/no-explicit-aux fallback above reads
+    # compressor.base_url (the MAIN model's URL) raw — and some proxies carry
+    # credentials as ?key=... (#72636 review, defect 2). A user-facing
+    # diagnostic must never be one forgetful producer away from leaking one.
+    try:
+        from agent.auxiliary_client import _extract_url_query_params
+        _aux_base, _ = _extract_url_query_params(_aux_base)
+    except Exception:
+        _aux_base = str(_aux_base).split("?", 1)[0]
     agent._emit_warning(
         f"{_headline}"
         f"({_guidance}). "

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2237,39 +2237,57 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     """Surface the compression auxiliary's own provider/model/endpoint when
     compression aborted on an auxiliary auth/quota failure (#72636).
 
-    The compressor records the failing identity on itself
-    (``provider`` / ``summary_model`` / ``base_url``); the surrounding
-    "Compression aborted" warning already says *that* something failed,
-    but with an auxiliary summary model the main-model identity
-    (``agent.provider`` / ``agent.model`` / ``agent.base_url``) is the
-    wrong one to chase. This companion block points the user at the
-    actual compression endpoint to fix.
+    The identity actually used on the wire for the summary call is
+    resolved from ``auxiliary.compression`` config by
+    ``_resolve_task_provider_model`` and recorded on the compressor as
+    ``_last_aux_call_provider`` / ``_last_aux_call_model`` /
+    ``_last_aux_call_base_url``. This is *not* the same as
+    ``compressor.provider`` / ``compressor.summary_model`` /
+    ``compressor.base_url`` — those carry the *main* model's identity
+    (the compressor is initialized against the main runtime), so reading
+    them here would point the user at the wrong endpoint whenever the
+    compression auxiliary is configured separately. The surrounding
+    "Compression aborted" warning says *that* something failed; this
+    companion block says *which* endpoint to fix.
 
     Called only from the compression-abort branch of
     :func:`_candidate_rejected`. The helper runs after the current
     compression attempt has completed, avoiding the pre-request and
     unrelated-main-error ordering problems that an earlier call site
-    in the main-model API-error path introduced.
+    in the main-model API-error path introduced. The identity fields
+    are populated before the summary ``call_llm`` fires, so they are
+    fresh at this call site.
 
     Silent when no compressor is attached or the abort was not an auth
-    failure (the gate is ``_last_summary_auth_failure``). Tolerates a
-    misbehaving compressor missing any of the three identity fields via
-    ``getattr`` defaults so this diagnostic can never mask the abort
-    warning itself.
+    failure (the gate is ``_last_summary_auth_failure``). Falls back to
+    the main-model identity when no separate auxiliary was resolved
+    (``auxiliary.compression`` unset / ``auto``) and says so explicitly,
+    rather than silently reporting a wrong endpoint.
     """
     _ctx_comp = getattr(agent, "context_compressor", None)
     if _ctx_comp is None or not getattr(_ctx_comp, "_last_summary_auth_failure", False):
         return
 
-    _comp_provider = getattr(_ctx_comp, "provider", "auto") or "auto"
-    _comp_model = getattr(_ctx_comp, "summary_model", "unknown") or "unknown"
-    _comp_base = getattr(_ctx_comp, "base_url", "unknown") or "unknown"
+    _aux_provider = (getattr(_ctx_comp, "_last_aux_call_provider", "") or "").strip()
+    _aux_model = (getattr(_ctx_comp, "_last_aux_call_model", "") or "").strip()
+    _aux_base = (getattr(_ctx_comp, "_last_aux_call_base_url", "") or "").strip()
+
+    # When auxiliary.compression is unset / "auto", the summary call runs
+    # against the main model — report that honestly instead of inventing a
+    # phantom auxiliary endpoint.
+    if not _aux_provider and not _aux_model and not _aux_base:
+        _aux_provider = (getattr(_ctx_comp, "provider", "") or "auto").strip() or "auto"
+        _aux_model = (getattr(_ctx_comp, "model", "") or "unknown").strip() or "unknown"
+        _aux_base = (getattr(_ctx_comp, "base_url", "") or "unknown").strip() or "unknown"
+        _note = " (auxiliary.compression is not configured — using main model)"
+    else:
+        _note = ""
 
     agent._emit_warning(
         f"⚠ Auxiliary compression model failed with an auth/permission "
         f"error — check auxiliary.compression in config.yaml. "
-        f"🔌 Provider: {_comp_provider}  Model: {_comp_model}  "
-        f"🌐 Endpoint: {_comp_base}"
+        f"🔌 Provider: {_aux_provider}  Model: {_aux_model}  "
+        f"🌐 Endpoint: {_aux_base}{_note}"
     )
 
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2235,7 +2235,7 @@ def finalize_context_engine_compression_notification(agent: Any, *, committed: b
 
 def _emit_compression_auth_hint(agent: Any) -> None:
     """Surface the compression auxiliary's own provider/model/endpoint when
-    compression aborted on an auxiliary auth/quota failure (#72636).
+    compression aborted on the auxiliary summary call (#72636).
 
     The identity actually used on the wire for the summary call is
     resolved from ``auxiliary.compression`` config by
@@ -2258,14 +2258,28 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     are populated before the summary ``call_llm`` fires, so they are
     fresh at this call site.
 
-    Silent when no compressor is attached or the abort was not an auth
-    failure (the gate is ``_last_summary_auth_failure``). Falls back to
-    the main-model identity when no separate auxiliary was resolved
-    (``auxiliary.compression`` unset / ``auto``) and says so explicitly,
-    rather than silently reporting a wrong endpoint.
+    The gate is the per-attempt ``_last_attempt_failure_class`` (reset at
+    the top of every ``_generate_summary`` attempt), NOT the sticky
+    ``_last_summary_auth_failure`` — that flag intentionally persists
+    across compress() calls to protect the cooldown guard, so a 401
+    followed by a forced retry that fails with a 500 would otherwise be
+    mis-attributed as an auth failure (#72636).
+
+    Falls back to the main-model identity when no separate auxiliary was
+    resolved (``auxiliary.compression`` unset / ``auto``) and says so
+    explicitly, rather than silently reporting a wrong endpoint.
+
+    Wording is chosen to pass the gateway noise filter
+    (``_TELEGRAM_NOISY_STATUS_RE``) — it must NOT match
+    ``auxiliary\\s+.+\\s+failed`` / ``compression\\s+summary\\s+failed``
+    patterns, otherwise messaging platforms (Telegram/Discord/Slack)
+    silently swallow the diagnostic and the user never sees it.
     """
     _ctx_comp = getattr(agent, "context_compressor", None)
-    if _ctx_comp is None or not getattr(_ctx_comp, "_last_summary_auth_failure", False):
+    if _ctx_comp is None:
+        return
+    _cls = getattr(_ctx_comp, "_last_attempt_failure_class", None)
+    if _cls not in ("auth", "network", "other"):
         return
 
     _aux_provider = (getattr(_ctx_comp, "_last_aux_call_provider", "") or "").strip()
@@ -2283,9 +2297,22 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     else:
         _note = ""
 
+    # Per-class guidance. Wording avoids the gateway noise-filter patterns
+    # (notably "auxiliary ... failed" and "compression summary failed") so
+    # the message reaches Telegram/Discord/Slack, not just local/CLI.
+    if _cls == "auth":
+        _guidance = (
+            "auth/permission error — check the credential and "
+            "auxiliary.compression in config.yaml"
+        )
+    elif _cls == "network":
+        _guidance = "network/connection error — this is usually transient"
+    else:
+        _guidance = "error — see agent.log for detail"
+
     agent._emit_warning(
-        f"⚠ Auxiliary compression model failed with an auth/permission "
-        f"error — check auxiliary.compression in config.yaml. "
+        f"⚠ Compression auxiliary endpoint could not be reached "
+        f"({_guidance}). "
         f"🔌 Provider: {_aux_provider}  Model: {_aux_model}  "
         f"🌐 Endpoint: {_aux_base}{_note}"
     )
@@ -3208,11 +3235,10 @@ def _candidate_rejected(
                 "No messages were dropped — conversation continues unchanged. "
                 "Run /compress to retry, or /new to start a fresh session."
             )
-        # When the abort was caused by an auxiliary compression-model
-        # auth/quota failure, point at the *compression* endpoint —
-        # agent.provider/model/base_url are the main model's, which is
-        # the wrong thing to chase (#72636). The flag is set during
-        # summary generation, so it is fresh at this call site.
+        # Point at the *compression* endpoint that failed, not the
+        # main model's identity (agent.provider/model/base_url are the
+        # main model's). The helper gates on the per-attempt failure
+        # class and is silent when no useful attribution applies (#72636).
         _emit_compression_auth_hint(agent)
         _emit_aborted_attempt_telemetry(
             agent, attempt_started_at, _summary_error and "summary_generation_aborted"

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2233,6 +2233,46 @@ def finalize_context_engine_compression_notification(agent: Any, *, committed: b
     return bool(pending())
 
 
+def _emit_compression_auth_hint(agent: Any) -> None:
+    """Surface the compression auxiliary's own provider/model/endpoint when
+    compression aborted on an auxiliary auth/quota failure (#72636).
+
+    The compressor records the failing identity on itself
+    (``provider`` / ``summary_model`` / ``base_url``); the surrounding
+    "Compression aborted" warning already says *that* something failed,
+    but with an auxiliary summary model the main-model identity
+    (``agent.provider`` / ``agent.model`` / ``agent.base_url``) is the
+    wrong one to chase. This companion block points the user at the
+    actual compression endpoint to fix.
+
+    Called only from the compression-abort branch of
+    :func:`_candidate_rejected`. The helper runs after the current
+    compression attempt has completed, avoiding the pre-request and
+    unrelated-main-error ordering problems that an earlier call site
+    in the main-model API-error path introduced.
+
+    Silent when no compressor is attached or the abort was not an auth
+    failure (the gate is ``_last_summary_auth_failure``). Tolerates a
+    misbehaving compressor missing any of the three identity fields via
+    ``getattr`` defaults so this diagnostic can never mask the abort
+    warning itself.
+    """
+    _ctx_comp = getattr(agent, "context_compressor", None)
+    if _ctx_comp is None or not getattr(_ctx_comp, "_last_summary_auth_failure", False):
+        return
+
+    _comp_provider = getattr(_ctx_comp, "provider", "auto") or "auto"
+    _comp_model = getattr(_ctx_comp, "summary_model", "unknown") or "unknown"
+    _comp_base = getattr(_ctx_comp, "base_url", "unknown") or "unknown"
+
+    agent._emit_warning(
+        f"⚠ Auxiliary compression model failed with an auth/permission "
+        f"error — check auxiliary.compression in config.yaml. "
+        f"🔌 Provider: {_comp_provider}  Model: {_comp_model}  "
+        f"🌐 Endpoint: {_comp_base}"
+    )
+
+
 class _CompactionLifecycle:
     """Owns the one-shot terminal edge of the compaction status lifecycle.
     ``commit_status`` is rebound to "committed" only on success and read at ``complete()`` time, so abort
@@ -3150,6 +3190,12 @@ def _candidate_rejected(
                 "No messages were dropped — conversation continues unchanged. "
                 "Run /compress to retry, or /new to start a fresh session."
             )
+        # When the abort was caused by an auxiliary compression-model
+        # auth/quota failure, point at the *compression* endpoint —
+        # agent.provider/model/base_url are the main model's, which is
+        # the wrong thing to chase (#72636). The flag is set during
+        # summary generation, so it is fresh at this call site.
+        _emit_compression_auth_hint(agent)
         _emit_aborted_attempt_telemetry(
             agent, attempt_started_at, _summary_error and "summary_generation_aborted"
         )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2237,26 +2237,27 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     """Surface the compression auxiliary's own provider/model/endpoint when
     compression aborted on the auxiliary summary call (#72636).
 
-    The identity actually used on the wire for the summary call is
-    resolved from ``auxiliary.compression`` config by
-    ``_resolve_task_provider_model`` and recorded on the compressor as
-    ``_last_aux_call_provider`` / ``_last_aux_call_model`` /
-    ``_last_aux_call_base_url``. This is *not* the same as
-    ``compressor.provider`` / ``compressor.summary_model`` /
-    ``compressor.base_url`` — those carry the *main* model's identity
-    (the compressor is initialized against the main runtime), so reading
-    them here would point the user at the wrong endpoint whenever the
-    compression auxiliary is configured separately. The surrounding
-    "Compression aborted" warning says *that* something failed; this
-    companion block says *which* endpoint to fix.
+    The identity ACTUALLY used on the wire is recorded by
+    ``call_llm``'s ``route_callback`` — invoked after the real client is
+    built (auto-detection, fallback chains, and ``client.base_url``
+    applied), so it reflects the route the failed request really took,
+    not the config-layer pre-resolution from
+    ``_resolve_task_provider_model`` (which ``call_llm`` may override).
+    The callback writes ``_last_aux_call_provider`` /
+    ``_last_aux_call_model`` / ``_last_aux_call_base_url`` on the
+    compressor, with the base_url query-stripped to avoid leaking
+    credentials that some proxies carry as ``?key=...``. This is *not*
+    the same as ``compressor.provider`` / ``compressor.summary_model`` /
+    ``compressor.base_url`` — those carry the *main* model's identity.
+
+    The surrounding "Compression aborted" warning says *that* something
+    failed; this companion block says *which* endpoint to fix.
 
     Called only from the compression-abort branch of
     :func:`_candidate_rejected`. The helper runs after the current
     compression attempt has completed, avoiding the pre-request and
     unrelated-main-error ordering problems that an earlier call site
-    in the main-model API-error path introduced. The identity fields
-    are populated before the summary ``call_llm`` fires, so they are
-    fresh at this call site.
+    in the main-model API-error path introduced.
 
     The gate is the per-attempt ``_last_attempt_failure_class`` (reset at
     the top of every ``_generate_summary`` attempt), NOT the sticky
@@ -2265,9 +2266,10 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     followed by a forced retry that fails with a 500 would otherwise be
     mis-attributed as an auth failure (#72636).
 
-    Falls back to the main-model identity when no separate auxiliary was
-    resolved (``auxiliary.compression`` unset / ``auto``) and says so
-    explicitly, rather than silently reporting a wrong endpoint.
+    When the route_callback never fired (e.g. ``call_llm`` raised "no
+    provider configured" before a client existed), the identity fields
+    stay empty and the diagnostic falls back to the main-model identity
+    with an explicit note, rather than inventing a phantom endpoint.
 
     Wording is chosen to pass the gateway noise filter
     (``_TELEGRAM_NOISY_STATUS_RE``) — it must NOT match
@@ -2286,9 +2288,13 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     _aux_model = (getattr(_ctx_comp, "_last_aux_call_model", "") or "").strip()
     _aux_base = (getattr(_ctx_comp, "_last_aux_call_base_url", "") or "").strip()
 
-    # When auxiliary.compression is unset / "auto", the summary call runs
-    # against the main model — report that honestly instead of inventing a
-    # phantom auxiliary endpoint.
+    # _last_aux_call_* is written by call_llm's route_callback after the real
+    # client is built (auto-detection / fallback applied). When the callback
+    # never fired — e.g. call_llm raised "no provider configured" before a
+    # client existed — the fields stay empty; fall back to the main-model
+    # identity and say so, rather than inventing a phantom endpoint. A non-
+    # empty "auto" provider here is a REAL auto-chain route, not a missing
+    # config, so it is reported as-is.
     if not _aux_provider and not _aux_model and not _aux_base:
         _aux_provider = (getattr(_ctx_comp, "provider", "") or "auto").strip() or "auto"
         _aux_model = (getattr(_ctx_comp, "model", "") or "unknown").strip() or "unknown"

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2238,10 +2238,10 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     compression aborted on the auxiliary summary call (#72636).
 
     The identity ACTUALLY used on the wire is recorded by
-    ``call_llm``'s ``route_callback`` — invoked after the real client is
-    built (auto-detection, fallback chains, and ``client.base_url``
-    applied), so it reflects the route the failed request really took,
-    not the config-layer pre-resolution from
+    ``call_llm``'s ``route_callback`` — invoked before every physical wire
+    attempt after the real client is built (auto-detection, fallback chains,
+    and ``client.base_url`` applied), so the final snapshot reflects the route
+    the failed request really took, not the config-layer pre-resolution from
     ``_resolve_task_provider_model`` (which ``call_llm`` may override).
     The callback writes ``_last_aux_call_provider`` /
     ``_last_aux_call_model`` / ``_last_aux_call_base_url`` on the

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2288,18 +2288,36 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     _aux_model = (getattr(_ctx_comp, "_last_aux_call_model", "") or "").strip()
     _aux_base = (getattr(_ctx_comp, "_last_aux_call_base_url", "") or "").strip()
 
+    _cfg_provider = (getattr(_ctx_comp, "_last_aux_config_provider", "") or "").strip()
+    _cfg_model = (getattr(_ctx_comp, "_last_aux_config_model", "") or "").strip()
+    _cfg_base = (getattr(_ctx_comp, "_last_aux_config_base_url", "") or "").strip()
+
     # _last_aux_call_* is written by call_llm's route_callback after the real
     # client is built (auto-detection / fallback applied). When the callback
-    # never fired — e.g. call_llm raised "no provider configured" before a
-    # client existed — the fields stay empty; fall back to the main-model
-    # identity and say so, rather than inventing a phantom endpoint. A non-
-    # empty "auto" provider here is a REAL auto-chain route, not a missing
-    # config, so it is reported as-is.
+    # never fired, no physical request was dispatched. Two distinct shapes
+    # must not be conflated (#72636):
+    #
+    # 1. auxiliary.compression IS configured with an explicit provider, but
+    #    the call died before dispatch — e.g. that provider's API key is
+    #    missing ("Provider 'X' is set in config.yaml but no API key was
+    #    found"). Report the CONFIGURED identity as a pre-dispatch failure;
+    #    never substitute the healthy main endpoint here.
+    # 2. auxiliary.compression is unset, so the summary call would have used
+    #    the main model. Fall back to the main-model identity and say so,
+    #    rather than inventing a phantom endpoint.
+    _pre_dispatch = False
     if not _aux_provider and not _aux_model and not _aux_base:
-        _aux_provider = (getattr(_ctx_comp, "provider", "") or "auto").strip() or "auto"
-        _aux_model = (getattr(_ctx_comp, "model", "") or "unknown").strip() or "unknown"
-        _aux_base = (getattr(_ctx_comp, "base_url", "") or "unknown").strip() or "unknown"
-        _note = " (auxiliary.compression is not configured — using main model)"
+        if _cfg_provider or _cfg_model or _cfg_base:
+            _aux_provider = _cfg_provider or "unknown"
+            _aux_model = _cfg_model or "unknown"
+            _aux_base = _cfg_base or "unknown"
+            _pre_dispatch = True
+            _note = " (no request was dispatched)"
+        else:
+            _aux_provider = (getattr(_ctx_comp, "provider", "") or "auto").strip() or "auto"
+            _aux_model = (getattr(_ctx_comp, "model", "") or "unknown").strip() or "unknown"
+            _aux_base = (getattr(_ctx_comp, "base_url", "") or "unknown").strip() or "unknown"
+            _note = " (auxiliary.compression is not configured — using main model)"
     else:
         _note = ""
 
@@ -2307,17 +2325,25 @@ def _emit_compression_auth_hint(agent: Any) -> None:
     # (notably "auxiliary ... failed" and "compression summary failed") so
     # the message reaches Telegram/Discord/Slack, not just local/CLI.
     if _cls == "auth":
-        _guidance = (
-            "auth/permission error — check the credential and "
-            "auxiliary.compression in config.yaml"
-        )
+        if _pre_dispatch:
+            _guidance = "credential missing — set this provider's API key"
+        else:
+            _guidance = (
+                "auth/permission error — check the credential and "
+                "auxiliary.compression in config.yaml"
+            )
     elif _cls == "network":
         _guidance = "network/connection error — this is usually transient"
     else:
         _guidance = "error — see agent.log for detail"
 
+    _headline = (
+        "⚠ Compression auxiliary provider could not start its request "
+        if _pre_dispatch
+        else "⚠ Compression auxiliary endpoint could not be reached "
+    )
     agent._emit_warning(
-        f"⚠ Compression auxiliary endpoint could not be reached "
+        f"{_headline}"
         f"({_guidance}). "
         f"🔌 Provider: {_aux_provider}  Model: {_aux_model}  "
         f"🌐 Endpoint: {_aux_base}{_note}"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4213,6 +4213,32 @@ def run_conversation(
                 agent._buffer_vprint(f"   🔌 Provider: {_provider}  Model: {_model}")
                 agent._buffer_vprint(f"   🌐 Endpoint: {_base}")
                 agent._buffer_vprint(f"   📝 Error: {_error_summary}")
+
+                # If the context compressor has a pending auth/permission failure from
+                # the auxiliary compression model, surface it so the user knows the
+                # real source of the error — not the main model displayed above.
+                # Without this, a broken auxiliary.compression provider confuses users
+                # because the error endpoint shows the (working) main model instead of
+                # the (broken) compression model (e.g. HTTP 401 from an expired custom
+                # provider configured for compression).
+                _ctx_comp = getattr(agent, "context_compressor", None)
+                if _ctx_comp is not None and getattr(_ctx_comp, "_last_summary_auth_failure", False):
+                    _comp_provider = getattr(_ctx_comp, "provider", "auto") or "auto"
+                    _comp_model = getattr(_ctx_comp, "summary_model", "unknown") or "unknown"
+                    _comp_base = getattr(_ctx_comp, "base_url", "unknown") or "unknown"
+                    agent._buffer_vprint(
+                        f"   ⚠️  Auxiliary compression model also failed with auth error:"
+                    )
+                    agent._buffer_vprint(
+                        f"      🔌 Compression provider: {_comp_provider}  Model: {_comp_model}"
+                    )
+                    agent._buffer_vprint(
+                        f"      🌐 Compression endpoint: {_comp_base}"
+                    )
+                    agent._buffer_vprint(
+                        f"      💡 Check auxiliary.compression in config.yaml or update "
+                        f"with: hermes config set auxiliary.compression.model <model>"
+                    )
                 if status_code and status_code < 500:
                     _err_body = getattr(api_error, "body", None)
                     _err_body_str = str(_err_body)[:300] if _err_body else None
@@ -5162,6 +5188,29 @@ def run_conversation(
                     agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
                     agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
+
+                    # If the context compressor has a pending auth/permission failure from
+                    # the auxiliary compression model, surface it so the user knows the
+                    # real source of the error.
+                    _ctx_comp2 = getattr(agent, "context_compressor", None)
+                    if _ctx_comp2 is not None and getattr(_ctx_comp2, "_last_summary_auth_failure", False):
+                        _comp_provider2 = getattr(_ctx_comp2, "provider", "auto") or "auto"
+                        _comp_model2 = getattr(_ctx_comp2, "summary_model", "unknown") or "unknown"
+                        _comp_base2 = getattr(_ctx_comp2, "base_url", "unknown") or "unknown"
+                        agent._vprint(
+                            f"{agent.log_prefix}   ⚠️  Auxiliary compression model also failed with auth error — "
+                            f"check auxiliary.compression in config.yaml:",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}      🔌 Compression provider: {_comp_provider2}  "
+                            f"Model: {_comp_model2}",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}      🌐 Compression endpoint: {_comp_base2}",
+                            force=True,
+                        )
                     # Actionable guidance for common auth errors
                     if classified.is_auth or classified.reason == FailoverReason.billing:
                         if classified.reason == FailoverReason.billing and _print_billing_or_entitlement_guidance(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -966,6 +966,73 @@ def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool
     return False
 
 
+def _maybe_emit_compression_auth_hint(agent, *, force_vprint: bool = False) -> None:
+    """Surface auxiliary compression model auth/permission errors (#72636).
+
+    When ``auxiliary.compression`` returns HTTP 401/403, the conversation
+    loop's error display sites use ``agent.provider`` / ``agent.base_url`` /
+    ``agent.model`` — which are always the *main* model. The user sees the
+    working main model reported as the broken endpoint and chases the wrong
+    fix.
+
+    The compressor correctly records the failure on
+    ``_last_summary_auth_failure``. This helper reads that flag and emits a
+    short block pointing at the actual compression provider/model/endpoint.
+
+    Called from both error display sites:
+      * retry buffer (~line 2964) → ``_buffer_vprint`` (deferred until
+        terminal abort, so users on the gateway don't see an explosion of
+        per-retry copy)
+      * terminal abort (~line 3783) → ``_vprint(..., force=True)`` (immediate,
+        with the agent's log prefix)
+
+    Silent when no compressor is attached or no auth failure is pending —
+    otherwise every successful compression would spam a phantom banner.
+    Tolerates a misbehaving compressor missing any of the three fields
+    (``getattr`` defaults).
+    """
+    _ctx_comp = getattr(agent, "context_compressor", None)
+    if _ctx_comp is None or not getattr(_ctx_comp, "_last_summary_auth_failure", False):
+        return
+
+    _comp_provider = getattr(_ctx_comp, "provider", "auto") or "auto"
+    _comp_model = getattr(_ctx_comp, "summary_model", "unknown") or "unknown"
+    _comp_base = getattr(_ctx_comp, "base_url", "unknown") or "unknown"
+
+    if force_vprint:
+        log_prefix = getattr(agent, "log_prefix", "") or ""
+        agent._vprint(
+            f"{log_prefix}   ⚠️  Auxiliary compression model also failed with auth error — "
+            f"check auxiliary.compression in config.yaml:",
+            force=True,
+        )
+        agent._vprint(
+            f"{log_prefix}      🔌 Compression provider: {_comp_provider}  "
+            f"Model: {_comp_model}",
+            force=True,
+        )
+        agent._vprint(
+            f"{log_prefix}      🌐 Compression endpoint: {_comp_base}",
+            force=True,
+        )
+    else:
+        agent._buffer_vprint(
+            "   ⚠️  Auxiliary compression model also failed with auth error:"
+        )
+        agent._buffer_vprint(
+            f"      🔌 Compression provider: {_comp_provider}  Model: {_comp_model}"
+        )
+        agent._buffer_vprint(
+            f"      🌐 Compression endpoint: {_comp_base}"
+        )
+        agent._buffer_vprint(
+            "      💡 Check auxiliary.compression in config.yaml or update "
+            "with: hermes config set auxiliary.compression.model <model>"
+        )
+
+
+
+
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     """Refresh the in-flight system message after a provider failover.
 
@@ -4213,32 +4280,7 @@ def run_conversation(
                 agent._buffer_vprint(f"   🔌 Provider: {_provider}  Model: {_model}")
                 agent._buffer_vprint(f"   🌐 Endpoint: {_base}")
                 agent._buffer_vprint(f"   📝 Error: {_error_summary}")
-
-                # If the context compressor has a pending auth/permission failure from
-                # the auxiliary compression model, surface it so the user knows the
-                # real source of the error — not the main model displayed above.
-                # Without this, a broken auxiliary.compression provider confuses users
-                # because the error endpoint shows the (working) main model instead of
-                # the (broken) compression model (e.g. HTTP 401 from an expired custom
-                # provider configured for compression).
-                _ctx_comp = getattr(agent, "context_compressor", None)
-                if _ctx_comp is not None and getattr(_ctx_comp, "_last_summary_auth_failure", False):
-                    _comp_provider = getattr(_ctx_comp, "provider", "auto") or "auto"
-                    _comp_model = getattr(_ctx_comp, "summary_model", "unknown") or "unknown"
-                    _comp_base = getattr(_ctx_comp, "base_url", "unknown") or "unknown"
-                    agent._buffer_vprint(
-                        f"   ⚠️  Auxiliary compression model also failed with auth error:"
-                    )
-                    agent._buffer_vprint(
-                        f"      🔌 Compression provider: {_comp_provider}  Model: {_comp_model}"
-                    )
-                    agent._buffer_vprint(
-                        f"      🌐 Compression endpoint: {_comp_base}"
-                    )
-                    agent._buffer_vprint(
-                        f"      💡 Check auxiliary.compression in config.yaml or update "
-                        f"with: hermes config set auxiliary.compression.model <model>"
-                    )
+                _maybe_emit_compression_auth_hint(agent)
                 if status_code and status_code < 500:
                     _err_body = getattr(api_error, "body", None)
                     _err_body_str = str(_err_body)[:300] if _err_body else None
@@ -5188,29 +5230,7 @@ def run_conversation(
                     agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
                     agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
-
-                    # If the context compressor has a pending auth/permission failure from
-                    # the auxiliary compression model, surface it so the user knows the
-                    # real source of the error.
-                    _ctx_comp2 = getattr(agent, "context_compressor", None)
-                    if _ctx_comp2 is not None and getattr(_ctx_comp2, "_last_summary_auth_failure", False):
-                        _comp_provider2 = getattr(_ctx_comp2, "provider", "auto") or "auto"
-                        _comp_model2 = getattr(_ctx_comp2, "summary_model", "unknown") or "unknown"
-                        _comp_base2 = getattr(_ctx_comp2, "base_url", "unknown") or "unknown"
-                        agent._vprint(
-                            f"{agent.log_prefix}   ⚠️  Auxiliary compression model also failed with auth error — "
-                            f"check auxiliary.compression in config.yaml:",
-                            force=True,
-                        )
-                        agent._vprint(
-                            f"{agent.log_prefix}      🔌 Compression provider: {_comp_provider2}  "
-                            f"Model: {_comp_model2}",
-                            force=True,
-                        )
-                        agent._vprint(
-                            f"{agent.log_prefix}      🌐 Compression endpoint: {_comp_base2}",
-                            force=True,
-                        )
+                    _maybe_emit_compression_auth_hint(agent, force_vprint=True)
                     # Actionable guidance for common auth errors
                     if classified.is_auth or classified.reason == FailoverReason.billing:
                         if classified.reason == FailoverReason.billing and _print_billing_or_entitlement_guidance(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -966,73 +966,6 @@ def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool
     return False
 
 
-def _maybe_emit_compression_auth_hint(agent, *, force_vprint: bool = False) -> None:
-    """Surface auxiliary compression model auth/permission errors (#72636).
-
-    When ``auxiliary.compression`` returns HTTP 401/403, the conversation
-    loop's error display sites use ``agent.provider`` / ``agent.base_url`` /
-    ``agent.model`` — which are always the *main* model. The user sees the
-    working main model reported as the broken endpoint and chases the wrong
-    fix.
-
-    The compressor correctly records the failure on
-    ``_last_summary_auth_failure``. This helper reads that flag and emits a
-    short block pointing at the actual compression provider/model/endpoint.
-
-    Called from both error display sites:
-      * retry buffer (~line 2964) → ``_buffer_vprint`` (deferred until
-        terminal abort, so users on the gateway don't see an explosion of
-        per-retry copy)
-      * terminal abort (~line 3783) → ``_vprint(..., force=True)`` (immediate,
-        with the agent's log prefix)
-
-    Silent when no compressor is attached or no auth failure is pending —
-    otherwise every successful compression would spam a phantom banner.
-    Tolerates a misbehaving compressor missing any of the three fields
-    (``getattr`` defaults).
-    """
-    _ctx_comp = getattr(agent, "context_compressor", None)
-    if _ctx_comp is None or not getattr(_ctx_comp, "_last_summary_auth_failure", False):
-        return
-
-    _comp_provider = getattr(_ctx_comp, "provider", "auto") or "auto"
-    _comp_model = getattr(_ctx_comp, "summary_model", "unknown") or "unknown"
-    _comp_base = getattr(_ctx_comp, "base_url", "unknown") or "unknown"
-
-    if force_vprint:
-        log_prefix = getattr(agent, "log_prefix", "") or ""
-        agent._vprint(
-            f"{log_prefix}   ⚠️  Auxiliary compression model also failed with auth error — "
-            f"check auxiliary.compression in config.yaml:",
-            force=True,
-        )
-        agent._vprint(
-            f"{log_prefix}      🔌 Compression provider: {_comp_provider}  "
-            f"Model: {_comp_model}",
-            force=True,
-        )
-        agent._vprint(
-            f"{log_prefix}      🌐 Compression endpoint: {_comp_base}",
-            force=True,
-        )
-    else:
-        agent._buffer_vprint(
-            "   ⚠️  Auxiliary compression model also failed with auth error:"
-        )
-        agent._buffer_vprint(
-            f"      🔌 Compression provider: {_comp_provider}  Model: {_comp_model}"
-        )
-        agent._buffer_vprint(
-            f"      🌐 Compression endpoint: {_comp_base}"
-        )
-        agent._buffer_vprint(
-            "      💡 Check auxiliary.compression in config.yaml or update "
-            "with: hermes config set auxiliary.compression.model <model>"
-        )
-
-
-
-
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     """Refresh the in-flight system message after a provider failover.
 
@@ -4280,7 +4213,6 @@ def run_conversation(
                 agent._buffer_vprint(f"   🔌 Provider: {_provider}  Model: {_model}")
                 agent._buffer_vprint(f"   🌐 Endpoint: {_base}")
                 agent._buffer_vprint(f"   📝 Error: {_error_summary}")
-                _maybe_emit_compression_auth_hint(agent)
                 if status_code and status_code < 500:
                     _err_body = getattr(api_error, "body", None)
                     _err_body_str = str(_err_body)[:300] if _err_body else None
@@ -5230,7 +5162,6 @@ def run_conversation(
                     agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
                     agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
-                    _maybe_emit_compression_auth_hint(agent, force_vprint=True)
                     # Actionable guidance for common auth errors
                     if classified.is_auth or classified.reason == FailoverReason.billing:
                         if classified.reason == FailoverReason.billing and _print_billing_or_entitlement_guidance(

--- a/tests/agent/test_compression_auth_error_attribution.py
+++ b/tests/agent/test_compression_auth_error_attribution.py
@@ -1,37 +1,30 @@
-"""End-to-end regression for #72636: when ``auxiliary.compression`` fails
-with an auth/quota error (HTTP 401/403), the compression-abort warning
-must point the user at the *compression* model's provider/model/endpoint,
-NOT the main model's.
+"""End-to-end regression for #72636: when ``auxiliary.compression``
+fails, the compression-abort diagnostic must (a) point at the
+*compression* model's provider/model/endpoint (not the main model's),
+(b) classify the CURRENT attempt's failure mode correctly (a 401 then
+a forced retry that fails with a 500 must NOT be mis-attributed as an
+auth failure), and (c) actually reach messaging gateways rather than
+be swallowed by the noise filter.
 
-Two failure modes are guarded here, both reported by the original
-reviewer / follow-up:
+Three failure modes are guarded:
 
-1. **Ordering** — the diagnostic must render from the centralized
+1. **Ordering + identity** — the diagnostic renders from the
    compression-abort branch in ``compress_context`` (after the
-   compressor has set ``_last_summary_auth_failure``), not from a
-   main-model API-error display site in the conversation loop (where
-   the flag is still false for a fresh 401/403 and goes stale until
-   the next successful summary).
+   compressor has recorded the failure), reads the resolved auxiliary
+   identity (``_last_aux_call_*``) rather than the main-model fields on
+   the compressor, and runs after the current attempt completed.
 
-2. **Identity attribution** — the compressor's ``provider`` /
-   ``summary_model`` / ``base_url`` fields carry the *main* model's
-   identity (the compressor is initialized against the main runtime).
-   The identity actually used on the wire for the summary call is
-   resolved from ``auxiliary.compression`` config and recorded by the
-   compressor as ``_last_aux_call_provider`` / ``_last_aux_call_model``
-   / ``_last_aux_call_base_url``. The diagnostic must read those, not
-   the main-model fields — otherwise it points the user at the wrong
-   endpoint whenever the compression auxiliary is configured
-   separately.
+2. **Per-attempt classification** — the gate is the per-attempt
+   ``_last_attempt_failure_class`` (reset on every ``_generate_summary``
+   entry), NOT the sticky ``_last_summary_auth_failure`` (which persists
+   across compress() calls to protect the cooldown guard). Without this,
+   a 401 followed by a forced retry that fails with a 500 would surface
+   a stale "auth failure" verdict.
 
-These tests drive the real ``agent._compress_context`` →
-``compress_context`` → abort path with a mock compressor whose
-``compress()`` mirrors what the real ``ContextCompressor.compress``
-does when the auxiliary summary call 401s: abort, preserve the
-transcript unchanged, and record both the failure flag and the
-resolved auxiliary identity on itself. The main-model identity on the
-compressor is deliberately distinct from the auxiliary identity, so a
-diagnostic that reads the wrong fields is caught.
+3. **Gateway visibility** — the diagnostic wording is chosen to pass
+   ``_TELEGRAM_NOISY_STATUS_RE`` so it reaches Telegram/Discord/Slack,
+   not just local/CLI. The generic "Compression aborted" warning is
+   already visible; the companion identity block must be too.
 """
 
 from __future__ import annotations
@@ -61,7 +54,7 @@ def _build_agent_with_compressor(
     db: SessionDB,
     session_id: str,
     *,
-    auth_failure: bool,
+    failure_class: str | None,  # "auth" | "network" | "other" | None
     compression_count: int = 0,
     aux_provider: str = _AUX_PROVIDER,
     aux_model: str = _AUX_MODEL,
@@ -84,19 +77,14 @@ def _build_agent_with_compressor(
     compressor = MagicMock()
 
     def _noop_compress(messages, **_kwargs):
-        # Mirror what ContextCompressor.compress does when the auxiliary
-        # summary call 401s: the identity was already resolved from
-        # auxiliary.compression config and recorded on the instance
-        # (_last_aux_call_*), then the call failed and the compressor
-        # aborts, preserving the transcript unchanged with the auth-failure
-        # flag set. compress_context's abort branch fires because the
-        # returned list is left equal to the input.
+        # Mirror what ContextCompressor.compress does after a failed
+        # auxiliary summary call: the identity was already resolved and
+        # recorded on the instance, then the call failed and the compressor
+        # aborted, preserving the transcript unchanged. compress_context's
+        # abort branch fires because the returned list equals the input.
         compressor._last_compress_aborted = True
-        compressor._last_summary_error = "401 Client Error: Unauthorized"
-        if auth_failure:
-            compressor._last_summary_auth_failure = True
-        # The resolved auxiliary identity — recorded BEFORE the call_llm
-        # that 401'd, so it is present at abort time.
+        compressor._last_summary_error = "simulated summary failure"
+        compressor._last_attempt_failure_class = failure_class
         compressor._last_aux_call_provider = aux_provider
         compressor._last_aux_call_model = aux_model
         compressor._last_aux_call_base_url = aux_base_url
@@ -108,7 +96,7 @@ def _build_agent_with_compressor(
     compressor.last_completion_tokens = 0
     compressor._last_summary_error = None
     compressor._last_compress_aborted = False
-    compressor._last_summary_auth_failure = bool(auth_failure)
+    compressor._last_attempt_failure_class = None
     # IMPORTANT: these carry the MAIN model's identity, mirroring production
     # (the compressor is initialized against the main runtime). They are
     # distinct from the auxiliary identity above. A diagnostic that reads
@@ -140,24 +128,17 @@ def _run_compression(agent) -> list[str]:
     return emitted
 
 
-# ── Auth-failure attribution (the fix) ─────────────────────────────────
+# ── Failure-class attribution (the fix) ───────────────────────────────
 
 
-def test_aux_auth_failure_abort_surfaces_compression_identity(tmp_path: Path) -> None:
-    """Compression aborted on an auxiliary 401 → the user must see the
-    *compression* provider/model/endpoint, never the main model's.
-
-    This is the end-to-end ordering the fix targets: overflow → compress →
-    auxiliary auth failure → abort → diagnostic. It also pins identity
-    attribution: the compressor's main-model fields (provider / model /
-    base_url) are the SiliconFlow main runtime, but the diagnostic must
-    surface the DeepSeek auxiliary identity actually used on the wire.
-    """
+def test_auth_failure_abort_surfaces_compression_identity(tmp_path: Path) -> None:
+    """Compression aborted on an auxiliary auth failure → the user must see
+    the *compression* provider/model/endpoint, never the main model's."""
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "PARENT_72636_AUTH"
     db.create_session(sid, source="cli")
 
-    agent, _ = _build_agent_with_compressor(db, sid, auth_failure=True)
+    agent, _ = _build_agent_with_compressor(db, sid, failure_class="auth")
     emitted = _run_compression(agent)
 
     rendered = "\n".join(emitted)
@@ -172,48 +153,61 @@ def test_aux_auth_failure_abort_surfaces_compression_identity(tmp_path: Path) ->
     assert _AUX_BASE_URL in rendered, (
         f"compression endpoint missing from abort output: {emitted}"
     )
-    # The MAIN model is healthy and must NOT be named as the failing endpoint —
-    # that misattribution is exactly the bug this regression guards against.
+    # The MAIN model is healthy and must NOT be named as the failing endpoint.
     assert "siliconflow.cn" not in rendered, (
-        f"main endpoint leaked into compression auth diagnostic: {emitted}"
+        f"main endpoint leaked into compression diagnostic: {emitted}"
     )
     assert _MAIN_MODEL not in rendered, (
-        f"main model leaked into compression auth diagnostic: {emitted}"
+        f"main model leaked into compression diagnostic: {emitted}"
     )
 
 
-def test_aux_auth_diagnostic_silent_on_non_auth_abort(tmp_path: Path) -> None:
-    """When compression ABORTS but NOT on an auth failure (e.g. transient
-    network, summary-abort), the compression-identity diagnostic must stay
-    silent — only the generic "Compression aborted" warning fires.
-
-    Pins that the gate is ``_last_summary_auth_failure``, not
-    ``_last_compress_aborted``.
-    """
+def test_network_failure_abort_uses_network_guidance(tmp_path: Path) -> None:
+    """A network/connection abort surfaces the compression identity with the
+    transient-error guidance, not the auth credential guidance."""
     db = SessionDB(db_path=tmp_path / "state.db")
-    sid = "PARENT_72636_NOAUTH"
+    sid = "PARENT_72636_NET"
     db.create_session(sid, source="cli")
 
-    agent, _ = _build_agent_with_compressor(db, sid, auth_failure=False)
+    agent, _ = _build_agent_with_compressor(db, sid, failure_class="network")
     emitted = _run_compression(agent)
-
     rendered = "\n".join(emitted)
+
+    assert _AUX_BASE_URL in rendered, f"compression endpoint missing: {emitted}"
+    assert "transient" in rendered.lower(), (
+        f"network guidance missing on network abort: {emitted}"
+    )
+    # Must NOT show the auth credential guidance for a network failure.
+    assert "credential" not in rendered.lower(), (
+        f"auth guidance leaked into network abort: {emitted}"
+    )
+
+
+def test_diagnostic_silent_when_no_failure_class(tmp_path: Path) -> None:
+    """When compression ABORTS but no failure was classified (e.g. the
+    compressor aborted for a non-summary reason), the identity diagnostic
+    must stay silent — only the generic "Compression aborted" warning fires.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_NOCLASS"
+    db.create_session(sid, source="cli")
+
+    agent, _ = _build_agent_with_compressor(db, sid, failure_class=None)
+    emitted = _run_compression(agent)
+    rendered = "\n".join(emitted)
+
     # Generic abort warning is expected...
     assert any("Compression aborted" in m for m in emitted), (
         f"generic abort warning missing: {emitted}"
     )
     # ...but the compression-identity block must NOT appear.
     assert _AUX_PROVIDER not in rendered, (
-        f"compression identity leaked on a non-auth abort: {emitted}"
-    )
-    assert _AUX_MODEL not in rendered, (
-        f"compression model leaked on a non-auth abort: {emitted}"
+        f"compression identity leaked when no failure was classified: {emitted}"
     )
 
 
-def test_successful_compression_emits_no_auth_diagnostic(tmp_path: Path) -> None:
-    """When compression succeeds, no auth diagnostic fires — otherwise every
-    healthy compression would spam a phantom auth-error banner."""
+def test_successful_compression_emits_no_diagnostic(tmp_path: Path) -> None:
+    """When compression succeeds, no diagnostic fires."""
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "PARENT_72636_OK"
     db.create_session(sid, source="cli")
@@ -232,7 +226,6 @@ def test_successful_compression_emits_no_auth_diagnostic(tmp_path: Path) -> None
             skip_memory=True,
         )
 
-    # A *successful* compressor: returns a compressed transcript, no abort.
     compressor = MagicMock()
     compressor.compress.return_value = [
         {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
@@ -243,7 +236,7 @@ def test_successful_compression_emits_no_auth_diagnostic(tmp_path: Path) -> None
     compressor.last_completion_tokens = 0
     compressor._last_summary_error = None
     compressor._last_compress_aborted = False
-    compressor._last_summary_auth_failure = False
+    compressor._last_attempt_failure_class = None
     compressor.provider = _MAIN_PROVIDER
     compressor.summary_model = ""
     compressor.base_url = _MAIN_BASE_URL
@@ -263,22 +256,114 @@ def test_successful_compression_emits_no_auth_diagnostic(tmp_path: Path) -> None
     )
 
 
+# ── Per-attempt classification: the 401 → 500 sequence ────────────────
+
+
+def test_stale_auth_flag_does_not_poison_subsequent_non_auth_abort(
+    tmp_path: Path,
+) -> None:
+    """Regression for the sticky-flag bug: a 401 that sets
+    ``_last_summary_auth_failure`` must NOT cause a later, unrelated abort
+    (e.g. a 500 on a forced retry) to be mis-attributed as an auth failure.
+
+    The gate is the per-attempt ``_last_attempt_failure_class``, reset on
+    every ``_generate_summary`` entry — not the sticky
+    ``_last_summary_auth_failure`` (which intentionally persists across
+    compress() calls to protect the cooldown guard).
+
+    This test simulates the two-attempt sequence directly against the
+    helper's contract: the SECOND abort carries a non-auth
+    ``_last_attempt_failure_class`` even though the sticky auth flag from
+    the first attempt is still set on the compressor.
+    """
+    from agent.conversation_compression import _emit_compression_auth_hint
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_SEQ"
+    db.create_session(sid, source="cli")
+
+    agent, comp = _build_agent_with_compressor(db, sid, failure_class="other")
+    # Simulate the aftermath of a PRIOR 401: the sticky auth flag is still
+    # True (compress() never clears it — only a successful summary does).
+    comp._last_summary_auth_failure = True
+    # But the CURRENT attempt failed with a 500 (transient/other), so the
+    # per-attempt class must win.
+    comp._last_attempt_failure_class = "other"
+
+    emitted: list[str] = []
+    agent._emit_warning = lambda message: emitted.append(message)
+    _emit_compression_auth_hint(agent)
+
+    rendered = "\n".join(emitted)
+    # The diagnostic DID fire (the current attempt failed)...
+    assert any("Compression auxiliary endpoint" in m for m in emitted), (
+        f"diagnostic missing for current 'other' attempt: {emitted}"
+    )
+    # ...but it must NOT show auth credential guidance — the current
+    # attempt is not an auth failure, regardless of the stale sticky flag.
+    assert "credential" not in rendered.lower(), (
+        f"stale auth flag mis-attributed a 500 as an auth failure: {emitted}"
+    )
+    assert "see agent.log" in rendered.lower(), (
+        f"'other' guidance missing on non-auth abort: {emitted}"
+    )
+
+
+# ── Gateway visibility (the diagnostic must not be swallowed) ─────────
+
+
+def test_diagnostic_survives_gateway_noise_filter() -> None:
+    """The diagnostic wording must pass ``_TELEGRAM_NOISY_STATUS_RE`` so it
+    reaches Telegram/Discord/Slack, not just local/CLI. The generic
+    "Compression aborted" warning already passes; this pins that the
+    companion identity block does too — across the failure classes.
+    """
+    from gateway.platforms.base import Platform
+    from gateway.run import _prepare_gateway_status_message
+
+    from agent.conversation_compression import _emit_compression_auth_hint
+
+    # Build a minimal stand-in agent whose _emit_warning captures the
+    # message, then route that message through the real gateway filter.
+    for failure_class in ("auth", "network", "other"):
+        comp = MagicMock()
+        comp._last_attempt_failure_class = failure_class
+        comp._last_aux_call_provider = _AUX_PROVIDER
+        comp._last_aux_call_model = _AUX_MODEL
+        comp._last_aux_call_base_url = _AUX_BASE_URL
+        comp.provider = _MAIN_PROVIDER
+        comp.model = _MAIN_MODEL
+        comp.base_url = _MAIN_BASE_URL
+        agent = MagicMock()
+        agent.context_compressor = comp
+        captured: list[str] = []
+        agent._emit_warning = lambda message, _c=captured: _c.append(message)
+
+        _emit_compression_auth_hint(agent)
+        assert captured, f"no diagnostic emitted for class={failure_class}"
+
+        for platform in (Platform.TELEGRAM, "discord", "slack"):
+            result = _prepare_gateway_status_message(platform, "warn", captured[0])
+            assert result is not None, (
+                f"diagnostic swallowed by gateway filter "
+                f"(class={failure_class}, platform={platform}): {captured[0]}"
+            )
+
+
 # ── Identity fallback when auxiliary is not separately configured ──────
 
 
 def test_aux_unset_falls_back_to_main_model_with_note(tmp_path: Path) -> None:
     """When ``auxiliary.compression`` is unset / "auto", the summary call
     runs against the main model — no separate auxiliary identity was
-    resolved. The diagnostic must NOT invent a phantom endpoint; it falls
-    back to the main-model identity and says so explicitly, so the user
-    is not sent chasing a non-existent auxiliary config."""
+    resolved. The diagnostic falls back to the main-model identity and
+    says so explicitly, rather than inventing a phantom auxiliary endpoint."""
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "PARENT_72636_AUTO"
     db.create_session(sid, source="cli")
 
-    # No auxiliary identity resolved — all _last_aux_call_* empty.
     agent, _ = _build_agent_with_compressor(
-        db, sid, auth_failure=True, aux_provider="", aux_model="", aux_base_url=""
+        db, sid, failure_class="auth", aux_provider="", aux_model="", aux_base_url=""
     )
     emitted = _run_compression(agent)
 
@@ -287,8 +372,7 @@ def test_aux_unset_falls_back_to_main_model_with_note(tmp_path: Path) -> None:
     assert _MAIN_BASE_URL in rendered, (
         f"main endpoint missing from fallback diagnostic: {emitted}"
     )
-    # ...and explicitly flags that auxiliary.compression is not configured,
-    # so the user knows the main model is the one to fix.
+    # ...and explicitly flags that auxiliary.compression is not configured.
     assert "not configured" in rendered, (
         f"missing 'not configured' note on aux-unset fallback: {emitted}"
     )
@@ -298,10 +382,9 @@ def test_aux_unset_falls_back_to_main_model_with_note(tmp_path: Path) -> None:
 
 
 def test_missing_compressor_identity_does_not_crash_abort(tmp_path: Path) -> None:
-    """A misbehaving compressor that aborts on auth failure but is missing
-    the resolved auxiliary identity must not crash the abort path — the
-    generic "Compression aborted" warning must still reach the user, and
-    the diagnostic falls back to the main-model identity."""
+    """A misbehaving compressor that aborts but is missing the resolved
+    auxiliary identity must not crash the abort path — the diagnostic falls
+    back to the main-model identity."""
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "PARENT_72636_PARTIAL"
     db.create_session(sid, source="cli")
@@ -309,19 +392,16 @@ def test_missing_compressor_identity_does_not_crash_abort(tmp_path: Path) -> Non
     agent, _ = _build_agent_with_compressor(
         db,
         sid,
-        auth_failure=True,
+        failure_class="auth",
         aux_provider="",
         aux_model="",
         aux_base_url="",
     )
     emitted = _run_compression(agent)
 
-    # Did not raise, and the generic abort warning still fired...
     assert any("Compression aborted" in m for m in emitted), (
         f"generic abort warning missing on partial-compressor abort: {emitted}"
     )
-    # ...and the diagnostic still emitted, falling back to the main-model
-    # identity rather than crashing.
-    assert any("auth/permission" in m for m in emitted), (
-        f"compression auth diagnostic missing on partial-compressor abort: {emitted}"
+    assert any("Compression auxiliary endpoint" in m for m in emitted), (
+        f"diagnostic missing on partial-compressor abort: {emitted}"
     )

--- a/tests/agent/test_compression_auth_error_attribution.py
+++ b/tests/agent/test_compression_auth_error_attribution.py
@@ -3,21 +3,35 @@ with an auth/quota error (HTTP 401/403), the compression-abort warning
 must point the user at the *compression* model's provider/model/endpoint,
 NOT the main model's.
 
-The diagnostic is rendered from the centralized compression-abort branch
-in ``agent.conversation_compression.compress_context`` — *after* the
-compressor has set ``_last_summary_auth_failure`` during summary
-generation. Rendering it earlier (e.g. from a main-model API-error
-display site in the conversation loop) is wrong on both ends: the flag
-is still false for a fresh auxiliary 401/403, and once set it stays set
-until the next successful summary, so a later unrelated main-model
-error would surface a stale compression failure.
+Two failure modes are guarded here, both reported by the original
+reviewer / follow-up:
 
-These tests drive the real ``agent._compress_context`` forwarder into
-``compress_context`` with a mock compressor whose ``compress()`` returns
-the transcript unchanged with ``_last_compress_aborted`` /
-``_last_summary_auth_failure`` set — the same path production takes
-when the auxiliary summary model 401s — and assert what reaches
-``_emit_warning``.
+1. **Ordering** — the diagnostic must render from the centralized
+   compression-abort branch in ``compress_context`` (after the
+   compressor has set ``_last_summary_auth_failure``), not from a
+   main-model API-error display site in the conversation loop (where
+   the flag is still false for a fresh 401/403 and goes stale until
+   the next successful summary).
+
+2. **Identity attribution** — the compressor's ``provider`` /
+   ``summary_model`` / ``base_url`` fields carry the *main* model's
+   identity (the compressor is initialized against the main runtime).
+   The identity actually used on the wire for the summary call is
+   resolved from ``auxiliary.compression`` config and recorded by the
+   compressor as ``_last_aux_call_provider`` / ``_last_aux_call_model``
+   / ``_last_aux_call_base_url``. The diagnostic must read those, not
+   the main-model fields — otherwise it points the user at the wrong
+   endpoint whenever the compression auxiliary is configured
+   separately.
+
+These tests drive the real ``agent._compress_context`` →
+``compress_context`` → abort path with a mock compressor whose
+``compress()`` mirrors what the real ``ContextCompressor.compress``
+does when the auxiliary summary call 401s: abort, preserve the
+transcript unchanged, and record both the failure flag and the
+resolved auxiliary identity on itself. The main-model identity on the
+compressor is deliberately distinct from the auxiliary identity, so a
+diagnostic that reads the wrong fields is caught.
 """
 
 from __future__ import annotations
@@ -28,10 +42,16 @@ from unittest.mock import MagicMock, patch
 
 from hermes_state import SessionDB
 
-# Identity of the failing AUXILIARY compression model — the values the
-# diagnostic must surface. Deliberately distinct from the main model below
-# (DeepSeek official API vs the main model's SiliconFlow endpoint), so the
-# assertions can verify the diagnostic surfaces the *auxiliary* identity.
+# The MAIN model the agent is running against. Healthy, NOT the source of
+# the failure. The compressor is initialized against this runtime, so its
+# provider / summary_model / base_url / model fields carry these values.
+_MAIN_BASE_URL = "https://api.siliconflow.cn/v1"
+_MAIN_MODEL = "deepseek-ai/DeepSeek-V4-Pro"
+_MAIN_PROVIDER = "custom"
+
+# Identity of the failing AUXILIARY compression model — deliberately
+# distinct from the main model (DeepSeek official API vs the main model's
+# SiliconFlow endpoint), so assertions can verify attribution.
 _AUX_PROVIDER = "api.deepseek.com"
 _AUX_MODEL = "deepseek-chat"
 _AUX_BASE_URL = "https://api.deepseek.com"
@@ -50,12 +70,10 @@ def _build_agent_with_compressor(
     with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
         from run_agent import AIAgent
 
-        # The MAIN model is a known-good endpoint that is NOT the source of
-        # the failure. The compression auxiliary is a different provider.
         agent = AIAgent(
             api_key="test-key",
-            base_url="https://api.siliconflow.cn/v1",
-            model="deepseek-ai/DeepSeek-V4-Pro",
+            base_url=_MAIN_BASE_URL,
+            model=_MAIN_MODEL,
             quiet_mode=True,
             session_db=db,
             session_id=session_id,
@@ -67,15 +85,21 @@ def _build_agent_with_compressor(
 
     def _noop_compress(messages, **_kwargs):
         # Mirror what ContextCompressor.compress does when the auxiliary
-        # summary call 401s: abort, preserve the transcript unchanged, and
-        # record the failure on itself. compress_context's abort branch
-        # fires because the returned list is left equal to the input.
+        # summary call 401s: the identity was already resolved from
+        # auxiliary.compression config and recorded on the instance
+        # (_last_aux_call_*), then the call failed and the compressor
+        # aborts, preserving the transcript unchanged with the auth-failure
+        # flag set. compress_context's abort branch fires because the
+        # returned list is left equal to the input.
         compressor._last_compress_aborted = True
-        compressor._last_summary_error = (
-            "401 Client Error: Unauthorized"
-        )
+        compressor._last_summary_error = "401 Client Error: Unauthorized"
         if auth_failure:
             compressor._last_summary_auth_failure = True
+        # The resolved auxiliary identity — recorded BEFORE the call_llm
+        # that 401'd, so it is present at abort time.
+        compressor._last_aux_call_provider = aux_provider
+        compressor._last_aux_call_model = aux_model
+        compressor._last_aux_call_base_url = aux_base_url
         return list(messages)
 
     compressor.compress.side_effect = _noop_compress
@@ -85,10 +109,20 @@ def _build_agent_with_compressor(
     compressor._last_summary_error = None
     compressor._last_compress_aborted = False
     compressor._last_summary_auth_failure = bool(auth_failure)
-    # Failing AUXILIARY compression model identity.
-    compressor.provider = aux_provider
-    compressor.summary_model = aux_model
-    compressor.base_url = aux_base_url
+    # IMPORTANT: these carry the MAIN model's identity, mirroring production
+    # (the compressor is initialized against the main runtime). They are
+    # distinct from the auxiliary identity above. A diagnostic that reads
+    # these instead of _last_aux_call_* misattributes the failure to the
+    # main model — exactly the bug this regression guards against.
+    compressor.provider = _MAIN_PROVIDER
+    compressor.summary_model = ""  # empty in production (agent_init passes None)
+    compressor.base_url = _MAIN_BASE_URL
+    compressor.model = _MAIN_MODEL
+    # Pre-populate the resolved auxiliary identity as the real compressor
+    # would at construction (empty until _generate_summary resolves it).
+    compressor._last_aux_call_provider = ""
+    compressor._last_aux_call_model = ""
+    compressor._last_aux_call_base_url = ""
     compressor._last_aux_model_failure_model = None
     compressor._last_aux_model_failure_error = None
     agent.context_compressor = compressor
@@ -114,7 +148,10 @@ def test_aux_auth_failure_abort_surfaces_compression_identity(tmp_path: Path) ->
     *compression* provider/model/endpoint, never the main model's.
 
     This is the end-to-end ordering the fix targets: overflow → compress →
-    auxiliary auth failure → abort → diagnostic.
+    auxiliary auth failure → abort → diagnostic. It also pins identity
+    attribution: the compressor's main-model fields (provider / model /
+    base_url) are the SiliconFlow main runtime, but the diagnostic must
+    surface the DeepSeek auxiliary identity actually used on the wire.
     """
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "PARENT_72636_AUTH"
@@ -130,7 +167,7 @@ def test_aux_auth_failure_abort_surfaces_compression_identity(tmp_path: Path) ->
         f"compression provider missing from abort output: {emitted}"
     )
     assert _AUX_MODEL in rendered, (
-        f"compression summary_model missing from abort output: {emitted}"
+        f"compression model missing from abort output: {emitted}"
     )
     assert _AUX_BASE_URL in rendered, (
         f"compression endpoint missing from abort output: {emitted}"
@@ -140,7 +177,7 @@ def test_aux_auth_failure_abort_surfaces_compression_identity(tmp_path: Path) ->
     assert "siliconflow.cn" not in rendered, (
         f"main endpoint leaked into compression auth diagnostic: {emitted}"
     )
-    assert "DeepSeek-V4-Pro" not in rendered, (
+    assert _MAIN_MODEL not in rendered, (
         f"main model leaked into compression auth diagnostic: {emitted}"
     )
 
@@ -186,8 +223,8 @@ def test_successful_compression_emits_no_auth_diagnostic(tmp_path: Path) -> None
 
         agent = AIAgent(
             api_key="test-key",
-            base_url="https://api.siliconflow.cn/v1",
-            model="deepseek-ai/DeepSeek-V4-Pro",
+            base_url=_MAIN_BASE_URL,
+            model=_MAIN_MODEL,
             quiet_mode=True,
             session_db=db,
             session_id=sid,
@@ -207,9 +244,13 @@ def test_successful_compression_emits_no_auth_diagnostic(tmp_path: Path) -> None
     compressor._last_summary_error = None
     compressor._last_compress_aborted = False
     compressor._last_summary_auth_failure = False
-    compressor.provider = _AUX_PROVIDER
-    compressor.summary_model = _AUX_MODEL
-    compressor.base_url = _AUX_BASE_URL
+    compressor.provider = _MAIN_PROVIDER
+    compressor.summary_model = ""
+    compressor.base_url = _MAIN_BASE_URL
+    compressor.model = _MAIN_MODEL
+    compressor._last_aux_call_provider = _AUX_PROVIDER
+    compressor._last_aux_call_model = _AUX_MODEL
+    compressor._last_aux_call_base_url = _AUX_BASE_URL
     compressor._last_aux_model_failure_model = None
     compressor._last_aux_model_failure_error = None
     agent.context_compressor = compressor
@@ -222,26 +263,55 @@ def test_successful_compression_emits_no_auth_diagnostic(tmp_path: Path) -> None
     )
 
 
+# ── Identity fallback when auxiliary is not separately configured ──────
+
+
+def test_aux_unset_falls_back_to_main_model_with_note(tmp_path: Path) -> None:
+    """When ``auxiliary.compression`` is unset / "auto", the summary call
+    runs against the main model — no separate auxiliary identity was
+    resolved. The diagnostic must NOT invent a phantom endpoint; it falls
+    back to the main-model identity and says so explicitly, so the user
+    is not sent chasing a non-existent auxiliary config."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_AUTO"
+    db.create_session(sid, source="cli")
+
+    # No auxiliary identity resolved — all _last_aux_call_* empty.
+    agent, _ = _build_agent_with_compressor(
+        db, sid, auth_failure=True, aux_provider="", aux_model="", aux_base_url=""
+    )
+    emitted = _run_compression(agent)
+
+    rendered = "\n".join(emitted)
+    # Falls back to the main-model identity (since aux is unset)...
+    assert _MAIN_BASE_URL in rendered, (
+        f"main endpoint missing from fallback diagnostic: {emitted}"
+    )
+    # ...and explicitly flags that auxiliary.compression is not configured,
+    # so the user knows the main model is the one to fix.
+    assert "not configured" in rendered, (
+        f"missing 'not configured' note on aux-unset fallback: {emitted}"
+    )
+
+
 # ── Robustness ─────────────────────────────────────────────────────────
 
 
 def test_missing_compressor_identity_does_not_crash_abort(tmp_path: Path) -> None:
     """A misbehaving compressor that aborts on auth failure but is missing
-    one of the identity fields must not crash the abort path — the generic
-    "Compression aborted" warning must still reach the user, and the
-    diagnostic falls back to its defaults."""
+    the resolved auxiliary identity must not crash the abort path — the
+    generic "Compression aborted" warning must still reach the user, and
+    the diagnostic falls back to the main-model identity."""
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "PARENT_72636_PARTIAL"
     db.create_session(sid, source="cli")
 
-    # Pass empty/None for each identity field; the helper's
-    # ``getattr(..., default) or default`` covers falsy values.
     agent, _ = _build_agent_with_compressor(
         db,
         sid,
         auth_failure=True,
         aux_provider="",
-        aux_model=None,
+        aux_model="",
         aux_base_url="",
     )
     emitted = _run_compression(agent)
@@ -250,8 +320,8 @@ def test_missing_compressor_identity_does_not_crash_abort(tmp_path: Path) -> Non
     assert any("Compression aborted" in m for m in emitted), (
         f"generic abort warning missing on partial-compressor abort: {emitted}"
     )
-    # ...and the diagnostic still emitted, falling back to the defaults
-    # rather than crashing.
+    # ...and the diagnostic still emitted, falling back to the main-model
+    # identity rather than crashing.
     assert any("auth/permission" in m for m in emitted), (
         f"compression auth diagnostic missing on partial-compressor abort: {emitted}"
     )

--- a/tests/agent/test_compression_auth_error_attribution.py
+++ b/tests/agent/test_compression_auth_error_attribution.py
@@ -1,216 +1,257 @@
-"""Regression for #72636: when auxiliary.compression fails with an auth
-error (HTTP 401/403), the conversation-loop error display sites must
-identify the *compression* model's provider/model/endpoint, not the main
-model's.
+"""End-to-end regression for #72636: when ``auxiliary.compression`` fails
+with an auth/quota error (HTTP 401/403), the compression-abort warning
+must point the user at the *compression* model's provider/model/endpoint,
+NOT the main model's.
 
-Previously both error display sites (retry buffer and terminal abort)
-used ``agent.provider`` / ``agent.base_url`` / ``agent.model`` — which
-are always the main model — even when the actual failure came from the
-compression auxiliary. Users saw the working main model reported as the
-broken endpoint and chased the wrong fix.
+The diagnostic is rendered from the centralized compression-abort branch
+in ``agent.conversation_compression.compress_context`` — *after* the
+compressor has set ``_last_summary_auth_failure`` during summary
+generation. Rendering it earlier (e.g. from a main-model API-error
+display site in the conversation loop) is wrong on both ends: the flag
+is still false for a fresh auxiliary 401/403, and once set it stays set
+until the next successful summary, so a later unrelated main-model
+error would surface a stale compression failure.
 
-The fix extracts a small helper in ``agent.conversation_loop``,
-``_maybe_emit_compression_auth_hint(agent, *, force_vprint=False)``,
-called from both error sites. Tests import the real helper — not a
-copy — so the helper and the inline call sites cannot drift.
+These tests drive the real ``agent._compress_context`` forwarder into
+``compress_context`` with a mock compressor whose ``compress()`` returns
+the transcript unchanged with ``_last_compress_aborted`` /
+``_last_summary_auth_failure`` set — the same path production takes
+when the auxiliary summary model 401s — and assert what reaches
+``_emit_warning``.
 """
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from unittest.mock import MagicMock
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-import pytest
+from hermes_state import SessionDB
 
-from agent.conversation_loop import _maybe_emit_compression_auth_hint
+# Identity of the failing AUXILIARY compression model — the values the
+# diagnostic must surface. Deliberately distinct from the main model below
+# (DeepSeek official API vs the main model's SiliconFlow endpoint), so the
+# assertions can verify the diagnostic surfaces the *auxiliary* identity.
+_AUX_PROVIDER = "api.deepseek.com"
+_AUX_MODEL = "deepseek-chat"
+_AUX_BASE_URL = "https://api.deepseek.com"
 
 
-def _make_compressor(
+def _build_agent_with_compressor(
+    db: SessionDB,
+    session_id: str,
     *,
     auth_failure: bool,
-    provider: str = "auto",
-    summary_model: str = "",
-    base_url: str = "",
-) -> MagicMock:
-    """Stand-in for ContextCompressor carrying only the fields the helper
-    reads. Real compressor construction drags in network calls and
-    config side effects we don't need here.
+    compression_count: int = 0,
+    aux_provider: str = _AUX_PROVIDER,
+    aux_model: str = _AUX_MODEL,
+    aux_base_url: str = _AUX_BASE_URL,
+):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        # The MAIN model is a known-good endpoint that is NOT the source of
+        # the failure. The compression auxiliary is a different provider.
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.siliconflow.cn/v1",
+            model="deepseek-ai/DeepSeek-V4-Pro",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    compressor = MagicMock()
+
+    def _noop_compress(messages, **_kwargs):
+        # Mirror what ContextCompressor.compress does when the auxiliary
+        # summary call 401s: abort, preserve the transcript unchanged, and
+        # record the failure on itself. compress_context's abort branch
+        # fires because the returned list is left equal to the input.
+        compressor._last_compress_aborted = True
+        compressor._last_summary_error = (
+            "401 Client Error: Unauthorized"
+        )
+        if auth_failure:
+            compressor._last_summary_auth_failure = True
+        return list(messages)
+
+    compressor.compress.side_effect = _noop_compress
+    compressor.compression_count = compression_count
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_summary_auth_failure = bool(auth_failure)
+    # Failing AUXILIARY compression model identity.
+    compressor.provider = aux_provider
+    compressor.summary_model = aux_model
+    compressor.base_url = aux_base_url
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+    return agent, compressor
+
+
+def _run_compression(agent) -> list[str]:
+    """Drive the real ``_compress_context`` → ``compress_context`` path and
+    capture every user-visible warning emitted along the way."""
+    emitted: list[str] = []
+    agent._emit_warning = lambda message: emitted.append(message)
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    agent._compress_context(messages, "sys", approx_tokens=120_000)
+    return emitted
+
+
+# ── Auth-failure attribution (the fix) ─────────────────────────────────
+
+
+def test_aux_auth_failure_abort_surfaces_compression_identity(tmp_path: Path) -> None:
+    """Compression aborted on an auxiliary 401 → the user must see the
+    *compression* provider/model/endpoint, never the main model's.
+
+    This is the end-to-end ordering the fix targets: overflow → compress →
+    auxiliary auth failure → abort → diagnostic.
     """
-    comp = MagicMock()
-    comp._last_summary_auth_failure = auth_failure
-    comp.provider = provider
-    comp.summary_model = summary_model
-    comp.base_url = base_url
-    return comp
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_AUTH"
+    db.create_session(sid, source="cli")
 
+    agent, _ = _build_agent_with_compressor(db, sid, auth_failure=True)
+    emitted = _run_compression(agent)
 
-def _make_agent(
-    *,
-    main_provider: str = "custom",
-    main_base_url: str = "https://api.siliconflow.cn/v1",
-    main_model: str = "deepseek-ai/DeepSeek-V4-Pro",
-    compressor: MagicMock | None = None,
-    log_prefix: str = "",
-) -> SimpleNamespace:
-    """Minimal stand-in for AIAgent exposing the attributes the helper
-    reads. We don't instantiate a real AIAgent — it drags in the session
-    DB, credential pool, and globals unrelated to this regression.
-    """
-    captured: list[str] = []
+    rendered = "\n".join(emitted)
 
-    def _capture(*args, **kwargs) -> None:
-        if args:
-            captured.append(str(args[0]))
-
-    agent = SimpleNamespace(
-        provider=main_provider,
-        base_url=main_base_url,
-        model=main_model,
-        log_prefix=log_prefix,
-        context_compressor=compressor,
-        _buffer_vprint=_capture,
-        _vprint=_capture,
+    # Compression auxiliary identity MUST appear in the abort diagnostics.
+    assert _AUX_PROVIDER in rendered, (
+        f"compression provider missing from abort output: {emitted}"
     )
-    agent._captured = captured  # type: ignore[attr-defined]
-    return agent
-
-
-# ── Positive case ──────────────────────────────────────────────────────
-
-
-def test_compression_auth_failure_emits_compression_model_lines() -> None:
-    """The auxiliary compression model is the one that 401'd. The
-    emitted lines must point at the compression provider/endpoint, NOT
-    the main model.
-    """
-    agent = _make_agent(
-        compressor=_make_compressor(
-            auth_failure=True,
-            provider="Oneai.17usoft.com",
-            summary_model="deepseek-v4-flash",
-            base_url="https://oneai.17usoft.com/v1",
-        ),
+    assert _AUX_MODEL in rendered, (
+        f"compression summary_model missing from abort output: {emitted}"
     )
-
-    _maybe_emit_compression_auth_hint(agent)
-
-    rendered = "\n".join(agent._captured)  # type: ignore[attr-defined]
-    # Compression model must appear.
-    assert "Oneai.17usoft.com" in rendered, f"compression provider missing: {agent._captured}"
-    assert "deepseek-v4-flash" in rendered, f"compression model missing: {agent._captured}"
-    assert "oneai.17usoft.com" in rendered, f"compression endpoint missing: {agent._captured}"
-    # Main model must NOT appear — that was the bug.
+    assert _AUX_BASE_URL in rendered, (
+        f"compression endpoint missing from abort output: {emitted}"
+    )
+    # The MAIN model is healthy and must NOT be named as the failing endpoint —
+    # that misattribution is exactly the bug this regression guards against.
     assert "siliconflow.cn" not in rendered, (
-        f"main endpoint leaked into compression auth block: {agent._captured}"
+        f"main endpoint leaked into compression auth diagnostic: {emitted}"
     )
-    assert "deepseek-ai/DeepSeek-V4-Pro" not in rendered, (
-        f"main model leaked into compression auth block: {agent._captured}"
+    assert "DeepSeek-V4-Pro" not in rendered, (
+        f"main model leaked into compression auth diagnostic: {emitted}"
     )
 
 
-# ── Negative cases (helper must stay silent) ───────────────────────────
+def test_aux_auth_diagnostic_silent_on_non_auth_abort(tmp_path: Path) -> None:
+    """When compression ABORTS but NOT on an auth failure (e.g. transient
+    network, summary-abort), the compression-identity diagnostic must stay
+    silent — only the generic "Compression aborted" warning fires.
 
-
-def test_no_lines_when_compression_succeeded() -> None:
-    """When the compressor has no pending auth failure, the helper must
-    be silent — otherwise every successful compression would spam a
-    phantom auth-error banner.
+    Pins that the gate is ``_last_summary_auth_failure``, not
+    ``_last_compress_aborted``.
     """
-    agent = _make_agent(
-        compressor=_make_compressor(
-            auth_failure=False,
-            provider="Oneai.17usoft.com",
-            summary_model="deepseek-v4-flash",
-            base_url="https://oneai.17usoft.com/v1",
-        ),
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_NOAUTH"
+    db.create_session(sid, source="cli")
+
+    agent, _ = _build_agent_with_compressor(db, sid, auth_failure=False)
+    emitted = _run_compression(agent)
+
+    rendered = "\n".join(emitted)
+    # Generic abort warning is expected...
+    assert any("Compression aborted" in m for m in emitted), (
+        f"generic abort warning missing: {emitted}"
     )
-
-    _maybe_emit_compression_auth_hint(agent)
-
-    assert agent._captured == []  # type: ignore[attr-defined]
-
-
-def test_no_lines_when_compressor_missing() -> None:
-    """Defensive: if context_compressor is absent (compression disabled
-    or pre-init), the helper must not raise — silently skip.
-    """
-    agent = _make_agent(compressor=None)
-
-    _maybe_emit_compression_auth_hint(agent)
-
-    assert agent._captured == []  # type: ignore[attr-defined]
-
-
-def test_no_lines_when_only_main_model_failed_auth() -> None:
-    """Main model 401 with compression healthy → no compression block.
-    Verifies the gate is *compressor-driven*, not main-model-driven —
-    otherwise we'd flag the wrong source.
-    """
-    agent = _make_agent(
-        main_provider="anthropic",
-        main_base_url="https://api.anthropic.com",
-        main_model="claude-sonnet-4.5",
-        compressor=_make_compressor(auth_failure=False),
+    # ...but the compression-identity block must NOT appear.
+    assert _AUX_PROVIDER not in rendered, (
+        f"compression identity leaked on a non-auth abort: {emitted}"
     )
-
-    _maybe_emit_compression_auth_hint(agent)
-
-    assert agent._captured == []  # type: ignore[attr-defined]
-
-
-# ── Display site variants ──────────────────────────────────────────────
-
-
-def test_force_vprint_routes_through_vprint_for_terminal_abort_site() -> None:
-    """The terminal-abort display site uses ``_vprint(..., force=True)``,
-    the retry-buffer site uses ``_buffer_vprint``. Both must produce the
-    same lines; the helper accepts ``force_vprint`` to pick the channel.
-    """
-    agent = _make_agent(
-        compressor=_make_compressor(
-            auth_failure=True,
-            provider="Oneai.17usoft.com",
-            summary_model="deepseek-v4-flash",
-            base_url="https://oneai.17usoft.com/v1",
-        ),
-        log_prefix="[agent] ",
-    )
-
-    _maybe_emit_compression_auth_hint(agent, force_vprint=True)
-
-    rendered = "\n".join(agent._captured)  # type: ignore[attr-defined]
-    assert "Oneai.17usoft.com" in rendered
-    # Terminal site uses log_prefix; retry site does not. Sanity-check
-    # the prefix actually got applied (not a hard assertion — log_prefix
-    # formatting may evolve — but it must be present in at least one line).
-    assert any("[agent]" in line for line in agent._captured), (  # type: ignore[attr-defined]
-        f"log_prefix not applied in force_vprint mode: {agent._captured}"
+    assert _AUX_MODEL not in rendered, (
+        f"compression model leaked on a non-auth abort: {emitted}"
     )
 
 
-# ── Robustness to unexpected compressor shapes ─────────────────────────
+def test_successful_compression_emits_no_auth_diagnostic(tmp_path: Path) -> None:
+    """When compression succeeds, no auth diagnostic fires — otherwise every
+    healthy compression would spam a phantom auth-error banner."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_OK"
+    db.create_session(sid, source="cli")
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.siliconflow.cn/v1",
+            model="deepseek-ai/DeepSeek-V4-Pro",
+            quiet_mode=True,
+            session_db=db,
+            session_id=sid,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    # A *successful* compressor: returns a compressed transcript, no abort.
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail"},
+    ]
+    compressor.compression_count = 0
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_summary_auth_failure = False
+    compressor.provider = _AUX_PROVIDER
+    compressor.summary_model = _AUX_MODEL
+    compressor.base_url = _AUX_BASE_URL
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+
+    emitted = _run_compression(agent)
+    rendered = "\n".join(emitted)
+
+    assert _AUX_PROVIDER not in rendered, (
+        f"compression identity surfaced on a successful compression: {emitted}"
+    )
 
 
-@pytest.mark.parametrize(
-    "missing_attr",
-    ["provider", "summary_model", "base_url"],
-)
-def test_missing_compressor_attribute_does_not_raise(missing_attr: str) -> None:
-    """A misbehaving compressor missing one of the fields the helper
-    reads must not crash the error path. ``getattr(..., default)`` covers
-    this in the implementation; the test pins the behavior.
-    """
-    compressor = _make_compressor(
+# ── Robustness ─────────────────────────────────────────────────────────
+
+
+def test_missing_compressor_identity_does_not_crash_abort(tmp_path: Path) -> None:
+    """A misbehaving compressor that aborts on auth failure but is missing
+    one of the identity fields must not crash the abort path — the generic
+    "Compression aborted" warning must still reach the user, and the
+    diagnostic falls back to its defaults."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_PARTIAL"
+    db.create_session(sid, source="cli")
+
+    # Pass empty/None for each identity field; the helper's
+    # ``getattr(..., default) or default`` covers falsy values.
+    agent, _ = _build_agent_with_compressor(
+        db,
+        sid,
         auth_failure=True,
-        provider="Oneai.17usoft.com",
-        summary_model="deepseek-v4-flash",
-        base_url="https://oneai.17usoft.com/v1",
+        aux_provider="",
+        aux_model=None,
+        aux_base_url="",
     )
-    # Delete the attribute so getattr hits its default branch.
-    delattr(compressor, missing_attr)
-    agent = _make_agent(compressor=compressor)
+    emitted = _run_compression(agent)
 
-    _maybe_emit_compression_auth_hint(agent)  # must not raise
-
-    # At least one line still got emitted (the "auth failed" header).
-    assert len(agent._captured) >= 1  # type: ignore[attr-defined]
+    # Did not raise, and the generic abort warning still fired...
+    assert any("Compression aborted" in m for m in emitted), (
+        f"generic abort warning missing on partial-compressor abort: {emitted}"
+    )
+    # ...and the diagnostic still emitted, falling back to the defaults
+    # rather than crashing.
+    assert any("auth/permission" in m for m in emitted), (
+        f"compression auth diagnostic missing on partial-compressor abort: {emitted}"
+    )

--- a/tests/agent/test_compression_auth_error_attribution.py
+++ b/tests/agent/test_compression_auth_error_attribution.py
@@ -405,3 +405,213 @@ def test_missing_compressor_identity_does_not_crash_abort(tmp_path: Path) -> Non
     assert any("Compression auxiliary endpoint" in m for m in emitted), (
         f"diagnostic missing on partial-compressor abort: {emitted}"
     )
+
+
+# ── Real ContextCompressor: verify route_callback writes the wire identity ──
+#
+# These tests do NOT mock compressor.compress. They use a real
+# ContextCompressor and patch agent.context_compressor.call_llm so the
+# route_callback inside call_llm is exercised against the real code path.
+# This pins that the identity written by route_callback (the authoritative
+# "route actually used on the wire", after auto-detection / fallback) flows
+# through to the abort diagnostic — not the config-layer pre-resolution from
+# _resolve_task_provider_model, which call_llm may override.
+
+
+def _build_real_compressor_agent(
+    db: SessionDB,
+    session_id: str,
+    *,
+    wire_provider: str,
+    wire_model: str,
+    wire_base_url: str,
+):
+    """Build an agent with a REAL ContextCompressor whose call_llm is patched
+    to invoke route_callback with the wire identity, then raise a 401."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url=_MAIN_BASE_URL,
+            model=_MAIN_MODEL,
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    # Replace the MagicMock compressor that AIAgent installs with a real one.
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        from agent.context_compressor import ContextCompressor
+
+        comp = ContextCompressor(
+            model=_MAIN_MODEL,
+            base_url=_MAIN_BASE_URL,
+            provider=_MAIN_PROVIDER,
+            quiet_mode=True,
+            protect_first_n=2,
+            protect_last_n=2,
+            abort_on_summary_failure=False,
+        )
+    agent.context_compressor = comp
+
+    # Patch call_llm so it (1) invokes route_callback with the wire identity
+    # (mirroring what real call_llm does after building the client) and
+    # (2) raises a 401 that _is_summary_access_or_quota_error classifies as
+    # an auth failure → _last_attempt_failure_class = "auth".
+    _Stub401 = type("Stub401", (Exception,), {"status_code": 401})
+
+    def _fake_call_llm(*args, **kwargs):
+        _cb = kwargs.get("route_callback")
+        if _cb is not None:
+            _cb(wire_provider, wire_model, wire_base_url)
+        raise _Stub401("401 Client Error: Unauthorized")
+
+    # Force past the cooldown so compress() actually calls _generate_summary.
+    comp._clear_compression_failure_cooldown()
+    return agent, "agent.context_compressor.call_llm", _fake_call_llm
+
+
+def test_real_compressor_route_callback_identity_reaches_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """End-to-end with a REAL ContextCompressor: call_llm's route_callback
+    writes the wire identity, the 401 abort surfaces it in the diagnostic.
+
+    This is the test the previous MagicMock-based suite was missing: it proves
+    the identity saved by route_callback (after auto-detection / fallback
+    inside call_llm) flows through to _emit_compression_auth_hint, not the
+    pre-resolution guess from _resolve_task_provider_model.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_REAL"
+    db.create_session(sid, source="cli")
+
+    agent, _patch_target, _fake = _build_real_compressor_agent(
+        db, sid,
+        wire_provider="api.deepseek.com",
+        wire_model="deepseek-chat",
+        wire_base_url="https://api.deepseek.com",
+    )
+    emitted: list[str] = []
+    agent._emit_warning = lambda message: emitted.append(message)
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    with patch(_patch_target, side_effect=_fake):
+        agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    rendered = "\n".join(emitted)
+    # The wire identity written by route_callback MUST surface...
+    assert "api.deepseek.com" in rendered, (
+        f"wire provider from route_callback missing: {emitted}"
+    )
+    assert "deepseek-chat" in rendered, (
+        f"wire model from route_callback missing: {emitted}"
+    )
+    assert "https://api.deepseek.com" in rendered, (
+        f"wire endpoint from route_callback missing: {emitted}"
+    )
+    # ...and the MAIN model must NOT leak (route_callback overrode it).
+    assert "siliconflow.cn" not in rendered, (
+        f"main endpoint leaked despite route_callback: {emitted}"
+    )
+
+
+def test_real_compressor_strips_query_from_base_url(tmp_path: Path) -> None:
+    """route_callback's base_url is query-stripped, so credentials some
+    proxies carry as ?key=... are not leaked into the user-facing diagnostic."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_QUERY"
+    db.create_session(sid, source="cli")
+
+    _SECRET = "sk-super-secret-token-12345"
+    agent, _patch_target, _fake = _build_real_compressor_agent(
+        db, sid,
+        wire_provider="custom",
+        wire_model="some-aux",
+        # Wire base_url carries a credential in the query string — as a real
+        # client built from a config base_url like this would.
+        wire_base_url=f"https://proxy.example.com/v1?key={_SECRET}",
+    )
+    emitted: list[str] = []
+    agent._emit_warning = lambda message: emitted.append(message)
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    with patch(_patch_target, side_effect=_fake):
+        agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    rendered = "\n".join(emitted)
+    # The proxy host is reported (sanitized)...
+    assert "proxy.example.com" in rendered, (
+        f"sanitized endpoint missing: {emitted}"
+    )
+    # ...but the query-string credential MUST NOT leak.
+    assert _SECRET not in rendered, (
+        f"query-string credential leaked into diagnostic: {emitted}"
+    )
+    assert "key=" not in rendered, (
+        f"query string leaked into diagnostic: {emitted}"
+    )
+
+
+def test_real_compressor_no_provider_does_not_emit_aux_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """When call_llm raises 'no provider configured' BEFORE building a client,
+    route_callback never fires and compression falls back to the static marker
+    (no abort, no sticky auth flag). The aux-identity diagnostic therefore
+    does NOT fire — there is no wire route to attribute, and the generic
+    fallback warning already tells the user what happened."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_NOPROV"
+    db.create_session(sid, source="cli")
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url=_MAIN_BASE_URL,
+            model=_MAIN_MODEL,
+            quiet_mode=True,
+            session_db=db,
+            session_id=sid,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        from agent.context_compressor import ContextCompressor
+
+        comp = ContextCompressor(
+            model=_MAIN_MODEL, base_url=_MAIN_BASE_URL, provider=_MAIN_PROVIDER,
+            quiet_mode=True, protect_first_n=2, protect_last_n=2,
+            abort_on_summary_failure=False,
+        )
+    agent.context_compressor = comp
+    comp._clear_compression_failure_cooldown()
+
+    # call_llm raises "no provider configured" without calling route_callback.
+    def _fake_no_provider(*args, **kwargs):
+        raise RuntimeError("No LLM provider configured for task=compression")
+
+    emitted: list[str] = []
+    agent._emit_warning = lambda message: emitted.append(message)
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    with patch("agent.context_compressor.call_llm", side_effect=_fake_no_provider):
+        agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    rendered = "\n".join(emitted)
+    # No client was built → no abort → no aux-identity diagnostic. The static
+    # fallback warning fires instead (the no-provider case is already covered
+    # by the generic warning, not the per-route diagnostic).
+    assert "Compression auxiliary endpoint" not in rendered, (
+        f"aux diagnostic fired on no-provider (no route to attribute): {emitted}"
+    )
+    # The broken 'Provider: auto / Endpoint: (empty)' shape that the
+    # pre-resolution approach produced must NOT appear either.
+    assert "Provider: auto" not in rendered, (
+        f"phantom 'Provider: auto' on no-provider: {emitted}"
+    )
+

--- a/tests/agent/test_compression_auth_error_attribution.py
+++ b/tests/agent/test_compression_auth_error_attribution.py
@@ -614,4 +614,3 @@ def test_real_compressor_no_provider_does_not_emit_aux_diagnostic(
     assert "Provider: auto" not in rendered, (
         f"phantom 'Provider: auto' on no-provider: {emitted}"
     )
-

--- a/tests/agent/test_compression_auth_error_attribution.py
+++ b/tests/agent/test_compression_auth_error_attribution.py
@@ -33,6 +33,8 @@ import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hermes_state import SessionDB
 
 # The MAIN model the agent is running against. Healthy, NOT the source of
@@ -407,15 +409,105 @@ def test_missing_compressor_identity_does_not_crash_abort(tmp_path: Path) -> Non
     )
 
 
-# ── Real ContextCompressor: verify route_callback writes the wire identity ──
+# ── Real call_llm routing: observe every physical wire attempt ─────────
+
+
+def test_real_call_llm_reports_concrete_auto_route_and_strips_query() -> None:
+    """The real call_llm orchestration must resolve ``auto`` to the client
+    backend and sanitize its endpoint before publishing the wire attempt."""
+    from agent.auxiliary_client import call_llm
+
+    secret = "sk-route-secret"
+    client = MagicMock()
+    client.base_url = f"https://api.minimax.chat/v1?key={secret}"
+    client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="ok"))]
+    )
+    routes: list[tuple[str, str | None, str]] = []
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "minimax/minimax-m2.7", None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "minimax/minimax-m2.7"),
+        ),
+    ):
+        call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+            route_callback=lambda *route: routes.append(route),
+        )
+
+    assert routes == [(
+        "minimax",
+        "minimax/minimax-m2.7",
+        "https://api.minimax.chat/v1",
+    )]
+    assert secret not in repr(routes)
+
+
+def test_real_call_llm_updates_route_when_fallback_fails() -> None:
+    """If a fallback becomes the terminal failing request, the last observed
+    identity must describe that fallback rather than the stale primary."""
+    from agent.auxiliary_client import call_llm
+
+    auth_error = type("Auth401", (Exception,), {"status_code": 401})("expired key")
+    primary = MagicMock()
+    primary.base_url = "https://api.minimax.chat/v1"
+    primary.chat.completions.create.side_effect = auth_error
+
+    fallback = MagicMock()
+    fallback.base_url = "https://openrouter.ai/api/v1"
+    fallback.chat.completions.create.side_effect = ValueError(
+        "fallback malformed response"
+    )
+    routes: list[tuple[str, str | None, str]] = []
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "minimax/minimax-m2.7", None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary, "minimax/minimax-m2.7"),
+        ),
+        patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(None, None, ""),
+        ),
+        patch(
+            "agent.auxiliary_client._try_main_fallback_chain",
+            return_value=(None, None, ""),
+        ),
+        patch(
+            "agent.auxiliary_client._try_payment_fallback",
+            return_value=(fallback, "fallback-model", "openrouter"),
+        ),
+    ):
+        with pytest.raises(ValueError, match="fallback malformed response"):
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                route_callback=lambda *route: routes.append(route),
+            )
+
+    assert routes == [
+        ("minimax", "minimax/minimax-m2.7", "https://api.minimax.chat/v1"),
+        ("openrouter", "fallback-model", "https://openrouter.ai/api/v1"),
+    ]
+
+
+# ── Real ContextCompressor: verify callback state reaches the abort ───
 #
 # These tests do NOT mock compressor.compress. They use a real
-# ContextCompressor and patch agent.context_compressor.call_llm so the
-# route_callback inside call_llm is exercised against the real code path.
-# This pins that the identity written by route_callback (the authoritative
-# "route actually used on the wire", after auto-detection / fallback) flows
-# through to the abort diagnostic — not the config-layer pre-resolution from
-# _resolve_task_provider_model, which call_llm may override.
+# ContextCompressor and patch its imported call_llm reference so the callback
+# state can be checked independently of routing. The tests above exercise the
+# real auxiliary_client.call_llm auto/fallback orchestration; these tests pin
+# that the resulting state flows through to the abort diagnostic.
 
 
 def _build_real_compressor_agent(
@@ -480,10 +572,9 @@ def test_real_compressor_route_callback_identity_reaches_diagnostic(
     """End-to-end with a REAL ContextCompressor: call_llm's route_callback
     writes the wire identity, the 401 abort surfaces it in the diagnostic.
 
-    This is the test the previous MagicMock-based suite was missing: it proves
-    the identity saved by route_callback (after auto-detection / fallback
-    inside call_llm) flows through to _emit_compression_auth_hint, not the
-    pre-resolution guess from _resolve_task_provider_model.
+    This proves the identity supplied by call_llm flows through to
+    _emit_compression_auth_hint, not the pre-resolution guess from
+    _resolve_task_provider_model. Real call_llm routing is covered separately.
     """
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "PARENT_72636_REAL"

--- a/tests/agent/test_compression_auth_error_attribution.py
+++ b/tests/agent/test_compression_auth_error_attribution.py
@@ -1,0 +1,216 @@
+"""Regression for #72636: when auxiliary.compression fails with an auth
+error (HTTP 401/403), the conversation-loop error display sites must
+identify the *compression* model's provider/model/endpoint, not the main
+model's.
+
+Previously both error display sites (retry buffer and terminal abort)
+used ``agent.provider`` / ``agent.base_url`` / ``agent.model`` — which
+are always the main model — even when the actual failure came from the
+compression auxiliary. Users saw the working main model reported as the
+broken endpoint and chased the wrong fix.
+
+The fix extracts a small helper in ``agent.conversation_loop``,
+``_maybe_emit_compression_auth_hint(agent, *, force_vprint=False)``,
+called from both error sites. Tests import the real helper — not a
+copy — so the helper and the inline call sites cannot drift.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.conversation_loop import _maybe_emit_compression_auth_hint
+
+
+def _make_compressor(
+    *,
+    auth_failure: bool,
+    provider: str = "auto",
+    summary_model: str = "",
+    base_url: str = "",
+) -> MagicMock:
+    """Stand-in for ContextCompressor carrying only the fields the helper
+    reads. Real compressor construction drags in network calls and
+    config side effects we don't need here.
+    """
+    comp = MagicMock()
+    comp._last_summary_auth_failure = auth_failure
+    comp.provider = provider
+    comp.summary_model = summary_model
+    comp.base_url = base_url
+    return comp
+
+
+def _make_agent(
+    *,
+    main_provider: str = "custom",
+    main_base_url: str = "https://api.siliconflow.cn/v1",
+    main_model: str = "deepseek-ai/DeepSeek-V4-Pro",
+    compressor: MagicMock | None = None,
+    log_prefix: str = "",
+) -> SimpleNamespace:
+    """Minimal stand-in for AIAgent exposing the attributes the helper
+    reads. We don't instantiate a real AIAgent — it drags in the session
+    DB, credential pool, and globals unrelated to this regression.
+    """
+    captured: list[str] = []
+
+    def _capture(*args, **kwargs) -> None:
+        if args:
+            captured.append(str(args[0]))
+
+    agent = SimpleNamespace(
+        provider=main_provider,
+        base_url=main_base_url,
+        model=main_model,
+        log_prefix=log_prefix,
+        context_compressor=compressor,
+        _buffer_vprint=_capture,
+        _vprint=_capture,
+    )
+    agent._captured = captured  # type: ignore[attr-defined]
+    return agent
+
+
+# ── Positive case ──────────────────────────────────────────────────────
+
+
+def test_compression_auth_failure_emits_compression_model_lines() -> None:
+    """The auxiliary compression model is the one that 401'd. The
+    emitted lines must point at the compression provider/endpoint, NOT
+    the main model.
+    """
+    agent = _make_agent(
+        compressor=_make_compressor(
+            auth_failure=True,
+            provider="Oneai.17usoft.com",
+            summary_model="deepseek-v4-flash",
+            base_url="https://oneai.17usoft.com/v1",
+        ),
+    )
+
+    _maybe_emit_compression_auth_hint(agent)
+
+    rendered = "\n".join(agent._captured)  # type: ignore[attr-defined]
+    # Compression model must appear.
+    assert "Oneai.17usoft.com" in rendered, f"compression provider missing: {agent._captured}"
+    assert "deepseek-v4-flash" in rendered, f"compression model missing: {agent._captured}"
+    assert "oneai.17usoft.com" in rendered, f"compression endpoint missing: {agent._captured}"
+    # Main model must NOT appear — that was the bug.
+    assert "siliconflow.cn" not in rendered, (
+        f"main endpoint leaked into compression auth block: {agent._captured}"
+    )
+    assert "deepseek-ai/DeepSeek-V4-Pro" not in rendered, (
+        f"main model leaked into compression auth block: {agent._captured}"
+    )
+
+
+# ── Negative cases (helper must stay silent) ───────────────────────────
+
+
+def test_no_lines_when_compression_succeeded() -> None:
+    """When the compressor has no pending auth failure, the helper must
+    be silent — otherwise every successful compression would spam a
+    phantom auth-error banner.
+    """
+    agent = _make_agent(
+        compressor=_make_compressor(
+            auth_failure=False,
+            provider="Oneai.17usoft.com",
+            summary_model="deepseek-v4-flash",
+            base_url="https://oneai.17usoft.com/v1",
+        ),
+    )
+
+    _maybe_emit_compression_auth_hint(agent)
+
+    assert agent._captured == []  # type: ignore[attr-defined]
+
+
+def test_no_lines_when_compressor_missing() -> None:
+    """Defensive: if context_compressor is absent (compression disabled
+    or pre-init), the helper must not raise — silently skip.
+    """
+    agent = _make_agent(compressor=None)
+
+    _maybe_emit_compression_auth_hint(agent)
+
+    assert agent._captured == []  # type: ignore[attr-defined]
+
+
+def test_no_lines_when_only_main_model_failed_auth() -> None:
+    """Main model 401 with compression healthy → no compression block.
+    Verifies the gate is *compressor-driven*, not main-model-driven —
+    otherwise we'd flag the wrong source.
+    """
+    agent = _make_agent(
+        main_provider="anthropic",
+        main_base_url="https://api.anthropic.com",
+        main_model="claude-sonnet-4.5",
+        compressor=_make_compressor(auth_failure=False),
+    )
+
+    _maybe_emit_compression_auth_hint(agent)
+
+    assert agent._captured == []  # type: ignore[attr-defined]
+
+
+# ── Display site variants ──────────────────────────────────────────────
+
+
+def test_force_vprint_routes_through_vprint_for_terminal_abort_site() -> None:
+    """The terminal-abort display site uses ``_vprint(..., force=True)``,
+    the retry-buffer site uses ``_buffer_vprint``. Both must produce the
+    same lines; the helper accepts ``force_vprint`` to pick the channel.
+    """
+    agent = _make_agent(
+        compressor=_make_compressor(
+            auth_failure=True,
+            provider="Oneai.17usoft.com",
+            summary_model="deepseek-v4-flash",
+            base_url="https://oneai.17usoft.com/v1",
+        ),
+        log_prefix="[agent] ",
+    )
+
+    _maybe_emit_compression_auth_hint(agent, force_vprint=True)
+
+    rendered = "\n".join(agent._captured)  # type: ignore[attr-defined]
+    assert "Oneai.17usoft.com" in rendered
+    # Terminal site uses log_prefix; retry site does not. Sanity-check
+    # the prefix actually got applied (not a hard assertion — log_prefix
+    # formatting may evolve — but it must be present in at least one line).
+    assert any("[agent]" in line for line in agent._captured), (  # type: ignore[attr-defined]
+        f"log_prefix not applied in force_vprint mode: {agent._captured}"
+    )
+
+
+# ── Robustness to unexpected compressor shapes ─────────────────────────
+
+
+@pytest.mark.parametrize(
+    "missing_attr",
+    ["provider", "summary_model", "base_url"],
+)
+def test_missing_compressor_attribute_does_not_raise(missing_attr: str) -> None:
+    """A misbehaving compressor missing one of the fields the helper
+    reads must not crash the error path. ``getattr(..., default)`` covers
+    this in the implementation; the test pins the behavior.
+    """
+    compressor = _make_compressor(
+        auth_failure=True,
+        provider="Oneai.17usoft.com",
+        summary_model="deepseek-v4-flash",
+        base_url="https://oneai.17usoft.com/v1",
+    )
+    # Delete the attribute so getattr hits its default branch.
+    delattr(compressor, missing_attr)
+    agent = _make_agent(compressor=compressor)
+
+    _maybe_emit_compression_auth_hint(agent)  # must not raise
+
+    # At least one line still got emitted (the "auth failed" header).
+    assert len(agent._captured) >= 1  # type: ignore[attr-defined]

--- a/tests/agent/test_compression_auth_error_attribution.py
+++ b/tests/agent/test_compression_auth_error_attribution.py
@@ -61,6 +61,9 @@ def _build_agent_with_compressor(
     aux_provider: str = _AUX_PROVIDER,
     aux_model: str = _AUX_MODEL,
     aux_base_url: str = _AUX_BASE_URL,
+    aux_config_provider: str = "",
+    aux_config_model: str = "",
+    aux_config_base_url: str = "",
 ):
     with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
         from run_agent import AIAgent
@@ -113,6 +116,13 @@ def _build_agent_with_compressor(
     compressor._last_aux_call_provider = ""
     compressor._last_aux_call_model = ""
     compressor._last_aux_call_base_url = ""
+    # Config-layer auxiliary identity (empty until _generate_summary resolves
+    # an explicit auxiliary.compression provider). Set explicitly because a
+    # MagicMock auto-attribute would be a truthy Mock and leak into the
+    # pre-dispatch branch of the diagnostic.
+    compressor._last_aux_config_provider = aux_config_provider
+    compressor._last_aux_config_model = aux_config_model
+    compressor._last_aux_config_base_url = aux_config_base_url
     compressor._last_aux_model_failure_model = None
     compressor._last_aux_model_failure_error = None
     agent.context_compressor = compressor
@@ -704,4 +714,163 @@ def test_real_compressor_no_provider_does_not_emit_aux_diagnostic(
     # pre-resolution approach produced must NOT appear either.
     assert "Provider: auto" not in rendered, (
         f"phantom 'Provider: auto' on no-provider: {emitted}"
+    )
+
+
+def test_real_call_llm_quarantined_fallback_auth_propagates_last_attempt_error() -> None:
+    """Primary rate-limit → fallback candidate with an unrefreshable 401 →
+    no remaining candidate. The error that propagates must be the FALLBACK's
+    terminal auth error, not the primary's rate-limit: the route snapshot
+    already identifies the fallback, so re-raising the primary would pair one
+    attempt's endpoint with a different attempt's failure class (#72636
+    review, defect 1)."""
+    from agent.auxiliary_client import call_llm
+
+    primary_err = type("Rate429", (Exception,), {"status_code": 429})(
+        "429 Too Many Requests: rate limit exceeded"
+    )
+    fallback_err = type("Auth401", (Exception,), {"status_code": 401})(
+        "expired fallback key"
+    )
+    primary = MagicMock()
+    primary.base_url = "https://api.minimax.chat/v1"
+    primary.chat.completions.create.side_effect = primary_err
+
+    fallback = MagicMock()
+    fallback.base_url = "https://openrouter.ai/api/v1"
+    fallback.chat.completions.create.side_effect = fallback_err
+    routes: list[tuple[str, str | None, str]] = []
+
+    # Discovery order for an auto primary: configured chain (None) → main
+    # chain (None) → payment fallback (the 401-looping candidate). After the
+    # candidate is quarantined, the chain is walked once more — this time it
+    # must yield nothing, so the chain exhausts.
+    payment_walks = [
+        (fallback, "fallback-model", "openrouter"),
+        (None, None, ""),
+    ]
+
+    def _payment_fallback(*_args, **_kwargs):
+        return payment_walks.pop(0) if payment_walks else (None, None, "")
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "minimax/minimax-m2.7", None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary, "minimax/minimax-m2.7"),
+        ),
+        patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(None, None, ""),
+        ),
+        patch(
+            "agent.auxiliary_client._try_main_fallback_chain",
+            return_value=(None, None, ""),
+        ),
+        patch(
+            "agent.auxiliary_client._try_payment_fallback",
+            side_effect=_payment_fallback,
+        ),
+    ):
+        with pytest.raises(Exception) as excinfo:
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                route_callback=lambda *route: routes.append(route),
+            )
+
+    # The terminal route snapshot is the fallback...
+    assert routes == [
+        ("minimax", "minimax/minimax-m2.7", "https://api.minimax.chat/v1"),
+        ("openrouter", "fallback-model", "https://openrouter.ai/api/v1"),
+    ]
+    # ...so the propagated error must be the fallback's own 401, chained to
+    # the primary origin — never the primary's 429 re-raised bare.
+    assert excinfo.value is fallback_err, (
+        f"propagated error is not the quarantined fallback 401: {excinfo.value!r}"
+    )
+    assert excinfo.value.__cause__ is primary_err
+
+
+def test_real_compressor_explicit_provider_missing_key_reports_pre_dispatch(
+    tmp_path: Path,
+) -> None:
+    """auxiliary.compression names an explicit provider whose API key is
+    missing → call_llm raises BEFORE any client exists, so route_callback
+    never fires. The diagnostic must report the CONFIGURED auxiliary
+    identity as a pre-dispatch failure — it must NOT substitute the healthy
+    main endpoint and must NOT claim auxiliary.compression is unconfigured
+    (#72636 review, defect 2)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_NOKEY"
+    db.create_session(sid, source="cli")
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url=_MAIN_BASE_URL,
+            model=_MAIN_MODEL,
+            quiet_mode=True,
+            session_db=db,
+            session_id=sid,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        from agent.context_compressor import ContextCompressor
+
+        comp = ContextCompressor(
+            model=_MAIN_MODEL, base_url=_MAIN_BASE_URL, provider=_MAIN_PROVIDER,
+            quiet_mode=True, protect_first_n=2, protect_last_n=2,
+            abort_on_summary_failure=False,
+        )
+    agent.context_compressor = comp
+    comp._clear_compression_failure_cooldown()
+
+    # call_llm dies before dispatch — route_callback never fires.
+    def _fake_missing_key(*args, **kwargs):
+        raise RuntimeError(
+            "Provider 'openrouter' is set in config.yaml but no API key was found"
+        )
+
+    emitted: list[str] = []
+    agent._emit_warning = lambda message: emitted.append(message)
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    with (
+        patch("agent.context_compressor.call_llm", side_effect=_fake_missing_key),
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("openrouter", "or-aux-model", "https://openrouter.ai/api/v1", None, None),
+        ),
+    ):
+        agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    rendered = "\n".join(emitted)
+    # The CONFIGURED auxiliary identity is reported...
+    assert "openrouter" in rendered, (
+        f"configured aux provider missing from pre-dispatch diagnostic: {emitted}"
+    )
+    assert "or-aux-model" in rendered, (
+        f"configured aux model missing from pre-dispatch diagnostic: {emitted}"
+    )
+    assert "https://openrouter.ai/api/v1" in rendered, (
+        f"configured aux endpoint missing from pre-dispatch diagnostic: {emitted}"
+    )
+    # ...flagged as pre-dispatch...
+    assert "no request was dispatched" in rendered, (
+        f"pre-dispatch note missing: {emitted}"
+    )
+    # ...and the two false claims the old fallback produced are gone: the
+    # healthy MAIN endpoint must not appear as the failed route...
+    assert _MAIN_BASE_URL not in rendered, (
+        f"main endpoint substituted on pre-dispatch failure: {emitted}"
+    )
+    # ...and the diagnostic must not claim auxiliary.compression is unset.
+    assert "not configured" not in rendered, (
+        f"false 'not configured' note on explicit-provider failure: {emitted}"
     )

--- a/tests/agent/test_compression_auth_error_attribution.py
+++ b/tests/agent/test_compression_auth_error_attribution.py
@@ -390,6 +390,45 @@ def test_aux_unset_falls_back_to_main_model_with_note(tmp_path: Path) -> None:
     )
 
 
+def test_aux_unset_fallback_strips_query_from_main_base_url(tmp_path: Path) -> None:
+    """The aux-unset fallback reads compressor.base_url (the MAIN model's
+    URL) raw — no producer strips it on this path. When the main endpoint
+    carries a proxy credential as ?key=..., the sink must sanitize it before
+    the user-facing warning: route_callback never fired (pre-dispatch abort)
+    and auxiliary.compression is unset, so nothing else stands between the
+    raw URL and Telegram/Discord/Slack (#72636 review, defect 2)."""
+    _SECRET = "sk-super-secret-token-12345"
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "PARENT_72636_SINK_SANITIZE"
+    db.create_session(sid, source="cli")
+
+    agent, compressor = _build_agent_with_compressor(
+        db, sid, failure_class="auth", aux_provider="", aux_model="", aux_base_url=""
+    )
+    # The main endpoint carries a credential in the query string — as real
+    # proxy deployments do.
+    compressor.base_url = f"https://proxy.example.com/v1?key={_SECRET}"
+
+    emitted = _run_compression(agent)
+    rendered = "\n".join(emitted)
+
+    # Prove we exercised the third fallback (not another branch)...
+    assert "not configured" in rendered, (
+        f"expected the aux-unset fallback note, got: {emitted}"
+    )
+    # ...the sanitized endpoint is still reported...
+    assert "https://proxy.example.com/v1" in rendered, (
+        f"sanitized main endpoint missing from diagnostic: {emitted}"
+    )
+    # ...but the query-string credential MUST NOT leak.
+    assert _SECRET not in rendered, (
+        f"query-string credential leaked into diagnostic: {emitted}"
+    )
+    assert "key=" not in rendered, (
+        f"query string leaked into diagnostic: {emitted}"
+    )
+
+
 # ── Robustness ─────────────────────────────────────────────────────────
 
 
@@ -793,6 +832,75 @@ def test_real_call_llm_quarantined_fallback_auth_propagates_last_attempt_error()
         f"propagated error is not the quarantined fallback 401: {excinfo.value!r}"
     )
     assert excinfo.value.__cause__ is primary_err
+
+
+def test_real_call_llm_quarantined_fallback_keeps_primary_error_for_other_tasks() -> None:
+    """Same wire scenario as the compression test above, but for an auxiliary
+    task that did NOT opt into route attribution (no route_callback, task is
+    not compression — e.g. web_extract or title generation): call_llm's
+    exception contract must be unchanged from before this PR. The swallowed
+    fallback 401 stays swallowed and the caller observes the PRIMARY error
+    (429), which upper layers key retry/backoff decisions on (#72636
+    review, defect 1 scoping)."""
+    from agent.auxiliary_client import call_llm
+
+    primary_err = type("Rate429", (Exception,), {"status_code": 429})(
+        "429 Too Many Requests: rate limit exceeded"
+    )
+    fallback_err = type("Auth401", (Exception,), {"status_code": 401})(
+        "expired fallback key"
+    )
+    primary = MagicMock()
+    primary.base_url = "https://api.minimax.chat/v1"
+    primary.chat.completions.create.side_effect = primary_err
+
+    fallback = MagicMock()
+    fallback.base_url = "https://openrouter.ai/api/v1"
+    fallback.chat.completions.create.side_effect = fallback_err
+
+    payment_walks = [
+        (fallback, "fallback-model", "openrouter"),
+        (None, None, ""),
+    ]
+
+    def _payment_fallback(*_args, **_kwargs):
+        return payment_walks.pop(0) if payment_walks else (None, None, "")
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "minimax/minimax-m2.7", None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary, "minimax/minimax-m2.7"),
+        ),
+        patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(None, None, ""),
+        ),
+        patch(
+            "agent.auxiliary_client._try_main_fallback_chain",
+            return_value=(None, None, ""),
+        ),
+        patch(
+            "agent.auxiliary_client._try_payment_fallback",
+            side_effect=_payment_fallback,
+        ),
+    ):
+        with pytest.raises(Exception) as excinfo:
+            call_llm(
+                task="web_extract",
+                messages=[{"role": "user", "content": "describe"}],
+            )
+
+    # Pre-PR contract: the caller sees the primary 429, not the fallback's
+    # quarantined 401 — retry/backoff classification must not flip to
+    # "credential broken" for tasks outside the attribution path.
+    assert excinfo.value is primary_err, (
+        f"non-compression task received the quarantined fallback error "
+        f"instead of the primary: {excinfo.value!r}"
+    )
 
 
 def test_real_compressor_explicit_provider_missing_key_reports_pre_dispatch(


### PR DESCRIPTION
## Summary

When auxiliary context compression fails, Hermes can surface the main model's provider, model, and endpoint instead of the route that actually failed. This sends users to troubleshoot a healthy main endpoint and becomes especially misleading when `provider: auto`, retries, or a runtime fallback changes the physical request route.

## Root Cause

The compressor is initialized with the main model runtime fields, while the auxiliary route is resolved later inside `call_llm()`. The previous diagnostic therefore could not reliably identify the auxiliary request. An initial route callback was also insufficient because it ran only once: it could retain `Provider: auto` or the first client after a retry or fallback had already moved the request elsewhere.

## Changes

- `agent/auxiliary_client.py`
  - Carry an optional route callback in the per-call relay context.
  - Invoke it immediately before every physical synchronous wire attempt, including the initial call, same-provider retries, client rebuilds, credential rotation, and runtime fallback candidates.
  - Report a concrete provider derived from the actual client endpoint when configuration resolution returns `auto`. Endpoints whose provider cannot be inferred from the wire URL report `custom` — this means "auto-selected HTTP client with an unrecognized endpoint", not a provider name, so dashboards/logs should not read it as one.
  - Report the final request model and query-stripped `client.base_url`, so later attempts replace earlier route snapshots without exposing query credentials. The relay context's `main_runtime.base_url` copy is also stored query-stripped for the same reason.
- `agent/context_compressor.py`
  - Record the latest physical auxiliary route for the current summary attempt.
  - Classify the current attempt as `auth`, `network`, or `other` without reusing a stale sticky cooldown classification.
- `agent/conversation_compression.py`
  - Emit the diagnostic only from the centralized compression-abort path, after the auxiliary attempt has completed.
  - Use the terminating route snapshot and gateway-visible wording.
- `tests/agent/test_compression_auth_error_attribution.py`
  - Cover the real `call_llm()` orchestration for `provider: auto`, exact provider/model/endpoint reporting, query-string redaction, and a primary-to-fallback terminal failure.
  - Retain end-to-end coverage from `ContextCompressor` through the compression-abort diagnostic, including stale-classification and gateway visibility cases.

## Validation

Rebased onto current `main` (`7166071fca`); the commit series was semantically re-transplanted onto the upstream refactors (`_candidate_rejected` in `conversation_compression`, `_reset_session_compaction_state` / `_call_summary_llm` / `_on_summary_failure` in `context_compressor`, and the `_plan_aux_call` recovery-ladder in `auxiliary_client`). Net diff vs `main` is unchanged in scope: 4 files, +1385/-5.

```text
scripts/run_tests.sh tests/agent/test_compression_auth_error_attribution.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_relay.py tests/agent/test_context_compressor.py tests/gateway/test_telegram_noise_filter.py -q
```

- 513 focused tests passed (17/17 in the attribution regression suite, including the round-1 review tests).
- Full `tests/agent/` on this head: 6335 passed / 24 skipped / 492 files. The 13–14 failures are the identical pre-existing set observed on a clean `main` baseline run (relay/aux/vision tests untouched by this PR; one flakes between runs).
- `python3 -m py_compile` passed for the modified Python files.
- `git diff --check` passed.
- Tested on macOS 26.5.

Closes #72636
