### PR TITLE
fix(desktop): keep the highlighted slash/@ menu row visible during keyboard navigation

### DIFF
--- a/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
@@ -1,4 +1,5 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import type { Unstable_TriggerItem } from '@assistant-ui/core'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
@@ -53,5 +54,104 @@ describe('ComposerTriggerPopover i18n', () => {
 
     expect(screen.getByText('没有匹配项。')).toBeTruthy()
     expect(container.textContent).toContain('/help')
+  })
+})
+
+describe('ComposerTriggerPopover keyboard-driven scroll', () => {
+  const items: readonly Unstable_TriggerItem[] = Array.from({ length: 8 }, (_, i) => ({
+    id: `cmd${i}|${i}`,
+    label: `cmd${i}`,
+    type: 'slash'
+  }))
+
+  function renderListPopover(activeIndex: number) {
+    const onHover = vi.fn()
+    const onPick = vi.fn()
+
+    const rendered = render(
+      <I18nProvider configClient={null} initialLocale="zh">
+        <ComposerTriggerPopover
+          activeIndex={activeIndex}
+          items={items}
+          kind="/"
+          loading={false}
+          onHover={onHover}
+          onPick={onPick}
+        />
+      </I18nProvider>
+    )
+
+    const rerenderAt = (index: number) =>
+      rendered.rerender(
+        <I18nProvider configClient={null} initialLocale="zh">
+          <ComposerTriggerPopover
+            activeIndex={index}
+            items={items}
+            kind="/"
+            loading={false}
+            onHover={onHover}
+            onPick={onPick}
+          />
+        </I18nProvider>
+      )
+
+    return { ...rendered, onHover, onPick, rerenderAt }
+  }
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('scrolls the highlighted row into view as the active index advances', () => {
+    // jsdom has no layout, so scrollIntoView is the observable contract here.
+    const scrollIntoView = vi.fn()
+    Element.prototype.scrollIntoView = scrollIntoView
+
+    const { container, rerenderAt } = renderListPopover(0)
+
+    rerenderAt(3)
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
+    const highlighted = container.querySelector('[data-highlighted]')
+    expect(highlighted?.textContent).toContain('/cmd3')
+  })
+
+  it('pins the drawer to the top when the highlight wraps back to the first row', () => {
+    Element.prototype.scrollIntoView = vi.fn()
+
+    const { rerenderAt } = renderListPopover(6)
+    const drawer = screen.getByRole('listbox')
+
+    rerenderAt(7)
+    drawer.scrollTop = 120
+
+    rerenderAt(0)
+
+    expect(drawer.scrollTop).toBe(0)
+  })
+
+  it('does not scroll for hover-driven highlight changes', () => {
+    const scrollIntoView = vi.fn()
+    Element.prototype.scrollIntoView = scrollIntoView
+
+    const { container, onHover, rerenderAt } = renderListPopover(0)
+    scrollIntoView.mockClear()
+
+    const rows = container.querySelectorAll('button')
+    fireEvent.mouseEnter(rows[4]!)
+
+    expect(onHover).toHaveBeenCalledWith(4)
+
+    // The parent echoes the hover back as the new active index — that update
+    // must not move the drawer out from under the pointer.
+    rerenderAt(4)
+
+    expect(scrollIntoView).not.toHaveBeenCalled()
+
+    // The next keyboard step scrolls again.
+    rerenderAt(5)
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
   })
 })

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -1,5 +1,5 @@
 import type { Unstable_TriggerItem } from '@assistant-ui/core'
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
@@ -69,6 +69,34 @@ export function ComposerTriggerPopover({
   const { t } = useI18n()
   const copy = t.composer
   const isSlash = kind === '/'
+  const listRef = useRef<HTMLDivElement>(null)
+  // Index of the row the mouse last highlighted. Hover-driven highlights must
+  // not scroll (the row is already under the cursor, and a nudge would move
+  // rows under the pointer and re-fire hover in a loop) — only keyboard
+  // navigation may drive the drawer's scroll position.
+  const hoverIndexRef = useRef(-1)
+
+  useEffect(() => {
+    if (activeIndex === hoverIndexRef.current) {
+      return
+    }
+
+    const list = listRef.current
+
+    if (!list) {
+      return
+    }
+
+    // At the top, pin the drawer to 0 so the first group header stays visible;
+    // `nearest` alone would stop at the row and leave the header clipped.
+    if (activeIndex <= 0) {
+      list.scrollTop = 0
+
+      return
+    }
+
+    list.querySelector('[data-highlighted]')?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex, items])
 
   let lastGroup: string | undefined
 
@@ -78,6 +106,10 @@ export function ComposerTriggerPopover({
       data-slot="composer-completion-drawer"
       data-state="open"
       onMouseDown={event => event.preventDefault()}
+      onMouseLeave={() => {
+        hoverIndexRef.current = -1
+      }}
+      ref={listRef}
       role="listbox"
     >
       {items.length === 0 ? (
@@ -127,7 +159,10 @@ export function ComposerTriggerPopover({
                 className={cn(ROW_BASE_CLASS, isSlash ? 'flex-col gap-0' : 'items-center gap-2')}
                 data-highlighted={active ? '' : undefined}
                 onClick={() => onPick(item)}
-                onMouseEnter={() => onHover(index)}
+                onMouseEnter={() => {
+                  hoverIndexRef.current = index
+                  onHover(index)
+                }}
                 type="button"
               >
                 {isSlash ? (


### PR DESCRIPTION
## What does this PR do?

Fixes a keyboard-navigation observability bug in the Desktop composer's completion drawer (the popup recommending skills/slash commands when you type `/`, and `@` references). Holding **ArrowDown** advanced the highlighted row past the drawer's visible area, but the drawer's scroll position never followed — the highlight walked off-screen and the user could no longer see what they were about to accept.

The drawer is a scroll container (`overflow-y-auto` + `max-h` in `completion-drawer.tsx`) and the active row is marked with `data-highlighted`, but nothing ever scrolled the active row into view when `activeIndex` changed. This PR makes `ComposerTriggerPopover` keep the highlighted row visible:

- On a keyboard-driven `activeIndex` change, scroll the highlighted row into view with `scrollIntoView({ block: 'nearest' })`.
- When the highlight returns/wraps to the first row, pin the drawer to `scrollTop = 0` so the leading group header ("suggested", etc.) stays visible — `nearest` alone would leave it clipped.
- Hover-driven highlight changes never scroll (the row is already under the cursor, and a nudge would shift rows under the pointer and re-fire hover in a loop). The last hover index is tracked in a ref, set on `mouseenter` and cleared on drawer `mouseleave`.

This approach keeps the fix local to the popover (presentation-only state stays in the renderer component), with no changes to the keyboard handlers in `index.tsx`.

## Related Issue

Fixes #72639

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/trigger-popover.tsx` — add a `listRef` on the drawer and an effect that scrolls the `data-highlighted` row into view on keyboard-driven `activeIndex` changes; pin to top for index 0; track hover via `hoverIndexRef` (`mouseenter` sets, drawer `mouseleave` clears) so hover-driven changes don't scroll.
- `apps/desktop/src/app/chat/composer/trigger-popover.test.tsx` — new `ComposerTriggerPopover keyboard-driven scroll` suite: asserts the highlighted row is scrolled into view with `{ block: 'nearest' }` as the index advances, the drawer pins to `scrollTop = 0` when the highlight wraps back to the first row, and hover-driven highlight changes do not scroll.

## How to Test

1. `cd apps/desktop && npm install && npm run dev` (or a packaged build), focus the composer.
2. Type `/` so the completion drawer opens with more items than fit in its max height.
3. Hold **ArrowDown**: before this fix the highlight disappears below the drawer's viewport while the drawer stays frozen; with the fix the drawer scrolls so the highlighted row is always visible, wraps back to the top (header included), and ArrowUp works symmetrically.
4. Mouse-hover rows near the drawer's edge: the list must not shift under the pointer.
5. Automated: `cd apps/desktop && npm run typecheck && npm run lint && npm run test:ui && npm run test:desktop:platforms` — all green (2526 + 794 tests passed locally).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suites this diff touches — renderer-only change: `npm run typecheck`, `npm run lint`, `npm run test:ui`, `npm run test:desktop:platforms` all pass (Python suite untouched by this diff)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior fix, no API/config surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — DOM-only change, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Screen recording of the bug (highlight walking off-screen while the drawer stays frozen) is attached below.
