### PR TITLE
fix(custom): forward provider routing prefs via the profile path

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -17,9 +17,45 @@ from typing import Any
 from providers import register_provider
 from providers.base import ProviderProfile
 
+# Hostnames / URL patterns that do NOT support OpenRouter-style routing.
+_NON_ROUTING_HOSTMARKERS = (
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "ollama",
+    "llamacpp",
+    "llama.cpp",
+    "vllm",
+)
+
+def _endpoint_supports_provider_routing(base_url: str | None) -> bool:
+    """conservative check: only hosted (non-local) endpoints get routing fields."""
+    if not base_url:
+        return False
+    normalized = str(base_url).strip().lower()
+    for marker in _NON_ROUTING_HOSTMARKERS:
+        if marker in normalized:
+            return False
+    return True
+
 
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
+
+    def build_extra_body(
+        self,
+        *,
+        session_id: str | None = None,
+        **context: Any,
+    ) -> dict[str, Any]:
+        """Forward provider routing prefs for OpenRouter-compatible custom endpoints."""
+        extra_body: dict[str, Any] = {}
+        provider_prefs = context.get("provider_preferences")
+        base_url = context.get("base_url")
+        if provider_prefs and _endpoint_supports_provider_routing(base_url):
+            extra_body["provider"] = provider_prefs
+        return extra_body
+        
 
     def build_api_kwargs_extras(
         self,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -381,6 +381,43 @@ class TestChatCompletionsBuildKwargs:
             {"id": "pareto-router", "min_coding_score": 0.8}
         ]
 
+    def test_custom_provider_gets_provider_pref(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            provider_profile=profile,
+            provider_preferences={"only": ["openai"]},
+            base_url="https://api.polza.ai/v1",
+        )
+        assert kw["extra_body"]["provider"] == {"only": ["openai"]}
+
+    def test_custom_provider_no_prefs_no_provider_key(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        result = profile.build_extra_body(session_id=None)
+        assert isinstance(result, dict)
+        assert result == {}
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            provider_profile=profile,
+        )
+        assert "provider" not in (kw.get("extra_body") or {})
+
+    def test_custom_provider_local_endpoint_skips_provider_pref(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="llama3", messages=msgs,
+            provider_profile=profile,
+            provider_preferences={"only": ["openai"]},
+            base_url="http://localhost:11434/v1",
+        )
+        assert "provider" not in (kw.get("extra_body") or {})
+
     def test_nous_tags(self, transport):
         from agent.portal_tags import nous_portal_tags
         from providers import get_provider_profile


### PR DESCRIPTION
Supersedes #24542 and #72600. Fixes #24450.