### PR TITLE
fix(tool_search): accept sanitized keys in deferred tool_call probe

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -516,3 +516,117 @@ class TestDeferredCallSchemaProbe:
         ))
         assert result.get("ok") is True
         assert result.get("doc") == "abc"
+
+    @staticmethod
+    def _register_renamed_required(name: str, toolset: str):
+        """Register a deferred tool whose required property key is sanitized.
+
+        Mirrors Cloudflare-style filter params (e.g. ``issue_class~neq``) that
+        get renamed for provider schema compatibility before the model sees
+        them via tool_describe / the tools array.
+
+        Schema shape matches MCP registration (flat name/description/parameters),
+        which is what coerce_tool_args + unrename_tool_args expect at dispatch.
+        """
+        from tools.registry import registry
+
+        def _handler(args, task_id=None, **kw):
+            return json.dumps({
+                "ok": True,
+                "issue_class_neq": args.get("issue_class~neq"),
+                "zone_id": args.get("zone_id"),
+            })
+
+        params = {
+            "type": "object",
+            "properties": {
+                "issue_class~neq": {
+                    "type": "string",
+                    "description": "Exclude this issue class",
+                },
+                "zone_id": {"type": "string", "description": "Zone id"},
+            },
+            "required": ["issue_class~neq", "zone_id"],
+        }
+        registry.register(
+            name=name,
+            handler=_handler,
+            schema={
+                "name": name,
+                "description": f"desc {name}",
+                "parameters": params,
+            },
+            toolset=toolset,
+        )
+
+    def test_validator_accepts_sanitized_required_keys(self):
+        """Model-facing keys from tool_describe must pass the probe.
+
+        Regression: the probe used to check registry wire names only, so a
+        complete call with sanitized keys (issue_class_neq) was rejected as
+        missing issue_class~neq and never reached unrename/dispatch.
+        """
+        from tools.tool_search import validate_deferred_call_args
+
+        self._register_renamed_required("mcp_probe_cf_accept", "mcp-probe-cf")
+        # Model args match the sanitized schema (tool_describe / tools array).
+        assert validate_deferred_call_args(
+            "mcp_probe_cf_accept",
+            {"issue_class_neq": "bug", "zone_id": "z1"},
+        ) is None
+        # Wire names still work too (identity path / unrename no-op).
+        assert validate_deferred_call_args(
+            "mcp_probe_cf_accept",
+            {"issue_class~neq": "bug", "zone_id": "z1"},
+        ) is None
+
+    def test_validator_still_blocks_missing_after_unrename(self):
+        """Sanitized keys do not hide a genuinely missing required field."""
+        from tools.tool_search import validate_deferred_call_args
+
+        self._register_renamed_required("mcp_probe_cf_missing", "mcp-probe-cf")
+        err = validate_deferred_call_args(
+            "mcp_probe_cf_missing",
+            {"issue_class_neq": "bug"},  # zone_id missing
+        )
+        assert err is not None
+        parsed = json.loads(err)
+        assert "zone_id" in parsed["error"]
+        assert "NOT invoked" in parsed["error"]
+        # Error schema matches model-facing names (sanitized).
+        assert "issue_class_neq" in parsed["parameters"]["properties"]
+        assert "issue_class~neq" not in parsed["parameters"]["properties"]
+        assert parsed["parameters"]["required"] == ["issue_class_neq", "zone_id"]
+
+    def test_handle_function_call_dispatches_sanitized_required_keys(self):
+        """End-to-end: tool_call with sanitized args invokes the tool."""
+        import model_tools
+
+        self._register_renamed_required("mcp_probe_cf_dispatch", "mcp-probe-cf-d")
+        result = json.loads(model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={
+                "name": "mcp_probe_cf_dispatch",
+                "arguments": {"issue_class_neq": "bug", "zone_id": "z1"},
+            },
+            enabled_toolsets=["mcp-probe-cf-d"],
+        ))
+        assert result.get("ok") is True
+        assert result.get("issue_class_neq") == "bug"
+        assert result.get("zone_id") == "z1"
+        assert "missing required" not in json.dumps(result)
+
+    def test_blind_tool_call_error_uses_model_facing_required_names(self):
+        """Probe error lists sanitized required names when keys are renamed."""
+        import model_tools
+
+        self._register_renamed_required("mcp_probe_cf_blind", "mcp-probe-cf-b")
+        result = json.loads(model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={"name": "mcp_probe_cf_blind", "arguments": {}},
+            enabled_toolsets=["mcp-probe-cf-b"],
+        ))
+        assert "error" in result
+        assert "issue_class_neq" in result["error"]
+        assert "issue_class~neq" not in result["error"]
+        assert result["parameters"]["required"] == ["issue_class_neq", "zone_id"]

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -934,6 +934,32 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     return frozenset(names)
 
 
+def _model_facing_parameters(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the parameter schema the model actually sees (sanitized).
+
+    Provider-illegal property keys are renamed before tools leave
+    ``get_tool_definitions`` / ``tool_describe``. Probe errors must teach the
+    same names so a repair round-trip matches ``tool_describe``.
+    """
+    try:
+        from tools.schema_sanitizer import sanitize_tool_schemas
+        sanitized = sanitize_tool_schemas([{
+            "type": "function",
+            "function": {
+                "name": "_probe",
+                "description": "",
+                "parameters": params,
+            },
+        }])
+        if not sanitized:
+            return params
+        fn = (sanitized[0].get("function") or {})
+        out = fn.get("parameters")
+        return out if isinstance(out, dict) else params
+    except Exception:
+        return params
+
+
 def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str]:
     """Probe-validate ``tool_call`` arguments against the deferred tool's schema.
 
@@ -955,6 +981,13 @@ def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str
     tool's own business, and ``coerce_tool_args`` already handles type repair
     downstream. Returns a JSON error string when invalid, ``None`` when the
     call should dispatch.
+
+    Model-facing property keys may differ from the registry wire names when
+    the schema sanitizer renames provider-illegal characters (e.g. Cloudflare
+    ``issue_class~neq`` -> ``issue_class_neq``). Args are reverse-mapped with
+    the same ``unrename_tool_args`` path ``coerce_tool_args`` uses before the
+    key-absence check, so a call that matches ``tool_describe`` is never
+    rejected as missing required fields.
     """
     try:
         from tools.registry import registry as _registry
@@ -970,13 +1003,48 @@ def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str
         required = params.get("required")
         if not isinstance(required, list) or not required:
             return None
-        missing = [r for r in required if isinstance(r, str) and r not in args]
-        if not missing:
+
+        # Model args use the SANITIZED keys from tool_describe / the tools
+        # array. Map them back to wire names before checking required fields,
+        # matching coerce_tool_args. Fail open if unrename itself errors.
+        check_args: Dict[str, Any] = args if isinstance(args, dict) else {}
+        try:
+            from tools.schema_sanitizer import unrename_tool_args
+            unrenamed = unrename_tool_args(params, check_args)
+            if isinstance(unrenamed, dict):
+                check_args = unrenamed
+        except Exception:
+            logger.debug(
+                "validate_deferred_call_args unrename failed for %s",
+                name, exc_info=True,
+            )
+
+        missing_wire = [
+            r for r in required if isinstance(r, str) and r not in check_args
+        ]
+        if not missing_wire:
             return None
+        # Teach the model the same names it already sees from tool_describe.
+        display_params = _model_facing_parameters(params)
+        wire_to_display: Dict[str, str] = {}
+        try:
+            from tools.schema_sanitizer import unrename_tool_args as _unrename
+            for display_key in (display_params.get("properties") or {}):
+                if not isinstance(display_key, str):
+                    continue
+                mapped = _unrename(params, {display_key: True})
+                if isinstance(mapped, dict):
+                    for wire_key in mapped:
+                        if isinstance(wire_key, str):
+                            wire_to_display[wire_key] = display_key
+        except Exception:
+            wire_to_display = {}
+        missing_display = [wire_to_display.get(r, r) for r in missing_wire]
+
         return tool_error(
             f"tool_call to '{name}' is missing required argument(s): "
-            f"{', '.join(missing)}. The tool was NOT invoked.",
-            parameters=params,
+            f"{', '.join(missing_display)}. The tool was NOT invoked.",
+            parameters=display_params,
             hint=(
                 "Retry tool_call with 'arguments' matching the parameters "
                 "schema above."


### PR DESCRIPTION
Accept model-facing sanitized keys in deferred tool calls by reverse-mapping them before required-field validation. Preserve canonical coercion, full JSON Schema validation, nullable handling, and external-reference safeguards. Return sanitized schemas and model-facing argument paths in validation errors.

Fixes #72648

Validation: All 52 tool-search tests passed through scripts/run_tests.sh. New contracts exercise real tool_call dispatch for both key forms, coercion, and rejection without invocation for missing fields and invalid enum values.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
