### PR TITLE
feat(gateway): add revisioned mobile conversation synchronization

### DIFF
--- a/contributors/emails/ericlewis777@gmail.com
+++ b/contributors/emails/ericlewis777@gmail.com
@@ -1,0 +1,2 @@
+ericlewis
+# PR #62858 salvage via #72635

--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -27,9 +27,10 @@ from another reconstructed live stream. Clients must never treat either
 outcome as complete replay.
 
 Synchronization state and replay retention begin when an authorized mobile
-transport attaches to a live session. Legacy stdio and Desktop transports keep
-their original response and event shapes and do not pay the per-delta replay
-copying cost.
+transport first attaches to a live session. A session that has never negotiated
+sync does not pay the per-delta replay copying cost. If a legacy transport later
+attaches to a previously negotiated session, retention continues for the next
+mobile reconnect, but the legacy response and event shapes remain unchanged.
 
 ## Snapshot and event barrier
 

--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -26,6 +26,11 @@ limits. `gap` means an event needed after the supplied cursor was evicted.
 from another reconstructed live stream. Clients must never treat either
 outcome as complete replay.
 
+Synchronization state and replay retention begin when an authorized mobile
+transport attaches to a live session. Legacy stdio and Desktop transports keep
+their original response and event shapes and do not pay the per-delta replay
+copying cost.
+
 ## Snapshot and event barrier
 
 Hermes serializes snapshot-visible live state, event sequence allocation,

--- a/docs/mobile-client-contract.md
+++ b/docs/mobile-client-contract.md
@@ -1,0 +1,55 @@
+# Mobile Client Contract
+
+Hermes exposes its additive Mobile Client Contract on the existing
+authenticated `/api/ws` JSON-RPC transport. Clients must negotiate features
+from `gateway.ready`; a contract major or server version alone does not imply a
+capability.
+
+## Revisioned conversation synchronization
+
+When `conversation.sync` version 1 is advertised, `session.create` and
+`session.resume` include the same `synchronization` envelope:
+
+- `snapshot` is authoritative conversation state. It identifies the server
+  process, live event stream, stable conversation lineage, current stored
+  session tip, and process-local live session. It also includes a revision,
+  event watermark, messages, inflight turn, active tool descriptors, pending
+  interactions, and runtime status.
+- `recovery` reports `complete`, `gap`, or `reset`, the cursor at the snapshot
+  watermark, and any replayable events after the supplied cursor.
+- Every session event carries `schema_major`, `stream_id`, and a monotonically
+  increasing `sequence` within that stream.
+
+The replay store is bounded in memory by both the advertised event and byte
+limits. `gap` means an event needed after the supplied cursor was evicted.
+`reset` means the cursor is absent, invalid, from another server process, or
+from another reconstructed live stream. Clients must never treat either
+outcome as complete replay.
+
+## Snapshot and event barrier
+
+Hermes serializes snapshot-visible live state, event sequence allocation,
+replay retention, and event transport enqueueing at one per-stream boundary.
+Snapshot capture takes the conversation history lock before that stream
+boundary. The returned watermark therefore covers every state transition
+published before the snapshot.
+
+A client should:
+
+1. Buffer events for the returned `stream_id` while create or resume is in
+   flight.
+2. Install the complete snapshot at its `watermark`.
+3. Discard buffered or replayed events at or below the watermark.
+4. Apply only events for the same server and stream whose sequence is greater
+   than the watermark, in sequence order.
+5. Replace local state from the snapshot whenever recovery is `gap` or
+   `reset`.
+
+Assistant `message.delta` events additionally carry one `turn_id` and an
+absolute `offset`. The `conversation.sync.delta_offsets.unit` capability names
+the unit as `utf8_bytes`. Clients can therefore ignore an overlapping prefix
+instead of duplicating text after replay or transport coalescing.
+
+This slice does not claim durable mutation idempotency or addressable,
+recoverable approvals. Those features require separately advertised
+capabilities.

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -832,11 +832,13 @@ async def api_auth_ws_ticket(request: Request):
             raise HTTPException(status_code=400, detail="Expected a JSON object")
 
     audience = str(requested.get("audience") or "").strip()
-    if "scopes" in requested and not audience:
-        raise HTTPException(
-            status_code=400,
-            detail="audience is required when scopes are requested",
+    if body and not audience:
+        detail = (
+            "audience is required when scopes are requested"
+            if "scopes" in requested
+            else "audience is required for a non-empty ticket request"
         )
+        raise HTTPException(status_code=400, detail=detail)
     if audience:
         from tui_gateway.mobile_contract import (
             MOBILE_AUDIENCE,

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -15,6 +15,7 @@ The routes:
 """
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import time
@@ -807,7 +808,9 @@ async def api_auth_ws_ticket(request: Request):
 
     The ticket has a 30-second TTL and is single-use. Calling this endpoint
     multiple times in quick succession (e.g. one ticket per WS) is the
-    expected pattern.
+    expected pattern. A bodyless request intentionally retains the dashboard's
+    full legacy authority. A mobile audience requests a narrower grant for one
+    WebSocket connection; it is not a persistent device credential.
     """
     sess = getattr(request.state, "session", None)
     if sess is None:
@@ -818,14 +821,61 @@ async def api_auth_ws_ticket(request: Request):
     # don't load the ticket store.
     from hermes_cli.dashboard_auth.ws_tickets import TTL_SECONDS, mint_ticket
 
-    ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
+    body = await request.body()
+    requested = {}
+    if body:
+        try:
+            requested = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(status_code=400, detail="Invalid JSON")
+        if not isinstance(requested, dict):
+            raise HTTPException(status_code=400, detail="Expected a JSON object")
+
+    audience = str(requested.get("audience") or "").strip()
+    if "scopes" in requested and not audience:
+        raise HTTPException(
+            status_code=400,
+            detail="audience is required when scopes are requested",
+        )
+    if audience:
+        from tui_gateway.mobile_contract import (
+            MOBILE_AUDIENCE,
+            normalize_mobile_scopes,
+        )
+
+        if audience != MOBILE_AUDIENCE:
+            raise HTTPException(status_code=400, detail="Unsupported WebSocket audience")
+        raw_scopes = requested.get("scopes")
+        if not isinstance(raw_scopes, list):
+            raise HTTPException(status_code=400, detail="scopes must be an array")
+        try:
+            granted_scopes = normalize_mobile_scopes(raw_scopes)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        ticket = mint_ticket(
+            user_id=sess.user_id,
+            provider=sess.provider,
+            audience=audience,
+            scopes=granted_scopes,
+        )
+    else:
+        # Preserve the existing dashboard contract exactly for bodyless calls.
+        ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
     audit_log(
         AuditEvent.WS_TICKET_MINTED,
         provider=sess.provider,
         user_id=sess.user_id,
         ip=_client_ip(request),
     )
-    return {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    response = {"ticket": ticket, "ttl_seconds": TTL_SECONDS}
+    if audience:
+        response.update(
+            {
+                "audience": audience,
+                "granted_scopes": list(granted_scopes),
+            }
+        )
+    return response
 
 
 # ---------------------------------------------------------------------------
@@ -962,3 +1012,4 @@ async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
         },
         status_code=401,
     )
+

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -1014,4 +1014,3 @@ async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
         },
         status_code=401,
     )
-

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -5,10 +5,13 @@ mode the legacy ``?token=<_SESSION_TOKEN>`` query param works because the
 token is injected into the SPA bundle. In gated mode there is no injected
 token — so this module provides two credential shapes:
 
-1. **Single-use browser tickets** (``mint_ticket`` / ``consume_ticket``).
-   The SPA gets a fresh ticket via the authenticated REST endpoint
-   ``POST /api/auth/ws-ticket`` and passes it as ``?ticket=`` on the WS
-   upgrade. Single-use, TTL = 30 seconds — a leaked ticket is uninteresting.
+1. **Single-use client tickets** (``mint_ticket`` / ``consume_ticket``).
+   The SPA gets a full-authority legacy ticket from a bodyless authenticated
+   ``POST /api/auth/ws-ticket``. A native client can request a mobile audience
+   and explicit scopes instead. Both pass ``?ticket=`` on the WS upgrade and
+   are single-use with TTL = 30 seconds. The scoped ticket narrows one socket;
+   it is not a persistent device credential or a replacement for the legacy
+   compatibility path.
 
 2. **A process-lifetime internal credential** (``internal_ws_credential`` /
    ``consume_internal_credential``). This authenticates *server-spawned*
@@ -53,13 +56,21 @@ _internal_credential: Optional[str] = None
 #: credential, so audit logs distinguish them from browser-initiated tickets.
 INTERNAL_USER_ID = "server-internal"
 INTERNAL_PROVIDER = "server-internal"
+LEGACY_AUDIENCE = "dashboard"
+LEGACY_SCOPES = ("*",)
 
 
 class TicketInvalid(Exception):
     """Ticket missing, expired, or already consumed."""
 
 
-def mint_ticket(*, user_id: str, provider: str) -> str:
+def mint_ticket(
+    *,
+    user_id: str,
+    provider: str,
+    audience: str = LEGACY_AUDIENCE,
+    scopes: tuple[str, ...] = LEGACY_SCOPES,
+) -> str:
     """Generate a one-shot ticket bound to this user identity.
 
     The returned token is base64url, 43 bytes of entropy (32-byte random
@@ -70,6 +81,8 @@ def mint_ticket(*, user_id: str, provider: str) -> str:
     info = {
         "user_id": user_id,
         "provider": provider,
+        "audience": audience,
+        "scopes": tuple(scopes),
         "minted_at": int(time.time()),
     }
     with _lock:
@@ -132,10 +145,10 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     Unlike :func:`consume_ticket` this is **not** single-use — the value is
     not removed on success, so a server-spawned child can present it on every
     (re)connect. Returns the fixed server-internal identity ``info`` dict
-    (``{user_id, provider}``), mirroring the ``info`` shape ``consume_ticket``
-    returns, so a caller that wants to record the connecting identity can; the
-    current ``_ws_auth_ok`` caller validates for the boolean outcome only and
-    discards the dict.
+    (identity plus legacy audience/scopes), mirroring the ``info`` shape
+    ``consume_ticket`` returns so the gateway can carry one effective grant
+    shape through its transport. Non-gateway callers may validate only the
+    boolean outcome and discard the dict.
 
     A constant-time compare against the (lazily-minted) credential avoids
     leaking length / prefix information on mismatch. If no internal
@@ -150,6 +163,8 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
     return {
         "user_id": INTERNAL_USER_ID,
         "provider": INTERNAL_PROVIDER,
+        "audience": LEGACY_AUDIENCE,
+        "scopes": LEGACY_SCOPES,
     }
 
 

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -77,12 +77,20 @@ def mint_ticket(
     seed). Stash returns the ``info`` dict to the caller on consume so the
     WS handler can carry the identity forward into its session log.
     """
+    scope_tuple = tuple(scopes)
+    if audience == "hermes.mobile":
+        from tui_gateway.mobile_contract import normalize_mobile_scopes
+
+        scope_tuple = normalize_mobile_scopes(scope_tuple)
+    elif audience != LEGACY_AUDIENCE or scope_tuple != LEGACY_SCOPES:
+        raise ValueError(f"unsupported WebSocket audience or grant: {audience}")
+
     ticket = secrets.token_urlsafe(32)
     info = {
         "user_id": user_id,
         "provider": provider,
         "audience": audience,
-        "scopes": tuple(scopes),
+        "scopes": scope_tuple,
         "minted_at": int(time.time()),
     }
     with _lock:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14405,8 +14405,10 @@ def _ws_auth_mode() -> str:
     return "loopback"
 
 
-def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
-    """Validate WS-upgrade auth; return ``(reason, credential)``.
+def _ws_auth_result(
+    ws: "WebSocket",
+) -> tuple[Optional[str], str, Optional[Dict[str, Any]]]:
+    """Validate WS-upgrade auth and return its effective authorization grant.
 
     ``reason`` is None when the credential is accepted, else a short
     machine-parseable token explaining the rejection (``no_credential``,
@@ -14414,15 +14416,18 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     ``credential`` names which credential type was presented (``ticket``,
     ``internal``, ``token``, or ``none``) so the accepted path can log *how*
     a peer authed, not just that it did.
+    ``authorization`` is the server-derived grant carried by an accepted
+    credential; it is ``None`` for every rejected request.
 
     Loopback / ``--insecure``: legacy ``?token=<_SESSION_TOKEN>`` query
     parameter, constant-time compared.
 
     Gated (public bind, no ``--insecure``): one of two credentials —
 
-    * ``?ticket=<single-use>`` — a browser-minted, single-use, 30s-TTL ticket
-      consumed against the dashboard-auth ticket store. This is what the SPA
-      (and native clients) use.
+    * ``?ticket=<single-use>`` — a client-minted, single-use, 30s-TTL ticket
+      consumed against the dashboard-auth ticket store. The bodyless SPA flow
+      retains legacy dashboard authority. A native mobile ticket is restricted
+      to ``/api/ws`` and carries explicit scopes into its dispatcher.
     * ``?internal=<process-credential>`` — the process-lifetime internal
       credential, used only by WS clients the server spawns itself (the
       embedded-TUI PTY child attaching to ``/api/ws`` and ``/api/pub``). It
@@ -14454,8 +14459,8 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         internal = ws.query_params.get("internal", "")
         if internal:
             try:
-                consume_internal_credential(internal)
-                return None, "internal"
+                grant = consume_internal_credential(internal)
+                return None, "internal", grant
             except TicketInvalid as exc:
                 audit_log(
                     AuditEvent.WS_TICKET_REJECTED,
@@ -14463,15 +14468,26 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                     ip=(ws.client.host if ws.client else ""),
                     path=ws.url.path,
                 )
-                return "internal_invalid", "internal"
+                return "internal_invalid", "internal", None
 
         ticket = ws.query_params.get("ticket", "")
         if not ticket:
-            return "no_credential", "none"
+            return "no_credential", "none", None
 
         try:
-            consume_ticket(ticket)
-            return None, "ticket"
+            grant = consume_ticket(ticket)
+            if (
+                grant.get("audience") == "hermes.mobile"
+                and ws.url.path != "/api/ws"
+            ):
+                audit_log(
+                    AuditEvent.WS_TICKET_REJECTED,
+                    reason="mobile ticket used outside /api/ws",
+                    ip=(ws.client.host if ws.client else ""),
+                    path=ws.url.path,
+                )
+                return "ticket_audience_mismatch", "ticket", None
+            return None, "ticket", grant
         except TicketInvalid as exc:
             audit_log(
                 AuditEvent.WS_TICKET_REJECTED,
@@ -14479,14 +14495,29 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 ip=(ws.client.host if ws.client else ""),
                 path=ws.url.path,
             )
-            return "ticket_invalid", "ticket"
+            return "ticket_invalid", "ticket", None
 
     token = ws.query_params.get("token", "")
     if not token:
-        return "no_credential", "none"
+        return "no_credential", "none", None
     if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
-        return None, "token"
-    return "token_mismatch", "token"
+        return (
+            None,
+            "token",
+            {
+                "user_id": "loopback",
+                "provider": "loopback",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            },
+        )
+    return "token_mismatch", "token", None
+
+
+def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
+    """Compatibility view of :func:`_ws_auth_result` for non-gateway sockets."""
+    reason, credential, _authorization = _ws_auth_result(ws)
+    return reason, credential
 
 
 def _ws_auth_ok(ws: "WebSocket") -> bool:
@@ -15577,7 +15608,8 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
+    auth_reason, _credential, authorization = _ws_auth_result(ws)
+    if auth_reason is not None:
         await ws.close(code=4401)
         return
 
@@ -15587,7 +15619,7 @@ async def gateway_ws(ws: WebSocket) -> None:
 
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    await handle_ws(ws, authorization=authorization)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -13,6 +13,8 @@ pre-existing regression unrelated to dashboard-auth.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -20,14 +22,18 @@ import pytest
 from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
+from hermes_cli import mcp_startup
 from hermes_cli.dashboard_auth import clear_providers, register_provider
 from hermes_cli.dashboard_auth.ws_tickets import (
     _reset_for_tests,
+    consume_ticket,
     consume_internal_credential,
     internal_ws_credential,
     mint_ticket,
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+from tui_gateway import server as tui_server
+from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -116,10 +122,13 @@ class TestWsTicketEndpoint:
         r = gated_app.post("/api/auth/ws-ticket")
         assert r.status_code == 200
         body = r.json()
-        assert "ticket" in body
+        assert set(body) == {"ticket", "ttl_seconds"}
         assert isinstance(body["ticket"], str)
         assert len(body["ticket"]) >= 32
         assert body["ttl_seconds"] == 30
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "dashboard"
+        assert grant["scopes"] == ("*",)
 
     def test_unauthenticated_returns_401_or_redirect(self, gated_app):
         r = gated_app.post("/api/auth/ws-ticket", follow_redirects=False)
@@ -127,6 +136,58 @@ class TestWsTicketEndpoint:
         # returns either 401 or 302. Either is fine.
         assert r.status_code in (302, 401)
 
+
+    def test_mobile_ticket_returns_and_preserves_the_granted_scopes(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.read", "conversation.write"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["audience"] == "hermes.mobile"
+        assert body["granted_scopes"] == [
+            "conversation.read",
+            "conversation.write",
+        ]
+        grant = consume_ticket(body["ticket"])
+        assert grant["audience"] == "hermes.mobile"
+        assert grant["scopes"] == ("conversation.read", "conversation.write")
+
+    @pytest.mark.parametrize("scope", ["approval.respond", "shell.exec"])
+    def test_mobile_ticket_rejects_scopes_not_enforced_by_this_contract(
+        self,
+        gated_app,
+        scope,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"audience": "hermes.mobile", "scopes": [scope]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"unsupported mobile scope: {scope}"
+
+    def test_scopes_without_a_mobile_audience_do_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={"scopes": ["conversation.read"]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "audience is required when scopes are requested"
 
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
@@ -145,6 +206,54 @@ class TestWsTicketEndpoint:
             f"GET /api/auth/ws-ticket leaked a ticket (status={r.status_code}, "
             f"body[:200]={body[:200]!r})"
         )
+
+
+def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
+    sent = []
+    monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+    monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
+    ticket = mint_ticket(
+        user_id="mobile-user",
+        provider="stub",
+        audience="hermes.mobile",
+        scopes=("conversation.read",),
+    )
+
+    class QueryParams:
+        def get(self, key, default=""):
+            return {"ticket": ticket}.get(key, default)
+
+    class FakeWS:
+        query_params = QueryParams()
+        client = SimpleNamespace(host="203.0.113.10")
+        url = SimpleNamespace(path="/api/ws")
+        headers = {
+            "host": "fly-app.fly.dev",
+            "origin": "https://fly-app.fly.dev",
+        }
+
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise tui_ws._WebSocketDisconnect()
+
+        async def close(self, code=None):
+            pass
+
+    asyncio.run(web_server.gateway_ws(FakeWS()))
+
+    authorization = sent[0]["params"]["payload"]["authorization"]
+    assert authorization == {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ["conversation.read"],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -204,6 +313,26 @@ class TestWsAuthOkLoopback:
 class TestWsAuthOkGated:
     """Gate ON — ticket path only."""
 
+
+    @pytest.mark.parametrize("path", ["/api/pty", "/api/console", "/api/pub", "/api/events"])
+    def test_mobile_ticket_cannot_authenticate_non_gateway_websockets(
+        self,
+        gated_app,
+        path,
+    ):
+        ticket = mint_ticket(
+            user_id="mobile-user",
+            provider="stub",
+            audience="hermes.mobile",
+            scopes=("conversation.read",),
+        )
+        ws = _fake_ws(query={"ticket": ticket}, path=path)
+
+        reason, credential, authorization = web_server._ws_auth_result(ws)
+
+        assert reason == "ticket_audience_mismatch"
+        assert credential == "ticket"
+        assert authorization is None
 
     def test_consumed_ticket_rejected(self, gated_app):
         ticket = mint_ticket(user_id="u1", provider="stub")

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -5,16 +5,14 @@ The dashboard's WS endpoints (``/api/pty``, ``/api/console``, ``/api/ws``,
 loopback mode it accepts ``?token=<_SESSION_TOKEN>``; in gated mode it accepts
 a single-use ``?ticket=`` minted by ``POST /api/auth/ws-ticket``.
 
-These tests exercise the helper at the unit level (no actual WS upgrade)
-plus the ticket-mint endpoint under realistic gated-mode setup. We don't
-test the full WS upgrade because the starlette TestClient WS path has a
-pre-existing regression unrelated to dashboard-auth.
+These tests exercise the helper at the unit level, the ticket-mint endpoint
+under realistic gated-mode setup, and one public mint-to-upgrade-to-dispatch
+round trip. The full upgrade supplies explicit Host/Origin headers because
+Starlette's WebSocket TestClient does not inherit the HTTP ``base_url`` host.
 """
 
 from __future__ import annotations
 
-import asyncio
-import json
 from types import SimpleNamespace
 
 import pytest
@@ -33,7 +31,6 @@ from hermes_cli.dashboard_auth.ws_tickets import (
 )
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 from tui_gateway import server as tui_server
-from tui_gateway import ws as tui_ws
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +186,35 @@ class TestWsTicketEndpoint:
         assert response.status_code == 400
         assert response.json()["detail"] == "audience is required when scopes are requested"
 
+    def test_nonempty_request_without_an_audience_does_not_mint_legacy_authority(
+        self,
+        gated_app,
+    ):
+        _logged_in(gated_app)
+
+        response = gated_app.post("/api/auth/ws-ticket", json={})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "audience is required for a non-empty ticket request"
+        )
+
+    def test_mobile_write_grant_requires_read_scope(self, gated_app):
+        _logged_in(gated_app)
+
+        response = gated_app.post(
+            "/api/auth/ws-ticket",
+            json={
+                "audience": "hermes.mobile",
+                "scopes": ["conversation.write"],
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "conversation.read is required for every mobile WebSocket grant"
+        )
+
     def test_get_method_is_not_allowed(self, gated_app):
         _logged_in(gated_app)
         r = gated_app.get("/api/auth/ws-ticket", follow_redirects=False)
@@ -208,52 +234,47 @@ class TestWsTicketEndpoint:
         )
 
 
-def test_scoped_ticket_grant_reaches_gateway_ready(gated_app, monkeypatch):
-    sent = []
+def test_scoped_ticket_grant_reaches_gateway_ready_and_dispatch(gated_app, monkeypatch):
     monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
     monkeypatch.setattr(tui_server, "resolve_skin", lambda: "test-skin")
-    ticket = mint_ticket(
-        user_id="mobile-user",
-        provider="stub",
-        audience="hermes.mobile",
-        scopes=("conversation.read",),
+
+    _logged_in(gated_app)
+    minted = gated_app.post(
+        "/api/auth/ws-ticket",
+        json={
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
+        },
     )
+    assert minted.status_code == 200
 
-    class QueryParams:
-        def get(self, key, default=""):
-            return {"ticket": ticket}.get(key, default)
-
-    class FakeWS:
-        query_params = QueryParams()
-        client = SimpleNamespace(host="203.0.113.10")
-        url = SimpleNamespace(path="/api/ws")
-        headers = {
-            "host": "fly-app.fly.dev",
-            "origin": "https://fly-app.fly.dev",
+    with gated_app.websocket_connect(
+        f"/api/ws?ticket={minted.json()['ticket']}",
+        headers={
+            "Host": "fly-app.fly.dev",
+            "Origin": "https://fly-app.fly.dev",
+        },
+    ) as socket:
+        ready = socket.receive_json()
+        authorization = ready["params"]["payload"]["authorization"]
+        assert authorization == {
+            "subject": "stub-user-1",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ["conversation.read"],
         }
 
-        async def accept(self):
-            pass
-
-        async def send_text(self, line):
-            sent.append(json.loads(line))
-
-        async def receive_text(self):
-            raise tui_ws._WebSocketDisconnect()
-
-        async def close(self, code=None):
-            pass
-
-    asyncio.run(web_server.gateway_ws(FakeWS()))
-
-    authorization = sent[0]["params"]["payload"]["authorization"]
-    assert authorization == {
-        "subject": "mobile-user",
-        "provider": "stub",
-        "audience": "hermes.mobile",
-        "scopes": ["conversation.read"],
-    }
+        socket.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": "denied-write",
+                "method": "prompt.submit",
+                "params": {},
+            }
+        )
+        denied = socket.receive_json()
+        assert denied["error"]["data"]["required_scope"] == "conversation.write"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -60,6 +60,28 @@ class TestMintAndConsume:
         assert info["audience"] == "hermes.mobile"
         assert info["scopes"] == ("conversation.read", "conversation.write")
 
+    def test_ticket_store_rejects_unknown_audiences(self):
+        with pytest.raises(ValueError, match="unsupported WebSocket audience"):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.future",
+                scopes=("*",),
+            )
+
+    def test_ticket_store_rejects_mobile_grants_without_read_scope(self):
+        with pytest.raises(
+            ValueError,
+            match="conversation.read is required for every mobile WebSocket grant",
+        ):
+            mint_ticket(
+                user_id="u1",
+                provider="nous",
+                audience="hermes.mobile",
+                scopes=("conversation.write",),
+            )
+
+
 # ---------------------------------------------------------------------------
 # Single-use
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -47,6 +47,18 @@ class TestMintAndConsume:
         ticket = mint_ticket(user_id="u1", provider="nous")
         assert len(ticket) >= 32
 
+    def test_scoped_ticket_preserves_its_authorization_grant(self):
+        ticket = mint_ticket(
+            user_id="u1",
+            provider="nous",
+            audience="hermes.mobile",
+            scopes=("conversation.read", "conversation.write"),
+        )
+
+        info = consume_ticket(ticket)
+
+        assert info["audience"] == "hermes.mobile"
+        assert info["scopes"] == ("conversation.read", "conversation.write")
 
 # ---------------------------------------------------------------------------
 # Single-use

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -13767,8 +13767,9 @@ def test_session_close_rpc_claims_then_tears_down(monkeypatch):
 def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     seen = []
     monkeypatch.setattr(
-        server, "_close_session_by_id",
-        lambda sid, *, end_reason: bool(seen.append((sid, end_reason))) or True,
+        server,
+        "_teardown_session",
+        lambda session, *, end_reason: seen.append((session, end_reason)),
     )
     # Detached session "b" would schedule a real grace-reap threading.Timer that
     # outlives the test; grace=0 short-circuits it so no thread lingers.
@@ -13778,8 +13779,10 @@ def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     server._sessions["a"] = {"transport": transport, "close_on_disconnect": True}
     server._sessions["b"] = {"transport": transport, "close_on_disconnect": False}
     try:
+        flagged = server._sessions["a"]
         server._close_sessions_for_transport(transport, end_reason="ws_disconnect")
-        assert seen == [("a", "ws_disconnect")]  # only the flagged one closed
+        assert seen == [(flagged, "ws_disconnect")]  # only the flagged one closed
+        assert "a" not in server._sessions  # claimed before teardown can race resume
         assert server._sessions["b"]["transport"] is server._detached_ws_transport  # re-pointed
     finally:
         server._sessions.clear()

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -722,6 +722,88 @@ def test_ws_disconnect_releases_wake_word_owner(monkeypatch):
     assert released == created
 
 
+def test_old_socket_disconnect_cannot_detach_a_concurrent_reconnect(monkeypatch):
+    old_transport = object()
+    new_transport = object()
+    cleanup_reached_session = threading.Event()
+    allow_cleanup = threading.Event()
+    scheduled = []
+
+    class GateLock:
+        def __enter__(self):
+            cleanup_reached_session.set()
+            assert allow_cleanup.wait(timeout=2)
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    server._sessions.clear()
+    server._sessions["raced"] = {
+        "transport": old_transport,
+        "close_on_disconnect": False,
+        "history_lock": GateLock(),
+        "session_key": "stored",
+    }
+    monkeypatch.setattr(
+        server,
+        "_schedule_ws_orphan_reap",
+        lambda sid: scheduled.append(sid),
+    )
+    result = {}
+
+    def disconnect_old_socket():
+        result["counts"] = server._close_sessions_for_transport(old_transport)
+
+    cleanup = threading.Thread(target=disconnect_old_socket)
+    cleanup.start()
+    assert cleanup_reached_session.wait(timeout=1)
+    server._sessions["raced"]["transport"] = new_transport
+    allow_cleanup.set()
+    cleanup.join(timeout=1)
+    assert not cleanup.is_alive()
+
+    assert result["counts"] == (0, 0)
+    assert server._sessions["raced"]["transport"] is new_transport
+    assert scheduled == []
+    server._sessions.clear()
+
+
+def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
+    """A write that times out because the event loop is stalled (GIL-heavy
+    agent turn) must NOT latch the transport closed — the frame is already
+    scheduled and flushes when the loop recovers. Latching here permanently
+    silenced live watch windows after one slow write."""
+    monkeypatch.setattr(ws_mod, "_WS_WRITE_TIMEOUT_S", 0.05)
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            sent.append(line)
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="stall-test")
+        # Stall the loop well past the write timeout, then write from this
+        # (non-loop) thread: the wait times out but the send stays in flight.
+        loop.call_soon_threadsafe(time.sleep, 0.3)
+        assert transport.write({"a": 1}) is True
+        assert transport._closed is False
+
+        # Once the loop breathes again, both the stalled frame and new writes
+        # must reach the socket.
+        assert transport.write({"b": 2}) is True
+        deadline = time.time() + 2
+        while len(sent) < 2 and time.time() < deadline:
+            time.sleep(0.01)
+        assert len(sent) == 2
+        assert transport._closed is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()
 
 
 def test_ws_starts_mcp_discovery_before_ready(monkeypatch):

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -769,6 +769,55 @@ def test_old_socket_disconnect_cannot_detach_a_concurrent_reconnect(monkeypatch)
     server._sessions.clear()
 
 
+def test_close_on_disconnect_claim_blocks_a_concurrent_reconnect(monkeypatch):
+    old_transport = object()
+    new_transport = object()
+    teardown_entered = threading.Event()
+    release_teardown = threading.Event()
+    session = {
+        "agent": None,
+        "close_on_disconnect": True,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "session_key": "stored",
+        "transport": old_transport,
+    }
+    server._sessions.clear()
+    server._sessions["flagged"] = session
+
+    def blocked_teardown(claimed, *, end_reason):
+        assert claimed is session
+        assert end_reason == "ws_disconnect"
+        teardown_entered.set()
+        assert release_teardown.wait(timeout=2)
+
+    monkeypatch.setattr(server, "_teardown_session", blocked_teardown)
+    result = {}
+
+    def disconnect_old_socket():
+        result["counts"] = server._close_sessions_for_transport(old_transport)
+
+    cleanup = threading.Thread(target=disconnect_old_socket)
+    cleanup.start()
+    assert teardown_entered.wait(timeout=1)
+    assert "flagged" not in server._sessions
+
+    payload = server._live_session_payload(
+        "flagged",
+        session,
+        transport=new_transport,
+    )
+    assert payload is None
+    assert session["transport"] is old_transport
+
+    release_teardown.set()
+    cleanup.join(timeout=1)
+    assert not cleanup.is_alive()
+    assert result["counts"] == (1, 0)
+    server._sessions.clear()
+
+
 def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
     """A write that times out because the event loop is stalled (GIL-heavy
     agent turn) must NOT latch the transport closed — the frame is already

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -9,6 +9,301 @@ from tui_gateway import server
 from tui_gateway import ws as ws_mod
 
 
+def test_gateway_ready_advertises_revisioned_mobile_sync(monkeypatch):
+    sent = []
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    authorization = {
+        "subject": "user-1",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": ("conversation.read", "conversation.write"),
+    }
+
+    asyncio.run(ws_mod.handle_ws(FakeWS(), authorization=authorization))
+
+    assert sent[0] == {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "gateway.ready",
+            "payload": {
+                "skin": "test-skin",
+                "server": {
+                    "version": "test-version",
+                    "release_date": "test-release",
+                    "instance_id": "test-instance",
+                },
+                "protocol": {"name": "hermes.tui.jsonrpc", "major": 1},
+                "contract": {"name": "hermes.mobile", "major": 1},
+                "schemas": {
+                    "gateway.ready": 1,
+                    "authorization.grant": 1,
+                    "authorization.error": 1,
+                    "session.synchronization": 1,
+                    "session.event": 1,
+                },
+                "capabilities": {
+                    "auth.ws_scopes": {"version": 1},
+                    "conversation.sync": {
+                        "version": 1,
+                        "delta_offsets": {"unit": "utf8_bytes"},
+                        "replay": {
+                            "max_events": 512,
+                            "max_bytes": 1048576,
+                        },
+                    },
+                },
+                "authorization": {
+                    "subject": "user-1",
+                    "provider": "stub",
+                    "audience": "hermes.mobile",
+                    "scopes": ["conversation.read", "conversation.write"],
+                },
+            },
+        },
+    }
+
+
+def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
+    monkeypatch,
+):
+    sent = []
+    received = False
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_kw: None)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal received
+            if not received:
+                received = True
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "mobile-request",
+                        "method": "not.a.mobile.method",
+                        "params": {},
+                    }
+                )
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(
+        ws_mod.handle_ws(
+            FakeWS(),
+            authorization={
+                "subject": "user-1",
+                "provider": "stub",
+                "audience": "hermes.mobile",
+                "scopes": ("conversation.read",),
+            },
+        )
+    )
+
+    assert sent[1]["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "not.a.mobile.method",
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
+            "granted_scopes": ["conversation.read"],
+            "grantable": False,
+        },
+    }
+
+
+def test_mobile_socket_create_delta_and_live_resume_share_one_sync_stream(
+    monkeypatch,
+):
+    """Exercise synchronization through the real handle_ws transport boundary."""
+    sent = []
+    receive_index = 0
+    state = {}
+    server._sessions.clear()
+    monkeypatch.setattr(
+        mcp_startup, "start_background_mcp_discovery", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_profile_home", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server, "_completion_cwd", lambda *_a, **_k: server.os.getcwd()
+    )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda *_a, **_k: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        server, "_close_sessions_for_transport", lambda *_a, **_k: (0, 0)
+    )
+
+    class FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id, "cwd": server.os.getcwd()}
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def resolve_resume_session_id(self, session_id):
+            return session_id
+
+        def get_messages_as_conversation(self, _session_id, include_ancestors=False):
+            return []
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+
+    async def wait_for_response(request_id):
+        deadline = asyncio.get_running_loop().time() + 2
+        while asyncio.get_running_loop().time() < deadline:
+            match = next(
+                (frame for frame in sent if frame.get("id") == request_id), None
+            )
+            if match is not None:
+                return match
+            await asyncio.sleep(0.01)
+        raise AssertionError(f"missing WebSocket response {request_id}")
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal receive_index
+            receive_index += 1
+            if receive_index == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "create-sync",
+                        "method": "session.create",
+                        "params": {"cols": 100},
+                    }
+                )
+            if receive_index == 2:
+                created = (await wait_for_response("create-sync"))["result"]
+                state["created"] = created
+                sid = created["session_id"]
+                session = server._sessions[sid]
+
+                def emit_deltas():
+                    with session["history_lock"]:
+                        server._start_inflight_turn(session, "question")
+                    server._emit_inflight_delta(sid, session, "A💡")
+                    server._emit_inflight_delta(sid, session, "B")
+
+                await asyncio.to_thread(emit_deltas)
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "resume-sync",
+                        "method": "session.resume",
+                        "params": {
+                            "session_id": created["stored_session_id"],
+                            "cols": 100,
+                            "cursor": created["synchronization"]["recovery"]["cursor"],
+                        },
+                    }
+                )
+            await wait_for_response("resume-sync")
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    authorization = {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": (
+            "conversation.read",
+            "conversation.write",
+            "conversation.control",
+        ),
+    }
+
+    try:
+        asyncio.run(ws_mod.handle_ws(FakeWS(), authorization=authorization))
+    finally:
+        server._sessions.clear()
+
+    created = state["created"]
+    resumed = next(frame for frame in sent if frame.get("id") == "resume-sync")[
+        "result"
+    ]
+    deltas = [
+        frame["params"]
+        for frame in sent
+        if frame.get("params", {}).get("type") == "message.delta"
+    ]
+    assert [params["payload"]["offset"] for params in deltas] == [0, 5]
+    assert len({params["payload"]["turn_id"] for params in deltas}) == 1
+    assert [params["sequence"] for params in deltas] == [1, 2]
+    assert resumed["session_id"] == created["session_id"]
+    assert (
+        resumed["synchronization"]["snapshot"]["stream_id"]
+        == created["synchronization"]["snapshot"]["stream_id"]
+    )
+    assert resumed["synchronization"]["recovery"]["outcome"] == "complete"
+    assert len(resumed["synchronization"]["recovery"]["events"]) == 2
+
+
+    calls = []
+
+    monkeypatch.setattr(
+        mcp_startup,
+        "start_background_mcp_discovery",
+        lambda **kw: calls.append(kw),
+    )
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            pass
+
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    server._sessions.clear()
+    try:
+        asyncio.run(ws_mod.handle_ws(FakeWS()))
+    finally:
+        server._sessions.clear()
+
+    assert calls == []
 
 
 def _run_disconnect(monkeypatch, seed):

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -5,6 +5,7 @@ import threading
 import time
 
 from hermes_cli import mcp_startup
+from tui_gateway import mobile_contract
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
 from tui_gateway.mobile_sync import SessionEventStream
@@ -35,47 +36,14 @@ def test_gateway_ready_advertises_revisioned_mobile_sync(monkeypatch):
 
     asyncio.run(ws_mod.handle_ws(FakeWS(), authorization=authorization))
 
-    assert sent[0] == {
-        "jsonrpc": "2.0",
-        "method": "event",
-        "params": {
-            "type": "gateway.ready",
-            "payload": {
-                "skin": "test-skin",
-                "server": {
-                    "version": "test-version",
-                    "release_date": "test-release",
-                    "instance_id": "test-instance",
-                },
-                "protocol": {"name": "hermes.tui.jsonrpc", "major": 1},
-                "contract": {"name": "hermes.mobile", "major": 1},
-                "schemas": {
-                    "gateway.ready": 1,
-                    "authorization.grant": 1,
-                    "authorization.error": 1,
-                    "session.synchronization": 1,
-                    "session.event": 1,
-                },
-                "capabilities": {
-                    "auth.ws_scopes": {"version": 1},
-                    "conversation.sync": {
-                        "version": 1,
-                        "delta_offsets": {"unit": "utf8_bytes"},
-                        "replay": {
-                            "max_events": 512,
-                            "max_bytes": 1048576,
-                        },
-                    },
-                },
-                "authorization": {
-                    "subject": "user-1",
-                    "provider": "stub",
-                    "audience": "hermes.mobile",
-                    "scopes": ["conversation.read", "conversation.write"],
-                },
-            },
-        },
-    }
+    ready = sent[0]["params"]["payload"]
+    assert ready["schemas"]["session.synchronization"] == 1
+    assert ready["schemas"]["session.event"] == 1
+    sync = ready["capabilities"]["conversation.sync"]
+    assert sync["delta_offsets"] == {"unit": "utf8_bytes"}
+    assert sync["replay"]["max_events"] > 0
+    assert sync["replay"]["max_bytes"] > 0
+    assert ready["authorization"]["audience"] == "hermes.mobile"
 
 
 def test_mobile_authorization_is_enforced_on_requests_from_the_live_socket(
@@ -322,6 +290,13 @@ class _MobileSessionDB:
 
     def get_messages_as_conversation(self, _session_id, include_ancestors=False):
         return list(self.messages)
+
+    def get_resume_conversations(self, _session_id):
+        messages = list(self.messages)
+        return messages, messages
+
+    def get_ancestor_display_prefix(self, _session_id):
+        return []
 
 
 _MOBILE_AUTHORIZATION = {
@@ -576,12 +551,8 @@ def test_mobile_socket_concurrent_events_have_monotonic_wire_sequences(
     assert len({event["params"]["stream_id"] for event in events}) == 1
 
 
-def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
-    """The desktop app and dashboard chat reach the agent through this WS
-    sidecar, not through tui_gateway.entry.main() (which spawns the discovery
-    thread for the stdio TUI). handle_ws must start discovery itself, otherwise
-    _make_agent's wait_for_mcp_discovery no-ops and the agent snapshots an
-    MCP-less tool list. Regression test for #38945."""
+def test_ws_does_not_own_mcp_discovery_startup(monkeypatch):
+    """MCP discovery belongs to the profile-scoped agent build path."""
 
     calls = []
 

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -7,6 +7,7 @@ import time
 from hermes_cli import mcp_startup
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
+from tui_gateway.mobile_sync import SessionEventStream
 
 
 def test_gateway_ready_advertises_revisioned_mobile_sync(monkeypatch):
@@ -275,6 +276,312 @@ def test_mobile_socket_create_delta_and_live_resume_share_one_sync_stream(
     assert resumed["synchronization"]["recovery"]["outcome"] == "complete"
     assert len(resumed["synchronization"]["recovery"]["events"]) == 2
 
+
+def _isolate_mobile_ws_gateway(monkeypatch, db):
+    server._sessions.clear()
+    monkeypatch.setattr(
+        mcp_startup, "start_background_mcp_discovery", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_profile_home", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server, "_completion_cwd", lambda *_a, **_k: server.os.getcwd()
+    )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda *_a, **_k: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(
+        server, "_close_sessions_for_transport", lambda *_a, **_k: (0, 0)
+    )
+
+
+class _MobileSessionDB:
+    def __init__(self, session_id, messages=None):
+        self.session_id = session_id
+        self.messages = list(messages or [])
+
+    def get_session(self, session_id):
+        if session_id == self.session_id:
+            return {"id": session_id, "cwd": server.os.getcwd()}
+        return None
+
+    def get_session_by_title(self, _title):
+        return None
+
+    def resolve_resume_session_id(self, session_id):
+        return session_id
+
+    def reopen_session(self, _session_id):
+        return None
+
+    def get_messages_as_conversation(self, _session_id, include_ancestors=False):
+        return list(self.messages)
+
+
+_MOBILE_AUTHORIZATION = {
+    "subject": "mobile-user",
+    "provider": "stub",
+    "audience": "hermes.mobile",
+    "scopes": (
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    ),
+}
+
+
+async def _wait_for_ws_response(sent, request_id):
+    deadline = asyncio.get_running_loop().time() + 2
+    while asyncio.get_running_loop().time() < deadline:
+        match = next((frame for frame in sent if frame.get("id") == request_id), None)
+        if match is not None:
+            return match
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"missing WebSocket response {request_id}")
+
+
+def test_mobile_socket_cold_resume_reports_stream_reset(monkeypatch):
+    sent = []
+    received = False
+    stored_id = "stored-cold"
+    _isolate_mobile_ws_gateway(
+        monkeypatch,
+        _MobileSessionDB(
+            stored_id,
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ],
+        ),
+    )
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal received
+            if not received:
+                received = True
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "cold-resume",
+                        "method": "session.resume",
+                        "params": {
+                            "session_id": stored_id,
+                            "cols": 100,
+                            "cursor": {
+                                "server_instance_id": (
+                                    mobile_contract.SERVER_INSTANCE_ID
+                                ),
+                                "stream_id": "retired-stream",
+                                "sequence": 12,
+                            },
+                        },
+                    }
+                )
+            await _wait_for_ws_response(sent, "cold-resume")
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    try:
+        asyncio.run(
+            ws_mod.handle_ws(FakeWS(), authorization=_MOBILE_AUTHORIZATION)
+        )
+    finally:
+        server._sessions.clear()
+
+    result = next(frame for frame in sent if frame.get("id") == "cold-resume")[
+        "result"
+    ]
+    synchronization = result["synchronization"]
+    assert synchronization["snapshot"]["messages"] == [
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": "hi"},
+    ]
+    assert synchronization["recovery"]["outcome"] == "reset"
+    assert synchronization["recovery"]["reason"] == "stream_changed"
+    assert synchronization["recovery"]["snapshot_required"] is True
+    assert synchronization["recovery"]["events"] == []
+
+
+def test_mobile_socket_resume_reports_gap_after_replay_eviction(monkeypatch):
+    sent = []
+    receive_index = 0
+    db = _MobileSessionDB("unused-until-create")
+    _isolate_mobile_ws_gateway(monkeypatch, db)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal receive_index
+            receive_index += 1
+            if receive_index == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "gap-create",
+                        "method": "session.create",
+                        "params": {"cols": 100},
+                    }
+                )
+            if receive_index == 2:
+                created = (await _wait_for_ws_response(sent, "gap-create"))["result"]
+                sid = created["session_id"]
+                db.session_id = created["stored_session_id"]
+                stream = SessionEventStream(
+                    mobile_contract.SERVER_INSTANCE_ID,
+                    max_events=2,
+                    max_bytes=1024 * 1024,
+                )
+                server._sessions[sid]["mobile_sync"] = stream
+                cursor = stream.cursor()
+
+                def fill_replay():
+                    for index in range(3):
+                        server._emit(
+                            "status.update",
+                            sid,
+                            {"kind": "step", "text": str(index)},
+                        )
+
+                await asyncio.to_thread(fill_replay)
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "gap-resume",
+                        "method": "session.resume",
+                        "params": {
+                            "session_id": created["stored_session_id"],
+                            "cols": 100,
+                            "cursor": cursor,
+                        },
+                    }
+                )
+            await _wait_for_ws_response(sent, "gap-resume")
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    try:
+        asyncio.run(
+            ws_mod.handle_ws(FakeWS(), authorization=_MOBILE_AUTHORIZATION)
+        )
+    finally:
+        server._sessions.clear()
+
+    result = next(frame for frame in sent if frame.get("id") == "gap-resume")[
+        "result"
+    ]
+    recovery = result["synchronization"]["recovery"]
+    assert recovery["outcome"] == "gap"
+    assert recovery["reason"] == "replay_evicted"
+    assert recovery["available_after"] == 1
+    assert recovery["snapshot_required"] is True
+    assert recovery["events"] == []
+
+
+def test_mobile_socket_concurrent_events_have_monotonic_wire_sequences(
+    monkeypatch,
+):
+    sent = []
+    receive_index = 0
+    db = _MobileSessionDB("unused-until-create")
+    _isolate_mobile_ws_gateway(monkeypatch, db)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            nonlocal receive_index
+            receive_index += 1
+            if receive_index == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "concurrent-create",
+                        "method": "session.create",
+                        "params": {"cols": 100},
+                    }
+                )
+
+            created = (await _wait_for_ws_response(sent, "concurrent-create"))[
+                "result"
+            ]
+            sid = created["session_id"]
+            start = threading.Barrier(9)
+
+            def publish(index):
+                start.wait()
+                server._emit(
+                    "status.update",
+                    sid,
+                    {"kind": "worker", "text": str(index)},
+                )
+
+            def publish_concurrently():
+                threads = [
+                    threading.Thread(target=publish, args=(index,))
+                    for index in range(8)
+                ]
+                for thread in threads:
+                    thread.start()
+                start.wait()
+                for thread in threads:
+                    thread.join(timeout=1)
+                    assert not thread.is_alive()
+
+            await asyncio.to_thread(publish_concurrently)
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    try:
+        asyncio.run(
+            ws_mod.handle_ws(FakeWS(), authorization=_MOBILE_AUTHORIZATION)
+        )
+    finally:
+        server._sessions.clear()
+
+    events = [
+        frame
+        for frame in sent
+        if frame.get("params", {}).get("type") == "status.update"
+    ]
+    assert [event["params"]["sequence"] for event in events] == list(range(1, 9))
+    assert all(event["params"]["schema_major"] == 1 for event in events)
+    assert len({event["params"]["stream_id"] for event in events}) == 1
+
+
+def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
+    """The desktop app and dashboard chat reach the agent through this WS
+    sidecar, not through tui_gateway.entry.main() (which spawns the discovery
+    thread for the stdio TUI). handle_ws must start discovery itself, otherwise
+    _make_agent's wait_for_mcp_discovery no-ops and the agent snapshots an
+    MCP-less tool list. Regression test for #38945."""
 
     calls = []
 

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,0 +1,217 @@
+"""Public JSON-RPC conformance tests for the mobile authorization contract."""
+
+import pytest
+
+from tui_gateway import server
+
+
+class RecordingTransport:
+    def __init__(self, authorization=None):
+        self.authorization = authorization
+        self.frames = []
+
+    def write(self, obj):
+        self.frames.append(obj)
+        return True
+
+    def close(self):
+        pass
+
+
+def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-1",
+            "method": "prompt.submit",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-1",
+        "error": {
+            "code": 4030,
+            "message": "insufficient authorization scope",
+            "data": {
+                "reason": "missing_scope",
+                "method": "prompt.submit",
+                "required_scope": "conversation.write",
+                "granted_scopes": ["conversation.read"],
+            },
+        },
+    }
+
+
+def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-2",
+            "method": "shell.exec",
+            "params": {"command": "true"},
+        },
+        transport,
+    )
+
+    assert response["error"] == {
+        "code": 4030,
+        "message": "insufficient authorization scope",
+        "data": {
+            "reason": "method_not_available_to_mobile",
+            "method": "shell.exec",
+            "required_scope": None,
+            "granted_scopes": ["conversation.read", "conversation.write"],
+        },
+    }
+
+
+def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read", "conversation.write"),
+        }
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "approval-request",
+            "method": "approval.respond",
+            "params": {"choice": "once"},
+        },
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "method_not_available_to_mobile",
+        "method": "approval.respond",
+        "required_scope": None,
+        "granted_scopes": ["conversation.read", "conversation.write"],
+    }
+
+
+def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": ("conversation.read",),
+        }
+    )
+    server._sessions.clear()
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "request-3",
+            "method": "session.active_list",
+            "params": {},
+        },
+        transport,
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "request-3",
+        "result": {"sessions": []},
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "required_scope"),
+    [
+        ("session.list", "conversation.read"),
+        ("session.active_list", "conversation.read"),
+        ("session.activate", "conversation.read"),
+        ("session.history", "conversation.read"),
+        ("session.status", "conversation.read"),
+        ("session.usage", "conversation.read"),
+        ("session.create", "conversation.write"),
+        ("session.resume", "conversation.write"),
+        ("prompt.submit", "conversation.write"),
+        ("session.interrupt", "conversation.control"),
+        ("session.steer", "conversation.control"),
+    ],
+)
+def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
+    method,
+    required_scope,
+):
+    transport = RecordingTransport(
+        {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": (),
+        }
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": method,
+        "required_scope": required_scope,
+        "granted_scopes": [],
+    }
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        None,
+        {
+            "subject": "server-internal",
+            "provider": "server-internal",
+            "audience": "dashboard",
+            "scopes": ("*",),
+        },
+    ],
+)
+def test_legacy_and_internal_dispatch_keep_the_existing_behavior(authorization):
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "legacy-request",
+            "method": "not.a.real.method",
+            "params": {},
+        },
+        RecordingTransport(authorization),
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "legacy-request",
+        "error": {
+            "code": -32601,
+            "message": "unknown method: not.a.real.method",
+        },
+    }

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -1,7 +1,10 @@
 """Public JSON-RPC conformance tests for the mobile authorization contract."""
 
+import threading
+
 import pytest
 
+from tui_gateway import mobile_contract
 from tui_gateway import server
 
 
@@ -18,15 +21,17 @@ class RecordingTransport:
         pass
 
 
+def _mobile_authorization(*scopes):
+    return {
+        "subject": "mobile-user",
+        "provider": "stub",
+        "audience": "hermes.mobile",
+        "scopes": scopes,
+    }
+
+
 def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
 
     response = server.dispatch(
         {
@@ -48,7 +53,10 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
                 "reason": "missing_scope",
                 "method": "prompt.submit",
                 "required_scope": "conversation.write",
+                "required_scopes": ["conversation.write"],
+                "missing_scopes": ["conversation.write"],
                 "granted_scopes": ["conversation.read"],
+                "grantable": True,
             },
         },
     }
@@ -56,12 +64,7 @@ def test_mobile_dispatch_rejects_a_mapped_method_without_its_required_scope():
 
 def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -80,20 +83,18 @@ def test_mobile_dispatch_rejects_an_unmapped_method_fail_closed():
         "data": {
             "reason": "method_not_available_to_mobile",
             "method": "shell.exec",
-            "required_scope": None,
+            "required_scope": "mobile.unavailable",
+            "required_scopes": ["mobile.unavailable"],
+            "missing_scopes": ["mobile.unavailable"],
             "granted_scopes": ["conversation.read", "conversation.write"],
+            "grantable": False,
         },
     }
 
 
 def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read", "conversation.write"),
-        }
+        _mobile_authorization("conversation.read", "conversation.write")
     )
 
     response = server.dispatch(
@@ -109,20 +110,16 @@ def test_mobile_dispatch_does_not_expose_legacy_fifo_approval_resolution():
     assert response["error"]["data"] == {
         "reason": "method_not_available_to_mobile",
         "method": "approval.respond",
-        "required_scope": None,
+        "required_scope": "mobile.unavailable",
+        "required_scopes": ["mobile.unavailable"],
+        "missing_scopes": ["mobile.unavailable"],
         "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": False,
     }
 
 
 def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": ("conversation.read",),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization("conversation.read"))
     server._sessions.clear()
 
     response = server.dispatch(
@@ -147,29 +144,19 @@ def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
     [
         ("session.list", "conversation.read"),
         ("session.active_list", "conversation.read"),
-        ("session.activate", "conversation.read"),
+        ("session.activate", "conversation.control"),
         ("session.history", "conversation.read"),
-        ("session.status", "conversation.read"),
-        ("session.usage", "conversation.read"),
         ("session.create", "conversation.write"),
-        ("session.resume", "conversation.write"),
+        ("session.resume", "conversation.control"),
         ("prompt.submit", "conversation.write"),
         ("session.interrupt", "conversation.control"),
-        ("session.steer", "conversation.control"),
     ],
 )
 def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
     method,
     required_scope,
 ):
-    transport = RecordingTransport(
-        {
-            "subject": "mobile-user",
-            "provider": "stub",
-            "audience": "hermes.mobile",
-            "scopes": (),
-        }
-    )
+    transport = RecordingTransport(_mobile_authorization())
 
     response = server.dispatch(
         {"jsonrpc": "2.0", "id": "scope-check", "method": method, "params": {}},
@@ -180,8 +167,142 @@ def test_mobile_dispatch_declares_the_minimum_conversation_scope_map(
         "reason": "missing_scope",
         "method": method,
         "required_scope": required_scope,
+        "required_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
+        "missing_scopes": (
+            ["conversation.write", "conversation.control"]
+            if method == "session.create"
+            else [required_scope]
+        ),
         "granted_scopes": [],
+        "grantable": True,
     }
+
+
+def test_mobile_create_requires_write_and_control():
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "create", "method": "session.create", "params": {}},
+        transport,
+    )
+
+    assert response["error"]["data"] == {
+        "reason": "missing_scope",
+        "method": "session.create",
+        "required_scope": "conversation.control",
+        "required_scopes": ["conversation.write", "conversation.control"],
+        "missing_scopes": ["conversation.control"],
+        "granted_scopes": ["conversation.read", "conversation.write"],
+        "grantable": True,
+    }
+
+
+@pytest.mark.parametrize("method", ["session.status", "session.usage", "session.steer"])
+def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(method):
+    response = server.dispatch(
+        {"jsonrpc": "2.0", "id": "unavailable", "method": method, "params": {}},
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    assert response["error"]["data"]["required_scope"] == "mobile.unavailable"
+    assert response["error"]["data"]["grantable"] is False
+
+
+def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
+    authorization = _mobile_authorization(
+        "conversation.read",
+        "conversation.write",
+        "conversation.control",
+    )
+
+    delete_denial = mobile_contract.mobile_method_denial(
+        "prompt.submit",
+        authorization,
+        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
+    )
+    profile_denial = mobile_contract.mobile_method_denial(
+        "session.create",
+        authorization,
+        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
+    )
+
+    assert delete_denial == {
+        "reason": "parameter_not_available_to_mobile",
+        "method": "prompt.submit",
+        "parameter": "truncate_before_user_ordinal",
+        "required_scope": "conversation.delete",
+        "required_scopes": ["conversation.delete"],
+        "missing_scopes": ["conversation.delete"],
+        "granted_scopes": [
+            "conversation.read",
+            "conversation.write",
+            "conversation.control",
+        ],
+        "grantable": False,
+    }
+    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
+    assert profile_denial["parameter"] == "messages"
+    assert profile_denial["required_scope"] == "mobile.unavailable"
+    assert profile_denial["grantable"] is False
+
+
+def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
+    monkeypatch,
+):
+    class Agent:
+        interrupted = False
+
+        def interrupt(self):
+            self.interrupted = True
+
+    agent = Agent()
+    session = {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": True,
+        "transport": None,
+    }
+    server._sessions.clear()
+    server._sessions["busy"] = session
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
+    transport = RecordingTransport(
+        _mobile_authorization("conversation.read", "conversation.write")
+    )
+
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "busy-write",
+            "method": "prompt.submit",
+            "params": {"session_id": "busy", "text": "next"},
+        },
+        transport,
+    )
+
+    assert response["result"] == {"status": "queued"}
+    assert agent.interrupted is False
+    assert session["queued_prompt"]["text"] == "next"
+
+
+def test_mobile_scope_grants_require_read_access():
+    with pytest.raises(
+        ValueError,
+        match="conversation.read is required for every mobile WebSocket grant",
+    ):
+        mobile_contract.normalize_mobile_scopes(["conversation.write"])
 
 
 @pytest.mark.parametrize(

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -359,6 +359,26 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
     assert session["queued_prompt"]["transport"] is transport
 
 
+def test_mobile_write_without_control_rechecks_busy_state_before_queueing():
+    session = {
+        "history_lock": threading.Lock(),
+        "queued_prompt": None,
+        "running": False,
+    }
+
+    response = server._handle_busy_submit(
+        "busy-write-race",
+        "busy",
+        session,
+        "next",
+        RecordingTransport(),
+        allow_control=False,
+    )
+
+    assert response is None
+    assert session["queued_prompt"] is None
+
+
 def test_mobile_scope_grants_require_read_access():
     with pytest.raises(
         ValueError,

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -4,8 +4,8 @@ import threading
 
 import pytest
 
-from tui_gateway import mobile_contract
-from tui_gateway import server
+from tui_gateway import mobile_contract, server
+from tui_gateway.mobile_contract import gateway_ready_payload
 
 
 class RecordingTransport:
@@ -19,6 +19,15 @@ class RecordingTransport:
 
     def close(self):
         pass
+
+
+def test_gateway_ready_payload_preserves_change_event_capability():
+    skin = {"name": "default", "colors": {}}
+
+    payload = gateway_ready_payload(skin=skin)
+
+    assert payload["skin"] == skin
+    assert payload["change_events"] is True
 
 
 def _mobile_authorization(*scopes):

--- a/tests/tui_gateway/test_mobile_contract.py
+++ b/tests/tui_gateway/test_mobile_contract.py
@@ -126,16 +126,18 @@ def test_mobile_dispatch_allows_a_mapped_method_with_its_scope():
         {
             "jsonrpc": "2.0",
             "id": "request-3",
-            "method": "session.active_list",
-            "params": {},
+            "method": "session.history",
+            "params": {"session_id": "missing"},
         },
         transport,
     )
 
+    # Authorization passed: the request reached the handler and failed only
+    # because the synthetic session does not exist.
     assert response == {
         "jsonrpc": "2.0",
         "id": "request-3",
-        "result": {"sessions": []},
+        "error": {"code": 4001, "message": "session not found"},
     }
 
 
@@ -220,25 +222,28 @@ def test_mobile_contract_keeps_nonessential_or_account_methods_unavailable(metho
     assert response["error"]["data"]["grantable"] is False
 
 
-def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters():
-    authorization = _mobile_authorization(
-        "conversation.read",
-        "conversation.write",
-        "conversation.control",
+def test_mobile_dispatch_rejects_hidden_history_deletion():
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "hidden-delete",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "known",
+                "text": "replace",
+                "truncate_before_user_ordinal": 1,
+            },
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
     )
 
-    delete_denial = mobile_contract.mobile_method_denial(
-        "prompt.submit",
-        authorization,
-        {"session_id": "known", "text": "replace", "truncate_before_user_ordinal": 1},
-    )
-    profile_denial = mobile_contract.mobile_method_denial(
-        "session.create",
-        authorization,
-        {"profile": "../../outside", "messages": [{"role": "system", "content": "x"}]},
-    )
-
-    assert delete_denial == {
+    assert response["error"]["data"] == {
         "reason": "parameter_not_available_to_mobile",
         "method": "prompt.submit",
         "parameter": "truncate_before_user_ordinal",
@@ -252,10 +257,55 @@ def test_mobile_contract_rejects_hidden_delete_and_privileged_create_parameters(
         ],
         "grantable": False,
     }
-    assert profile_denial["reason"] == "parameter_not_available_to_mobile"
-    assert profile_denial["parameter"] == "messages"
-    assert profile_denial["required_scope"] == "mobile.unavailable"
-    assert profile_denial["grantable"] is False
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("close_on_disconnect", True),
+        ("cwd", "/tmp/outside"),
+        ("fast", True),
+        ("messages", [{"role": "system", "content": "override"}]),
+        ("model", "provider/model"),
+        ("parent_session_id", "parent"),
+        ("profile", "../../outside"),
+        ("provider", "custom"),
+        ("reasoning_effort", "high"),
+        ("source", "spoofed-platform"),
+    ],
+)
+def test_mobile_dispatch_rejects_each_privileged_create_parameter(
+    monkeypatch,
+    parameter,
+    value,
+):
+    def fail_if_handler_runs(_profile):
+        raise AssertionError("session.create handler ran before mobile authorization")
+
+    monkeypatch.setattr(server, "_profile_home", fail_if_handler_runs)
+    server._sessions.clear()
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "privileged-create",
+            "method": "session.create",
+            "params": {parameter: value},
+        },
+        RecordingTransport(
+            _mobile_authorization(
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            )
+        ),
+    )
+
+    denial = response["error"]["data"]
+    assert denial["reason"] == "parameter_not_available_to_mobile"
+    assert denial["parameter"] == parameter
+    assert denial["required_scope"] == "mobile.unavailable"
+    assert denial["grantable"] is False
+    assert server._sessions == {}
 
 
 def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
@@ -268,12 +318,13 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
             self.interrupted = True
 
     agent = Agent()
+    original_transport = RecordingTransport()
     session = {
         "agent": agent,
         "history_lock": threading.Lock(),
         "queued_prompt": None,
         "running": True,
-        "transport": None,
+        "transport": original_transport,
     }
     server._sessions.clear()
     server._sessions["busy"] = session
@@ -294,7 +345,9 @@ def test_mobile_write_without_control_queues_a_busy_prompt_without_interrupting(
 
     assert response["result"] == {"status": "queued"}
     assert agent.interrupted is False
+    assert session["transport"] is original_transport
     assert session["queued_prompt"]["text"] == "next"
+    assert session["queued_prompt"]["transport"] is transport
 
 
 def test_mobile_scope_grants_require_read_access():

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -479,6 +479,94 @@ def test_legacy_session_keeps_original_response_and_event_shape():
     assert "mobile_sync" not in server._sessions[sid]
 
 
+def test_mobile_replay_stays_retained_across_a_legacy_handoff(monkeypatch):
+    class LegacyTransport(RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.authorization = {
+                "subject": "dashboard-user",
+                "provider": "password",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            }
+
+    mobile = RecordingTransport()
+    legacy = LegacyTransport()
+    created = create_session(mobile)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    cursor = created["synchronization"]["recovery"]["cursor"]
+    session = server._sessions[sid]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+
+    legacy_payload = server._live_session_payload(
+        sid,
+        session,
+        transport=legacy,
+        cursor=cursor,
+    )
+    assert "synchronization" not in legacy_payload
+
+    server._emit("status.update", sid, {"kind": "legacy", "text": "Still here"})
+    legacy_event = legacy.frames[-1]
+    assert "sequence" not in legacy_event["params"]
+    assert "stream_id" not in legacy_event["params"]
+
+    reconnected = resume_session(mobile, stored_id, cursor)
+    recovery = reconnected["synchronization"]["recovery"]
+    assert recovery["outcome"] == "complete"
+    assert [event["params"]["type"] for event in recovery["events"]] == [
+        "status.update"
+    ]
+    assert recovery["events"][0]["params"]["sequence"] == 1
+
+
+def test_concurrent_first_mobile_snapshot_and_publish_share_one_stream():
+    transport = RecordingTransport()
+    sid = "first-attach"
+    session = {
+        "agent": None,
+        "conversation_id": "first-conversation",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "running": False,
+        "session_key": "first-stored",
+        "transport": transport,
+    }
+    server._sessions[sid] = session
+    start = threading.Barrier(3)
+    attached = {}
+
+    def attach():
+        start.wait()
+        attached["payload"] = server._attach_synchronization({}, sid, session)
+
+    def publish():
+        start.wait()
+        server._emit("status.update", sid, {"kind": "race", "text": "Ready"})
+
+    attach_thread = threading.Thread(target=attach)
+    publish_thread = threading.Thread(target=publish)
+    attach_thread.start()
+    publish_thread.start()
+    start.wait()
+    attach_thread.join(timeout=1)
+    publish_thread.join(timeout=1)
+    assert not attach_thread.is_alive()
+    assert not publish_thread.is_alive()
+
+    snapshot = attached["payload"]["synchronization"]["snapshot"]
+    event = next(
+        frame
+        for frame in transport.frames
+        if frame.get("params", {}).get("type") == "status.update"
+    )
+    assert snapshot["stream_id"] == event["params"]["stream_id"]
+    assert session["mobile_sync"].stream_id == snapshot["stream_id"]
+
+
 def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
     transport = RecordingTransport()
     sid = "barrier-live"
@@ -491,7 +579,7 @@ def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
         "history_version": 0,
         "inflight_turn": None,
         "mobile_sync": stream,
-        "mobile_sync_enabled": True,
+        "mobile_sync_retention": True,
         "running": True,
         "session_key": "barrier-stored",
         "transport": transport,
@@ -558,6 +646,53 @@ def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
         event["params"]["type"]
         for event in synchronization["recovery"]["events"]
     ] == ["message.complete"]
+
+
+def test_deferred_prompt_start_advances_revision_before_agent_ready(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    cursor = created["synchronization"]["recovery"]["cursor"]
+    initial_revision = created["synchronization"]["snapshot"]["revision"]
+    entered_wait = threading.Event()
+    release_wait = threading.Event()
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+
+    def blocked_wait(_session, rid):
+        entered_wait.set()
+        assert release_wait.wait(timeout=2)
+        return server._err(rid, 5000, "test build stopped")
+
+    monkeypatch.setattr(server, "_wait_agent", blocked_wait)
+    try:
+        submitted = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "deferred-submit",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "question"},
+            },
+            transport,
+        )
+        assert submitted["result"] == {"status": "streaming"}
+        assert entered_wait.wait(timeout=1)
+
+        resumed = resume_session(transport, stored_id, cursor)
+        synchronization = resumed["synchronization"]
+        assert synchronization["snapshot"]["revision"] == initial_revision + 1
+        assert synchronization["snapshot"]["watermark"] == cursor["sequence"]
+        assert synchronization["snapshot"]["inflight_turn"]["user"] == "question"
+        assert synchronization["recovery"]["outcome"] == "complete"
+        assert synchronization["recovery"]["events"] == []
+    finally:
+        release_wait.set()
+        run_thread = server._sessions.get(sid, {}).get("_run_thread")
+        if run_thread is not None:
+            run_thread.join(timeout=1)
 
 
 def test_undo_advances_snapshot_revision_without_a_wire_event(monkeypatch):
@@ -649,5 +784,21 @@ def test_child_mirror_sync_recovers_inflight_text_and_active_tool(monkeypatch):
     assert settled["active_tools"] == []
     assert settled["messages"][-1] == {
         "role": "assistant",
-        "text": "goal\nanswer",
+        "text": "answer",
     }
+    complete = next(
+        frame
+        for frame in reversed(transport.frames)
+        if frame.get("params", {}).get("type") == "message.complete"
+    )
+    assert complete["params"]["payload"]["text"] == "answer"
+
+
+def test_conversation_root_does_not_hide_callable_attribute_errors():
+    class BrokenLineageDB:
+        @staticmethod
+        def get_compression_lineage(_session_id):
+            raise AttributeError("lineage implementation bug")
+
+    with pytest.raises(AttributeError, match="lineage implementation bug"):
+        server._conversation_root(BrokenLineageDB(), "stored")

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -444,3 +444,210 @@ def test_snapshot_recovers_and_then_clears_a_pending_interaction(monkeypatch):
 
     settled = resume_session(transport, stored_id)
     assert settled["synchronization"]["snapshot"]["pending_interactions"] == []
+
+
+def test_legacy_session_keeps_original_response_and_event_shape():
+    class LegacyTransport(RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.authorization = {
+                "subject": "dashboard-user",
+                "provider": "password",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            }
+
+    transport = LegacyTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+
+    assert "synchronization" not in created
+    assert "mobile_sync" not in server._sessions[sid]
+
+    server._emit("status.update", sid, {"kind": "idle", "text": "Ready"})
+
+    event = transport.frames[-1]
+    assert event == {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "status.update",
+            "session_id": sid,
+            "payload": {"kind": "idle", "text": "Ready"},
+        },
+    }
+    assert "mobile_sync" not in server._sessions[sid]
+
+
+def test_completion_history_and_event_share_one_snapshot_barrier(monkeypatch):
+    transport = RecordingTransport()
+    sid = "barrier-live"
+    stream = SessionEventStream(mobile_contract.SERVER_INSTANCE_ID)
+    session = {
+        "agent": None,
+        "conversation_id": "barrier-conversation",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "mobile_sync": stream,
+        "mobile_sync_enabled": True,
+        "running": True,
+        "session_key": "barrier-stored",
+        "transport": transport,
+    }
+    server._sessions[sid] = session
+    with session["history_lock"]:
+        server._start_inflight_turn(session, "question")
+    cursor = stream.cursor()
+
+    entered_completion = threading.Event()
+    release_completion = threading.Event()
+    original_clear = server._clear_inflight_turn
+
+    def blocking_clear(target):
+        entered_completion.set()
+        assert release_completion.wait(timeout=2)
+        original_clear(target)
+
+    monkeypatch.setattr(server, "_clear_inflight_turn", blocking_clear)
+    completion = threading.Thread(
+        target=server._commit_prompt_completion,
+        kwargs={
+            "sid": sid,
+            "session": session,
+            "expected_history_version": 0,
+            "result_messages": [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "answer"},
+            ],
+            "payload": {"text": "answer", "status": "complete", "usage": {}},
+        },
+    )
+    completion.start()
+    assert entered_completion.wait(timeout=1)
+
+    captured = {}
+    snapshot_started = threading.Event()
+    snapshot_done = threading.Event()
+
+    def capture_snapshot():
+        snapshot_started.set()
+        captured["value"] = server._session_synchronization(sid, session, cursor)
+        snapshot_done.set()
+
+    snapshot_thread = threading.Thread(target=capture_snapshot)
+    snapshot_thread.start()
+    assert snapshot_started.wait(timeout=1)
+    assert not snapshot_done.wait(timeout=0.05)
+
+    release_completion.set()
+    completion.join(timeout=1)
+    snapshot_thread.join(timeout=1)
+    assert not completion.is_alive()
+    assert not snapshot_thread.is_alive()
+
+    synchronization = captured["value"]
+    assert synchronization["snapshot"]["messages"] == [
+        {"role": "user", "text": "question"},
+        {"role": "assistant", "text": "answer"},
+    ]
+    assert synchronization["snapshot"]["inflight_turn"] is None
+    assert synchronization["snapshot"]["watermark"] == 1
+    assert [
+        event["params"]["type"]
+        for event in synchronization["recovery"]["events"]
+    ] == ["message.complete"]
+
+
+def test_undo_advances_snapshot_revision_without_a_wire_event(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    session = server._sessions[sid]
+    session["agent"] = object()
+    session["history"] = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    initial_revision = created["synchronization"]["snapshot"]["revision"]
+    initial_watermark = created["synchronization"]["snapshot"]["watermark"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+
+    result = server._methods["session.undo"]("undo", {"session_id": sid})
+    resumed = resume_session(transport, stored_id)
+
+    assert result["result"] == {"removed": 2}
+    snapshot = resumed["synchronization"]["snapshot"]
+    assert snapshot["messages"] == []
+    assert snapshot["revision"] == initial_revision + 1
+    assert snapshot["watermark"] == initial_watermark
+
+
+def test_child_mirror_sync_recovers_inflight_text_and_active_tool(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: True)
+
+    server._mirror_subagent_to_child(
+        "subagent.start",
+        {"child_session_id": stored_id, "text": "goal"},
+    )
+    server._mirror_subagent_to_child(
+        "subagent.text",
+        {"child_session_id": stored_id, "text": "answer"},
+    )
+    server._mirror_subagent_to_child(
+        "subagent.tool",
+        {
+            "child_session_id": stored_id,
+            "tool_name": "terminal",
+            "tool_preview": "workspace command",
+        },
+    )
+
+    running = resume_session(transport, stored_id)
+    snapshot = running["synchronization"]["snapshot"]
+    assert snapshot["status"] == "working"
+    assert snapshot["inflight_turn"]["assistant"] == "goal\nanswer"
+    assert snapshot["inflight_turn"]["streaming"] is True
+    assert snapshot["active_tools"] == [
+        {
+            "tool_id": snapshot["active_tools"][0]["tool_id"],
+            "name": "terminal",
+            "started_at": snapshot["active_tools"][0]["started_at"],
+        }
+    ]
+    assert isinstance(snapshot["active_tools"][0]["started_at"], float)
+    assert "preview" not in snapshot["active_tools"][0]
+
+    deltas = [
+        frame["params"]["payload"]
+        for frame in transport.frames
+        if frame.get("params", {}).get("type") == "message.delta"
+    ]
+    assert [delta["offset"] for delta in deltas] == [0, 5]
+    assert len({delta["turn_id"] for delta in deltas}) == 1
+
+    server._mirror_subagent_to_child(
+        "subagent.complete",
+        {
+            "child_session_id": stored_id,
+            "summary": "done",
+        },
+    )
+    completed = resume_session(transport, stored_id)
+    settled = completed["synchronization"]["snapshot"]
+    assert settled["status"] == "idle"
+    assert settled["inflight_turn"] is None
+    assert settled["active_tools"] == []
+    assert settled["messages"][-1] == {
+        "role": "assistant",
+        "text": "goal\nanswer",
+    }

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -1,0 +1,446 @@
+"""Public JSON-RPC conformance tests for revisioned conversation sync."""
+
+import threading
+import time
+
+import pytest
+
+from tui_gateway import mobile_contract
+from tui_gateway import server
+from tui_gateway.mobile_sync import SessionEventStream
+
+
+class RecordingTransport:
+    def __init__(self):
+        self.authorization = {
+            "subject": "mobile-user",
+            "provider": "stub",
+            "audience": "hermes.mobile",
+            "scopes": (
+                "conversation.read",
+                "conversation.write",
+                "conversation.control",
+            ),
+        }
+        self.frames = []
+
+    def write(self, obj):
+        self.frames.append(obj)
+        return True
+
+    def close(self):
+        pass
+
+
+class SessionDBStub:
+    def __init__(self, session_id, messages=None):
+        self.session_id = session_id
+        self.messages = list(messages or [])
+
+    def get_session(self, session_id):
+        if session_id == self.session_id:
+            return {"id": self.session_id, "cwd": server.os.getcwd()}
+        return None
+
+    def get_session_by_title(self, _title):
+        return None
+
+    def resolve_resume_session_id(self, session_id):
+        return session_id
+
+    def reopen_session(self, _session_id):
+        return None
+
+    def get_messages_as_conversation(self, _session_id, include_ancestors=False):
+        return list(self.messages)
+
+
+@pytest.fixture(autouse=True)
+def isolated_gateway(monkeypatch):
+    server._sessions.clear()
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *_a, **_k: (None, None)
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_profile_home", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server, "_completion_cwd", lambda *_a, **_k: server.os.getcwd()
+    )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda *_a, **_k: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    yield
+    server._sessions.clear()
+
+
+def create_session(transport):
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": "create",
+            "method": "session.create",
+            "params": {"cols": 100},
+        },
+        transport,
+    )
+    assert response is not None
+    return response["result"]
+
+
+def resume_session(transport, stored_session_id, cursor=None):
+    params = {"session_id": stored_session_id, "cols": 100}
+    if cursor is not None:
+        params["cursor"] = cursor
+    request_id = f"resume-{len(transport.frames)}"
+    response = server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "session.resume",
+            "params": params,
+        },
+        transport,
+    )
+    if response is not None:
+        return response["result"]
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        responses = [
+            frame for frame in transport.frames if frame.get("id") == request_id
+        ]
+        if responses:
+            assert "error" not in responses[-1]
+            return responses[-1]["result"]
+        time.sleep(0.01)
+    raise AssertionError("session.resume response was not delivered")
+
+
+def test_create_returns_revisioned_authoritative_sync_snapshot():
+    transport = RecordingTransport()
+
+    result = create_session(transport)
+
+    synchronization = result["synchronization"]
+    snapshot = synchronization["snapshot"]
+    assert synchronization["schema_major"] == 1
+    assert snapshot == {
+        "schema_major": 1,
+        "server_instance_id": mobile_contract.SERVER_INSTANCE_ID,
+        "stream_id": snapshot["stream_id"],
+        "revision": 1,
+        "watermark": 0,
+        "conversation_id": result["stored_session_id"],
+        "stored_session_id": result["stored_session_id"],
+        "live_session_id": result["session_id"],
+        "messages": [],
+        "inflight_turn": None,
+        "active_tools": [],
+        "pending_interactions": [],
+        "status": "idle",
+    }
+    assert synchronization["recovery"] == {
+        "outcome": "reset",
+        "reason": "cursor_missing",
+        "snapshot_required": True,
+        "events": [],
+        "cursor": {
+            "server_instance_id": mobile_contract.SERVER_INSTANCE_ID,
+            "stream_id": snapshot["stream_id"],
+            "sequence": 0,
+        },
+    }
+
+
+def test_live_resume_replays_every_event_after_a_matching_cursor(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    cursor = created["synchronization"]["recovery"]["cursor"]
+    sid = created["session_id"]
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(created["stored_session_id"]),
+    )
+
+    server._emit("status.update", sid, {"kind": "working", "text": "Working"})
+    server._emit("session.info", sid, {"running": True})
+    resumed = resume_session(transport, created["stored_session_id"], cursor)
+
+    synchronization = resumed["synchronization"]
+    assert resumed["session_id"] == sid
+    assert synchronization["snapshot"]["stream_id"] == cursor["stream_id"]
+    assert synchronization["snapshot"]["watermark"] == 2
+    assert synchronization["snapshot"]["revision"] == 3
+    assert synchronization["recovery"]["outcome"] == "complete"
+    assert synchronization["recovery"]["snapshot_required"] is False
+    assert [
+        event["params"]["type"] for event in synchronization["recovery"]["events"]
+    ] == ["status.update", "session.info"]
+    assert [
+        event["params"]["sequence"] for event in synchronization["recovery"]["events"]
+    ] == [1, 2]
+
+
+def test_cold_resume_has_the_same_shape_and_requires_stream_reset(monkeypatch):
+    stored_id = "stored-cold"
+    transport = RecordingTransport()
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(
+            stored_id,
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ],
+        ),
+    )
+    prior_cursor = {
+        "server_instance_id": mobile_contract.SERVER_INSTANCE_ID,
+        "stream_id": "retired-stream",
+        "sequence": 12,
+    }
+
+    resumed = resume_session(transport, stored_id, prior_cursor)
+
+    synchronization = resumed["synchronization"]
+    snapshot = synchronization["snapshot"]
+    assert set(snapshot) == {
+        "schema_major",
+        "server_instance_id",
+        "stream_id",
+        "revision",
+        "watermark",
+        "conversation_id",
+        "stored_session_id",
+        "live_session_id",
+        "messages",
+        "inflight_turn",
+        "active_tools",
+        "pending_interactions",
+        "status",
+    }
+    assert snapshot["conversation_id"] == stored_id
+    assert snapshot["messages"] == [
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": "hi"},
+    ]
+    assert synchronization["recovery"]["outcome"] == "reset"
+    assert synchronization["recovery"]["reason"] == "stream_changed"
+
+
+def test_resume_preserves_conversation_lineage_while_exposing_current_ids(
+    monkeypatch,
+):
+    class LineageDB(SessionDBStub):
+        def get_compression_lineage(self, _session_id):
+            return ["conversation-root", self.session_id]
+
+    stored_id = "compression-tip"
+    transport = RecordingTransport()
+    monkeypatch.setattr(server, "_get_db", lambda: LineageDB(stored_id))
+
+    resumed = resume_session(transport, stored_id)
+
+    snapshot = resumed["synchronization"]["snapshot"]
+    assert snapshot["conversation_id"] == "conversation-root"
+    assert snapshot["stored_session_id"] == stored_id
+    assert snapshot["live_session_id"] == resumed["session_id"]
+
+
+def test_replay_overflow_is_an_explicit_gap(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    session["mobile_sync"] = SessionEventStream(
+        mobile_contract.SERVER_INSTANCE_ID,
+        max_events=2,
+        max_bytes=1024 * 1024,
+    )
+    cursor = session["mobile_sync"].cursor()
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(created["stored_session_id"]),
+    )
+
+    for index in range(3):
+        server._emit("status.update", sid, {"kind": "step", "text": str(index)})
+    resumed = resume_session(transport, created["stored_session_id"], cursor)
+
+    recovery = resumed["synchronization"]["recovery"]
+    assert recovery["outcome"] == "gap"
+    assert recovery["reason"] == "replay_evicted"
+    assert recovery["snapshot_required"] is True
+    assert recovery["events"] == []
+
+
+def test_oversized_event_is_delivered_live_but_not_claimed_as_replayable(
+    monkeypatch,
+):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    session["mobile_sync"] = SessionEventStream(
+        mobile_contract.SERVER_INSTANCE_ID,
+        max_events=20,
+        max_bytes=128,
+    )
+    cursor = session["mobile_sync"].cursor()
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: SessionDBStub(created["stored_session_id"]),
+    )
+
+    server._emit("status.update", sid, {"kind": "large", "text": "x" * 256})
+    assert transport.frames[-1]["params"]["sequence"] == 1
+    resumed = resume_session(transport, created["stored_session_id"], cursor)
+
+    recovery = resumed["synchronization"]["recovery"]
+    assert recovery["outcome"] == "gap"
+    assert recovery["snapshot_required"] is True
+    assert recovery["events"] == []
+
+
+def test_concurrent_session_events_are_monotonic_in_wire_order():
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    start = threading.Barrier(9)
+
+    def publish(index):
+        start.wait()
+        server._emit("status.update", sid, {"kind": "worker", "text": str(index)})
+
+    threads = [threading.Thread(target=publish, args=(index,)) for index in range(8)]
+    for thread in threads:
+        thread.start()
+    start.wait()
+    for thread in threads:
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+
+    events = [frame for frame in transport.frames if frame.get("method") == "event"]
+    assert [event["params"]["sequence"] for event in events] == list(range(1, 9))
+    assert all(event["params"]["schema_major"] == 1 for event in events)
+    assert len({event["params"]["stream_id"] for event in events}) == 1
+
+
+def test_coalesced_deltas_carry_one_turn_identity_and_absolute_utf8_offsets():
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    session = server._sessions[sid]
+    with session["history_lock"]:
+        server._start_inflight_turn(session, "question")
+        turn_id = session["inflight_turn"]["turn_id"]
+    server._emit_inflight_delta(sid, session, "A💡")
+    server._emit_inflight_delta(sid, session, "B")
+
+    deltas = [
+        frame["params"]["payload"]
+        for frame in transport.frames
+        if frame.get("params", {}).get("type") == "message.delta"
+    ]
+    assert deltas == [
+        {"text": "A💡", "turn_id": turn_id, "offset": 0},
+        {"text": "B", "turn_id": turn_id, "offset": 5},
+    ]
+
+
+def test_snapshot_tracks_only_sanitized_active_tool_descriptors(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: True)
+    monkeypatch.setattr(server, "_tool_ctx", lambda _name, _args: "workspace file")
+
+    server._on_tool_start(
+        sid,
+        "tool-1",
+        "terminal",
+        {"command": "printf super-secret"},
+    )
+    running = resume_session(transport, stored_id)
+
+    descriptor = running["synchronization"]["snapshot"]["active_tools"][0]
+    assert descriptor["tool_id"] == "tool-1"
+    assert descriptor["name"] == "terminal"
+    assert isinstance(descriptor["started_at"], float)
+    assert "context" not in descriptor
+    assert "args" not in descriptor
+    assert "command" not in descriptor
+
+    server._on_tool_complete(sid, "tool-1", "terminal", {}, "{}")
+    finished = resume_session(transport, stored_id)
+    assert finished["synchronization"]["snapshot"]["active_tools"] == []
+
+
+def test_snapshot_recovers_and_then_clears_a_pending_interaction(monkeypatch):
+    transport = RecordingTransport()
+    created = create_session(transport)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+    answer = {}
+
+    def ask():
+        answer["value"] = server._block(
+            "clarify.request",
+            sid,
+            {"question": "Pick one", "choices": ["A", "B"]},
+            timeout=2,
+        )
+
+    thread = threading.Thread(target=ask)
+    thread.start()
+    deadline = time.monotonic() + 1
+    request = None
+    while time.monotonic() < deadline:
+        request = next(
+            (
+                frame
+                for frame in transport.frames
+                if frame.get("params", {}).get("type") == "clarify.request"
+            ),
+            None,
+        )
+        if request is not None:
+            break
+        time.sleep(0.01)
+    assert request is not None
+    request_id = request["params"]["payload"]["request_id"]
+
+    waiting = resume_session(transport, stored_id)
+    snapshot = waiting["synchronization"]["snapshot"]
+    assert snapshot["status"] == "waiting"
+    assert snapshot["pending_interactions"] == [
+        {
+            "request_id": request_id,
+            "kind": "clarify",
+            "payload": {
+                "request_id": request_id,
+                "question": "Pick one",
+                "choices": ["A", "B"],
+            },
+        }
+    ]
+
+    response = server._methods["clarify.respond"](
+        "answer",
+        {"request_id": request_id, "answer": "A"},
+    )
+    assert response["result"] == {"status": "ok"}
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert answer == {"value": "A"}
+
+    settled = resume_session(transport, stored_id)
+    assert settled["synchronization"]["snapshot"]["pending_interactions"] == []

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -462,7 +462,7 @@ def test_legacy_session_keeps_original_response_and_event_shape():
     sid = created["session_id"]
 
     assert "synchronization" not in created
-    assert "mobile_sync" not in server._sessions[sid]
+    assert not server._sessions[sid].get("mobile_sync_retention")
 
     server._emit("status.update", sid, {"kind": "idle", "text": "Ready"})
 
@@ -476,7 +476,8 @@ def test_legacy_session_keeps_original_response_and_event_shape():
             "payload": {"kind": "idle", "text": "Ready"},
         },
     }
-    assert "mobile_sync" not in server._sessions[sid]
+    assert not server._sessions[sid].get("mobile_sync_retention")
+    assert server._sessions[sid]["mobile_sync"].cursor()["sequence"] == 0
 
 
 def test_mobile_replay_stays_retained_across_a_legacy_handoff(monkeypatch):
@@ -519,6 +520,116 @@ def test_mobile_replay_stays_retained_across_a_legacy_handoff(monkeypatch):
         "status.update"
     ]
     assert recovery["events"][0]["params"]["sequence"] == 1
+
+
+def test_transport_handoffs_serialize_audience_snapshot_and_delivery(monkeypatch):
+    class LegacyTransport(RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.authorization = {
+                "subject": "dashboard-user",
+                "provider": "password",
+                "audience": "dashboard",
+                "scopes": ("*",),
+            }
+
+    class BlockingWriteMobile(RecordingTransport):
+        def __init__(self, entered, release):
+            super().__init__()
+            self._entered = entered
+            self._release = release
+
+        def write(self, obj):
+            self._entered.set()
+            assert self._release.wait(timeout=2)
+            return super().write(obj)
+
+    mobile = RecordingTransport()
+    legacy = LegacyTransport()
+    created = create_session(mobile)
+    sid = created["session_id"]
+    stored_id = created["stored_session_id"]
+    session = server._sessions[sid]
+    monkeypatch.setattr(server, "_get_db", lambda: SessionDBStub(stored_id))
+
+    write_entered = threading.Event()
+    release_write = threading.Event()
+    blocking_mobile = BlockingWriteMobile(write_entered, release_write)
+    with session["history_lock"]:
+        server._set_session_transport_locked(session, blocking_mobile)
+
+    emitted = threading.Thread(
+        target=server._emit,
+        args=("status.update", sid, {"kind": "race", "text": "mobile"}),
+    )
+    legacy_result = {}
+
+    def attach_legacy():
+        legacy_result["payload"] = server._live_session_payload(
+            sid,
+            session,
+            transport=legacy,
+        )
+
+    emitted.start()
+    assert write_entered.wait(timeout=1)
+    legacy_handoff = threading.Thread(target=attach_legacy)
+    legacy_handoff.start()
+    assert legacy_handoff.is_alive()
+    release_write.set()
+    emitted.join(timeout=1)
+    legacy_handoff.join(timeout=1)
+    assert not emitted.is_alive()
+    assert not legacy_handoff.is_alive()
+    mobile_event = blocking_mobile.frames[-1]
+    assert mobile_event["params"]["sequence"] == 1
+    assert "synchronization" not in legacy_result["payload"]
+
+    auth_entered = threading.Event()
+    release_auth = threading.Event()
+
+    class BlockingAuthMobile(RecordingTransport):
+        def __init__(self):
+            self._authorization = dict(RecordingTransport().authorization)
+            self.frames = []
+
+        @property
+        def authorization(self):
+            auth_entered.set()
+            assert release_auth.wait(timeout=2)
+            return self._authorization
+
+    blocking_auth_mobile = BlockingAuthMobile()
+    mobile_result = {}
+    final_legacy_result = {}
+
+    def attach_mobile():
+        mobile_result["payload"] = server._live_session_payload(
+            sid,
+            session,
+            transport=blocking_auth_mobile,
+        )
+
+    def attach_final_legacy():
+        final_legacy_result["payload"] = server._live_session_payload(
+            sid,
+            session,
+            transport=legacy,
+        )
+
+    mobile_handoff = threading.Thread(target=attach_mobile)
+    mobile_handoff.start()
+    assert auth_entered.wait(timeout=1)
+    final_legacy_handoff = threading.Thread(target=attach_final_legacy)
+    final_legacy_handoff.start()
+    assert final_legacy_handoff.is_alive()
+    release_auth.set()
+    mobile_handoff.join(timeout=1)
+    final_legacy_handoff.join(timeout=1)
+    assert not mobile_handoff.is_alive()
+    assert not final_legacy_handoff.is_alive()
+    assert "synchronization" in mobile_result["payload"]
+    assert "synchronization" not in final_legacy_result["payload"]
 
 
 def test_concurrent_first_mobile_snapshot_and_publish_share_one_stream():

--- a/tests/tui_gateway/test_mobile_sync_contract.py
+++ b/tests/tui_gateway/test_mobile_sync_contract.py
@@ -54,6 +54,13 @@ class SessionDBStub:
     def get_messages_as_conversation(self, _session_id, include_ancestors=False):
         return list(self.messages)
 
+    def get_resume_conversations(self, _session_id):
+        messages = list(self.messages)
+        return messages, messages
+
+    def get_ancestor_display_prefix(self, _session_id):
+        return []
+
 
 @pytest.fixture(autouse=True)
 def isolated_gateway(monkeypatch):
@@ -778,7 +785,7 @@ def test_deferred_prompt_start_advances_revision_before_agent_ready(monkeypatch)
         assert release_wait.wait(timeout=2)
         return server._err(rid, 5000, "test build stopped")
 
-    monkeypatch.setattr(server, "_wait_agent", blocked_wait)
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda session, rid, _sid: blocked_wait(session, rid))
     try:
         submitted = server.dispatch(
             {

--- a/tests/tui_gateway/test_subagent_child_mirror.py
+++ b/tests/tui_gateway/test_subagent_child_mirror.py
@@ -110,8 +110,7 @@ def test_live_child_session_gets_native_stream(server, emits):
     assert child[2][1] == {"text": "hmm"}
     # The rotated-out tool closes with the same id it opened with.
     assert child[3][1]["tool_id"] == first_tool["tool_id"]
-    assert child[6][1]["text"] == "done deal"
-    assert child[6][1]["turn_id"] == child[0][1]["turn_id"]
+    assert child[6][1] == {"text": "done deal"}
 
     # Parent relay is untouched alongside the mirror.
     assert [e for e, s, _ in emits if s == "parent-sid"] == [
@@ -216,17 +215,9 @@ def test_start_mirrors_as_immediate_header_line(server, emits):
     _relay(server, "subagent.progress", preview="step 1/3", child_session_id="child-1")
 
     child = [(e, p) for e, s, p in emits if s == "live-1"]
-    turn_id = child[0][1]["turn_id"]
     assert child == [
-        ("message.start", {"turn_id": turn_id}),
-        (
-            "message.delta",
-            {
-                "text": "starting child branch\n",
-                "turn_id": turn_id,
-                "offset": 0,
-            },
-        ),
+        ("message.start", None),
+        ("message.delta", {"text": "starting child branch\n"}),
     ]
 
 
@@ -240,17 +231,10 @@ def test_text_mirrors_as_message_delta(server, emits):
     _relay(server, "subagent.text", preview="the answer.", child_session_id="child-1")
 
     child = [(e, p) for e, s, p in emits if s == "live-1"]
-    turn_id = child[0][1]["turn_id"]
     assert child == [
-        ("message.start", {"turn_id": turn_id}),
-        (
-            "message.delta",
-            {"text": "Here is ", "turn_id": turn_id, "offset": 0},
-        ),
-        (
-            "message.delta",
-            {"text": "the answer.", "turn_id": turn_id, "offset": 8},
-        ),
+        ("message.start", None),
+        ("message.delta", {"text": "Here is "}),
+        ("message.delta", {"text": "the answer."}),
     ]
 
 
@@ -286,9 +270,5 @@ def test_text_routes_to_watch_transport_without_contextvar(server, monkeypatch):
         for f in frames
         if f.get("method") == "event" and f["params"]["session_id"] == "live-1"
     ]
-    start = next(payload for event, sid, payload in routed if event == "message.start")
-    assert (
-        "message.delta",
-        "live-1",
-        {"text": "streamed reply", "turn_id": start["turn_id"], "offset": 0},
-    ) in routed
+    assert ("message.start", "live-1", None) in routed
+    assert ("message.delta", "live-1", {"text": "streamed reply"}) in routed

--- a/tests/tui_gateway/test_subagent_child_mirror.py
+++ b/tests/tui_gateway/test_subagent_child_mirror.py
@@ -110,7 +110,8 @@ def test_live_child_session_gets_native_stream(server, emits):
     assert child[2][1] == {"text": "hmm"}
     # The rotated-out tool closes with the same id it opened with.
     assert child[3][1]["tool_id"] == first_tool["tool_id"]
-    assert child[6][1] == {"text": "done deal"}
+    assert child[6][1]["text"] == "done deal"
+    assert child[6][1]["turn_id"] == child[0][1]["turn_id"]
 
     # Parent relay is untouched alongside the mirror.
     assert [e for e, s, _ in emits if s == "parent-sid"] == [
@@ -215,9 +216,17 @@ def test_start_mirrors_as_immediate_header_line(server, emits):
     _relay(server, "subagent.progress", preview="step 1/3", child_session_id="child-1")
 
     child = [(e, p) for e, s, p in emits if s == "live-1"]
+    turn_id = child[0][1]["turn_id"]
     assert child == [
-        ("message.start", None),
-        ("message.delta", {"text": "starting child branch\n"}),
+        ("message.start", {"turn_id": turn_id}),
+        (
+            "message.delta",
+            {
+                "text": "starting child branch\n",
+                "turn_id": turn_id,
+                "offset": 0,
+            },
+        ),
     ]
 
 
@@ -231,10 +240,55 @@ def test_text_mirrors_as_message_delta(server, emits):
     _relay(server, "subagent.text", preview="the answer.", child_session_id="child-1")
 
     child = [(e, p) for e, s, p in emits if s == "live-1"]
+    turn_id = child[0][1]["turn_id"]
     assert child == [
-        ("message.start", None),
-        ("message.delta", {"text": "Here is "}),
-        ("message.delta", {"text": "the answer."}),
+        ("message.start", {"turn_id": turn_id}),
+        (
+            "message.delta",
+            {"text": "Here is ", "turn_id": turn_id, "offset": 0},
+        ),
+        (
+            "message.delta",
+            {"text": "the answer.", "turn_id": turn_id, "offset": 8},
+        ),
     ]
 
 
+def test_text_routes_to_watch_transport_without_contextvar(server, monkeypatch):
+    """Async/background path: the child runs on a detached daemon thread that
+    carries NO contextvar transport binding. Routing must still reach the
+    watch window because write_json keys event frames off the session's STORED
+    transport, not the current context. Exercises the real _emit/write_json."""
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda sid: True)
+
+    frames: list = []
+
+    class RecTransport:
+        def write(self, obj):
+            frames.append(obj)
+            return True
+
+    watch_t = RecTransport()
+    # A lazy watch resume stored its transport on the live child session.
+    server._sessions["live-1"] = {
+        "session_key": "child-1",
+        "agent": None,
+        "transport": watch_t,
+    }
+
+    # Relay with NO transport bound on the current context (the daemon worker
+    # thread never inherits the parent's contextvar) — mirrors the async case.
+    assert server.current_transport() is None
+    _relay(server, "subagent.text", preview="streamed reply", child_session_id="child-1")
+
+    routed = [
+        (f["params"]["type"], f["params"]["session_id"], f["params"].get("payload"))
+        for f in frames
+        if f.get("method") == "event" and f["params"]["session_id"] == "live-1"
+    ]
+    start = next(payload for event, sid, payload in routed if event == "message.start")
+    assert (
+        "message.delta",
+        "live-1",
+        {"text": "streamed reply", "turn_id": start["turn_id"], "offset": 0},
+    ) in routed

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -123,25 +123,39 @@ def _(rid, params: dict) -> dict:
         )
     isolation_cfg = _load_dashboard_process_isolation_config()
     turn_isolation = _session_uses_compute_host(session, isolation_cfg)
-    # Re-bind to the current client transport for this request. This keeps
-    # streaming events on the active websocket even if an earlier disconnect
-    # or fallback moved the session transport to stdio.
-    if (t := current_transport()) is not None:
-        session["transport"] = t
+    # Re-bind accepted idle work to the current client. A busy scoped writer
+    # without conversation.control may queue its next turn on this transport,
+    # but must not seize the in-flight turn from the attached controller.
+    t = current_transport()
     while True:
         busy_transport = None
+        allow_control = True
         with session["history_lock"]:
             if session.get("running"):
-                # Don't reject a mid-turn prompt — queue it (and, by default,
-                # interrupt the live turn) so it runs as the next turn. The
-                # provider interrupt itself must happen after this lock is
-                # released: a non-interruptible tool may keep it waiting.
                 busy_transport = t or session.get("transport")
+                from tui_gateway.mobile_contract import (
+                    CONVERSATION_CONTROL_SCOPE,
+                    authorization_allows_scope,
+                )
+
+                allow_control = authorization_allows_scope(
+                    getattr(busy_transport, "authorization", None),
+                    CONVERSATION_CONTROL_SCOPE,
+                )
+                if t is not None and allow_control:
+                    session["transport"] = t
             else:
+                if t is not None:
+                    session["transport"] = t
                 break
         busy_response = _handle_busy_submit(
-            rid, sid, session, text, busy_transport,
+            rid,
+            sid,
+            session,
+            text,
+            busy_transport,
             queued=bool(params.get("queued")),
+            allow_control=allow_control,
         )
         if busy_response is not None:
             return busy_response
@@ -157,6 +171,8 @@ def _(rid, params: dict) -> dict:
         # the upgrade resumes the child's transcript as a normal conversation.
         if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
+        if t is not None:
+            session["transport"] = t
         if truncate_user_ordinal is not None:
             try:
                 ordinal = int(truncate_user_ordinal)

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -113,6 +113,11 @@ def _(rid, params: dict) -> dict:
         return err
     if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
         return _err(rid, 4090, limit_message)
+    # A child-watch session mirrors the delegated run as `running` for sync
+    # snapshots. Reject input before the generic busy-submit path can interpret
+    # that synthetic liveness as a steer/queue-capable local agent turn.
+    if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
+        return _err(rid, 4009, "subagent still running — wait for it to finish")
     if truncate_user_ordinal is not None and isinstance(text, str):
         # A rewind/regenerate replays a turn from what the transcript shows. A
         # skill turn shows its invocation, so re-expand it here — otherwise
@@ -143,10 +148,10 @@ def _(rid, params: dict) -> dict:
                     CONVERSATION_CONTROL_SCOPE,
                 )
                 if t is not None and allow_control:
-                    session["transport"] = t
+                    _set_session_transport_locked(session, t)
             else:
                 if t is not None:
-                    session["transport"] = t
+                    _set_session_transport_locked(session, t)
                 break
         busy_response = _handle_busy_submit(
             rid,
@@ -172,7 +177,7 @@ def _(rid, params: dict) -> dict:
         if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
         if t is not None:
-            session["transport"] = t
+            _set_session_transport_locked(session, t)
         if truncate_user_ordinal is not None:
             try:
                 ordinal = int(truncate_user_ordinal)
@@ -228,6 +233,7 @@ def _(rid, params: dict) -> dict:
             )
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
             if (db := _get_db()) is not None:
                 try:
                     db.replace_messages(session["session_key"], truncated)
@@ -237,6 +243,7 @@ def _(rid, params: dict) -> dict:
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)
+        _mark_snapshot_mutation(session)
 
     if turn_isolation:
         isolated_response = _submit_prompt_to_compute_host(rid, sid, session, text)
@@ -274,6 +281,8 @@ def _(rid, params: dict) -> dict:
             with session["history_lock"]:
                 session["running"] = False
                 session["last_active"] = time.time()
+                _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
             _emit("session.info", sid, _session_info(session.get("agent"), session))
             return
         with session["history_lock"]:
@@ -295,6 +304,7 @@ def _(rid, params: dict) -> dict:
                         else "Session no longer running before the agent was ready"
                     },
                 )
+                _mark_snapshot_mutation(session)
                 return
         _run_prompt_submit(rid, sid, session, text)
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -83,6 +83,7 @@ def _(rid, params: dict) -> dict:
             "close_on_disconnect": is_truthy_value(params.get("close_on_disconnect", False)),
             "active_session_lease": lease,
             "cols": cols,
+            "conversation_id": key,
             "created_at": now,
             "edit_snapshots": {},
             "explicit_cwd": explicit_cwd,
@@ -94,6 +95,8 @@ def _(rid, params: dict) -> dict:
             "inflight_turn": None,
             "last_active": now,
             "model_override": session_model_override,
+            "mobile_sync": _new_session_event_stream(),
+            "mobile_sync_retention": False,
             "create_reasoning_override": create_reasoning_override,
             "create_service_tier_override": create_service_tier_override,
             "parent_session_id": parent_session_id,
@@ -124,39 +127,33 @@ def _(rid, params: dict) -> dict:
     _schedule_agent_build(sid)
     _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
 
-    return _ok(
-        rid,
-        {
-            "session_id": sid,
-            "stored_session_id": key,
-            "message_count": len(history),
-            "messages": _history_to_messages(history),
-            "info": {
-                # Reflect the per-session model override (desktop composer pick)
-                # in the immediate response so the client doesn't briefly clobber
-                # its sticky pick with the global default before the deferred
-                # build's session.info lands.
-                "model": (
-                    session_model_override.get("model")
-                    if session_model_override
-                    else _resolve_model()
-                ),
-                **(
-                    {"provider": session_model_override["provider"]}
-                    if session_model_override and session_model_override.get("provider")
-                    else {}
-                ),
-                "tools": {},
-                "skills": {},
-                "cwd": _sessions[sid]["cwd"],
-                "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
-                "project": _project_info_for_cwd(_sessions[sid]["cwd"]),
-                "lazy": True,
-                "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-                "profile_name": _response_profile_name(profile),
-            },
+    payload = {
+        "session_id": sid,
+        "stored_session_id": key,
+        "message_count": len(history),
+        "messages": _history_to_messages(history),
+        "info": {
+            "model": (
+                session_model_override.get("model")
+                if session_model_override
+                else _resolve_model()
+            ),
+            **(
+                {"provider": session_model_override["provider"]}
+                if session_model_override and session_model_override.get("provider")
+                else {}
+            ),
+            "tools": {},
+            "skills": {},
+            "cwd": _sessions[sid]["cwd"],
+            "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
+            "project": _project_info_for_cwd(_sessions[sid]["cwd"]),
+            "lazy": True,
+            "desktop_contract": DESKTOP_BACKEND_CONTRACT,
+            "profile_name": _response_profile_name(profile),
         },
-    )
+    }
+    return _ok(rid, _attach_synchronization(payload, sid, _sessions[sid]))
 
 
 @method("session.list")
@@ -305,6 +302,7 @@ def _(rid, params: dict) -> dict:
 @method("session.resume")
 def _(rid, params: dict) -> dict:
     target = params.get("session_id", "")
+    cursor = params.get("cursor")
     if not target:
         return _err(rid, 4006, "session_id required")
     try:
@@ -379,6 +377,7 @@ def _(rid, params: dict) -> dict:
             cols=cols,
             touch=True,
             transport=current_transport() or _stdio_transport,
+            cursor=cursor,
         )
         payload["resumed"] = target
         # A lazy watch session never owns a run loop, so its payload's running
@@ -431,6 +430,7 @@ def _(rid, params: dict) -> dict:
             profile_home=profile_home,
             lazy=True,
         )
+        record["conversation_id"] = _conversation_root(db, target)
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
         # A delegated child mid-run emits no session events of its own — report
@@ -450,9 +450,7 @@ def _(rid, params: dict) -> dict:
             logger.debug("child-watch display projection read failed", exc_info=True)
             display_history = history
         messages = _history_to_messages(display_history)
-        return _ok(
-            rid,
-            {
+        payload = {
                 "session_id": sid,
                 "resumed": target,
                 "message_count": len(messages),
@@ -463,8 +461,8 @@ def _(rid, params: dict) -> dict:
                 "session_key": target,
                 "started_at": record["created_at"],
                 "status": "streaming" if child_running else "idle",
-            },
-        )
+            }
+        return _ok(rid, _attach_synchronization(payload, sid, record, cursor))
 
     # Cold resume default: register the live session and read its stored
     # transcript, but build the agent OFF the response path. _make_agent can
@@ -522,6 +520,7 @@ def _(rid, params: dict) -> dict:
             model_override=overrides.get("model_override"),
             resume_runtime_overrides=overrides or None,
         )
+        record["conversation_id"] = _conversation_root(db, target)
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
 
@@ -549,7 +548,7 @@ def _(rid, params: dict) -> dict:
         }
         if auto_continue is not None:
             payload["auto_continue"] = auto_continue
-        return _ok(rid, payload)
+        return _ok(rid, _attach_synchronization(payload, sid, record, cursor))
 
     # Build the agent OUTSIDE the lock — _make_agent can block for seconds
     # (MCP discovery, prompt/skill build, AIAgent construction). Holding
@@ -631,6 +630,7 @@ def _(rid, params: dict) -> dict:
                 cols=cols,
                 touch=True,
                 transport=current_transport() or _stdio_transport,
+                cursor=cursor,
             )
             payload["resumed"] = target
             return _ok(rid, payload)
@@ -662,6 +662,7 @@ def _(rid, params: dict) -> dict:
                 if init_secret_token is not None:
                     reset_secret_scope(init_secret_token)
             if sid in _sessions:
+                _sessions[sid]["conversation_id"] = _conversation_root(db, target)
                 if stored_runtime_overrides.get("model_override") is not None:
                     _sessions[sid]["model_override"] = stored_runtime_overrides[
                         "model_override"
@@ -695,7 +696,7 @@ def _(rid, params: dict) -> dict:
     }
     if auto_continue is not None:
         payload["auto_continue"] = auto_continue
-    return _ok(rid, payload)
+    return _ok(rid, _attach_synchronization(payload, sid, session, cursor))
 
 
 @method("session.cwd.set")
@@ -781,6 +782,7 @@ def _(rid, params: dict) -> dict:
             session,
             touch=True,
             transport=current_transport() or _stdio_transport,
+            cursor=params.get("cursor"),
         ),
     )
 
@@ -2311,6 +2313,7 @@ def _(rid, params: dict) -> dict:
             removed = len(history) - last_user_idx
             del history[last_user_idx:]
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
     return _ok(rid, {"removed": removed})
 
 
@@ -2751,6 +2754,7 @@ def _(rid, params: dict) -> dict:
             if session.get("running"):
                 session["running"] = False
                 _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
 
     # Stop = stop the TURN (cooperative interrupt above also kills the in-flight
     # foreground subprocess). Background processes the agent started (dev servers,

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -737,6 +737,7 @@ def _(rid, params: dict) -> dict:
         with session["history_lock"]:
             session["history"] = history[:last_user_idx]
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
         return _ok(rid, {"type": "send", "message": content})
 
     if name == "steer":
@@ -887,6 +888,7 @@ def _(rid, params: dict) -> dict:
         with session["history_lock"]:
             session["history"] = list(active)
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
         # Notify memory providers — same hook /branch fires, plus the
         # rewound flag so providers caching per-turn document state
         # know to invalidate. See #6672 + #21910.
@@ -1309,6 +1311,7 @@ def _(rid, params: dict) -> dict:
                         session["history_version"] = (
                             int(session.get("history_version", 0)) + 1
                         )
+                        _mark_snapshot_mutation(session)
                 result["history_removed"] = removed
             return result
 

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -12,6 +12,10 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from hermes_cli import __release_date__, __version__
+from tui_gateway.mobile_sync import (
+    DEFAULT_REPLAY_MAX_BYTES,
+    DEFAULT_REPLAY_MAX_EVENTS,
+)
 
 MOBILE_AUDIENCE = "hermes.mobile"
 LEGACY_AUDIENCE = "dashboard"
@@ -27,13 +31,15 @@ SERVER_RELEASE_DATE = __release_date__
 # durable deployment identity remains outside this first contract slice.
 SERVER_INSTANCE_ID = str(uuid.uuid4())
 
-# Advertise only schemas this slice actually defines.  Conversation snapshots,
-# replay, mutation idempotency, and recoverable approvals land in later slices
-# and must not be inferred from Mobile Client Contract v1 alone.
+# Advertise only schemas implemented by the stacked contract slices. Mutation
+# idempotency and recoverable approvals still land later and must not be
+# inferred from Mobile Client Contract v1 alone.
 CLIENT_SCHEMA_MAJORS = {
     "gateway.ready": 1,
     "authorization.grant": 1,
     "authorization.error": 1,
+    "session.synchronization": 1,
+    "session.event": 1,
 }
 
 CONVERSATION_READ_SCOPE = "conversation.read"
@@ -92,7 +98,7 @@ MOBILE_METHOD_POLICIES = {
     ),
     "session.resume": MobileMethodPolicy(
         (CONVERSATION_CONTROL_SCOPE,),
-        frozenset({"cols", "session_id"}),
+        frozenset({"cols", "cursor", "session_id"}),
     ),
     "prompt.submit": MobileMethodPolicy(
         (CONVERSATION_WRITE_SCOPE,),
@@ -158,7 +164,17 @@ def gateway_ready_payload(
             "major": MOBILE_CONTRACT_MAJOR,
         },
         "schemas": dict(CLIENT_SCHEMA_MAJORS),
-        "capabilities": {"auth.ws_scopes": {"version": 1}},
+        "capabilities": {
+            "auth.ws_scopes": {"version": 1},
+            "conversation.sync": {
+                "version": 1,
+                "delta_offsets": {"unit": "utf8_bytes"},
+                "replay": {
+                    "max_events": DEFAULT_REPLAY_MAX_EVENTS,
+                    "max_bytes": DEFAULT_REPLAY_MAX_BYTES,
+                },
+            },
+        },
         "authorization": effective_authorization(authorization),
     }
 

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterable
+from dataclasses import dataclass
 
 from hermes_cli import __release_date__, __version__
 
@@ -41,6 +42,11 @@ CONVERSATION_WRITE_SCOPE = "conversation.write"
 # mutation idempotency; clients must wait for that separately advertised
 # capability before treating retries as safe.
 CONVERSATION_CONTROL_SCOPE = "conversation.control"
+CONVERSATION_DELETE_SCOPE = "conversation.delete"
+# Error-only marker for a method or parameter that has no grantable mobile
+# scope in this contract version.  It is deliberately absent from
+# SUPPORTED_MOBILE_SCOPES; clients must also inspect ``grantable``.
+MOBILE_UNAVAILABLE_SCOPE = "mobile.unavailable"
 
 SUPPORTED_MOBILE_SCOPES = frozenset(
     {
@@ -50,18 +56,52 @@ SUPPORTED_MOBILE_SCOPES = frozenset(
     }
 )
 
-MOBILE_METHOD_SCOPES = {
-    "session.list": CONVERSATION_READ_SCOPE,
-    "prompt.submit": CONVERSATION_WRITE_SCOPE,
-    "session.active_list": CONVERSATION_READ_SCOPE,
-    "session.activate": CONVERSATION_READ_SCOPE,
-    "session.history": CONVERSATION_READ_SCOPE,
-    "session.status": CONVERSATION_READ_SCOPE,
-    "session.usage": CONVERSATION_READ_SCOPE,
-    "session.create": CONVERSATION_WRITE_SCOPE,
-    "session.resume": CONVERSATION_WRITE_SCOPE,
-    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
-    "session.steer": CONVERSATION_CONTROL_SCOPE,
+@dataclass(frozen=True)
+class MobileMethodPolicy:
+    """Scopes and parameters that make one existing gateway method mobile-safe."""
+
+    required_scopes: tuple[str, ...]
+    allowed_parameters: frozenset[str]
+
+
+MOBILE_METHOD_POLICIES = {
+    "session.list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset(),
+    ),
+    "session.active_list": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"current_session_id"}),
+    ),
+    # Activating or resuming rebinds the live transport, so read access alone
+    # is intentionally insufficient even though both responses contain history.
+    "session.activate": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    "session.history": MobileMethodPolicy(
+        (CONVERSATION_READ_SCOPE,),
+        frozenset({"session_id"}),
+    ),
+    # Creating a live session starts Hermes-owned workers and hooks.  It is both
+    # a conversation write and a runtime-control action, with server-derived
+    # profile/source/model/cwd rather than client-selected privileged knobs.
+    "session.create": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE, CONVERSATION_CONTROL_SCOPE),
+        frozenset({"cols", "title"}),
+    ),
+    "session.resume": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"cols", "session_id"}),
+    ),
+    "prompt.submit": MobileMethodPolicy(
+        (CONVERSATION_WRITE_SCOPE,),
+        frozenset({"session_id", "text"}),
+    ),
+    "session.interrupt": MobileMethodPolicy(
+        (CONVERSATION_CONTROL_SCOPE,),
+        frozenset({"session_id"}),
+    ),
 }
 
 
@@ -76,6 +116,10 @@ def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
             granted.append(scope)
     if not granted:
         raise ValueError("at least one mobile scope is required")
+    if CONVERSATION_READ_SCOPE not in granted:
+        raise ValueError(
+            "conversation.read is required for every mobile WebSocket grant"
+        )
     return tuple(granted)
 
 
@@ -119,25 +163,85 @@ def gateway_ready_payload(
     }
 
 
-def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+def authorization_allows_scope(authorization: dict | None, scope: str) -> bool:
+    """Return whether a connection may perform a scope-gated side effect."""
+    grant = effective_authorization(authorization)
+    return grant["audience"] != MOBILE_AUDIENCE or scope in grant["scopes"]
+
+
+def _denial(
+    *,
+    reason: str,
+    method: str,
+    grant: dict,
+    required_scopes: tuple[str, ...],
+    grantable: bool,
+    parameter: str | None = None,
+) -> dict:
+    missing = (
+        list(required_scopes)
+        if not grantable
+        else [scope for scope in required_scopes if scope not in grant["scopes"]]
+    )
+    data = {
+        "reason": reason,
+        "method": method,
+        "required_scope": missing[0] if missing else required_scopes[0],
+        "required_scopes": list(required_scopes),
+        "missing_scopes": missing,
+        "granted_scopes": grant["scopes"],
+        "grantable": grantable,
+    }
+    if parameter is not None:
+        data["parameter"] = parameter
+    return data
+
+
+def mobile_method_denial(
+    method: str,
+    authorization: dict | None,
+    params: dict | None = None,
+) -> dict | None:
     """Describe why a mobile grant cannot call *method*, or return ``None``."""
     grant = effective_authorization(authorization)
     if grant["audience"] != MOBILE_AUDIENCE:
         return None
 
-    required_scope = MOBILE_METHOD_SCOPES.get(method)
-    if required_scope is None:
-        return {
-            "reason": "method_not_available_to_mobile",
-            "method": method,
-            "required_scope": None,
-            "granted_scopes": grant["scopes"],
-        }
-    if required_scope not in grant["scopes"]:
-        return {
-            "reason": "missing_scope",
-            "method": method,
-            "required_scope": required_scope,
-            "granted_scopes": grant["scopes"],
-        }
+    policy = MOBILE_METHOD_POLICIES.get(method)
+    if policy is None:
+        return _denial(
+            reason="method_not_available_to_mobile",
+            method=method,
+            grant=grant,
+            required_scopes=(MOBILE_UNAVAILABLE_SCOPE,),
+            grantable=False,
+        )
+
+    params = params or {}
+    unsupported_parameters = sorted(set(params) - policy.allowed_parameters)
+    if unsupported_parameters:
+        parameter = unsupported_parameters[0]
+        required_scope = (
+            CONVERSATION_DELETE_SCOPE
+            if method == "prompt.submit"
+            and parameter == "truncate_before_user_ordinal"
+            else MOBILE_UNAVAILABLE_SCOPE
+        )
+        return _denial(
+            reason="parameter_not_available_to_mobile",
+            method=method,
+            parameter=parameter,
+            grant=grant,
+            required_scopes=(required_scope,),
+            grantable=False,
+        )
+
+    if any(scope not in grant["scopes"] for scope in policy.required_scopes):
+        return _denial(
+            reason="missing_scope",
+            method=method,
+            grant=grant,
+            required_scopes=policy.required_scopes,
+            grantable=True,
+        )
     return None

--- a/tui_gateway/mobile_contract.py
+++ b/tui_gateway/mobile_contract.py
@@ -1,0 +1,143 @@
+"""Versioned authorization contract for native/mobile gateway clients.
+
+This module is deliberately transport-only: it defines what a scoped client
+may ask the existing TUI JSON-RPC gateway to do. It does not introduce a new
+runtime or duplicate any Hermes-owned session state.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+from hermes_cli import __release_date__, __version__
+
+MOBILE_AUDIENCE = "hermes.mobile"
+LEGACY_AUDIENCE = "dashboard"
+PROTOCOL_NAME = "hermes.tui.jsonrpc"
+PROTOCOL_MAJOR = 1
+MOBILE_CONTRACT_NAME = "hermes.mobile"
+MOBILE_CONTRACT_MAJOR = 1
+
+SERVER_VERSION = __version__
+SERVER_RELEASE_DATE = __release_date__
+# A new server process is a new event-stream authority.  This identity is
+# intentionally stable across connections but changes after process restart;
+# durable deployment identity remains outside this first contract slice.
+SERVER_INSTANCE_ID = str(uuid.uuid4())
+
+# Advertise only schemas this slice actually defines.  Conversation snapshots,
+# replay, mutation idempotency, and recoverable approvals land in later slices
+# and must not be inferred from Mobile Client Contract v1 alone.
+CLIENT_SCHEMA_MAJORS = {
+    "gateway.ready": 1,
+    "authorization.grant": 1,
+    "authorization.error": 1,
+}
+
+CONVERSATION_READ_SCOPE = "conversation.read"
+CONVERSATION_WRITE_SCOPE = "conversation.write"
+# This scope is an authorization boundary only.  It does not claim durable
+# mutation idempotency; clients must wait for that separately advertised
+# capability before treating retries as safe.
+CONVERSATION_CONTROL_SCOPE = "conversation.control"
+
+SUPPORTED_MOBILE_SCOPES = frozenset(
+    {
+        CONVERSATION_READ_SCOPE,
+        CONVERSATION_WRITE_SCOPE,
+        CONVERSATION_CONTROL_SCOPE,
+    }
+)
+
+MOBILE_METHOD_SCOPES = {
+    "session.list": CONVERSATION_READ_SCOPE,
+    "prompt.submit": CONVERSATION_WRITE_SCOPE,
+    "session.active_list": CONVERSATION_READ_SCOPE,
+    "session.activate": CONVERSATION_READ_SCOPE,
+    "session.history": CONVERSATION_READ_SCOPE,
+    "session.status": CONVERSATION_READ_SCOPE,
+    "session.usage": CONVERSATION_READ_SCOPE,
+    "session.create": CONVERSATION_WRITE_SCOPE,
+    "session.resume": CONVERSATION_WRITE_SCOPE,
+    "session.interrupt": CONVERSATION_CONTROL_SCOPE,
+    "session.steer": CONVERSATION_CONTROL_SCOPE,
+}
+
+
+def normalize_mobile_scopes(scopes: Iterable[object]) -> tuple[str, ...]:
+    """Validate and de-duplicate a requested mobile authorization grant."""
+    granted: list[str] = []
+    for raw in scopes:
+        scope = str(raw or "").strip()
+        if not scope or scope not in SUPPORTED_MOBILE_SCOPES:
+            raise ValueError(f"unsupported mobile scope: {scope or '<empty>'}")
+        if scope not in granted:
+            granted.append(scope)
+    if not granted:
+        raise ValueError("at least one mobile scope is required")
+    return tuple(granted)
+
+
+def effective_authorization(raw: dict | None = None) -> dict:
+    """Return the stable, JSON-safe authorization grant exposed to a client."""
+    raw = raw or {}
+    scopes = raw.get("scopes", ("*",))
+    if not isinstance(scopes, (list, tuple)):
+        scopes = (str(scopes),)
+    return {
+        "subject": str(raw.get("subject") or raw.get("user_id") or "legacy"),
+        "provider": str(raw.get("provider") or "legacy"),
+        "audience": str(raw.get("audience") or LEGACY_AUDIENCE),
+        "scopes": [str(scope) for scope in scopes],
+    }
+
+
+def gateway_ready_payload(
+    *, skin: dict[str, object], authorization: dict | None = None
+) -> dict:
+    """Build the additive first-frame contract for every WebSocket client."""
+    return {
+        "skin": skin,
+        # This backend broadcasts pet.changed / cron.changed /
+        # sessions.changed, so clients can demote legacy polls to slow
+        # backstops without losing compatibility with older transports.
+        "change_events": True,
+        "server": {
+            "version": SERVER_VERSION,
+            "release_date": SERVER_RELEASE_DATE,
+            "instance_id": SERVER_INSTANCE_ID,
+        },
+        "protocol": {"name": PROTOCOL_NAME, "major": PROTOCOL_MAJOR},
+        "contract": {
+            "name": MOBILE_CONTRACT_NAME,
+            "major": MOBILE_CONTRACT_MAJOR,
+        },
+        "schemas": dict(CLIENT_SCHEMA_MAJORS),
+        "capabilities": {"auth.ws_scopes": {"version": 1}},
+        "authorization": effective_authorization(authorization),
+    }
+
+
+def mobile_method_denial(method: str, authorization: dict | None) -> dict | None:
+    """Describe why a mobile grant cannot call *method*, or return ``None``."""
+    grant = effective_authorization(authorization)
+    if grant["audience"] != MOBILE_AUDIENCE:
+        return None
+
+    required_scope = MOBILE_METHOD_SCOPES.get(method)
+    if required_scope is None:
+        return {
+            "reason": "method_not_available_to_mobile",
+            "method": method,
+            "required_scope": None,
+            "granted_scopes": grant["scopes"],
+        }
+    if required_scope not in grant["scopes"]:
+        return {
+            "reason": "missing_scope",
+            "method": method,
+            "required_scope": required_scope,
+            "granted_scopes": grant["scopes"],
+        }
+    return None

--- a/tui_gateway/mobile_sync.py
+++ b/tui_gateway/mobile_sync.py
@@ -1,0 +1,241 @@
+"""Revisioned conversation snapshots and bounded session-event replay.
+
+The synchronization boundary is one lock per live session stream.  Callers
+mutate snapshot-visible state, allocate the matching event sequence, and queue
+that event for transport while this lock is held.  Snapshot capture takes the
+conversation history lock first and this stream lock second.  A snapshot's
+``watermark`` therefore covers every state transition published before it;
+clients install the snapshot at that watermark and apply only events with a
+larger sequence.
+
+Replay is intentionally process-local and bounded.  A process restart changes
+``server_instance_id`` and rebuilding a live session changes ``stream_id``;
+either condition produces an explicit reset instead of pretending replay is
+complete.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import threading
+import uuid
+from collections import deque
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import Any
+
+SYNC_SCHEMA_MAJOR = 1
+EVENT_SCHEMA_MAJOR = 1
+DEFAULT_REPLAY_MAX_EVENTS = 512
+DEFAULT_REPLAY_MAX_BYTES = 1024 * 1024
+
+
+class SessionEventStream:
+    """Thread-safe synchronization authority for one live Hermes session."""
+
+    def __init__(
+        self,
+        server_instance_id: str,
+        *,
+        max_events: int = DEFAULT_REPLAY_MAX_EVENTS,
+        max_bytes: int = DEFAULT_REPLAY_MAX_BYTES,
+    ) -> None:
+        self.server_instance_id = str(server_instance_id)
+        self.stream_id = str(uuid.uuid4())
+        self.max_events = max(1, int(max_events))
+        self.max_bytes = max(1, int(max_bytes))
+        self._lock = threading.RLock()
+        self._sequence = 0
+        self._revision = 1
+        self._discarded_through = 0
+        self._replay_bytes = 0
+        self._replay: deque[tuple[int, int, dict[str, Any]]] = deque()
+        self._active_tools: dict[str, dict[str, Any]] = {}
+        self._pending_interactions: dict[str, dict[str, Any]] = {}
+
+    def track_tool(self, descriptor: dict[str, Any]) -> None:
+        tool_id = str(descriptor.get("tool_id") or "")
+        if tool_id:
+            self._active_tools[tool_id] = copy.deepcopy(descriptor)
+
+    def finish_tool(self, tool_id: str) -> None:
+        self._active_tools.pop(str(tool_id), None)
+
+    def track_pending_interaction(self, descriptor: dict[str, Any]) -> None:
+        request_id = str(descriptor.get("request_id") or "")
+        if request_id:
+            self._pending_interactions[request_id] = copy.deepcopy(descriptor)
+
+    def finish_pending_interaction(self, request_id: str) -> None:
+        """Remove state that has no legacy completion event.
+
+        The revision changes so the next authoritative snapshot cannot compare
+        equal to one that still contained the interaction.  The future
+        addressable-approval slice can replace this with an explicit lifecycle
+        event without changing the synchronization envelope.
+        """
+        with self._lock:
+            if self._pending_interactions.pop(str(request_id), None) is not None:
+                self._revision += 1
+
+    def mutate(self, update: Callable[[SessionEventStream], None]) -> None:
+        """Apply snapshot-only state when the legacy protocol emits no event."""
+        with self._lock:
+            update(self)
+            self._revision += 1
+
+    @contextmanager
+    def transition(self, update: Callable[[SessionEventStream], None]):
+        """Keep a state update and the caller's event publication atomic."""
+        with self._lock:
+            update(self)
+            yield
+
+    def publish(
+        self,
+        event: str,
+        session_id: str,
+        payload: dict[str, Any] | None,
+        deliver: Callable[[dict[str, Any]], Any],
+        *,
+        update: Callable[[SessionEventStream], None] | None = None,
+    ) -> dict[str, Any]:
+        """Allocate, retain, and deliver one event in monotonic wire order."""
+        with self._lock:
+            retained_payload = copy.deepcopy(payload) if payload is not None else None
+            if update is not None:
+                update(self)
+            self._sequence += 1
+            self._revision += 1
+            params: dict[str, Any] = {
+                "type": event,
+                "session_id": session_id,
+                "schema_major": EVENT_SCHEMA_MAJOR,
+                "stream_id": self.stream_id,
+                "sequence": self._sequence,
+            }
+            if retained_payload is not None:
+                params["payload"] = retained_payload
+            frame = {"jsonrpc": "2.0", "method": "event", "params": params}
+            retained = copy.deepcopy(frame)
+            try:
+                size = len(
+                    json.dumps(
+                        retained,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                )
+            except (TypeError, ValueError):
+                # A malformed event cannot be replayed. Preserve the explicit
+                # gap invariant even if its producer catches serialization.
+                self._discard_all_through(self._sequence)
+                raise
+            self._retain(self._sequence, size, retained)
+            # Keep delivery under the stream lock so concurrent publishers
+            # cannot put sequence N+1 on the transport before sequence N.
+            deliver(frame)
+            return copy.deepcopy(frame)
+
+    def synchronization(
+        self,
+        snapshot_factory: Callable[[dict[str, Any]], dict[str, Any]],
+        cursor: object = None,
+    ) -> dict[str, Any]:
+        """Capture one authoritative snapshot and classify cursor recovery."""
+        with self._lock:
+            watermark = self._sequence
+            snapshot = snapshot_factory({
+                "active_tools": copy.deepcopy(list(self._active_tools.values())),
+                "pending_interactions": copy.deepcopy(
+                    list(self._pending_interactions.values())
+                ),
+            })
+            snapshot.update({
+                "schema_major": SYNC_SCHEMA_MAJOR,
+                "server_instance_id": self.server_instance_id,
+                "stream_id": self.stream_id,
+                "revision": self._revision,
+                "watermark": watermark,
+            })
+            recovery = self._recovery(cursor, watermark)
+            return {
+                "schema_major": SYNC_SCHEMA_MAJOR,
+                "snapshot": snapshot,
+                "recovery": recovery,
+            }
+
+    def cursor(self) -> dict[str, Any]:
+        with self._lock:
+            return self._cursor(self._sequence)
+
+    def _retain(self, sequence: int, size: int, frame: dict[str, Any]) -> None:
+        if size > self.max_bytes:
+            self._discard_all_through(sequence)
+            return
+        self._replay.append((sequence, size, frame))
+        self._replay_bytes += size
+        while (
+            len(self._replay) > self.max_events or self._replay_bytes > self.max_bytes
+        ):
+            evicted_sequence, evicted_size, _ = self._replay.popleft()
+            self._replay_bytes -= evicted_size
+            self._discarded_through = max(
+                self._discarded_through,
+                evicted_sequence,
+            )
+
+    def _discard_all_through(self, sequence: int) -> None:
+        self._replay.clear()
+        self._replay_bytes = 0
+        self._discarded_through = max(self._discarded_through, sequence)
+
+    def _cursor(self, sequence: int) -> dict[str, Any]:
+        return {
+            "server_instance_id": self.server_instance_id,
+            "stream_id": self.stream_id,
+            "sequence": sequence,
+        }
+
+    def _recovery(self, cursor: object, watermark: int) -> dict[str, Any]:
+        current = self._cursor(watermark)
+        base: dict[str, Any] = {
+            "cursor": current,
+            "events": [],
+            "snapshot_required": True,
+        }
+        if not isinstance(cursor, dict):
+            return {**base, "outcome": "reset", "reason": "cursor_missing"}
+        if cursor.get("server_instance_id") != self.server_instance_id:
+            return {
+                **base,
+                "outcome": "reset",
+                "reason": "server_instance_changed",
+            }
+        if cursor.get("stream_id") != self.stream_id:
+            return {**base, "outcome": "reset", "reason": "stream_changed"}
+        raw_sequence = cursor.get("sequence")
+        if isinstance(raw_sequence, bool) or not isinstance(raw_sequence, int):
+            return {**base, "outcome": "reset", "reason": "cursor_invalid"}
+        sequence = raw_sequence
+        if sequence < 0 or sequence > watermark:
+            return {**base, "outcome": "reset", "reason": "cursor_invalid"}
+        if sequence < self._discarded_through:
+            return {
+                **base,
+                "outcome": "gap",
+                "reason": "replay_evicted",
+                "available_after": self._discarded_through,
+            }
+        events = [
+            copy.deepcopy(frame)
+            for event_sequence, _size, frame in self._replay
+            if sequence < event_sequence <= watermark
+        ]
+        return {
+            **base,
+            "outcome": "complete",
+            "events": events,
+            "snapshot_required": False,
+        }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -41,6 +41,7 @@ from tui_gateway.turn_marker import (
     read_turn_marker,
     record_turn_start,
 )
+from tui_gateway.mobile_sync import SessionEventStream
 from tui_gateway.transport import (
     StdioTransport,
     Transport,
@@ -947,14 +948,31 @@ def _close_sessions_for_transport(
     reaped = 0
     detached = 0
     for sid, session in owned:
-        if session.get("close_on_disconnect"):
-            _close_session_by_id(sid, end_reason=end_reason)
+        claimed = False
+        close_claim = False
+        with session.setdefault("history_lock", threading.RLock()):
+            stream = _session_event_stream(session)
+            with stream.transition(lambda _stream: None):
+                # The ownership snapshot above can race a reconnect. The old
+                # socket may detach only if it still owns the session here.
+                if session.get("transport") is transport:
+                    if session.get("close_on_disconnect"):
+                        with _sessions_lock:
+                            if _sessions.get(sid) is session:
+                                _sessions.pop(sid, None)
+                                session["_sid"] = sid
+                                session["_disconnect_claimed"] = True
+                                claimed = True
+                                close_claim = True
+                    else:
+                        session["transport"] = _detached_ws_transport
+                        claimed = True
+        if not claimed:
+            continue
+        if close_claim:
+            _teardown_session(session, end_reason=end_reason)
             reaped += 1
         else:
-            # Point detached sessions at the drop sentinel (NOT real stdio) so
-            # _ws_session_is_orphaned recognizes them and the grace-reap can
-            # actually fire; a standalone `hermes --tui` keeps real _stdio.
-            session["transport"] = _detached_ws_transport
             detached += 1
             try:
                 _schedule_ws_orphan_reap(sid)
@@ -1363,8 +1381,186 @@ def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
     return {"jsonrpc": "2.0", "method": "event", "params": params}
 
 
+_session_event_stream_init_lock = threading.RLock()
+
+
+def _session_event_stream_locked(session: dict) -> SessionEventStream:
+    stream = session.get("mobile_sync")
+    if isinstance(stream, SessionEventStream):
+        return stream
+    from tui_gateway.mobile_contract import SERVER_INSTANCE_ID
+
+    stream = SessionEventStream(SERVER_INSTANCE_ID)
+    session["mobile_sync"] = stream
+    return stream
+
+
+def _new_session_event_stream() -> SessionEventStream:
+    from tui_gateway.mobile_contract import SERVER_INSTANCE_ID
+
+    return SessionEventStream(SERVER_INSTANCE_ID)
+
+
+def _session_event_stream(session: dict) -> SessionEventStream:
+    stream = session.get("mobile_sync")
+    if isinstance(stream, SessionEventStream):
+        return stream
+    with _session_event_stream_init_lock:
+        return _session_event_stream_locked(session)
+
+
+def _transport_requests_sync(transport: Any) -> bool:
+    authorization = getattr(transport, "authorization", None)
+    if not isinstance(authorization, dict):
+        return False
+    from tui_gateway.mobile_contract import MOBILE_AUDIENCE, effective_authorization
+
+    return effective_authorization(authorization)["audience"] == MOBILE_AUDIENCE
+
+
+def _captured_session_transport(session: dict) -> Transport:
+    return session.get("transport") or current_transport() or _stdio_transport
+
+
+def _set_session_transport_locked(session: dict, transport: Transport) -> None:
+    """Replace the event recipient while holding history then stream locks."""
+    stream = _session_event_stream(session)
+    with stream.transition(lambda _stream: None):
+        session["transport"] = transport
+
+
+def _emit_with_sync_update(event: str, sid: str, payload: dict, update):
+    session = _sessions.get(sid)
+    if session is None:
+        return _emit(event, sid, payload)
+    with _session_event_stream(session).transition(update):
+        return _emit(event, sid, payload)
+
+
+def _mark_snapshot_mutation(session: dict) -> None:
+    """Advance the snapshot revision for a state change with no wire event."""
+    stream = _session_event_stream(session)
+    with stream.transition(lambda _stream: None):
+        if _transport_requests_sync(_captured_session_transport(session)):
+            session["mobile_sync_retention"] = True
+        if session.get("mobile_sync_retention"):
+            stream.mutate(lambda _stream: None)
+
+
+def _conversation_root(db, session_id: str) -> str:
+    lineage_reader = getattr(db, "get_compression_lineage", None)
+    if not callable(lineage_reader):
+        return str(session_id)
+    try:
+        lineage = lineage_reader(session_id)
+    except Exception:
+        logger.warning(
+            "failed to resolve stable conversation lineage for %s",
+            session_id,
+            exc_info=True,
+        )
+        raise
+    return str(
+        lineage[0]
+        if isinstance(lineage, (list, tuple)) and lineage
+        else session_id
+    )
+
+
+def _session_synchronization_locked(
+    sid: str,
+    session: dict,
+    stream: SessionEventStream,
+    cursor: object = None,
+) -> dict:
+    """Capture synchronization while history and stream boundaries are held."""
+    history = list(session.get("display_history_prefix") or []) + list(
+        session.get("history") or []
+    )
+    messages = _history_to_messages(history)
+    inflight = _inflight_snapshot(session, include_turn_id=True)
+    stored_session_id = _session_lookup_key(session, fallback=sid)
+    conversation_id = str(
+        session.get("conversation_id") or stored_session_id or sid
+    )
+    running = bool(session.get("running"))
+
+    def snapshot(state: dict) -> dict:
+        status = "waiting" if state["pending_interactions"] else (
+            "working" if running else "idle"
+        )
+        return {
+            "conversation_id": conversation_id,
+            "stored_session_id": stored_session_id,
+            "live_session_id": sid,
+            "messages": messages,
+            "inflight_turn": inflight,
+            "active_tools": state["active_tools"],
+            "pending_interactions": state["pending_interactions"],
+            "status": status,
+        }
+
+    return stream.synchronization(snapshot, cursor)
+
+
+def _session_synchronization(
+    sid: str,
+    session: dict,
+    cursor: object = None,
+) -> dict:
+    with session["history_lock"]:
+        stream = _session_event_stream(session)
+        with stream.transition(lambda _stream: None):
+            return _session_synchronization_locked(sid, session, stream, cursor)
+
+
+def _attach_synchronization(
+    payload: dict,
+    sid: str,
+    session: dict,
+    cursor: object = None,
+) -> dict:
+    if not _transport_requests_sync(_captured_session_transport(session)):
+        return payload
+    with session["history_lock"]:
+        stream = _session_event_stream(session)
+        with stream.transition(lambda _stream: None):
+            session["mobile_sync_retention"] = True
+            payload["synchronization"] = _session_synchronization_locked(
+                sid, session, stream, cursor
+            )
+            return payload
+
+
 def _emit(event: str, sid: str, payload: dict | None = None):
-    write_json(_event_frame(event, sid, payload))
+    session = _sessions.get(sid)
+    params = {"type": event, "session_id": sid}
+    if payload is not None:
+        params["payload"] = payload
+    legacy_frame = {"jsonrpc": "2.0", "method": "event", "params": params}
+    if session is None:
+        write_json(legacy_frame)
+        return legacy_frame
+
+    stream = _session_event_stream(session)
+    with stream.transition(lambda _stream: None):
+        recipient = _captured_session_transport(session)
+        mobile_recipient = _transport_requests_sync(recipient)
+        if mobile_recipient:
+            session["mobile_sync_retention"] = True
+        if not session.get("mobile_sync_retention"):
+            recipient.write(legacy_frame)
+            return legacy_frame
+        if mobile_recipient:
+            return stream.publish(event, sid, payload, recipient.write)
+
+        stream.publish(
+            event,
+            sid,
+            payload,
+            lambda _sequenced: recipient.write(legacy_frame),
+        )
+        return legacy_frame
 
 
 # Live client transports, one per connected WS peer (maintained by tui_gateway.ws).
@@ -2881,7 +3077,18 @@ def _block(event: str, sid: str, payload: dict, timeout: float | None = 300) -> 
     answer = ""
     answer_present = False
     try:
-        _emit(event, sid, payload)
+        _emit_with_sync_update(
+            event,
+            sid,
+            payload,
+            lambda stream: stream.track_pending_interaction(
+                {
+                    "request_id": rid,
+                    "kind": event.removesuffix(".request"),
+                    "payload": dict(payload),
+                }
+            ),
+        )
         # Natural Event semantics: None → wait forever (clarify configured with
         # clarify_timeout <= 0, released only by a real answer or
         # session.interrupt), 0 → return immediately, > 0 → bounded wait.
@@ -2892,6 +3099,9 @@ def _block(event: str, sid: str, payload: dict, timeout: float | None = 300) -> 
             _pending_prompt_payloads.pop(rid, None)
             answer_present = rid in _answers
             answer = _answers.pop(rid, "")
+        session = _sessions.get(sid)
+        if session is not None:
+            _session_event_stream(session).finish_pending_interaction(rid)
 
     # Emit an `.expire` notification on timeout for every blocking request type
     # whose `*.respond` handler tolerates a late reply (allow_expired=True).
@@ -3596,6 +3806,7 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         with lock:
             session.setdefault("history", []).append(entry)
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
     else:
         session.setdefault("history", []).append(entry)
         session["history_version"] = int(session.get("history_version", 0)) + 1
@@ -4481,6 +4692,7 @@ def _compress_session_history(
             return 0, usage
         session["history"] = compressed
         session["history_version"] = history_version + 1
+        _mark_snapshot_mutation(session)
     usage = _get_usage(agent)
     return len(history) - len(compressed), usage
 
@@ -5033,6 +5245,7 @@ def _tool_summary(name: str, result: str, duration_s: float | None) -> str | Non
 
 def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
     session = _sessions.get(sid)
+    started_at = time.time()
     if session is not None:
         try:
             from agent.display import capture_local_edit_snapshot
@@ -5042,7 +5255,7 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
                 session.setdefault("edit_snapshots", {})[tool_call_id] = snapshot
         except Exception:
             pass
-        session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
+        session.setdefault("tool_started_at", {})[tool_call_id] = started_at
     if _tool_progress_enabled(sid) or _tool_lifecycle_required_for_ui(name):
         payload = {
             "tool_id": tool_call_id,
@@ -5055,7 +5268,18 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
                 payload["args_text"] = args_text
         # tool.complete is the source of truth for todos (full list from the
         # tool result). args.todos here may be a partial merge update.
-        _emit("tool.start", sid, payload)
+        _emit_with_sync_update(
+            "tool.start",
+            sid,
+            payload,
+            lambda stream: stream.track_tool(
+                {
+                    "tool_id": tool_call_id,
+                    "name": name,
+                    "started_at": started_at,
+                }
+            ),
+        )
 
 
 def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result: str):
@@ -5102,7 +5326,12 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     except Exception:
         pass
     if _tool_progress_enabled(sid) or payload.get("inline_diff") or _tool_lifecycle_required_for_ui(name):
-        _emit("tool.complete", sid, payload)
+        _emit_with_sync_update(
+            "tool.complete",
+            sid,
+            payload,
+            lambda stream: stream.finish_tool(tool_call_id),
+        )
 
 
 def _on_tool_progress(
@@ -5306,29 +5535,55 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
         with _child_mirrors_lock:
             _child_mirrors.pop(child_key, None)
         return
-    csid = live[0]
+    csid, child_session = live
+    history_lock = child_session.setdefault("history_lock", threading.RLock())
+    child_session.setdefault("history", [])
+    child_session.setdefault("history_version", 0)
+    child_session.setdefault("inflight_turn", None)
+    child_session.setdefault("running", False)
+
+    def finish_open_tool(tool: dict | None) -> None:
+        if not tool:
+            return
+        tool_id = str(tool.get("tool_id") or "")
+        _emit_with_sync_update(
+            "tool.complete",
+            csid,
+            tool,
+            lambda stream: stream.finish_tool(tool_id),
+        )
+
     with _child_mirrors_lock:
-        st = _child_mirrors.setdefault(child_key, {"seq": 0, "open_tool": None, "started": False})
+        st = _child_mirrors.setdefault(
+            child_key,
+            {"seq": 0, "open_tool": None, "reply_text": "", "started": False},
+        )
+        st.setdefault("reply_text", "")
         if not st["started"]:
             st["started"] = True
-            _emit("message.start", csid)
+            with history_lock:
+                child_session["running"] = True
+                if not isinstance(child_session.get("inflight_turn"), dict):
+                    _start_inflight_turn(child_session, "")
+                turn_id = str(
+                    (child_session.get("inflight_turn") or {}).get("turn_id") or ""
+                )
+                sync_enabled = _transport_requests_sync(
+                    _captured_session_transport(child_session)
+                )
+                _emit("message.start", csid, {"turn_id": turn_id} if sync_enabled else None)
         if event_type == "subagent.thinking":
             if text := str(payload.get("text") or ""):
                 _emit("reasoning.delta", csid, {"text": text})
         elif event_type == "subagent.text":
-            # The child's streamed reply text — the actual "agent talking".
-            # Relayed token-by-token from the child's run_conversation
-            # stream_callback, so the watch window streams the reply live.
             if text := str(payload.get("text") or ""):
-                _emit("message.delta", csid, {"text": text})
+                st["reply_text"] = f"{st['reply_text']}{text}"
+                _emit_inflight_delta(csid, child_session, text)
         elif event_type == "subagent.start":
-            # One-time header line (the child's goal) so a freshly opened window
-            # shows immediate context before the first reply token streams.
             if text := str(payload.get("text") or ""):
-                _emit("message.delta", csid, {"text": f"{text}\n"})
+                _emit_inflight_delta(csid, child_session, f"{text}\n")
         elif event_type == "subagent.tool":
-            if st["open_tool"]:
-                _emit("tool.complete", csid, st["open_tool"])
+            finish_open_tool(st["open_tool"])
             st["seq"] += 1
             tool = {
                 "name": str(payload.get("tool_name") or "tool"),
@@ -5338,12 +5593,42 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             if preview := str(payload.get("tool_preview") or payload.get("text") or ""):
                 tool["preview"] = preview
             st["open_tool"] = tool
-            _emit("tool.start", csid, tool)
+            descriptor = {
+                "tool_id": tool["tool_id"],
+                "name": tool["name"],
+                "started_at": time.time(),
+            }
+            _emit_with_sync_update(
+                "tool.start",
+                csid,
+                tool,
+                lambda stream: stream.track_tool(descriptor),
+            )
         elif event_type == "subagent.complete":
-            if st["open_tool"]:
-                _emit("tool.complete", csid, st["open_tool"])
+            finish_open_tool(st["open_tool"])
+            st["open_tool"] = None
             summary = str(payload.get("summary") or payload.get("text") or "")
-            _emit("message.complete", csid, {"text": summary})
+            with history_lock:
+                turn = child_session.get("inflight_turn") or {}
+                turn_id = str(turn.get("turn_id") or "")
+                assistant = str(turn.get("assistant") or "")
+                final_text = str(st.get("reply_text") or "") or summary or assistant
+                history = child_session.setdefault("history", [])
+                if final_text and not (
+                    history
+                    and history[-1].get("role") == "assistant"
+                    and history[-1].get("content") == final_text
+                ):
+                    history.append({"role": "assistant", "content": final_text})
+                    child_session["history_version"] = int(
+                        child_session.get("history_version", 0)
+                    ) + 1
+                child_session["running"] = False
+                _clear_inflight_turn(child_session)
+                complete_payload = {"text": final_text}
+                if _transport_requests_sync(_captured_session_transport(child_session)):
+                    complete_payload["turn_id"] = turn_id
+                _emit("message.complete", csid, complete_payload)
             _child_mirrors.pop(child_key, None)
 
 
@@ -5620,6 +5905,7 @@ def _apply_personality_to_session(
         with session["history_lock"]:
             session["history"].append({"role": "user", "content": marker})
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            _mark_snapshot_mutation(session)
         info = _session_info(agent)
         _emit("session.info", sid, info)
         return False, info
@@ -5871,6 +6157,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     with session["history_lock"]:
         session["history"] = []
         session["history_version"] = int(session.get("history_version", 0)) + 1
+        _mark_snapshot_mutation(session)
     info = _session_info(new_agent, session)
     _emit("session.info", sid, info)
     _restart_slash_worker(sid, session)
@@ -6815,22 +7102,50 @@ def _start_inflight_turn(session: dict, text: Any) -> None:
         "assistant": "",
         "started_at": now,
         "streaming": True,
+        "turn_id": str(uuid.uuid4()),
         "updated_at": now,
         "user": _inflight_text(text),
     }
 
 
-def _append_inflight_delta(session: dict, delta: Any) -> None:
+def _append_inflight_delta(session: dict, delta: Any) -> int:
     text = "" if delta is None else str(delta)
-    if not text:
-        return
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
-        turn = {"assistant": "", "streaming": True, "user": ""}
+        turn = {
+            "assistant": "",
+            "streaming": True,
+            "turn_id": str(uuid.uuid4()),
+            "user": "",
+        }
+    offset = len(str(turn.get("assistant") or "").encode("utf-8"))
+    if not text:
+        return offset
     turn["assistant"] = f"{turn.get('assistant') or ''}{text}"
     turn["streaming"] = True
     turn["updated_at"] = time.time()
     session["inflight_turn"] = turn
+    return offset
+
+
+def _emit_inflight_delta(
+    sid: str,
+    session: dict,
+    delta: Any,
+    *,
+    rendered: Any = None,
+) -> None:
+    """Append and publish a delta with its absolute UTF-8 byte offset."""
+    with session["history_lock"]:
+        offset = _append_inflight_delta(session, delta)
+        turn_id = str((session.get("inflight_turn") or {}).get("turn_id") or "")
+        payload = {"text": delta}
+        if _transport_requests_sync(_captured_session_transport(session)):
+            payload["turn_id"] = turn_id
+            payload["offset"] = offset
+        if rendered is not None:
+            payload["rendered"] = rendered
+        _emit("message.delta", sid, payload)
 
 
 def _record_inflight_correction(session: dict, text: Any) -> None:
@@ -7226,7 +7541,11 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     return True
 
 
-def _inflight_snapshot(session: dict) -> dict | None:
+def _inflight_snapshot(
+    session: dict,
+    *,
+    include_turn_id: bool = False,
+) -> dict | None:
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
         return None
@@ -7253,6 +7572,8 @@ def _inflight_snapshot(session: dict) -> dict | None:
         snapshot["error"] = error
         snapshot["status"] = str(turn.get("status") or "error")
         snapshot["recoverable"] = bool(turn.get("recoverable"))
+    if include_turn_id:
+        snapshot["turn_id"] = str(turn.get("turn_id") or "")
     return snapshot
 
 
@@ -7603,23 +7924,36 @@ def _live_session_payload(
     cols: int | None = None,
     touch: bool = False,
     transport: Transport | None = None,
-) -> dict:
+    cursor: object = None,
+) -> dict | None:
+    with _sessions_lock:
+        was_registered = _sessions.get(sid) is session
     with session["history_lock"]:
-        if cols is not None:
-            session["cols"] = cols
-        if transport is not None:
-            session["transport"] = transport
-        if touch:
-            session["last_active"] = time.time()
-        in_memory_history = list(session.get("display_history_prefix") or []) + list(
-            session.get("history") or []
-        )
-        inflight = _inflight_snapshot(session)
-        queued = _queued_prompt_snapshot(session)
-        running = bool(session.get("running"))
-    # Prefer the persisted display lineage (candidate-inclusive) so this payload
-    # matches the eager session.resume + REST transcript; the DB has its own
-    # lock, so read it outside the session history lock.
+        stream = _session_event_stream(session)
+        with stream.transition(lambda _stream: None):
+            if session.get("_disconnect_claimed"):
+                return None
+            with _sessions_lock:
+                if was_registered and _sessions.get(sid) is not session:
+                    return None
+            if cols is not None:
+                session["cols"] = cols
+            if transport is not None:
+                session["transport"] = transport
+            if touch:
+                session["last_active"] = time.time()
+            in_memory_history = list(session.get("display_history_prefix") or []) + list(
+                session.get("history") or []
+            )
+            inflight = _inflight_snapshot(session)
+            queued = _queued_prompt_snapshot(session)
+            running = bool(session.get("running"))
+            synchronization = None
+            if _transport_requests_sync(_captured_session_transport(session)):
+                session["mobile_sync_retention"] = True
+                synchronization = _session_synchronization_locked(
+                    sid, session, stream, cursor
+                )
     history = _live_visible_history(session, _get_db(), in_memory_history)
     payload = {
         "info": _fallback_session_info(session),
@@ -7635,6 +7969,8 @@ def _live_session_payload(
         payload["inflight"] = inflight
     if queued:
         payload["queued"] = queued
+    if synchronization is not None:
+        payload["synchronization"] = synchronization
     return payload
 
 
@@ -8995,6 +9331,50 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
+def _commit_prompt_completion(
+    sid: str,
+    session: dict,
+    *,
+    expected_history_version: int,
+    result_messages: list | None,
+    payload: dict[str, Any],
+    retained_error: str | None = None,
+) -> str | None:
+    """Publish final history and completion at one snapshot/event barrier."""
+    status_note = None
+    with session["history_lock"]:
+        if result_messages is not None:
+            current_version = int(session.get("history_version", 0))
+            if current_version == expected_history_version:
+                session["history"] = result_messages
+                session["history_version"] = expected_history_version + 1
+            else:
+                print(
+                    f"[tui_gateway] prompt.submit: history_version mismatch "
+                    f"(expected={expected_history_version} current={current_version}) — "
+                    f"agent output NOT written to session history",
+                    file=sys.stderr,
+                )
+                status_note = (
+                    "History changed during this turn — the response above is visible "
+                    "but was not saved to session history."
+                )
+                payload["warning"] = status_note
+
+        if _transport_requests_sync(_captured_session_transport(session)):
+            payload["turn_id"] = str(
+                (session.get("inflight_turn") or {}).get("turn_id") or ""
+            )
+        if retained_error is not None:
+            _fail_inflight_turn(session, retained_error)
+            payload["error"] = retained_error
+            payload["recoverable"] = True
+        else:
+            _clear_inflight_turn(session)
+        _emit("message.complete", sid, payload)
+    return status_note
+
+
 def _run_prompt_submit(
     rid, sid: str, session: dict, text: Any, *, display_kind: str | None = None,
     display_metadata: dict | None = None,
@@ -9009,14 +9389,15 @@ def _run_prompt_submit(
         # by the time a new turn starts — replace it, never append onto it.
         if not isinstance(inflight, dict) or inflight.get("status") == "error":
             _start_inflight_turn(session, text)
+        turn_id = str((session.get("inflight_turn") or {}).get("turn_id") or "")
+        sync_enabled = _transport_requests_sync(_captured_session_transport(session))
+        _emit("message.start", sid, {"turn_id": turn_id} if sync_enabled else None)
     agent = session["agent"]
     if hasattr(agent, "clear_interrupt"):
         try:
             agent.clear_interrupt()
         except Exception:
             pass
-    _emit("message.start", sid)
-
     def run():
         approval_token = None
         session_tokens = []
@@ -9351,33 +9732,10 @@ def _run_prompt_submit(
                     session["model_override"] = _restore
 
             last_reasoning = None
-            status_note = None
+            result_messages = None
             if isinstance(result, dict):
                 if isinstance(result.get("messages"), list):
-                    with session["history_lock"]:
-                        current_version = int(session.get("history_version", 0))
-                        if current_version == history_version:
-                            session["history"] = result["messages"]
-                            session["history_version"] = history_version + 1
-                        else:
-                            # History mutated externally during the turn
-                            # (undo/compress/retry/rollback now guard on
-                            # session.running, but this is the defensive
-                            # backstop for any path that slips past).
-                            # Surface the desync rather than silently
-                            # dropping the agent's output — the UI can
-                            # show the response and warn that it was
-                            # not persisted.
-                            print(
-                                f"[tui_gateway] prompt.submit: history_version mismatch "
-                                f"(expected={history_version} current={current_version}) — "
-                                f"agent output NOT written to session history",
-                                file=sys.stderr,
-                            )
-                            status_note = (
-                                "History changed during this turn — the response above is visible "
-                                "but was not saved to session history."
-                            )
+                    result_messages = result["messages"]
 
                 # If auto-compression fired inside run_conversation(), agent.session_id
                 # may have rotated. Sync session_key before downstream title/goal/finalize
@@ -9426,8 +9784,7 @@ def _run_prompt_submit(
             payload = {"text": raw, "usage": _get_usage(agent), "status": status}
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
-            if status_note:
-                payload["warning"] = status_note
+
             if result.get("response_previewed"):
                 payload["response_previewed"] = True
             # Forward the structured billing-wall descriptor (provider,
@@ -9440,26 +9797,21 @@ def _run_prompt_submit(
             rendered = render_message(raw, cols)
             if rendered:
                 payload["rendered"] = rendered
-            with session["history_lock"]:
-                if status == "error":
-                    # Returned-error result (provider 4xx, budget, etc.): retain
-                    # the failed turn for resume replay instead of clearing it.
-                    # If this terminal frame is lost to a disconnect, resume's
-                    # inflight payload is the only carrier of the failure.
-                    _fail_inflight_turn(
-                        session,
-                        result.get("error") if isinstance(result, dict) else raw,
-                    )
-                    turn_error_retained = True
-                else:
-                    _clear_inflight_turn(session)
+            retained_error = None
             if status == "error":
-                payload["error"] = str(
+                retained_error = str(
                     (result.get("error") if isinstance(result, dict) else "") or raw
                 )
-                payload["recoverable"] = True
+                turn_error_retained = True
             _retire_turn_marker(session, marker_key)
-            _emit("message.complete", sid, payload)
+            _commit_prompt_completion(
+                sid,
+                session,
+                expected_history_version=history_version,
+                result_messages=result_messages,
+                payload=payload,
+                retained_error=retained_error,
+            )
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge
@@ -9672,6 +10024,7 @@ def _run_prompt_submit(
                 session["last_active"] = time.time()
                 if not turn_error_retained:
                     _clear_inflight_turn(session)
+                _mark_snapshot_mutation(session)
             # Backstop for turns that never reached a terminal frame (the
             # frame paths retire the marker as they emit).
             _retire_turn_marker(session, marker_key)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1657,8 +1657,11 @@ def _ok(rid, result: dict) -> dict:
     return {"jsonrpc": "2.0", "id": rid, "result": result}
 
 
-def _err(rid, code: int, msg: str) -> dict:
-    return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": msg}}
+def _err(rid, code: int, msg: str, *, data: dict | None = None) -> dict:
+    error = {"code": code, "message": msg}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": rid, "error": error}
 
 
 def method(name: str):
@@ -1720,6 +1723,16 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             return normalized
 
         _rid, method, _params = normalized
+        from tui_gateway.mobile_contract import mobile_method_denial
+
+        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        if denial is not None:
+            return _err(
+                _rid,
+                4030,
+                "insufficient authorization scope",
+                data=denial,
+            )
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1725,7 +1725,11 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
         _rid, method, _params = normalized
         from tui_gateway.mobile_contract import mobile_method_denial
 
-        denial = mobile_method_denial(method, getattr(t, "authorization", None))
+        denial = mobile_method_denial(
+            method,
+            getattr(t, "authorization", None),
+            _params,
+        )
         if denial is not None:
             return _err(
                 _rid,
@@ -7095,7 +7099,14 @@ def _interrupt_busy_session(sid: str, session: dict, agent: Any) -> None:
 
 
 def _handle_busy_submit(
-    rid, sid: str, session: dict, text: Any, transport: Any, queued: bool = False
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    transport: Any,
+    *,
+    queued: bool = False,
+    allow_control: bool = True,
 ) -> dict | None:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
@@ -7116,6 +7127,18 @@ def _handle_busy_submit(
     unwinding the turn) redirected the live turn with next-turn text — queue
     semantics betrayed by a millisecond race the user can't see.
     """
+    # A scoped writer may enqueue the next user turn, but must not inherit the
+    # dashboard's interrupt/steer preference unless its connection also holds
+    # conversation.control. Re-check running under the queue-drain lock so a
+    # just-finished turn cannot strand work after teardown already drained it.
+    if not allow_control:
+        with session["history_lock"]:
+            if not session.get("running"):
+                return None
+            _enqueue_prompt(session, text, transport)
+            session["last_active"] = time.time()
+        return _ok(rid, {"status": "queued"})
+
     mode = "queue" if queued else _load_busy_input_mode()
     agent = session.get("agent")
     with session["history_lock"]:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -81,6 +81,10 @@ class WSTransport:
     the loop we're currently blocking. We detect that case and fire-and-
     forget instead. Callers that need to know when the bytes are on the wire
     should use :meth:`write_async` from the loop thread.
+
+    ``authorization`` is the server-derived grant for this connection. The
+    dispatcher reads it before resolving any method; clients cannot mutate it
+    through JSON-RPC input.
     """
 
     def __init__(
@@ -89,10 +93,12 @@ class WSTransport:
         loop: asyncio.AbstractEventLoop,
         *,
         peer: str = "unknown",
+        authorization: dict | None = None,
     ) -> None:
         self._ws = ws
         self._loop = loop
         self._peer = peer
+        self.authorization = authorization
         self._closed = False
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
@@ -283,7 +289,7 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any) -> None:
+async def handle_ws(ws: Any, *, authorization: dict | None = None) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
     peer = _ws_peer_label(ws)
     transport: WSTransport | None = None
@@ -301,7 +307,14 @@ async def handle_ws(ws: Any) -> None:
         _disable_nagle(ws)
         _log.info("ws accepted peer=%s", peer)
 
-        transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
+        transport = WSTransport(
+            ws,
+            asyncio.get_running_loop(),
+            peer=peer,
+            authorization=authorization,
+        )
+
+        from tui_gateway.mobile_contract import gateway_ready_payload
 
         ready_ok = await transport.write_async(
             {
@@ -309,10 +322,10 @@ async def handle_ws(ws: Any) -> None:
                 "method": "event",
                 "params": {
                     "type": "gateway.ready",
-                    # change_events: this backend broadcasts pet.changed /
-                    # cron.changed / sessions.changed, so clients can demote
-                    # their legacy polls to slow backstops.
-                    "payload": {"skin": server.resolve_skin(), "change_events": True},
+                    "payload": gateway_ready_payload(
+                        skin=server.resolve_skin(),
+                        authorization=authorization,
+                    ),
                 },
             }
         )


### PR DESCRIPTION
## Summary

Reconstructs the revisioned mobile conversation synchronization work from #63149 on current `main` and the scoped mobile WebSocket authorization foundation in #72635.

This adds:

- an authoritative revisioned synchronization snapshot;
- stable server, stream, stored-conversation, and live-session identities;
- monotonically sequenced session events;
- UTF-8 byte offsets for streamed assistant deltas;
- client cursors and bounded replay;
- explicit `complete`, `gap`, and `reset` recovery outcomes;
- a snapshot/event publication barrier so clients cannot observe a watermark without the corresponding state;
- reconnect-safe transport handoff and atomic disconnect ownership;
- a single transport-aware `_emit` publication path (the shadowed duplicate was removed during final review);
- a documented native-mobile client contract.

## Related upstream issues

- Addresses the P2 transport-takeover failure in #55564 by preserving transport ownership and making handoff/recovery explicit.
- Implements the revisioned cross-client synchronization foundation requested in #22547.

## Architecture

This is intentionally layered on #72635:

1. #72635 authenticates and authorizes the mobile WebSocket connection with server-derived scopes.
2. This PR adds synchronization only after the connection has negotiated the `hermes.mobile` contract.

Legacy TUI and desktop WebSocket clients retain their existing event payload shapes. Revision, sequence, replay, turn-ID, and delta-offset metadata are activated only for the mobile synchronization contract.

The reconstruction preserves current upstream behavior for:

- desktop crash continuation and retained failed/inflight turns;
- turn markers and auto-continuation;
- candidate-inclusive display history;
- compute-host/process-isolated turns;
- busy-session queueing and active-turn control;
- transport ownership and reconnect grace;
- MCP startup ownership;
- streaming TTS;
- subagent child-session mirroring.

## Authorship and provenance

The seven original synchronization commits retain **Eric Lewis** as author. The final integration commit adapts those changes to current upstream recovery and gateway behavior. Contributor attribution is supplied by #72635.

Supersedes #63149 after verification. The original source branch is hosted in `ericlewis/hermes-agent`, where the replacement author has read-only access, so it cannot be safely refreshed in place.

## Validation

Against current `main` plus #72635:

```text
561 focused post-rebase tests passed
All Ruff checks passed
git diff --check passed
No conflict markers remain
GitHub: All required checks pass
```

Focused coverage includes:

- synchronization snapshots and identity;
- complete replay, bounded replay gap, and stream reset;
- snapshot/event ordering races;
- UTF-8 delta offsets;
- cold and live resume;
- mobile WebSocket end-to-end synchronization;
- scoped mobile authorization;
- current gateway server and busy-session behavior;
- subagent child-session mirroring;
- reconnect/disconnect ownership races.

## Dependency

- Depends on #72635. Once #72635 merges, GitHub will automatically reduce this PR to the seven synchronization files shown relative to that foundation.

## Checklist

- [x] Original contributor authorship preserved
- [x] Current upstream recovery behavior retained
- [x] Legacy event shapes preserved
- [x] Real WebSocket-path tests included
- [x] Focused current-main test suite passes
- [x] Ruff passes
- [x] `git diff --check` passes
- [x] Contributor attribution mapping included through #72635
- [x] Full GitHub CI passes