### PR TITLE
fix(cli): register Discord prompt timeout config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2772,6 +2772,10 @@ DEFAULT_CONFIG = {
         "mode": "smart",
         "timeout": 300,
         "cron_mode": "deny",
+        # Interactive Discord views (exec approval, slash confirmation,
+        # update prompt, and clarify choices) use this separate timeout.
+        # The adapter clamps it to Discord's supported 30–900s range.
+        "discord_prompt_timeout": 300,
         # Operator-customizable policy text for smart approvals. When
         # non-empty, this is appended to the smart-approval guardian's
         # SYSTEM prompt (trusted channel) as additional rules — e.g.

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -496,6 +496,25 @@ class TestSchemaValidation:
         assert "✓ Set" in out
         assert "not a recognized config key" in out
 
+    def test_discord_prompt_timeout_is_a_recognized_integer_key(
+        self, _isolated_hermes_home, capsys
+    ):
+        """The Discord adapter's supported timeout must be in the CLI schema."""
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["approvals"]["discord_prompt_timeout"] == 300
+
+        set_config_value("approvals.discord_prompt_timeout", "120")
+
+        out = capsys.readouterr().out
+        assert "✓ Set approvals.discord_prompt_timeout = 120" in out
+        assert "not a recognized config key" not in out
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["approvals"]["discord_prompt_timeout"] == 120
+        assert isinstance(saved["approvals"]["discord_prompt_timeout"], int)
+
     def test_platforms_container_is_accepted(self, _isolated_hermes_home, capsys):
         """``platforms.<name>.<field>`` is a valid current shape: gateway/
         config.py resolves a top-level ``platforms`` map in addition to the


### PR DESCRIPTION
## What

Register the already-supported `approvals.discord_prompt_timeout` setting in `hermes_cli.config.DEFAULT_CONFIG` with the Discord adapter's existing 300-second default.

Add a CLI regression test that verifies:

- the setting is recognized without the unknown-key notice;
- string input is coerced to an integer;
- the configured value is persisted under `approvals`.

## Why

The Discord adapter already reads this key and clamps it to the supported 30–900 second range, but the CLI schema does not declare it. As a result, `hermes config set approvals.discord_prompt_timeout 120` saves a valid runtime setting while incorrectly warning that Hermes may not read it.

This change only aligns the CLI schema with existing runtime behavior. It does not change any timeout value for existing installations.

## Testing

- RED reproduction on unmodified `main`: the new regression test failed on the unexpected `not a recognized config key` notice.
- `247 passed` across CLI config, config validation, Discord timeout/buttons, and clarify tool/gateway tests.
- `ruff check` and `py_compile` passed for both changed Python files.
- `git diff --check` passed.
- Manual isolated-home smoke:
  - `hermes config set approvals.discord_prompt_timeout 120` emitted no schema warning;
  - `hermes config get approvals.discord_prompt_timeout` returned `120`.

## Platforms

Tested on Linux under WSL2. The change is data-only plus a platform-independent unit test.
