### PR TITLE
fix(model_metadata): also check max_input_tokens in generic endpoint probe

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1833,10 +1833,13 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
             resp = client.get(f"{server_url}/v1/models/{model}")
             if resp.status_code == 200:
                 data = resp.json()
-                # vLLM returns max_model_len
-                ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
-                if ctx and isinstance(ctx, (int, float)):
-                    return int(ctx)
+                # vLLM returns max_model_len; OpenAI-compatible passthroughs
+                # (LiteLLM etc.) may publish max_input_tokens. Use the shared
+                # helper so output-oriented keys like max_tokens are never read
+                # as the input context window.
+                ctx = _extract_context_length(data)
+                if ctx is not None:
+                    return ctx
 
             # Try /v1/models and find the model in the list.
             # Use _model_id_matches to handle "publisher/slug" vs bare "slug".
@@ -1846,9 +1849,9 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                 models_list = data.get("data", [])
                 for m in models_list:
                     if _model_id_matches(m.get("id", ""), model):
-                        ctx = m.get("max_model_len") or m.get("max_input_tokens") or m.get("context_length") or m.get("max_tokens")
-                        if ctx and isinstance(ctx, (int, float)):
-                            return int(ctx)
+                        ctx = _extract_context_length(m)
+                        if ctx is not None:
+                            return ctx
     except Exception:
         pass
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1846,7 +1846,7 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                 models_list = data.get("data", [])
                 for m in models_list:
                     if _model_id_matches(m.get("id", ""), model):
-                        ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens") or m.get("max_input_tokens")
+                        ctx = m.get("max_model_len") or m.get("max_input_tokens") or m.get("context_length") or m.get("max_tokens")
                         if ctx and isinstance(ctx, (int, float)):
                             return int(ctx)
     except Exception:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1846,7 +1846,7 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                 models_list = data.get("data", [])
                 for m in models_list:
                     if _model_id_matches(m.get("id", ""), model):
-                        ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
+                        ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens") or m.get("max_input_tokens")
                         if ctx and isinstance(ctx, (int, float)):
                             return int(ctx)
     except Exception:

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -190,6 +190,48 @@ class TestQueryLocalContextLengthVllm:
 
         assert result == 32768
 
+    def test_vllm_max_input_tokens_wins_over_max_tokens(self):
+        """OpenAI-compatible passthrough: max_input_tokens (window) beats
+        max_tokens (output cap) when both are present in the detail response."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {
+            "id": "some-model",
+            "max_input_tokens": 1_000_000,
+            "max_tokens": 128_000,
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.return_value = detail_resp
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("some-model", "http://localhost:8000/v1")
+
+        assert result == 1_000_000
+
+    def test_vllm_max_tokens_only_is_not_read_as_context(self):
+        """A response with only max_tokens (output cap) must NOT be read as the
+        input context window — resolves to None."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {"id": "some-model", "max_tokens": 128_000})
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.return_value = detail_resp
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("some-model", "http://localhost:8000/v1")
+
+        assert result is None
+
 
 class TestQueryLocalContextLengthModelsList:
     """_query_local_context_length: falls back to /v1/models list."""
@@ -246,6 +288,67 @@ class TestQueryLocalContextLengthModelsList:
             if call_count[0] == 1:
                 return detail_resp
             return list_resp
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("omnicoder-9b", "http://localhost:1234")
+
+        assert result is None
+
+    def test_models_list_max_input_tokens_wins_over_max_tokens(self):
+        """OpenAI-compatible passthrough: max_input_tokens (window) beats
+        max_tokens (output cap) when both are present in the list response."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {"id": "other-model", "max_model_len": 4096},
+                {"id": "omnicoder-9b", "max_input_tokens": 1_000_000, "max_tokens": 128_000},
+            ]
+        })
+
+        call_count = [0]
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp  # /v1/models/omnicoder-9b
+            return list_resp  # /v1/models
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("omnicoder-9b", "http://localhost:1234")
+
+        assert result == 1_000_000
+
+    def test_models_list_max_tokens_only_is_not_read_as_context(self):
+        """A list entry with only max_tokens (output cap) must NOT be read as the
+        input context window — resolves to None."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [{"id": "omnicoder-9b", "max_tokens": 128_000}]
+        })
+
+        call_count = [0]
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp  # /v1/models/omnicoder-9b
+            return list_resp  # /v1/models
 
         client_mock = MagicMock()
         client_mock.__enter__ = lambda s: client_mock


### PR DESCRIPTION
## Problem

`get_model_context_length()` probes the endpoint via `/v1/models` for context length information, but the generic OpenAI-compatible path only checks `max_model_len`, `context_length`, and `max_tokens`. 

LiteLLM and other proxies serve their configured context window as `max_input_tokens` (set via `model_info` in the proxy config), not `max_model_len`. This causes Hermes to underestimate the context window for proxied backends, triggering context compression earlier than necessary.

## Fix

Add `max_input_tokens` as a fourth fallback in the fallback chain at `agent/model_metadata.py:1849`.

```python
- ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
+ ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens") or m.get("max_input_tokens")
```

## Notes

- `max_input_tokens` is already checked in the Anthropic-specific path (line 1891) but was missing from the generic path.
- Order preserved: `max_model_len` (vLLM native) checked first, `max_input_tokens` (LiteLLM style) last.
- The existing `context_length` (lm-studio, ollama style) and `max_tokens` (generic fallback) remain unchanged.

## Changes since review

The original fix targeted only the `/v1/models` list branch (`:1849`). Review comments (teknium1, hermes-sweeper) pointed out that the sibling `/v1/models/{model}` detail branch (`:1837`) still read `max_tokens` as the context window and never inspected `max_input_tokens`, and that no regression covered `max_input_tokens` precedence.

Updated to fix the whole bug class: both branches now use the existing shared helper `_extract_context_length()` (`agent/model_metadata.py:846`), which inspects only input-window keys (`_CONTEXT_LENGTH_KEYS`) and deliberately excludes output-oriented keys (`max_tokens` / `max_output_tokens` / `max_completion_tokens`). So `max_tokens` is never read as the input context window, while `max_input_tokens` (LiteLLM style) is still picked up on both branches.

```python
# before (both branches)
ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")

# after (both branches)
ctx = _extract_context_length(data)
```

Added regressions in `tests/agent/test_model_metadata_local_ctx.py` for both branches: `max_input_tokens` beats `max_tokens` when both are present, and a `max_tokens`-only payload resolves to `None` (not misread as the window).

All existing tests in the file pass (38), and the broader `tests/agent` context/metadata suite passes (876).