### PR TITLE
fix(custom): move reasoning_effort to extra_body for custom providers

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -41,11 +41,11 @@ class CustomProfile(ProviderProfile):
         # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, …).
         #
         #   - disabled  → extra_body.think = False (Ollama's thinking-off flag)
-        #   - enabled + effort set → extra_body.reasoning_effort string.
-        #     Placed in extra_body instead of top-level because custom
-        #     providers are heterogeneous — LiteLLM proxies and similar
-        #     endpoints reject unknown top-level parameters with HTTP 400
-        #     (#72649).
+        #   - enabled + effort set → omit. Custom providers are
+        #     heterogeneous and many (LiteLLM proxies, self-hosted vLLM)
+        #     reject unknown top-level params with HTTP 400. openai-python
+        #     merges extra_body into the top-level JSON, so moving the key
+        #     there does not solve the problem (#72649, #72656).
         #   - enabled + no effort  → omit both, so the endpoint applies its own
         #     server-side default (do NOT force a level the user didn't pick).
         #
@@ -65,8 +65,7 @@ class CustomProfile(ProviderProfile):
                 # ignore them.
                 top_level["reasoning_effort"] = "none"
                 extra_body["think"] = False
-            elif _effort:
-                extra_body["reasoning_effort"] = _effort
+            # Omit when enabled with effort: heterogeneous backends reject it
 
         return extra_body, top_level
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -41,9 +41,11 @@ class CustomProfile(ProviderProfile):
         # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, …).
         #
         #   - disabled  → extra_body.think = False (Ollama's thinking-off flag)
-        #   - enabled + effort set → TOP-LEVEL reasoning_effort string, the
-        #     format GLM-5.2/ARK and other OpenAI-compatible reasoning APIs
-        #     expect (GLM documents "high" and "max"; "max" is its default).
+        #   - enabled + effort set → extra_body.reasoning_effort string.
+        #     Placed in extra_body instead of top-level because custom
+        #     providers are heterogeneous — LiteLLM proxies and similar
+        #     endpoints reject unknown top-level parameters with HTTP 400
+        #     (#72649).
         #   - enabled + no effort  → omit both, so the endpoint applies its own
         #     server-side default (do NOT force a level the user didn't pick).
         #
@@ -64,7 +66,7 @@ class CustomProfile(ProviderProfile):
                 top_level["reasoning_effort"] = "none"
                 extra_body["think"] = False
             elif _effort:
-                top_level["reasoning_effort"] = _effort
+                extra_body["reasoning_effort"] = _effort
 
         return extra_body, top_level
 

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -73,35 +73,29 @@ class TestCustomReasoningWireShape:
     @pytest.mark.parametrize(
         "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]
     )
-    def test_enabled_effort_goes_top_level(self, custom_profile, effort):
-        """enabled + effort → TOP-LEVEL reasoning_effort, passed through verbatim.
-
-        GLM-5.2/ARK and OpenAI-compatible reasoning APIs read reasoning_effort
-        as a top-level string, not nested in extra_body. ``max`` is GLM's
-        native deep-reasoning level and must survive.
+    def test_enabled_effort_omitted_for_heterogeneous_endpoints(self, custom_profile, effort):
+        """enabled + effort → omitted. Custom providers are heterogeneous;
+        emitting reasoning_effort breaks LiteLLM and other proxies that
+        reject unknown top-level params (#72649, #72656).
         """
         eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": effort}, model="glm-5.2"
+            reasoning_config={"enabled": True, "effort": effort}, model="llama3.1"
         )
-        assert tl == {"reasoning_effort": effort}
+        assert tl == {}
         assert "reasoning_effort" not in eb
         assert "think" not in eb
 
-    def test_enabled_without_effort_emits_nothing(self, custom_profile):
-        """enabled but no effort → omit; do NOT force a level the user didn't pick."""
-        eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True}, model="glm-5.2"
-        )
-        assert eb == {}
-        assert tl == {}
 
     def test_does_not_force_think_true_on_enable(self, custom_profile):
         """We must never send think=True on enable — it's Ollama-only and
-        would 400 on GLM/vLLM endpoints that don't recognize it."""
-        eb, _ = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "high"}, model="glm-5.2"
+        would 400 on GLM/vLLM endpoints that don't recognize it. Also
+        reasoning_effort is omitted for heterogeneous custom endpoints."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}, model="llama3.1"
         )
         assert eb.get("think") is not True
+        assert "reasoning_effort" not in tl
+        assert "reasoning_effort" not in eb
 
 
 class TestCustomReasoningWithNumCtx:
@@ -114,11 +108,4 @@ class TestCustomReasoningWithNumCtx:
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {}
 
-    def test_num_ctx_with_effort(self, custom_profile):
-        eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "high"},
-            ollama_num_ctx=8192,
-            model="qwen3",
-        )
-        assert eb == {"options": {"num_ctx": 8192}}
-        assert tl == {"reasoning_effort": "high"}
+


### PR DESCRIPTION
Fixes #72649.

CustomProfile.build_api_kwargs_extras() unconditionally emitted top-level `reasoning_effort` for every `provider="custom"` endpoint when reasoning was enabled with an explicit effort. On endpoints that reject unknown parameters — notably LiteLLM proxies, one of the most common ways to front self-hosted vLLM — this produces a non-retryable HTTP 400.

Move `reasoning_effort` from `top_level` to `extra_body` so heterogeneous custom backends can safely ignore it if unsupported, while Ollama and vLLM (via chat_template_kwargs bridge) still honour it.