### PR TITLE
fix(slack): stop interactive-caller auth falling open on multiplexed profiles

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6647,6 +6647,24 @@ class SlackAdapter(BasePlatformAdapter):
         if not normalized_user_id:
             return False
 
+        chat_type = "dm" if str(channel_id or "").startswith("D") else "group"
+
+        # The authorization callback ``GatewayRunner`` injects at adapter-connect
+        # time (``set_authorization_check``) is the authoritative chain: env
+        # allowlists, config allowlists, group allowlists, pairing store, and
+        # allow-all flags, all resolved under THIS adapter's profile. It is
+        # registered for primary and multiplexed adapters alike, so prefer it
+        # over the ``__self__`` introspection below — which resolves to nothing
+        # on a multiplexed profile, whose message handler is the closure built
+        # by ``GatewayRunner._make_profile_message_handler`` (no ``__self__``).
+        injected = self._is_sender_authorized(
+            normalized_user_id, chat_type, str(channel_id or "")
+        )
+        if injected is not None:
+            return injected
+
+        # Legacy resolution for adapters wired without the injected check
+        # (bare-adapter embedding, existing tests).
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
@@ -6656,7 +6674,7 @@ class SlackAdapter(BasePlatformAdapter):
                 source = SessionSource(
                     platform=Platform.SLACK,
                     chat_id=str(channel_id or normalized_user_id),
-                    chat_type="dm" if str(channel_id or "").startswith("D") else "group",
+                    chat_type=chat_type,
                     user_id=normalized_user_id,
                     user_name=str(user_name).strip() if user_name else None,
                     scope_id=str(team_id) if team_id else None,
@@ -6669,20 +6687,39 @@ class SlackAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
-        if os.getenv("SLACK_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
-            return True
-
         def _env(name: str) -> str:
-            # Multiplex: profile .env is in secret_scope, not process environ.
-            try:
-                from agent.secret_scope import get_secret
+            """Read an authz env var, honoring the active profile secret scope.
 
-                val = get_secret(name)
-                if val is not None and str(val).strip():
-                    return str(val).strip()
+            Under multiplexing a scope miss must NOT fall through to
+            ``os.environ``: that holds the DEFAULT profile's values, so falling
+            through lets one profile's allowlist / allow-all flag authorize
+            callers on another profile's bot. ``agent.secret_scope`` already
+            refuses that read (returning the default, or raising
+            ``UnscopedSecretError`` when no scope is installed); this helper
+            must not undo it. Fail closed instead, and keep the plain
+            ``os.environ`` read for single-profile deployments, where there is
+            no other profile to leak from.
+            """
+            try:
+                from agent.secret_scope import get_secret, is_multiplex_active
             except Exception:
-                pass
+                return (os.getenv(name) or "").strip()
+
+            try:
+                val = get_secret(name)
+            except Exception:
+                # UnscopedSecretError under multiplex is the deliberate
+                # fail-closed signal — never downgrade it to an os.environ read.
+                return "" if is_multiplex_active() else (os.getenv(name) or "").strip()
+
+            if val is not None and str(val).strip():
+                return str(val).strip()
+            if is_multiplex_active():
+                return ""
             return (os.getenv(name) or "").strip()
+
+        if _env("SLACK_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}:
+            return True
 
         allowed_ids = set()
         platform_allowlist = _env("SLACK_ALLOWED_USERS")
@@ -6695,8 +6732,6 @@ class SlackAdapter(BasePlatformAdapter):
         if allowed_ids:
             return "*" in allowed_ids or normalized_user_id in allowed_ids
 
-        if _env("SLACK_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}:
-            return True
         return _env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:

--- a/tests/gateway/test_slack_interactive_authz_multiplex.py
+++ b/tests/gateway/test_slack_interactive_authz_multiplex.py
@@ -1,0 +1,258 @@
+"""Regression tests for Slack interactive-caller auth under multiplex profiles.
+
+``SlackAdapter._is_interactive_user_authorized`` gates approval-button,
+slash-confirm and clarify clicks. Button clicks bypass the normal message auth
+flow in ``gateway/run.py``, so this is the only gate on that path.
+
+Two failure modes are covered here:
+
+1. It used to resolve the gateway auth chain only by introspecting
+   ``_message_handler.__self__``. On a multiplexed profile the handler is the
+   closure built by ``GatewayRunner._make_profile_message_handler``, which has
+   no ``__self__``, so the introspection silently yielded nothing and the
+   method fell through to its env-only fallback.
+2. That fallback read the process environment — the DEFAULT profile's ``.env``
+   — so a secondary profile inherited another profile's allowlist and
+   allow-all flags. Direction is fail-OPEN: a caller the profile never
+   allowlisted could resolve its approvals.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Slack SDK mock so SlackAdapter can be imported
+# ---------------------------------------------------------------------------
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules:
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    sys.modules["slack_bolt"] = slack_bolt
+    sys.modules["slack_bolt.async_app"] = slack_bolt.async_app
+    handler_mod = MagicMock()
+    handler_mod.AsyncSocketModeHandler = MagicMock
+    sys.modules["slack_bolt.adapter"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode.async_handler"] = handler_mod
+    sdk_mod = MagicMock()
+    sdk_mod.web = MagicMock()
+    sdk_mod.web.async_client = MagicMock()
+    sdk_mod.web.async_client.AsyncWebClient = MagicMock
+    sys.modules["slack_sdk"] = sdk_mod
+    sys.modules["slack_sdk.web"] = sdk_mod.web
+    sys.modules["slack_sdk.web.async_client"] = sdk_mod.web.async_client
+
+
+_ensure_slack_mock()
+
+from agent import secret_scope  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+_AUTH_ENV_KEYS = (
+    "SLACK_ALLOWED_USERS",
+    "SLACK_ALLOW_ALL_USERS",
+    "GATEWAY_ALLOWED_USERS",
+    "GATEWAY_ALLOW_ALL_USERS",
+)
+
+OWNER = "U_OWNER_B"
+STRANGER = "U_STRANGER"
+
+
+@pytest.fixture
+def multiplex(monkeypatch):
+    """Enable/disable multiplex without leaking the module global across tests."""
+    previous = secret_scope.is_multiplex_active()
+
+    def _set(active: bool):
+        secret_scope.set_multiplex_active(active)
+
+    yield _set
+    secret_scope.set_multiplex_active(previous)
+
+
+@pytest.fixture
+def profile_scope():
+    """Install a profile secret scope, always resetting it."""
+    tokens = []
+
+    def _install(mapping):
+        tokens.append(secret_scope.set_secret_scope(mapping))
+
+    yield _install
+    for token in reversed(tokens):
+        secret_scope.reset_secret_scope(token)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for key in _AUTH_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+def _make_adapter():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test-token"))
+    adapter._app = MagicMock()
+    adapter._bot_user_id = "U_BOT"
+    return adapter
+
+
+def _multiplexed_handler():
+    """A per-profile message handler closure — no ``__self__``, like the real one."""
+
+    async def _handler(event):
+        return None
+
+    return _handler
+
+
+def test_injected_authorization_check_is_preferred(clean_env, multiplex, profile_scope):
+    """The profile-bound callback wins over process env and handler introspection."""
+    clean_env.setenv("SLACK_ALLOW_ALL_USERS", "true")
+    multiplex(True)
+    profile_scope({"SLACK_BOT_TOKEN": "xoxb-b"})
+
+    adapter = _make_adapter()
+    adapter._message_handler = _multiplexed_handler()
+
+    seen = []
+
+    def check(user_id, chat_type=None, chat_id=None):
+        seen.append((user_id, chat_type, chat_id))
+        return user_id == OWNER
+
+    adapter.set_authorization_check(check)
+
+    assert adapter._is_interactive_user_authorized(STRANGER, channel_id="C1") is False
+    assert adapter._is_interactive_user_authorized(OWNER, channel_id="C1") is True
+    assert seen == [(STRANGER, "group", "C1"), (OWNER, "group", "C1")]
+
+
+def test_dm_channel_passes_dm_chat_type(clean_env, multiplex):
+    """A ``D``-prefixed channel is reported to the auth chain as a DM."""
+    multiplex(False)
+    adapter = _make_adapter()
+    seen = []
+
+    def check(user_id, chat_type=None, chat_id=None):
+        seen.append(chat_type)
+        return True
+
+    adapter.set_authorization_check(check)
+
+    adapter._is_interactive_user_authorized(OWNER, channel_id="D123")
+    assert seen == ["dm"]
+
+
+def test_multiplex_does_not_inherit_process_env_allow_all(
+    clean_env, multiplex, profile_scope
+):
+    """A secondary profile must not inherit the default profile's allow-all flag."""
+    clean_env.setenv("SLACK_ALLOW_ALL_USERS", "true")
+    clean_env.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    multiplex(True)
+    profile_scope({"SLACK_BOT_TOKEN": "xoxb-b", "SLACK_ALLOWED_USERS": OWNER})
+
+    adapter = _make_adapter()
+    adapter._message_handler = _multiplexed_handler()
+
+    assert adapter._is_interactive_user_authorized(STRANGER, channel_id="C1") is False
+    assert adapter._is_interactive_user_authorized(OWNER, channel_id="C1") is True
+
+
+def test_multiplex_does_not_inherit_process_env_allowlist(
+    clean_env, multiplex, profile_scope
+):
+    """A secondary profile must not inherit the default profile's allowlists."""
+    clean_env.setenv("SLACK_ALLOWED_USERS", STRANGER)
+    clean_env.setenv("GATEWAY_ALLOWED_USERS", STRANGER)
+    multiplex(True)
+    profile_scope({"SLACK_BOT_TOKEN": "xoxb-b", "SLACK_ALLOWED_USERS": OWNER})
+
+    adapter = _make_adapter()
+    adapter._message_handler = _multiplexed_handler()
+
+    assert adapter._is_interactive_user_authorized(STRANGER, channel_id="C1") is False
+    assert adapter._is_interactive_user_authorized(OWNER, channel_id="C1") is True
+
+
+def test_multiplex_without_scope_fails_closed(clean_env, multiplex):
+    """No scope installed under multiplex is the fail-closed signal, not an env read."""
+    clean_env.setenv("SLACK_ALLOW_ALL_USERS", "true")
+    clean_env.setenv("GATEWAY_ALLOWED_USERS", STRANGER)
+    multiplex(True)
+
+    adapter = _make_adapter()
+    adapter._message_handler = _multiplexed_handler()
+
+    # get_secret raises UnscopedSecretError here; it must not be downgraded
+    # to an os.environ read.
+    with pytest.raises(secret_scope.UnscopedSecretError):
+        secret_scope.get_secret("SLACK_ALLOW_ALL_USERS")
+
+    assert adapter._is_interactive_user_authorized(STRANGER, channel_id="C1") is False
+
+
+def test_single_profile_env_fallback_unchanged(clean_env, multiplex):
+    """Single-profile deployments keep reading credentials from the process env."""
+    multiplex(False)
+    adapter = _make_adapter()
+    adapter._message_handler = _multiplexed_handler()
+
+    assert adapter._is_interactive_user_authorized(STRANGER, channel_id="C1") is False
+
+    clean_env.setenv("SLACK_ALLOWED_USERS", OWNER)
+    assert adapter._is_interactive_user_authorized(OWNER, channel_id="C1") is True
+    assert adapter._is_interactive_user_authorized(STRANGER, channel_id="C1") is False
+
+    clean_env.delenv("SLACK_ALLOWED_USERS")
+    clean_env.setenv("SLACK_ALLOW_ALL_USERS", "true")
+    assert adapter._is_interactive_user_authorized(STRANGER, channel_id="C1") is True
+
+
+def test_handler_introspection_still_honored_without_injected_check(
+    clean_env, multiplex
+):
+    """Bare-adapter embedding keeps working via ``_message_handler.__self__``."""
+    multiplex(False)
+    adapter = _make_adapter()
+
+    class _Runner:
+        def __init__(self):
+            self.seen = []
+
+        def _is_user_authorized(self, source):
+            self.seen.append(source.user_id)
+            return source.user_id == OWNER
+
+        async def handle(self, event):
+            return None
+
+    runner = _Runner()
+    adapter._message_handler = runner.handle
+
+    assert adapter._is_interactive_user_authorized(OWNER, channel_id="C1") is True
+    assert adapter._is_interactive_user_authorized(STRANGER, channel_id="C1") is False
+    assert runner.seen == [OWNER, STRANGER]
+
+
+def test_empty_user_id_denied(multiplex):
+    multiplex(False)
+    adapter = _make_adapter()
+    assert adapter._is_interactive_user_authorized("") is False
+    assert adapter._is_interactive_user_authorized("   ") is False


### PR DESCRIPTION
## What does this PR do?

Closes a fail-open in Slack interactive-caller authorization on multiplexed profiles. `SlackAdapter._is_interactive_user_authorized` gates approval-button, slash-confirm and clarify clicks; button clicks bypass the normal message auth flow in `gateway/run.py`, so this is the only gate on that path. On a secondary profile it stopped consulting the gateway auth chain entirely and authorized callers from the **default** profile's process environment instead.

### Bug Cause

Two defects compose:

1. The method resolved the gateway auth chain by introspecting `_message_handler.__self__`. Under `gateway.multiplex_profiles` the handler is the closure built by `GatewayRunner._make_profile_message_handler`, which has no `__self__`, so the introspection silently yielded nothing and control fell through to the env-only fallback. This is the same introspection gap #65589 describes for Telegram.

2. That fallback read the **process** environment — the default profile's `.env`. Its first line was a raw `os.getenv("SLACK_ALLOW_ALL_USERS")`, and its `_env()` helper fell through to `os.getenv` whenever the profile secret scope returned empty or raised. `agent/secret_scope.py` deliberately refuses that read (returning the default under multiplex, raising `UnscopedSecretError` when no scope is installed); the helper undid it.

So a secondary profile inherited another profile's `SLACK_ALLOWED_USERS` / `GATEWAY_ALLOWED_USERS` and, worse, its `SLACK_ALLOW_ALL_USERS` / `GATEWAY_ALLOW_ALL_USERS` flags. On Telegram (#65589) this fallback happens to fail closed, so it is a denial bug. On Slack it fails **open**: a caller the profile never allowlisted can resolve its approvals.

Meanwhile the correct authority was already available and unused — the multiplexer registers a profile-bound callback via `adapter.set_authorization_check(self._make_adapter_auth_check(platform, profile_name=profile_name))`, which delegates to the full `_is_user_authorized` chain (env allowlists, config allowlists, group allowlists, pairing store, allow-all flags) under that profile's own secret scope.

This surface has been hardened before — #36848, #41226, #33844 — and the multiplex path reintroduced the same failure direction.

### Reproduction Steps

1. Enable `gateway.multiplex_profiles` with a default profile and a secondary profile running its own Slack app.
2. Default profile's `.env` sets `SLACK_ALLOW_ALL_USERS=true` (or simply lists its own users in `SLACK_ALLOWED_USERS`).
3. Secondary profile's `.env` sets only its bot token plus `SLACK_ALLOWED_USERS=<its owner>`.
4. From a Slack user that is **not** in the secondary profile's allowlist, click an exec-approval button posted by the secondary profile's bot.

Expected: ignored, `[Slack] Unauthorized approval click by …`.
Before this PR: the click is honored.

Equivalent unit-level repro:

```python
adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
adapter.set_authorization_check(lambda uid, ct=None, cid=None: uid == "U_OWNER")
adapter._message_handler = _profile_closure()      # no __self__, as multiplex builds it

os.environ["SLACK_ALLOW_ALL_USERS"] = "true"       # default profile's .env
set_multiplex_active(True)
set_secret_scope({"SLACK_BOT_TOKEN": "xoxb-b"})    # secondary profile's .env

adapter._is_interactive_user_authorized("U_STRANGER", channel_id="C1")
# before: True, and the registered check is never called
```

### Fix

- Prefer the injected `self._is_sender_authorized(...)` check (registered for primary and multiplexed adapters alike) before any other resolution. Returns `True`/`False` when a check is wired, `None` when it isn't.
- Keep the `__self__` introspection as the next step, for adapters wired without the injected check (bare-adapter embedding, existing tests).
- Make the env fallback multiplex-safe: on a scope miss or `UnscopedSecretError`, fail closed rather than reading `os.environ`. Single-profile deployments keep the plain env read — there is no other profile to leak from.
- Route the early `SLACK_ALLOW_ALL_USERS` check through the same scoped helper, preserving its existing precedence over the allowlists.

No behavior change for single-profile deployments; `test_single_profile_env_fallback_unchanged` and `test_handler_introspection_still_honored_without_injected_check` pin that.

## Related Issue

No issue filed for the Slack instance. Related: #65589 (same introspection gap on Telegram, fail-closed there), #70122 (the sibling `_auth_env` fallthrough in `gateway/authz_mixin.py`, still open — this PR does not touch that file).

Found via an adversarial scan of the external-surface authorization paths named in `SECURITY.md` §2.6.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/slack/adapter.py` — prefer the injected profile-bound auth check; multiplex-safe, fail-closed env fallback
- `tests/gateway/test_slack_interactive_authz_multiplex.py` — new regression tests

## How to Test

```bash
scripts/run_tests.sh \
  tests/gateway/test_slack_interactive_authz_multiplex.py \
  tests/gateway/test_slack.py \
  tests/gateway/test_slack_approval_buttons.py \
  tests/gateway/test_slack_clarify_buttons.py \
  tests/gateway/test_slack_bot_auth_bypass.py \
  tests/gateway/test_multiplex_profile_authz.py \
  -q
```

523 passed, 0 failed locally. 5 of the 8 new tests fail against `main` without the adapter change; the other 3 guard behavior this PR deliberately leaves alone.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure authorization / env resolution)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
