### PR TITLE
docs: use canonical TUI workspace commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,16 +464,14 @@ Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. Se
 
 ### Dev Commands
 
+Run these from the repository root; `ui-tui` is an npm workspace:
+
 ```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run typecheck # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
+npm install                         # first time
+npm run --workspace ui-tui dev      # watch mode (rebuilds hermes-ink + tsx --watch)
+npm run --workspace ui-tui start    # production
+npm run --workspace ui-tui check    # build, typecheck, tests, and lint
+npm run --workspace ui-tui fix      # eslint --fix and prettier
 ```
 
 ### TUI in the Dashboard (`hermes dashboard` → `/chat`)


### PR DESCRIPTION
## Summary

- replace the TUI command block's cwd-dependent npm invocations with explicit `ui-tui` workspace commands runnable from the repository root
- use the workspace's canonical `check` and `fix` scripts so build, typecheck, tests, lint, and formatting stay aligned with `ui-tui/package.json`

## Validation

- `git diff --check origin/main...HEAD` — pass
- manifest/docs resolver — pass; all four documented commands resolve to scripts declared by the root's `ui-tui` workspace
- `npm run --workspace ui-tui lint` — pass
- `npm run --workspace ui-tui check` — build and typecheck passed; Vitest reported 1,382 passed, 8 skipped, and 8 pre-existing Windows-only failures in `editor.test.ts`, `terminalParity.test.ts`, and `terminalSetup.test.ts`. No `ui-tui` source or tests changed in this docs-only branch; authoritative Linux CI remains the merge gate.
- `npm run verify` — unavailable because the root package has no `verify` script

## Git base

- final base: `d71033a4077a6dfdcdb42c9e9eeab4c41e4a7012` (`origin/main`)
- final distance behind `origin/main`: 0 commits
