### PR TITLE
test(gateway): isolate channel directory JSON fallback

### DIFF
--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -269,6 +269,14 @@ class TestResolveChannelName:
 
 
 class TestBuildFromSessions:
+    @pytest.fixture(autouse=True)
+    def _force_legacy_json_fallback(self, monkeypatch):
+        """Keep these tests focused on the legacy sessions.json source."""
+        monkeypatch.setattr(
+            "gateway.channel_directory._build_from_sessions_db",
+            lambda _platform_name: [],
+        )
+
     def _write_sessions(self, tmp_path, sessions_data):
         """Write sessions.json at the path _build_from_sessions expects."""
         sessions_path = tmp_path / "sessions" / "sessions.json"
@@ -301,6 +309,8 @@ class TestBuildFromSessions:
             },
         })
 
+        # This test targets the legacy JSON fallback explicitly. The normal
+        # production path prefers state.db when it has session rows.
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             entries = _build_from_sessions("telegram")
 


### PR DESCRIPTION
## What does this PR do?

Makes `TestBuildFromSessions` explicitly exercise the legacy `sessions.json` fallback instead of depending on whatever rows are present in `state.db`. The production channel-directory contract remains unchanged: `state.db` is primary and `sessions.json` is the legacy fallback. This is a test-isolation change only.

## Related Issue

No issue link: this is a narrowly scoped upstream test-fixture follow-up.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/gateway/test_channel_directory.py`: add an autouse fixture scoped to `TestBuildFromSessions` that monkeypatches `_build_from_sessions_db()` to return no rows.
- Document that the JSON test targets the legacy fallback.
- No production-code, state.db-priority, dependency, configuration, or formatter changes.

## How to Test

1. `uv run --extra dev pytest tests/gateway/test_channel_directory.py -q` → **45 passed**.
2. `uv run --extra dev ruff check .` → **passed**; only an existing invalid `# noqa` warning in `run_agent.py` was reported.
3. `uv run --extra dev ty check tests/gateway/test_channel_directory.py` → **passed**; `git diff --check` and clean-worktree/scope checks → **passed**.

Exact evidence:

- Base SHA: `d71033a4077a6dfdcdb42c9e9eeab4c41e4a7012`
- Candidate head SHA: `81538b835837544403c03652e36972c64bd47bea`
- Stable patch-id: `e3bf32d021c6d187ecaba4288a3a61ddeda78fd7` (same as local `40b58034e`)
- `git range-diff 40b58034e^..40b58034e origin/main..81538b835`: patch unchanged except attribution metadata.
- `ruff format --check` reports the same pre-existing formatting baseline on `origin/main`; no formatter changes are included.
- Canonical `scripts/run_tests.sh -j 4` completed on this exact head with **31 failures in six unrelated files**; neither candidate file is in the failure list. `tests/agent/test_context_compressor.py` was reported as a parallel-runner collection/timeout case, but a separate canonical run of that exact file passed **214 tests in 248.0s**. The full suite is therefore not green, but the observed failures are outside this PR's scope.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`test(gateway): ...`)
- [x] I searched existing PRs, issues, commit history, and current `main` for overlap
- [x] My PR contains only changes related to this test-fixture fix
- [ ] I've run `pytest tests/ -q` and all tests pass — not claimed; the canonical full suite has 31 unrelated failures outside this PR's scope
- [x] I've added/improved tests
- [x] Focused tests run on Linux/Python 3.13.14

### Documentation & Housekeeping

- [x] Relevant documentation/docstrings: N/A; the change is confined to a test fixture
- [x] Config keys: N/A
- [x] Architecture/workflow docs: N/A
- [x] Cross-platform impact considered; no production behavior or platform adapter changed
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

No screenshots applicable. Focused test output: `45 passed in 1.33s`.

Human sponsor and review-response owner: @tmielika

<!-- Draft PR: do not merge or mark ready-for-review from this task. -->
