### PR TITLE
fix(gateway): preserve email attachment boundaries

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2566,6 +2566,12 @@ class BasePlatformAdapter(ABC):
     # generic seam; Slack is merely the first consumer).
     supports_inchannel_continuable: bool = False
 
+    # Some platforms deliver native albums as multiple attachment events and
+    # want them merged into one busy-session turn. Platforms whose events are
+    # already complete messages can opt out so message IDs, attachment
+    # provenance, and reply threading remain intact.
+    preserve_media_message_boundaries: bool = False
+
     # Whether a human is interactively present on this platform to answer a
     # "session restored — what next?" prompt.  The startup auto-resume turn
     # (``_schedule_resume_pending_sessions`` → the ``_is_resume_pending``
@@ -5282,6 +5288,34 @@ class BasePlatformAdapter(ABC):
                         return
                 except Exception as e:
                     logger.error("[%s] Busy-session handler failed: %s", self.name, e, exc_info=True)
+
+            # Some adapters deliver each media-bearing event as a complete
+            # native message rather than one fragment of an album. Their
+            # message IDs and attachments must stay together even on this
+            # fallback path (missing/failed gateway busy handler).
+            if self.preserve_media_message_boundaries and (
+                event.message_type == MessageType.PHOTO
+                or bool(getattr(event, "media_urls", None))
+                or bool(getattr(event, "media_types", None))
+            ):
+                runner = getattr(self, "gateway_runner", None)
+                queue_event = getattr(runner, "_queue_or_replace_pending_event", None)
+                if callable(queue_event):
+                    queue_event(session_key, event)
+                elif session_key not in self._pending_messages:
+                    # A gateway-managed adapter normally always has the runner
+                    # helper. If that contract is broken, preserve the first
+                    # complete message and fail closed rather than merging a
+                    # later attachment under the wrong identity.
+                    self._pending_messages[session_key] = event
+                else:
+                    logger.error(
+                        "[%s] Dropping media follow-up for %s because the "
+                        "boundary-preserving FIFO is unavailable",
+                        self.name,
+                        session_key,
+                    )
+                return
 
             # Special case: photo bursts/albums frequently arrive as multiple near-
             # simultaneous messages. Queue them without interrupting the active run,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5213,6 +5213,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             queued_events.setdefault(session_key, []).insert(0, next_queued)
         return pending_event
 
+    def _restore_pending_event_to_fifo_head(
+        self,
+        session_key: str,
+        adapter: Any,
+        pending_event: "MessageEvent",
+    ) -> None:
+        """Restore a drained event ahead of any item already promoted.
+
+        The recursion-depth guard may stop before processing ``pending_event``
+        after ``_promote_queued_event`` has staged the following item in the
+        adapter slot. Put the unprocessed event back at the head and move that
+        staged successor to the front of overflow without merging either one.
+        """
+        pending_slot = getattr(adapter, "_pending_messages", None)
+        if not isinstance(pending_slot, dict):
+            return
+        staged_successor = pending_slot.pop(session_key, None)
+        pending_slot[session_key] = pending_event
+        if staged_successor is not None and staged_successor is not pending_event:
+            queued_events = getattr(self, "_queued_events", None)
+            if queued_events is None:
+                queued_events = {}
+                self._queued_events = queued_events
+            queued_events.setdefault(session_key, []).insert(0, staged_successor)
+
     def _queue_depth(self, session_key: str, *, adapter: Any = None) -> int:
         """Total pending /queue items for a session — slot + overflow."""
         queued_events = getattr(self, "_queued_events", None) or {}
@@ -6107,10 +6132,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # infrastructure shared with ``/queue`` so each follow-up gets
         # its own turn in arrival order. Photo bursts still merge into
         # the head slot via ``merge_pending_message_event`` (album
-        # semantics); everything else appends to the overflow tail.
+        # semantics), except on adapters whose events are already complete
+        # messages and must retain message IDs and reply-thread provenance.
+        # Everything else appends to the overflow tail.
         pending_slot = getattr(adapter, "_pending_messages", None)
         existing = pending_slot.get(session_key) if isinstance(pending_slot, dict) else None
-        if existing is not None and (
+        preserve_media_boundary = bool(
+            getattr(adapter, "preserve_media_message_boundaries", False)
+        )
+        if not preserve_media_boundary and existing is not None and (
             getattr(existing, "message_type", None) == MessageType.PHOTO
             or event.message_type == MessageType.PHOTO
             or bool(getattr(existing, "media_urls", None))
@@ -11579,9 +11609,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
-                adapter = self._adapter_for_source(source)
-                if adapter:
-                    merge_pending_message_event(adapter._pending_messages, _quick_key, event)
+                self._queue_or_replace_pending_event(_quick_key, event)
                 return None
 
             _telegram_followup_grace = float(
@@ -11625,12 +11653,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # agent starts.
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
-                        _quick_key,
-                        event,
-                        merge_text=True,
-                    )
+                    if (
+                        getattr(adapter, "preserve_media_message_boundaries", False)
+                        and (
+                            event.message_type == MessageType.PHOTO
+                            or bool(getattr(event, "media_urls", None))
+                            or bool(getattr(event, "media_types", None))
+                        )
+                    ):
+                        self._queue_or_replace_pending_event(_quick_key, event)
+                    else:
+                        merge_pending_message_event(
+                            adapter._pending_messages,
+                            _quick_key,
+                            event,
+                            merge_text=True,
+                        )
                 return None
             if self._draining:
                 if self._queue_during_drain_enabled():
@@ -23377,7 +23415,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     adapter = self._adapter_for_source(source)
                     if adapter and pending_event:
-                        merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
+                        self._restore_pending_event_to_fifo_head(
+                            session_key,
+                            adapter,
+                            pending_event,
+                        )
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -422,6 +422,8 @@ def _extract_attachments(
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    preserve_media_message_boundaries = True
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 
@@ -875,6 +877,7 @@ class EmailAdapter(BasePlatformAdapter):
             chat_type="dm",
             user_id=sender_addr,
             user_name=msg_data["sender_name"] or sender_addr,
+            message_id=msg_data["message_id"],
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -323,6 +323,8 @@ class TestDispatchMessage(unittest.TestCase):
         self.assertEqual(len(captured_events), 1)
         self.assertIn("[Subject: Help with Python]", captured_events[0].text)
         self.assertIn("How do I use lists?", captured_events[0].text)
+        self.assertEqual(captured_events[0].message_id, "<msg2@test.com>")
+        self.assertEqual(captured_events[0].source.message_id, "<msg2@test.com>")
 
     def test_reply_subject_not_duplicated(self):
         """Re: subjects should not be prepended to body."""

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -17,6 +17,7 @@ from gateway.platforms.base import (
     PlatformConfig,
     Platform,
 )
+from gateway.session import SessionSource, build_session_key
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +393,61 @@ class TestBusyInputModeQueueFifo:
             message_id=f"m-{text}",
         )
 
+    def _email_event(
+        self,
+        index: int,
+        *,
+        source=None,
+        document: bool = False,
+    ) -> MessageEvent:
+        source = source or MagicMock(
+            chat_id="sender@example.com",
+            platform=Platform.EMAIL,
+            profile=None,
+        )
+        extension = "pdf" if document else "jpg"
+        media_type = "application/pdf" if document else "image/jpeg"
+        message_type = MessageType.DOCUMENT if document else MessageType.PHOTO
+        return MessageEvent(
+            text=f"invoice {index}",
+            message_type=message_type,
+            source=source,
+            message_id=f"<mail-{index}@example.com>",
+            media_urls=[f"/tmp/invoice-{index}.{extension}"],
+            media_types=[media_type],
+        )
+
+    def _run_email_base_fallback(self, *, with_runner: bool):
+        runner, adapter = self._make_runner_and_adapter()
+        adapter.platform = Platform.EMAIL
+        adapter.preserve_media_message_boundaries = True
+        adapter.gateway_runner = runner if with_runner else None
+        runner.adapters = {Platform.EMAIL: adapter}
+        source = SessionSource(
+            platform=Platform.EMAIL,
+            chat_id="sender@example.com",
+            user_id="sender@example.com",
+            chat_type="dm",
+        )
+        session_key = build_session_key(source)
+
+        async def scenario():
+            adapter._message_handler = MagicMock()
+            adapter._active_sessions[session_key] = asyncio.Event()
+            adapter._session_tasks[session_key] = asyncio.current_task()
+
+            async def failed_busy_handler(_event, _session_key):
+                raise RuntimeError("simulated busy-handler failure")
+
+            adapter._busy_session_handler = failed_busy_handler
+            for index in range(2):
+                await adapter.handle_message(
+                    self._email_event(index, source=source, document=True)
+                )
+
+        asyncio.run(scenario())
+        return runner, adapter, session_key
+
     def test_rapid_text_followups_are_queued_in_fifo_order(self):
         """Five rapid texts in queue mode must all survive (none silently dropped)."""
         runner, adapter = self._make_runner_and_adapter()
@@ -454,3 +510,88 @@ class TestBusyInputModeQueueFifo:
         head = adapter._pending_messages[session_key]
         assert head.message_type == MessageType.PHOTO
         assert len(head.media_urls) == 3
+
+    def test_email_media_keeps_one_fifo_turn_per_rfc_message(self):
+        """Different emails must not merge attachments or reply provenance."""
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        assert EmailAdapter.preserve_media_message_boundaries is True
+        runner, adapter = self._make_runner_and_adapter()
+        runner.adapters[Platform.EMAIL] = adapter
+        adapter.preserve_media_message_boundaries = True
+        session_key = "email:sender@example.com"
+
+        for i in range(3):
+            runner._queue_or_replace_pending_event(
+                session_key,
+                self._email_event(i),
+            )
+
+        head = adapter._pending_messages[session_key]
+        overflow = runner._queued_events[session_key]
+        assert head.message_id == "<mail-0@example.com>"
+        assert head.media_urls == ["/tmp/invoice-0.jpg"]
+        assert [event.message_id for event in overflow] == [
+            "<mail-1@example.com>",
+            "<mail-2@example.com>",
+        ]
+        assert [event.media_urls for event in overflow] == [
+            ["/tmp/invoice-1.jpg"],
+            ["/tmp/invoice-2.jpg"],
+        ]
+
+    def test_email_base_fallback_uses_gateway_fifo_when_busy_handler_fails(self):
+        """The adapter fallback must not merge complete email messages."""
+        runner, adapter, session_key = self._run_email_base_fallback(with_runner=True)
+
+        head = adapter._pending_messages[session_key]
+        overflow = runner._queued_events[session_key]
+        assert head.message_id == "<mail-0@example.com>"
+        assert head.media_urls == ["/tmp/invoice-0.pdf"]
+        assert [event.message_id for event in overflow] == ["<mail-1@example.com>"]
+        assert overflow[0].media_urls == ["/tmp/invoice-1.pdf"]
+
+    def test_email_base_fallback_without_runner_never_merges_identities(self):
+        """A broken standalone contract may drop, but must not misattribute."""
+        _runner, adapter, session_key = self._run_email_base_fallback(with_runner=False)
+
+        head = adapter._pending_messages[session_key]
+        assert head.message_id == "<mail-0@example.com>"
+        assert head.text == "invoice 0"
+        assert head.media_urls == ["/tmp/invoice-0.pdf"]
+
+    def test_recursion_cap_restores_drained_email_ahead_of_promoted_successor(self):
+        """Depth resets must preserve FIFO order and exact media identities."""
+        runner, adapter = self._make_runner_and_adapter()
+        runner.adapters[Platform.EMAIL] = adapter
+        adapter.preserve_media_message_boundaries = True
+        session_key = "email:sender@example.com"
+
+        events = []
+        for i in range(5):
+            event = self._email_event(i, document=True)
+            events.append(event)
+            runner._queue_or_replace_pending_event(session_key, event)
+
+        # Model four normal recursive drains. Each promotion stages its
+        # successor in the adapter slot while the drained event is processed.
+        for expected in events[:4]:
+            pending = adapter.get_pending_message(session_key)
+            assert pending is expected
+            pending = runner._promote_queued_event(session_key, adapter, pending)
+            assert pending is expected
+
+        # The depth guard fires after event 3 was drained and event 4 was
+        # promoted. Restore event 3 ahead of event 4 without merging/reversal.
+        runner._restore_pending_event_to_fifo_head(session_key, adapter, events[3])
+
+        restored = [adapter.get_pending_message(session_key)]
+        restored.extend(runner._queued_events.get(session_key, []))
+        assert [event.message_id for event in restored] == [
+            "<mail-3@example.com>",
+            "<mail-4@example.com>",
+        ]
+        assert [event.media_urls for event in restored] == [
+            ["/tmp/invoice-3.pdf"],
+            ["/tmp/invoice-4.pdf"],
+        ]


### PR DESCRIPTION
## What does this PR do?

Preserves native message boundaries for adapters such as Email whose media-bearing events are already complete messages.

Before this change, two emails arriving from the same sender while a turn was busy could be merged into one pending event. The merged event retained the first email's Message-ID and source while appending the later email's text and attachments. A downstream hook therefore could not determine which attachment belonged to which RFC message.

This adds a generic, default-off adapter capability:

```python
preserve_media_message_boundaries = True
```

Email opts in. Busy-session queueing then uses the existing FIFO instead of album merging. Telegram and every other adapter retain their current default media-burst behavior.

The fix also closes sibling bypasses in the base-adapter fallback, the direct running-agent PHOTO/sentinel paths, and the recursion-depth reset. The latter had a broader FIFO bug: after five or more queued events it could merge/reorder media or overwrite text while resetting recursion depth.

Email now also binds its RFC Message-ID onto `SessionSource`, matching the `MessageEvent`.

## Related Issue

No matching issue or PR was found after searching open and closed results for email attachment merging and busy-session media queues.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a generic adapter capability for complete media-message boundaries.
- Opt Email into boundary-preserving FIFO behavior.
- Route fallback/direct busy paths through the same queue contract.
- Restore recursion-capped pending events at the FIFO head without merging or reversing them.
- Bind `SessionSource.message_id` for Email.
- Add behavioral coverage for Email FIFO identity, base fallback with and without a runner, recursion-depth restoration, source Message-ID, and unchanged default photo-burst merging.

## How to Test

```bash
HERMES_PYTHON=/path/to/dev-venv/bin/python \
  scripts/run_tests.sh \
  tests/gateway/test_queue_consumption.py \
  tests/gateway/test_email.py \
  tests/gateway/test_busy_session_ack.py -q

ruff check \
  gateway/platforms/base.py \
  gateway/run.py \
  plugins/platforms/email/adapter.py \
  tests/gateway/test_email.py \
  tests/gateway/test_queue_consumption.py
```

Result: 134 tests passed; Ruff and `git diff --check` passed on macOS.

The full repository suite was also started through `scripts/run_tests.sh`, but this minimal local dev environment lacks the optional `acp` package and produced unrelated existing credential-test failures. The affected gateway suites above are clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing open and closed issues/PRs
- [x] The PR contains only this fix
- [ ] Full `pytest tests/ -q` in a complete all-extras environment
- [x] Tests were added for the bug
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Relevant inline capability documentation updated
- [x] `cli-config.yaml.example` — N/A; no user configuration key
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; existing generic architecture retained
- [x] Cross-platform impact considered; no platform-specific APIs added
- [x] Tool descriptions/schemas — N/A
