### PR TITLE
docs(mcp): update tool naming convention to double-underscore format

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
@@ -41,7 +41,7 @@ mcp_servers:
 Restart Hermes Agent. On startup it will:
 1. Connect to the server
 2. Discover available tools
-3. Register them with the prefix `mcp_time_*`
+3. Register them with the prefix `mcp__time__*`
 4. Inject them into all platform toolsets
 
 You can then use the tools naturally -- just ask the agent to get the current time.
@@ -105,15 +105,15 @@ When Hermes Agent starts, `discover_mcp_tools()` is called during tool initializ
 MCP tools are registered with the naming pattern:
 
 ```
-mcp_{server_name}_{tool_name}
+mcp__{server_name}__{tool_name}
 ```
 
-Hyphens and dots in names are replaced with underscores for LLM API compatibility.
+Double underscores separate each part. Hyphens and dots in names are replaced with underscores for LLM API compatibility.
 
 Examples:
-- Server `filesystem`, tool `read_file` → `mcp_filesystem_read_file`
-- Server `github`, tool `list-issues` → `mcp_github_list_issues`
-- Server `my-api`, tool `fetch.data` → `mcp_my_api_fetch_data`
+- Server `filesystem`, tool `read_file` → `mcp__filesystem__read_file`
+- Server `github`, tool `list-issues` → `mcp__github__list-issues`
+- Server `my-api`, tool `fetch.data` → `mcp__my_api__fetch_data`
 
 ### Auto-Injection
 
@@ -224,7 +224,7 @@ pip install --upgrade mcp
 - Check that the server is listed under `mcp_servers` (not `mcp` or `servers`)
 - Ensure the YAML indentation is correct
 - Look at Hermes Agent startup logs for connection messages
-- Tool names are prefixed with `mcp_{server}_{tool}` -- look for that pattern
+- Tool names are prefixed with `mcp__{server}__{tool}` -- look for that pattern
 
 ### Connection keeps dropping
 
@@ -241,7 +241,7 @@ mcp_servers:
     args: ["mcp-server-time"]
 ```
 
-Registers tools like `mcp_time_get_current_time`.
+Registers tools like `mcp__time__get_current_time`.
 
 ### Filesystem Server (npx)
 
@@ -253,7 +253,7 @@ mcp_servers:
     timeout: 30
 ```
 
-Registers tools like `mcp_filesystem_read_file`, `mcp_filesystem_write_file`, `mcp_filesystem_list_directory`.
+Registers tools like `mcp__filesystem__read_file`, `mcp__filesystem__write_file`, `mcp__filesystem__list_directory`.
 
 ### GitHub Server with Authentication
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -247,19 +247,19 @@ After changing MCP config, reload servers with:
 Server-native MCP tools become:
 
 ```text
-mcp_<server>_<tool>
+mcp__<server>__<tool>
 ```
 
 Examples:
-- `mcp_github_create_issue`
-- `mcp_filesystem_read_file`
-- `mcp_my_api_query_data`
+- `mcp__github__create_issue`
+- `mcp__filesystem__read_file`
+- `mcp__my_api__query_data`
 
 Utility tools follow the same prefixing pattern:
-- `mcp_<server>_list_resources`
-- `mcp_<server>_read_resource`
-- `mcp_<server>_list_prompts`
-- `mcp_<server>_get_prompt`
+- `mcp__<server>__list_resources`
+- `mcp__<server>__read_resource`
+- `mcp__<server>__list_prompts`
+- `mcp__<server>__get_prompt`
 
 ### Name sanitization
 
@@ -268,7 +268,7 @@ Hyphens (`-`) and dots (`.`) in both server names and tool names are replaced wi
 For example, a server named `my-api` exposing a tool called `list-items.v2` becomes:
 
 ```text
-mcp_my_api_list_items_v2
+mcp__my_api__list_items_v2
 ```
 
 Keep this in mind when writing `include` / `exclude` filters — use the **original** MCP tool name (with hyphens/dots), not the sanitized version.

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -383,16 +383,16 @@ You can pick any local name (`hermes mcp add my-codex --preset codex` is fine); 
 Hermes prefixes MCP tools so they do not collide with built-in names:
 
 ```text
-mcp_<server_name>_<tool_name>
+mcp__<server_name>__<tool_name>
 ```
 
 Examples:
 
 | Server | MCP tool | Registered name |
 |---|---|---|
-| `filesystem` | `read_file` | `mcp_filesystem_read_file` |
-| `github` | `create-issue` | `mcp_github_create_issue` |
-| `my-api` | `query.data` | `mcp_my_api_query_data` |
+| `filesystem` | `read_file` | `mcp__filesystem__read_file` |
+| `github` | `create-issue` | `mcp__github__create-issue` |
+| `my-api` | `query.data` | `mcp__my_api__query_data` |
 
 In practice, you usually do not need to call the prefixed name manually — Hermes sees the tool and chooses it during normal reasoning.
 
@@ -407,8 +407,8 @@ When supported, Hermes also registers utility tools around MCP resources and pro
 
 These are registered per server with the same prefix pattern, for example:
 
-- `mcp_github_list_resources`
-- `mcp_github_get_prompt`
+- `mcp__github__list_resources`
+- `mcp__github__get_prompt`
 
 ### Important
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/mcp-config-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/mcp-config-reference.md
@@ -204,19 +204,19 @@ mcp_servers:
 服务器原生 MCP 工具的命名格式为：
 
 ```text
-mcp_<server>_<tool>
+mcp__<server>__<tool>
 ```
 
 示例：
-- `mcp_github_create_issue`
-- `mcp_filesystem_read_file`
-- `mcp_my_api_query_data`
+- `mcp__github__create_issue`
+- `mcp__filesystem__read_file`
+- `mcp__my_api__query_data`
 
 工具包装器遵循相同的前缀规则：
-- `mcp_<server>_list_resources`
-- `mcp_<server>_read_resource`
-- `mcp_<server>_list_prompts`
-- `mcp_<server>_get_prompt`
+- `mcp__<server>__list_resources`
+- `mcp__<server>__read_resource`
+- `mcp__<server>__list_prompts`
+- `mcp__<server>__get_prompt`
 
 ### 名称规范化
 
@@ -225,7 +225,7 @@ mcp_<server>_<tool>
 例如，名为 `my-api` 的服务器暴露了名为 `list-items.v2` 的工具，注册后变为：
 
 ```text
-mcp_my_api_list_items_v2
+mcp__my_api__list_items_v2
 ```
 
 编写 `include` / `exclude` 过滤器时请注意——使用**原始** MCP 工具名称（含连字符/点号），而非规范化后的名称。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/mcp.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/mcp.md
@@ -156,16 +156,16 @@ mcp_servers:
 Hermes 为 MCP 工具添加前缀，避免与内置名称冲突：
 
 ```text
-mcp_<server_name>_<tool_name>
+mcp__<server_name>__<tool_name>
 ```
 
 示例：
 
 | 服务器 | MCP 工具 | 注册名称 |
 |---|---|---|
-| `filesystem` | `read_file` | `mcp_filesystem_read_file` |
-| `github` | `create-issue` | `mcp_github_create_issue` |
-| `my-api` | `query.data` | `mcp_my_api_query_data` |
+| `filesystem` | `read_file` | `mcp__filesystem__read_file` |
+| `github` | `create-issue` | `mcp__github__create-issue` |
+| `my-api` | `query.data` | `mcp__my_api__query_data` |
 
 实际使用中，你通常不需要手动调用带前缀的名称——Hermes 在正常推理过程中会自动识别并选择该工具。
 
@@ -180,8 +180,8 @@ mcp_<server_name>_<tool_name>
 
 这些工具按服务器注册，遵循相同的前缀规则，例如：
 
-- `mcp_github_list_resources`
-- `mcp_github_get_prompt`
+- `mcp__github__list_resources`
+- `mcp__github__get_prompt`
 
 ### 重要说明
 


### PR DESCRIPTION
## Problem

The MCP tool naming documentation describes the old `mcp_<server>_<tool>` (single underscore) convention, but the codebase adopted `mcp__<server>__<tool>` (double underscore) in commit `e01f58ff1` on 2026-07-05 (`feat(mcp): adopt mcp__server__tool naming convention`). The docs were not updated when the naming change landed.

This causes user confusion when:
- Writing `include`/`exclude` filters for MCP tools (the filter patterns must match the registered name)
- Referencing MCP tools by name in tool_call arguments
- Looking up tool names in logs or debug output

## Triage / Root cause

Commit `e01f58ff1` changed the naming convention in `agent/anthropic_adapter.py` and `agent/codex_runtime.py` (plus a companion test update `3d0276182`), but did not update any documentation files. Five files still contain the old single-underscore examples.

## Fix

Updated all MCP tool name examples from `mcp_<server>_<tool>` to `mcp__<server>__<tool>` across:

1. `website/docs/user-guide/features/mcp.md` — English user guide (naming section + utility tools examples)
2. `website/docs/reference/mcp-config-reference.md` — English config reference (tool naming + name sanitization examples)
3. `website/i18n/zh-Hans/.../user-guide/features/mcp.md` — Simplified Chinese locale mirror
4. `website/i18n/zh-Hans/.../reference/mcp-config-reference.md` — Simplified Chinese locale mirror
5. `skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md` — Agent skill reference (naming convention, examples, troubleshooting, and example server configs)

## Verification

- Confirmed the old naming (`mcp_filesystem_read_file`) no longer appears in any of the five updated files
- Confirmed the new naming (`mcp__filesystem__read_file`) matches the actual code convention used in `agent/anthropic_adapter.py` (`_MCP_TOOL_PREFIX = "mcp__"`)
- Checked for existing PRs addressing this docs drift — none found
