### PR TITLE
fix(hermes_cli): stop container privilege escalation via s6 gateway log symlink chown

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -287,6 +287,21 @@ if [ -d "$HERMES_HOME/cron" ]; then
     chown_hermes_tree "$HERMES_HOME/cron"
 fi
 
+# Always ensure logs/gateways is hermes-owned (#45258). Formerly healed by
+# restartable gateway log/run chown — removed due to symlink TOCTOU
+# (CWE-59/367). The targeted data-volume chown above only runs when the
+# top-level $HERMES_HOME is mis-owned, so a warm volume with hermes-owned
+# HERMES_HOME but root-owned logs/gateways would otherwise leave
+# s6-setuidgid hermes mkdir failing with Permission denied. Non-recursive:
+# profile leaf dirs are each created/owned by their own log/run as hermes.
+if [ -d "$HERMES_HOME/logs/gateways" ]; then
+    if refuse_symlinked_path "chown" "$HERMES_HOME/logs/gateways"; then
+        :
+    else
+        chown hermes:hermes "$HERMES_HOME/logs/gateways" 2>/dev/null || true
+    fi
+fi
+
 # Always reset ownership of pairing data on every boot, same docker-exec/
 # root-write reason as profiles/ and cron/. `docker exec <container>
 # hermes pairing approve …` defaults to uid=0 and writes 0600 root-owned

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -783,19 +783,20 @@ class S6ServiceManager:
             f"# shellcheck shell=sh\n"
             f': "${{HERMES_HOME:=/opt/data}}"\n'
             f'log_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
-            # Create the leaf as hermes when this script starts as root.
-            # Never chown hermes-writable volume paths from this restartable
-            # root-context script: log/supervise/control is hermes-owned, so
-            # an unprivileged user can race a pathname check/chown through a
-            # symlink swap (CWE-59 / CWE-367). Parent logs/gateways is seeded
-            # hermes-owned at stage2 boot (#45258;
-            # tests/docker/test_log_dir_seed.py).
+            # Create the leaf and clear a stale s6-log lock as hermes when
+            # this script starts as root. Never chown or unlink hermes-writable
+            # volume paths from this restartable root-context script:
+            # log/supervise/control is hermes-owned, so an unprivileged user
+            # can race a pathname op through a symlink swap (CWE-59 /
+            # CWE-367). Parent logs/gateways is seeded hermes-owned at stage2
+            # boot (#45258; tests/docker/test_log_dir_seed.py).
             f'if [ "$(id -u)" = 0 ]; then\n'
             f'  s6-setuidgid hermes mkdir -p "$log_dir"\n'
+            f'  s6-setuidgid hermes rm -f "$log_dir/lock"\n'
             f'else\n'
             f'  mkdir -p "$log_dir"\n'
+            f'  rm -f "$log_dir/lock"\n'
             f'fi\n'
-            f'rm -f "$log_dir/lock"\n'
             # Skip the drop when already non-root (CAP_SETGID).
             f'[ "$(id -u)" = 0 ] || exec s6-log 1 n10 s1000000 T "$log_dir"\n'
             f'exec s6-setuidgid hermes s6-log 1 n10 s1000000 T "$log_dir"\n'

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -783,17 +783,18 @@ class S6ServiceManager:
             f"# shellcheck shell=sh\n"
             f': "${{HERMES_HOME:=/opt/data}}"\n'
             f'log_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
-            f'mkdir -p "$log_dir"\n'
-            # The gateways/ parent must be chowned too (non-recursively):
-            # `mkdir -p` creates it root-owned on a root-context boot, and a
-            # leaf-only chown leaves it that way — every profile registered
-            # later then runs its log service as hermes and crash-loops on
-            # `mkdir: Permission denied`. The parent chown runs on every
-            # root-context boot, so it also heals volumes already poisoned
-            # by older images. Non-recursive on purpose: sibling profile
-            # dirs are each managed by their own log/run. See #45258.
-            f'chown hermes:hermes "$HERMES_HOME/logs/gateways" 2>/dev/null || true\n'
-            f'chown -R hermes:hermes "$log_dir" 2>/dev/null || true\n'
+            # Create the leaf as hermes when this script starts as root.
+            # Never chown hermes-writable volume paths from this restartable
+            # root-context script: log/supervise/control is hermes-owned, so
+            # an unprivileged user can race a pathname check/chown through a
+            # symlink swap (CWE-59 / CWE-367). Parent logs/gateways is seeded
+            # hermes-owned at stage2 boot (#45258;
+            # tests/docker/test_log_dir_seed.py).
+            f'if [ "$(id -u)" = 0 ]; then\n'
+            f'  s6-setuidgid hermes mkdir -p "$log_dir"\n'
+            f'else\n'
+            f'  mkdir -p "$log_dir"\n'
+            f'fi\n'
             f'rm -f "$log_dir/lock"\n'
             # Skip the drop when already non-root (CAP_SETGID).
             f'[ "$(id -u)" = 0 ] || exec s6-log 1 n10 s1000000 T "$log_dir"\n'

--- a/tests/docker/test_log_dir_seed.py
+++ b/tests/docker/test_log_dir_seed.py
@@ -10,7 +10,11 @@ s6-log crash-loops on mkdir: Permission denied.
 """
 from __future__ import annotations
 
-from tests.docker.conftest import docker_exec_sh, start_container
+from tests.docker.conftest import (
+    docker_exec_sh,
+    restart_container,
+    start_container,
+)
 
 
 def test_logs_gateways_seeded_and_hermes_owned(
@@ -45,3 +49,50 @@ def test_logs_gateways_seeded_and_hermes_owned(
     assert "gateways=hermes" in r.stdout, (
         f"logs/gateways/ not owned by hermes: {r.stdout}"
     )
+
+
+def test_logs_gateways_healed_when_parent_root_owned(
+    built_image: str, container_name: str,
+) -> None:
+    """Warm-boot stage2 must heal root-owned logs/gateways (#45258).
+
+    Mimics a poisoned volume: HERMES_HOME already hermes-owned (so the
+    bulk data-volume chown is skipped) while logs/gateways is root-owned.
+    Restartable log/run no longer root-chowns that path (symlink TOCTOU),
+    so stage2 must repair the parent on every boot.
+    """
+    start_container(built_image, container_name)
+
+    poison = docker_exec_sh(
+        container_name,
+        "chown root:root /opt/data/logs/gateways && "
+        'home_owner=$(stat -c "%U" /opt/data); '
+        'gateways_owner=$(stat -c "%U" /opt/data/logs/gateways); '
+        'echo "home=$home_owner gateways=$gateways_owner"',
+        user="root",
+        timeout=10,
+    )
+    assert poison.returncode == 0, (poison.stdout, poison.stderr)
+    assert "home=hermes" in poison.stdout, poison.stdout
+    assert "gateways=root" in poison.stdout, poison.stdout
+
+    denied = docker_exec_sh(
+        container_name,
+        "mkdir -p /opt/data/logs/gateways/poison-probe 2>/dev/null "
+        "&& echo MKDIR_OK || echo MKDIR_DENIED",
+        timeout=10,
+    )
+    assert "MKDIR_DENIED" in denied.stdout, denied.stdout
+
+    restart_container(container_name)
+
+    healed = docker_exec_sh(
+        container_name,
+        'gateways_owner=$(stat -c "%U" /opt/data/logs/gateways); '
+        "mkdir -p /opt/data/logs/gateways/poison-probe && "
+        'echo "gateways=$gateways_owner MKDIR_OK"',
+        timeout=10,
+    )
+    assert healed.returncode == 0, (healed.stdout, healed.stderr)
+    assert "gateways=hermes" in healed.stdout, healed.stdout
+    assert "MKDIR_OK" in healed.stdout, healed.stdout

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -1134,7 +1134,7 @@ def test_s6_log_run_creates_leaf_as_hermes_without_chown(
         f"saw: {log_text!r}"
     )
     assert 's6-setuidgid hermes mkdir -p "$log_dir"' in log_text
-    assert 'mkdir -p "$log_dir"' in log_text
+    assert 'else\n  mkdir -p "$log_dir"\nfi\n' in log_text
 
     mkdir_as_hermes_idx = log_text.index('s6-setuidgid hermes mkdir -p "$log_dir"')
     exec_idx = log_text.index("s6-log 1 ")

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -1103,36 +1103,226 @@ def test_s6_stop_tolerates_marker_write_failure(monkeypatch, s6_scandir):
     assert any(cmd[0] == "s6-svc" and "-d" in cmd for cmd in svc_calls)
 
 
-def test_s6_log_run_chowns_gateways_parent(s6_scandir, fake_subprocess_run) -> None:
-    """The log/run script must chown the logs/gateways/ parent, not just the leaf.
+def _log_run_setup_fragment(rendered: str) -> str:
+    """Keep mkdir/rm setup from ``_render_log_run``; stop before ``s6-log``."""
+    keep: list[str] = []
+    for line in rendered.splitlines(keepends=True):
+        if line.startswith("#!/") or "shellcheck" in line:
+            continue
+        if "s6-log" in line:
+            break
+        keep.append(line)
+    return "#!/bin/sh\n" + "".join(keep)
 
-    Regression guard for #45258: `mkdir -p` creates the gateways/ parent
-    root-owned on a root-context boot, and a leaf-only chown leaves it that
-    way. Every profile registered later then runs its log service as the
-    dropped hermes user and s6-log crash-loops on `mkdir: Permission denied`.
+
+def test_s6_log_run_creates_leaf_as_hermes_without_chown(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """log/run must not root-chown volume paths; create the leaf as hermes.
+
+    #45258 parent ownership is stage2's job (``logs/gateways`` seeded as
+    hermes). Restartable log/run must not pathname-chown a hermes-writable
+    tree from root — that is a symlink TOCTOU privilege-escalation hole.
     """
     mgr = S6ServiceManager(scandir=s6_scandir)
     mgr.register_profile_gateway("coder")
 
     log_text = (s6_scandir / "gateway-coder" / "log" / "run").read_text()
 
-    parent_chown = 'chown hermes:hermes "$HERMES_HOME/logs/gateways"'
-    assert parent_chown in log_text, (
-        "log/run must chown the logs/gateways parent so profiles added "
-        f"after a root-context boot can create their leaf dirs. Saw: {log_text!r}"
+    assert not any(line.lstrip().startswith("chown ") for line in log_text.splitlines()), (
+        "restartable log/run must not invoke chown on hermes-writable paths; "
+        f"saw: {log_text!r}"
     )
-    # Non-recursive on purpose: sibling profile leaf dirs are each managed
-    # by their own log/run; a recursive parent chown would race them.
-    assert 'chown -R hermes:hermes "$HERMES_HOME/logs/gateways"' not in log_text
+    assert 's6-setuidgid hermes mkdir -p "$log_dir"' in log_text
+    assert 'mkdir -p "$log_dir"' in log_text
 
-    # Ordering: mkdir creates the parent, then the parent chown repairs its
-    # ownership, then the leaf chown — all before s6-log execs.
-    mkdir_idx = log_text.index('mkdir -p "$log_dir"')
-    parent_idx = log_text.index(parent_chown)
-    leaf_idx = log_text.index('chown -R hermes:hermes "$log_dir"')
+    mkdir_as_hermes_idx = log_text.index('s6-setuidgid hermes mkdir -p "$log_dir"')
     exec_idx = log_text.index("s6-log 1 ")
-    assert mkdir_idx < parent_idx < leaf_idx < exec_idx
+    assert mkdir_as_hermes_idx < exec_idx
 
-    # The parent path must be a runtime env expansion, never a baked-in
-    # absolute path (same contract as the log_dir itself).
+    # Runtime path expansion, never a baked-in absolute path.
     assert '/opt/data/logs/gateways"' not in log_text
+
+
+def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None:
+    """Symlinked ``$log_dir`` must not cause any chown of the referent."""
+    import os
+    import stat
+    import subprocess
+    import threading
+    import time
+
+    import pytest
+
+    if os.name == "nt":
+        pytest.skip("POSIX symlink + /bin/sh required")
+
+    hermes_home = tmp_path / "hermes"
+    gateways = hermes_home / "logs" / "gateways"
+    gateways.mkdir(parents=True)
+    leaf = gateways / "coder"
+    leaf.mkdir()
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "marker").write_text("keep", encoding="utf-8")
+    before = victim.stat()
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    recorder = tmp_path / "chown_calls.txt"
+    (bin_dir / "chown").write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> "{recorder.as_posix()}"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    # Pretend we are root so the script takes the s6-setuidgid mkdir path,
+    # and make s6-setuidgid a no-op drop that just runs the command.
+    (bin_dir / "id").write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "-u" ]; then echo 0; exit 0; fi\n'
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    (bin_dir / "s6-setuidgid").write_text(
+        "#!/bin/sh\n"
+        "shift\n"
+        'exec "$@"\n',
+        encoding="utf-8",
+    )
+    for name in ("chown", "id", "s6-setuidgid"):
+        p = bin_dir / name
+        p.chmod(p.stat().st_mode | stat.S_IXUSR)
+
+    script_path = tmp_path / "log_run_setup.sh"
+    script_path.write_text(
+        _log_run_setup_fragment(S6ServiceManager._render_log_run("coder")),
+        encoding="utf-8",
+    )
+    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+
+    stop = threading.Event()
+
+    def _clear_leaf() -> None:
+        if leaf.is_symlink():
+            leaf.unlink()
+        elif leaf.is_dir():
+            leaf.rmdir()
+        elif leaf.exists():
+            leaf.unlink()
+
+    def _swap_race() -> None:
+        # Alternate leaf between a real dir and a symlink to the victim while
+        # the setup fragment runs — proves there is no privileged chown window
+        # to win, unlike a check-then-chown preflight.
+        while not stop.is_set():
+            try:
+                _clear_leaf()
+                leaf.symlink_to(victim)
+                time.sleep(0.001)
+                _clear_leaf()
+                leaf.mkdir()
+            except OSError:
+                pass
+            time.sleep(0.001)
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["PATH"] = f"{bin_dir.as_posix()}{os.pathsep}{env.get('PATH', '')}"
+
+    racer = threading.Thread(target=_swap_race, daemon=True)
+    racer.start()
+    try:
+        for _ in range(40):
+            proc = subprocess.run(
+                ["/bin/sh", str(script_path)],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert proc.returncode == 0, (proc.stdout, proc.stderr)
+    finally:
+        stop.set()
+        racer.join(timeout=2)
+
+    assert not recorder.exists() or recorder.read_text(encoding="utf-8").strip() == ""
+    after = victim.stat()
+    assert after.st_uid == before.st_uid
+    assert after.st_gid == before.st_gid
+    assert (victim / "marker").read_text(encoding="utf-8") == "keep"
+
+
+def test_s6_log_run_mkdir_as_hermes_on_real_dirs(tmp_path) -> None:
+    """Root-context setup creates ``$log_dir`` via ``s6-setuidgid hermes mkdir``."""
+    import os
+    import stat
+    import subprocess
+
+    import pytest
+
+    if os.name == "nt":
+        pytest.skip("POSIX /bin/sh required")
+
+    hermes_home = tmp_path / "hermes"
+    (hermes_home / "logs" / "gateways").mkdir(parents=True)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    mkdir_recorder = tmp_path / "mkdir_via_setuidgid.txt"
+    chown_recorder = tmp_path / "chown_calls.txt"
+
+    (bin_dir / "id").write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "-u" ]; then echo 0; exit 0; fi\n'
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    (bin_dir / "s6-setuidgid").write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> "{mkdir_recorder.as_posix()}"\n'
+        "shift\n"
+        'exec "$@"\n',
+        encoding="utf-8",
+    )
+    (bin_dir / "chown").write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> "{chown_recorder.as_posix()}"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    for name in ("id", "s6-setuidgid", "chown"):
+        p = bin_dir / name
+        p.chmod(p.stat().st_mode | stat.S_IXUSR)
+
+    script_path = tmp_path / "log_run_setup.sh"
+    script_path.write_text(
+        _log_run_setup_fragment(S6ServiceManager._render_log_run("coder")),
+        encoding="utf-8",
+    )
+    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["PATH"] = f"{bin_dir.as_posix()}{os.pathsep}{env.get('PATH', '')}"
+
+    proc = subprocess.run(
+        ["/bin/sh", str(script_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (proc.stdout, proc.stderr)
+
+    mkdir_calls = mkdir_recorder.read_text(encoding="utf-8").strip().splitlines()
+    assert any(
+        c.split()[:3] == ["hermes", "mkdir", "-p"] and "gateways/coder" in c
+        for c in mkdir_calls
+    ), mkdir_calls
+    assert (hermes_home / "logs" / "gateways" / "coder").is_dir()
+    assert (
+        not chown_recorder.exists()
+        or chown_recorder.read_text(encoding="utf-8").strip() == ""
+    )

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -1118,11 +1118,11 @@ def _log_run_setup_fragment(rendered: str) -> str:
 def test_s6_log_run_creates_leaf_as_hermes_without_chown(
     s6_scandir, fake_subprocess_run,
 ) -> None:
-    """log/run must not root-chown volume paths; create the leaf as hermes.
+    """log/run must not root-chown/unlink volume paths; create leaf as hermes.
 
     #45258 parent ownership is stage2's job (``logs/gateways`` seeded as
-    hermes). Restartable log/run must not pathname-chown a hermes-writable
-    tree from root — that is a symlink TOCTOU privilege-escalation hole.
+    hermes). Restartable log/run must not pathname-chown or pathname-rm a
+    hermes-writable tree from root — that is a symlink TOCTOU hole.
     """
     mgr = S6ServiceManager(scandir=s6_scandir)
     mgr.register_profile_gateway("coder")
@@ -1134,18 +1134,23 @@ def test_s6_log_run_creates_leaf_as_hermes_without_chown(
         f"saw: {log_text!r}"
     )
     assert 's6-setuidgid hermes mkdir -p "$log_dir"' in log_text
-    assert 'else\n  mkdir -p "$log_dir"\nfi\n' in log_text
+    assert 's6-setuidgid hermes rm -f "$log_dir/lock"' in log_text
+    assert 'else\n  mkdir -p "$log_dir"\n  rm -f "$log_dir/lock"\nfi\n' in log_text
+    # Lock cleanup must not remain a bare root-context pathname op after fi.
+    after_fi = log_text.split("fi\n", 1)[-1]
+    assert 'rm -f "$log_dir/lock"' not in after_fi
 
     mkdir_as_hermes_idx = log_text.index('s6-setuidgid hermes mkdir -p "$log_dir"')
+    rm_as_hermes_idx = log_text.index('s6-setuidgid hermes rm -f "$log_dir/lock"')
     exec_idx = log_text.index("s6-log 1 ")
-    assert mkdir_as_hermes_idx < exec_idx
+    assert mkdir_as_hermes_idx < rm_as_hermes_idx < exec_idx
 
     # Runtime path expansion, never a baked-in absolute path.
     assert '/opt/data/logs/gateways"' not in log_text
 
 
 def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None:
-    """Symlinked ``$log_dir`` must not cause any chown of the referent."""
+    """Symlinked ``$log_dir`` must not redirect root chown/rm to the referent."""
     import os
     import stat
     import subprocess
@@ -1166,6 +1171,7 @@ def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None
     victim = tmp_path / "victim"
     victim.mkdir()
     (victim / "marker").write_text("keep", encoding="utf-8")
+    (victim / "lock").write_text("keep-lock", encoding="utf-8")
     before = victim.stat()
 
     bin_dir = tmp_path / "bin"
@@ -1177,8 +1183,9 @@ def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None
         "exit 0\n",
         encoding="utf-8",
     )
-    # Pretend we are root so the script takes the s6-setuidgid mkdir path,
-    # and make s6-setuidgid a no-op drop that just runs the command.
+    # Pretend we are root so the script takes the s6-setuidgid setup path.
+    # Mark the drop so fake rm can refuse unlink outside HERMES_HOME the way
+    # a real hermes uid cannot delete a foreign root-owned lock.
     (bin_dir / "id").write_text(
         "#!/bin/sh\n"
         'if [ "$1" = "-u" ]; then echo 0; exit 0; fi\n'
@@ -1188,10 +1195,23 @@ def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None
     (bin_dir / "s6-setuidgid").write_text(
         "#!/bin/sh\n"
         "shift\n"
-        'exec "$@"\n',
+        'HERMES_TEST_DROPPED=1 exec "$@"\n',
         encoding="utf-8",
     )
-    for name in ("chown", "id", "s6-setuidgid"):
+    real_rm = "/bin/rm"
+    (bin_dir / "rm").write_text(
+        "#!/bin/sh\n"
+        # Privilege-dropped: no-op. Models that hermes cannot unlink a foreign
+        # root-owned lock outside the volume; avoids a realpath/rm TOCTOU in
+        # the test double itself. Root-context: real rm — a residual bare
+        # ``rm -f "$log_dir/lock"`` would delete victim/lock via the symlink.
+        'if [ -n "$HERMES_TEST_DROPPED" ]; then\n'
+        "  exit 0\n"
+        "fi\n"
+        f'exec {real_rm} "$@"\n',
+        encoding="utf-8",
+    )
+    for name in ("chown", "id", "s6-setuidgid", "rm"):
         p = bin_dir / name
         p.chmod(p.stat().st_mode | stat.S_IXUSR)
 
@@ -1214,8 +1234,8 @@ def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None
 
     def _swap_race() -> None:
         # Alternate leaf between a real dir and a symlink to the victim while
-        # the setup fragment runs — proves there is no privileged chown window
-        # to win, unlike a check-then-chown preflight.
+        # the setup fragment runs — proves there is no privileged chown/rm
+        # window to win, unlike a check-then-use preflight.
         while not stop.is_set():
             try:
                 _clear_leaf()
@@ -1243,6 +1263,7 @@ def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None
                 check=False,
             )
             assert proc.returncode == 0, (proc.stdout, proc.stderr)
+            assert (victim / "lock").is_file(), "symlinked leaf must not let root unlink victim/lock"
     finally:
         stop.set()
         racer.join(timeout=2)
@@ -1252,6 +1273,7 @@ def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None
     assert after.st_uid == before.st_uid
     assert after.st_gid == before.st_gid
     assert (victim / "marker").read_text(encoding="utf-8") == "keep"
+    assert (victim / "lock").read_text(encoding="utf-8") == "keep-lock"
 
 
 def test_s6_log_run_mkdir_as_hermes_on_real_dirs(tmp_path) -> None:
@@ -1270,7 +1292,7 @@ def test_s6_log_run_mkdir_as_hermes_on_real_dirs(tmp_path) -> None:
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    mkdir_recorder = tmp_path / "mkdir_via_setuidgid.txt"
+    setuid_recorder = tmp_path / "setuidgid_calls.txt"
     chown_recorder = tmp_path / "chown_calls.txt"
 
     (bin_dir / "id").write_text(
@@ -1281,7 +1303,7 @@ def test_s6_log_run_mkdir_as_hermes_on_real_dirs(tmp_path) -> None:
     )
     (bin_dir / "s6-setuidgid").write_text(
         "#!/bin/sh\n"
-        f'printf "%s\\n" "$*" >> "{mkdir_recorder.as_posix()}"\n'
+        f'printf "%s\\n" "$*" >> "{setuid_recorder.as_posix()}"\n'
         "shift\n"
         'exec "$@"\n',
         encoding="utf-8",
@@ -1316,11 +1338,15 @@ def test_s6_log_run_mkdir_as_hermes_on_real_dirs(tmp_path) -> None:
     )
     assert proc.returncode == 0, (proc.stdout, proc.stderr)
 
-    mkdir_calls = mkdir_recorder.read_text(encoding="utf-8").strip().splitlines()
+    setuid_calls = setuid_recorder.read_text(encoding="utf-8").strip().splitlines()
     assert any(
         c.split()[:3] == ["hermes", "mkdir", "-p"] and "gateways/coder" in c
-        for c in mkdir_calls
-    ), mkdir_calls
+        for c in setuid_calls
+    ), setuid_calls
+    assert any(
+        c.split()[:3] == ["hermes", "rm", "-f"] and c.rstrip().endswith("/lock")
+        for c in setuid_calls
+    ), setuid_calls
     assert (hermes_home / "logs" / "gateways" / "coder").is_dir()
     assert (
         not chown_recorder.exists()


### PR DESCRIPTION
## Summary
Removes restartable root `chown` from s6 gateway `log/run` scripts to close a symlink TOCTOU privilege escalation (CWE-59/CWE-367) where an unprivileged `hermes` user could swap a symlink to re-own arbitrary paths like `/etc`.

## Changes
- `hermes_cli/service_manager.py`: Replace root-context `chown`/`rm` on hermes-writable volume paths with `s6-setuidgid hermes mkdir`/`rm` (privilege-dropped ops that can't redirect through symlink swaps)
- `docker/stage2-hook.sh`: Heal `logs/gateways` parent ownership on every boot (non-recursive, with `refuse_symlinked_path` guard) — moves the chown from the restartable high-risk path to the single-shot low-risk boot path
- `tests/hermes_cli/test_service_manager.py`: No-chown contract test, symlink swap-race proving test, mkdir-as-hermes integration test
- `tests/docker/test_log_dir_seed.py`: Container regression test for poisoned parent after reboot

## Validation
| | Before | After |
|---|---|---|
| `chown` in restartable log/run | yes (CWE-59/367) | none |
| Parent ownership heal | in log/run (restartable) | in stage2 (boot-only) |
| Tests | 65 (old contract) | 68 (new contract + swap-race + mkdir-as-hermes) |
| E2E smoke | chown present | no chown, s6-setuidgid hermes mkdir/rm confirmed |

Salvage of #71682 by @fangliquanflq — cherry-picked with authorship preserved.

Closes #71682
