### PR TITLE
fix(agent): redecorate prompt-cache breakpoints after provider failover

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -72,7 +72,10 @@ from agent.model_metadata import (
     save_context_length,
 )
 from agent.process_bootstrap import _install_safe_stdio
-from agent.prompt_caching import apply_anthropic_cache_control
+from agent.prompt_caching import (
+    apply_anthropic_cache_control,
+    strip_anthropic_cache_control,
+)
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
@@ -834,6 +837,134 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
         if not _rewrite_system_content_blocks(api_messages[0], effective):
             api_messages[0]["content"] = effective
     return sp
+
+
+def _ensure_cached_system_prompt_static(agent, system_message=None) -> None:
+    """Rebuild ``_cached_system_prompt_static`` when caching becomes active.
+
+    Sessions restored under a cache-off primary skip the static-prefix rebuild
+    (gated on ``_use_prompt_caching`` at restore time). A later failover to a
+    cache-on provider would otherwise redecorate with ``static_system_prefix=
+    None`` and silently fall back to the legacy system-plus-3 layout (#72626).
+    """
+    if not getattr(agent, "_use_prompt_caching", False):
+        return
+    stored = getattr(agent, "_cached_system_prompt", None)
+    if not isinstance(stored, str) or not stored:
+        return
+    existing = getattr(agent, "_cached_system_prompt_static", None)
+    if isinstance(existing, str) and existing and stored.startswith(existing):
+        return
+    try:
+        from agent.system_prompt import build_system_prompt_parts as _build_parts
+
+        static = _build_parts(agent, system_message=system_message)["stable"]
+        if static and stored.startswith(static):
+            agent._cached_system_prompt_static = static
+        else:
+            agent._cached_system_prompt_static = None
+    except Exception:
+        logger.debug(
+            "static system-prefix reconstruction failed on failover redecoration",
+            exc_info=True,
+        )
+        agent._cached_system_prompt_static = None
+
+
+def _peel_moa_guidance(
+    messages: List[Dict[str, Any]],
+    guidance: Any,
+) -> List[Dict[str, Any]]:
+    """Remove MoA reference guidance previously attached by ``_attach_reference_guidance``.
+
+    Redecoration must run on the base transcript so the last cache breakpoint
+    does not land on the turn-varying guidance block; callers then rebase via
+    ``rebase_prepared_request`` (#72626).
+    """
+    if not guidance or not messages:
+        return messages
+    guidance_text = str(guidance)
+    last = messages[-1]
+    if not isinstance(last, dict) or last.get("role") != "user":
+        return messages
+    content = last.get("content")
+    if content == guidance_text:
+        return list(messages[:-1])
+    suffix = "\n\n" + guidance_text
+    if isinstance(content, str) and content.endswith(suffix):
+        peeled = dict(last)
+        peeled["content"] = content[: -len(suffix)]
+        return [*messages[:-1], peeled]
+    if isinstance(content, list) and content:
+        last_part = content[-1]
+        if isinstance(last_part, dict) and last_part.get("type", "text") == "text":
+            text = last_part.get("text") or ""
+            if text == suffix or text == guidance_text:
+                peeled = dict(last)
+                peeled["content"] = list(content[:-1])
+                return [*messages[:-1], peeled]
+            if text.endswith(suffix):
+                new_part = dict(last_part)
+                new_part["text"] = text[: -len(suffix)]
+                peeled = dict(last)
+                peeled["content"] = [*content[:-1], new_part]
+                return [*messages[:-1], peeled]
+    return messages
+
+
+def _redecorate_prompt_cache_for_provider(
+    agent,
+    api_messages: List[Dict[str, Any]],
+    *,
+    system_message=None,
+    moa_prepared: Optional[Dict[str, Any]] = None,
+) -> tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Strip and re-apply cache_control for the *current* provider policy.
+
+    Decoration runs once per call block before the retry loop for the primary
+    provider. ``try_activate_fallback`` refreshes ``_use_prompt_caching`` /
+    ``_use_native_cache_layout`` but the nine failover ``continue`` paths reused
+    the old ``api_messages`` (#72626). Mirror ``_reapply_reasoning_echo_for_provider``
+    by reshaping at the top of each retry attempt.
+
+    The source list is the mutated in-flight request (image shrink / ASCII /
+    reasoning_details recoveries already applied) — never a pristine
+    pre-decoration snapshot. MoA guidance is peeled, the base is redecorated,
+    then ``rebase_prepared_request`` re-attaches guidance outside the cached
+    span.
+    """
+    messages: List[Dict[str, Any]] = [
+        dict(m) if isinstance(m, dict) else m for m in (api_messages or [])
+    ]
+    prepared = moa_prepared
+    guidance = prepared.get("guidance") if isinstance(prepared, dict) else None
+    if guidance:
+        messages = _peel_moa_guidance(messages, guidance)
+
+    strip_anthropic_cache_control(messages)
+
+    if getattr(agent, "_use_prompt_caching", False):
+        _ensure_cached_system_prompt_static(agent, system_message=system_message)
+        static = getattr(agent, "_cached_system_prompt_static", None)
+        messages = apply_anthropic_cache_control(
+            messages,
+            cache_ttl=getattr(agent, "_cache_ttl", None) or "5m",
+            native_anthropic=bool(getattr(agent, "_use_native_cache_layout", False)),
+            static_system_prefix=static if isinstance(static, str) else None,
+        )
+
+    if (
+        prepared is not None
+        and getattr(agent, "provider", None) == "moa"
+        and guidance
+    ):
+        completions = getattr(getattr(agent.client, "chat", None), "completions", None)
+        rebase = getattr(completions, "rebase_prepared_request", None)
+        if callable(rebase):
+            prepared = rebase(prepared, messages)
+            messages = prepared["messages"]
+
+    return messages, prepared
 
 
 def _apply_context_engine_selection(
@@ -1906,6 +2037,18 @@ def run_conversation(
                 # unless the active provider needs it) so the fallback request
                 # isn't sent with stale, primary-shaped reasoning fields.
                 agent._reapply_reasoning_echo_for_provider(api_messages)
+                # Same story for prompt-cache decoration (#72626): try_activate_
+                # fallback refreshes the policy flags, but the decorated list
+                # still carries the primary's breakpoints (or none). Strip and
+                # re-render for the current provider before building kwargs.
+                api_messages, _moa_prepared_request = (
+                    _redecorate_prompt_cache_for_provider(
+                        agent,
+                        api_messages,
+                        system_message=system_message,
+                        moa_prepared=_moa_prepared_request,
+                    )
+                )
                 api_kwargs = agent._build_api_kwargs(api_messages)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -119,6 +119,43 @@ def _apply_system_cache_markers(
     return 1
 
 
+def strip_anthropic_cache_control(
+    api_messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Remove ``cache_control`` markers and flatten pure-text content lists.
+
+    Used before re-applying decoration after a mid-turn provider failover so
+    the mutated, undecorated shape (image shrink / ASCII cleanup / etc.) is
+    preserved while markers match the *new* provider's cache policy (#72626).
+
+    Pure-text content lists (including the ``[static, volatile]`` system
+    layout) are flattened back to a single string so
+    :func:`apply_anthropic_cache_control` can re-split them. Multimodal
+    content lists keep their part structure; only per-part markers are
+    removed.
+
+    Mutates ``api_messages`` in place and returns the same list.
+    """
+    for msg in api_messages:
+        if not isinstance(msg, dict):
+            continue
+        msg.pop("cache_control", None)
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if isinstance(part, dict):
+                part.pop("cache_control", None)
+        if content and all(
+            isinstance(part, dict)
+            and part.get("type", "text") == "text"
+            and isinstance(part.get("text"), str)
+            for part in content
+        ):
+            msg["content"] = "".join(part["text"] for part in content)
+    return api_messages
+
+
 def apply_anthropic_cache_control(
     api_messages: List[Dict[str, Any]],
     cache_ttl: str = "5m",

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -11,7 +11,10 @@ gpt-5.4-mini after a Codex usage-limit 429.
 from types import SimpleNamespace
 
 from agent.chat_completion_helpers import rewrite_prompt_model_identity
-from agent.conversation_loop import _sync_failover_system_message
+from agent.conversation_loop import (
+    _redecorate_prompt_cache_for_provider,
+    _sync_failover_system_message,
+)
 from agent.prompt_caching import apply_anthropic_cache_control
 
 
@@ -31,6 +34,40 @@ def _agent(prompt=_PROMPT, ephemeral=None):
     return SimpleNamespace(
         _cached_system_prompt=prompt,
         ephemeral_system_prompt=ephemeral,
+    )
+
+
+def _count_cache_markers(messages):
+    count = 0
+    for msg in messages:
+        if "cache_control" in msg:
+            count += 1
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and "cache_control" in part:
+                    count += 1
+    return count
+
+
+def _cache_agent(
+    *,
+    use_caching,
+    native=False,
+    prompt=_PROMPT,
+    static=None,
+    cache_ttl="5m",
+    provider="openai",
+):
+    return SimpleNamespace(
+        _cached_system_prompt=prompt,
+        _cached_system_prompt_static=static,
+        ephemeral_system_prompt=None,
+        _use_prompt_caching=use_caching,
+        _use_native_cache_layout=native,
+        _cache_ttl=cache_ttl,
+        provider=provider,
+        client=None,
     )
 
 
@@ -189,3 +226,153 @@ class TestSyncFailoverPreservesCacheDecoration:
         ]
         _sync_failover_system_message(agent, api_messages, _PROMPT)
         assert api_messages[0]["content"] == agent._cached_system_prompt
+
+
+class TestRedecoratePromptCacheOnPolicyChange:
+    """#72626: failover must re-render breakpoints for the *new* cache policy.
+
+    ``TestSyncFailoverPreservesCacheDecoration`` only covers same-policy
+    identity sync (native→native). These cases cover the policy-change class.
+    """
+
+    _STATIC = "You are a helpful assistant.\n\nStable brief.\n"
+
+    def test_cache_off_to_cache_on_adds_breakpoints(self):
+        prompt = self._STATIC + "Model: gpt-5.4-mini\nProvider: openai"
+        # Primary never decorated (cache-off).
+        undecorated = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "again"},
+        ]
+        assert _count_cache_markers(undecorated) == 0
+
+        agent = _cache_agent(
+            use_caching=True,
+            native=True,
+            prompt=prompt,
+            static=self._STATIC,
+            provider="anthropic",
+        )
+        decorated, _ = _redecorate_prompt_cache_for_provider(agent, undecorated)
+        assert _count_cache_markers(decorated) >= 2
+        assert isinstance(decorated[0]["content"], list)
+        assert decorated[0]["content"][0]["text"] == self._STATIC
+
+    def test_cache_on_to_cache_off_strips_breakpoints(self):
+        prompt = self._STATIC + "Model: claude\nProvider: anthropic"
+        decorated = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": "hello"},
+            ],
+            native_anthropic=True,
+            static_system_prefix=self._STATIC,
+        )
+        assert _count_cache_markers(decorated) >= 2
+
+        agent = _cache_agent(
+            use_caching=False,
+            native=False,
+            prompt=prompt,
+            static=self._STATIC,
+            provider="custom",
+        )
+        stripped, _ = _redecorate_prompt_cache_for_provider(agent, decorated)
+        assert _count_cache_markers(stripped) == 0
+        assert stripped[0]["content"] == prompt
+
+    def test_native_to_envelope_relocates_breakpoints_to_carriers(self):
+        prompt = "Model: claude\nProvider: anthropic"
+        # Native layout can mark empty assistant turns; envelope cannot.
+        native = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": "do it"},
+                {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+                {"role": "tool", "content": "ok", "tool_call_id": "1"},
+                {"role": "user", "content": "thanks"},
+            ],
+            native_anthropic=True,
+        )
+        agent = _cache_agent(
+            use_caching=True,
+            native=False,
+            prompt=prompt,
+            provider="openrouter",
+        )
+        envelope, _ = _redecorate_prompt_cache_for_provider(agent, native)
+        # Empty assistant must not carry a wasted top-level marker on envelope.
+        empty_assistant = next(
+            m for m in envelope if m.get("role") == "assistant" and not m.get("content")
+        )
+        assert "cache_control" not in empty_assistant
+        assert _count_cache_markers(envelope) >= 1
+
+    def test_preserves_mutated_tool_result_bytes(self):
+        # Redecoration must use the in-flight mutated list, not a pristine
+        # pre-decoration snapshot — image-shrink / ASCII recoveries live here.
+        prompt = "sys"
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "run"},
+            {"role": "tool", "content": "SHRUNK_IMAGE_PAYLOAD", "tool_call_id": "t1"},
+        ]
+        agent = _cache_agent(use_caching=True, native=True, prompt=prompt)
+        out, _ = _redecorate_prompt_cache_for_provider(agent, messages)
+        tool = next(m for m in out if m.get("role") == "tool")
+        text = (
+            tool["content"]
+            if isinstance(tool["content"], str)
+            else tool["content"][0]["text"]
+        )
+        assert text == "SHRUNK_IMAGE_PAYLOAD"
+
+    def test_moa_guidance_stays_outside_last_breakpoint(self):
+        prompt = "sys"
+        guidance = (
+            "[Mixture of Agents context — use this as private guidance for the "
+            "normal Hermes agent loop.]\nAggregator: agg\n\nadvice"
+        )
+        base = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "task\n\n" + guidance},
+        ]
+        decorated = apply_anthropic_cache_control(base, native_anthropic=True)
+
+        class _Completions:
+            def rebase_prepared_request(self, prepared, messages):
+                from agent.moa_loop import _attach_reference_guidance
+
+                out = [dict(m) for m in messages]
+                _attach_reference_guidance(out, prepared["guidance"])
+                return {**prepared, "messages": out}
+
+        agent = _cache_agent(use_caching=True, native=True, prompt=prompt, provider="moa")
+        agent.client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+        prepared = {"guidance": guidance, "messages": decorated}
+        out, new_prepared = _redecorate_prompt_cache_for_provider(
+            agent, decorated, moa_prepared=prepared
+        )
+        assert new_prepared is not None
+        # Guidance must be present, but the cache marker on the last user
+        # turn's content parts must terminate *before* the guidance text.
+        last = out[-1]
+        assert last.get("role") == "user"
+        content = last["content"]
+        if isinstance(content, list):
+            marked = [p for p in content if isinstance(p, dict) and "cache_control" in p]
+            guidance_parts = [
+                p for p in content
+                if isinstance(p, dict) and guidance in (p.get("text") or "")
+            ]
+            assert marked, "base transcript should still carry breakpoints"
+            assert guidance_parts, "guidance must be re-attached"
+            # Marked part should not contain the guidance body.
+            assert all(guidance not in (p.get("text") or "") for p in marked)
+        else:
+            assert guidance in content
+

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -5,6 +5,7 @@ from agent.prompt_caching import (
     _apply_cache_marker,
     _can_carry_marker,
     apply_anthropic_cache_control,
+    strip_anthropic_cache_control,
 )
 
 
@@ -317,7 +318,10 @@ class TestNormalizationOrdering:
         from agent import conversation_loop
 
         src = inspect.getsource(conversation_loop)
-        mark = src.index("apply_anthropic_cache_control(\n")
+        # Anchor on the call-block decoration (before the retry loop), not the
+        # mid-failover redecoration helper which also calls apply_*.
+        anchor = src.index("Runs LAST, after every message mutation above")
+        mark = src.index("apply_anthropic_cache_control(\n", anchor)
         for earlier in (
             'am["content"].strip()',              # whitespace normalization
             "_sanitize_api_messages(api_messages)",       # orphan sweep
@@ -327,3 +331,65 @@ class TestNormalizationOrdering:
             assert src.index(earlier) < mark, (
                 f"{earlier!r} must run before cache breakpoints are injected"
             )
+
+
+class TestStripAnthropicCacheControl:
+    """strip must undo decoration so failover can re-render for a new policy."""
+
+    def test_removes_top_level_and_part_markers(self):
+        messages = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "yo"},
+            ],
+            native_anthropic=True,
+        )
+        assert any(
+            "cache_control" in (m if isinstance(m.get("content"), str) else {})
+            or (
+                isinstance(m.get("content"), list)
+                and any(
+                    isinstance(p, dict) and "cache_control" in p for p in m["content"]
+                )
+            )
+            or "cache_control" in m
+            for m in messages
+        )
+        strip_anthropic_cache_control(messages)
+        for msg in messages:
+            assert "cache_control" not in msg
+            content = msg.get("content")
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict):
+                        assert "cache_control" not in part
+
+    def test_flattens_system_static_volatile_back_to_string(self):
+        static = "You are helpful.\n"
+        full = static + "Model: claude\nProvider: anthropic"
+        messages = apply_anthropic_cache_control(
+            [{"role": "system", "content": full}, {"role": "user", "content": "hi"}],
+            native_anthropic=True,
+            static_system_prefix=static,
+        )
+        assert isinstance(messages[0]["content"], list)
+        strip_anthropic_cache_control(messages)
+        assert messages[0]["content"] == full
+
+    def test_preserves_multimodal_part_structure(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "see", "cache_control": {"type": "ephemeral"}},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,xx"}},
+                ],
+            }
+        ]
+        strip_anthropic_cache_control(messages)
+        content = messages[0]["content"]
+        assert isinstance(content, list) and len(content) == 2
+        assert content[0] == {"type": "text", "text": "see"}
+        assert content[1]["type"] == "image_url"
+


### PR DESCRIPTION
## Summary

- Provider failover refreshed `_use_prompt_caching` / `_use_native_cache_layout` but the retry loop kept shipping the primary's decorated `api_messages` (#72626).
- Cache-off → cache-on ran with **zero** breakpoints (full input price); cache-on → cache-off left stale `cache_control`; native ↔ envelope misplaced markers on empty assistant/tool turns.
- Add `strip_anthropic_cache_control` and a single `_redecorate_prompt_cache_for_provider` chokepoint at each retry attempt (next to reasoning-echo reapply), peel/rebase MoA guidance so the last marker stays off the turn-varying block, and rebuild `_cached_system_prompt_static` when caching becomes active mid-turn.

Fixes #72626

## Test plan

- [x] `scripts/run_tests.sh tests/agent/test_prompt_caching.py tests/agent/test_failover_identity.py -q`
- [ ] Fail over cache-off primary → Anthropic/OpenRouter cache-on fallback; confirm request carries breakpoints (not zero)
- [ ] Fail over cache-on → cache-off; confirm no stale `cache_control` on the wire
- [ ] MoA path: after failover redecoration, guidance remains after the last cache marker

## Infographic

![Failover prompt-cache redecoration](https://cdn.jsdelivr.net/gh/HexLab98/hermes-agent-fork@pr-assets-72626/failover-cache-redecoration.png)
