### PR TITLE
fix(model): named custom providers keep their prefix and identity

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -245,6 +245,14 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
     This prevents arbitrary slash-bearing model IDs from being mangled on
     native providers while still repairing manual config values like
     ``zai/glm-5.1`` for the ``zai`` provider.
+
+    ``custom`` is a generic bucket for arbitrary user-defined endpoints, not
+    a vendor identity like ``zai``/``gemini``/``xai``. An alias that merely
+    *resolves to* ``custom`` (e.g. ``ollama``, via ``_PROVIDER_ALIASES``)
+    does not mean a ``ollama/`` prefix is redundant -- it may be the actual
+    routing prefix a proxy in front of the custom endpoint (e.g. LiteLLM)
+    requires, as in ``ollama/glm-5.2``. Only a literal ``custom/`` prefix --
+    the bucket's own name -- is treated as redundant here.
     """
     if "/" not in model_name:
         return model_name
@@ -253,8 +261,13 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
     if not prefix.strip() or not remainder.strip():
         return model_name
 
-    normalized_prefix = _normalize_provider_alias(prefix)
     normalized_target = _normalize_provider_alias(target_provider)
+    if normalized_target == "custom":
+        if prefix.strip().lower() == "custom":
+            return remainder.strip()
+        return model_name
+
+    normalized_prefix = _normalize_provider_alias(prefix)
     if normalized_prefix and normalized_prefix == normalized_target:
         return remainder.strip()
     return model_name

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1518,10 +1518,15 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
     # mismatch, entry missing from custom_providers/providers) must still
     # not be treated as a stray vendor prefix -- it isn't a known Hermes
     # provider/alias, but it also isn't the analytics-vendor case this
-    # fallback exists for.
+    # fallback exists for. Match only the durable named-custom syntax
+    # (bare "custom" bucket, or "custom:<name>" per
+    # ``providers.custom_provider_slug``) -- a bare ``startswith("custom")``
+    # would also swallow unrelated unconfigured vendor names that merely
+    # happen to start with "custom" (e.g. "customproxy").
+    is_custom_provider_slug = canonical == "custom" or canonical.startswith("custom:")
     if (
         canonical not in _KNOWN_PROVIDER_NAMES
-        and not canonical.startswith("custom")
+        and not is_custom_provider_slug
         and "/" in model_in
     ):
         # Vendor prefix posing as a provider (analytics fallback). Resolve

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1472,6 +1472,14 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
        known but ``poolside`` isn't) but the model is a vendor-prefixed
        aggregator slug, keep the user's CURRENT aggregator if they're on
        one, else fall back to openrouter.
+
+       Named custom providers (``custom:litellm``, etc.) are excluded from
+       this fallback: ``_KNOWN_PROVIDER_NAMES`` only lists the bare
+       ``"custom"`` bucket, never a specific ``custom:<name>`` slug, so
+       without this exclusion every named custom provider paired with a
+       slash-bearing model (e.g. ``ollama/glm-5.2`` behind a LiteLLM proxy)
+       looked exactly like the stray-vendor-prefix case above and got
+       silently reassigned to ``openrouter``.
     2. Model-format normalization for the resolved provider via
        ``normalize_model_for_provider`` (e.g. ``anthropic/claude-opus-4.6``
        on native anthropic → ``claude-opus-4-6``).
@@ -1506,7 +1514,16 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
     if custom_provider is not None:
         return custom_provider.id, model_in
 
-    if canonical not in _KNOWN_PROVIDER_NAMES and "/" in model_in:
+    # A named custom provider that didn't resolve above (typo, config
+    # mismatch, entry missing from custom_providers/providers) must still
+    # not be treated as a stray vendor prefix -- it isn't a known Hermes
+    # provider/alias, but it also isn't the analytics-vendor case this
+    # fallback exists for.
+    if (
+        canonical not in _KNOWN_PROVIDER_NAMES
+        and not canonical.startswith("custom")
+        and "/" in model_in
+    ):
         # Vendor prefix posing as a provider (analytics fallback). Resolve
         # against the user's current provider when it's an aggregator that
         # serves vendor-prefixed slugs; otherwise default to openrouter.

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -182,6 +182,27 @@ class TestIssue6211NativeProviderPrefixNormalization:
         assert normalize_model_for_provider(model, target_provider) == expected
 
 
+class TestCustomProviderIsNotAVendorIdentity:
+    """``custom`` is a generic bucket, not a vendor -- an alias that merely
+    *resolves to* ``custom`` (e.g. ``ollama`` -> ``custom`` in
+    ``_PROVIDER_ALIASES``) must not be treated as a redundant prefix the
+    way ``zai/``, ``gemini/``, etc. are for their own native providers.
+
+    Regression for: a named custom provider (e.g. a LiteLLM proxy fronting
+    Ollama) registers its own routing name as ``ollama/glm-5.2``. Stripping
+    the ``ollama/`` prefix because it happens to alias to ``custom``
+    produced a bare ``glm-5.2`` the proxy doesn't recognise.
+    """
+
+    @pytest.mark.parametrize("model,expected", [
+        ("ollama/glm-5.2", "ollama/glm-5.2"),
+        ("ollama/llama3.2", "ollama/llama3.2"),
+        ("custom/some-model", "some-model"),
+    ])
+    def test_only_literal_custom_prefix_is_stripped(self, model, expected):
+        assert normalize_model_for_provider(model, "custom") == expected
+
+
 # ── detect_vendor ──────────────────────────────────────────────────────
 
 class TestDetectVendor:

--- a/tests/hermes_cli/test_normalize_main_model_assignment.py
+++ b/tests/hermes_cli/test_normalize_main_model_assignment.py
@@ -1,0 +1,43 @@
+"""Regression tests for ``_normalize_main_model_assignment`` (POST /api/model/set).
+
+Named custom providers are represented as ``custom:<name>`` slugs everywhere
+else in the codebase (``runtime_provider.py``, ``model_switch.py``), but
+``_KNOWN_PROVIDER_NAMES`` only lists the bare ``"custom"`` bucket. Before this
+fix, persisting a main-slot assignment for a named custom provider (e.g. a
+LiteLLM proxy fronting Ollama, registered as ``custom:litellm``) together with
+a slash-bearing model id (``ollama/glm-5.2``) was indistinguishable from the
+"vendor prefix posing as a provider" analytics-fallback case, and got silently
+rewritten to ``provider: openrouter`` in ``config.yaml`` -- reassigning the
+provider entirely, not just mangling the model id.
+"""
+
+from hermes_cli.web_server import _normalize_main_model_assignment
+
+
+class TestNamedCustomProviderIsNotTreatedAsStrayVendorPrefix:
+    def test_named_custom_provider_slug_is_preserved(self):
+        assert _normalize_main_model_assignment("custom:litellm", "ollama/glm-5.2") == (
+            "custom:litellm",
+            "ollama/glm-5.2",
+        )
+
+    def test_bare_custom_bucket_is_preserved(self):
+        assert _normalize_main_model_assignment("custom", "ollama/glm-5.2") == (
+            "custom",
+            "ollama/glm-5.2",
+        )
+
+
+class TestStrayVendorPrefixFallbackStillWorks:
+    """The original bug this function fixes: an analytics row with no
+    ``billing_provider`` falls back to the model's vendor prefix as the
+    "provider" (e.g. ``provider="anthropic"`` from
+    ``modelVendor("anthropic/claude-opus-4.6")``). That must still resolve
+    to the native provider with its model normalized -- unaffected by the
+    ``custom:`` exclusion above.
+    """
+
+    def test_known_native_provider_still_normalizes_model(self):
+        assert _normalize_main_model_assignment(
+            "anthropic", "anthropic/claude-opus-4.6"
+        ) == ("anthropic", "claude-opus-4-6")

--- a/tests/hermes_cli/test_normalize_main_model_assignment.py
+++ b/tests/hermes_cli/test_normalize_main_model_assignment.py
@@ -9,23 +9,82 @@ a slash-bearing model id (``ollama/glm-5.2``) was indistinguishable from the
 "vendor prefix posing as a provider" analytics-fallback case, and got silently
 rewritten to ``provider: openrouter`` in ``config.yaml`` -- reassigning the
 provider entirely, not just mangling the model id.
+
+A properly *configured* ``custom:<name>`` provider is now resolved earlier,
+via ``resolve_custom_provider`` against ``custom_providers``/``providers`` in
+config -- that's the primary, intended path and isn't this module's concern
+to re-test. What's tested here is the fallback safety net for when that
+resolution comes up empty (typo, config drift, entry removed) -- a
+``custom:<name>`` slug must still not be misread as a stray analytics vendor
+prefix and reassigned to openrouter, even though it isn't in
+``_KNOWN_PROVIDER_NAMES`` either.
 """
+
+from unittest.mock import patch
 
 from hermes_cli.web_server import _normalize_main_model_assignment
 
 
-class TestNamedCustomProviderIsNotTreatedAsStrayVendorPrefix:
-    def test_named_custom_provider_slug_is_preserved(self):
-        assert _normalize_main_model_assignment("custom:litellm", "ollama/glm-5.2") == (
-            "custom:litellm",
-            "ollama/glm-5.2",
-        )
+def _no_custom_providers_configured():
+    """Patch load_config so resolve_user_provider/resolve_custom_provider
+    both come up empty, forcing execution into the fallback path under
+    test -- independent of whatever config.yaml happens to be on disk."""
+    return patch("hermes_cli.web_server.load_config", return_value={})
+
+
+class TestUnresolvedNamedCustomProviderIsNotTreatedAsStrayVendorPrefix:
+    """Covers the case where ``resolve_custom_provider`` finds no match --
+    e.g. ``custom:litellm`` was configured once, then the entry was renamed
+    or dropped from ``custom_providers``, but old sessions/config still
+    reference the old slug.
+    """
+
+    def test_unresolved_named_custom_provider_slug_is_preserved(self):
+        with _no_custom_providers_configured():
+            assert _normalize_main_model_assignment("custom:litellm", "ollama/glm-5.2") == (
+                "custom:litellm",
+                "ollama/glm-5.2",
+            )
 
     def test_bare_custom_bucket_is_preserved(self):
-        assert _normalize_main_model_assignment("custom", "ollama/glm-5.2") == (
-            "custom",
-            "ollama/glm-5.2",
-        )
+        with _no_custom_providers_configured():
+            assert _normalize_main_model_assignment("custom", "ollama/glm-5.2") == (
+                "custom",
+                "ollama/glm-5.2",
+            )
+
+    def test_unconfigured_non_custom_vendor_name_still_falls_back(self):
+        """A name that merely starts with the substring "custom" but isn't
+        the durable ``custom:<name>`` syntax (no colon) is NOT exempted --
+        it's just another unknown vendor label and should still hit the
+        openrouter fallback like any other unrecognized provider string.
+        """
+        with _no_custom_providers_configured():
+            assert _normalize_main_model_assignment(
+                "customproxy", "anthropic/claude-opus-4.6"
+            ) == ("openrouter", "anthropic/claude-opus-4.6")
+
+
+class TestConfiguredNamedCustomProviderResolvesViaPrimaryPath:
+    """The primary, intended path: a ``custom:<name>`` slug that IS present
+    in ``custom_providers`` resolves through ``resolve_custom_provider``
+    before the fallback under test above is ever reached.
+    """
+
+    def test_configured_named_custom_provider_resolves(self):
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "litellm",
+                    "base_url": "http://localhost:4000/v1",
+                    "key_env": "LITELLM_API_KEY",
+                }
+            ]
+        }
+        with patch("hermes_cli.web_server.load_config", return_value=cfg):
+            assert _normalize_main_model_assignment(
+                "custom:litellm", "ollama/glm-5.2"
+            ) == ("custom:litellm", "ollama/glm-5.2")
 
 
 class TestStrayVendorPrefixFallbackStillWorks:


### PR DESCRIPTION
## Summary

Salvage of PR #56671 by @oreoluwa — fixes two bugs where named custom providers (`custom:litellm`, etc.) lose their identity.

**Bug 1** — `normalize_model_for_provider("ollama/glm-5.2", "custom")` returned `"glm-5.2"` (stripped the prefix) because `ollama` aliases to `custom` via `_PROVIDER_ALIASES` and `_strip_matching_provider_prefix` treated the matching alias as a redundant vendor prefix. For custom providers, only a literal `custom/` prefix is redundant — an alias that merely *resolves to* `custom` may be the actual routing prefix a proxy (LiteLLM, vLLM) requires.

**Bug 2** — Desktop's model save endpoint (`_normalize_main_model_assignment`) silently reassigned `custom:litellm` + `ollama/glm-5.2` to `provider: openrouter` because `_KNOWN_PROVIDER_NAMES` only lists the bare `"custom"` bucket, never `custom:<name>` slugs — so every named custom provider with a slash-bearing model looked like the stray-vendor-prefix analytics case.

Cherry-picked all 3 contributor commits onto current main (717 commits ahead of the original branch). Authorship preserved via rebase-merge.

## Changes
- `hermes_cli/model_normalize.py`: `_strip_matching_provider_prefix` only strips literal `custom/` for the `custom` bucket; aliases like `ollama` no longer qualify.
- `hermes_cli/web_server.py`: `_normalize_main_model_assignment` excludes `custom:` slugs from the stray-vendor-prefix fallback.
- Tests: 3 new regression tests in `test_model_normalize.py` + new `test_normalize_main_model_assignment.py` (4 tests).

## Validation

E2E with real imports on current main:
- `normalize_model_for_provider("ollama/glm-5.2", "custom")` → `"ollama/glm-5.2"` (was `"glm-5.2"`)
- `_normalize_main_model_assignment("custom:litellm", "ollama/glm-5.2")` → `("custom:litellm", "ollama/glm-5.2")` (was `("openrouter", ...)`)
- Existing behavior preserved: `custom/some-model` still strips, `zai/glm-5.1` still strips, analytics fallback for `anthropic/claude-opus-4.6` still works.

Closes #56671
