### PR TITLE
fix(auth): harden Codex quota probe token refresh

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -797,28 +797,66 @@ class CredentialPool:
         try:
             with _auth_store_lock():
                 auth_store = _load_auth_store()
+                providers = auth_store.get("providers")
+                owns_provider_state = bool(
+                    isinstance(providers, dict)
+                    and isinstance(providers.get("openai-codex"), dict)
+                )
                 state = _load_provider_state(auth_store, "openai-codex")
+                active_pool = auth_store.get("credential_pool")
+                active_rows = (
+                    active_pool.get("openai-codex")
+                    if isinstance(active_pool, dict)
+                    else None
+                )
+                active_persisted_payload = next(
+                    (
+                        payload
+                        for payload in active_rows
+                        if isinstance(payload, dict)
+                        and str(payload.get("id") or "") == entry.id
+                    ),
+                    None,
+                ) if isinstance(active_rows, list) else None
+                persisted_payload = next(
+                    (
+                        payload
+                        for payload in read_credential_pool("openai-codex")
+                        if isinstance(payload, dict)
+                        and str(payload.get("id") or "") == entry.id
+                    ),
+                    None,
+                )
             if not isinstance(state, dict):
                 return entry
             tokens = state.get("tokens")
             if not isinstance(tokens, dict):
                 return entry
-            store_access = tokens.get("access_token", "")
-            store_refresh = tokens.get("refresh_token", "")
-            # Adopt auth.json tokens when either side differs.  Codex refresh
-            # tokens are single-use too, so a fresh refresh_token from
-            # another process means our entry's pair is consumed/stale.
+            store_access = str(tokens.get("access_token") or "").strip()
+            store_refresh = str(tokens.get("refresh_token") or "").strip()
+            store_last_refresh = str(state.get("last_refresh") or "").strip()
+            if not store_access:
+                return entry
+
             entry_access = entry.access_token or ""
             entry_refresh = entry.refresh_token or ""
-            if store_access and (
+            singleton_chain_changed = (
                 store_access != entry_access
                 or (store_refresh and store_refresh != entry_refresh)
-            ):
-                logger.debug(
-                    "Pool entry %s: syncing Codex tokens from auth.json "
-                    "(refreshed by another process)",
-                    entry.id,
+                or (
+                    store_last_refresh
+                    and store_last_refresh != (entry.last_refresh or "")
                 )
+            )
+            if (
+                owns_provider_state
+                and not isinstance(active_persisted_payload, dict)
+                and singleton_chain_changed
+            ):
+                # A fresh local device-code login replaces provider state and
+                # can omit the old pool row entirely. That write-side event is
+                # stronger than a singleton-only refresh, so it may clear the
+                # stale DEAD/EXHAUSTED lifecycle in this process.
                 field_updates: Dict[str, Any] = {
                     "access_token": store_access,
                     "refresh_token": store_refresh or entry.refresh_token,
@@ -829,11 +867,52 @@ class CredentialPool:
                     "last_error_message": None,
                     "last_error_reset_at": None,
                 }
-                if state.get("last_refresh"):
-                    field_updates["last_refresh"] = state["last_refresh"]
+                if store_last_refresh:
+                    field_updates["last_refresh"] = store_last_refresh
                 updated = replace(entry, **field_updates)
                 self._replace_entry(entry, updated)
-                self._persist()
+                return updated
+
+            if isinstance(persisted_payload, dict):
+                persisted = PooledCredential.from_dict(
+                    self.provider, persisted_payload
+                )
+                persisted_matches_singleton = (
+                    persisted.access_token == store_access
+                    and (
+                        not store_refresh
+                        or persisted.refresh_token == store_refresh
+                    )
+                    and (
+                        not store_last_refresh
+                        or persisted.last_refresh == store_last_refresh
+                    )
+                )
+                if persisted_matches_singleton and persisted != entry:
+                    # A write-side reauthentication updates both the singleton
+                    # and pool row (including status). Adopt that full row so a
+                    # genuine login can clear DEAD/EXHAUSTED state.
+                    self._replace_entry(entry, persisted)
+                    return persisted
+
+            if singleton_chain_changed:
+                logger.debug(
+                    "Pool entry %s: adopting Codex singleton token metadata "
+                    "while preserving quota status",
+                    entry.id,
+                )
+                field_updates: Dict[str, Any] = {
+                    "access_token": store_access,
+                    "refresh_token": store_refresh or entry.refresh_token,
+                }
+                if store_last_refresh:
+                    field_updates["last_refresh"] = store_last_refresh
+                updated = replace(entry, **field_updates)
+                # Do not persist a whole active-profile snapshot here: this may
+                # be a root fallback, and token rotation alone does not prove
+                # quota recovery. The owner-locked quota helper writes the
+                # matching row while preserving its cooldown.
+                self._replace_entry(entry, updated)
                 return updated
         except Exception as exc:
             logger.debug("Failed to sync Codex entry from auth.json: %s", exc)
@@ -1587,26 +1666,48 @@ class CredentialPool:
                 }
             )
             fresh_access = str(probe_status.get("access_token") or "").strip()
-            if not fresh_access or fresh_access == entry.access_token:
+            if not fresh_access:
+                return entry
+            fresh_refresh = (
+                str(probe_status.get("refresh_token") or "").strip()
+                or entry.refresh_token
+            )
+            fresh_last_refresh = (
+                str(probe_status.get("last_refresh") or "").strip()
+                or entry.last_refresh
+            )
+            if (
+                fresh_access == entry.access_token
+                and fresh_refresh == entry.refresh_token
+                and fresh_last_refresh == entry.last_refresh
+            ):
                 return entry
             updated = replace(
                 entry,
                 access_token=fresh_access,
-                refresh_token=(
-                    str(probe_status.get("refresh_token") or "").strip()
-                    or entry.refresh_token
-                ),
-                last_refresh=(
-                    str(probe_status.get("last_refresh") or "").strip()
-                    or entry.last_refresh
-                ),
+                refresh_token=fresh_refresh,
+                last_refresh=fresh_last_refresh,
             )
             # The auth helper already persisted this token pair under the
             # cross-process auth-store lock while retaining exhausted/error
             # fields. This only synchronizes the process-local mirror.
             self._replace_entry(entry, updated)
             return updated
-        except Exception:
+        except Exception as exc:
+            if auth_mod._is_terminal_codex_oauth_refresh_error(exc):
+                dead = replace(
+                    entry,
+                    last_status=STATUS_DEAD,
+                    last_status_at=time.time(),
+                    last_error_code=401,
+                    last_error_reason=(
+                        getattr(exc, "code", None) or "invalid_grant"
+                    ),
+                    last_error_message=str(exc),
+                    last_error_reset_at=None,
+                )
+                self._replace_entry(entry, dead)
+                return dead
             logger.debug(
                 "Failed to refresh Codex quota-probe credential",
                 exc_info=True,
@@ -1659,6 +1760,7 @@ class CredentialPool:
         entries_to_prune: List[str] = []
         available: List[PooledCredential] = []
         for entry in self._entries:
+            cooldown_cleared_in_owner = False
             # Borrowed credentials persist as metadata-only references and are
             # hydrated from their live source on load.  A stale duplicate row
             # can remain unhydrated; never lease or select it as an empty key.
@@ -1695,7 +1797,6 @@ class CredentialPool:
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
-                    cleared_any = True
             # For xai-oauth singleton-seeded entries, identical pattern:
             # an entry frozen as exhausted may simply be holding stale
             # tokens that another process (or a fresh `hermes model` ->
@@ -1754,6 +1855,27 @@ class CredentialPool:
                         and self._codex_quota_restored_upstream(entry)
                     ):
                         continue
+                    # The usage request ran without the auth-store lock. A
+                    # concurrent device-code refresh may have replaced this
+                    # chain while the probe was in flight; adopt it before any
+                    # later pool persistence can write the probe snapshot back.
+                    entry = self._sync_codex_entry_from_auth_store(entry)
+                    # Refresh persistence deliberately kept the quota markers;
+                    # a positive usage probe now owns clearing them on disk.
+                    # Do this before the pool snapshot write so the cooldown
+                    # merge cannot resurrect the just-confirmed stale marker.
+                    cleared_count = auth_mod.clear_codex_pool_quota_cooldowns(
+                        entry.access_token,
+                        include_global_fallback=True,
+                    )
+                    if cleared_count:
+                        cooldown_cleared_in_owner = True
+                    elif entry.last_status == STATUS_EXHAUSTED:
+                        # A positive usage response is not enough to mutate an
+                        # owner we could not atomically identify and update.
+                        # Keep the row frozen rather than shadowing/rolling back
+                        # a concurrent profile or global-store write.
+                        continue
                 if clear_expired:
                     cleared = replace(
                         entry,
@@ -1766,7 +1888,8 @@ class CredentialPool:
                     )
                     self._replace_entry(entry, cleared)
                     entry = cleared
-                    cleared_any = True
+                    if not cooldown_cleared_in_owner:
+                        cleared_any = True
             if refresh and self._entry_needs_refresh(entry):
                 refreshed = self._refresh_entry(entry, force=False)
                 if refreshed is None:
@@ -2792,6 +2915,58 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
     raw_entries = read_credential_pool(provider)
+    active_store = _load_auth_store()
+    active_pool = active_store.get("credential_pool")
+    active_entries = (
+        active_pool.get(provider) if isinstance(active_pool, dict) else None
+    )
+    active_providers = active_store.get("providers")
+    active_provider_state = (
+        active_providers.get(provider)
+        if isinstance(active_providers, dict)
+        else None
+    )
+    codex_global_fallback = bool(
+        provider == "openai-codex"
+        and raw_entries
+        and not active_entries
+        and not isinstance(active_provider_state, dict)
+    )
+    active_codex_tokens = (
+        active_provider_state.get("tokens")
+        if isinstance(active_provider_state, dict)
+        else None
+    )
+    active_codex_access = (
+        str(active_codex_tokens.get("access_token") or "").strip()
+        if isinstance(active_codex_tokens, dict)
+        else ""
+    )
+    active_codex_refresh = (
+        str(active_codex_tokens.get("refresh_token") or "").strip()
+        if isinstance(active_codex_tokens, dict)
+        else ""
+    )
+    codex_local_reauth_over_global = bool(
+        provider == "openai-codex"
+        and raw_entries
+        and not active_entries
+        and active_codex_access
+        and any(
+            isinstance(payload, dict)
+            and payload.get("source") == "device_code"
+            and (
+                str(payload.get("access_token") or "").strip()
+                != active_codex_access
+                or (
+                    active_codex_refresh
+                    and str(payload.get("refresh_token") or "").strip()
+                    != active_codex_refresh
+                )
+            )
+            for payload in raw_entries
+        )
+    )
     disk_ids = {
         entry.get("id")
         for entry in raw_entries
@@ -2816,8 +2991,6 @@ def load_pool(provider: str) -> CredentialPool:
         # A profile may be reading this provider from the global-root fallback.
         # Keep that fallback read-only: only the store that owns these rows may
         # rewrite them. Loading the default/root profile will heal global rows.
-        active_pool = _load_auth_store().get("credential_pool")
-        active_entries = active_pool.get(provider) if isinstance(active_pool, dict) else None
         raw_needs_auth_normalization = bool(active_entries)
 
     if provider.startswith(CUSTOM_POOL_PREFIX):
@@ -2844,6 +3017,36 @@ def load_pool(provider: str) -> CredentialPool:
             prune_env_sources=False,
         )
         changed |= _normalize_pool_priorities(provider, entries)
+        if codex_local_reauth_over_global:
+            for index, item in enumerate(entries):
+                if (
+                    item.source != "device_code"
+                    or item.access_token != active_codex_access
+                    or (
+                        active_codex_refresh
+                        and item.refresh_token != active_codex_refresh
+                    )
+                ):
+                    continue
+                healthy = replace(
+                    item,
+                    last_status=None,
+                    last_status_at=None,
+                    last_error_code=None,
+                    last_error_reason=None,
+                    last_error_message=None,
+                    last_error_reset_at=None,
+                )
+                if healthy != item:
+                    entries[index] = healthy
+                    changed = True
+        if codex_global_fallback and not env_changed:
+            # ``read_credential_pool`` supplied root-owned rows. Codex's
+            # singleton loader can also see the root fallback and normalize the
+            # in-memory copy, but that must not turn a read into a profile pool
+            # shadow. A genuine local singleton was excluded above; an explicit
+            # local env credential still keeps its existing write behavior.
+            changed = False
 
     if changed:
         new_ids = {entry.id for entry in entries}

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1566,6 +1566,53 @@ class CredentialPool:
             logger.debug("Codex quota-restored probe failed", exc_info=True)
             return False
 
+    def _refresh_codex_quota_probe_entry(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
+        """Adopt a fresh probe token while deliberately preserving quota state.
+
+        The usage endpoint cannot authenticate an expired access token, so the
+        token pair must be rotated first. That rotation does *not* prove quota
+        availability: ``last_status=exhausted`` and its reset metadata remain
+        intact unless the subsequent usage probe returns a positive result.
+        """
+        if self.provider != "openai-codex":
+            return entry
+        try:
+            probe_status = auth_mod._refresh_codex_pool_token_for_quota_probe(
+                {
+                    "id": entry.id,
+                    "access_token": entry.access_token,
+                    "base_url": entry.base_url,
+                }
+            )
+            fresh_access = str(probe_status.get("access_token") or "").strip()
+            if not fresh_access or fresh_access == entry.access_token:
+                return entry
+            updated = replace(
+                entry,
+                access_token=fresh_access,
+                refresh_token=(
+                    str(probe_status.get("refresh_token") or "").strip()
+                    or entry.refresh_token
+                ),
+                last_refresh=(
+                    str(probe_status.get("last_refresh") or "").strip()
+                    or entry.last_refresh
+                ),
+            )
+            # The auth helper already persisted this token pair under the
+            # cross-process auth-store lock while retaining exhausted/error
+            # fields. This only synchronizes the process-local mirror.
+            self._replace_entry(entry, updated)
+            return updated
+        except Exception:
+            logger.debug(
+                "Failed to refresh Codex quota-probe credential",
+                exc_info=True,
+            )
+            return entry
+
     def _entry_needs_refresh(self, entry: PooledCredential) -> bool:
         if entry.auth_type != AUTH_TYPE_OAUTH:
             return False
@@ -1700,6 +1747,8 @@ class CredentialPool:
                     # while the account is already usable again — a throttled
                     # live probe of the Codex usage endpoint detects that and
                     # lifts the stale cooldown (issue #43747).
+                    if clear_expired:
+                        entry = self._refresh_codex_quota_probe_entry(entry)
                     if not (
                         clear_expired
                         and self._codex_quota_restored_upstream(entry)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3904,9 +3904,10 @@ def resolve_codex_runtime_credentials(
             # redeemed, plan upgraded, window reset upstream).  The persisted
             # ``last_error_reset_at`` can be days in the future while the
             # account is already usable again — see issue #43747.
-            stale_token = str(pool_rate_limit.get("access_token") or "").strip()
-            if stale_token and _probe_codex_quota_restored(
-                stale_token,
+            probe_status = _refresh_codex_pool_token_for_quota_probe(pool_rate_limit)
+            probe_token = str(probe_status.get("access_token") or "").strip()
+            if probe_token and _probe_codex_quota_restored(
+                probe_token,
                 base_url=pool_rate_limit.get("base_url"),
             ):
                 logger.info(
@@ -4237,6 +4238,7 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
             if reset_at is not None and reset_at <= now:
                 continue
             return {
+                "id": entry.get("id"),
                 "label": entry.get("label"),
                 "last_refresh": entry.get("last_refresh"),
                 "reset_at": reset_at,
@@ -4248,6 +4250,96 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
     except Exception:
         logger.debug("Codex pool rate-limit lookup failed", exc_info=True)
     return None
+
+
+def _refresh_codex_pool_token_for_quota_probe(
+    rate_limit_status: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Persist a usable probe token while preserving its quota cooldown.
+
+    A persisted 429 may outlive the access token that originally received it.
+    The usage endpoint cannot authenticate that expired token, so refresh and
+    persist the matching pool row first under the auth-store lock. This changes
+    only token metadata: all quota error/reset fields remain intact until a
+    subsequent positive usage probe invokes the normal cooldown-clear path. A
+    negative probe therefore leaves a fresh token paired with
+    ``last_status=exhausted`` by design.
+    """
+    result = dict(rate_limit_status)
+    stale_token = str(result.get("access_token") or "").strip()
+    if not stale_token or not _codex_access_token_is_expiring(stale_token, 0):
+        return result
+
+    entry_id = str(result.get("id") or "").strip()
+    if not entry_id:
+        return result
+
+    try:
+        # Serialize the complete single-use lifecycle: re-read the latest row,
+        # exchange its refresh token, then atomically save the replacement
+        # before another process can load and reuse the consumed token.
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+            pool = auth_store.get("credential_pool")
+            entries = pool.get("openai-codex") if isinstance(pool, dict) else None
+            if not isinstance(entries, list):
+                return result
+
+            entry = next(
+                (
+                    candidate
+                    for candidate in entries
+                    if isinstance(candidate, dict)
+                    and str(candidate.get("id") or "") == entry_id
+                ),
+                None,
+            )
+            if not isinstance(entry, dict):
+                return result
+            if entry.get("last_status") != "exhausted" or not _is_codex_rate_limit_shaped(
+                entry.get("last_error_code"),
+                entry.get("last_error_reason"),
+                entry.get("last_error_message"),
+            ):
+                return result
+
+            current_access = str(entry.get("access_token") or "").strip()
+            if not current_access:
+                return result
+            if not _codex_access_token_is_expiring(current_access, 0):
+                result["access_token"] = current_access
+                current_refresh = str(entry.get("refresh_token") or "").strip()
+                if current_refresh:
+                    result["refresh_token"] = current_refresh
+                if entry.get("last_refresh"):
+                    result["last_refresh"] = entry["last_refresh"]
+                return result
+
+            current_refresh = str(entry.get("refresh_token") or "").strip()
+            if not current_refresh:
+                return result
+            refreshed = refresh_codex_oauth_pure(current_access, current_refresh)
+            fresh_access = str(refreshed.get("access_token") or "").strip()
+            if not fresh_access:
+                return result
+
+            entry["access_token"] = fresh_access
+            fresh_refresh = str(refreshed.get("refresh_token") or "").strip()
+            if fresh_refresh:
+                entry["refresh_token"] = fresh_refresh
+            if refreshed.get("last_refresh"):
+                entry["last_refresh"] = refreshed["last_refresh"]
+            _save_auth_store(auth_store)
+            result["access_token"] = fresh_access
+            result["refresh_token"] = entry.get("refresh_token")
+            result["last_refresh"] = entry.get("last_refresh")
+            return result
+    except Exception:
+        logger.debug(
+            "Failed to refresh expired Codex token for quota probe",
+            exc_info=True,
+        )
+        return result
 
 
 def _pool_codex_access_token() -> str:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1473,7 +1473,7 @@ def _merge_disk_cooldown_state(
     disk_entry: Optional[Dict[str, Any]],
     provider_id: str,
 ) -> Dict[str, Any]:
-    """Keep a newer on-disk cooldown/quarantine over a stale in-memory one.
+    """Keep newer on-disk cooldown/quarantine and Codex chain over stale memory.
 
     ``write_credential_pool`` callers persist an in-memory snapshot that may
     predate another process marking the same credential exhausted or dead
@@ -1484,6 +1484,13 @@ def _merge_disk_cooldown_state(
     marker, or an EXHAUSTED cooldown that has not yet expired.  Expired
     cooldowns are not resurrected, so the pool's own expiry-clear (which
     resets ``last_status_at`` to None) is never overridden.
+
+    For singleton-seeded Codex OAuth rows, also retain an on-disk token chain
+    with a strictly newer ``last_refresh``. Codex refresh tokens are single-use;
+    allowing any stale whole-pool snapshot to restore the older refresh token
+    would make the next process replay an already consumed grant. For every
+    Codex row, the same recency rule preserves a newer persisted quota-refresh
+    failure marker so a stale snapshot cannot disable the cross-process throttle.
     """
     if not isinstance(disk_entry, dict):
         return entry
@@ -1497,6 +1504,51 @@ def _merge_disk_cooldown_state(
         )
 
         disk_status = disk_entry.get("last_status")
+        if (
+            provider_id == "openai-codex"
+            and entry.get("source") == "device_code"
+            and disk_entry.get("source") == "device_code"
+        ):
+            disk_refresh_at = (
+                _parse_absolute_timestamp(disk_entry.get("last_refresh")) or 0.0
+            )
+            memory_refresh_at = (
+                _parse_absolute_timestamp(entry.get("last_refresh")) or 0.0
+            )
+            if disk_refresh_at > memory_refresh_at:
+                # OAuth refresh tokens are single-use. A stale full-pool
+                # snapshot must never roll a newer persisted chain back after
+                # another process reauthenticated or refreshed it.
+                entry = dict(entry)
+                for token_field in (
+                    "access_token",
+                    "refresh_token",
+                    "last_refresh",
+                ):
+                    disk_value = disk_entry.get(token_field)
+                    if disk_value not in (None, ""):
+                        entry[token_field] = disk_value
+        if provider_id == "openai-codex":
+            disk_failure_at = (
+                _parse_absolute_timestamp(
+                    disk_entry.get(_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD)
+                )
+                or 0.0
+            )
+            memory_failure_at = (
+                _parse_absolute_timestamp(
+                    entry.get(_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD)
+                )
+                or 0.0
+            )
+            if disk_failure_at > memory_failure_at:
+                entry = dict(entry)
+                entry[_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD] = disk_entry.get(
+                    _CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD
+                )
+                entry[_CODEX_QUOTA_REFRESH_FAILURE_CHAIN_FIELD] = disk_entry.get(
+                    _CODEX_QUOTA_REFRESH_FAILURE_CHAIN_FIELD
+                )
         if disk_status not in (STATUS_DEAD, STATUS_EXHAUSTED):
             return entry
         # A token change means the caller re-authed/refreshed this entry and
@@ -3589,6 +3641,8 @@ def _sync_codex_pool_entries(
         entry["last_error_reason"] = None
         entry["last_error_message"] = None
         entry["last_error_reset_at"] = None
+        entry.pop(_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD, None)
+        entry.pop(_CODEX_QUOTA_REFRESH_FAILURE_CHAIN_FIELD, None)
 
 
 def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
@@ -3913,7 +3967,10 @@ def resolve_codex_runtime_credentials(
                 logger.info(
                     "Codex quota restored upstream — clearing stale pool cooldown(s)."
                 )
-                clear_codex_pool_quota_cooldowns()
+                clear_codex_pool_quota_cooldowns(
+                    probe_token,
+                    include_global_fallback=True,
+                )
                 pool_token = _pool_codex_access_token()
                 if pool_token:
                     base_url = (
@@ -4011,11 +4068,40 @@ def _is_codex_rate_limit_shaped(
     )
 
 
+def _parse_codex_reset_at(value: Any) -> Optional[float]:
+    """Normalize persisted Codex reset timestamps to Unix seconds."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if numeric <= 0:
+            return None
+        return numeric / 1000.0 if numeric > 1_000_000_000_000 else numeric
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            numeric = float(raw)
+        except ValueError:
+            numeric = None
+        if numeric is not None:
+            return numeric / 1000.0 if numeric > 1_000_000_000_000 else numeric
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
 # Throttle for the live Codex quota probe below.  The probe runs on the hot
 # credential-selection path while the pool is exhausted, so without a floor a
 # busy gateway would hammer the usage endpoint on every model/auxiliary call.
 CODEX_QUOTA_PROBE_MIN_INTERVAL_SECONDS = 300  # 5 minutes
+_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD = "quota_probe_refresh_failure_at"
+_CODEX_QUOTA_REFRESH_FAILURE_CHAIN_FIELD = "quota_probe_refresh_failure_chain"
 _codex_quota_probe_cache: Dict[str, Tuple[float, Optional[bool]]] = {}
+_codex_quota_refresh_failure_cache: Dict[str, float] = {}
 _codex_quota_probe_lock = threading.Lock()
 
 
@@ -4125,8 +4211,10 @@ def _probe_codex_quota_restored(
     return result
 
 
-def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
-    """Clear rate-limit cooldowns on persisted openai-codex pool entries.
+def _clear_codex_pool_quota_cooldowns_in_store(
+    access_token: Optional[str], target_path: Path
+) -> int:
+    """Clear matching Codex cooldowns in one explicitly owned store.
 
     Called after the upstream quota is KNOWN to be restored (a successful
     ``/usage reset`` redemption, or a positive live probe) so auth.json stops
@@ -4143,8 +4231,8 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
     """
     cleared = 0
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
+        with _auth_store_lock(target_path=target_path):
+            auth_store = _load_auth_store(target_path)
             pool = auth_store.get("credential_pool")
             entries = pool.get("openai-codex") if isinstance(pool, dict) else None
             if not isinstance(entries, list):
@@ -4170,45 +4258,48 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
                 entry["last_error_reset_at"] = None
                 cleared += 1
             if cleared:
-                _save_auth_store(auth_store)
+                _save_auth_store(auth_store, target_path)
     except Exception:
         logger.debug("Failed to clear Codex pool quota cooldowns", exc_info=True)
     return cleared
 
 
+def clear_codex_pool_quota_cooldowns(
+    access_token: Optional[str] = None,
+    *,
+    include_global_fallback: bool = False,
+) -> int:
+    """Clear verified Codex quota cooldowns in active and optional owner fallback.
+
+    By default this preserves the historical active-store-only behavior. Quota
+    probes pass ``include_global_fallback=True`` because their selected pool row
+    may have been read from the profile's global-root fallback.
+    """
+    try:
+        paths = (
+            _codex_pool_owner_paths()
+            if include_global_fallback
+            else [_auth_file_path()]
+        )
+    except Exception:
+        logger.debug("Failed to resolve Codex cooldown owner", exc_info=True)
+        return 0
+
+    cleared = 0
+    for target_path in paths:
+        count = _clear_codex_pool_quota_cooldowns_in_store(
+            access_token, target_path
+        )
+        cleared += count
+        if access_token and count:
+            break
+    return cleared
+
+
 def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
     """Return metadata for a pool-only Codex credential in quota cooldown."""
-    def _parse_reset_at(value: Any) -> Optional[float]:
-        if value is None or value == "":
-            return None
-        if isinstance(value, (int, float)):
-            numeric = float(value)
-            if numeric <= 0:
-                return None
-            return numeric / 1000.0 if numeric > 1_000_000_000_000 else numeric
-        if isinstance(value, str):
-            raw = value.strip()
-            if not raw:
-                return None
-            try:
-                numeric = float(raw)
-            except ValueError:
-                numeric = None
-            if numeric is not None:
-                return numeric / 1000.0 if numeric > 1_000_000_000_000 else numeric
-            try:
-                return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
-            except ValueError:
-                return None
-        return None
-
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return None
-        entries = pool.get("openai-codex")
+        entries: Any = read_credential_pool("openai-codex")
         if not isinstance(entries, list):
             return None
         now = time.time()
@@ -4234,7 +4325,7 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
             )
             if not is_rate_limited:
                 continue
-            reset_at = _parse_reset_at(entry.get("last_error_reset_at"))
+            reset_at = _parse_codex_reset_at(entry.get("last_error_reset_at"))
             if reset_at is not None and reset_at <= now:
                 continue
             return {
@@ -4252,9 +4343,32 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
     return None
 
 
-def _refresh_codex_pool_token_for_quota_probe(
+def _codex_pool_owner_paths() -> List[Path]:
+    """Return write-capable auth-store candidates for a Codex pool row.
+
+    Profile entries shadow global entries, so the active store is always
+    checked first.  The global path is included only when it is distinct and
+    pytest's real-home seat belt permits it.
+    """
+    active_path = _auth_file_path()
+    paths = [active_path]
+    global_path = _global_auth_file_path()
+    if global_path is None or _same_path(active_path, global_path):
+        return paths
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env and _same_path(
+            global_path, Path(real_home_env) / ".hermes" / "auth.json"
+        ):
+            return paths
+    paths.append(global_path)
+    return paths
+
+
+def _refresh_codex_pool_token_for_quota_probe_in_store(
     rate_limit_status: Dict[str, Any],
-) -> Dict[str, Any]:
+    target_path: Path,
+) -> Optional[Dict[str, Any]]:
     """Persist a usable probe token while preserving its quota cooldown.
 
     A persisted 429 may outlive the access token that originally received it.
@@ -4267,7 +4381,7 @@ def _refresh_codex_pool_token_for_quota_probe(
     """
     result = dict(rate_limit_status)
     stale_token = str(result.get("access_token") or "").strip()
-    if not stale_token or not _codex_access_token_is_expiring(stale_token, 0):
+    if not stale_token:
         return result
 
     entry_id = str(result.get("id") or "").strip()
@@ -4278,12 +4392,12 @@ def _refresh_codex_pool_token_for_quota_probe(
         # Serialize the complete single-use lifecycle: re-read the latest row,
         # exchange its refresh token, then atomically save the replacement
         # before another process can load and reuse the consumed token.
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
+        with _auth_store_lock(target_path=target_path):
+            auth_store = _load_auth_store(target_path)
             pool = auth_store.get("credential_pool")
             entries = pool.get("openai-codex") if isinstance(pool, dict) else None
             if not isinstance(entries, list):
-                return result
+                return None
 
             entry = next(
                 (
@@ -4295,13 +4409,48 @@ def _refresh_codex_pool_token_for_quota_probe(
                 None,
             )
             if not isinstance(entry, dict):
-                return result
+                return None
             if entry.get("last_status") != "exhausted" or not _is_codex_rate_limit_shaped(
                 entry.get("last_error_code"),
                 entry.get("last_error_reason"),
                 entry.get("last_error_message"),
             ):
                 return result
+
+            if entry.get("source") == "device_code":
+                providers = auth_store.get("providers")
+                state = (
+                    providers.get("openai-codex")
+                    if isinstance(providers, dict)
+                    else None
+                )
+                tokens = state.get("tokens") if isinstance(state, dict) else None
+                if isinstance(tokens, dict):
+                    canonical_access = str(tokens.get("access_token") or "").strip()
+                    canonical_refresh = str(tokens.get("refresh_token") or "").strip()
+                    canonical_last_refresh = (
+                        state.get("last_refresh") if isinstance(state, dict) else None
+                    )
+                    canonical_changed = False
+                    if canonical_access and canonical_access != str(
+                        entry.get("access_token") or ""
+                    ).strip():
+                        entry["access_token"] = canonical_access
+                        canonical_changed = True
+                    if canonical_refresh and canonical_refresh != str(
+                        entry.get("refresh_token") or ""
+                    ).strip():
+                        entry["refresh_token"] = canonical_refresh
+                        canonical_changed = True
+                    if canonical_last_refresh and canonical_last_refresh != entry.get(
+                        "last_refresh"
+                    ):
+                        entry["last_refresh"] = canonical_last_refresh
+                        canonical_changed = True
+                    if canonical_changed:
+                        # Persist only token metadata; the exhausted/reset
+                        # fields remain frozen until a positive usage probe.
+                        _save_auth_store(auth_store, target_path)
 
             current_access = str(entry.get("access_token") or "").strip()
             if not current_access:
@@ -4318,9 +4467,108 @@ def _refresh_codex_pool_token_for_quota_probe(
             current_refresh = str(entry.get("refresh_token") or "").strip()
             if not current_refresh:
                 return result
-            refreshed = refresh_codex_oauth_pure(current_access, current_refresh)
-            fresh_access = str(refreshed.get("access_token") or "").strip()
+
+            refresh_cache_key = hashlib.sha256(
+                f"{current_access}\0{current_refresh}".encode("utf-8")
+            ).hexdigest()[:16]
+            persisted_failure_at = _parse_codex_reset_at(
+                entry.get(_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD)
+            )
+            persisted_failure_chain = str(
+                entry.get(_CODEX_QUOTA_REFRESH_FAILURE_CHAIN_FIELD) or ""
+            ).strip()
+            wall_now = time.time()
+            if (
+                persisted_failure_chain == refresh_cache_key
+                and persisted_failure_at is not None
+                and wall_now - persisted_failure_at
+                < CODEX_QUOTA_PROBE_MIN_INTERVAL_SECONDS
+            ):
+                return result
+            refresh_started_at = time.monotonic()
+            with _codex_quota_probe_lock:
+                last_failed_at = _codex_quota_refresh_failure_cache.get(
+                    refresh_cache_key
+                )
+                if (
+                    last_failed_at is not None
+                    and refresh_started_at - last_failed_at
+                    < CODEX_QUOTA_PROBE_MIN_INTERVAL_SECONDS
+                ):
+                    return result
+                # Reserve before the POST so concurrent selectors in this
+                # process cannot spend the same single-use refresh token.
+                # A successful persisted rotation removes the reservation;
+                # any exception leaves it as the transient-failure throttle.
+                _codex_quota_refresh_failure_cache[refresh_cache_key] = (
+                    refresh_started_at
+                )
+
+            try:
+                refreshed = refresh_codex_oauth_pure(
+                    current_access, current_refresh
+                )
+            except Exception as exc:
+                if _is_terminal_codex_oauth_refresh_error(exc):
+                    if entry.get("source") == "device_code":
+                        providers = auth_store.get("providers")
+                        state = (
+                            providers.get("openai-codex")
+                            if isinstance(providers, dict)
+                            else None
+                        )
+                        tokens = (
+                            state.get("tokens") if isinstance(state, dict) else None
+                        )
+                        if isinstance(state, dict) and isinstance(tokens, dict):
+                            store_refresh = str(
+                                tokens.get("refresh_token") or ""
+                            ).strip()
+                            if not store_refresh or store_refresh == current_refresh:
+                                tokens.pop("access_token", None)
+                                tokens.pop("refresh_token", None)
+                                state["tokens"] = tokens
+                                state["last_auth_error"] = {
+                                    "provider": "openai-codex",
+                                    "code": getattr(exc, "code", "unknown"),
+                                    "message": str(exc),
+                                    "reason": "quota_probe_refresh_failure",
+                                    "relogin_required": True,
+                                    "at": datetime.now(timezone.utc).isoformat(),
+                                }
+                    entry.pop(_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD, None)
+                    entry.pop(_CODEX_QUOTA_REFRESH_FAILURE_CHAIN_FIELD, None)
+                    entry["last_status"] = "dead"
+                    entry["last_status_at"] = time.time()
+                    entry["last_error_code"] = 401
+                    entry["last_error_reason"] = (
+                        getattr(exc, "code", None) or "invalid_grant"
+                    )
+                    entry["last_error_message"] = str(exc)
+                    entry["last_error_reset_at"] = None
+                    _save_auth_store(auth_store, target_path)
+                else:
+                    entry[_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD] = time.time()
+                    entry[_CODEX_QUOTA_REFRESH_FAILURE_CHAIN_FIELD] = (
+                        refresh_cache_key
+                    )
+                    try:
+                        _save_auth_store(auth_store, target_path)
+                    except Exception:
+                        logger.debug(
+                            "Failed to persist Codex quota-refresh throttle",
+                            exc_info=True,
+                        )
+                raise
+            fresh_access = (
+                str(refreshed.get("access_token") or "").strip()
+                if isinstance(refreshed, dict)
+                else ""
+            )
             if not fresh_access:
+                entry[_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD] = time.time()
+                entry[_CODEX_QUOTA_REFRESH_FAILURE_CHAIN_FIELD] = refresh_cache_key
+                _save_auth_store(auth_store, target_path)
                 return result
 
             entry["access_token"] = fresh_access
@@ -4329,17 +4577,62 @@ def _refresh_codex_pool_token_for_quota_probe(
                 entry["refresh_token"] = fresh_refresh
             if refreshed.get("last_refresh"):
                 entry["last_refresh"] = refreshed["last_refresh"]
-            _save_auth_store(auth_store)
+
+            if entry.get("source") == "device_code":
+                providers = auth_store.get("providers")
+                state = (
+                    providers.get("openai-codex")
+                    if isinstance(providers, dict)
+                    else None
+                )
+                tokens = state.get("tokens") if isinstance(state, dict) else None
+                if isinstance(state, dict) and isinstance(tokens, dict):
+                    tokens["access_token"] = fresh_access
+                    if fresh_refresh:
+                        tokens["refresh_token"] = fresh_refresh
+                    if refreshed.get("last_refresh"):
+                        state["last_refresh"] = refreshed["last_refresh"]
+
+            entry.pop(_CODEX_QUOTA_REFRESH_FAILURE_AT_FIELD, None)
+            entry.pop(_CODEX_QUOTA_REFRESH_FAILURE_CHAIN_FIELD, None)
+            _save_auth_store(auth_store, target_path)
+            with _codex_quota_probe_lock:
+                _codex_quota_refresh_failure_cache.pop(refresh_cache_key, None)
             result["access_token"] = fresh_access
             result["refresh_token"] = entry.get("refresh_token")
             result["last_refresh"] = entry.get("last_refresh")
             return result
-    except Exception:
+    except Exception as exc:
+        if _is_terminal_codex_oauth_refresh_error(exc):
+            raise
         logger.debug(
             "Failed to refresh expired Codex token for quota probe",
             exc_info=True,
         )
         return result
+
+
+def _refresh_codex_pool_token_for_quota_probe(
+    rate_limit_status: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Refresh the matching Codex quota row in its owning auth store."""
+    result = dict(rate_limit_status)
+    stale_token = str(result.get("access_token") or "").strip()
+    entry_id = str(result.get("id") or "").strip()
+    if not stale_token or not entry_id:
+        return result
+    try:
+        owner_paths = _codex_pool_owner_paths()
+    except Exception:
+        logger.debug("Failed to resolve Codex quota credential owner", exc_info=True)
+        return result
+    for target_path in owner_paths:
+        owner_result = _refresh_codex_pool_token_for_quota_probe_in_store(
+            result, target_path
+        )
+        if owner_result is not None:
+            return owner_result
+    return result
 
 
 def _pool_codex_access_token() -> str:
@@ -4353,12 +4646,7 @@ def _pool_codex_access_token() -> str:
     the original AuthError).
     """
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return ""
-        entries = pool.get("openai-codex")
+        entries: Any = read_credential_pool("openai-codex")
         if not isinstance(entries, list):
             return ""
 
@@ -4368,9 +4656,16 @@ def _pool_codex_access_token() -> str:
             token = entry.get("access_token")
             if not isinstance(token, str) or not token.strip():
                 return False
-            # Skip entries currently in an exhaustion cooldown window.
-            reset_at = entry.get("last_error_reset_at")
-            if isinstance(reset_at, (int, float)) and reset_at > time.time():
+            status = str(entry.get("last_status") or "").lower()
+            if status == "dead":
+                return False
+            reset_at = _parse_codex_reset_at(entry.get("last_error_reset_at"))
+            if reset_at is not None and reset_at > time.time():
+                return False
+            # An exhausted row without a parseable reset remains unavailable;
+            # the quota-status path below can probe it or surface a fail-closed
+            # cooldown instead of sending an auth/quota-bad token to the wire.
+            if status == "exhausted" and reset_at is None:
                 return False
             return True
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1485,8 +1485,8 @@ def _merge_disk_cooldown_state(
     cooldowns are not resurrected, so the pool's own expiry-clear (which
     resets ``last_status_at`` to None) is never overridden.
 
-    For singleton-seeded Codex OAuth rows, also retain an on-disk token chain
-    with a strictly newer ``last_refresh``. Codex refresh tokens are single-use;
+    For Codex device-code OAuth rows, also retain an on-disk token chain with a
+    strictly newer ``last_refresh``. Codex refresh tokens are single-use;
     allowing any stale whole-pool snapshot to restore the older refresh token
     would make the next process replay an already consumed grant. For every
     Codex row, the same recency rule preserves a newer persisted quota-refresh
@@ -1504,10 +1504,12 @@ def _merge_disk_cooldown_state(
         )
 
         disk_status = disk_entry.get("last_status")
+        memory_source = entry.get("source")
+        disk_source = disk_entry.get("source")
         if (
             provider_id == "openai-codex"
-            and entry.get("source") == "device_code"
-            and disk_entry.get("source") == "device_code"
+            and memory_source in {"device_code", "manual:device_code"}
+            and disk_source == memory_source
         ):
             disk_refresh_at = (
                 _parse_absolute_timestamp(disk_entry.get("last_refresh")) or 0.0
@@ -1528,6 +1530,13 @@ def _merge_disk_cooldown_state(
                     disk_value = disk_entry.get(token_field)
                     if disk_value not in (None, ""):
                         entry[token_field] = disk_value
+                # Lifecycle state belongs to the token generation. A quota-
+                # probe refresh preserves its exhausted gate on disk, while a
+                # newer explicit reauthentication clears that gate. Adopting
+                # only the chain would let a stale snapshot re-freeze the new
+                # login on its next whole-pool write.
+                for status_field in _POOL_STATUS_FIELDS:
+                    entry[status_field] = disk_entry.get(status_field)
         if provider_id == "openai-codex":
             disk_failure_at = (
                 _parse_absolute_timestamp(

--- a/tests/hermes_cli/test_auth_codex_quota_probe.py
+++ b/tests/hermes_cli/test_auth_codex_quota_probe.py
@@ -345,6 +345,60 @@ def test_resolver_recovers_when_probe_confirms_reset(tmp_path, monkeypatch):
     assert entry["last_error_reset_at"] is None
 
 
+def test_resolver_refreshes_expired_token_before_quota_reset_probe(
+    tmp_path, monkeypatch
+):
+    """A stale 429 cooldown must not become permanent when its probe token expires."""
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    fresh_token = _jwt({"exp": now + 3600})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "manual:device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    _write_auth_store(hermes_home, store)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    refresh_calls = []
+
+    def _refresh(access_token, refresh_token, **kwargs):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": fresh_token,
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-07-27T08:00:00Z",
+        }
+
+    probe_tokens = []
+
+    def _probe(token, **kwargs):
+        probe_tokens.append(token)
+        return token == fresh_token
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _refresh)
+    monkeypatch.setattr(auth_mod, "_probe_codex_quota_restored", _probe)
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == fresh_token
+    assert resolved["source"] == "credential_pool"
+    assert refresh_calls == [(expired_token, "refresh-old")]
+    assert probe_tokens == [fresh_token]
+
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["access_token"] == fresh_token
+    assert persisted_entry["refresh_token"] == "refresh-new"
+    assert persisted_entry["last_status"] is None
+    assert persisted_entry["last_error_reset_at"] is None
+
+
 def test_resolver_keeps_cooldown_when_probe_negative(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _write_auth_store(hermes_home, _pool_only_rate_limited_store())
@@ -358,6 +412,60 @@ def test_resolver_keeps_cooldown_when_probe_negative(tmp_path, monkeypatch):
         resolve_codex_runtime_credentials()
     assert exc.value.code == auth_mod.CODEX_RATE_LIMITED_CODE
     assert "retry after" in str(exc.value)
+
+
+def test_resolver_keeps_cooldown_after_refresh_when_probe_negative(
+    tmp_path, monkeypatch
+):
+    """A fresh probe token is persisted, but refresh alone must not lift quota."""
+    now = time.time()
+    reset_at = now + 3 * 24 * 3600
+    expired_token = _jwt({"exp": now - 60})
+    fresh_token = _jwt({"exp": now + 3600})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "manual:device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+            "last_error_reset_at": reset_at,
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    _write_auth_store(hermes_home, store)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    monkeypatch.setattr(
+        auth_mod,
+        "refresh_codex_oauth_pure",
+        lambda *args, **kwargs: {
+            "access_token": fresh_token,
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-07-27T08:00:00Z",
+        },
+    )
+    probe_tokens = []
+
+    def _probe(token, **kwargs):
+        probe_tokens.append(token)
+        return False
+
+    monkeypatch.setattr(auth_mod, "_probe_codex_quota_restored", _probe)
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+    assert exc.value.code == auth_mod.CODEX_RATE_LIMITED_CODE
+    assert probe_tokens == [fresh_token]
+
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["access_token"] == fresh_token
+    assert persisted_entry["refresh_token"] == "refresh-new"
+    assert persisted_entry["last_status"] == "exhausted"
+    assert persisted_entry["last_error_code"] == 429
+    assert persisted_entry["last_error_reason"] == "usage_limit_reached"
+    assert persisted_entry["last_error_reset_at"] == reset_at
 
 
 def test_resolver_keeps_cooldown_when_probe_indeterminate(tmp_path, monkeypatch):
@@ -394,6 +502,57 @@ def test_pool_entry_recovers_when_probe_confirms_reset(tmp_path, monkeypatch):
     assert len(available) == 1
     assert available[0].last_status == "ok"
     assert available[0].last_error_reset_at is None
+
+
+def test_pool_refreshes_expired_token_before_quota_reset_probe(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    fresh_token = _jwt({"exp": now + 3600})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "manual:device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    refresh_calls = []
+
+    def _refresh(access_token, refresh_token, **kwargs):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": fresh_token,
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-07-27T08:00:00Z",
+        }
+
+    probe_tokens = []
+
+    def _probe(token, **kwargs):
+        probe_tokens.append(token)
+        return token == fresh_token
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _refresh)
+    monkeypatch.setattr(auth_mod, "_probe_codex_quota_restored", _probe)
+
+    available = pool._available_entries(clear_expired=True, refresh=True)
+
+    assert len(available) == 1
+    assert available[0].access_token == fresh_token
+    assert available[0].refresh_token == "refresh-new"
+    assert available[0].last_status == "ok"
+    assert refresh_calls == [(expired_token, "refresh-old")]
+    assert probe_tokens == [fresh_token]
 
 
 def test_pool_entry_stays_frozen_when_probe_negative(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_codex_quota_probe.py
+++ b/tests/hermes_cli/test_auth_codex_quota_probe.py
@@ -189,7 +189,9 @@ def test_probe_sends_chatgpt_account_id_from_jwt(monkeypatch):
 
 def _write_auth_store(hermes_home, payload):
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
+    (hermes_home / "auth.json").write_text(
+        json.dumps(payload, indent=2), encoding="utf-8"
+    )
 
 
 def _exhausted_pool_store(now=None):
@@ -249,7 +251,7 @@ def test_clear_cooldowns_only_touches_quota_shaped_entries(tmp_path, monkeypatch
 
     assert clear_codex_pool_quota_cooldowns() == 1
 
-    store = json.loads((hermes_home / "auth.json").read_text())
+    store = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     entries = {e["id"]: e for e in store["credential_pool"]["openai-codex"]}
     assert entries["cred-quota"]["last_status"] is None
     assert entries["cred-quota"]["last_error_reset_at"] is None
@@ -281,7 +283,7 @@ def test_clear_cooldowns_scoped_to_access_token(tmp_path, monkeypatch):
 
     assert clear_codex_pool_quota_cooldowns("tok-other") == 1
 
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     entries = {e["id"]: e for e in persisted["credential_pool"]["openai-codex"]}
     assert entries["cred-quota-2"]["last_status"] is None
     assert entries["cred-quota"]["last_status"] == "exhausted"
@@ -341,7 +343,7 @@ def test_resolver_recovers_when_probe_confirms_reset(tmp_path, monkeypatch):
     assert resolved["api_key"] == "tok-quota"
     assert resolved["source"] == "credential_pool"
 
-    store = json.loads((hermes_home / "auth.json").read_text())
+    store = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     entry = store["credential_pool"]["openai-codex"][0]
     assert entry["last_status"] is None
     assert entry["last_error_reset_at"] is None
@@ -393,7 +395,7 @@ def test_resolver_refreshes_expired_token_before_quota_reset_probe(
     assert refresh_calls == [(expired_token, "refresh-old")]
     assert probe_tokens == [fresh_token]
 
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     persisted_entry = persisted["credential_pool"]["openai-codex"][0]
     assert persisted_entry["access_token"] == fresh_token
     assert persisted_entry["refresh_token"] == "refresh-new"
@@ -460,7 +462,7 @@ def test_resolver_keeps_cooldown_after_refresh_when_probe_negative(
     assert exc.value.code == auth_mod.CODEX_RATE_LIMITED_CODE
     assert probe_tokens == [fresh_token]
 
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     persisted_entry = persisted["credential_pool"]["openai-codex"][0]
     assert persisted_entry["access_token"] == fresh_token
     assert persisted_entry["refresh_token"] == "refresh-new"
@@ -611,7 +613,7 @@ def test_device_code_probe_refresh_syncs_pool_and_singleton_with_probe_owned_coo
     assert [item.access_token for item in available] == (
         [fresh_token] if probe_restored else []
     )
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     persisted_entry = persisted["credential_pool"]["openai-codex"][0]
     singleton = persisted["providers"]["openai-codex"]
     assert persisted_entry["access_token"] == fresh_token
@@ -664,14 +666,16 @@ def test_pool_quota_refresh_rereads_latest_canonical_chain_under_lock(
     pool = load_pool("openai-codex")
 
     def _reauth_after_preliminary_sync(item):
-        latest = json.loads((hermes_home / "auth.json").read_text())
+        latest = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
         singleton = latest["providers"]["openai-codex"]
         singleton["tokens"] = {
             "access_token": latest_expired_token,
             "refresh_token": "refresh-latest",
         }
         singleton["last_refresh"] = "2026-07-27T08:00:00Z"
-        (hermes_home / "auth.json").write_text(json.dumps(latest))
+        (hermes_home / "auth.json").write_text(
+            json.dumps(latest), encoding="utf-8"
+        )
         return item
 
     monkeypatch.setattr(
@@ -694,7 +698,7 @@ def test_pool_quota_refresh_rereads_latest_canonical_chain_under_lock(
 
     assert pool._available_entries(clear_expired=True, refresh=False) == []
     assert refresh_calls == [(latest_expired_token, "refresh-latest")]
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     persisted_entry = persisted["credential_pool"]["openai-codex"][0]
     assert persisted_entry["access_token"] == fresh_token
     assert persisted_entry["refresh_token"] == "refresh-fresh"
@@ -736,14 +740,16 @@ def test_pool_singleton_rotation_preserves_quota_cooldown_until_positive_probe(
     from agent.credential_pool import load_pool
 
     pool = load_pool("openai-codex")
-    rotated_store = json.loads((hermes_home / "auth.json").read_text())
+    rotated_store = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     rotated_singleton = rotated_store["providers"]["openai-codex"]
     rotated_singleton["tokens"] = {
         "access_token": rotated_token,
         "refresh_token": "refresh-rotated",
     }
     rotated_singleton["last_refresh"] = "2026-07-27T08:00:00Z"
-    (hermes_home / "auth.json").write_text(json.dumps(rotated_store))
+    (hermes_home / "auth.json").write_text(
+        json.dumps(rotated_store), encoding="utf-8"
+    )
     probe_tokens = []
 
     def _probe(token, **kwargs):
@@ -754,7 +760,7 @@ def test_pool_singleton_rotation_preserves_quota_cooldown_until_positive_probe(
 
     assert pool._available_entries(clear_expired=True, refresh=False) == []
     assert probe_tokens == [rotated_token]
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     persisted_entry = persisted["credential_pool"]["openai-codex"][0]
     assert persisted_entry["access_token"] == rotated_token
     assert persisted_entry["refresh_token"] == "refresh-rotated"
@@ -823,7 +829,7 @@ def test_pool_probe_does_not_overwrite_concurrent_reauthentication(
 
     assert [item.access_token for item in available] == [newer_token]
     assert available[0].refresh_token == "refresh-newer"
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     persisted_entry = persisted["credential_pool"]["openai-codex"][0]
     singleton = persisted["providers"]["openai-codex"]
     assert persisted_entry["access_token"] == newer_token
@@ -913,7 +919,7 @@ def test_pool_final_persist_does_not_rollback_reauth_after_owner_clear(
 
     pool._available_entries(clear_expired=True, refresh=False)
 
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     persisted_entry = next(
         item
         for item in persisted["credential_pool"]["openai-codex"]
@@ -925,6 +931,100 @@ def test_pool_final_persist_does_not_rollback_reauth_after_owner_clear(
     assert persisted_entry["last_refresh"] == "2026-07-27T09:00:00Z"
     assert singleton["tokens"]["access_token"] == newer_token
     assert singleton["tokens"]["refresh_token"] == "refresh-newer"
+
+
+def test_stale_pool_write_preserves_newer_manual_device_code_chain(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    stale_token = _jwt({"exp": now + 1800, "jti": "stale-manual"})
+    newer_token = _jwt({"exp": now + 3600, "jti": "newer-manual"})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "manual:device_code",
+            "access_token": stale_token,
+            "refresh_token": "refresh-stale-manual",
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+    stale_snapshot = dict(entry)
+
+    newer_store = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
+    newer_entry = newer_store["credential_pool"]["openai-codex"][0]
+    newer_entry.update(
+        {
+            "access_token": newer_token,
+            "refresh_token": "refresh-newer-manual",
+            "last_refresh": "2026-07-27T09:00:00Z",
+        }
+    )
+    _write_auth_store(hermes_home, newer_store)
+
+    auth_mod.write_credential_pool("openai-codex", [stale_snapshot])
+
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["access_token"] == newer_token
+    assert persisted_entry["refresh_token"] == "refresh-newer-manual"
+    assert persisted_entry["last_refresh"] == "2026-07-27T09:00:00Z"
+
+
+def test_stale_pool_write_does_not_refreeze_newer_reauthentication(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    stale_token = _jwt({"exp": now + 1800, "jti": "stale-reauth"})
+    newer_token = _jwt({"exp": now + 3600, "jti": "newer-reauth"})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "device_code",
+            "access_token": stale_token,
+            "refresh_token": "refresh-stale-reauth",
+            "last_refresh": "2026-07-27T07:00:00Z",
+            "last_status": "exhausted",
+            "last_status_at": now - 60,
+            "last_error_code": 429,
+            "last_error_reason": "usage_limit_reached",
+            "last_error_reset_at": now + 3600,
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+    stale_snapshot = dict(entry)
+
+    newer_store = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
+    newer_entry = newer_store["credential_pool"]["openai-codex"][0]
+    newer_entry.update(
+        {
+            "access_token": newer_token,
+            "refresh_token": "refresh-newer-reauth",
+            "last_refresh": "2026-07-27T09:00:00Z",
+        }
+    )
+    for status_field in auth_mod._POOL_STATUS_FIELDS:
+        newer_entry[status_field] = None
+    _write_auth_store(hermes_home, newer_store)
+
+    auth_mod.write_credential_pool("openai-codex", [stale_snapshot])
+
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["access_token"] == newer_token
+    assert persisted_entry["refresh_token"] == "refresh-newer-reauth"
+    assert persisted_entry["last_refresh"] == "2026-07-27T09:00:00Z"
+    assert persisted_entry["last_status"] is None
+    assert persisted_entry["last_status_at"] is None
+    assert persisted_entry["last_error_code"] is None
+    assert persisted_entry["last_error_reason"] is None
+    assert persisted_entry["last_error_reset_at"] is None
 
 
 def test_resolver_surfaces_terminal_probe_refresh_failure(tmp_path, monkeypatch):
@@ -961,7 +1061,7 @@ def test_resolver_surfaces_terminal_probe_refresh_failure(tmp_path, monkeypatch)
 
     assert exc_info.value.code == "invalid_grant"
     assert exc_info.value.relogin_required is True
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     persisted_entry = persisted["credential_pool"]["openai-codex"][0]
     assert persisted_entry["last_status"] == "dead"
     assert persisted_entry["last_error_code"] == 401
@@ -1022,7 +1122,7 @@ def test_pool_adopts_terminal_probe_refresh_failure_as_dead(tmp_path, monkeypatc
     assert adopted.last_error_code == 401
     assert adopted.last_error_reason == "invalid_grant"
     assert adopted.last_error_reset_at is None
-    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     singleton = persisted["providers"]["openai-codex"]
     assert "access_token" not in singleton["tokens"]
     assert "refresh_token" not in singleton["tokens"]
@@ -1074,10 +1174,12 @@ def test_pool_throttles_repeated_quota_probe_refresh_failures(
     assert reloaded_pool._available_entries(clear_expired=True, refresh=False) == []
     assert refresh_calls == [(expired_token, "refresh-old")]
 
-    rotated_store = json.loads((hermes_home / "auth.json").read_text())
+    rotated_store = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     rotated_entry = rotated_store["credential_pool"]["openai-codex"][0]
     rotated_entry["refresh_token"] = "refresh-new-chain"
-    (hermes_home / "auth.json").write_text(json.dumps(rotated_store))
+    (hermes_home / "auth.json").write_text(
+        json.dumps(rotated_store), encoding="utf-8"
+    )
     getattr(auth_mod, "_codex_quota_refresh_failure_cache").clear()
     rotated_pool = load_pool("openai-codex")
     assert rotated_pool._available_entries(clear_expired=True, refresh=False) == []
@@ -1125,34 +1227,34 @@ def test_profile_load_keeps_canonical_global_codex_fallback_read_only(
     loaded = load_pool("openai-codex")
 
     assert [entry.id for entry in loaded.entries()] == ["cred-quota"]
-    profile_after = json.loads(profile_path.read_text())
+    profile_after = json.loads(profile_path.read_text(encoding="utf-8"))
     assert not profile_after["credential_pool"].get("openai-codex")
     assert "openai-codex" not in profile_after["providers"]
 
     rotated_token = _jwt({"exp": now + 3600, "jti": "rotated-global"})
-    rotated_global = json.loads(global_path.read_text())
+    rotated_global = json.loads(global_path.read_text(encoding="utf-8"))
     singleton = rotated_global["providers"]["openai-codex"]
     singleton["tokens"] = {
         "access_token": rotated_token,
         "refresh_token": "refresh-global-rotated",
     }
     singleton["last_refresh"] = "2026-07-27T08:00:00Z"
-    global_path.write_text(json.dumps(rotated_global))
+    global_path.write_text(json.dumps(rotated_global), encoding="utf-8")
     monkeypatch.setattr(
         auth_mod, "_probe_codex_quota_restored", lambda token, **kwargs: False
     )
 
     assert loaded._available_entries(clear_expired=True, refresh=False) == []
-    profile_after = json.loads(profile_path.read_text())
+    profile_after = json.loads(profile_path.read_text(encoding="utf-8"))
     assert not profile_after["credential_pool"].get("openai-codex")
-    global_after = json.loads(global_path.read_text())
+    global_after = json.loads(global_path.read_text(encoding="utf-8"))
     global_entry = global_after["credential_pool"]["openai-codex"][0]
     assert global_entry["access_token"] == rotated_token
     assert global_entry["refresh_token"] == "refresh-global-rotated"
     assert global_entry["last_status"] == "exhausted"
 
     local_token = _jwt({"exp": now + 7200, "jti": "local-login"})
-    local_store = json.loads(profile_path.read_text())
+    local_store = json.loads(profile_path.read_text(encoding="utf-8"))
     local_store["providers"]["openai-codex"] = {
         "auth_mode": "chatgpt",
         "label": "local-login",
@@ -1162,11 +1264,11 @@ def test_profile_load_keeps_canonical_global_codex_fallback_read_only(
         },
         "last_refresh": "2026-07-27T09:00:00Z",
     }
-    profile_path.write_text(json.dumps(local_store))
+    profile_path.write_text(json.dumps(local_store), encoding="utf-8")
 
     available = loaded._available_entries(clear_expired=True, refresh=False)
     assert [item.access_token for item in available] == [local_token]
-    global_after_local_login = json.loads(global_path.read_text())
+    global_after_local_login = json.loads(global_path.read_text(encoding="utf-8"))
     unchanged_global = global_after_local_login["credential_pool"]["openai-codex"][0]
     assert unchanged_global["access_token"] == rotated_token
     assert unchanged_global["last_status"] == "exhausted"
@@ -1226,12 +1328,12 @@ def test_profile_local_reauth_does_not_inherit_global_fallback_cooldown(
     available = pool._available_entries(clear_expired=True, refresh=False)
 
     assert [item.access_token for item in available] == [local_token]
-    profile_after = json.loads(profile_path.read_text())
+    profile_after = json.loads(profile_path.read_text(encoding="utf-8"))
     local_entry = profile_after["credential_pool"]["openai-codex"][0]
     assert local_entry["access_token"] == local_token
     assert local_entry["refresh_token"] == "refresh-profile-new"
     assert local_entry["last_status"] is None
-    global_after = json.loads(global_path.read_text())
+    global_after = json.loads(global_path.read_text(encoding="utf-8"))
     persisted_global = global_after["credential_pool"]["openai-codex"][0]
     assert persisted_global["access_token"] == global_token
     assert persisted_global["last_status"] == "exhausted"
@@ -1304,8 +1406,8 @@ def test_profile_quota_probe_refreshes_global_fallback_owner(
     )
     assert refresh_calls == [(expired_token, "refresh-global-old")]
 
-    profile_after = json.loads(profile_path.read_text())
-    global_after = json.loads(global_path.read_text())
+    profile_after = json.loads(profile_path.read_text(encoding="utf-8"))
+    global_after = json.loads(global_path.read_text(encoding="utf-8"))
     assert not profile_after["credential_pool"].get("openai-codex")
     assert "openai-codex" not in profile_after["providers"]
     persisted_entry = global_after["credential_pool"]["openai-codex"][0]
@@ -1365,8 +1467,8 @@ def test_resolver_refreshes_global_fallback_owner(tmp_path, monkeypatch):
     assert resolved["api_key"] == fresh_token
     assert resolved["source"] == "credential_pool"
     assert refresh_calls == [(expired_token, "refresh-global-old")]
-    profile_after = json.loads(profile_path.read_text())
-    global_after = json.loads(global_path.read_text())
+    profile_after = json.loads(profile_path.read_text(encoding="utf-8"))
+    global_after = json.loads(global_path.read_text(encoding="utf-8"))
     assert not profile_after["credential_pool"].get("openai-codex")
     persisted_entry = global_after["credential_pool"]["openai-codex"][0]
     assert persisted_entry["access_token"] == fresh_token
@@ -1524,7 +1626,7 @@ def test_redeem_reset_clears_pool_cooldowns(tmp_path, monkeypatch):
     )
     assert result.redeemed
 
-    store = json.loads((hermes_home / "auth.json").read_text())
+    store = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
     entry = store["credential_pool"]["openai-codex"][0]
     assert entry["last_status"] is None
     assert entry["last_error_reset_at"] is None

--- a/tests/hermes_cli/test_auth_codex_quota_probe.py
+++ b/tests/hermes_cli/test_auth_codex_quota_probe.py
@@ -28,8 +28,10 @@ from hermes_cli.auth import (
 @pytest.fixture(autouse=True)
 def _clear_probe_cache():
     auth_mod._codex_quota_probe_cache.clear()
+    auth_mod._codex_quota_refresh_failure_cache.clear()
     yield
     auth_mod._codex_quota_probe_cache.clear()
+    auth_mod._codex_quota_refresh_failure_cache.clear()
 
 
 def _jwt(claims: dict) -> str:
@@ -553,6 +555,867 @@ def test_pool_refreshes_expired_token_before_quota_reset_probe(
     assert available[0].last_status == "ok"
     assert refresh_calls == [(expired_token, "refresh-old")]
     assert probe_tokens == [fresh_token]
+
+
+@pytest.mark.parametrize("probe_restored", [False, True])
+def test_device_code_probe_refresh_syncs_pool_and_singleton_with_probe_owned_cooldown(
+    tmp_path, monkeypatch, probe_restored
+):
+    now = time.time()
+    reset_at = now + 3 * 24 * 3600
+    expired_token = _jwt({"exp": now - 60})
+    fresh_token = _jwt({"exp": now + 3600})
+    store = _pool_only_rate_limited_store(now)
+    store["providers"]["openai-codex"] = {
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+        },
+        "last_refresh": "2026-07-27T07:00:00Z",
+    }
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+            "last_refresh": "2026-07-27T07:00:00Z",
+            "last_error_reset_at": reset_at,
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    monkeypatch.setattr(
+        auth_mod,
+        "refresh_codex_oauth_pure",
+        lambda *args, **kwargs: {
+            "access_token": fresh_token,
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-07-27T08:00:00Z",
+        },
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "_probe_codex_quota_restored",
+        lambda token, **kwargs: probe_restored,
+    )
+
+    available = pool._available_entries(clear_expired=True, refresh=False)
+
+    assert [item.access_token for item in available] == (
+        [fresh_token] if probe_restored else []
+    )
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    singleton = persisted["providers"]["openai-codex"]
+    assert persisted_entry["access_token"] == fresh_token
+    assert persisted_entry["refresh_token"] == "refresh-new"
+    assert persisted_entry["last_refresh"] == "2026-07-27T08:00:00Z"
+    assert singleton["tokens"]["access_token"] == fresh_token
+    assert singleton["tokens"]["refresh_token"] == "refresh-new"
+    assert singleton["last_refresh"] == "2026-07-27T08:00:00Z"
+    if probe_restored:
+        assert persisted_entry["last_status"] is None
+        assert persisted_entry["last_error_reset_at"] is None
+    else:
+        assert persisted_entry["last_status"] == "exhausted"
+        assert persisted_entry["last_error_code"] == 429
+        assert persisted_entry["last_error_reset_at"] == reset_at
+
+
+def test_pool_quota_refresh_rereads_latest_canonical_chain_under_lock(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    old_expired_token = _jwt({"exp": now - 120, "jti": "old"})
+    latest_expired_token = _jwt({"exp": now - 60, "jti": "latest"})
+    fresh_token = _jwt({"exp": now + 3600, "jti": "fresh"})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "device_code",
+            "access_token": old_expired_token,
+            "refresh_token": "refresh-old",
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    )
+    store["providers"]["openai-codex"] = {
+        "auth_mode": "chatgpt",
+        "label": entry["label"],
+        "tokens": {
+            "access_token": old_expired_token,
+            "refresh_token": "refresh-old",
+        },
+        "last_refresh": "2026-07-27T07:00:00Z",
+    }
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+
+    def _reauth_after_preliminary_sync(item):
+        latest = json.loads((hermes_home / "auth.json").read_text())
+        singleton = latest["providers"]["openai-codex"]
+        singleton["tokens"] = {
+            "access_token": latest_expired_token,
+            "refresh_token": "refresh-latest",
+        }
+        singleton["last_refresh"] = "2026-07-27T08:00:00Z"
+        (hermes_home / "auth.json").write_text(json.dumps(latest))
+        return item
+
+    monkeypatch.setattr(
+        pool, "_sync_codex_entry_from_auth_store", _reauth_after_preliminary_sync
+    )
+    refresh_calls = []
+
+    def _refresh(access_token, refresh_token, **kwargs):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": fresh_token,
+            "refresh_token": "refresh-fresh",
+            "last_refresh": "2026-07-27T09:00:00Z",
+        }
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _refresh)
+    monkeypatch.setattr(
+        auth_mod, "_probe_codex_quota_restored", lambda token, **kwargs: False
+    )
+
+    assert pool._available_entries(clear_expired=True, refresh=False) == []
+    assert refresh_calls == [(latest_expired_token, "refresh-latest")]
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["access_token"] == fresh_token
+    assert persisted_entry["refresh_token"] == "refresh-fresh"
+    assert persisted["providers"]["openai-codex"]["tokens"] == {
+        "access_token": fresh_token,
+        "refresh_token": "refresh-fresh",
+    }
+
+
+def test_pool_singleton_rotation_preserves_quota_cooldown_until_positive_probe(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    old_expired_token = _jwt({"exp": now - 60, "jti": "old"})
+    rotated_token = _jwt({"exp": now + 3600, "jti": "rotated"})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "device_code",
+            "access_token": old_expired_token,
+            "refresh_token": "refresh-old",
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    )
+    store["providers"]["openai-codex"] = {
+        "auth_mode": "chatgpt",
+        "label": entry["label"],
+        "tokens": {
+            "access_token": old_expired_token,
+            "refresh_token": "refresh-old",
+        },
+        "last_refresh": "2026-07-27T07:00:00Z",
+    }
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    rotated_store = json.loads((hermes_home / "auth.json").read_text())
+    rotated_singleton = rotated_store["providers"]["openai-codex"]
+    rotated_singleton["tokens"] = {
+        "access_token": rotated_token,
+        "refresh_token": "refresh-rotated",
+    }
+    rotated_singleton["last_refresh"] = "2026-07-27T08:00:00Z"
+    (hermes_home / "auth.json").write_text(json.dumps(rotated_store))
+    probe_tokens = []
+
+    def _probe(token, **kwargs):
+        probe_tokens.append(token)
+        return False
+
+    monkeypatch.setattr(auth_mod, "_probe_codex_quota_restored", _probe)
+
+    assert pool._available_entries(clear_expired=True, refresh=False) == []
+    assert probe_tokens == [rotated_token]
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["access_token"] == rotated_token
+    assert persisted_entry["refresh_token"] == "refresh-rotated"
+    assert persisted_entry["last_status"] == "exhausted"
+    assert persisted_entry["last_error_code"] == 429
+
+
+def test_pool_probe_does_not_overwrite_concurrent_reauthentication(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    probe_token = _jwt({"exp": now + 3600, "jti": "probe"})
+    newer_token = _jwt({"exp": now + 7200, "jti": "reauth"})
+    store = _pool_only_rate_limited_store(now)
+    store["providers"]["openai-codex"] = {
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+        },
+        "last_refresh": "2026-07-27T07:00:00Z",
+    }
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    monkeypatch.setattr(
+        auth_mod,
+        "refresh_codex_oauth_pure",
+        lambda *args, **kwargs: {
+            "access_token": probe_token,
+            "refresh_token": "refresh-probe",
+            "last_refresh": "2026-07-27T08:00:00Z",
+        },
+    )
+
+    def _probe_with_concurrent_reauth(token, **kwargs):
+        assert token == probe_token
+        auth_mod._save_codex_tokens(
+            {
+                "access_token": newer_token,
+                "refresh_token": "refresh-newer",
+            },
+            last_refresh="2026-07-27T09:00:00Z",
+        )
+        return True
+
+    monkeypatch.setattr(
+        auth_mod, "_probe_codex_quota_restored", _probe_with_concurrent_reauth
+    )
+
+    available = pool._available_entries(clear_expired=True, refresh=False)
+
+    assert [item.access_token for item in available] == [newer_token]
+    assert available[0].refresh_token == "refresh-newer"
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    singleton = persisted["providers"]["openai-codex"]
+    assert persisted_entry["access_token"] == newer_token
+    assert persisted_entry["refresh_token"] == "refresh-newer"
+    assert singleton["tokens"]["access_token"] == newer_token
+    assert singleton["tokens"]["refresh_token"] == "refresh-newer"
+
+
+def test_pool_final_persist_does_not_rollback_reauth_after_owner_clear(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60, "jti": "expired"})
+    probe_token = _jwt({"exp": now + 3600, "jti": "probe"})
+    newer_token = _jwt({"exp": now + 7200, "jti": "reauth-after-clear"})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    )
+    store["providers"]["openai-codex"] = {
+        "auth_mode": "chatgpt",
+        "label": entry["label"],
+        "tokens": {
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+        },
+        "last_refresh": "2026-07-27T07:00:00Z",
+    }
+    store["credential_pool"]["openai-codex"].append(
+        {
+            "id": "cred-expired-window",
+            "label": "other-account",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": _jwt({"exp": now + 3600, "jti": "other"}),
+            "refresh_token": "refresh-other",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_status": "exhausted",
+            "last_status_at": now - 120,
+            "last_error_code": 429,
+            "last_error_reason": "usage_limit_reached",
+            "last_error_reset_at": now - 60,
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    monkeypatch.setattr(
+        auth_mod,
+        "refresh_codex_oauth_pure",
+        lambda *args, **kwargs: {
+            "access_token": probe_token,
+            "refresh_token": "refresh-probe",
+            "last_refresh": "2026-07-27T08:00:00Z",
+        },
+    )
+    monkeypatch.setattr(
+        auth_mod, "_probe_codex_quota_restored", lambda token, **kwargs: True
+    )
+    real_clear = auth_mod.clear_codex_pool_quota_cooldowns
+
+    def _clear_then_reauth(*args, **kwargs):
+        cleared = real_clear(*args, **kwargs)
+        auth_mod._save_codex_tokens(
+            {
+                "access_token": newer_token,
+                "refresh_token": "refresh-newer",
+            },
+            last_refresh="2026-07-27T09:00:00Z",
+        )
+        return cleared
+
+    monkeypatch.setattr(
+        auth_mod, "clear_codex_pool_quota_cooldowns", _clear_then_reauth
+    )
+
+    pool._available_entries(clear_expired=True, refresh=False)
+
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = next(
+        item
+        for item in persisted["credential_pool"]["openai-codex"]
+        if item["id"] == "cred-quota"
+    )
+    singleton = persisted["providers"]["openai-codex"]
+    assert persisted_entry["access_token"] == newer_token
+    assert persisted_entry["refresh_token"] == "refresh-newer"
+    assert persisted_entry["last_refresh"] == "2026-07-27T09:00:00Z"
+    assert singleton["tokens"]["access_token"] == newer_token
+    assert singleton["tokens"]["refresh_token"] == "refresh-newer"
+
+
+def test_resolver_surfaces_terminal_probe_refresh_failure(tmp_path, monkeypatch):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "manual:device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-dead",
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    def _terminal_refresh(*args, **kwargs):
+        raise AuthError(
+            "refresh grant is no longer valid",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _terminal_refresh)
+    monkeypatch.setattr(
+        auth_mod, "_probe_codex_quota_restored", lambda token, **kwargs: False
+    )
+
+    with pytest.raises(AuthError) as exc_info:
+        resolve_codex_runtime_credentials()
+
+    assert exc_info.value.code == "invalid_grant"
+    assert exc_info.value.relogin_required is True
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["last_status"] == "dead"
+    assert persisted_entry["last_error_code"] == 401
+    assert persisted_entry["last_error_reason"] == "invalid_grant"
+    assert persisted_entry["last_error_reset_at"] is None
+
+    with pytest.raises(AuthError) as retry_info:
+        auth_mod.resolve_codex_runtime_credentials()
+    assert retry_info.value.relogin_required is True
+
+
+def test_pool_adopts_terminal_probe_refresh_failure_as_dead(tmp_path, monkeypatch):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-dead",
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    )
+    store["providers"]["openai-codex"] = {
+        "auth_mode": "chatgpt",
+        "label": entry["label"],
+        "tokens": {
+            "access_token": expired_token,
+            "refresh_token": "refresh-dead",
+        },
+        "last_refresh": entry["last_refresh"],
+    }
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+
+    def _terminal_refresh(*args, **kwargs):
+        raise AuthError(
+            "refresh grant is no longer valid",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _terminal_refresh)
+    monkeypatch.setattr(
+        auth_mod, "_probe_codex_quota_restored", lambda token, **kwargs: False
+    )
+
+    assert pool._available_entries(clear_expired=True, refresh=False) == []
+    adopted = pool.entries()[0]
+    assert adopted.last_status == "dead"
+    assert adopted.last_error_code == 401
+    assert adopted.last_error_reason == "invalid_grant"
+    assert adopted.last_error_reset_at is None
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    singleton = persisted["providers"]["openai-codex"]
+    assert "access_token" not in singleton["tokens"]
+    assert "refresh_token" not in singleton["tokens"]
+    assert singleton["last_auth_error"]["code"] == "invalid_grant"
+    assert singleton["last_auth_error"]["relogin_required"] is True
+
+
+def test_pool_throttles_repeated_quota_probe_refresh_failures(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "manual:device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    refresh_calls = []
+
+    def _refresh(access_token, refresh_token, **kwargs):
+        refresh_calls.append((access_token, refresh_token))
+        raise RuntimeError("temporary token endpoint failure")
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _refresh)
+    monkeypatch.setattr(
+        auth_mod, "_probe_codex_quota_restored", lambda token, **kwargs: False
+    )
+
+    assert pool._available_entries(clear_expired=True, refresh=False) == []
+    assert pool._available_entries(clear_expired=True, refresh=False) == []
+    # Simulate another process persisting a stale whole-pool snapshot that was
+    # loaded before the failure marker existed.
+    auth_mod.write_credential_pool("openai-codex", [dict(entry)])
+    # A second process has a fresh module-local cache but reads the same
+    # persisted auth-store row. The failure throttle must survive that boundary.
+    getattr(auth_mod, "_codex_quota_refresh_failure_cache").clear()
+    reloaded_pool = load_pool("openai-codex")
+    assert reloaded_pool._available_entries(clear_expired=True, refresh=False) == []
+    assert refresh_calls == [(expired_token, "refresh-old")]
+
+    rotated_store = json.loads((hermes_home / "auth.json").read_text())
+    rotated_entry = rotated_store["credential_pool"]["openai-codex"][0]
+    rotated_entry["refresh_token"] = "refresh-new-chain"
+    (hermes_home / "auth.json").write_text(json.dumps(rotated_store))
+    getattr(auth_mod, "_codex_quota_refresh_failure_cache").clear()
+    rotated_pool = load_pool("openai-codex")
+    assert rotated_pool._available_entries(clear_expired=True, refresh=False) == []
+    assert refresh_calls == [
+        (expired_token, "refresh-old"),
+        (expired_token, "refresh-new-chain"),
+    ]
+
+
+def test_profile_load_keeps_canonical_global_codex_fallback_read_only(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    global_path = tmp_path / "root" / "auth.json"
+    profile_store = {"version": 1, "providers": {}, "credential_pool": {}}
+    global_store = _pool_only_rate_limited_store(now)
+    global_entry = global_store["credential_pool"]["openai-codex"][0]
+    global_entry.update(
+        {
+            "source": "device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-global-old",
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    )
+    global_store["providers"]["openai-codex"] = {
+        "auth_mode": "chatgpt",
+        "label": global_entry["label"],
+        "tokens": {
+            "access_token": expired_token,
+            "refresh_token": "refresh-global-old",
+        },
+        "last_refresh": "2026-07-27T07:00:00Z",
+    }
+    _write_auth_store(profile_path.parent, profile_store)
+    _write_auth_store(global_path.parent, global_store)
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_file_path", lambda: global_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+
+    from agent.credential_pool import load_pool
+
+    loaded = load_pool("openai-codex")
+
+    assert [entry.id for entry in loaded.entries()] == ["cred-quota"]
+    profile_after = json.loads(profile_path.read_text())
+    assert not profile_after["credential_pool"].get("openai-codex")
+    assert "openai-codex" not in profile_after["providers"]
+
+    rotated_token = _jwt({"exp": now + 3600, "jti": "rotated-global"})
+    rotated_global = json.loads(global_path.read_text())
+    singleton = rotated_global["providers"]["openai-codex"]
+    singleton["tokens"] = {
+        "access_token": rotated_token,
+        "refresh_token": "refresh-global-rotated",
+    }
+    singleton["last_refresh"] = "2026-07-27T08:00:00Z"
+    global_path.write_text(json.dumps(rotated_global))
+    monkeypatch.setattr(
+        auth_mod, "_probe_codex_quota_restored", lambda token, **kwargs: False
+    )
+
+    assert loaded._available_entries(clear_expired=True, refresh=False) == []
+    profile_after = json.loads(profile_path.read_text())
+    assert not profile_after["credential_pool"].get("openai-codex")
+    global_after = json.loads(global_path.read_text())
+    global_entry = global_after["credential_pool"]["openai-codex"][0]
+    assert global_entry["access_token"] == rotated_token
+    assert global_entry["refresh_token"] == "refresh-global-rotated"
+    assert global_entry["last_status"] == "exhausted"
+
+    local_token = _jwt({"exp": now + 7200, "jti": "local-login"})
+    local_store = json.loads(profile_path.read_text())
+    local_store["providers"]["openai-codex"] = {
+        "auth_mode": "chatgpt",
+        "label": "local-login",
+        "tokens": {
+            "access_token": local_token,
+            "refresh_token": "refresh-local",
+        },
+        "last_refresh": "2026-07-27T09:00:00Z",
+    }
+    profile_path.write_text(json.dumps(local_store))
+
+    available = loaded._available_entries(clear_expired=True, refresh=False)
+    assert [item.access_token for item in available] == [local_token]
+    global_after_local_login = json.loads(global_path.read_text())
+    unchanged_global = global_after_local_login["credential_pool"]["openai-codex"][0]
+    assert unchanged_global["access_token"] == rotated_token
+    assert unchanged_global["last_status"] == "exhausted"
+
+
+def test_profile_local_reauth_does_not_inherit_global_fallback_cooldown(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    global_token = _jwt({"exp": now + 3600, "jti": "global-old"})
+    local_token = _jwt({"exp": now + 3600, "jti": "profile-login"})
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    global_path = tmp_path / "root" / "auth.json"
+    global_store = _pool_only_rate_limited_store(now)
+    global_entry = global_store["credential_pool"]["openai-codex"][0]
+    global_entry.update(
+        {
+            "source": "device_code",
+            "access_token": global_token,
+            "refresh_token": "refresh-global-old",
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    )
+    global_store["providers"]["openai-codex"] = {
+        "auth_mode": "chatgpt",
+        "label": global_entry["label"],
+        "tokens": {
+            "access_token": global_token,
+            "refresh_token": "refresh-global-old",
+        },
+        "last_refresh": "2026-07-27T07:00:00Z",
+    }
+    profile_store = {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "auth_mode": "chatgpt",
+                "label": "profile-login",
+                "tokens": {
+                    "access_token": local_token,
+                    "refresh_token": "refresh-profile-new",
+                },
+                "last_refresh": "2026-07-27T09:00:00Z",
+            }
+        },
+        "credential_pool": {},
+    }
+    _write_auth_store(profile_path.parent, profile_store)
+    _write_auth_store(global_path.parent, global_store)
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_file_path", lambda: global_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    available = pool._available_entries(clear_expired=True, refresh=False)
+
+    assert [item.access_token for item in available] == [local_token]
+    profile_after = json.loads(profile_path.read_text())
+    local_entry = profile_after["credential_pool"]["openai-codex"][0]
+    assert local_entry["access_token"] == local_token
+    assert local_entry["refresh_token"] == "refresh-profile-new"
+    assert local_entry["last_status"] is None
+    global_after = json.loads(global_path.read_text())
+    persisted_global = global_after["credential_pool"]["openai-codex"][0]
+    assert persisted_global["access_token"] == global_token
+    assert persisted_global["last_status"] == "exhausted"
+
+
+@pytest.mark.parametrize("probe_restored", [False, True])
+@pytest.mark.parametrize("source", ["manual:device_code", "device_code"])
+def test_profile_quota_probe_refreshes_global_fallback_owner(
+    tmp_path, monkeypatch, probe_restored, source
+):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    fresh_token = _jwt({"exp": now + 3600})
+    reset_at = now + 3 * 24 * 3600
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    global_path = tmp_path / "root" / "auth.json"
+
+    profile_store = {"version": 1, "providers": {}, "credential_pool": {}}
+    global_store = _pool_only_rate_limited_store(now)
+    global_entry = global_store["credential_pool"]["openai-codex"][0]
+    global_entry.update(
+        {
+            "source": source,
+            "access_token": expired_token,
+            "refresh_token": "refresh-global-old",
+            "last_refresh": "2026-07-27T07:00:00Z",
+            "last_error_reset_at": reset_at,
+        }
+    )
+    if source == "device_code":
+        global_store["providers"]["openai-codex"] = {
+            "auth_mode": "chatgpt",
+            "label": global_entry["label"],
+            "tokens": {
+                "access_token": expired_token,
+                "refresh_token": "refresh-global-old",
+            },
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    _write_auth_store(profile_path.parent, profile_store)
+    _write_auth_store(global_path.parent, global_store)
+
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_file_path", lambda: global_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    refresh_calls = []
+
+    def _refresh(access_token, refresh_token, **kwargs):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": fresh_token,
+            "refresh_token": "refresh-global-new",
+            "last_refresh": "2026-07-27T08:00:00Z",
+        }
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _refresh)
+    monkeypatch.setattr(
+        auth_mod,
+        "_probe_codex_quota_restored",
+        lambda token, **kwargs: probe_restored,
+    )
+
+    available = pool._available_entries(clear_expired=True, refresh=False)
+    assert [item.access_token for item in available] == (
+        [fresh_token] if probe_restored else []
+    )
+    assert refresh_calls == [(expired_token, "refresh-global-old")]
+
+    profile_after = json.loads(profile_path.read_text())
+    global_after = json.loads(global_path.read_text())
+    assert not profile_after["credential_pool"].get("openai-codex")
+    assert "openai-codex" not in profile_after["providers"]
+    persisted_entry = global_after["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["access_token"] == fresh_token
+    assert persisted_entry["refresh_token"] == "refresh-global-new"
+    if probe_restored:
+        assert persisted_entry["last_status"] is None
+        assert persisted_entry["last_error_reset_at"] is None
+    else:
+        assert persisted_entry["last_status"] == "exhausted"
+        assert persisted_entry["last_error_reset_at"] == reset_at
+    if source == "device_code":
+        singleton = global_after["providers"]["openai-codex"]
+        assert singleton["tokens"]["access_token"] == fresh_token
+        assert singleton["tokens"]["refresh_token"] == "refresh-global-new"
+        assert singleton["last_refresh"] == "2026-07-27T08:00:00Z"
+
+
+def test_resolver_refreshes_global_fallback_owner(tmp_path, monkeypatch):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    fresh_token = _jwt({"exp": now + 3600})
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    global_path = tmp_path / "root" / "auth.json"
+    profile_store = {"version": 1, "providers": {}, "credential_pool": {}}
+    global_store = _pool_only_rate_limited_store(now)
+    global_entry = global_store["credential_pool"]["openai-codex"][0]
+    global_entry.update(
+        {
+            "source": "manual:device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-global-old",
+        }
+    )
+    _write_auth_store(profile_path.parent, profile_store)
+    _write_auth_store(global_path.parent, global_store)
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_file_path", lambda: global_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    refresh_calls = []
+
+    def _refresh(access_token, refresh_token, **kwargs):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": fresh_token,
+            "refresh_token": "refresh-global-new",
+            "last_refresh": "2026-07-27T08:00:00Z",
+        }
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _refresh)
+    monkeypatch.setattr(
+        auth_mod, "_probe_codex_quota_restored", lambda token, **kwargs: True
+    )
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == fresh_token
+    assert resolved["source"] == "credential_pool"
+    assert refresh_calls == [(expired_token, "refresh-global-old")]
+    profile_after = json.loads(profile_path.read_text())
+    global_after = json.loads(global_path.read_text())
+    assert not profile_after["credential_pool"].get("openai-codex")
+    persisted_entry = global_after["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["access_token"] == fresh_token
+    assert persisted_entry["refresh_token"] == "refresh-global-new"
+    assert persisted_entry["last_status"] is None
+    assert persisted_entry["last_error_reset_at"] is None
+
+
+def test_pool_adopts_rotated_refresh_metadata_when_probe_access_is_unchanged(
+    tmp_path, monkeypatch
+):
+    now = time.time()
+    expired_token = _jwt({"exp": now - 60})
+    store = _pool_only_rate_limited_store(now)
+    entry = store["credential_pool"]["openai-codex"][0]
+    entry.update(
+        {
+            "source": "manual:device_code",
+            "access_token": expired_token,
+            "refresh_token": "refresh-old",
+            "last_refresh": "2026-07-27T07:00:00Z",
+        }
+    )
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(hermes_home, store)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    monkeypatch.setattr(
+        auth_mod,
+        "refresh_codex_oauth_pure",
+        lambda *args, **kwargs: {
+            "access_token": expired_token,
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-07-27T08:00:00Z",
+        },
+    )
+    monkeypatch.setattr(
+        auth_mod, "_probe_codex_quota_restored", lambda token, **kwargs: False
+    )
+
+    assert pool._available_entries(clear_expired=True, refresh=False) == []
+
+    adopted = pool.entries()[0]
+    assert adopted.access_token == expired_token
+    assert adopted.refresh_token == "refresh-new"
+    assert adopted.last_refresh == "2026-07-27T08:00:00Z"
 
 
 def test_pool_entry_stays_frozen_when_probe_negative(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Hardens the OpenAI Codex quota-restored probe so an expired access token can be refreshed safely before the usage request.

The refresh path now:

- resolves the credential's true owner store;
- acquires that store's cross-process lock before re-reading or exchanging a rotating refresh token;
- persists the complete access/refresh/timestamp replacement chain atomically;
- keeps canonical device-code and pool state synchronized;
- preserves quota/cooldown state unless the usage probe is explicitly positive;
- classifies terminal refresh failures separately from transient failures;
- persists transient-failure throttling across processes;
- conditionally merges concurrent reauthentication and newer lifecycle state so stale pool snapshots cannot overwrite them;
- keeps profile-local and global fallback ownership separate.

## Motivation

The quota-restored probe can run while a pooled Codex credential is still under a persisted cooldown. If the stored access token expires during that cooldown, probing with it returns an authentication error and cannot demonstrate that upstream quota recovered.

Refreshing outside the owning store's lock is unsafe because Codex refresh tokens rotate and are single-use. A concurrent process or a stale whole-pool write can otherwise replay an old refresh token, split the canonical and pool token chains, or restore stale cooldown state after a newer login.

This change treats authentication and quota as independent lifecycles: successful refresh only restores a usable probe credential; only an explicit positive usage response clears cooldown.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test improvement
- [ ] Other (please describe):

## Related Issues

- Follow-up hardening for #69494.
- Related ownership/rotation work: #64572, #70111, and #72413.
- No single open PR currently covers the complete quota-probe owner-lock, fail-closed, and stale-persist lifecycle in this change.

## Testing

- [x] Added regression coverage for expired-token refresh, same-access-token refresh-token rotation, owner-store locking, singleton/pool synchronization, concurrent reauthentication, terminal and transient refresh failures, cross-process throttling, stale whole-pool persistence, newer-generation preservation, global fallback ownership, and local takeover.
- [x] `scripts/run_tests.sh -j 4 tests/hermes_cli/test_auth_codex_quota_probe.py tests/agent/test_credential_pool.py tests/agent/test_credential_pool_oauth_writethrough.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_auth_codex_provider.py -q` — 204 passed.
- [x] Clean rebased-head affected and upstream-delta suite — 365 passed, 0 failed.
- [ ] `scripts/run_tests.sh -j 4 -q` — completed, but not fully green locally; see the baseline analysis below.
- [x] `ruff check` on all changed files.
- [x] `scripts/check-windows-footguns.py` on all changed files.
- [x] `git diff --check`.
- [x] Baseline-aware `ty check` on changed files — 0 new diagnostics relative to the same `origin/main` base.
- [x] Manual end-to-end Codex OAuth request before and after a graceful gateway reload; no related authentication or quota error was observed.

<details>
<summary>Local full-suite baseline analysis</summary>

The complete local runner finished with 8 failing files / 19 failing tests. None of the changed auth/pool regression files failed.

The same eight files were then rerun with the same Python environment and `-j 1` in two clean disposable worktrees: current `origin/main` and the rebased PR head.

- Both trees failed the same six unrelated files (session/SQLite recovery, gateway startup race, Qwen provider fallthrough, Honcho cache busting, Codex-response SQLite persistence, and execute-code approval routing).
- Two failures from the active worktree (`managed_uv` call count and bundled plugin discovery) passed in both clean worktrees; the latter was caused by an untracked local plugin directory.
- The only node-count difference was a Honcho cache-busting test that independently alternated between pass and fail on both base and head across five fresh-process repetitions.

This produced no deterministic head-only failure. GitHub CI remains authoritative for the clean x86 test matrix.

</details>

## Screenshots / Demos

Not applicable; this is an authentication lifecycle fix with no user-interface changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where necessary (no user-facing documentation change is required)
- [x] My changes generate no new warnings relative to the current baseline
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Notes for Reviewers

Codex refresh tokens are rotating and single-use, so the owner-store lock intentionally spans the latest-state re-read, token exchange, and atomic save. The usage request itself remains outside that lock; its final write therefore uses conditional merge logic rather than persisting the pre-probe snapshot.

This overlaps with #64572 around global/root ownership, but it is not a complete duplicate: this change is specifically a current-main follow-up to the quota-restored probe and includes probe refresh, quota/auth separation, persistent transient-failure throttling, terminal lifecycle handling, and stale post-probe/whole-pool write protection. Maintainer guidance on consolidating shared ownership helpers with #64572 is welcome.
