### PR TITLE
fix(agent): classify flat OpenRouter upstream errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1744,6 +1744,20 @@ def _extract_message(error: Exception, body: dict) -> str:
     return str(error)[:500]
 
 
+def _openrouter_error_payload(body: Any) -> Optional[dict]:
+    """Return OpenRouter's error object from nested HTTP or flat SDK bodies."""
+    if not isinstance(body, dict):
+        return None
+    nested = body.get("error")
+    if isinstance(nested, dict):
+        return nested
+    # The OpenAI SDK's APIStatusError.body is already the inner ``error``
+    # object, so OpenRouter metadata appears at the top level.
+    if isinstance(body.get("metadata"), dict):
+        return body
+    return None
+
+
 def _is_openrouter_upstream_error(body: Any, provider: str) -> bool:
     """Detect OpenRouter's aggregator-wrapped upstream provider errors.
 
@@ -1753,11 +1767,9 @@ def _is_openrouter_upstream_error(body: Any, provider: str) -> bool:
     user's OpenRouter key is healthy — the upstream provider is the one that
     failed — so credential rotation is the wrong recovery.
     """
-    if not isinstance(body, dict):
-        return False
     provider_lower = (provider or "").strip().lower()
-    err = body.get("error")
-    if not isinstance(err, dict):
+    err = _openrouter_error_payload(body)
+    if err is None:
         return False
     outer_msg = str(err.get("message") or "").strip().lower()
     if outer_msg != "provider returned error":
@@ -1776,10 +1788,8 @@ def _is_openrouter_upstream_error(body: Any, provider: str) -> bool:
 
 def _extract_upstream_provider_name(body: Any) -> Optional[str]:
     """Pull the upstream provider name out of OpenRouter's error metadata."""
-    if not isinstance(body, dict):
-        return None
-    err = body.get("error")
-    if not isinstance(err, dict):
+    err = _openrouter_error_payload(body)
+    if err is None:
         return None
     metadata = err.get("metadata")
     if not isinstance(metadata, dict):

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -371,6 +371,75 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.should_fallback is True
 
+    def test_openrouter_upstream_429_flat_body_does_not_rotate_credential(self):
+        """The OpenAI SDK exposes OpenRouter's inner error object as ``body``.
+
+        The live Kimi K3 failure therefore had a flat
+        ``{message, code, metadata}`` body rather than the HTTP response's
+        nested ``{error: {...}}`` envelope.  It must still be treated as an
+        upstream model-route limit, with provider context preserved.
+        """
+        error = MockAPIError(
+            "Error code: 429",
+            status_code=429,
+            body={
+                "message": "Provider returned error",
+                "code": 429,
+                "metadata": {
+                    "raw": (
+                        "moonshotai/kimi-k3 is temporarily rate-limited upstream. "
+                        "Please retry shortly."
+                    ),
+                    "provider_name": "Moonshot AI",
+                    "retry_after_seconds": 1,
+                },
+            },
+        )
+        result = classify_api_error(
+            error,
+            provider="openrouter",
+            model="moonshotai/kimi-k3",
+        )
+
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+        assert result.error_context == {"upstream_provider": "Moonshot AI"}
+
+    def test_openrouter_account_429_with_incidental_phrase_rotates_credential(self):
+        """Free-form text must not override an account-level OpenRouter 429."""
+
+        class RateLimitError(Exception):
+            status_code = 429
+
+        result = classify_api_error(
+            RateLimitError(
+                "This is not a Provider returned error; account rate limit exceeded"
+            ),
+            provider="openrouter",
+            model="moonshotai/kimi-k3",
+        )
+
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+    def test_non_openrouter_429_with_metadata_words_rotates_credential(self):
+        """Metadata words in unrelated free text are not OpenRouter structure."""
+
+        class RateLimitError(Exception):
+            status_code = 429
+
+        result = classify_api_error(
+            RateLimitError(
+                "Provider returned error; malformed metadata provider_name"
+            ),
+            provider="other-provider",
+            model="example/model",
+        )
+
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
     def test_alibaba_rate_increased_too_quickly(self):
         """Alibaba/DashScope returns a unique throttling message.
 


### PR DESCRIPTION
## Summary

- normalize both nested OpenRouter HTTP error envelopes and the flat inner bodies exposed by the OpenAI SDK
- preserve upstream provider metadata such as `provider_name`
- classify transient upstream/model-route limits as `upstream_rate_limit` so Hermes does not rotate or exhaust a valid user credential
- add regression coverage for the exact SDK-exposed flat body and negative guards for malformed or incidental free-text 429s

## Root cause

OpenRouter can return an HTTP body shaped as `{"error": {...}}`, but the OpenAI SDK raises the inner object as a flat body: `{"code": ..., "message": ..., "metadata": ...}`. The classifier only inspected the nested form. A transient upstream model limit was therefore treated as a credential-level rate limit, exhausting the sole usable credential and causing concurrent jobs to report `No LLM provider configured`.

The production-shaped regression includes an upstream Moonshot model-route limit with `provider_name=Moonshot AI`, `is_byok=false`, and a retry interval. No credential value or account data is included.

## Test plan

- Current-main RED proof: the structured flat-body regression fails before the fix
- Post-review focused verification: production-shaped flat body plus two false-positive guards — 3 passed
- `uvx ruff check agent/error_classifier.py tests/agent/test_error_classifier.py`
- `git diff --check origin/main...HEAD`