### PR TITLE
fix(acp): stop /compress from hard-deleting the stored transcript

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -409,6 +409,24 @@ class SessionManager:
             logger.debug("SessionDB unavailable for ACP persistence", exc_info=True)
             return None
 
+    @staticmethod
+    def _replace_would_shrink(db, state: SessionState) -> bool:
+        """True when replacing the stored transcript would drop live rows.
+
+        A save that carries FEWER messages than the session already has on disk
+        is a compaction (or a truncation), not an update — the destructive
+        ``replace_messages`` would delete the difference outright. Counting is
+        enough here: ACP's in-memory history is always a prefix-plus-tail of the
+        stored conversation, so a shorter history means stored turns are about
+        to disappear. Errors fall back to ``False`` so persistence keeps working
+        exactly as before when the count cannot be read.
+        """
+        try:
+            stored = db.get_messages(state.session_id)
+        except Exception:
+            return False
+        return len(stored) > len(state.history or [])
+
     def _persist(self, state: SessionState) -> None:
         """Write session state to the database.
 
@@ -488,6 +506,31 @@ class SessionManager:
                     has_archived = db.has_archived_messages(state.session_id)
                 except Exception:
                     has_archived = False
+                # "No archived rows" does NOT imply "nothing to lose". ACP
+                # /compress unsets agent._session_db before calling
+                # _compress_context (to avoid its session-splitting side
+                # effect), which also suppresses archive_and_compact() — so a
+                # compacted ACP session reaches this point with a FULL stored
+                # transcript, ZERO active=0 rows, and an in-memory history that
+                # is just the summary. The guard above then reads that absence
+                # as "fresh create/fork" and the replace hard-DELETEs every
+                # stored turn (and its FTS rows). Detect the shrink directly:
+                # when the write would drop stored live rows, soft-archive them
+                # instead via archive_and_compact() — same session id (#38763),
+                # summary becomes the live set, prior turns stay on disk and
+                # searchable.
+                if not has_archived and self._replace_would_shrink(db, state):
+                    try:
+                        db.archive_and_compact(state.session_id, state.history)
+                        return
+                    except Exception:
+                        logger.warning(
+                            "ACP: archive_and_compact failed for %s; falling back "
+                            "to a live-only replace to avoid deleting history",
+                            state.session_id,
+                            exc_info=True,
+                        )
+                        has_archived = True
                 db.replace_messages(
                     state.session_id, state.history, active_only=has_archived
                 )

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -308,6 +308,66 @@ class TestListAndCleanup:
         hits = {r["session_id"] for r in db.search_messages("needle")}
         assert state.session_id in hits
 
+    def test_acp_compress_preserves_the_pre_compaction_transcript(self, tmp_path):
+        """Regression: ``/compress`` must not hard-DELETE the stored transcript.
+
+        ``_cmd_compress`` unsets ``agent._session_db`` to avoid the
+        session-splitting side effect inside ``_compress_context``. That also
+        suppresses ``archive_and_compact()``, so NO ``active=0`` rows are
+        created — which is exactly the condition ``_persist`` reads as "fresh
+        create/fork with no archived history to lose" before taking the
+        destructive ``replace_messages(active_only=False)`` branch. The guard
+        is defeated by the very action that creates the need for it, and the
+        whole conversation (plus its FTS rows) is deleted, leaving the summary.
+
+        Reproduces the post-``/compress`` state exactly: a full stored
+        transcript, zero archived rows, and an in-memory history holding only
+        the summary — then saves.
+        """
+        db = SessionDB(tmp_path / "state.db")
+
+        def factory():
+            # A freshly restored / model-switched agent: it persists to this db
+            # but has not flushed anything yet, so it does not own persistence.
+            return SimpleNamespace(
+                model="test-model",
+                _session_db=db,
+                _session_db_created=False,
+            )
+
+        manager = SessionManager(agent_factory=factory, db=db)
+        state = manager.create_session(cwd="/work")
+
+        for role, content in (
+            ("user", "what is the migration needle policy?"),
+            ("assistant", "expand-migrate-contract, never drop in one release"),
+            ("user", "rollback window?"),
+            ("assistant", "24h, verified by the smoke suite"),
+        ):
+            db.append_message(session_id=state.session_id, role=role, content=content)
+
+        # /compress ran with _session_db unset, so nothing was archived.
+        assert db.has_archived_messages(state.session_id) is False
+
+        state.history = [{"role": "user", "content": "compacted summary"}]
+        manager.save_session(state.session_id)
+
+        # The live context is the summary only...
+        assert [
+            m["content"] for m in db.get_messages_as_conversation(state.session_id)
+        ] == ["compacted summary"]
+
+        # ...but every pre-compaction turn survives on disk and stays findable.
+        contents = [
+            m["content"]
+            for m in db.get_messages(state.session_id, include_inactive=True)
+        ]
+        assert "expand-migrate-contract, never drop in one release" in contents
+        assert "24h, verified by the smoke suite" in contents
+        assert db.has_archived_messages(state.session_id) is True
+        hits = {r["session_id"] for r in db.search_messages("needle")}
+        assert state.session_id in hits
+
     def test_save_session_still_replaces_when_agent_not_self_persisting(self, manager):
         """Agents that don't own DB persistence keep ACP as the source of truth.
 


### PR DESCRIPTION
## Summary

ACP `/compress` hard-DELETEs the entire durable transcript. `SessionManager._persist` decides between a destructive full replace and a live-only one by probing `has_archived_messages()`, on the stated premise that no archived rows means "fresh create/fork with no archived history to lose". `/compress` violates that premise — it suppresses archiving, so the probe returns False *precisely because* there is unarchived history to lose.

The guard is defeated by the very action that creates the need for it.

## Problem

**`_cmd_compress` suppresses archiving** — `acp_adapter/server.py`:

```python
# ACP sessions must keep a stable session id, so avoid the
# SQLite session-splitting side effect inside _compress_context.
agent._session_db = None
compressed, _ = agent._compress_context(...)
```

`compress_context` gates *all* durable work on that attribute — `agent/conversation_compression.py:2044` `if agent._session_db:`. With it unset, the branch is skipped entirely: neither the rotation path nor `archive_and_compact()` runs. `archive_and_compact` is the #38763 mechanism that keeps pre-compaction turns on disk as searchable `active=0 / compacted=1` rows. So **no archived rows are ever created**.

**`_persist` then reads that absence as safety** — `acp_adapter/session.py`:

```python
# ... when archived rows exist, replace ONLY the live (active=1) set and leave the
# archived turns untouched; otherwise the destructive replace is
# safe (fresh create/fork with no archived history to lose).
has_archived = db.has_archived_messages(state.session_id)
db.replace_messages(state.session_id, state.history, active_only=has_archived)
```

`has_archived` is False, so this takes `active_only=False` — `DELETE FROM messages WHERE session_id = ?` — and re-inserts only the summary. The `messages_fts` triggers drop the rows from the search index on DELETE.

The prior fixes in this area (#50405, #56342, #56359) added exactly these two guards, and their own body declares the remaining path safe: *"the destructive replace is safe (fresh create/fork with no archived history to lose)"*. This is that path, and the assumption does not hold for a compaction.

### Reproduced

Driving the real `SessionDB` and the real `SessionManager._persist`:

```
BEFORE  durable rows : 6
BEFORE  FTS 'migration': 2
restored history len : 6

AFTER   durable rows : 1
          user      [Compacted summary of 6 messages]
AFTER   rows incl inactive: 1
AFTER   has_archived_messages: False
AFTER   FTS 'migration': 0
original answer anywhere on disk: False
```

Six turns, gone. Nothing archived, nothing in the FTS index, no copy anywhere.

**Default config.** `/compress` is in `_ADVERTISED_COMMANDS`, so every ACP client (Zed) lists it with zero configuration, and `_cmd_compress` deliberately bypasses the only related setting (*"No compression_enabled gate: the flag disables automatic compaction only; manual /compress must keep working"*). `_cmd_context` actively tells the user to run it: *"Compression: due now … Run /compress."* `sessions.write_json_snapshots` defaults to False, so `state.db` is the only copy.

**Deterministic.** No race. `_cmd_compress` unconditionally unsets `_session_db`, which deterministically makes `has_archived_messages` False, which deterministically selects `active_only=False`.

**Two default routes reach it.**
1. *Reopen then compress.* The adapter is a stdio subprocess; on editor reconnect `load_session` → `_restore` builds a fresh `AIAgent` with `_session_db_created = False`. Until the first message, `agent_owns_persistence` is False — so `/compress` on a thread you just reopened (the natural moment, and what `/context` recommends) wipes it.
2. *Compress then switch model — no restart needed.* On a warm session `agent_owns_persistence` is True, so `/compress` writes nothing: the DB keeps the full transcript while `state.history` becomes the summary (a silent divergence). The next `set_session_model` — Zed's model picker — mints a fresh agent and immediately calls `save_session`, which then replaces the complete stored transcript with the one-message summary.

**Unrecoverable.** No `active=0` rows (archiving was suppressed). FTS entries dropped with the rows. No JSON spill (`write_json_snapshots` defaults False). No rotation parent (rotation lives in the same suppressed branch). Not re-askable: the next `session/load` replays `state.history`, which is now just the summary, so the thread renders one message.

## Fix

Detect the shrink directly instead of inferring it from the archive probe. When a save would drop stored live rows, soft-archive them with `archive_and_compact()` — same session id, summary becomes the live set, prior turns stay on disk and searchable:

```python
if not has_archived and self._replace_would_shrink(db, state):
    db.archive_and_compact(state.session_id, state.history)
    return
db.replace_messages(state.session_id, state.history, active_only=has_archived)
```

`_replace_would_shrink` compares the stored live-row count against `len(state.history)`. A save carrying fewer messages than the session already has on disk is a compaction, not an update. Ordinary saves never shrink the transcript, so they keep the existing replace path byte-for-byte. `archive_and_compact` failure falls back to a live-only replace rather than the destructive one.

Fixing it in `_persist` rather than in `_cmd_compress` covers route 2 as well (the model-switch save), and protects any future caller that arrives with a compacted history.

## Scope

- `acp_adapter/session.py` — one branch in `_persist` plus a small `_replace_would_shrink` helper. No change to the existing `agent_owns_persistence` or `has_archived` guards, to `/compress` itself, or to any other write path.
- Behaviour for non-shrinking saves is unchanged: `test_save_session_still_replaces_when_agent_not_self_persisting` and `test_save_session_preserves_existing_messages_on_encode_failure` pass unmodified.

## Testing

New `test_acp_compress_preserves_the_pre_compaction_transcript` in `tests/acp/test_session.py`, alongside the existing archived-rows regressions. It reproduces the post-`/compress` state exactly — full stored transcript, zero archived rows, in-memory history holding only the summary — then saves, and asserts the live set is the summary while every pre-compaction turn survives and stays findable via `search_messages`.

**Fails on `main`:**

```
assert 'expand-migrate-contract, never drop in one release' in contents
AssertionError: assert '...' in ['compacted summary']
```

```bash
python -m pytest tests/acp/test_session.py -o addopts= -q
46 passed

python -m pytest tests/acp/test_session.py tests/acp/test_session_db_private_access.py \
  tests/acp/test_session_provenance.py tests/test_hermes_state.py -o addopts= -q
526 passed, 1 skipped
```

Note: `tests/acp/test_server.py` and five other files in that directory need the `acp` package, which is not installed in this environment — they fail to collect on unmodified `main` too, so they were not exercised locally.
