### PR TITLE
fix(tui): exclude timeline rows from the rewind truncation ordinal

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7972,6 +7972,101 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_prompt_submit_ordinal_skips_display_kind_timeline_rows(monkeypatch):
+    """Bookkeeping timeline rows must not shift the truncation ordinal.
+
+    ``model_switch`` / ``async_delegation_complete`` / ``auto_continue`` /
+    ``hidden`` rows are stored as durable ``role="user"`` rows, but no client
+    presents them as user turns — the desktop demotes them to ``role:'system'``
+    (or drops them) in ``toChatMessages`` before ``visibleUserOrdinal`` counts,
+    and the CLI excludes them with the same predicate. Counting them here made
+    the ordinal resolve one real turn too early, and ``replace_messages`` then
+    hard-DELETEd a completed exchange the user never selected.
+    """
+
+    class _Agent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            return {
+                "final_response": "edited reply",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "edited reply"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    # A backgrounded delegation finished early in the chat; two ordinary
+    # exchanges followed. The desktop renders the delegation row as a grey
+    # system row, so the edit pencil on "third" sends ordinal 2 — counting
+    # only first/second/third.
+    original_history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+        {
+            "role": "user",
+            "content": "background agent work finished",
+            "display_kind": "async_delegation_complete",
+        },
+        {"role": "assistant", "content": "ack"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "second reply"},
+        {"role": "user", "content": "third"},
+        {"role": "assistant", "content": "third reply"},
+    ]
+    server._sessions["sid"] = _session(agent=_Agent(), history=original_history)
+
+    class _StubDb:
+        def __init__(self):
+            self.replaced = []
+
+        def replace_messages(self, session_id, messages):
+            self.replaced.append((session_id, list(messages)))
+
+    stub_db = _StubDb()
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+        monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "edited third",
+                    "truncate_before_user_ordinal": 2,
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+
+        # The cut belongs at "third" (index 6), NOT at "second" (index 4).
+        # Counting the delegation row as a user turn shifts the ordinal one
+        # place early and destroys the completed second/second-reply exchange
+        # the user never selected.
+        assert stub_db.replaced == [("session-key", original_history[:6])]
+        kept = [m["content"] for m in stub_db.replaced[0][1]]
+        assert "second" in kept and "second reply" in kept
+        assert server._sessions["sid"]["history"] == [
+            *original_history[:6],
+            {"role": "user", "content": "edited third"},
+            {"role": "assistant", "content": "edited reply"},
+        ]
+    finally:
+        server._sessions.pop("sid", None)
+
+
 # ---------------------------------------------------------------------------
 # session.interrupt must only cancel pending prompts owned by the calling
 # session — it must not blast-resolve clarify/sudo/secret prompts on

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10843,7 +10843,22 @@ def _(rid, params: dict) -> dict:
             except (TypeError, ValueError):
                 return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
             history = session.get("history", [])
-            user_indices = [i for i, m in enumerate(history) if m.get("role") == "user"]
+            # Count the SAME rows the client counted when it produced this
+            # ordinal. Bookkeeping timeline rows (model_switch,
+            # async_delegation_complete, auto_continue, hidden) are stored as
+            # durable ``role="user"`` rows, but no client ever presents them as
+            # user turns: the desktop demotes them to ``role: 'system'`` /
+            # drops them in ``toChatMessages`` before ``visibleUserOrdinal``
+            # counts, and the CLI excludes them with this same predicate
+            # (hermes_cli/cli_agent_setup_mixin.py, cli_commands_mixin.py).
+            # Counting them here made the ordinal resolve N real turns too
+            # early, and the ``replace_messages`` below then hard-DELETEd those
+            # extra completed turns — in range, so neither guard fires.
+            user_indices = [
+                i
+                for i, m in enumerate(history)
+                if m.get("role") == "user" and not m.get("display_kind")
+            ]
             # Reject out-of-range ordinals on BOTH ends. A negative value would
             # otherwise sail past the upper-bound check and hit Python's negative
             # indexing below (user_indices[-1] -> the LAST user turn), silently


### PR DESCRIPTION
## Summary

`prompt.submit` resolves `truncate_before_user_ordinal` against **every** `role == "user"` row in `session["history"]`. No client counts them that way. Bookkeeping timeline rows — `model_switch`, `async_delegation_complete`, `auto_continue`, `hidden` — are stored as durable user rows, but the desktop demotes them to `role: 'system'` (or drops them) in `toChatMessages` before `visibleUserOrdinal` counts.

The ordinal therefore resolves *N* real turns too early, and the `replace_messages()` that follows hard-DELETEs those extra completed exchanges. Same class as #70895: an index into the frontend's message array treated as an index into the backend's history.

## Problem

**Producer** — `apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts:362`:

```ts
export function visibleUserOrdinal(messages: readonly ChatMessage[], end: number): number {
  return messages.slice(0, end).filter(m => m.role === 'user' && !m.hidden).length
}
```

Its only filter is `!m.hidden`, a client-side branch flag `applyBranchVisibility` sets on **assistant** rows. It never needs to know about `display_kind`, because by the time it runs `toChatMessages` has already removed those rows from the `user` role — `apps/desktop/src/lib/chat-messages.ts:949-955`:

```ts
const displayRole =
  message.display_kind === 'model_switch' ||
  message.display_kind === 'async_delegation_complete' ||
  message.display_kind === 'auto_continue'
    ? 'system'
    : message.role
```

and `display_kind: 'hidden'` yields no parts at all, so the row is skipped entirely.

**Consumer** — `tui_gateway/server.py:10790`:

```python
user_indices = [i for i, m in enumerate(history) if m.get("role") == "user"]
...
truncated = history[: user_indices[ordinal]]
...
db.replace_messages(session["session_key"], truncated)
```

No `display_kind` exclusion. The marker rows *are* in `session["history"]` with `role == "user"` — `server.py:11828` stamps `message["display_kind"]` on the in-memory row after the run, and `hermes_state.py:7283` rehydrates it on resume.

**Twin-guard asymmetry.** The CLI performs the same logical operation — count user turns in a stored history — and *does* exclude them, with exactly this predicate:

- `hermes_cli/cli_agent_setup_mixin.py:518` — `if m.get("role") == "user" and not m.get("display_kind")`
- `hermes_cli/cli_commands_mixin.py:854` — same expression

Only the destructive gateway path omits it.

**Neither existing guard fires.** The skewed ordinal is always *smaller* than the true one, so it stays in range for the 4018 bounds check at `server.py:10796` — whose own comment already names this hazard class ("silently truncating history to everything before it and persisting that loss via `replace_messages` — an unrecoverable overwrite of the session DB"). And the truncation is non-empty, so the 4028 `confirm_empty_truncate` guard (added for #70895/#70516) does not apply either.

### Reproduced

Running the real client rule and the real gateway expressions over one history:

```
client ChatMessage roles : ['user','assistant','system','assistant','user','assistant','user','assistant']
client counts as 'user'  : ['Q0', 'Q1', 'Q2']
ordinal sent to gateway  : 2

gateway user_indices     : [0, 2, 4, 6]
gateway counts as 'user' : ['Q0', 'background agent work finished', 'Q1', 'Q2']
cut index                : 4

DELETED rows:
   user      Q1
   assistant A1
   user      Q2
   assistant A2

user intended to delete  : Q2 / A2
EXTRA rows destroyed     : ['Q1', 'A1']
```

A completed question and its answer, permanently deleted, with no warning.

**Default config.** `_AUTO_CONTINUE_ENABLED_DEFAULT = True` (`server.py:6421`); `async_delegation_complete` is emitted unconditionally by the notification poller (`server.py:11379`, `:11457`). No flag or setting is involved on either side.

**Deterministic.** Pure integer arithmetic over two lists — the skew is exactly the number of timeline rows before the target, on the first attempt, every time.

**Frequent.** Edit-a-message, Regenerate and Restore-checkpoint are always-visible controls and all funnel through this ordinal. Once one timeline row exists it is permanent for the session, so *every* subsequent rewind in that chat is misaligned, and the skew accumulates with each additional marker.

**Unrecoverable.** `replace_messages` takes its default `active_only=False` path — `DELETE FROM messages WHERE session_id = ?`, whose docstring says "DESTRUCTIVE by default: every row for the session is DELETEd (and drops out of the FTS index)". Nothing holds a copy: `archive_and_compact`'s soft-archive is a different method and is not used here, so `include_inactive=True` returns nothing; there is no JSONL mirror on this path; and the desktop already sliced its own `state.messages` optimistically, then repaints from the truncated DB on the next resume.

## Fix

Count the same rows the client counted:

```python
user_indices = [
    i
    for i, m in enumerate(history)
    if m.get("role") == "user" and not m.get("display_kind")
]
```

The predicate is copied verbatim from the CLI siblings. It is exactly right for every `display_kind` value that exists — `model_switch`, `async_delegation_complete` and `auto_continue` are demoted to `system` client-side, and `hidden` is dropped — so no client ever counts any of them.

## Scope

- `tui_gateway/server.py` — one list comprehension in the `prompt.submit` truncation branch, plus a comment. No change to the 4018/4028 guards, to `replace_messages`, or to any other RPC.
- No desktop change required: the client is already consistent with itself and with the CLI. Making the gateway agree with both is the smaller, safer half of the fix.

Related but distinct: #41275 (open) touches the same `visibleUserOrdinal` helper in the **opposite** direction — optimistic *failed* user bubbles make the client ordinal overshoot, producing a visible 4018 rejection. Its fix skips failed turns and cannot correct an undercount, and it describes no silent deletion.

## Testing

New `test_prompt_submit_ordinal_skips_display_kind_timeline_rows` in `tests/test_tui_gateway_server.py`, built in the same idiom as the existing `test_prompt_submit_can_truncate_before_user_ordinal` directly above it: a history where a delegation-complete row sits between the first and second real exchanges, then an edit of the third user turn (ordinal 2).

It asserts the cut lands at "third" and that "second"/"second reply" survive. **Fails on `main`** — the stored transcript comes back as `original_history[:4]`, having destroyed the second exchange — and passes here.

```bash
python -m pytest tests/test_tui_gateway_server.py -o addopts= -q
468 passed
```

The pre-existing `test_prompt_submit_can_truncate_before_user_ordinal` passes unmodified, so ordinary rewind behaviour is unchanged.

Note on `tests/tui_gateway/`: that directory has order-dependent failures unrelated to this change — running the full directory on unmodified `main` gives 6 failures (`test_compute_host*`, `test_projects_rpc*`, `test_subagent_child_mirror`), and 3 on this branch. Each of those tests passes in isolation on both.
