### PR TITLE
feat(memory): add OptMem local memory provider (append-only, decay, BM25)

### DIFF
--- a/plugins/memory/optmem/__init__.py
+++ b/plugins/memory/optmem/__init__.py
@@ -1,0 +1,342 @@
+"""OptMem memory provider for Hermes.
+
+A portable, append-only, decay-compressed memory backend that plugs into
+Hermes via the MemoryProvider interface. On-disk format is byte-compatible
+with https://github.com/VictorTaelin/OptMem, so logs are interchangable
+with the original ``memo`` tool.
+
+Activation (profile-scoped, set in config.yaml):
+    memory:
+      provider: optmem
+    plugins:
+      optmem:
+        memory_dir: $HERMES_HOME/optmem_memory   # optional, default below
+
+Only ONE external memory provider may be active at a time (Hermes enforces
+this). The builtin short-term ``memory`` tool keeps running alongside.
+
+Design notes
+------------
+- The agent records durable facts with ``optmem_note`` (one line, <=280 chars).
+- When a pair of memories forms, the provider surfaces a pending compression
+  via ``prefetch`` (and ``optmem_nap``), and the agent performs the "nap":
+  it merges the block into one line. This is Taelin's "nap, don't sleep".
+- ``optmem_recall`` does accent-normalized BM25 search across all history.
+- Builtin ``memory`` writes are mirrored automatically (on_memory_write).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+from .engine import OptMemEngine
+
+logger = logging.getLogger(__name__)
+
+
+def _load_plugin_config() -> dict:
+    from hermes_cli.config import cfg_get
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        return cfg_get(config, "plugins", "optmem", default={}) or {}
+    except Exception:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+NOTE_SCHEMA = {
+    "name": "optmem_note",
+    "description": (
+        "Record one durable memory line to the OptMem append-only log "
+        "(family facts, decisions, events of lasting effect). One line, "
+        "max 280 chars. If a compression is due, do it (optmem_nap) before "
+        "your next action. Use for things worth remembering forever — not "
+        "ephemeral chat."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "The memory, one line (<=280 chars).",
+            },
+        },
+        "required": ["text"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "optmem_recall",
+    "description": (
+        "Search the entire OptMem history with accent-normalized BM25 "
+        "(e.g. 'caçula' matches 'cacula'). Returns ranked memory lines. "
+        "Use when you need an old fact, decision, or event."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query."},
+            "topk": {"type": "integer", "description": "Max results (default 5)."},
+            "regex": {
+                "type": "boolean",
+                "description": "Use literal regex instead of BM25 (default false).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+NAP_SCHEMA = {
+    "name": "optmem_nap",
+    "description": (
+        "Apply a compression the provider asked for. Call optmem_nap with "
+        "the block id and a one-line summary (<=280 chars) that keeps what "
+        "has lasting effect and drops the rest. Invent nothing. Mirrors "
+        "Taelin's 'nap, don't sleep'."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "lo": {"type": "integer", "description": "Block start id (inclusive)."},
+            "hi": {"type": "integer", "description": "Block end id (inclusive)."},
+            "summary": {"type": "string", "description": "One-line compression."},
+        },
+        "required": ["lo", "hi", "summary"],
+    },
+}
+
+WAKE_SCHEMA = {
+    "name": "optmem_wake",
+    "description": (
+        "Print the current OptMem context (recent memories verbatim, old ones "
+        "decayed into summaries). Run at session start or when you need the "
+        "full picture."
+    ),
+    "parameters": {"type": "object", "properties": {}},
+}
+
+
+class OptMemProvider(MemoryProvider):
+    """Hermes MemoryProvider backed by the OptMem append-only engine."""
+
+    def __init__(self, config: Optional[dict] = None):
+        self._config = config or _load_plugin_config()
+        self._engine: Optional[OptMemEngine] = None
+        self._memory_dir: Optional[str] = None
+
+    @property
+    def name(self) -> str:
+        return "optmem"
+
+    def is_available(self) -> bool:
+        # Pure-local, no credentials. Always available.
+        return True
+
+    def get_config_schema(self):
+        from hermes_constants import display_hermes_home
+        default_dir = f"{display_hermes_home()}/optmem_memory"
+        return [
+            {
+                "key": "memory_dir",
+                "description": "Directory for LOG.txt + TREE/ (default: $HERMES_HOME/optmem_memory)",
+                "default": default_dir,
+            },
+        ]
+
+    def save_config(self, values, hermes_home):
+        from pathlib import Path
+        config_path = Path(hermes_home) / "config.yaml"
+        try:
+            import yaml
+            existing = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8-sig") as f:
+                    existing = yaml.safe_load(f) or {}
+            existing.setdefault("plugins", {})
+            existing["plugins"]["optmem"] = values
+            with open(config_path, "w", encoding="utf-8") as f:
+                yaml.dump(existing, f, default_flow_style=False)
+        except Exception as e:
+            logger.warning("OptMem save_config failed: %s", e)
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        from hermes_constants import get_hermes_home
+        home = str(get_hermes_home())
+        mem_dir = self._config.get("memory_dir", f"{home}/optmem_memory")
+        if isinstance(mem_dir, str):
+            mem_dir = mem_dir.replace("$HERMES_HOME", home).replace("${HERMES_HOME}", home)
+        self._memory_dir = mem_dir
+        self._engine = OptMemEngine(mem_dir)
+        self._session_id = session_id
+
+    # -- context ------------------------------------------------------------
+
+    def system_prompt_block(self) -> str:
+        if self._engine is None:
+            return ""
+        n = self._engine.log_len()
+        if n == 0:
+            return (
+                "# OptMem (permanent memory)\n"
+                "Active and empty. Use optmem_note to store durable facts about "
+                "the family, decisions, and events of lasting effect. They are "
+                "never deleted and decay (older ones compress) over time."
+            )
+        pending = len(self._engine.pending_naps())
+        msg = (
+            f"# OptMem (permanent memory)\n"
+            f"Active. {n} memories stored (append-only, decay-compressed). "
+            f"Use optmem_recall to search all history, optmem_note to add, "
+            f"optmem_wake to see the full context."
+        )
+        if pending:
+            msg += f"\n{pending} compression(s) pending — do them via optmem_nap when asked."
+        return msg
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._engine is None:
+            return ""
+        try:
+            lines = []
+            # Always surface the decayed context. This lets OptMem fully replace
+            # the builtin short-term memory when memory_enabled is False — the
+            # agent still sees the permanent context every turn via prefetch
+            # (dynamic context, does NOT break the cached system prompt).
+            wake = self._engine.wake_lines()
+            if wake:
+                lines.append("## OptMem context (permanent, decay-compressed)\n" + "\n".join(wake))
+            # Pending nap first so the agent acts before context grows.
+            nap = self._engine.next_nap()
+            if nap:
+                (lo, hi), prompt = nap
+                lines.append(
+                    f"[OptMem] Compression due for #{lo}-{hi}. Run:\n"
+                    f"optmem_nap(lo={lo}, hi={hi}, summary=\\\"<one line>\\\")\\n"
+                    f"{prompt}"
+                )
+            if query:
+                results = self._engine.recall(query, topk=5)
+                if results:
+                    body = "\n".join(
+                        f"- [{score:.2f}] #{mid} {date} {text}"
+                        for score, mid, date, text in results
+                    )
+                    lines.append("## OptMem recall\n" + body)
+            return "\n\n".join(lines)
+        except Exception as e:
+            logger.debug("OptMem prefetch failed: %s", e)
+            return ""
+
+    # -- writes -------------------------------------------------------------
+
+    def sync_turn(self, user_content, assistant_content, *, session_id="", messages=None) -> None:
+        # OptMem stores explicit facts via optmem_note, not auto-sync.
+        pass
+
+    def on_memory_write(self, action: str, target: str, content: str, metadata=None) -> None:
+        """Mirror builtin memory writes into the permanent OptMem log."""
+        if action == "add" and self._engine is not None and content:
+            try:
+                self._engine.append(content)
+            except Exception as e:
+                logger.debug("OptMem mirror failed: %s", e)
+
+    # -- tools --------------------------------------------------------------
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [NOTE_SCHEMA, RECALL_SCHEMA, NAP_SCHEMA, WAKE_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if tool_name == "optmem_note":
+            return self._handle_note(args)
+        if tool_name == "optmem_recall":
+            return self._handle_recall(args)
+        if tool_name == "optmem_nap":
+            return self._handle_nap(args)
+        if tool_name == "optmem_wake":
+            return self._handle_wake(args)
+        return tool_error(f"Unknown tool: {tool_name}")
+
+    def _handle_note(self, args: dict) -> str:
+        try:
+            text = args["text"].strip()
+            mid = self._engine.append(text)
+            out = {"saved_as": f"#{mid}", "status": "added"}
+            nap = self._engine.next_nap()
+            if nap:
+                (lo, hi), _ = nap
+                out["nap_due"] = {"lo": lo, "hi": hi}
+                out["note"] = "Run optmem_nap for this block before your next action."
+            return _json(out)
+        except (KeyError, ValueError) as exc:
+            return tool_error(str(exc))
+        except Exception as exc:
+            return tool_error(str(exc))
+
+    def _handle_recall(self, args: dict) -> str:
+        try:
+            query = args["query"]
+            topk = int(args.get("topk", 5))
+            regex = bool(args.get("regex", False))
+            hits = self._engine.recall(query, topk=topk, regex=regex)
+            if not hits:
+                return _json({"results": [], "count": 0})
+            results = [
+                {"score": round(s, 2), "id": mid, "date": date, "text": text}
+                for s, mid, date, text in hits
+            ]
+            return _json({"results": results, "count": len(results)})
+        except (KeyError, ValueError) as exc:
+            return tool_error(str(exc))
+        except Exception as exc:
+            return tool_error(str(exc))
+
+    def _handle_nap(self, args: dict) -> str:
+        try:
+            lo = int(args["lo"])
+            hi = int(args["hi"])
+            summary = args["summary"].strip()
+            ok = self._engine.apply_nap(lo, hi, summary)
+            if not ok:
+                return tool_error(f"#{lo}-{hi} was settled or forgotten meanwhile.")
+            return _json({"status": "compressed", "block": f"{lo}-{hi}"})
+        except (KeyError, ValueError) as exc:
+            return tool_error(str(exc))
+        except Exception as exc:
+            return tool_error(str(exc))
+
+    def _handle_wake(self, args: dict) -> str:
+        try:
+            lines = self._engine.wake_lines()
+            if not lines:
+                return _json({"context": [], "note": "OptMem empty."})
+            return _json({"context": lines, "count": len(lines)})
+        except Exception as exc:
+            return tool_error(str(exc))
+
+    def shutdown(self) -> None:
+        self._engine = None
+
+
+def _json(obj) -> str:
+    import json
+    return json.dumps(obj, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register the OptMem memory provider with Hermes."""
+    config = _load_plugin_config()
+    provider = OptMemProvider(config=config)
+    ctx.register_memory_provider(provider)

--- a/plugins/memory/optmem/engine.py
+++ b/plugins/memory/optmem/engine.py
@@ -1,0 +1,497 @@
+"""OptMem engine — portable reimplementation of Taelin's OptMem store.
+
+This is a dependency-free, cross-platform reimplementation of the OptMem
+append-only memory. It keeps the EXACT on-disk format of the original
+``memo`` tool (fixed-width records, ``LOG.txt`` + ``TREE/<size>``), so logs
+are interchangable with https://github.com/VictorTaelin/OptMem.
+
+Differences from the original:
+- No ``fcntl`` (POSIX-only). Uses a portable advisory lock: ``msvcrt`` on
+  Windows, ``fcntl`` on Unix. Falls back to no-op if neither is available.
+- Adds a BM25 ranked search (``recall``) with accent normalization, on top
+  of the original regex recall.
+- Exposes a small API used by the Hermes ``MemoryProvider`` wrapper:
+  ``append``, ``wake_lines``, ``pending_naps``, ``apply_nap``, ``recall``.
+
+Records are fixed width so a memory or block is found by seeking to its
+offset — no index file to keep in sync.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import re
+import sys
+import unicodedata
+from collections import defaultdict, deque
+from typing import List, Optional, Tuple
+
+# Fixed-width records, identical to the original memo tool so the two are
+# byte-compatible on disk.
+LOG_REC = 320
+TREE_REC = 288
+
+# Blocks up to this many raw memories compress straight from the log.
+RAW_MAX = 16
+
+# Sizes (mirror memo defaults).
+WAKE_LINES = 208          # ~16k tokens of context printed by wake
+ENTRY_CHARS = 280         # longest one memory line, in bytes
+
+
+# ---------------------------------------------------------------------------
+# Portable advisory lock
+# ---------------------------------------------------------------------------
+
+def _make_lock(path: str):
+    """Return a context manager granting an exclusive lock on ``path``.
+
+    Uses msvcrt on Windows, fcntl on Unix. No-op if neither is importable.
+    """
+    lockf = open(path + ".lock", "a")
+    if sys.platform == "win32":
+        try:
+            import msvcrt
+        except Exception:
+            return _NullLock(lockf)
+        def _acquire():
+            # LK_NBLCK never blocks; spin with backoff so parallel processes
+            # (Taelin's target: many concurrent sessions) queue instead of
+            # raising 'Resource deadlock avoided' like LK_LOCK does under load.
+            import time as _t
+            waited = 0.0
+            while True:
+                try:
+                    msvcrt.locking(lockf.fileno(), msvcrt.LK_NBLCK, 1)
+                    return
+                except OSError:
+                    if waited > 30.0:
+                        raise
+                    _t.sleep(min(0.01 + waited * 0.2, 0.25))
+                    waited += 0.01
+        def _release():
+            try:
+                msvcrt.locking(lockf.fileno(), msvcrt.LK_UNLCK, 1)
+            except Exception:
+                pass
+        return _Flock(lockf, _acquire, _release)
+    try:
+        import fcntl
+    except Exception:
+        return _NullLock(lockf)
+    def _acquire():
+        fcntl.flock(lockf.fileno(), fcntl.LOCK_EX)
+    def _release():
+        try:
+            fcntl.flock(lockf.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+    return _Flock(lockf, _acquire, _release)
+
+
+class _Flock:
+    def __init__(self, f, acquire, release):
+        self._f = f
+        self._acquire = acquire
+        self._release = release
+    def __enter__(self):
+        self._acquire()
+        return self
+    def __exit__(self, *exc):
+        self._release()
+        return False
+
+
+class _NullLock:
+    def __init__(self, f):
+        self._f = f
+    def __enter__(self):
+        return self
+    def __exit__(self, *exc):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize(s: str) -> str:
+    """lowercase + strip diacritics so 'caçula' == 'cacula'."""
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return s.lower()
+
+
+def _tokenize(s: str) -> List[str]:
+    return [t for t in re.split(r"[^a-z0-9]+", _normalize(s)) if t]
+
+
+def _pad(text: str, rec: int) -> bytes:
+    b = text.encode("utf-8")
+    if len(b) > rec - 1:
+        raise ValueError("entry too long: %d bytes, limit %d" % (len(b), rec - 1))
+    return b + b" " * (rec - 1 - len(b)) + b"\n"
+
+
+def _parse(line: str) -> Tuple[int, str, str]:
+    head, _, rest = line.partition(" ")
+    date, _, text = rest.partition(" ")
+    return int(head[1:]), date, text
+
+
+# ---------------------------------------------------------------------------
+# Cover / decay tree (identical math to memo)
+# ---------------------------------------------------------------------------
+
+def _cover(T: int, alpha: float) -> List[Tuple[int, int]]:
+    """Tile [0,T) with aligned power-of-two blocks; keep a block whole iff its
+    size is at most ``alpha`` times its age. Bigger alpha = coarser."""
+    root = 1
+    while root < T:
+        root *= 2
+    out: List[Tuple[int, int]] = []
+    stack = [(0, root)]
+    while stack:
+        lo, hi = stack.pop()
+        if lo >= T:
+            continue
+        size = hi - lo
+        if size > 1 and (hi > T or size > alpha * (T - lo)):
+            mid = (lo + hi) // 2
+            stack.append((mid, hi))
+            stack.append((lo, mid))
+        else:
+            out.append((lo, hi))
+    out.sort()
+    return out
+
+
+def cover(T: int, budget: int) -> List[Tuple[int, int]]:
+    """The blocks ``wake`` prints: at most ``budget`` of them, finest near T.
+
+    Detail decays with age: recent memories stay verbatim, ancient ones
+    collapse. If everything fits, nothing is compressed at all.
+    """
+    if T <= 0:
+        return []
+    if T <= budget:
+        return [(i, i + 1) for i in range(T)]
+    lo, hi = 0.0, 1.0
+    for _ in range(60):
+        mid = (lo + hi) / 2
+        if len(_cover(T, mid)) > budget:
+            lo = mid
+        else:
+            hi = mid
+    out = _cover(T, hi)
+    while len(out) < budget:
+        i = max((i for i, b in enumerate(out) if b[1] - b[0] > 1), default=None)
+        if i is None:
+            break
+        lo_, hi_ = out[i]
+        mid = (lo_ + hi_) // 2
+        out[i:i + 1] = [(lo_, mid), (mid, hi_)]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+class OptMemEngine:
+    """Append-only memory store with a binary decay tree and BM25 search."""
+
+    def __init__(self, memory_dir: str):
+        self.dir = memory_dir
+        os.makedirs(os.path.join(self.dir, "TREE"), exist_ok=True)
+        self.log_path = os.path.join(self.dir, "LOG.txt")
+        if not os.path.exists(self.log_path):
+            open(self.log_path, "a").close()
+
+    # -- low level ----------------------------------------------------------
+
+    def _lock(self):
+        return _make_lock(self.log_path)
+
+    def _count(self, path: str, rec: int) -> int:
+        try:
+            return os.path.getsize(path) // rec
+        except FileNotFoundError:
+            return 0
+
+    def log_len(self) -> int:
+        return self._count(self.log_path, LOG_REC)
+
+    def _repair(self, path: str, rec: int) -> None:
+        try:
+            n = os.path.getsize(path)
+        except FileNotFoundError:
+            return
+        if n % rec:
+            with open(path, "r+b") as f:
+                f.truncate(n - n % rec)
+
+    def _log_slice(self, lo: int, hi: int) -> List[Tuple[int, str, str]]:
+        with open(self.log_path, "rb") as f:
+            f.seek(lo * LOG_REC)
+            buf = f.read((hi - lo) * LOG_REC)
+        out = []
+        for i in range(len(buf) // LOG_REC):
+            raw = buf[i * LOG_REC:(i + 1) * LOG_REC].decode("utf-8", "replace").rstrip()
+            if not raw.strip():
+                continue
+            try:
+                mid, date, text = _parse(raw)
+            except Exception:
+                continue
+            out.append((mid, date, text))
+        return out
+
+    def _tree_path(self, size: int) -> str:
+        return os.path.join(self.dir, "TREE", str(size))
+
+    def _tree_get(self, lo: int, hi: int) -> Optional[str]:
+        size = hi - lo
+        p = self._tree_path(size)
+        try:
+            with open(p, "rb") as f:
+                f.seek((lo // size) * TREE_REC)
+                rec = f.read(TREE_REC)
+        except FileNotFoundError:
+            return None
+        try:
+            return rec.decode("utf-8", "replace").rstrip() or None
+        except Exception:
+            return None
+
+    def _tree_put(self, lo: int, hi: int, text: str) -> bool:
+        size = hi - lo
+        p = self._tree_path(size)
+        with self._lock():
+            self._repair(p, TREE_REC)
+            if self._count(p, TREE_REC) != lo // size:
+                return False
+            with open(p, "ab") as f:
+                f.write(_pad(text, TREE_REC))
+                f.flush()
+                os.fsync(f.fileno())
+        return True
+
+    # -- public writes ------------------------------------------------------
+
+    def append(self, text: str, date: Optional[str] = None) -> int:
+        """Append one memory line. Returns its id."""
+        text = text.strip()
+        if not text:
+            raise ValueError("empty memory")
+        if "\n" in text or "\r" in text:
+            raise ValueError("a memory is one line")
+        b = text.encode("utf-8")
+        if len(b) > ENTRY_CHARS:
+            raise ValueError("too long: %d bytes, limit %d" % (len(b), ENTRY_CHARS))
+        if date is None:
+            date = datetime.date.today().isoformat()
+        with self._lock():
+            self._repair(self.log_path, LOG_REC)
+            base = self.log_len()
+            with open(self.log_path, "ab") as f:
+                f.write(_pad("#%d %s %s" % (base, date, text), LOG_REC))
+                f.flush()
+                os.fsync(f.fileno())
+        return base
+
+    def import_lines(self, lines: List[Tuple[str, str]]) -> int:
+        """Bulk append (date, text) pairs. Returns first id."""
+        with self._lock():
+            self._repair(self.log_path, LOG_REC)
+            base = self.log_len()
+            with open(self.log_path, "ab") as f:
+                for k, (date, text) in enumerate(lines):
+                    f.write(_pad("#%d %s %s" % (base + k, date, text), LOG_REC))
+                f.flush()
+                os.fsync(f.fileno())
+        return base
+
+    # -- reads --------------------------------------------------------------
+
+    def wake_lines(self, budget: int = WAKE_LINES) -> List[str]:
+        """Return the memory context (recent verbatim, old collapsed)."""
+        T = self.log_len()
+        if T == 0:
+            return []
+        out: List[str] = []
+        for lo, hi in cover(T, budget):
+            if hi - lo == 1:
+                mid, date, text = self._log_slice(lo, hi)[0]
+                out.append("#%d %s %s" % (mid, date, text))
+            else:
+                s = self._tree_get(lo, hi)
+                out.append("#%d-%d %s" % (lo, hi - 1, s or ""))
+        return out
+
+    # -- naps (compression) -------------------------------------------------
+
+    def _pending(self, T: int, limit: Optional[int] = None) -> List[Tuple[int, int]]:
+        todo: List[Tuple[int, int]] = []
+        size = 2
+        while size <= T:
+            have = self._count(self._tree_path(size), TREE_REC)
+            for k in range(have, T // size):
+                todo.append((k * size, (k + 1) * size))
+                if limit and len(todo) >= limit:
+                    return todo
+            size *= 2
+        return todo
+
+    def pending_naps(self, limit: Optional[int] = None) -> List[Tuple[int, int]]:
+        """Blocks that can be built and have not been, smallest first."""
+        return self._pending(self.log_len(), limit)
+
+    def nap_prompt(self, lo: int, hi: int) -> str:
+        """Build the compression instruction for block [lo,hi)."""
+        if hi - lo <= RAW_MAX:
+            body = "\n".join("  #%d %s %s" % e for e in self._log_slice(lo, hi))
+        else:
+            mid = (lo + hi) // 2
+            halves = []
+            for a, b in ((lo, mid), (mid, hi)):
+                s = self._tree_get(a, b)
+                if s is None:
+                    s = "(missing — rebuild)"
+                halves.append("  #%d-%d %s" % (a, b - 1, s))
+            body = "\n".join(halves)
+        left = len(self.pending_naps()) - 1
+        tail = "" if left <= 0 else (
+            "\n%d compressions remain" % left)
+        return (
+            "Compress memories #%d-%d into one line of at most %d characters.\n"
+            "Keep what has lasting effect, drop what does not. Invent nothing.\n\n"
+            "%s%s\n"
+            % (lo, hi - 1, ENTRY_CHARS, body, tail)
+        )
+
+    def next_nap(self) -> Optional[Tuple[Tuple[int, int], str]]:
+        todo = self.pending_naps(limit=1)
+        if not todo:
+            return None
+        lo, hi = todo[0]
+        return (lo, hi), self.nap_prompt(lo, hi)
+
+    def apply_nap(self, lo: int, hi: int, summary: str) -> bool:
+        """Store a compression. Returns False if block order changed meanwhile."""
+        summary = summary.strip()
+        if not summary:
+            raise ValueError("empty summary")
+        if len(summary.encode("utf-8")) > TREE_REC - 1:
+            raise ValueError("summary too long")
+        return self._tree_put(lo, hi, summary)
+
+    def forget(self, lo: int, hi: int) -> None:
+        """Drop a summary and everything built on top of it; log untouched."""
+        size = hi - lo
+        with self._lock():
+            while size <= self.log_len():
+                p = self._tree_path(size)
+                k = lo // size
+                n = self._count(p, TREE_REC)
+                if n > k:
+                    with open(p, "r+b") as f:
+                        f.truncate(k * TREE_REC)
+                size *= 2
+
+    # -- search (BM25 + regex) ----------------------------------------------
+
+    def _all_records(self) -> List[Tuple[int, str, str, List[str]]]:
+        T = self.log_len()
+        docs = []
+        for i in range(T):
+            try:
+                mid, date, text = self._log_slice(i, i + 1)[0]
+            except Exception:
+                continue
+            docs.append((mid, date, text, _tokenize(text)))
+        return docs
+
+    # -- index (built once, reused) ---------------------------------------
+
+    def build_index(self) -> None:
+        """Build the in-memory BM25 index from the whole log.
+
+        Call once after writes settle (or before a batch of recall calls).
+        Avoids re-tokenizing every record on every query. The index is
+        invalidated automatically when the log grows (see ``_index_len``).
+        """
+        docs = self._all_records()
+        self._index_docs = docs
+        self._index_len = len(docs)
+        N = len(docs)
+        df = defaultdict(int)
+        for _, _, _, toks in docs:
+            for t in set(toks):
+                df[t] += 1
+        self._index_idf = {t: (N - df[t] + 0.5) / (df[t] + 0.5) for t in df}
+        self._index_avgdl = sum(len(t) for _, _, _, t in docs) / N if N else 0
+        self._index_n = N
+
+    def _index_stale(self) -> bool:
+        """True if the log changed since the index was built."""
+        if getattr(self, "_index_docs", None) is None:
+            return True
+        return self.log_len() != getattr(self, "_index_len", -1)
+
+    def recall(self, query: str, topk: int = 5, regex: bool = False,
+               use_index: bool = True) -> List[Tuple[float, int, str, str]]:
+        """Ranked recall. Accent-normalized BM25 by default; regex if requested.
+
+        With ``use_index`` (default), builds/caches the BM25 index and rebuilds
+        it lazily only when the log has grown since the last build — so new
+        notes become searchable without re-tokenizing every record each call.
+        """
+        if not self.log_len():
+            return []
+        if regex:
+            if use_index and self._index_stale():
+                self.build_index()
+            docs = self._index_docs if getattr(self, "_index_docs", None) is not None else self._all_records()
+            pat = re.compile(query, re.I)
+            hits = [(1.0, mid, date, text) for mid, date, text, _ in docs if pat.search(text)]
+            return hits[:topk]
+        if use_index and self._index_stale():
+            self.build_index()
+        docs = self._index_docs if use_index else self._all_records()
+        if not docs:
+            return []
+        q = _tokenize(query)
+        if not q:
+            return []
+        idf = self._index_idf if use_index else None
+        avgdl = self._index_avgdl if use_index else None
+        if not use_index:
+            N = len(docs)
+            df = defaultdict(int)
+            for _, _, _, toks in docs:
+                for t in set(toks):
+                    df[t] += 1
+            idf = {t: (N - df[t] + 0.5) / (df[t] + 0.5) for t in df}
+            avgdl = sum(len(t) for _, _, _, t in docs) / N if N else 0
+        k1, b = 1.5, 0.75
+        scored = []
+        for mid, date, text, toks in docs:
+            dl = len(toks)
+            tf = defaultdict(int)
+            for t in toks:
+                tf[t] += 1
+            score = 0.0
+            for term in set(q):
+                if term not in idf:
+                    continue
+                f = tf.get(term, 0)
+                if f == 0:
+                    continue
+                denom = f + k1 * (1 - b + b * dl / avgdl)
+                score += idf[term] * (f * (k1 + 1)) / denom
+            if score > 0:
+                scored.append((score, mid, date, text))
+        scored.sort(reverse=True)
+        return scored[:topk]

--- a/plugins/memory/optmem/plugin.yaml
+++ b/plugins/memory/optmem/plugin.yaml
@@ -1,0 +1,5 @@
+name: optmem
+version: 0.1.0
+description: "OptMem — permanent append-only memory with decay compression and BM25 search. Portable reimplementation of Victor Taelin's OptMem (byte-compatible log), pluggable into Hermes as an external memory provider."
+hooks:
+  - on_memory_write

--- a/tests/agent/test_memory_provider_optmem.py
+++ b/tests/agent/test_memory_provider_optmem.py
@@ -1,0 +1,174 @@
+"""E2E tests for the OptMem memory provider and its append-only engine.
+
+These exercise the real engine against a temp HERMES_HOME — no mocks of the
+store, no network. Covers the four tools (note/recall/nap/wake), accent-
+normalized BM25, decay compression, and the builtin-memory mirror hook.
+"""
+
+import json
+
+import pytest
+
+from plugins.memory.optmem.engine import OptMemEngine
+from plugins.memory.optmem import OptMemProvider
+
+
+# ---------------------------------------------------------------------------
+# Engine-level behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestOptMemEngine:
+    def test_append_and_count(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        mid = eng.append("primeira memoria duravel")
+        assert mid == 0
+        assert eng.log_len() == 1
+        eng.append("segunda memoria")
+        assert eng.log_len() == 2
+
+    def test_append_rejects_newline(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        with pytest.raises(ValueError):
+            eng.append("linha um\nlinha dois")
+
+    def test_append_rejects_overlong(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        with pytest.raises(ValueError):
+            eng.append("x" * 400)
+
+    def test_bm25_accent_normalization(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        eng.append("a caçula chegou cedo")          # id 0
+        eng.append("o cachorro late de noite")      # id 1
+        eng.append("comprei cacau para a receita")  # id 2
+        hits = eng.recall("cacula", topk=3)
+        assert hits, "expected at least one BM25 hit"
+        ids = [mid for _, mid, _, _ in hits]
+        # 'caçula' (id 0) must match a query for 'cacula' (no accent).
+        assert 0 in ids
+        # top hit should be the exact-match memory, not the cocoa one.
+        assert hits[0][1] == 0
+
+    def test_regex_recall_fallback(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        eng.append("regex test: AllDrivers paywall pendente")
+        hits = eng.recall("AllDrivers.*paywall", topk=1, regex=True)
+        assert hits and hits[0][1] == 0
+
+    def test_index_rebuilds_after_append(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        eng.append("seed memory for index staleness")
+        eng.recall("seed")  # builds index
+        assert not eng._index_stale()
+        eng.append("second memory changes length")
+        assert eng._index_stale(), "index must be invalidated when log grows"
+
+    def test_nap_compresses_block(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        for i in range(4):
+            eng.append("memoria efemera numero %d" % i)
+        # Blocks of size 2 become due once both halves exist.
+        pending = eng.pending_naps()
+        assert pending, "expected at least one compressible block"
+        lo, hi = pending[0]
+        ok = eng.apply_nap(lo, hi, "resumo das memorias efemeras")
+        assert ok is True
+        # After compression the block is no longer pending.
+        remaining = eng.pending_naps()
+        assert (lo, hi) not in remaining
+
+    def test_nap_rejects_oversize_summary(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        for i in range(2):
+            eng.append("m %d" % i)
+        lo, hi = eng.pending_naps()[0]
+        with pytest.raises(ValueError):
+            eng.apply_nap(lo, hi, "x" * 400)
+
+    def test_wake_shows_verbatim_recent_and_collapsed_old(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        eng.append("fato recente um")
+        eng.append("fato recente dois")
+        lines = eng.wake_lines()
+        assert any("fato recente um" in ln for ln in lines)
+        assert any("fato recente dois" in ln for ln in lines)
+
+    def test_on_disk_format_is_fixed_width(self, tmp_path):
+        eng = OptMemEngine(str(tmp_path))
+        eng.append("registro de largura fixa")
+        log = tmp_path / "LOG.txt"
+        assert log.stat().st_size == 320  # LOG_REC
+
+
+# ---------------------------------------------------------------------------
+# Provider integration (tools + hook) against a temp HERMES_HOME
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(tmp_path):
+    mem_dir = tmp_path / "optmem_memory"
+    provider = OptMemProvider(config={"memory_dir": str(mem_dir)})
+    provider.initialize("test-session", hermes_home=str(tmp_path))
+    return provider
+
+
+class TestOptMemProvider:
+    def test_is_always_available(self):
+        assert OptMemProvider().is_available() is True
+
+    def test_tool_schemas_present(self):
+        names = {s["name"] for s in OptMemProvider().get_tool_schemas()}
+        assert {"optmem_note", "optmem_recall", "optmem_nap", "optmem_wake"} <= names
+
+    def test_note_and_recall_roundtrip(self, tmp_path):
+        p = _make_provider(tmp_path)
+        out = json.loads(p.handle_tool_call("optmem_note", {"text": "deploy em staging autorizado"}))
+        assert out["status"] == "added"
+        res = json.loads(p.handle_tool_call("optmem_recall", {"query": "deploy staging"}))
+        assert res["count"] >= 1
+        assert any("deploy" in r["text"] for r in res["results"])
+
+    def test_nap_via_tool(self, tmp_path):
+        p = _make_provider(tmp_path)
+        p.handle_tool_call("optmem_note", {"text": "a"})
+        p.handle_tool_call("optmem_note", {"text": "b"})
+        # Force a pending block to surface.
+        nap = p._engine.next_nap()
+        assert nap, "expected a pending compression after 2 notes"
+        (lo, hi), _ = nap
+        res = json.loads(p.handle_tool_call(
+            "optmem_nap", {"lo": lo, "hi": hi, "summary": "ab resumido"}))
+        assert res["status"] == "compressed"
+
+    def test_wake_tool(self, tmp_path):
+        p = _make_provider(tmp_path)
+        p.handle_tool_call("optmem_note", {"text": "contexto permanente"})
+        res = json.loads(p.handle_tool_call("optmem_wake", {}))
+        assert res["count"] >= 1
+
+    def test_prefetch_includes_context_and_pending_nap(self, tmp_path):
+        p = _make_provider(tmp_path)
+        p.handle_tool_call("optmem_note", {"text": "x"})
+        p.handle_tool_call("optmem_note", {"text": "y"})
+        ctx = p.prefetch("")
+        assert "OptMem context" in ctx
+        assert "Compression due" in ctx  # a nap is pending after 2 notes
+
+    def test_on_memory_write_mirrors_builtin(self, tmp_path):
+        p = _make_provider(tmp_path)
+        before = p._engine.log_len()
+        p.on_memory_write("add", "memory", "fato do builtin espelhado")
+        after = p._engine.log_len()
+        assert after == before + 1
+        # The mirrored line is searchable.
+        hits = p._engine.recall("espelhado", topk=1)
+        assert hits and "espelhado" in hits[0][3]
+
+    def test_byte_compatible_log_survives_reopen(self, tmp_path):
+        p = _make_provider(tmp_path)
+        p.handle_tool_call("optmem_note", {"text": "persiste entre instancias"})
+        # Re-open the same dir with a fresh engine — fixed-width format holds.
+        reopened = OptMemEngine(str(tmp_path / "optmem_memory"))
+        assert reopened.log_len() == 1
+        assert "persiste" in reopened.wake_lines()[0]


### PR DESCRIPTION
## Summary

Portable reimplementation of Victor Taelin's OptMem, wired into Hermes as a real `MemoryProvider`. Append-only `LOG.txt` + decay `TREE/`, byte-compatible with the original `memo` tool. Accent-normalized BM25 recall (`caçula` finds `cacula`), zero dependencies, native Windows (msvcrt advisory lock — no WSL).

The provider mirrors builtin `memory` writes via `on_memory_write`, so existing memory files keep feeding permanent recall without a separate migration path. It exposes four tools: `optmem_note`, `optmem_recall`, `optmem_nap`, `optmem_wake`.

This PR adds:
- `tests/agent/test_memory_provider_optmem.py` — 18 E2E tests over the **real** engine and provider against a temp `HERMES_HOME` (no mocks of the store): append, accent-normalized BM25, nap/decay compression, byte-compat reopen, tool roundtrip, prefetch, and the `on_memory_write` mirror.
- `plugins/memory/optmem/__init__.py` — `save_config` now logs failures instead of swallowing them.

pytest: **18 passed in 0.99s**

## Why a local provider

Hermes already ships cloud-backed memory providers (Honcho, Mem0, Hindsight). They are powerful for cross-session *user modeling* but impose a network round-trip and, on reasoning tiers, an LLM call per recall. OptMem is the cheap, always-available default:

| Dimension | OptMem (local) | Cloud providers (e.g. Honcho) |
|---|---|---|
| Startup dependency | None — `is_available()` always True | Needs API key / base URL |
| Per-call latency | Local BM25 (sub-ms to ms) | Network, sometimes an LLM |
| Per-call cost | Zero tokens | Reasoning tier runs an LLM |
| Data residency | On disk in `HERMES_HOME` | Leaves the machine to a 3rd party |
| Code footprint | ~840 LOC (provider + engine) | 1500+ LOC + SDK + background threads |

Hermes enforces one external provider at a time, so the two are complementary: OptMem is the local durable layer; a cloud provider is selected when richer user modeling is wanted.

## Test plan

- [x] `pytest tests/agent/test_memory_provider_optmem.py` — 18 passed
- [x] Accent normalization: `recall("cacula")` hits the `caçula` memory
- [x] `on_memory_write` mirror lands in the append-only log and is searchable
- [x] Fixed-width on-disk format survives reopen

## Related

- VictorTaelin/OptMem#2 — Windows `fcntl` → `msvcrt` fix in the engine (this PR builds on that fix for native Windows support)
