### PR TITLE
fix(gateway): persist transcript retries across restarts

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1209,6 +1209,15 @@ class SessionStore:
             self._db = SessionDB()
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+        if self._db is not None:
+            try:
+                self._restore_durable_transcript_retries()
+            except Exception as e:
+                logger.warning(
+                    "Gateway transcript retry recovery failed; durable rows "
+                    "remain queued for the next attempt: %s",
+                    e,
+                )
 
     def _has_active_processes_safe(self, session_key: str, *, context: str) -> bool:
         """Return whether a session has active work, failing closed on registry errors."""
@@ -2922,13 +2931,7 @@ class SessionStore:
         """Serialize transcript draining across queue migration boundaries."""
         if not self._db or skip_db:
             return
-        drain_lock = getattr(self, "_transcript_drain_lock", None)
-        if drain_lock is None:
-            # Compatibility for old in-memory/test instances created via
-            # object.__new__ before this field existed.
-            drain_lock = threading.RLock()
-            self._transcript_drain_lock = drain_lock
-        with drain_lock:
+        with self._get_transcript_drain_lock():
             reroutes = getattr(self, "_transcript_reroutes", None)
             if reroutes is None:
                 reroutes = {}
@@ -2939,24 +2942,72 @@ class SessionStore:
                 session_id = reroutes[session_id]
             self._append_to_transcript_serialized(session_id, message)
 
+    def _get_transcript_drain_lock(self) -> Any:
+        """Return the process-local transcript mutation lock."""
+        drain_lock = getattr(self, "_transcript_drain_lock", None)
+        if drain_lock is None:
+            # Compatibility for old in-memory/test instances created via
+            # object.__new__ before this field existed.
+            drain_lock = threading.RLock()
+            self._transcript_drain_lock = drain_lock
+        return drain_lock
+
     def _append_to_transcript_serialized(
-        self, session_id: str, message: Dict[str, Any]
+        self,
+        session_id: str,
+        message: Dict[str, Any],
+        *,
+        already_staged: bool = False,
     ) -> None:
         """Append a message to a session's transcript (SQLite).
 
-        Args:
-            skip_db: When True, skip the SQLite write. Used when the agent
-                     already persisted messages to SQLite via its own
-                     _flush_messages_to_session_db(), preventing the
-                     duplicate-write bug (#860).
+        ``already_staged`` is used only during startup replay, when the
+        durable journal row already exists and must not be duplicated.
         """
+        queued_message = dict(message)
+        if not already_staged:
+            queued_message = self._prepare_transcript_retry_message(message)
+            stager = getattr(self._db, "enqueue_gateway_transcript_retry", None)
+            if callable(stager):
+                try:
+                    staged = stager(
+                        session_id,
+                        queued_message,
+                        max_pending=self._MAX_PENDING_PER_SESSION,
+                    )
+                    queued_message[self._TRANSCRIPT_RETRY_ID_KEY] = staged["id"]
+                    dropped_ids = set(staged.get("dropped_ids") or [])
+                    if dropped_ids:
+                        with self._transcript_retry_lock:
+                            for dirty in self._dirty_transcripts.values():
+                                dirty[:] = [
+                                    item for item in dirty
+                                    if item.get(self._TRANSCRIPT_RETRY_ID_KEY)
+                                    not in dropped_ids
+                                ]
+                        logger.warning(
+                            "Session DB transcript pending queue full for %s "
+                            "(cap=%d); dropped %d oldest durable message(s)",
+                            session_id,
+                            self._MAX_PENDING_PER_SESSION,
+                            len(dropped_ids),
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "Could not durably stage transcript append for %s; "
+                        "falling back to the in-memory retry queue: %s",
+                        session_id,
+                        exc,
+                    )
+
         with self._transcript_retry_lock:
             pending = self._dirty_transcripts.setdefault(session_id, [])
-            pending.append(dict(message))
+            pending.append(queued_message)
             # Cap pending messages per session to avoid unbounded memory
             # growth when the DB is persistently broken. Drop the oldest.
             if len(pending) > self._MAX_PENDING_PER_SESSION:
                 dropped = pending.pop(0)
+                self._discard_durable_transcript_retry(dropped)
                 logger.warning(
                     "Session DB transcript pending queue full for %s "
                     "(cap=%d); dropping oldest message to make room",
@@ -2983,6 +3034,23 @@ class SessionStore:
                         except Exception as reroute_exc:
                             exc = reroute_exc
                         else:
+                            try:
+                                self._reroute_durable_transcript_retries(
+                                    queue_session_id, child_id
+                                )
+                            except Exception as reroute_exc:
+                                with self._transcript_retry_lock:
+                                    if pending and pending[0] is msg:
+                                        pending.pop(0)
+                                logger.warning(
+                                    "Session DB transcript retry journal reroute "
+                                    "failed for %s -> %s; remaining rows stay on "
+                                    "the parent for startup recovery: %s",
+                                    queue_session_id,
+                                    child_id,
+                                    reroute_exc,
+                                )
+                                return
                             with self._transcript_retry_lock:
                                 if pending and pending[0] is msg:
                                     pending.pop(0)
@@ -3029,6 +3097,7 @@ class SessionStore:
                             if not pending:
                                 self._dirty_transcripts.pop(queue_session_id, None)
                                 self._transcript_append_failures.pop(session_id, None)
+                        self._discard_durable_transcript_retry(msg)
                         logger.error(
                             "Session DB transcript append rejected for compression-ended "
                             "%s with no unique live child; not retrying",
@@ -3070,6 +3139,11 @@ class SessionStore:
 
     def _append_transcript_message(self, session_id: str, message: Dict[str, Any]) -> None:
         """Write one transcript row. Caller handles retry queuing."""
+        retry_id = message.get(self._TRANSCRIPT_RETRY_ID_KEY)
+        replayer = getattr(self._db, "replay_gateway_transcript_retry", None)
+        if retry_id is not None and callable(replayer):
+            replayer(int(retry_id), target_session_id=session_id)
+            return
         self._db.append_message(
             session_id=session_id,
             role=message.get("role", "unknown"),
@@ -3095,6 +3169,90 @@ class SessionStore:
     # Maximum in-memory pending messages per session before dropping the
     # oldest. Prevents unbounded growth when the DB is persistently broken.
     _MAX_PENDING_PER_SESSION = 200
+    _TRANSCRIPT_RETRY_ID_KEY = "_gateway_transcript_retry_id"
+
+    @staticmethod
+    def _prepare_transcript_retry_message(message: Dict[str, Any]) -> Dict[str, Any]:
+        """Keep the complete append contract in a JSON-serializable payload."""
+        fields = (
+            "role",
+            "content",
+            "tool_name",
+            "tool_calls",
+            "tool_call_id",
+            "observed",
+            "timestamp",
+        )
+        payload = {key: message.get(key) for key in fields if key in message}
+        role = message.get("role", "unknown")
+        payload["role"] = role
+        if role == "assistant":
+            for key in (
+                "reasoning",
+                "reasoning_content",
+                "reasoning_details",
+                "codex_reasoning_items",
+                "codex_message_items",
+            ):
+                if key in message:
+                    payload[key] = message.get(key)
+        platform_message_id = (
+            message.get("platform_message_id") or message.get("message_id")
+        )
+        if platform_message_id is not None:
+            payload["platform_message_id"] = platform_message_id
+        api_content = extract_api_content_sidecar(message)
+        if api_content is not None:
+            payload["api_content"] = api_content
+        return payload
+
+    def _restore_durable_transcript_retries(self) -> None:
+        """Load and drain transcript rows left by an interrupted process."""
+        loader = getattr(self._db, "list_gateway_transcript_retries", None)
+        if not callable(loader):
+            return
+        retries = loader()
+        if not retries:
+            return
+
+        # Compression reroutes publish gateway routing changes, so load the
+        # routing index before replaying any parent-session rows.
+        self._ensure_loaded()
+        with self._transcript_drain_lock:
+            for retry in retries:
+                message = retry.get("message")
+                if not isinstance(message, dict):
+                    discarder = getattr(
+                        self._db, "discard_gateway_transcript_retry", None
+                    )
+                    if callable(discarder):
+                        discarder(retry["id"])
+                    continue
+                queued = dict(message)
+                queued[self._TRANSCRIPT_RETRY_ID_KEY] = retry["id"]
+                self._append_to_transcript_serialized(
+                    retry["session_id"], queued, already_staged=True
+                )
+
+    def _discard_durable_transcript_retry(self, message: Dict[str, Any]) -> None:
+        retry_id = message.get(self._TRANSCRIPT_RETRY_ID_KEY)
+        discarder = getattr(self._db, "discard_gateway_transcript_retry", None)
+        if retry_id is not None and callable(discarder):
+            try:
+                discarder(int(retry_id))
+            except Exception as exc:
+                logger.warning(
+                    "Could not discard gateway transcript retry row %s: %s",
+                    retry_id,
+                    exc,
+                )
+
+    def _reroute_durable_transcript_retries(
+        self, source_session_id: str, target_session_id: str
+    ) -> None:
+        rerouter = getattr(self._db, "reroute_gateway_transcript_retries", None)
+        if callable(rerouter):
+            rerouter(source_session_id, target_session_id)
 
     @staticmethod
     def _is_fts_corruption_error(exc: Exception) -> bool:
@@ -3140,7 +3298,7 @@ class SessionStore:
             )
         return rebuilt > 0
 
-    def _clear_dirty_transcript(self, session_id: str) -> None:
+    def _clear_dirty_transcript(self, session_id: str) -> bool:
         """Drop queued pending messages for a session.
 
         Called by ``rewrite_transcript`` and ``rewind_session`` so that
@@ -3148,9 +3306,21 @@ class SessionStore:
         don't leave stale messages that would be re-inserted on the next
         append.
         """
+        clearer = getattr(self._db, "clear_gateway_transcript_retries", None)
+        if callable(clearer):
+            try:
+                clearer(session_id)
+            except Exception as exc:
+                logger.warning(
+                    "Could not clear durable transcript retries for %s: %s",
+                    session_id,
+                    exc,
+                )
+                return False
         with self._transcript_retry_lock:
             self._dirty_transcripts.pop(session_id, None)
             self._transcript_append_failures.pop(session_id, None)
+        return True
     
     def has_platform_message_id(
         self, session_id: str, platform_message_id: str
@@ -3186,13 +3356,15 @@ class SessionStore:
         """
         if not self._db:
             return True
-        self._clear_dirty_transcript(session_id)
-        try:
-            self._db.replace_messages(session_id, messages)
-            return True
-        except Exception as e:
-            logger.debug("Failed to rewrite transcript in DB: %s", e)
-            return False
+        with self._get_transcript_drain_lock():
+            if not self._clear_dirty_transcript(session_id):
+                return False
+            try:
+                self._db.replace_messages(session_id, messages)
+                return True
+            except Exception as e:
+                logger.debug("Failed to rewrite transcript in DB: %s", e)
+                return False
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
@@ -3229,11 +3401,22 @@ class SessionStore:
         """
         if not self._db:
             return None
-        self._clear_dirty_transcript(session_id)
+        with self._get_transcript_drain_lock():
+            return self._rewind_session_serialized(session_id, n)
+
+    def _rewind_session_serialized(
+        self, session_id: str, n: int
+    ) -> Optional[Dict[str, Any]]:
+        """Rewind while the transcript drain lock is held."""
+        db = self._db
+        if db is None:
+            return None
+        if not self._clear_dirty_transcript(session_id):
+            return None
         if n < 1:
             n = 1
         try:
-            recents = self._db.list_recent_user_messages(session_id, limit=max(n, 10))
+            recents = db.list_recent_user_messages(session_id, limit=max(n, 10))
         except Exception as e:
             logger.debug("rewind_session: failed to list user messages: %s", e)
             return None
@@ -3242,7 +3425,7 @@ class SessionStore:
         target_idx = min(n - 1, len(recents) - 1)
         target_id = recents[target_idx]["id"]
         try:
-            result = self._db.rewind_to_message(session_id, target_id)
+            result = db.rewind_to_message(session_id, target_id)
         except ValueError as e:
             logger.debug("rewind_session: %s", e)
             return None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1265,6 +1265,13 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS gateway_transcript_retries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    message_json TEXT NOT NULL,
+    created_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -1292,6 +1299,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_gateway_transcript_retries_session
+    ON gateway_transcript_retries(session_id, id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
@@ -6456,36 +6465,48 @@ class SessionDB:
         from every outgoing payload anyway, so the scrubbed form IS the
         wire bytes).
         """
-        # Display metadata is presentation-only and never changes the model
-        # context role/content replayed to providers.
-        display_metadata_json = self._encode_display_metadata(display_metadata)
-        # Serialize structured fields to JSON before entering the write txn
-        reasoning_details_json = (
-            json.dumps(reasoning_details)
-            if reasoning_details else None
+        message = {
+            "role": role,
+            "content": content,
+            "tool_name": tool_name,
+            "tool_calls": tool_calls,
+            "tool_call_id": tool_call_id,
+            "token_count": token_count,
+            "finish_reason": finish_reason,
+            "reasoning": reasoning,
+            "reasoning_content": reasoning_content,
+            "reasoning_details": reasoning_details,
+            "codex_reasoning_items": codex_reasoning_items,
+            "codex_message_items": codex_message_items,
+            "platform_message_id": platform_message_id,
+            "observed": observed,
+            "effect_disposition": effect_disposition,
+            "timestamp": timestamp,
+            "api_content": api_content,
+            "display_kind": display_kind,
+            "display_metadata": display_metadata,
+        }
+        prepared = self._prepare_appended_message(message)
+        return self._execute_write(
+            lambda conn: self._append_message_in_transaction(
+                conn,
+                session_id,
+                prepared,
+                compression_lock_holder=compression_lock_holder,
+            )
         )
-        codex_items_json = (
-            json.dumps(codex_reasoning_items)
-            if codex_reasoning_items else None
-        )
-        codex_message_items_json = (
-            json.dumps(codex_message_items)
-            if codex_message_items else None
-        )
-        # tool_calls may arrive as a Python list (from the live agent) or
-        # as a JSON string (from import/export). Parse first to avoid
-        # double-encoding.
+
+    def _prepare_appended_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize one append payload before entering a write transaction."""
+        tool_calls = message.get("tool_calls")
         if isinstance(tool_calls, str):
             try:
                 tool_calls = json.loads(tool_calls)
             except (json.JSONDecodeError, TypeError):
                 tool_calls = []
-        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
-        # Multimodal content (list of parts) must be JSON-encoded: sqlite3
-        # cannot bind list/dict parameters directly.
-        stored_content = self._encode_content(content)
 
         message_timestamp = time.time()
+        timestamp = message.get("timestamp")
         if timestamp is not None:
             try:
                 if hasattr(timestamp, "timestamp"):
@@ -6495,81 +6516,281 @@ class SessionDB:
             except (TypeError, ValueError):
                 logger.debug("Ignoring invalid explicit message timestamp: %r", timestamp)
 
-        # Pre-compute tool call count
         num_tool_calls = 0
         if tool_calls is not None:
             num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
 
-        def _do(conn):
-            active_lock = conn.execute(
-                "SELECT holder FROM compression_locks "
-                "WHERE session_id = ? AND expires_at > ?",
-                (session_id, time.time()),
-            ).fetchone()
-            if (
-                active_lock is not None
-                and active_lock["holder"] != compression_lock_holder
-            ):
-                raise CompressionSessionBusyError(
-                    f"Session {session_id!r} is being compressed by another writer"
-                )
-            session = conn.execute(
-                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
-            if (
-                session is not None
-                and session["ended_at"] is not None
-                and session["end_reason"] == "compression"
-            ):
-                raise CompressionSessionClosedError(session_id)
-            cursor = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    session_id,
-                    role,
-                    stored_content,
-                    tool_call_id,
-                    tool_calls_json,
-                    _scrub_surrogates(tool_name),
-                    effect_disposition,
-                    message_timestamp,
-                    token_count,
-                    finish_reason,
-                    _scrub_surrogates(reasoning),
-                    _scrub_surrogates(reasoning_content),
-                    reasoning_details_json,
-                    codex_items_json,
-                    codex_message_items_json,
-                    platform_message_id,
-                    1 if observed else 0,
-                    1,
-                    _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
-                    _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
-                    display_metadata_json,
-                ),
-            )
-            msg_id = cursor.lastrowid
+        return {
+            "role": message.get("role", "unknown"),
+            "content": self._encode_content(message.get("content")),
+            "tool_call_id": message.get("tool_call_id"),
+            "tool_calls": json.dumps(tool_calls) if tool_calls else None,
+            "tool_name": _scrub_surrogates(message.get("tool_name")),
+            "effect_disposition": message.get("effect_disposition"),
+            "timestamp": message_timestamp,
+            "token_count": message.get("token_count"),
+            "finish_reason": message.get("finish_reason"),
+            "reasoning": _scrub_surrogates(message.get("reasoning")),
+            "reasoning_content": _scrub_surrogates(message.get("reasoning_content")),
+            "reasoning_details": (
+                json.dumps(message.get("reasoning_details"))
+                if message.get("reasoning_details") else None
+            ),
+            "codex_reasoning_items": (
+                json.dumps(message.get("codex_reasoning_items"))
+                if message.get("codex_reasoning_items") else None
+            ),
+            "codex_message_items": (
+                json.dumps(message.get("codex_message_items"))
+                if message.get("codex_message_items") else None
+            ),
+            "platform_message_id": message.get("platform_message_id"),
+            "observed": 1 if message.get("observed") else 0,
+            "api_content": (
+                _scrub_surrogates(message.get("api_content"))
+                if isinstance(message.get("api_content"), str) else None
+            ),
+            "display_kind": (
+                _scrub_surrogates(message.get("display_kind"))
+                if isinstance(message.get("display_kind"), str) else None
+            ),
+            "display_metadata": self._encode_display_metadata(
+                message.get("display_metadata")
+            ),
+            "num_tool_calls": num_tool_calls,
+        }
 
-            # Update counters
-            if num_tool_calls > 0:
-                conn.execute(
-                    """UPDATE sessions SET message_count = message_count + 1,
-                       tool_call_count = tool_call_count + ? WHERE id = ?""",
-                    (num_tool_calls, session_id),
-                )
-            else:
-                conn.execute(
-                    "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+    def _append_message_in_transaction(
+        self,
+        conn: sqlite3.Connection,
+        session_id: str,
+        message: Dict[str, Any],
+        *,
+        compression_lock_holder: Optional[str] = None,
+    ) -> int:
+        """Insert one prepared message and update counters on *conn*."""
+        active_lock = conn.execute(
+            "SELECT holder FROM compression_locks "
+            "WHERE session_id = ? AND expires_at > ?",
+            (session_id, time.time()),
+        ).fetchone()
+        if (
+            active_lock is not None
+            and active_lock["holder"] != compression_lock_holder
+        ):
+            raise CompressionSessionBusyError(
+                f"Session {session_id!r} is being compressed by another writer"
+            )
+        session = conn.execute(
+            "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        if (
+            session is not None
+            and session["ended_at"] is not None
+            and session["end_reason"] == "compression"
+        ):
+            raise CompressionSessionClosedError(session_id)
+
+        cursor = conn.execute(
+            """INSERT INTO messages (session_id, role, content, tool_call_id,
+               tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
+               reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
+               codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                message["role"],
+                message["content"],
+                message["tool_call_id"],
+                message["tool_calls"],
+                message["tool_name"],
+                message["effect_disposition"],
+                message["timestamp"],
+                message["token_count"],
+                message["finish_reason"],
+                message["reasoning"],
+                message["reasoning_content"],
+                message["reasoning_details"],
+                message["codex_reasoning_items"],
+                message["codex_message_items"],
+                message["platform_message_id"],
+                message["observed"],
+                1,
+                message["api_content"],
+                message["display_kind"],
+                message["display_metadata"],
+            ),
+        )
+        msg_id = cursor.lastrowid
+        if msg_id is None:
+            raise RuntimeError("message insert did not produce a row id")
+        num_tool_calls = message["num_tool_calls"]
+        if num_tool_calls > 0:
+            conn.execute(
+                """UPDATE sessions SET message_count = message_count + 1,
+                   tool_call_count = tool_call_count + ? WHERE id = ?""",
+                (num_tool_calls, session_id),
+            )
+        else:
+            conn.execute(
+                "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+                (session_id,),
+            )
+        return msg_id
+
+    def enqueue_gateway_transcript_retry(
+        self,
+        session_id: str,
+        message: Dict[str, Any],
+        *,
+        max_pending: int = 200,
+    ) -> Dict[str, Any]:
+        """Durably stage a gateway transcript append before touching FTS.
+
+        This table has no FTS triggers, so it remains writable when a corrupt
+        FTS shadow table rejects inserts into ``messages``. The returned row id
+        is later consumed by :meth:`replay_gateway_transcript_retry`.
+        """
+        payload = dict(message)
+        staged_at = time.time()
+        timestamp = payload.get("timestamp")
+        if timestamp is None:
+            payload["timestamp"] = staged_at
+        else:
+            try:
+                if hasattr(timestamp, "timestamp"):
+                    payload["timestamp"] = float(timestamp.timestamp())
+                else:
+                    payload["timestamp"] = float(timestamp)
+            except (TypeError, ValueError):
+                payload["timestamp"] = staged_at
+        message_json = json.dumps(
+            payload,
+            ensure_ascii=True,
+            separators=(",", ":"),
+        )
+
+        def _do(conn):
+            cursor = conn.execute(
+                "INSERT INTO gateway_transcript_retries "
+                "(session_id, message_json, created_at) VALUES (?, ?, ?)",
+                (session_id, message_json, staged_at),
+            )
+            retry_id = int(cursor.lastrowid)
+            dropped_ids: List[int] = []
+            if max_pending > 0:
+                rows = conn.execute(
+                    "SELECT id FROM gateway_transcript_retries "
+                    "WHERE session_id = ? ORDER BY id DESC",
                     (session_id,),
-                )
-            return msg_id
+                ).fetchall()
+                if len(rows) > max_pending:
+                    dropped_ids = [int(row["id"]) for row in rows[max_pending:]]
+                    placeholders = ",".join("?" for _ in dropped_ids)
+                    conn.execute(
+                        f"DELETE FROM gateway_transcript_retries "
+                        f"WHERE id IN ({placeholders})",
+                        dropped_ids,
+                    )
+            return {"id": retry_id, "dropped_ids": dropped_ids}
 
         return self._execute_write(_do)
+
+    def list_gateway_transcript_retries(self) -> List[Dict[str, Any]]:
+        """Return staged gateway transcript appends in durable arrival order."""
+        conn = self._conn
+        if conn is None:
+            return []
+        with self._lock:
+            rows = conn.execute(
+                "SELECT id, session_id, message_json, created_at "
+                "FROM gateway_transcript_retries ORDER BY id"
+            ).fetchall()
+        retries = []
+        for row in rows:
+            try:
+                message = json.loads(row["message_json"])
+                if not isinstance(message, dict):
+                    raise TypeError("message payload is not an object")
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.error(
+                    "Ignoring invalid gateway transcript retry row %s: %s",
+                    row["id"],
+                    exc,
+                )
+                message = None
+            retries.append(
+                {
+                    "id": int(row["id"]),
+                    "session_id": row["session_id"],
+                    "message": message,
+                    "created_at": row["created_at"],
+                }
+            )
+        return retries
+
+    def replay_gateway_transcript_retry(
+        self,
+        retry_id: int,
+        *,
+        target_session_id: Optional[str] = None,
+    ) -> Optional[int]:
+        """Atomically append one staged message and acknowledge its journal row."""
+        def _do(conn):
+            row = conn.execute(
+                "SELECT session_id, message_json FROM gateway_transcript_retries "
+                "WHERE id = ?",
+                (retry_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            message = json.loads(row["message_json"])
+            if not isinstance(message, dict):
+                raise TypeError("gateway transcript retry payload is not an object")
+            prepared = self._prepare_appended_message(message)
+            message_id = self._append_message_in_transaction(
+                conn,
+                target_session_id or row["session_id"],
+                prepared,
+            )
+            conn.execute(
+                "DELETE FROM gateway_transcript_retries WHERE id = ?",
+                (retry_id,),
+            )
+            return message_id
+
+        return self._execute_write(_do)
+
+    def discard_gateway_transcript_retry(self, retry_id: int) -> None:
+        """Discard one retry row that can no longer be routed safely."""
+        self._execute_write(
+            lambda conn: conn.execute(
+                "DELETE FROM gateway_transcript_retries WHERE id = ?",
+                (retry_id,),
+            )
+        )
+
+    def clear_gateway_transcript_retries(self, session_id: str) -> None:
+        """Clear staged rows before a transcript rewrite or rewind."""
+        self._execute_write(
+            lambda conn: conn.execute(
+                "DELETE FROM gateway_transcript_retries WHERE session_id = ?",
+                (session_id,),
+            )
+        )
+
+    def reroute_gateway_transcript_retries(
+        self, source_session_id: str, target_session_id: str
+    ) -> None:
+        """Move a compression-ended parent's remaining retries to its child."""
+        self._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE gateway_transcript_retries SET session_id = ? "
+                "WHERE session_id = ?",
+                (target_session_id, source_session_id),
+            )
+        )
 
     def set_latest_matching_message_display_kind(
         self, session_id: str, *, role: str, content: str, display_kind: str,

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -2273,6 +2273,151 @@ class TestRewriteTranscriptPreservesReasoning:
 
 
 class TestGatewaySessionDbRecovery:
+    def test_transcript_retry_survives_restart_and_replays(self, tmp_path, monkeypatch):
+        import hermes_state
+        import sqlite3
+
+        db_path = tmp_path / "state.db"
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", db_path)
+
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+        store._db.create_session("s1", source="telegram")
+        if not store._db._fts_enabled:
+            store._db.close()
+            pytest.skip("FTS5 unavailable in this build")
+        store._db.append_message("s1", role="user", content="before corruption")
+
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "UPDATE messages_fts_data "
+            "SET block = X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'"
+        )
+        raw.commit()
+        raw.close()
+
+        # Simulate corruption persisting after both one-shot rebuild paths were
+        # already consumed in this process.
+        store._db._fts_runtime_rebuild_attempted = True
+        store._fts_rebuild_attempted = True
+        store.append_to_transcript("s1", {"role": "user", "content": "survive restart"})
+
+        assert [
+            message["content"]
+            for message in store._db.get_messages_as_conversation("s1")
+        ] == ["before corruption"]
+        assert [
+            row["message"]["content"]
+            for row in store._db.list_gateway_transcript_retries()
+        ] == ["survive restart"]
+        store._db.close()
+
+        restarted = SessionStore(
+            sessions_dir=tmp_path / "sessions", config=GatewayConfig()
+        )
+
+        assert [
+            message["content"]
+            for message in restarted._db.get_messages_as_conversation("s1")
+        ] == ["before corruption", "survive restart"]
+        assert restarted._db.list_gateway_transcript_retries() == []
+        restarted._db.close()
+
+    def test_transcript_retry_stays_durable_when_startup_replay_fails(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+        store._db.create_session("s1", source="telegram")
+
+        def fail_append(_session_id, _message):
+            raise RuntimeError("persistent write failure")
+
+        monkeypatch.setattr(store, "_append_transcript_message", fail_append)
+        store.append_to_transcript("s1", {"role": "user", "content": "keep me"})
+        store._db.close()
+
+        def fail_replay(*_args, **_kwargs):
+            raise RuntimeError("persistent write failure")
+
+        monkeypatch.setattr(SessionDB, "replay_gateway_transcript_retry", fail_replay)
+        restarted = SessionStore(
+            sessions_dir=tmp_path / "sessions", config=GatewayConfig()
+        )
+
+        assert restarted._db.get_messages_as_conversation("s1") == []
+        assert [
+            row["message"]["content"]
+            for row in restarted._db.list_gateway_transcript_retries()
+        ] == ["keep me"]
+        restarted._db.close()
+
+    def test_transcript_retry_restart_reroutes_parent_backlog_to_child(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+        store._db.create_session("parent", source="telegram")
+
+        def fail_append(_session_id, _message):
+            raise RuntimeError("persistent write failure")
+
+        monkeypatch.setattr(store, "_append_transcript_message", fail_append)
+        store.append_to_transcript("parent", {"role": "user", "content": "first"})
+        store.append_to_transcript(
+            "parent", {"role": "assistant", "content": "second"}
+        )
+        store._db.end_session("parent", "compression")
+        store._db.create_session(
+            "child", source="telegram", parent_session_id="parent"
+        )
+        store._db.close()
+
+        restarted = SessionStore(
+            sessions_dir=tmp_path / "sessions", config=GatewayConfig()
+        )
+
+        assert restarted._db.get_messages_as_conversation("parent") == []
+        assert [
+            message["content"]
+            for message in restarted._db.get_messages_as_conversation("child")
+        ] == ["first", "second"]
+        assert restarted._db.list_gateway_transcript_retries() == []
+        restarted._db.close()
+
+    @pytest.mark.parametrize("operation", ["rewrite", "rewind"])
+    def test_transcript_mutation_clears_durable_retries(
+        self, tmp_path, monkeypatch, operation
+    ):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+        store._db.create_session("s1", source="telegram")
+        store._db.append_message("s1", role="user", content="persisted")
+
+        def fail_append(_session_id, _message):
+            raise RuntimeError("persistent write failure")
+
+        monkeypatch.setattr(store, "_append_transcript_message", fail_append)
+        store.append_to_transcript(
+            "s1", {"role": "assistant", "content": "stale pending"}
+        )
+        assert len(store._db.list_gateway_transcript_retries()) == 1
+
+        if operation == "rewrite":
+            assert store.rewrite_transcript(
+                "s1", [{"role": "user", "content": "replacement"}]
+            )
+        else:
+            assert store.rewind_session("s1", 1) is not None
+
+        assert store._db.list_gateway_transcript_retries() == []
+        store._db.close()
+
     def test_compression_closed_parent_reroutes_without_retry_queue(self, tmp_path):
         import threading
         from types import SimpleNamespace

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1254,6 +1254,64 @@ class TestMessageStorage:
         session = db.get_session("s1")
         assert session["message_count"] == 2
 
+    def test_gateway_transcript_retry_replay_is_atomic(self, db, monkeypatch):
+        db.create_session(session_id="s1", source="telegram")
+        staged = db.enqueue_gateway_transcript_retry(
+            "s1",
+            {
+                "role": "assistant",
+                "content": "durable answer",
+                "tool_calls": [
+                    {"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}
+                ],
+                "reasoning": "private reasoning",
+                "api_content": "wire-exact answer",
+                "display_kind": "gateway",
+                "display_metadata": {"source": "telegram"},
+            },
+        )
+        original_append = db._append_message_in_transaction
+
+        def fail_before_ack(conn, session_id, message, **kwargs):
+            original_append(conn, session_id, message, **kwargs)
+            raise RuntimeError("crash before journal acknowledgement")
+
+        monkeypatch.setattr(db, "_append_message_in_transaction", fail_before_ack)
+        with pytest.raises(RuntimeError, match="journal acknowledgement"):
+            db.replay_gateway_transcript_retry(staged["id"])
+
+        assert db.get_messages_as_conversation("s1") == []
+        assert [row["id"] for row in db.list_gateway_transcript_retries()] == [
+            staged["id"]
+        ]
+        assert db.get_session("s1")["message_count"] == 0
+
+        monkeypatch.setattr(db, "_append_message_in_transaction", original_append)
+        db.replay_gateway_transcript_retry(staged["id"])
+
+        messages = db.get_messages("s1")
+        assert len(messages) == 1
+        assert messages[0]["content"] == "durable answer"
+        assert messages[0]["reasoning"] == "private reasoning"
+        assert messages[0]["api_content"] == "wire-exact answer"
+        assert messages[0]["display_metadata"] == {"source": "telegram"}
+        assert db.list_gateway_transcript_retries() == []
+        assert db.get_session("s1")["message_count"] == 1
+
+    def test_gateway_transcript_retry_cap_is_durable(self, db):
+        db.create_session(session_id="s1", source="telegram")
+        for index in range(3):
+            db.enqueue_gateway_transcript_retry(
+                "s1",
+                {"role": "user", "content": f"message-{index}"},
+                max_pending=2,
+            )
+
+        assert [
+            row["message"]["content"]
+            for row in db.list_gateway_transcript_retries()
+        ] == ["message-1", "message-2"]
+
     def test_observed_flag_round_trips_for_gateway_replay(self, db):
         db.create_session(session_id="s1", source="telegram:-100")
         db.append_message(


### PR DESCRIPTION
## What does this PR do?

Persists failed gateway transcript appends across process restarts.

Gateway transcript writes can fail when a corrupt FTS shadow table rejects the
`messages` insert through its synchronization trigger. The existing retry queue
kept those messages only in `SessionStore._dirty_transcripts`, so a gateway
restart permanently discarded the only remaining copy.

This change adds a small `gateway_transcript_retries` journal in `state.db`. The
journal has no FTS triggers, so the gateway can stage the complete append payload
before touching `messages`. Replay inserts the message and deletes its journal
row in the same SQLite transaction, preventing both loss and duplication across
crashes. `SessionStore` drains durable rows on startup and keeps compression
rerouting, queue caps, transcript rewrites, and rewinds synchronized with the
journal.

User impact: a persistent FTS write failure can still delay transcript
persistence, but restarting the gateway no longer turns that delay into permanent
conversation-history loss.

## Related Issue

Fixes #72680

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add an FTS-independent durable gateway transcript retry table in `hermes_state.py`.
- Share the transaction-local message insert contract between normal appends and retry replay.
- Stage gateway messages before writing `messages`, then atomically append and acknowledge them.
- Restore retries at gateway startup and preserve compression parent-to-child routing.
- Clear durable retries at rewrite/rewind boundaries and enforce the existing per-session cap.
- Add real-SQLite coverage for restart recovery, atomic rollback, replay failure, rerouting, mutation cleanup, and caps.

## How to Test

1. Corrupt `messages_fts_data` after seeding a session and consume the current process's one-shot rebuild guards.
2. Append a gateway message and verify it remains in `gateway_transcript_retries` while `messages` stays unchanged.
3. Recreate `SessionStore` and verify the FTS index rebuilds, the message is replayed once, and the journal is empty.
4. Inject a failure after the transactional message insert and verify both the message and counter roll back while the journal row remains.

Validation run:

```text
scripts/run_tests.sh tests/test_hermes_state.py tests/state/test_fts_runtime_rebuild.py tests/gateway/test_session.py tests/gateway/test_load_transcript_db_only.py tests/gateway/test_retry_replacement.py tests/gateway/test_session_dm_thread_seeding.py tests/gateway/platforms/test_yuanbao_recall_db_only.py tests/run_agent/test_860_dedup.py -q
648 passed

# Re-run after rebasing onto upstream/main
2 issue-critical tests passed
ruff, py_compile, and git diff --check passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal persistence fix with method docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-tool changes

## Screenshots / Logs

Not applicable; this is a SQLite persistence-path fix. The real FTS corruption
reproduction and restart assertions are covered by the tests above.
