### PR TITLE
fix(provider/vertex): sanitize assistant content with tool_calls and fix extra_body payload wrapping

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -125,7 +125,7 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     ``extra_content`` from earlier in a mixed-provider session.
     """
     m = str(model or "").lower()
-    return "gemini" in m or "gemma" in m
+    return "gemini" in m
 
 
 class ChatCompletionsTransport(ProviderTransport):
@@ -173,10 +173,15 @@ class ChatCompletionsTransport(ProviderTransport):
           gateways (e.g. opencode-go, codex.nekos.me) reject with
           ``Extra inputs are not permitted, field: 'messages[N]._empty_recovery_synthetic'``,
           which then poisons every subsequent request in the session.
+        - Non-empty ``content`` on assistant messages with ``tool_calls`` —
+          Vertex AI (e.g., ``gemini-3.6-flash``, ``gemini-3.5-flash-lite``)
+          rejects replaying assistant messages in history that have both
+          ``tool_calls`` and non-empty ``content`` with HTTP 400 INVALID_ARGUMENT.
         """
-        strip_extra_content = not _model_consumes_thought_signature(
+        is_gemini_target = _model_consumes_thought_signature(
             kwargs.get("model")
         )
+        strip_extra_content = not is_gemini_target
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
@@ -192,6 +197,14 @@ class ChatCompletionsTransport(ProviderTransport):
                 needs_sanitize = True
                 break
             if any(isinstance(k, str) and k.startswith("_") for k in msg):
+                needs_sanitize = True
+                break
+            if (
+                is_gemini_target
+                and msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+                and msg.get("content")
+            ):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
@@ -249,6 +262,18 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg = mutable_msg()
                 for key in internal_keys:
                     out_msg.pop(key, None)
+
+            # Vertex AI (gemini-3.6-flash, gemini-3.5-flash-lite) rejects
+            # replaying assistant messages in history that have both tool_calls
+            # and a non-empty content string. Clear content to "".
+            if (
+                is_gemini_target
+                and msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+                and msg.get("content")
+            ):
+                out_msg = mutable_msg()
+                out_msg["content"] = ""
 
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -42,7 +42,7 @@ class GeminiProfile(ProviderProfile):
         if self.name == "gemini" and _is_gemini_openai_compat_base_url(base_url):
             thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
             if thinking_config:
-                body["extra_body"] = {"google": {"thinking_config": thinking_config}}
+                body["google"] = {"thinking_config": thinking_config}
         else:
             body["thinking_config"] = raw_thinking_config
         return body

--- a/plugins/model-providers/vertex/__init__.py
+++ b/plugins/model-providers/vertex/__init__.py
@@ -26,6 +26,44 @@ from providers.base import ProviderProfile
 class VertexProfile(ProviderProfile):
     """Vertex AI — reuse Gemini's thinking_config translation for extra_body."""
 
+    def prepare_messages(
+        self, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Sanitize messages for Vertex AI.
+
+        Vertex AI's OpenAPI endpoint (specifically for models like
+        gemini-3.6-flash and gemini-3.5-flash-lite) rejects requests with
+        HTTP 400 INVALID_ARGUMENT if an assistant message in history contains
+        both `tool_calls` and a non-empty `content` string.
+        Clear `content` to "" on any assistant message that carries `tool_calls`.
+        """
+        needs_fix = False
+        for msg in messages:
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+                and msg.get("content")
+            ):
+                needs_fix = True
+                break
+
+        if not needs_fix:
+            return messages
+
+        sanitized = list(messages)
+        for idx, msg in enumerate(messages):
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+                and msg.get("content")
+            ):
+                copied = dict(msg)
+                copied["content"] = ""
+                sanitized[idx] = copied
+        return sanitized
+
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:
@@ -47,7 +85,7 @@ class VertexProfile(ProviderProfile):
         thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
         if not thinking_config:
             return {}
-        return {"extra_body": {"google": {"thinking_config": thinking_config}}}
+        return {"google": {"thinking_config": thinking_config}}
 
     def fetch_models(
         self,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -107,12 +107,40 @@ class TestChatCompletionsBasic:
         every turn — stripping it would 400. Keep extra_content for Gemini
         targets (including aggregator slugs like google/gemini-3-pro).
         """
-        for model in ("gemini-3-pro", "google/gemini-3-pro-preview", "gemma-3-27b"):
+        for model in ("gemini-3-pro", "google/gemini-3-pro-preview"):
             msgs = self._msg_with_extra_content()
             result = transport.convert_messages(msgs, model=model)
             assert result[0]["tool_calls"][0]["extra_content"] == {
                 "google": {"thought_signature": "SIG_123"}
             }, model
+
+    def test_convert_messages_strips_extra_content_for_gemma(self, transport):
+        """Gemma models (e.g. gemma-4-31b-it) do NOT use Gemini thought_signatures.
+        When falling back or switching to Gemma, extra_content must be stripped.
+        Fixes #36907.
+        """
+        msgs = self._msg_with_extra_content()
+        result = transport.convert_messages(msgs, model="gemma-4-31b-it")
+        assert "extra_content" not in result[0]["tool_calls"][0]
+
+    def test_convert_messages_clears_assistant_content_for_gemini_with_tool_calls(self, transport):
+        """Vertex AI (gemini-3.6-flash, gemini-3.5-flash-lite) rejects replaying
+        assistant messages in history that have both tool_calls and a non-empty
+        content string with HTTP 400 INVALID_ARGUMENT. Clear content to "".
+        Fixes #69231.
+        """
+        msgs = [
+            {"role": "user", "content": "Fetch data"},
+            {
+                "role": "assistant",
+                "content": "Checking the database now...",
+                "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "query", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "res"},
+        ]
+        result = transport.convert_messages(msgs, model="google/gemini-3.6-flash")
+        assert result[1]["content"] == ""
+        assert msgs[1]["content"] == "Checking the database now..."
 
     def test_convert_messages_strips_tool_name(self, transport):
         """Internal `tool_name` (used for FTS indexing in the SQLite store) is

--- a/tests/hermes_cli/test_vertex_provider.py
+++ b/tests/hermes_cli/test_vertex_provider.py
@@ -88,9 +88,9 @@ def test_vertex_extra_body_thinking_config():
         model="google/gemini-3-pro-preview",
         reasoning_config={"effort": "high"},
     )
-    assert "extra_body" in body
-    assert "google" in body["extra_body"]
-    assert "thinking_config" in body["extra_body"]["google"]
+    assert "google" in body
+    assert "thinking_config" in body["google"]
+    assert "extra_body" not in body
 
 
 def test_vertex_extra_body_empty_without_reasoning():
@@ -126,3 +126,23 @@ def test_vertex_registered_in_hermes_overlays():
     resolved = get_provider("vertex")
     assert resolved is not None
     assert resolved.auth_type == "vertex"
+
+
+def test_vertex_prepare_messages_clears_assistant_content_with_tool_calls():
+    from providers import get_provider_profile
+
+    p = get_provider_profile("vertex")
+    msgs = [
+        {"role": "user", "content": "What is the weather?"},
+        {
+            "role": "assistant",
+            "content": "Let me check that for you.",
+            "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "tc1", "content": '{"temp": 20}'},
+    ]
+    out = p.prepare_messages(msgs)
+    assert out[1]["content"] == ""
+    assert out[1]["tool_calls"] == msgs[1]["tool_calls"]
+    # Ensure input array is not mutated in place
+    assert msgs[1]["content"] == "Let me check that for you."


### PR DESCRIPTION
## Summary
Fixes `HTTP 400 INVALID_ARGUMENT` errors when using `provider: vertex` with Gemini models (e.g. `google/gemini-3.6-flash`, `gemini-3.5-flash-lite`), particularly on tool-calling turns.

## Motivation & Root Causes
1. **Assistant Message `content` with `tool_calls` (#69231)**:
   Vertex AI's OpenAPI-compatible endpoint strictly validates conversation history for models like `gemini-3.6-flash` and `gemini-3.5-flash-lite`. When replaying an assistant message in history that carries both `tool_calls` AND a non-empty `content` string (narrative preamble text), Vertex AI rejects the follow-up request with `HTTP 400 INVALID_ARGUMENT`. Clearing `content` to `""` on assistant messages that carry `tool_calls` when target model is Gemini/Vertex resolves the issue.
2. **Double Nesting of `extra_body`**:
   `VertexProfile.build_extra_body()` and `GeminiProfile.build_extra_body()` were returning `{"extra_body": {"google": ...}}`. Because the OpenAI SDK unpacks top-level keys of `extra_body` into the HTTP POST JSON body, this resulted in an invalid top-level `"extra_body"` JSON key being sent to Vertex AI.
3. **`thought_signature` Leakage to Gemma Models (#36907)**:
   `_model_consumes_thought_signature` matched `"gemma"`. Gemma open-weights models do not consume Gemini thought signatures; leaving `extra_content` on `tool_calls` when falling back to Gemma caused strict provider 400 errors.
## Changes Made
- **`plugins/model-providers/vertex/__init__.py`**:
  - Implemented `prepare_messages()` on `VertexProfile` to clear `content` to `""` on assistant messages with `tool_calls`.
  - Updated `build_extra_body()` to return `{"google": {"thinking_config": ...}}` directly without nesting under an `"extra_body"` wrapper key.
- **`plugins/model-providers/gemini/__init__.py`**:
  - Updated `build_extra_body()` to set `body["google"]` directly.
- **`agent/transports/chat_completions.py`**:
  - Sanitized assistant `content` for Gemini/Vertex target models in `convert_messages()`.
  - Restricted `_model_consumes_thought_signature` strictly to `"gemini" in m` (excluding `gemma`).
- **Unit Tests**:
  - Added unit tests in `tests/hermes_cli/test_vertex_provider.py` and `tests/agent/transports/test_chat_completions.py` to cover assistant message content sanitization, payload shape, and Gemma fallback stripping.
## Verification
- Ran test suite: 110/110 tests passed in `tests/hermes_cli/test_vertex_provider.py` and `tests/agent/transports/test_chat_completions.py`.