### PR TITLE
fix(slack): preserve bold next to adjacent text

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3664,6 +3664,8 @@ class SlackAdapter(BasePlatformAdapter):
         )
 
         # 9) Convert bold: **text** → *text* (Slack bold)
+        # Separate converted delimiters from adjacent non-whitespace text so
+        # Slack does not absorb CJK text or full-width punctuation into them.
         # Slack's mrkdwn parser fails to recognize the closing * when it is
         # immediately preceded by non-word characters (e.g. ), ], }, ., :, —).
         # This causes the parser to silently truncate the rest of the message.
@@ -3671,9 +3673,24 @@ class SlackAdapter(BasePlatformAdapter):
         # the closing * whenever the last character is not alphanumeric or _.
         def _convert_bold(m):
             inner = m.group(1)
+            before_char = m.string[m.start() - 1] if m.start() > 0 else ""
+            if before_char == "\x00":
+                adjacent = re.search(r"\x00SL\d+\x00$", m.string[: m.start()])
+                resolved = placeholders.get(adjacent.group(0)) if adjacent else None
+                if resolved is not None:
+                    before_char = resolved[-1:]
+            after_char = m.string[m.end()] if m.end() < len(m.string) else ""
+            if after_char == "\x00":
+                adjacent = re.match(r"\x00SL\d+\x00", m.string[m.end() :])
+                resolved = placeholders.get(adjacent.group(0)) if adjacent else None
+                if resolved is not None:
+                    after_char = resolved[:1]
+
+            before = "\u200b" if before_char and not before_char.isspace() else ""
+            after = "\u200b" if after_char and not after_char.isspace() else ""
             if inner and not (inner[-1].isalnum() or inner[-1] == "_"):
-                return _ph(f"*{inner}\u200b*")
-            return _ph(f"*{inner}*")
+                return _ph(f"{before}*{inner}\u200b*{after}")
+            return _ph(f"{before}*{inner}*{after}")
 
         text = re.sub(
             r"\*\*(.+?)\*\*",

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4191,6 +4191,67 @@ class TestFormatMessage:
     def test_bold_conversion(self, adapter):
         assert adapter.format_message("**hello**") == "*hello*"
 
+    @pytest.mark.parametrize(
+        ("markdown", "mrkdwn"),
+        [
+            (
+                "小さめのゲノム（約100–200 Mbp）では、"
+                "**5～10個程度のRNA-seqデータセットでも高品質な注釈を作れる可能性**"
+                "がある",
+                "小さめのゲノム（約100–200 Mbp）では、"
+                "\u200b*5～10個程度のRNA-seqデータセットでも高品質な注釈を作れる可能性*"
+                "\u200bがある",
+            ),
+            (
+                "・私は **NaotoGPT**。岩瀬直人が運用している AI チャットボット",
+                "・私は *NaotoGPT*\u200b。岩瀬直人が運用している AI チャットボット",
+            ),
+            (
+                "・実行基盤は **Hermes Agent**（Nous Research）",
+                "・実行基盤は *Hermes Agent*\u200b（Nous Research）",
+            ),
+        ],
+    )
+    def test_bold_delimiters_adjacent_to_cjk_text(self, adapter, markdown, mrkdwn):
+        assert adapter.format_message(markdown) == mrkdwn
+
+    @pytest.mark.parametrize(
+        ("markdown", "mrkdwn"),
+        [
+            ("**行頭**", "*行頭*"),
+            ("**行頭**\n**次行**", "*行頭*\n*次行*"),
+            ("前 **空白** 後", "前 *空白* 後"),
+        ],
+    )
+    def test_bold_boundary_controls_do_not_add_zero_width_spaces(
+        self, adapter, markdown, mrkdwn
+    ):
+        assert adapter.format_message(markdown) == mrkdwn
+        assert "\u200b" not in adapter.format_message(markdown)
+
+    def test_bold_boundary_guards_preserve_protected_regions(self, adapter):
+        markdown = (
+            "`前**code**後` [**link**](https://example.com) "
+            r"\*\*escaped\*\* <@U123>**太字**"
+        )
+        expected = (
+            "`前**code**後` <https://example.com|**link**> "
+            r"\_\_escaped\_\_ <@U123>" "\u200b*太字*"
+        )
+        assert adapter.format_message(markdown) == expected
+
+    @pytest.mark.parametrize(
+        ("markdown", "mrkdwn"),
+        [
+            ("\x00SL999\x00**b**", "\x00SL999\x00\u200b*b*"),
+            ("**b**\x00SL999\x00", "*b*\u200b\x00SL999\x00"),
+        ],
+    )
+    def test_bold_boundary_ignores_unknown_placeholder_like_literals(
+        self, adapter, markdown, mrkdwn
+    ):
+        assert adapter.format_message(markdown) == mrkdwn
+
     def test_italic_asterisk_conversion(self, adapter):
         assert adapter.format_message("*hello*") == "_hello_"
 
@@ -4637,7 +4698,7 @@ class TestEditMessageStreamingPipeline:
         result1 = await adapter.edit_message("C123", "ts1", "**Processing**...")
         assert result1.success is True
         kwargs1 = adapter._app.client.chat_update.call_args.kwargs
-        assert kwargs1["text"] == "*Processing*..."
+        assert kwargs1["text"] == "*Processing*\u200b..."
 
         # Second streaming update — bold + link
         result2 = await adapter.edit_message(


### PR DESCRIPTION
**Update (July 31):** I just noticed that this PR was opened unintentionally by my coding agent. Sorry for the noise. It was not meant to be submitted upstream, and no action is needed.

---

## Summary

- insert zero-width boundaries around converted Slack bold delimiters when adjacent text would prevent legacy `mrkdwn` parsing
- preserve protected code, links, Slack entities, escaped markup, whitespace, and line boundaries
- add regressions for CJK text, full-width punctuation, and unknown placeholder-like literals

## Test plan

- `pytest tests/gateway/test_slack.py` (508 passed)
- `ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`
- `git diff --check`
