### PR TITLE
docs: scope TUI npm commands to workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,16 +464,19 @@ Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. Se
 
 ### Dev Commands
 
+Run these from the repository root. The explicit workspace keeps each command
+scoped to the scripts declared in `ui-tui/package.json` rather than the root
+package's aggregate scripts.
+
 ```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run typecheck # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
+npm run install:tui                 # first time
+npm --workspace ui-tui run dev      # watch mode (rebuilds hermes-ink + tsx --watch)
+npm --workspace ui-tui start        # production
+npm --workspace ui-tui run build    # bundle TUI entrypoint with esbuild
+npm --workspace ui-tui run typecheck # typecheck only (tsc --noEmit)
+npm --workspace ui-tui run lint     # eslint
+npm --workspace ui-tui run fmt      # prettier
+npm --workspace ui-tui test         # vitest
 ```
 
 ### TUI in the Dashboard (`hermes dashboard` → `/chat`)


### PR DESCRIPTION
## Summary

- document TUI development commands as repository-root invocations with an explicit `ui-tui` workspace
- use the root `install:tui` script for setup and map every remaining command to a script declared in `ui-tui/package.json`
- keep the change documentation-only (`AGENTS.md`)

## Verification

- Package-metadata validator: root declares the `ui-tui` workspace, `install:tui` matches `npm install --workspace ui-tui`, and all seven documented TUI scripts exist (`missingScripts: []`)
- `npm --workspace ui-tui run build` — passed
- `npm --workspace ui-tui run typecheck` — passed
- `npm --workspace ui-tui run lint` — passed
- `npx prettier --check 'src/**/*.{ts,tsx}' 'packages/**/*.{ts,tsx}'` from `ui-tui/` — passed
- `git diff --check origin/main...HEAD` — passed
- `npm run verify` — unavailable because the root package does not define a `verify` script
- `npm --workspace ui-tui run check` — build and typecheck passed; the Windows test run reported 1,382 passed, 8 failed, and 8 skipped. The failures are in existing platform-sensitive terminal/editor tests; this branch changes only `AGENTS.md`. Linux CI remains the authoritative test gate.

## Pre-Landing Review

- Scope check: clean
- Findings: none

## Base

- Base branch: `main`
- Base SHA: `846b14ab01a84483d2c3dd429579173040474585`
- Final distance behind `origin/main`: `0`
