### PR TITLE
fix(desktop): raise runtime probe timeout past cold Windows imports

### DIFF
--- a/apps/desktop/electron/backend-probes.test.ts
+++ b/apps/desktop/electron/backend-probes.test.ts
@@ -15,6 +15,7 @@ import { test } from 'vitest'
 import {
   canImportHermesCli,
   hermesRuntimeImportProbe,
+  PROBE_TIMEOUT_MS,
   shouldTrustHermesOverride,
   verifyHermesCli
 } from './backend-probes'
@@ -100,9 +101,20 @@ test('verifyHermesCli returns true when --version exits 0', () => {
 })
 
 test('verifyHermesCli swallows timeouts (does not throw)', () => {
-  // We can't easily provoke a real 5s hang in CI without slowing the
-  // suite, but we CAN confirm that an invocation that DOES throw
-  // (because the binary is missing) returns false rather than
-  // propagating. Same code path the timeout case takes.
+  // We can't easily provoke a real hang equal to PROBE_TIMEOUT_MS in CI
+  // without slowing the suite, but we CAN confirm that an invocation
+  // that DOES throw (because the binary is missing) returns false
+  // rather than propagating. Same code path the timeout case takes.
   assert.equal(verifyHermesCli('/definitely/not/a/real/binary/anywhere'), false)
+})
+
+test('runtime probe timeout clears measured cold Windows import times', () => {
+  // Contract from #72632/#72707: cold `import hermes_cli` ~4.3s and
+  // `hermes --version` ~10.5s on a healthy Windows venv. A bound at or
+  // under those measurements false-negatives step-3 active-runtime
+  // usability and hands the user hermes-setup.exe --update.
+  assert.ok(
+    PROBE_TIMEOUT_MS >= 30_000,
+    `PROBE_TIMEOUT_MS=${PROBE_TIMEOUT_MS} must be >= 30s so cold Windows probes do not strand a healthy install`
+  )
 })

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -20,8 +20,11 @@
  * actually works.
  *
  * Both probes are deliberately fast and forgiving:
- *   - 5s timeout (a hung interpreter beats forever, but we still give
- *     slow disks / cold caches room to breathe)
+ *   - 30s timeout (a hung interpreter beats forever, but cold Windows
+ *     imports regularly need >5s — see #72632/#72707: a healthy venv
+ *     import took ~4.3s cold and `hermes --version` ~10.5s, so the old
+ *     5s bound false-negatived a usable active runtime into
+ *     bootstrap-needed → hermes-setup.exe --update)
  *   - stdio ignored (we only care about exit code; stdout/stderr are
  *     not surfaced to the user, just to recentHermesLog for forensics
  *     via the caller's catch block if it chooses)
@@ -34,7 +37,11 @@
 
 import { execFileSync } from 'node:child_process'
 
-const PROBE_TIMEOUT_MS = 5000
+// Floor must clear measured cold Windows import / --version times from
+// #72632 reproduction (~4.3s import, ~10.5s --version). Under AV/load the
+// same probes stretch further; 30s stays well under install timeouts while
+// stopping false "no Hermes install found" recovery loops (#72707).
+const PROBE_TIMEOUT_MS = 30_000
 
 /**
  * Return the Python snippet used to verify Hermes can import far enough to


### PR DESCRIPTION
## Summary
- `isActiveRuntimeUsable()` / PATH `hermes --version` probes used a **5s** bound. On cold Windows installs a healthy venv regularly needs longer (`~4.3s` import, `~10.5s --version` measured in [#72632](https://github.com/NousResearch/hermes-agent/issues/72632)), so the resolver false-negatives step-3 and falls through to `bootstrap-needed` → `hermes-setup.exe --update`.
- Raise `PROBE_TIMEOUT_MS` to **30s** and lock the floor with a contract test so a healthy install is not stranded into destructive recovery after a renderer reset ([#72707](https://github.com/NousResearch/hermes-agent/issues/72707)).

This does **not** claim to eliminate GIL event-loop stalls or mid-session WebSocket heartbeats; those already have adjacent open work (`#71398`, `#44931`, `#72677` for the MCP `signal.signal` crash). It fixes the unique, validated false-negative that turns a disconnect into a reinstall loop.

## Test plan
- [x] `npx vitest run electron/backend-probes.test.ts` (apps/desktop)
- [ ] On Windows cold start: confirm active venv is trusted (no `no Hermes install found` / setup handoff) when import takes >5s
- [ ] After a renderer `bootstrap:reset`, confirm resolve reuses the existing `%LOCALAPPDATA%\hermes\hermes-agent\venv` instead of launching `hermes-setup.exe --update`
