### PR TITLE
fix(cli): honor canonical clarify timeout after config merge

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -518,9 +518,6 @@ def load_cli_config() -> Dict[str, Any]:
 
             "skin": "default",
         },
-        "clarify": {
-            "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
-        },
         "code_execution": {
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
             "max_tool_calls": 50,  # Max RPC tool calls per execution

--- a/tests/cli/test_cli_clarify_timeout_config.py
+++ b/tests/cli/test_cli_clarify_timeout_config.py
@@ -1,0 +1,44 @@
+"""Integration coverage for clarify timeout resolution through CLI config."""
+
+import yaml
+
+
+def _load_cli_config(tmp_path, monkeypatch, config):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config),
+        encoding="utf-8",
+    )
+
+    import cli
+
+    monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+    return cli.load_cli_config()
+
+
+def test_cli_uses_canonical_clarify_timeout(tmp_path, monkeypatch):
+    """A CLI-only default must not mask agent.clarify_timeout."""
+    from tools.clarify_gateway import resolve_clarify_timeout
+
+    config = _load_cli_config(
+        tmp_path,
+        monkeypatch,
+        {"agent": {"clarify_timeout": 987}},
+    )
+
+    assert resolve_clarify_timeout(config) == 987
+
+
+def test_cli_preserves_explicit_legacy_clarify_timeout(tmp_path, monkeypatch):
+    """An explicit clarify.timeout remains the backward-compatible override."""
+    from tools.clarify_gateway import resolve_clarify_timeout
+
+    config = _load_cli_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "agent": {"clarify_timeout": 987},
+            "clarify": {"timeout": 42},
+        },
+    )
+
+    assert resolve_clarify_timeout(config) == 42


### PR DESCRIPTION
## What does this PR do?

Fixes the classic CLI continuing to time out clarify prompts after 120 seconds when the user configures only `agent.clarify_timeout`.

#69774 centralized timeout resolution with the intended precedence of explicit legacy `clarify.timeout` -> canonical `agent.clarify_timeout` -> 3600. However, `load_cli_config()` still injected `clarify.timeout: 120` into its defaults before merging user config. The resolver therefore could not distinguish that synthetic default from an explicit legacy override and returned 120.

This removes only the synthetic CLI default. The shared resolver and its backward-compatible precedence remain unchanged, so a genuinely user-authored `clarify.timeout` still wins.

## Related Issue

Fixes #72688

Follow-up to #69774.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Remove the legacy 120-second clarify default from `cli.py`'s merged CLI defaults.
- Add loader-to-resolver integration tests for canonical configuration and explicit legacy override behavior.

## How to Test

1. Write `agent.clarify_timeout: 987` to an isolated `config.yaml` without a top-level `clarify.timeout`.
2. Pass the result of the real `load_cli_config()` through `resolve_clarify_timeout()`.
3. Verify it returns 987; before this patch the same test returned 120.
4. Add an explicit `clarify.timeout: 42` and verify the backward-compatible override still returns 42.

```text
Before fix:
tests/cli/test_cli_clarify_timeout_config.py -> 1 failed, 1 passed
(canonical 987 resolved to 120)

After fix:
49 passed - CLI integration + clarify gateway tests
21 passed - config drift, managed scope, and env expansion tests
64 passed - CLI initialization and ignore-user-config tests
ruff check -> passed
git diff --check -> passed
```

Commands:

```bash
.venv/bin/pytest -q tests/cli/test_cli_clarify_timeout_config.py tests/tools/test_clarify_gateway.py
.venv/bin/pytest -q tests/hermes_cli/test_config_drift.py tests/hermes_cli/test_managed_scope_cli_config.py tests/hermes_cli/test_config_env_expansion.py
.venv/bin/pytest -q tests/cli/test_cli_init.py tests/hermes_cli/test_ignore_user_config_flags.py
.venv/bin/ruff check cli.py tests/cli/test_cli_clarify_timeout_config.py
git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A: no public configuration contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A: no key was added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A: no tool schema changed

## Screenshots / Logs

Not applicable; this is configuration resolution behavior covered by integration tests.
