### PR TITLE
feat(model-providers): add Poolside inference provider

### DIFF
--- a/plugins/model-providers/poolside/__init__.py
+++ b/plugins/model-providers/poolside/__init__.py
@@ -1,0 +1,20 @@
+"""Poolside provider profile — inference.poolside.ai.
+
+Laguna-s-2.1 output cap: 32768 (confirmed by API: "max_tokens (65536): Input should be less than or equal to 32768").
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+poolside = ProviderProfile(
+    name="poolside",
+    aliases=(),
+    env_vars=("POOLSIDE_API_KEY",),
+    display_name="Poolside",
+    description="Poolside — inference.poolside.ai",
+    signup_url="https://poolside.ai/",
+    base_url="https://inference.poolside.ai/v1",
+    default_max_tokens=32768,
+)
+
+register_provider(poolside)

--- a/plugins/model-providers/poolside/plugin.yaml
+++ b/plugins/model-providers/poolside/plugin.yaml
@@ -1,0 +1,5 @@
+name: poolside
+kind: model-provider
+version: 1.0.0
+description: Poolside API provider — inference.poolside.ai
+author: Nous Research


### PR DESCRIPTION
## What

Adds a new model-provider plugin for **Poolside** (inference.poolside.ai), exposing the Laguna model family through the existing provider plugin discovery path.

## Why

Poolside offers an OpenAI-compatible endpoint. The one non-obvious detail is that the API rejects `max_tokens` values above **32768** — it responds with `max_tokens (65536): Input should be less than or equal to 32768`. The profile sets `default_max_tokens=32768` so Hermes never sends a value the endpoint will refuse.

## How

- `plugins/model-providers/poolside/__init__.py` — registers a `ProviderProfile` named `poolside` gated on `POOLSIDE_API_KEY`, with `base_url=https://inference.poolside.ai/v1` and the 32768 output cap.
- `plugins/model-providers/poolside/plugin.yaml` — manifest declaring `kind: model-provider`.

Follows the same shape as the existing `plugins/model-providers/<name>/` plugins (gmi, novita, deepinfra, …): a minimal `__init__.py` that calls `register_provider()` plus a `plugin.yaml` manifest, discovered via the lazy provider scan in `providers/__init__.py`.

## Checklist

- [x] Plugin lives in its own directory under `plugins/model-providers/`
- [x] `__init__.py` registers via the standard `register_provider()` path
- [x] No core files modified
- [x] `default_max_tokens` respects the upstream API's confirmed hard cap