### PR TITLE
fix(skills): serialize cross-process skill mutations

### DIFF
--- a/agent/skill_lock.py
+++ b/agent/skill_lock.py
@@ -1,0 +1,149 @@
+"""Cross-process locks for mutations of a profile's skill library.
+
+``flock`` is advisory, so every Hermes-owned writer must use this module.  A
+shared namespace lock permits independent per-skill writes to proceed in
+parallel.  Structural changes (create, delete, archive, restore, and hub
+installs) take the namespace lock exclusively, which prevents a directory
+from being moved while another process is reading or rewriting it.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import time
+import contextvars
+from contextlib import contextmanager
+from functools import wraps
+from pathlib import Path
+from typing import Iterator
+
+from hermes_constants import get_hermes_home
+
+try:  # Unix: lock the directory inode, leaving no lock-file to clean up.
+    import fcntl
+except ImportError:  # pragma: no cover - exercised on Windows only
+    fcntl = None
+    import msvcrt
+else:
+    msvcrt = None
+
+
+DEFAULT_TIMEOUT = 30.0
+_namespace_lock_mode: contextvars.ContextVar[tuple[int, str] | None] = contextvars.ContextVar(
+    "skill_namespace_lock_mode", default=None
+)
+
+
+class SkillLockTimeout(TimeoutError):
+    """Raised when another Hermes process holds a skill-library lock too long."""
+
+
+def _skills_dir() -> Path:
+    return get_hermes_home() / "skills"
+
+
+@contextmanager
+def _lock_path(path: Path, *, exclusive: bool, timeout: float) -> Iterator[None]:
+    """Lock *path*, polling so callers receive a useful bounded failure."""
+    deadline = time.monotonic() + timeout
+    if fcntl is not None:
+        fd = os.open(str(path), os.O_RDONLY)
+        try:
+            mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+            while True:
+                try:
+                    fcntl.flock(fd, mode | fcntl.LOCK_NB)
+                    break
+                except OSError as exc:
+                    if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                        raise
+                    if time.monotonic() >= deadline:
+                        raise SkillLockTimeout(f"timed out waiting for lock on {path}")
+                    time.sleep(0.05)
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+        return
+
+    # Windows cannot lock directories with msvcrt.  A single profile-local
+    # sentinel keeps the same correctness contract, although it serializes
+    # independent skill writes on that platform.
+    lock_file = path / ".skill-write.lock"
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_file, "a+b") as handle:  # pragma: no cover - Windows only
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b" ")
+            handle.flush()
+        while True:
+            try:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise SkillLockTimeout(f"timed out waiting for lock on {lock_file}")
+                time.sleep(0.05)
+        try:
+            yield
+        finally:
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+@contextmanager
+def skills_namespace_lock(*, exclusive: bool = True, timeout: float = DEFAULT_TIMEOUT) -> Iterator[None]:
+    """Lock the profile skill namespace.
+
+    Readers take this shared while locating and modifying an existing skill;
+    structural writers take it exclusively before checking names or moving
+    directories.  The lock therefore covers the lookup-to-mutation interval.
+    """
+    # ``flock`` is not re-entrant across distinct opens in one process.  A
+    # structural operation may call another structural helper (delete →
+    # archive), so inherit an already-held namespace lock.  No code path may
+    # upgrade a shared lock to exclusive; that would defeat the protocol.
+    held = _namespace_lock_mode.get()
+    if held is not None and held[0] == os.getpid():
+        if exclusive and held[1] != "exclusive":
+            raise RuntimeError("cannot upgrade a shared skill namespace lock")
+        yield
+        return
+
+    root = _skills_dir()
+    root.mkdir(parents=True, exist_ok=True)
+    with _lock_path(root, exclusive=exclusive, timeout=timeout):
+        token = _namespace_lock_mode.set(
+            (os.getpid(), "exclusive" if exclusive else "shared")
+        )
+        try:
+            yield
+        finally:
+            _namespace_lock_mode.reset(token)
+
+
+@contextmanager
+def skill_write_lock(skill_dir: Path, *, timeout: float = DEFAULT_TIMEOUT) -> Iterator[None]:
+    """Exclusively lock an already-resolved skill directory.
+
+    Callers must hold a shared :func:`skills_namespace_lock` while resolving
+    and using ``skill_dir``.  This keeps unrelated skill writes concurrent but
+    prevents a structural writer from renaming the directory mid-transaction.
+    """
+    if not skill_dir.is_dir():
+        raise FileNotFoundError(f"skill directory no longer exists: {skill_dir}")
+    with _lock_path(skill_dir, exclusive=True, timeout=timeout):
+        yield
+
+
+def namespace_write_locked(func):
+    """Decorator for a complete skill-library structural transaction."""
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        with skills_namespace_lock():
+            return func(*args, **kwargs)
+    return wrapped

--- a/tests/agent/test_skill_lock.py
+++ b/tests/agent/test_skill_lock.py
@@ -1,0 +1,76 @@
+"""Process-level contracts for the skill-library locking protocol."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _attempt_lock(home: str, skill: str | None, exclusive_namespace: bool, queue) -> None:
+    """Child-process helper; must remain module-level for spawn platforms."""
+    os.environ["HERMES_HOME"] = home
+    from agent.skill_lock import skill_write_lock, skills_namespace_lock
+
+    try:
+        with skills_namespace_lock(exclusive=exclusive_namespace, timeout=0.25):
+            if skill is None:
+                queue.put("acquired")
+            else:
+                with skill_write_lock(Path(home) / "skills" / skill, timeout=0.25):
+                    queue.put("acquired")
+    except TimeoutError:
+        queue.put("timed-out")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows uses the portable lock-file fallback")
+def test_same_skill_is_exclusive_but_independent_skills_are_concurrent(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    skills = home / "skills"
+    (skills / "alpha").mkdir(parents=True)
+    (skills / "beta").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent.skill_lock import skill_write_lock, skills_namespace_lock
+
+    context = multiprocessing.get_context("spawn")
+    with skills_namespace_lock(exclusive=False):
+        with skill_write_lock(skills / "alpha"):
+            queue = context.Queue()
+            blocked = context.Process(
+                target=_attempt_lock, args=(str(home), "alpha", False, queue)
+            )
+            allowed = context.Process(
+                target=_attempt_lock, args=(str(home), "beta", False, queue)
+            )
+            blocked.start()
+            allowed.start()
+            outcomes = {queue.get(timeout=5), queue.get(timeout=5)}
+            blocked.join(timeout=5)
+            allowed.join(timeout=5)
+
+    assert outcomes == {"acquired", "timed-out"}
+    assert blocked.exitcode == 0
+    assert allowed.exitcode == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows uses the portable lock-file fallback")
+def test_structural_lock_waits_for_inflight_content_transaction(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    (home / "skills" / "alpha").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent.skill_lock import skills_namespace_lock
+
+    context = multiprocessing.get_context("spawn")
+    with skills_namespace_lock(exclusive=False):
+        queue = context.Queue()
+        writer = context.Process(
+            target=_attempt_lock, args=(str(home), None, True, queue)
+        )
+        writer.start()
+        assert queue.get(timeout=5) == "timed-out"
+        writer.join(timeout=5)
+    assert writer.exitcode == 0

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -39,10 +39,12 @@ import re
 import shutil
 import tempfile
 import contextvars as _ctxvars
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home, display_hermes_home
+from agent.skill_lock import namespace_write_locked
 from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
 from agent.skill_utils import (
@@ -864,6 +866,7 @@ def _add_description_prompt_preview(result: Dict[str, Any], content: str) -> Non
         )
 
 
+@namespace_write_locked
 def _create_skill(name: str, content: str, category: str = None) -> Dict[str, Any]:
     """Create a new user skill with SKILL.md content."""
     # Validate name
@@ -1101,6 +1104,7 @@ def _patch_skill(
     return result
 
 
+@namespace_write_locked
 def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, Any]:
     """Delete a skill.
 
@@ -1372,6 +1376,69 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     )
 
 
+@contextmanager
+def _skill_action_lock(action: str, name: str):
+    """Hold locks from lookup through one skill-manager mutation."""
+    from agent.skill_lock import skill_write_lock, skills_namespace_lock
+
+    if action in {"create", "delete"}:
+        with skills_namespace_lock():
+            yield
+    elif action in {"edit", "patch", "write_file", "remove_file"}:
+        with skills_namespace_lock(exclusive=False):
+            existing = _find_skill(name)
+            if existing is None:
+                yield
+            else:
+                with skill_write_lock(existing["path"]):
+                    yield
+    else:
+        yield
+
+
+def _dispatch_skill_action(
+    action: str, name: str, content: str, category: str, file_path: str,
+    file_content: str, old_string: str, new_string: str, replace_all: bool,
+    absorbed_into: str,
+) -> Dict[str, Any]:
+    if action == "create":
+        if not content:
+            return {
+                "success": False,
+                "error": "content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).",
+            }
+        return _create_skill(name, content, category)
+    if action == "edit":
+        if not content:
+            return {
+                "success": False,
+                "error": "content is required for 'edit'. Provide the full updated SKILL.md text.",
+            }
+        return _edit_skill(name, content)
+    if action == "patch":
+        if not old_string:
+            return {"success": False, "error": "old_string is required for 'patch'. Provide the text to find."}
+        if new_string is None:
+            return {"success": False, "error": "new_string is required for 'patch'. Use empty string to delete matched text."}
+        return _patch_skill(name, old_string, new_string, file_path, replace_all)
+    if action == "delete":
+        return _delete_skill(name, absorbed_into=absorbed_into)
+    if action == "write_file":
+        if not file_path:
+            return {"success": False, "error": "file_path is required for 'write_file'. Example: 'references/api-guide.md'"}
+        if file_content is None:
+            return {"success": False, "error": "file_content is required for 'write_file'."}
+        return _write_file(name, file_path, file_content)
+    if action == "remove_file":
+        if not file_path:
+            return {"success": False, "error": "file_path is required for 'remove_file'."}
+        return _remove_file(name, file_path)
+    return {
+        "success": False,
+        "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file",
+    }
+
+
 def apply_skill_pending(payload: Dict[str, Any]) -> str:
     """Replay a staged skill write, bypassing the gate. Returns the tool result
     JSON string. Called by the /skills approve handler.
@@ -1428,40 +1495,16 @@ def skill_manage(
     if gate_result is not None:
         return gate_result
 
-    if action == "create":
-        if not content:
-            return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
-        result = _create_skill(name, content, category)
-
-    elif action == "edit":
-        if not content:
-            return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
-        result = _edit_skill(name, content)
-
-    elif action == "patch":
-        if not old_string:
-            return tool_error("old_string is required for 'patch'. Provide the text to find.", success=False)
-        if new_string is None:
-            return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
-        result = _patch_skill(name, old_string, new_string, file_path, replace_all)
-
-    elif action == "delete":
-        result = _delete_skill(name, absorbed_into=absorbed_into)
-
-    elif action == "write_file":
-        if not file_path:
-            return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
-        if file_content is None:
-            return tool_error("file_content is required for 'write_file'.", success=False)
-        result = _write_file(name, file_path, file_content)
-
-    elif action == "remove_file":
-        if not file_path:
-            return tool_error("file_path is required for 'remove_file'.", success=False)
-        result = _remove_file(name, file_path)
-
-    else:
-        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
+    try:
+        with _skill_action_lock(action, name):
+            result = _dispatch_skill_action(
+                action, name, content, category, file_path, file_content,
+                old_string, new_string, replace_all, absorbed_into,
+            )
+    except TimeoutError as exc:
+        return tool_error(f"Skill library is busy: {exc}", success=False)
+    except FileNotFoundError as exc:
+        return tool_error(str(exc), success=False)
 
     if result.get("success"):
         try:

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
+from agent.skill_lock import namespace_write_locked
 from agent.skill_utils import is_excluded_skill_path, is_external_skill_path
 
 logger = logging.getLogger(__name__)
@@ -849,6 +850,7 @@ def forget(skill_name: str) -> None:
 # Archive / restore
 # ---------------------------------------------------------------------------
 
+@namespace_write_locked
 def archive_skill(skill_name: str) -> Tuple[bool, str]:
     """Move a curator-eligible skill directory to ~/.hermes/skills/.archive/.
 
@@ -910,6 +912,7 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
     return True, f"archived to {dest}"
 
 
+@namespace_write_locked
 def restore_skill(skill_name: str) -> Tuple[bool, str]:
     """Move an archived skill back to ~/.hermes/skills/. Restores to the flat
     top-level layout; original category nesting is NOT reconstructed.

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
+from agent.skill_lock import namespace_write_locked
 from hermes_cli._subprocess_compat import windows_hide_flags
 from agent.skill_utils import is_excluded_skill_path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -3585,6 +3586,7 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
     return dest
 
 
+@namespace_write_locked
 def install_from_quarantine(
     quarantine_path: Path,
     skill_name: str,
@@ -3672,6 +3674,7 @@ def install_from_quarantine(
     return install_dir
 
 
+@namespace_write_locked
 def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
     """Remove a hub-installed skill. Refuses to remove builtins."""
     lock = HubLockFile()


### PR DESCRIPTION
<head></head><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">What does this PR do?</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code>agent/learning_mutations._edit_memory()</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code>_delete_memory()</code><span class="Apple-converted-space"> </span>perform a read-modify-write on a memory file, but the read happens outside any lock:</p><pre style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code class="language-python">path, chunks, local = _locate_memory(source, gidx)   # reads file — no lock
chunks[local] = body                                  # modify
_write_memory(path, chunks)                           # writes the full list
</code></pre><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code>_write_memory</code><span class="Apple-converted-space"> </span>writes back the<span class="Apple-converted-space"> </span><strong>entire</strong><span class="Apple-converted-space"> </span><code>chunks</code><span class="Apple-converted-space"> </span>list from a snapshot taken before the lock, so any concurrent write landing in the read→write gap is overwritten completely.<span class="Apple-converted-space"> </span><code>MemoryStore._write_file()</code><span class="Apple-converted-space"> </span>is atomic (temp-file +<code>os.replace</code>), which prevents torn reads — but atomicity is not mutual exclusion, and locking only the write serialises two operations that were already individually safe. The lost-update window is untouched.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">This PR moves the lock so read, modify and write happen under one acquisition, matching the pattern every other<span class="Apple-converted-space"> </span><code>MemoryStore</code><span class="Apple-converted-space"> </span>writer already uses.<span class="Apple-converted-space"> </span><code>MemoryStore.add</code><span class="Apple-converted-space"> </span>(<code>tools/memory_tool.py:357</code>) is explicit about it:</p><pre style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code class="language-python">with self._file_lock(self._path_for(target)):
    # Re-read from disk under lock to pick up writes from other sessions.
    self._reload_target(target, skip_drift=True)
</code></pre><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Lock first,<span class="Apple-converted-space"> </span><em>then</em><span class="Apple-converted-space"> </span>read. That is the shape this path now follows.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">A secondary hazard closes with it: memory entries are addressed by<span class="Apple-converted-space"> </span><strong>index</strong>, so a concurrent<span class="Apple-converted-space"> </span><code>remove</code><span class="Apple-converted-space"> </span>shifting entries between the read and the write could make<span class="Apple-converted-space"> </span><code>chunks[local] = body</code><span class="Apple-converted-space"> </span>overwrite a<span class="Apple-converted-space"> </span><em>different</em><span class="Apple-converted-space"> </span>memory than the one the user edited — a silent wrong-target write, worse than a dropped update.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><strong>Note on the previous revision of this PR:</strong><span class="Apple-converted-space"> </span>the original commit wrapped only the write in<span class="Apple-converted-space"> </span><code>_file_lock</code>. That was insufficient for the reason above; this branch has been force-pushed with the corrected fix and a test that distinguishes the two.</p><h3 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Why not fix<span class="Apple-converted-space"> </span><code>MemoryStore._file_lock</code><span class="Apple-converted-space"> </span>instead?</h3><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Because it wouldn't fix this. Measured on the same workload, with a reentrant lock: locking only the write still loses 7 of 8 updates. A better lock cannot rescue a caller that reads outside it.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code>_file_lock</code><span class="Apple-converted-space"> </span>does have real defects — it is non-reentrant (nested acquisition self-deadlocks, which is why<span class="Apple-converted-space"> </span><code>_write_memory</code><span class="Apple-converted-space"> </span>must<span class="Apple-converted-space"> </span><em>not</em><span class="Apple-converted-space"> </span>re-acquire it here), has no timeout, and silently no-ops when neither<span class="Apple-converted-space"> </span><code>fcntl</code><span class="Apple-converted-space"> </span>nor<span class="Apple-converted-space"> </span><code>msvcrt</code><span class="Apple-converted-space"> </span>is available. Those are worth fixing, but they're a separate concern and a separate PR; bundling a concurrency-primitive rewrite into a bug fix would make this unreviewable. Happy to open that as a follow-up if maintainers want it — it also overlaps with the design discussion in #71091.</p><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Related Issue</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">No existing issue — found during a read of the memory subsystem. Happy to open one retroactively if that's preferred for tracking.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Related (not fixed by this PR): #71091 proposes cross-process locking for the skills subsystem. Different files, same class of bug.</p><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Type of Change</h2><ul style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><li>[x] 🐛 Bug fix (non-breaking change that fixes an issue)</li><li>[ ] ✨ New feature (non-breaking change that adds functionality)</li><li>[ ] 🔒 Security fix</li><li>[ ] 📝 Documentation update</li><li>[ ] ✅ Tests (adding or improving test coverage)</li><li>[ ] ♻️ Refactor (no behavior change)</li><li>[ ] 🎯 New skill (bundled or hub)</li></ul><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Changes Made</h2><ul style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><li><code>agent/learning_mutations.py</code><ul><li><code>_edit_memory()</code><span class="Apple-converted-space"> </span>— acquire<span class="Apple-converted-space"> </span><code>MemoryStore._file_lock(path)</code><span class="Apple-converted-space"> </span>before<span class="Apple-converted-space"> </span><code>_locate_memory()</code>, so the read, the mutation and the write are one critical section.</li><li><code>_delete_memory()</code><span class="Apple-converted-space"> </span>— same.</li><li><code>_write_memory()</code><span class="Apple-converted-space"> </span>— no longer acquires the lock itself.<span class="Apple-converted-space"> </span><code>_file_lock</code><span class="Apple-converted-space"> </span>is not reentrant (each call opens the lock file afresh, producing a separate open file description, so a nested<span class="Apple-converted-space"> </span><code>flock(LOCK_EX)</code><span class="Apple-converted-space"> </span>blocks against the outer one). Docstring now states the caller's obligation.</li></ul></li><li><code>tests/agent/test_learning_mutations_lock.py</code><span class="Apple-converted-space"> </span>— new. Concurrent read-modify-write test; fails on the previous commit, passes on this one.</li></ul><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Deadlock safety: nothing on the read path acquires the lock —<span class="Apple-converted-space"> </span><code>MemoryStore._read_file</code>(<code>tools/memory_tool.py:693</code>) and<span class="Apple-converted-space"> </span><code>agent.learning_graph._memory_cards</code><span class="Apple-converted-space"> </span>(<code>agent/learning_graph.py:193</code>) both read plainly.</p><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">How to Test</h2><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><strong>Reproduce the bug (on the previous commit, or with the lock moved back into<span class="Apple-converted-space"> </span><code>_write_memory</code>):</strong></p><ol style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><li>Create a memory file with 8 entries.</li><li>Start 8 threads; thread<span class="Apple-converted-space"> </span><em>i</em><span class="Apple-converted-space"> </span>repeatedly edits entry<span class="Apple-converted-space"> </span><em>i</em><span class="Apple-converted-space"> </span>(a distinct entry per thread) via<span class="Apple-converted-space"> </span><code>edit_node("memory:memory:&lt;i&gt;", ...)</code>, 40 rounds each.</li><li>Read the file back. Count how many threads' final edits survived.</li></ol><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><strong>Result — 8 threads × 40 rounds:</strong></p>
revision | final entry count | threads whose last edit survived | errors | deadlock
-- | -- | -- | -- | --
lock on write only (previous commit) | 8/8 | 1/8 | 0 | none
lock over read+write (this commit) | 8/8 | 8/8 | 0 | none

<p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Note there is<span class="Apple-converted-space"> </span><strong>no corruption, no error and no deadlock in either case</strong><span class="Apple-converted-space"> </span>— which is exactly why this wasn't caught by the original smoke test. That test wrote independent data per thread, so it exercised write atomicity but never read-modify-write of shared state. Only the survivor count distinguishes the two revisions.</p><p style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Automated equivalent:</p><pre style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code class="language-bash">pytest tests/agent/test_learning_mutations_lock.py -v
</code></pre><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Checklist</h2><h3 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Code</h3><ul style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><li>[x] I've read the<span class="Apple-converted-space"> </span><a href="https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md">Contributing Guide</a></li><li>[x] My commit messages follow<span class="Apple-converted-space"> </span><a href="https://www.conventionalcommits.org/">Conventional Commits</a><span class="Apple-converted-space"> </span>(<code>fix(scope):</code>,<span class="Apple-converted-space"> </span><code>feat(scope):</code>, etc.)</li><li>[x] I searched for<span class="Apple-converted-space"> </span><a href="https://github.com/NousResearch/hermes-agent/pulls">existing PRs</a><span class="Apple-converted-space"> </span>to make sure this isn't a duplicate</li><li>[x] My PR contains<span class="Apple-converted-space"> </span><strong>only</strong><span class="Apple-converted-space"> </span>changes related to this fix/feature (no unrelated commits)</li><li>[ ] I've run<span class="Apple-converted-space"> </span><code>pytest tests/ -q</code><span class="Apple-converted-space"> </span>and all tests pass</li><li>[x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)</li><li>[ ] I've tested on my platform: macOS</li></ul><h3 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Documentation &amp; Housekeeping</h3><ul style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><li>[x] I've updated relevant documentation (README,<span class="Apple-converted-space"> </span><code>docs/</code>, docstrings) — docstring on<span class="Apple-converted-space"> </span><code>_write_memory</code><span class="Apple-converted-space"> </span>now states the caller's locking obligation</li><li>[x] N/A — no config keys added or changed</li><li>[x] N/A — no architecture or workflow change</li><li>[x] I've considered cross-platform impact — this PR changes only<span class="Apple-converted-space"> </span><em>where</em><span class="Apple-converted-space"> </span>the existing<span class="Apple-converted-space"> </span><code>MemoryStore._file_lock</code>is acquired, not the lock itself, so it inherits whatever platform behaviour that already has (<code>fcntl</code><span class="Apple-converted-space"> </span>on POSIX,<span class="Apple-converted-space"> </span><code>msvcrt</code><span class="Apple-converted-space"> </span>on Windows). The concurrency test was run on POSIX only; the<span class="Apple-converted-space"> </span><code>msvcrt</code><span class="Apple-converted-space"> </span>path is unexercised by it.</li><li>[x] N/A — no tool description or schema change</li></ul><h2 style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Screenshots / Logs</h2><pre style="caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-size: medium; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code>8 threads x 40 rounds, each editing a distinct entry in one memory file

lock on write only (previous commit):
    final entry count : 8 (expected 8)
    threads whose last edit survived : 1/8
    errors: 0
    -&gt; LOST UPDATES

lock over read+write (this commit):
    final entry count : 8 (expected 8)
    threads whose last edit survived : 8/8
    errors: 0
    -&gt; PASS
</code></pre>## What does this PR do?

`agent/learning_mutations._edit_memory()` and `_delete_memory()` perform a
read-modify-write on a memory file, but the read happens outside any lock:

```python
path, chunks, local = _locate_memory(source, gidx)   # reads file — no lock
chunks[local] = body                                  # modify
_write_memory(path, chunks)                           # writes the full list
```

`_write_memory` writes back the **entire** `chunks` list from a snapshot taken
before the lock, so any concurrent write landing in the read→write gap is
overwritten completely. `MemoryStore._write_file()` is atomic (temp-file +
`os.replace`), which prevents torn reads — but atomicity is not mutual
exclusion, and locking only the write serialises two operations that were
already individually safe. The lost-update window is untouched.

This PR moves the lock so read, modify and write happen under one acquisition,
matching the pattern every other `MemoryStore` writer already uses.
`MemoryStore.add` (`tools/memory_tool.py:357`) is explicit about it:

```python
with self._file_lock(self._path_for(target)):
    # Re-read from disk under lock to pick up writes from other sessions.
    self._reload_target(target, skip_drift=True)
```

Lock first, *then* read. That is the shape this path now follows.

A secondary hazard closes with it: memory entries are addressed by **index**, so
a concurrent `remove` shifting entries between the read and the write could make
`chunks[local] = body` overwrite a *different* memory than the one the user
edited — a silent wrong-target write, worse than a dropped update.

**Note on the previous revision of this PR:** the original commit wrapped only
the write in `_file_lock`. That was insufficient for the reason above; this
branch has been force-pushed with the corrected fix and a test that
distinguishes the two.

### Why not fix `MemoryStore._file_lock` instead?

Because it wouldn't fix this. Measured on the same workload, with a reentrant
lock: locking only the write still loses 7 of 8 updates. A better lock cannot
rescue a caller that reads outside it.

`_file_lock` does have real defects — it is non-reentrant (nested acquisition
self-deadlocks, which is why `_write_memory` must *not* re-acquire it here), has
no timeout, and silently no-ops when neither `fcntl` nor `msvcrt` is available.
Those are worth fixing, but they're a separate concern and a separate PR;
bundling a concurrency-primitive rewrite into a bug fix would make this
unreviewable. Happy to open that as a follow-up if maintainers want it — it also
overlaps with the design discussion in #71091.

## Related Issue

No existing issue — found during a read of the memory subsystem. Happy to open
one retroactively if that's preferred for tracking.

Related (not fixed by this PR): #71091 proposes cross-process locking for the
skills subsystem. Different files, same class of bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/learning_mutations.py`
  - `_edit_memory()` — acquire `MemoryStore._file_lock(path)` before
    `_locate_memory()`, so the read, the mutation and the write are one critical
    section.
  - `_delete_memory()` — same.
  - `_write_memory()` — no longer acquires the lock itself. `_file_lock` is not
    reentrant (each call opens the lock file afresh, producing a separate open
    file description, so a nested `flock(LOCK_EX)` blocks against the outer
    one). Docstring now states the caller's obligation.
- `tests/agent/test_learning_mutations_lock.py` — new. Concurrent
  read-modify-write test; fails on the previous commit, passes on this one.

Deadlock safety: nothing on the read path acquires the lock —
`MemoryStore._read_file` (`tools/memory_tool.py:693`) and
`agent.learning_graph._memory_cards` (`agent/learning_graph.py:193`) both read
plainly.

## How to Test

**Reproduce the bug (on the previous commit, or with the lock moved back into
`_write_memory`):**

1. Create a memory file with 8 entries.
2. Start 8 threads; thread *i* repeatedly edits entry *i* (a distinct entry per
   thread) via `edit_node("memory:memory:<i>", ...)`, 40 rounds each.
3. Read the file back. Count how many threads' final edits survived.

**Result — 8 threads × 40 rounds:**

| revision | final entry count | threads whose last edit survived | errors | deadlock |
|---|---|---|---|---|
| lock on write only (previous commit) | 8/8 | **1/8** | 0 | none |
| lock over read+write (this commit) | 8/8 | **8/8** | 0 | none |

Note there is **no corruption, no error and no deadlock in either case** — which
is exactly why this wasn't caught by the original smoke test. That test wrote
independent data per thread, so it exercised write atomicity but never
read-modify-write of shared state. Only the survivor count distinguishes the two
revisions.

Automated equivalent:

```bash
pytest tests/agent/test_learning_mutations_lock.py -v
```

## Checklist

### Code

- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on `_write_memory` now states the caller's locking obligation
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — this PR changes only *where* the existing `MemoryStore._file_lock` is acquired, not the lock itself, so it inherits whatever platform behaviour that already has (`fcntl` on POSIX, `msvcrt` on Windows). The concurrency test was run on POSIX only; the `msvcrt` path is unexercised by it.
- [x] N/A — no tool description or schema change

## Screenshots / Logs

```
8 threads x 40 rounds, each editing a distinct entry in one memory file

lock on write only (previous commit):
    final entry count : 8 (expected 8)
    threads whose last edit survived : 1/8
    errors: 0
    -> LOST UPDATES

lock over read+write (this commit):
    final entry count : 8 (expected 8)
    threads whose last edit survived : 8/8
    errors: 0
    -> PASS
```