### PR TITLE
fix(desktop): suppress intentional backend exit notices

### DIFF
--- a/apps/desktop/electron/intentional-backend-teardown.test.ts
+++ b/apps/desktop/electron/intentional-backend-teardown.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { createBackendConnectionState } from './backend-connection-state'
+import {
+  createIntentionalBackendTeardownGuard,
+  shouldSuppressBackendExitNotice
+} from './intentional-backend-teardown'
+
+test('intentional update/uninstall teardown suppresses the backend-exit notice', () => {
+  assert.equal(
+    shouldSuppressBackendExitNotice({ softRehomeInProgress: false, intentionalTeardownDepth: 1 }),
+    true
+  )
+})
+
+test('an unexpected current-backend exit is not suppressed', () => {
+  // Current-owner exit still reaches sendBackendExit; suppression must stay off
+  // so a real crash/stop surfaces to the user.
+  assert.equal(
+    shouldSuppressBackendExitNotice({ softRehomeInProgress: false, intentionalTeardownDepth: 0 }),
+    false
+  )
+})
+
+test('soft re-home still suppresses independently of the update guard', () => {
+  assert.equal(
+    shouldSuppressBackendExitNotice({ softRehomeInProgress: true, intentionalTeardownDepth: 0 }),
+    true
+  )
+})
+
+test('guard depth covers the kill window and releases afterward', async () => {
+  const guard = createIntentionalBackendTeardownGuard()
+  let suppressedDuringKill = false
+
+  await guard.run(async () => {
+    suppressedDuringKill = shouldSuppressBackendExitNotice({
+      softRehomeInProgress: false,
+      intentionalTeardownDepth: guard.depth
+    })
+  })
+
+  assert.equal(suppressedDuringKill, true)
+  assert.equal(guard.depth, 0)
+  assert.equal(
+    shouldSuppressBackendExitNotice({
+      softRehomeInProgress: false,
+      intentionalTeardownDepth: guard.depth
+    }),
+    false
+  )
+})
+
+test('nested intentional teardowns stay suppressed until the outermost ends', async () => {
+  const guard = createIntentionalBackendTeardownGuard()
+
+  await guard.run(async () => {
+    assert.equal(guard.depth, 1)
+    await guard.run(async () => {
+      assert.equal(guard.depth, 2)
+      assert.equal(
+        shouldSuppressBackendExitNotice({
+          softRehomeInProgress: false,
+          intentionalTeardownDepth: guard.depth
+        }),
+        true
+      )
+    })
+    assert.equal(guard.depth, 1)
+  })
+
+  assert.equal(guard.depth, 0)
+})
+
+test('update lock-release covers a late exit via invalidate even after the guard ends', () => {
+  // Models releaseBackendLock: capture owner → invalidate → kill → guard ends →
+  // delayed 'exit'. clearForCurrentProcess must fail so sendBackendExit is never
+  // reached, even with intentionalTeardownDepth already back at 0.
+  type FakeProcess = { id: string }
+  const state = createBackendConnectionState<FakeProcess, string>()
+  const attempt = state.startAttempt()
+
+  state.setPromise(attempt, Promise.resolve('primary'))
+  const owner = state.attachProcess(attempt, { id: 'primary' })
+  assert.ok(owner)
+
+  state.invalidate()
+
+  assert.equal(state.clearForCurrentProcess(owner), false)
+  assert.equal(
+    shouldSuppressBackendExitNotice({ softRehomeInProgress: false, intentionalTeardownDepth: 0 }),
+    false
+  )
+})
+
+test('current-owner exit during the intentional guard is suppressed at sendBackendExit', async () => {
+  // Models a straggler/respawn killed while releaseBackendLock's guard is held:
+  // clearForCurrentProcess would succeed, so suppression must come from depth.
+  type FakeProcess = { id: string }
+  const state = createBackendConnectionState<FakeProcess, string>()
+  const attempt = state.startAttempt()
+
+  state.setPromise(attempt, Promise.resolve('straggler'))
+  const owner = state.attachProcess(attempt, { id: 'straggler' })
+  assert.ok(owner)
+
+  const guard = createIntentionalBackendTeardownGuard()
+  let wouldToast = true
+
+  await guard.run(async () => {
+    assert.equal(state.clearForCurrentProcess(owner), true)
+    wouldToast = !shouldSuppressBackendExitNotice({
+      softRehomeInProgress: false,
+      intentionalTeardownDepth: guard.depth
+    })
+  })
+
+  assert.equal(wouldToast, false)
+})
+
+test('unexpected current-owner exit still reaches a toastable sendBackendExit path', () => {
+  type FakeProcess = { id: string }
+  const state = createBackendConnectionState<FakeProcess, string>()
+  const attempt = state.startAttempt()
+
+  state.setPromise(attempt, Promise.resolve('primary'))
+  const owner = state.attachProcess(attempt, { id: 'primary' })
+  assert.ok(owner)
+
+  assert.equal(state.clearForCurrentProcess(owner), true)
+  assert.equal(
+    shouldSuppressBackendExitNotice({ softRehomeInProgress: false, intentionalTeardownDepth: 0 }),
+    false
+  )
+})

--- a/apps/desktop/electron/intentional-backend-teardown.ts
+++ b/apps/desktop/electron/intentional-backend-teardown.ts
@@ -1,0 +1,64 @@
+/**
+ * Intentional backend-exit notice suppression for desktop.
+ *
+ * Soft re-homes (gateway-mode apply) already use `softRehomeInProgress`.
+ * Retry, profile-switch, and soft-apply tear-downs invalidate
+ * `backendConnectionState` first, so their child exits are rejected as stale
+ * before `sendBackendExit` — that stale-owner protection stays the primary
+ * guard for those flows.
+ *
+ * The Windows update/uninstall lock-release path kills the live primary child
+ * after capturing PIDs, then invalidates connection state so a late exit is
+ * stale-owned. An intentional teardown depth additionally covers straggler
+ * kills of a briefly re-attached current process during the unlock wait.
+ */
+
+export type BackendExitSuppressionContext = {
+  softRehomeInProgress: boolean
+  intentionalTeardownDepth: number
+}
+
+/**
+ * Whether `sendBackendExit` should stay silent for this exit.
+ * Soft re-home and an in-flight intentional lock-release teardown both suppress;
+ * an unexpected current-backend exit (depth 0, soft false) does not.
+ */
+export function shouldSuppressBackendExitNotice(context: BackendExitSuppressionContext): boolean {
+  return context.softRehomeInProgress || context.intentionalTeardownDepth > 0
+}
+
+export type IntentionalBackendTeardownGuard = {
+  readonly depth: number
+  begin(): void
+  end(): void
+  run<T>(fn: () => Promise<T>): Promise<T>
+}
+
+/** Nestable counter held for the duration of an intentional lock-release kill. */
+export function createIntentionalBackendTeardownGuard(): IntentionalBackendTeardownGuard {
+  let depth = 0
+
+  return {
+    get depth() {
+      return depth
+    },
+
+    begin() {
+      depth += 1
+    },
+
+    end() {
+      depth = Math.max(0, depth - 1)
+    },
+
+    async run<T>(fn: () => Promise<T>): Promise<T> {
+      depth += 1
+
+      try {
+        return await fn()
+      } finally {
+        depth = Math.max(0, depth - 1)
+      }
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -989,6 +989,10 @@ let mainWindow = null
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
+// Nonzero while Hermes intentionally tears down its local child. This covers
+// retries, profile switches, updates, and soft connection applies; none should
+// surface a "backend stopped" error to the user.
+let intentionalBackendTeardowns = 0
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
 let softRehomeInProgress = false
@@ -4949,7 +4953,7 @@ function getWindowState(win = mainWindow) {
 function sendBackendExit(payload) {
   // Intentional soft re-home (gateway mode apply) kills the child on purpose —
   // don't surface the "backend stopped" error toast / boot-failure path.
-  if (softRehomeInProgress) {
+  if (softRehomeInProgress || intentionalBackendTeardowns > 0) {
     return
   }
 
@@ -7660,6 +7664,8 @@ async function teardownPrimaryBackendAndWait({ soft = false } = {}) {
   const hermesProcess = backendConnectionState.getProcess()
   const dying = hermesProcess && !hermesProcess.killed ? hermesProcess : null
 
+  intentionalBackendTeardowns += 1
+
   if (soft) {
     softRehomeInProgress = true
   }
@@ -7671,6 +7677,8 @@ async function teardownPrimaryBackendAndWait({ soft = false } = {}) {
     if (soft) {
       softRehomeInProgress = false
     }
+
+    intentionalBackendTeardowns = Math.max(0, intentionalBackendTeardowns - 1)
   }
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -120,6 +120,10 @@ import {
   resolveTimeoutMs,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
+import {
+  createIntentionalBackendTeardownGuard,
+  shouldSuppressBackendExitNotice
+} from './intentional-backend-teardown'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
 import {
@@ -989,10 +993,10 @@ let mainWindow = null
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
-// Nonzero while Hermes intentionally tears down its local child. This covers
-// retries, profile switches, updates, and soft connection applies; none should
-// surface a "backend stopped" error to the user.
-let intentionalBackendTeardowns = 0
+// Held only around the Windows update/uninstall lock-release kill. Retry,
+// profile-switch, and soft-apply already invalidate backendConnectionState so
+// their exits are rejected as stale before sendBackendExit.
+const intentionalBackendTeardown = createIntentionalBackendTeardownGuard()
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
 let softRehomeInProgress = false
@@ -2639,81 +2643,95 @@ async function releaseBackendLock(updateRoot, tag) {
     return { unlocked: true }
   }
 
-  // Collect every backend PID the desktop owns: primary window backend + pool.
-  const pids = []
-  const hermesProcess = backendConnectionState.getProcess()
+  // Kill without invalidate() alone would leave the primary child's exit
+  // "current" and toast. Hold the intentional guard for this window, and
+  // invalidate after capturing PIDs so stale-owner also covers a late exit
+  // if the wait times out before the Node 'exit' event.
+  return intentionalBackendTeardown.run(async () => {
+    // Collect every backend PID the desktop owns: primary window backend + pool.
+    const pids = []
+    const hermesProcess = backendConnectionState.getProcess()
 
-  if (hermesProcess && Number.isInteger(hermesProcess.pid)) {
-    pids.push(hermesProcess.pid)
-  }
-
-  for (const entry of backendPool.values()) {
-    if (entry.process && Number.isInteger(entry.process.pid)) {
-      pids.push(entry.process.pid)
-    }
-  }
-
-  // Graceful first (lets Python flush), then tree-kill to catch grandchildren.
-  if (hermesProcess && !hermesProcess.killed) {
-    try {
-      hermesProcess.kill('SIGTERM')
-    } catch {
-      void 0
-    }
-  }
-
-  stopAllPoolBackends()
-
-  for (const pid of pids) {
-    forceKillProcessTree(pid)
-  }
-
-  const shim = venvHermesShimPath(updateRoot)
-  const deadlineMs = Date.now() + 15000
-
-  while (Date.now() < deadlineMs) {
-    if (!isShimLocked(shim)) {
-      rememberLog(`[${tag}] venv shim unlocked; safe to proceed`)
-
-      return { unlocked: true }
-    }
-
-    // A supervised backend can respawn between kill and check (grandchildren,
-    // pool entries registered mid-teardown). Re-collect and re-kill each pass
-    // instead of trusting the initial sweep.
-    const stragglers = []
-
-    const currentHermesProcess = backendConnectionState.getProcess()
-
-    if (currentHermesProcess && Number.isInteger(currentHermesProcess.pid)) {
-      stragglers.push(currentHermesProcess.pid)
+    if (hermesProcess && Number.isInteger(hermesProcess.pid)) {
+      pids.push(hermesProcess.pid)
     }
 
     for (const entry of backendPool.values()) {
       if (entry.process && Number.isInteger(entry.process.pid)) {
-        stragglers.push(entry.process.pid)
+        pids.push(entry.process.pid)
       }
     }
 
-    for (const pid of stragglers) {
+    // Drop current-owner status before signalling so a delayed 'exit' cannot
+    // reach sendBackendExit after the suppress guard ends.
+    backendConnectionState.invalidate()
+
+    // Graceful first (lets Python flush), then tree-kill to catch grandchildren.
+    if (hermesProcess && !hermesProcess.killed) {
+      try {
+        hermesProcess.kill('SIGTERM')
+      } catch {
+        void 0
+      }
+    }
+
+    stopAllPoolBackends()
+
+    for (const pid of pids) {
       forceKillProcessTree(pid)
     }
 
-    await new Promise(r => setTimeout(r, 300))
-  }
+    // Prefer draining 'exit' while the guard is still held; invalidate above
+    // remains the backstop if this wait ends on its post-kill grace timeout.
+    await waitForBackendExit(hermesProcess)
 
-  // Do NOT proceed past a held lock: handing off to the updater while another
-  // process (a second desktop window, a user terminal, an unkillable child)
-  // still maps the venv's files guarantees a half-updated venv — the updater's
-  // dependency sync dies on access-denied partway through uninstalls, leaving
-  // imports broken (the July 2026 brotlicffi/_sodium.pyd incidents). Failing
-  // the update loudly and keeping the app running is strictly better than a
-  // bricked install that needs manual venv surgery.
-  rememberLog(
-    `[${tag}] venv shim still locked after 15s; aborting hand-off (something outside this app holds the venv)`
-  )
+    const shim = venvHermesShimPath(updateRoot)
+    const deadlineMs = Date.now() + 15000
 
-  return { unlocked: false }
+    while (Date.now() < deadlineMs) {
+      if (!isShimLocked(shim)) {
+        rememberLog(`[${tag}] venv shim unlocked; safe to proceed`)
+
+        return { unlocked: true }
+      }
+
+      // A supervised backend can respawn between kill and check (grandchildren,
+      // pool entries registered mid-teardown). Re-collect and re-kill each pass
+      // instead of trusting the initial sweep.
+      const stragglers = []
+
+      const currentHermesProcess = backendConnectionState.getProcess()
+
+      if (currentHermesProcess && Number.isInteger(currentHermesProcess.pid)) {
+        stragglers.push(currentHermesProcess.pid)
+      }
+
+      for (const entry of backendPool.values()) {
+        if (entry.process && Number.isInteger(entry.process.pid)) {
+          stragglers.push(entry.process.pid)
+        }
+      }
+
+      for (const pid of stragglers) {
+        forceKillProcessTree(pid)
+      }
+
+      await new Promise(r => setTimeout(r, 300))
+    }
+
+    // Do NOT proceed past a held lock: handing off to the updater while another
+    // process (a second desktop window, a user terminal, an unkillable child)
+    // still maps the venv's files guarantees a half-updated venv — the updater's
+    // dependency sync dies on access-denied partway through uninstalls, leaving
+    // imports broken (the July 2026 brotlicffi/_sodium.pyd incidents). Failing
+    // the update loudly and keeping the app running is strictly better than a
+    // bricked install that needs manual venv surgery.
+    rememberLog(
+      `[${tag}] venv shim still locked after 15s; aborting hand-off (something outside this app holds the venv)`
+    )
+
+    return { unlocked: false }
+  })
 }
 
 // applyUpdates — hand off to the installer's --update flow, then exit.
@@ -4951,9 +4969,15 @@ function getWindowState(win = mainWindow) {
 }
 
 function sendBackendExit(payload) {
-  // Intentional soft re-home (gateway mode apply) kills the child on purpose —
+  // Soft re-home + Windows update/uninstall lock-release kills are intentional —
   // don't surface the "backend stopped" error toast / boot-failure path.
-  if (softRehomeInProgress || intentionalBackendTeardowns > 0) {
+  // Stale-owner exits (after invalidate) never reach here; see clearForCurrentProcess.
+  if (
+    shouldSuppressBackendExitNotice({
+      softRehomeInProgress,
+      intentionalTeardownDepth: intentionalBackendTeardown.depth
+    })
+  ) {
     return
   }
 
@@ -7664,21 +7688,18 @@ async function teardownPrimaryBackendAndWait({ soft = false } = {}) {
   const hermesProcess = backendConnectionState.getProcess()
   const dying = hermesProcess && !hermesProcess.killed ? hermesProcess : null
 
-  intentionalBackendTeardowns += 1
-
   if (soft) {
     softRehomeInProgress = true
   }
 
   try {
+    // invalidate() makes the dying child's exit stale before sendBackendExit.
     resetHermesConnection({ soft })
     await waitForBackendExit(dying)
   } finally {
     if (soft) {
       softRehomeInProgress = false
     }
-
-    intentionalBackendTeardowns = Math.max(0, intentionalBackendTeardowns - 1)
   }
 }
 
@@ -7706,6 +7727,24 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
   }
 
   await new Promise<void>(resolve => {
+    let settled = false
+
+    const finish = () => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      clearTimeout(graceTimer)
+      clearTimeout(timer)
+      resolve()
+    }
+
+    // After the soft-wait budget, force-kill then keep waiting briefly for the
+    // real 'exit' event so callers that suppress notices for this window do not
+    // drop their guard before Node delivers the handler.
+    let graceTimer = null as ReturnType<typeof setTimeout> | null
+
     const timer = setTimeout(() => {
       try {
         if (IS_WINDOWS && Number.isInteger(child.pid)) {
@@ -7717,13 +7756,10 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
         // Already gone.
       }
 
-      resolve()
+      graceTimer = setTimeout(finish, 2000)
     }, timeoutMs)
 
-    child.once('exit', () => {
-      clearTimeout(timer)
-      resolve()
-    })
+    child.once('exit', finish)
   })
 }
 


### PR DESCRIPTION
## Summary
- suppress false backend-exit notices on the Windows update/uninstall lock-release path (`releaseBackendLock`), which kills the primary child without entering `teardownPrimaryBackendAndWait`
- keep existing stale-owner protection for retry / profile-switch / soft-apply (`invalidate` before exit handling)
- invalidate after capturing PIDs during lock release, and wait for the real child `exit` after force-kill, so a late exit cannot toast after the suppress guard ends

## Validation
- eslint `electron/main.ts` `electron/intentional-backend-teardown.ts` `electron/intentional-backend-teardown.test.ts`
- `vitest run --project electron electron/intentional-backend-teardown.test.ts electron/backend-connection-state.test.ts` (12 tests)
- git diff --check
- static placement audit: counter removed from `teardownPrimaryBackendAndWait`; guard + invalidate on `releaseBackendLock`
- decision-matrix check of `shouldSuppressBackendExitNotice` (update window vs unexpected current exit vs soft re-home)
- peer Grok 4.5 review: APPROVE after P1 timeout race fix

Addresses review https://github.com/NousResearch/hermes-agent/pull/72722#pullrequestreview-4819708682