### PR TITLE
fix(telegram): ignore private-topic bot-chat mirrors

### DIFF
--- a/contributors/emails/razsoc.01@gmail.com
+++ b/contributors/emails/razsoc.01@gmail.com
@@ -1,0 +1,2 @@
+Cossackx
+# PR #72723

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8459,19 +8459,30 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] Failed to observe Telegram group message: %s", adapter_name, exc)
 
     def _is_own_message(self, message: Message) -> bool:
-        """Return True when the message was sent by this bot itself.
+        """Return True when the message was sent by or mirrored to this bot.
 
         In some Telegram environments (groups, supergroups where the bot can
         see its own messages), getUpdates returns the bot's own outgoing
         messages as updates.  These must be filtered out so they are not
-        counted as incoming unread messages in the Hermes inbox.
+        counted as incoming unread messages in the Hermes inbox. Private-topic
+        mode can also mirror an owner-authored message into a chat whose ID is
+        the bot's own ID; that envelope is not a routable user conversation.
         """
         if not self._bot:
             return False
+        bot_id = getattr(self._bot, "id", None)
+        chat = getattr(message, "chat", None)
+        chat_id = getattr(chat, "id", None) if chat else None
+        if bot_id is not None and chat_id is not None and bot_id == chat_id:
+            logger.debug(
+                "[Telegram] Ignoring message mirrored into bot's own chat "
+                "(chat_id=%s)",
+                chat_id,
+            )
+            return True
         from_user = getattr(message, "from_user", None)
         if from_user is None:
             return False
-        bot_id = getattr(self._bot, "id", None)
         user_id = getattr(from_user, "id", None)
         return bot_id is not None and user_id is not None and bot_id == user_id
 

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -124,6 +124,48 @@ async def test_authorized_user_processed_normally():
 
 
 @pytest.mark.asyncio
+async def test_owner_message_mirrored_into_bot_chat_is_ignored():
+    """Private-topic mirrors addressed to the bot must not start an agent turn."""
+    adapter = _make_adapter(allow_from=["111"])
+
+    build_called = False
+    original_build = adapter._build_message_event
+
+    def track_build(*a, **kw):
+        nonlocal build_called
+        build_called = True
+        return original_build(*a, **kw)
+
+    adapter._build_message_event = track_build
+
+    update = SimpleNamespace(
+        update_id=1,
+        message=_make_message(
+            from_user_id=111,
+            chat_id=adapter._bot.id,
+            chat_type="private",
+        ),
+        effective_message=None,
+    )
+
+    await adapter._handle_text_message(update, SimpleNamespace())
+
+    assert build_called is False, "bot-chat mirror should be ignored before event building"
+
+
+def test_owner_message_in_owner_chat_is_not_filtered_as_own_message():
+    """A canonical owner DM must remain processable after mirror filtering."""
+    adapter = _make_adapter(allow_from=["111"])
+    message = _make_message(
+        from_user_id=111,
+        chat_id=111,
+        chat_type="private",
+    )
+
+    assert adapter._is_own_message(message) is False
+
+
+@pytest.mark.asyncio
 async def test_channel_post_passes_auth():
     """Messages with no from_user (channel posts) should pass user-level auth."""
     adapter = _make_adapter(allow_from=["111"])


### PR DESCRIPTION
## Summary
- ignore Telegram private-topic mirror envelopes whose chat ID is the bot's own ID
- preserve canonical owner-chat topic messages
- add handler-level regression coverage for the duplicate-agent-turn failure

## Root cause
Telegram private-topic mode can emit an owner-authored message twice: once as the canonical owner chat + topic thread, and once as a no-thread private envelope addressed to the bot's own chat ID. The existing self-message guard checks only `from_user`, so the owner-authored mirror passed authorization, started a second agent turn, and failed delivery with `Forbidden: the bot can't send messages to the bot`.

## Verification
- strict RED: new regression test failed before the fix because event construction occurred
- GREEN: focused post-review suite: 49 passed
- full Telegram gateway selection on modified branch: 1,539 passed, 6 failed
- identical clean-main baseline: 1,538 passed, the same 6 failed
- `ruff check` and `git diff --check`: passed
- independent review: passed; no security or logic defects

## Live reproduction
A single owner message in a configured private topic created two session origins: canonical owner chat + topic thread and an invalid bot-chat + no-thread mirror. Both generated responses; only the bot-chat delivery failed.
