### PR TITLE
fix(telegram): surface polling recovery in runtime status

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -864,6 +864,13 @@ class TelegramAdapter(BasePlatformAdapter):
     def _mark_connected(self) -> None:
         self._drop_delayed_deliveries = False
         super()._mark_connected()
+        if not self._webhook_mode and self._send_path_degraded:
+            self._write_runtime_status_safe(
+                "polling_retrying",
+                platform_state="retrying",
+                error_code=None,
+                error_message=None,
+            )
 
     def _mark_disconnected(self) -> None:
         self._drop_delayed_deliveries = True
@@ -2077,20 +2084,37 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_progress_event = asyncio.Event()
         self._polling_progress_accepting = True
         self._send_path_degraded = True
+        if not self.has_fatal_error:
+            self._write_runtime_status_safe(
+                "polling_retrying",
+                platform_state="retrying",
+                error_code=None,
+                error_message=None,
+            )
         return self._polling_generation, self._polling_progress_event
 
     def _record_polling_progress(self, generation: int) -> None:
         """Record successful getUpdates I/O for the current generation only."""
         if getattr(self, "_polling_teardown_started", False):
             return
+        if self.has_fatal_error:
+            return
         if not self._polling_progress_accepting:
             return
         if generation != self._polling_generation:
             return
+        was_degraded = self._send_path_degraded
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
         self._polling_conflict_count = 0
         self._send_path_degraded = False
+        if was_degraded:
+            self._write_runtime_status_safe(
+                "polling_progress",
+                platform_state="connected",
+                error_code=None,
+                error_message=None,
+            )
 
     def _observe_polling_request_result(self, request, generation, result):
         """Record getUpdates progress from an observed do_request result.

--- a/tests/gateway/test_telegram_polling_progress.py
+++ b/tests/gateway/test_telegram_polling_progress.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.status import read_runtime_status
 from plugins.platforms.telegram import adapter as tg_adapter
 from plugins.platforms.telegram.adapter import TelegramAdapter
 
@@ -42,6 +43,10 @@ class _ControlledRequest:
 
 def _make_adapter() -> TelegramAdapter:
     return TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+
+def _telegram_runtime_state() -> str:
+    return read_runtime_status()["platforms"]["telegram"]["state"]
 
 
 def _mock_polling_app(*, get_me=None):
@@ -232,6 +237,55 @@ async def test_current_polling_generation_success_records_progress():
     assert adapter._polling_network_error_count == 0
     assert adapter._send_path_degraded is False
     assert generation > 0
+
+
+@pytest.mark.asyncio
+async def test_polling_recovery_runtime_state_tracks_current_generation():
+    adapter = _make_adapter()
+    adapter._mark_connected()
+
+    previous_generation = adapter._polling_generation
+    generation, _ = adapter._begin_polling_generation()
+
+    assert adapter._send_path_degraded is True
+    assert _telegram_runtime_state() == "retrying"
+
+    adapter._mark_connected()
+
+    assert adapter._send_path_degraded is True
+    assert _telegram_runtime_state() == "retrying"
+
+    adapter._record_polling_progress(previous_generation)
+
+    assert adapter._send_path_degraded is True
+    assert _telegram_runtime_state() == "retrying"
+
+    adapter._record_polling_progress(generation)
+
+    assert adapter._send_path_degraded is False
+    assert _telegram_runtime_state() == "connected"
+
+    status_write = MagicMock()
+    adapter._write_runtime_status_safe = status_write
+    adapter._record_polling_progress(generation)
+    status_write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_late_polling_progress_does_not_overwrite_fatal_runtime_state():
+    adapter = _make_adapter()
+    adapter._mark_connected()
+    generation, _ = adapter._begin_polling_generation()
+    adapter._set_fatal_error(
+        "telegram_polling_conflict",
+        "polling retries exhausted",
+        retryable=False,
+    )
+
+    adapter._record_polling_progress(generation)
+
+    assert adapter._send_path_degraded is True
+    assert _telegram_runtime_state() == "fatal"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Surfaces Telegram polling recovery in `gateway_state.json` instead of leaving the platform reported as `connected` while its send path is degraded.

A new polling generation now persists `retrying`. Only successful `getUpdates` progress from the current generation restores `connected`; a stale generation, a general Bot API success such as `getMe`, or a late response after fatal exhaustion cannot restore health.

The connected-state hook also preserves `retrying` when `connect()` completes before polling progress, and repeated healthy long polls do not rewrite the status file.

## Related Issue

Addresses the runtime-status portion of #72664.

The issue also covers separate multi-profile ownership, stale-process status, `/start` UX, and restart-operation concerns; this PR intentionally does not claim to close those items.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update Telegram polling generation transitions to persist `retrying` and generation-bound recovery to persist `connected`.
- Preserve `retrying` when the adapter is generally connected but polling has not made progress.
- Ignore polling progress after fatal state and avoid repeated writes after the first healthy transition.
- Add real runtime-status regression tests using the isolated test `HERMES_HOME`.

## How to Test

1. On the parent commit, mark Telegram connected and begin a new polling generation.
2. Observe that `_send_path_degraded` becomes true while `gateway_state.json` remains `connected`.
3. Apply this change and observe `retrying` until matching-generation `getUpdates` progress changes it to `connected`.
4. Run:

```bash
scripts/run_tests.sh \
  tests/gateway/test_telegram_polling_progress.py \
  tests/gateway/test_telegram_conflict.py \
  tests/gateway/test_telegram_network_reconnect.py \
  tests/gateway/test_telegram_send_path_health.py \
  tests/gateway/test_runner_startup_failures.py \
  tests/hermes_cli/test_gateway_runtime_health.py \
  tests/hermes_cli/test_gateway_restart_loop.py -q

./.venv/bin/python -m ruff check \
  plugins/platforms/telegram/adapter.py \
  tests/gateway/test_telegram_polling_progress.py
```

## Validation

Parent-commit regression test:

```text
assert _telegram_runtime_state() == "retrying"
AssertionError: assert 'connected' == 'retrying'
```

Post-fix:

```text
7 files: 174 tests passed
Final polling/fatal boundary recheck: 39 tests passed
Focused polling-progress recheck: 24 tests passed
Ruff: All checks passed
py_compile: passed
git diff --check: passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing open PRs for overlap
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `pytest tests/ -q` suite
- [x] I've added tests for the change
- [x] I've tested on macOS 26.0.1 with Python 3.13

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] Config example update: N/A
- [x] Architecture/workflow docs update: N/A
- [x] Cross-platform impact considered: status transitions are platform-independent Python; the reported Windows runtime was not directly exercised
- [x] Tool descriptions/schemas update: N/A
