### PR TITLE
fix(desktop): restore reasoning-only turns dropped on session resume

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -285,6 +285,132 @@ describe('toChatMessages', () => {
   })
 })
 
+// tui_gateway/server.py's `_history_to_messages` forwards four reasoning keys
+// verbatim (`reasoning_keys`) and deliberately keeps a reasoning-only assistant
+// turn so "the desktop's reasoning disclosure" has something to render (#44022).
+// Two of them — `reasoning_details` and `codex_reasoning_items` — are provider
+// replay payloads: lists of structured entries, never plain strings.
+describe('toChatMessages structured reasoning on resume', () => {
+  const reasoningTextOf = (message: ChatMessage): string[] =>
+    message.parts.flatMap(part => (part.type === 'reasoning' ? [part.text] : []))
+
+  it('keeps a thinking-only assistant turn that carries only reasoning_details', () => {
+    const messages = toChatMessages([
+      { role: 'user', content: 'why?', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: 2,
+        reasoning_details: [
+          { type: 'reasoning.summary', summary: 'Weighing the two options.' },
+          { type: 'thinking', thinking: 'The second one is cheaper.', signature: 'sig-abc' }
+        ]
+      }
+    ])
+
+    // Without a reader for the list form the turn produces zero parts and is
+    // dropped by toChatMessages' empty-turn guard — it vanishes from the
+    // resumed transcript entirely.
+    expect(messages).toHaveLength(2)
+    expect(messages[1].role).toBe('assistant')
+    expect(reasoningTextOf(messages[1])).toEqual(['Weighing the two options.\n\nThe second one is cheaper.'])
+  })
+
+  it('surfaces Codex summary_text parts from codex_reasoning_items', () => {
+    const messages = toChatMessages([
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: 1,
+        codex_reasoning_items: [
+          { type: 'reasoning', summary: [{ type: 'summary_text', text: 'Reading the config.' }] }
+        ]
+      }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(reasoningTextOf(messages[0])).toEqual(['Reading the config.'])
+  })
+
+  it('shows Anthropic reasoning once when reasoning_details repeats it', () => {
+    // The Anthropic transport populates `reasoning` AND `reasoning_details`
+    // from the same thinking blocks, so a resumed Claude turn would otherwise
+    // render its reasoning twice.
+    const messages = toChatMessages([
+      {
+        role: 'assistant',
+        content: 'Done.',
+        timestamp: 1,
+        reasoning: 'Checking the lockfile.',
+        reasoning_details: [{ type: 'thinking', thinking: 'Checking the lockfile.', signature: 'sig-1' }]
+      }
+    ])
+
+    expect(reasoningTextOf(messages[0])).toEqual(['Checking the lockfile.'])
+    expect(chatMessageText(messages[0])).toBe('Done.')
+  })
+
+  it('ignores opaque replay blobs instead of rendering them as noise', () => {
+    const messages = toChatMessages([
+      {
+        role: 'assistant',
+        content: 'Done.',
+        timestamp: 1,
+        reasoning_details: [
+          { type: 'reasoning.encrypted', data: 'ZW5jcnlwdGVk', signature: 'sig-2' },
+          { type: 'redacted_thinking', encrypted_content: 'cmVkYWN0ZWQ=' }
+        ]
+      }
+    ])
+
+    expect(reasoningTextOf(messages[0])).toEqual([])
+    expect(chatMessageText(messages[0])).toBe('Done.')
+  })
+
+  it('degrades odd reasoning shapes to no reasoning part instead of throwing', () => {
+    const read = () =>
+      toChatMessages([
+        {
+          role: 'assistant',
+          content: 'Done.',
+          timestamp: 1,
+          reasoning_details: { type: 'thinking', thinking: 'not a list' },
+          codex_reasoning_items: 'unparsed json text'
+        }
+      ])
+
+    expect(read).not.toThrow()
+    expect(reasoningTextOf(read()[0])).toEqual([])
+    expect(chatMessageText(read()[0])).toBe('Done.')
+  })
+
+  it('leaves plain-string reasoning and reasoning_content unchanged', () => {
+    const [fromReasoning] = toChatMessages([
+      { role: 'assistant', content: 'Done.', timestamp: 1, reasoning: 'Direct field.' }
+    ])
+
+    const [fromReasoningContent] = toChatMessages([
+      { role: 'assistant', content: 'Done.', timestamp: 1, reasoning_content: 'Alternate field.' }
+    ])
+
+    expect(reasoningTextOf(fromReasoning)).toEqual(['Direct field.'])
+    expect(reasoningTextOf(fromReasoningContent)).toEqual(['Alternate field.'])
+  })
+
+  it('does not render reasoning on a non-assistant row', () => {
+    const messages = toChatMessages([
+      {
+        role: 'user',
+        content: 'hi',
+        timestamp: 1,
+        reasoning_details: [{ type: 'thinking', thinking: 'should not surface' }]
+      }
+    ])
+
+    expect(reasoningTextOf(messages[0])).toEqual([])
+  })
+})
+
 describe('renderMediaTags', () => {
   it('renders standalone and inline MEDIA tags as links', () => {
     expect(renderMediaTags('here\nMEDIA:/tmp/voice.mp3\nthere')).toBe(

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -872,6 +872,93 @@ function withUniqueToolCallIds(messages: ChatMessage[]): ChatMessage[] {
   })
 }
 
+// Human-readable members of a structured reasoning entry, in the precedence
+// the backend's own `extract_reasoning` (agent/agent_runtime_helpers.py) uses:
+//   * Anthropic thinking block  → {type: 'thinking', thinking, signature}
+//   * OpenRouter summary/text   → {type: 'reasoning.summary', summary} etc.
+//   * Codex Responses item      → {type: 'reasoning', summary: [{text}], …}
+// `signature`, `data` and `encrypted_content` are deliberately absent: those
+// are opaque replay blobs (redacted_thinking, reasoning.encrypted_content,
+// Codex encrypted reasoning) that would render as base64 noise, so an entry
+// carrying only those contributes nothing to the displayed text.
+const REASONING_DETAIL_FIELDS = ['summary', 'thinking', 'content', 'text'] as const
+
+function isReasoningRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// A readable member is either prose or a list of `{text}` parts — Codex stores
+// `summary` as `[{type: 'summary_text', text}]`, OpenRouter as a bare string.
+// Anything else degrades to '' rather than stringifying into `[object Object]`.
+function readableReasoningText(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map(part => (isReasoningRecord(part) && typeof part.text === 'string' ? part.text : ''))
+      .filter(Boolean)
+      .join('\n')
+  }
+
+  return ''
+}
+
+/**
+ * Flatten a persisted assistant row's reasoning fields into one display string.
+ *
+ * `tui_gateway/server.py`'s `_history_to_messages` forwards four reasoning keys
+ * verbatim out of persisted history (`reasoning_keys`), and deliberately keeps
+ * an assistant turn that carries *only* reasoning so "the desktop's reasoning
+ * disclosure" has something to render (#44022). Two of those keys —
+ * `reasoning_details` and `codex_reasoning_items` — are provider replay
+ * payloads, i.e. lists of structured entries, never plain strings.
+ *
+ * De-duplication is load-bearing rather than cosmetic: the Anthropic transport
+ * populates `reasoning` *and* `reasoning_details` from the same thinking
+ * blocks, so a resumed Claude turn would otherwise show its reasoning twice.
+ */
+function flattenStoredReasoning(message: SessionMessage): string {
+  const blocks: string[] = []
+
+  const add = (value: unknown) => {
+    const text = readableReasoningText(value).trim()
+
+    if (text && !blocks.includes(text)) {
+      blocks.push(text)
+    }
+  }
+
+  add(message.reasoning)
+  add(message.reasoning_content)
+
+  // `reasoning_details` before `codex_reasoning_items`, matching the order the
+  // gateway walks its `reasoning_keys` tuple.
+  for (const entries of [message.reasoning_details, message.codex_reasoning_items]) {
+    if (!Array.isArray(entries)) {
+      continue
+    }
+
+    for (const entry of entries) {
+      if (!isReasoningRecord(entry)) {
+        continue
+      }
+
+      // First readable member wins — an entry never carries two of these.
+      for (const name of REASONING_DETAIL_FIELDS) {
+        if (readableReasoningText(entry[name]).trim()) {
+          add(entry[name])
+
+          break
+        }
+      }
+    }
+  }
+
+  return blocks.join('\n\n')
+}
+
 export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
   const result: ChatMessage[] = []
   let pendingToolParts: ChatMessagePart[] = []
@@ -967,10 +1054,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
 
     const parts: ChatMessagePart[] = []
 
-    const reasoning =
-      message.reasoning ||
-      message.reasoning_content ||
-      (typeof message.reasoning_details === 'string' ? message.reasoning_details : '')
+    const reasoning = flattenStoredReasoning(message)
 
     if (reasoning && message.role === 'assistant') {
       parts.push(reasoningPart(reasoning))


### PR DESCRIPTION
## What does this PR do?

A resumed session silently loses whole assistant turns.

`toChatMessages` (`apps/desktop/src/lib/chat-messages.ts`) built its reasoning
string like this:

```ts
const reasoning =
  message.reasoning ||
  message.reasoning_content ||
  (typeof message.reasoning_details === 'string' ? message.reasoning_details : '')
```

Two problems:

1. **`reasoning_details` is never a string on the wire.** `tui_gateway/server.py`'s
   `_history_to_messages` forwards the persisted value verbatim through its
   `reasoning_keys` tuple, and providers store it as a **list** of structured
   entries. That third branch is dead code.
2. **`codex_reasoning_items` — the fourth key in the same tuple — is not read
   at all** anywhere in `apps/desktop/src`. `types/hermes.ts` already declares
   both as `unknown`, so this is purely a reader defect.

The consequence is content loss, not a missing disclosure. An extended-thinking
turn has empty text and carries its content *only* in those two keys, so `parts`
stays empty and the turn is discarded by the guard further down the same
function:

```ts
if (!parts.length && !extractedAttachmentRefs?.length) { … return }
```

The turn disappears from the resumed transcript entirely.

That directly defeats the stated intent of the gateway-side fix
[`2667601c0`](https://github.com/NousResearch/hermes-agent/commit/2667601c0)
(*"fix(tui): keep reasoning-only assistant turns visible on session resume"*),
whose comment above `reasoning_keys` reads:

> An assistant turn may carry only reasoning/thinking content with no visible
> text … dropping it here as "empty" makes it vanish from the resumed/reloaded
> session view while **the desktop's reasoning disclosure has nothing to
> render**. Keep it when it carries reasoning so the "Thinking…" block still
> shows. (#44022)

The gateway went out of its way to preserve these rows *for the desktop*, and
the desktop threw them away.

**Mirrors the backend resolver:** the new `flattenStoredReasoning` follows
`extract_reasoning` (`agent/agent_runtime_helpers.py:1615`) exactly — `reasoning`,
then `reasoning_content` if not already present, then each structured entry's
first readable member out of `summary` / `thinking` / `content` / `text`, skipping
duplicates and joining with a blank line.

**Scope — single site.** Grepping the four reasoning keys across
`apps/desktop/src` returns exactly one resume-path reader (`chat-messages.ts:970`).
The other hit, `app/session/hooks/use-message-stream/index.ts:219`, is the
**live-stream** path where `queued.reasoning` is already typed `string` — correct
as written and deliberately untouched. The remaining hits (`store/pet.ts`,
settings/shell) are `caps.reasoning` capability booleans.

## Related Issue

No filed issue — found while auditing the desktop resume path against the
gateway's `reasoning_keys` contract. Sibling fix for the same defect in the TUI
package: #72074 (`ui-tui/src/lib/reasoning.ts`); the two packages share no import
path, so this helper is local to the desktop app.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/chat-messages.ts` — added `flattenStoredReasoning`
  (plus `readableReasoningText` / `isReasoningRecord` helpers) and used it in
  `toChatMessages` in place of the string-only expression:
  - Reads all four gateway keys, in the order the gateway walks its tuple:
    `reasoning`, `reasoning_content`, `reasoning_details`, `codex_reasoning_items`.
  - A structured entry's readable member may be prose **or** a list of `{text}`
    parts — Codex stores `summary` as `[{type: 'summary_text', text}]`,
    OpenRouter uses a bare string.
  - **Skips `signature` / `data` / `encrypted_content`.** Those are opaque replay
    blobs (redacted_thinking, `reasoning.encrypted_content`, Codex encrypted
    reasoning); rendering them would dump base64 into the transcript, so an entry
    carrying only those contributes nothing.
  - **De-duplicates.** This is load-bearing, not cosmetic: the Anthropic transport
    populates `reasoning` *and* `reasoning_details` from the same thinking blocks,
    so a resumed Claude turn would otherwise show its reasoning twice.
  - Non-list / non-string shapes degrade to `''` — never throws, never
    stringifies an object into `[object Object]`.
  - The existing `if (reasoning && message.role === 'assistant')` guard is
    unchanged, so nothing renders on non-assistant rows.
- `apps/desktop/src/lib/chat-messages.test.ts` — 7 regression cases covering
  turn survival, Codex `summary_text`, Anthropic de-duplication, opaque-blob
  suppression, malformed shapes, unchanged plain-string behaviour, and the
  non-assistant guard.

## How to Test

1. `cd apps/desktop && npx vitest run src/lib/chat-messages.test.ts --project ui`
   → 57 passed.
2. Adjacent suites (`src/lib/`, `src/app/session/hooks/use-message-stream`) →
   65 files, 554 passed.
3. `npx eslint src/lib/chat-messages.ts src/lib/chat-messages.test.ts` → clean.

**Red before / green after.** Reverting only the production hunk to `main` and
re-running the same tests:

```
 ❯ |ui| src/lib/chat-messages.test.ts (57 tests | 2 failed) 12ms
     × keeps a thinking-only assistant turn that carries only reasoning_details
     × surfaces Codex summary_text parts from codex_reasoning_items

 FAIL  toChatMessages structured reasoning on resume >
       keeps a thinking-only assistant turn that carries only reasoning_details
 AssertionError: expected [ { id: '1-0-user', …(3) } ] to have a length of 2 but got 1

  Tests  2 failed | 55 passed (57)
```

The first failure is the bug in one line: a two-message transcript (user +
thinking-only assistant) comes back with **one** message — the assistant turn is
gone. With the fix restored, 57/57 pass.

Manual check: resume a session whose last assistant turn was extended-thinking
only (Claude with thinking enabled, or a Codex turn that emitted reasoning and
no text). Before: the turn is absent from the reloaded transcript. After: the
turn is present with its "Thinking…" disclosure.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- TypeScript-only change; ran the desktop vitest suites listed above instead -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure data-shape handling, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
