### PR TITLE
Add TiMEM memory provider plugin

### DIFF
--- a/plugins/memory/timem/README.md
+++ b/plugins/memory/timem/README.md
@@ -66,7 +66,7 @@ Optional settings live in `$HERMES_HOME/timem.json`:
 | `score_threshold` | `0.5` | Minimum semantic similarity for recall (0–1) |
 | `auto_recall` | `true` | Inject recalled context each turn |
 | `auto_capture` | `true` | Submit turns for memory generation |
-| `api_timeout` | `10.0` | Request timeout in seconds (1–60) |
+| `api_timeout` | `60.0` | Request timeout in seconds (1–60) |
 
 Environment overrides: `TIMEM_API_KEY` (required), `TIMEM_BASE_URL`.
 
@@ -78,3 +78,14 @@ Environment overrides: `TIMEM_API_KEY` (required), `TIMEM_BASE_URL`.
 - A circuit breaker opens after 5 consecutive API failures and retries after
   a 120s cooldown; the agent keeps working without memory in the meantime.
 - Trivial turns (short acknowledgements) are not captured.
+- **Reads and writes are serialized server-side.** While a turn is being
+  ingested (`sync_turn` / `timem_add` / built-in mirror), the engine may
+  briefly queue concurrent `timem_search` / prefetch calls — those can take
+  longer or, in the worst case, time out and return no context for that one
+  turn. The agent should treat prefetch as best-effort and fall back to the
+  explicit `timem_search` tool when it genuinely needs a recall. Empirically,
+  searches return in ~1–2s when no generation is in flight.
+- The TiMEM sync SDK wraps a single asyncio event loop that is not
+  thread-safe, so this plugin uses **two separate client instances** (one for
+  reads, one for writes), each internally locked, so a slow background write
+  never blocks a recall.

--- a/plugins/memory/timem/README.md
+++ b/plugins/memory/timem/README.md
@@ -1,0 +1,80 @@
+# TiMEM Memory Provider
+
+[TiMEM](https://docs.timem.cloud) is a temporal-hierarchical memory engine.
+Conversations are ingested server-side into a five-level Temporal Memory Tree:
+
+| Layer | Content |
+|-------|---------|
+| L1 | Raw interactions |
+| L2 | Session summaries |
+| L3 | Cross-session topics |
+| L4 | Long-term patterns |
+| L5 | Persona / user profile |
+
+Memory generation runs asynchronously on the TiMEM engine — Hermes submits
+completed turns and moves on; extraction, layering, and fusion happen
+server-side.
+
+## What this plugin does
+
+- **Auto recall** — before each turn, semantically searches layered memories
+  and injects relevant results as background context (`<timem-context>`).
+- **Auto capture** — after each turn, submits the user/assistant exchange for
+  server-side L1–L5 memory generation (non-blocking, fire-and-forget).
+- **Built-in mirror** — mirrors Hermes built-in memory-tool writes into TiMEM
+  as tagged L1 facts.
+- **Tools** — `timem_search` (semantic search), `timem_add` (store explicit
+  fact), `timem_profile` (fetch the computed L5 user profile).
+
+## Setup
+
+```bash
+hermes memory setup
+# choose: timem
+```
+
+Or manually:
+
+1. Get an API key from the [TiMEM console](https://console.timem.cloud/).
+2. Set the environment variable (or add to `$HERMES_HOME/.env`):
+
+   ```bash
+   export TIMEM_API_KEY=your-key
+   ```
+
+3. Activate the provider in `config.yaml`:
+
+   ```yaml
+   memory:
+     provider: timem
+   ```
+
+The `timem-ai` SDK is lazy-installed on first use (pin managed in
+`tools/lazy_deps.py`, mirrored by the `timem` extra in `pyproject.toml`).
+
+## Configuration
+
+Optional settings live in `$HERMES_HOME/timem.json`:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `user_id` | `hermes-user` | Stable user identifier for memory scoping |
+| `character_id` | `hermes` | Agent namespace (falls back to `agent_identity`) |
+| `domain` | `hermes` | Business domain tag on generated memories |
+| `base_url` | `https://api.timem.cloud` | Engine URL (self-hosted: e.g. `http://localhost:8001`) |
+| `max_recall_results` | `8` | Max memories injected per turn (1–20) |
+| `score_threshold` | `0.5` | Minimum semantic similarity for recall (0–1) |
+| `auto_recall` | `true` | Inject recalled context each turn |
+| `auto_capture` | `true` | Submit turns for memory generation |
+| `api_timeout` | `10.0` | Request timeout in seconds (1–60) |
+
+Environment overrides: `TIMEM_API_KEY` (required), `TIMEM_BASE_URL`.
+
+## Behavior notes
+
+- Only one external memory provider can be active at a time (Hermes rule).
+- Non-primary agent contexts (cron, flush, subagents) are read-only — recall
+  works, but no writes, so scheduled prompts can't pollute the memory tree.
+- A circuit breaker opens after 5 consecutive API failures and retries after
+  a 120s cooldown; the agent keeps working without memory in the meantime.
+- Trivial turns (short acknowledgements) are not captured.

--- a/plugins/memory/timem/__init__.py
+++ b/plugins/memory/timem/__init__.py
@@ -1,0 +1,735 @@
+"""TiMEM memory plugin using the MemoryProvider interface.
+
+TiMEM (https://docs.timem.cloud) is a temporal-hierarchical memory engine.
+Conversations are ingested server-side into a five-level Temporal Memory
+Tree (L1 raw interactions -> L5 persona), and recalled through semantic
+search over the layered store.
+
+This provider wires Hermes turns into TiMEM:
+  - sync_turn()       -> POST the completed turn for async server-side
+                         memory generation (L1-L5 extraction).
+  - prefetch()        -> semantic search over layered memories, injected
+                         as background context before each turn.
+  - on_memory_write() -> mirror built-in memory-tool writes as L1 facts.
+  - tools             -> timem_search / timem_add / timem_profile.
+
+Auth is a single API key (TIMEM_API_KEY) from https://console.timem.cloud.
+The SDK (timem-ai) is lazy-installed on first use via tools/lazy_deps.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.timem.cloud"
+_DEFAULT_DOMAIN = "hermes"
+_DEFAULT_CHARACTER_ID = "hermes"
+_DEFAULT_USER_ID = "hermes-user"
+_DEFAULT_MAX_RECALL_RESULTS = 8
+_DEFAULT_SCORE_THRESHOLD = 0.5
+_DEFAULT_API_TIMEOUT = 10.0
+_PREFETCH_WAIT_SECS = 3.0
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120.0
+_MIN_CAPTURE_LENGTH = 10
+_API_KEY_URL = "https://console.timem.cloud/"
+
+_TRIVIAL_RE = re.compile(
+    r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
+    re.IGNORECASE,
+)
+_CONTEXT_STRIP_RE = re.compile(r"<timem-context>[\s\S]*?</timem-context>\s*", re.DOTALL)
+
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+
+def _default_config() -> dict:
+    return {
+        "user_id": "",
+        "character_id": "",
+        "domain": _DEFAULT_DOMAIN,
+        "base_url": "",
+        "max_recall_results": _DEFAULT_MAX_RECALL_RESULTS,
+        "score_threshold": _DEFAULT_SCORE_THRESHOLD,
+        "auto_recall": True,
+        "auto_capture": True,
+        "api_timeout": _DEFAULT_API_TIMEOUT,
+    }
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "n", "off"}:
+            return False
+    return default
+
+
+def _load_timem_config(hermes_home: str) -> dict:
+    config = _default_config()
+    config_path = Path(hermes_home) / "timem.json"
+    if config_path.exists():
+        try:
+            raw = json.loads(config_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                config.update({k: v for k, v in raw.items() if v is not None})
+        except Exception:
+            logger.debug("Failed to parse %s", config_path, exc_info=True)
+
+    config["user_id"] = str(config.get("user_id", "") or "").strip()
+    config["character_id"] = str(config.get("character_id", "") or "").strip()
+    domain = str(config.get("domain", _DEFAULT_DOMAIN) or "").strip()
+    config["domain"] = domain or _DEFAULT_DOMAIN
+    config["base_url"] = str(config.get("base_url", "") or "").strip()
+    try:
+        config["max_recall_results"] = max(1, min(20, int(config.get("max_recall_results", _DEFAULT_MAX_RECALL_RESULTS))))
+    except Exception:
+        config["max_recall_results"] = _DEFAULT_MAX_RECALL_RESULTS
+    try:
+        config["score_threshold"] = max(0.0, min(1.0, float(config.get("score_threshold", _DEFAULT_SCORE_THRESHOLD))))
+    except Exception:
+        config["score_threshold"] = _DEFAULT_SCORE_THRESHOLD
+    config["auto_recall"] = _as_bool(config.get("auto_recall"), True)
+    config["auto_capture"] = _as_bool(config.get("auto_capture"), True)
+    try:
+        config["api_timeout"] = max(1.0, min(60.0, float(config.get("api_timeout", _DEFAULT_API_TIMEOUT))))
+    except Exception:
+        config["api_timeout"] = _DEFAULT_API_TIMEOUT
+    return config
+
+
+def _save_timem_config(values: dict, hermes_home: str) -> None:
+    config_path = Path(hermes_home) / "timem.json"
+    existing = {}
+    if config_path.exists():
+        try:
+            raw = json.loads(config_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                existing = raw
+        except Exception:
+            existing = {}
+    existing.update(values)
+    from utils import atomic_json_write
+    atomic_json_write(config_path, existing, mode=0o600, sort_keys=True)
+
+
+def _resolve_base_url(config_value: Any = "") -> str:
+    raw = (
+        str(config_value or "").strip()
+        or os.environ.get("TIMEM_BASE_URL", "").strip()
+    )
+    return (raw or _DEFAULT_BASE_URL).rstrip("/") or _DEFAULT_BASE_URL
+
+
+# ─── Result normalization ────────────────────────────────────────────────────
+
+def _memory_text(item: Any) -> str:
+    """Extract display text from one memory item (shape varies by layer/version)."""
+    if isinstance(item, str):
+        return item.strip()
+    if not isinstance(item, dict):
+        return str(item).strip()
+    for key in ("content", "memory", "text", "summary"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, dict):
+            for inner in ("text", "content", "summary", "description"):
+                inner_val = value.get(inner)
+                if isinstance(inner_val, str) and inner_val.strip():
+                    return inner_val.strip()
+            try:
+                return json.dumps(value, ensure_ascii=False)[:500]
+            except Exception:
+                return str(value)[:500]
+    return ""
+
+
+def _extract_memories(response: Any) -> List[dict]:
+    """Normalize a search response into a list of memory dicts."""
+    if not response:
+        return []
+    if isinstance(response, list):
+        raw = response
+    elif isinstance(response, dict):
+        raw = None
+        for key in ("memories", "results", "items", "data"):
+            value = response.get(key)
+            if isinstance(value, list):
+                raw = value
+                break
+            if isinstance(value, dict):
+                for inner in ("memories", "results", "items"):
+                    inner_val = value.get(inner)
+                    if isinstance(inner_val, list):
+                        raw = inner_val
+                        break
+                if raw is not None:
+                    break
+        if raw is None:
+            return []
+    else:
+        return []
+
+    out = []
+    for item in raw:
+        text = _memory_text(item)
+        if not text:
+            continue
+        entry = {"text": text}
+        if isinstance(item, dict):
+            entry["id"] = str(item.get("id") or item.get("memory_id") or "")
+            layer = item.get("layer") or item.get("layer_type") or ""
+            if layer:
+                entry["layer"] = str(layer)
+            for score_key in ("score", "retrieval_score", "similarity"):
+                if item.get(score_key) is not None:
+                    try:
+                        entry["score"] = float(item[score_key])
+                    except Exception:
+                        pass
+                    break
+        out.append(entry)
+    return out
+
+
+def _format_prefetch_context(memories: List[dict], max_results: int) -> str:
+    seen: set = set()
+    lines = []
+    for item in memories:
+        text = item.get("text", "")
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        bits = []
+        if item.get("layer"):
+            bits.append(f"[{item['layer']}]")
+        if item.get("score") is not None:
+            try:
+                bits.append(f"[{round(float(item['score']) * 100)}%]")
+            except Exception:
+                pass
+        prefix = " ".join(bits)
+        lines.append(f"- {prefix} {text}".strip() if prefix else f"- {text}")
+        if len(lines) >= max_results:
+            break
+    if not lines:
+        return ""
+    intro = (
+        "The following is background context recalled from TiMEM long-term "
+        "memory. Use it silently when relevant. Do not force memories into "
+        "the conversation."
+    )
+    body = "\n".join(lines)
+    return f"<timem-context>\n{intro}\n\n## Relevant Memories\n{body}\n</timem-context>"
+
+
+def _clean_text_for_capture(text: str) -> str:
+    return _CONTEXT_STRIP_RE.sub("", text or "").strip()
+
+
+def _is_trivial_message(text: str) -> bool:
+    return bool(_TRIVIAL_RE.match((text or "").strip()))
+
+
+# ─── SDK wrapper ─────────────────────────────────────────────────────────────
+
+class _TimemClient:
+    """Thin wrapper around the timem-ai SDK, lazy-installed on first use."""
+
+    def __init__(self, api_key: str, base_url: str, timeout: float,
+                 user_id: str, character_id: str, domain: str):
+        # Lazy-install the timem-ai SDK on demand. ensure() honors
+        # security.allow_lazy_installs and redirects to the durable target on
+        # sealed Docker venvs. On failure we fall through so the raw import
+        # below produces the canonical ImportError message.
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("memory.timem", prompt=False)
+        except ImportError:
+            pass
+        except Exception:
+            pass
+        from timem import TiMEMClient
+
+        self._user_id = user_id
+        self._character_id = character_id
+        self._domain = domain
+        self._client = TiMEMClient(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=0,
+            verify_ssl=True,
+        )
+
+    def search(self, query: str, *, limit: int, score_threshold: float) -> List[dict]:
+        response = self._client.search_memories(
+            user_id=self._user_id,
+            query_text=query,
+            character_id=self._character_id,
+            score_threshold=score_threshold,
+            limit=limit,
+        )
+        return _extract_memories(response)
+
+    def ingest_turn(self, session_id: str, messages: List[dict],
+                    metadata: Optional[dict] = None) -> dict:
+        # Async on the server: returns an acceptance with task_id. We do NOT
+        # poll — memory generation completes in the background server-side.
+        return self._client.generate_memory(
+            character_id=self._character_id,
+            session_id=session_id,
+            messages=messages,
+            user_id=self._user_id,
+            domain=self._domain,
+            metadata=metadata,
+        )
+
+    def add_fact(self, content: dict, *, tags: Optional[List[str]] = None,
+                 session_id: Optional[str] = None) -> dict:
+        return self._client.add_memory(
+            user_id=self._user_id,
+            domain=self._domain,
+            content=content,
+            layer_type="L1",
+            tags=tags,
+            session_id=session_id,
+        )
+
+    def get_profile(self) -> dict:
+        result = self._client.get_profile(
+            user_id=self._user_id, expert_id=self._character_id,
+        )
+        return result if isinstance(result, dict) else {}
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception:
+            pass
+
+
+# ─── Tool schemas ────────────────────────────────────────────────────────────
+
+SEARCH_SCHEMA = {
+    "name": "timem_search",
+    "description": (
+        "Semantic search over TiMEM layered long-term memory (L1 raw "
+        "interactions up to L5 persona). Use when you need context about "
+        "the user or past sessions that is not already in the conversation."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for."},
+            "limit": {"type": "integer", "description": "Max results (1-20, default 8)."},
+        },
+        "required": ["query"],
+    },
+}
+
+ADD_SCHEMA = {
+    "name": "timem_add",
+    "description": (
+        "Store an explicit fact in TiMEM long-term memory. Use for lasting "
+        "user facts, preferences, and decisions worth recalling later."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "The fact to store."},
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional tags for later filtering.",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+PROFILE_SCHEMA = {
+    "name": "timem_profile",
+    "description": (
+        "Fetch the user profile TiMEM computed from L5 persona memories. "
+        "Use to ground personalization decisions."
+    ),
+    "parameters": {"type": "object", "properties": {}},
+}
+
+
+# ─── Provider ────────────────────────────────────────────────────────────────
+
+class TimemMemoryProvider(MemoryProvider):
+    """TiMEM temporal-hierarchical memory provider."""
+
+    def __init__(self):
+        self._client: Optional[_TimemClient] = None
+        self._config: dict = _default_config()
+        self._session_id = ""
+        self._read_only = False
+        self._init_error = ""
+        self._lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+        self._prefetch_result = ""
+        self._sync_thread: Optional[threading.Thread] = None
+        self._consecutive_failures = 0
+        self._breaker_opened_at = 0.0
+
+    @property
+    def name(self) -> str:
+        return "timem"
+
+    # -- Availability / lifecycle --------------------------------------------
+
+    def is_available(self) -> bool:
+        # Config-presence only — do NOT gate on the timem SDK being
+        # importable. The SDK is lazy-installed at client construction
+        # (_TimemClient.__init__ -> tools.lazy_deps.ensure). Mirrors
+        # honcho/mem0/supermemory.
+        return bool(os.environ.get("TIMEM_API_KEY", "").strip())
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._session_id = session_id or ""
+        hermes_home = kwargs.get("hermes_home") or os.path.expanduser("~/.hermes")
+        self._config = _load_timem_config(hermes_home)
+
+        # Cron/flush system prompts would pollute the user's memory tree.
+        agent_context = str(kwargs.get("agent_context", "primary") or "primary")
+        self._read_only = agent_context not in ("primary", "")
+
+        user_id = (
+            self._config["user_id"]
+            or str(kwargs.get("user_id", "") or "").strip()
+            or _DEFAULT_USER_ID
+        )
+        character_id = (
+            self._config["character_id"]
+            or str(kwargs.get("agent_identity", "") or "").strip()
+            or _DEFAULT_CHARACTER_ID
+        )
+
+        api_key = os.environ.get("TIMEM_API_KEY", "").strip()
+        try:
+            self._client = _TimemClient(
+                api_key=api_key,
+                base_url=_resolve_base_url(self._config["base_url"]),
+                timeout=self._config["api_timeout"],
+                user_id=user_id,
+                character_id=character_id,
+                domain=self._config["domain"],
+            )
+            self._init_error = ""
+        except Exception as exc:
+            self._client = None
+            self._init_error = str(exc).strip()[:200] or "client construction failed"
+            logger.warning("TiMEM client init failed: %s", self._init_error)
+
+    def system_prompt_block(self) -> str:
+        if self._client is None:
+            return ""
+        return (
+            "## TiMEM Long-Term Memory\n"
+            "TiMEM stores layered memories (L1 raw interactions -> L5 persona) "
+            "across sessions. Relevant recall is injected automatically each "
+            "turn. Use timem_search for explicit lookups, timem_add to store "
+            "lasting facts, and timem_profile for the computed user profile."
+        )
+
+    # -- Circuit breaker -------------------------------------------------------
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() - self._breaker_opened_at > _BREAKER_COOLDOWN_SECS:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self) -> None:
+        self._consecutive_failures = 0
+
+    def _record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures == _BREAKER_THRESHOLD:
+            self._breaker_opened_at = time.monotonic()
+            logger.warning(
+                "TiMEM circuit breaker opened after %d consecutive failures",
+                _BREAKER_THRESHOLD,
+            )
+
+    # -- Recall (prefetch) -----------------------------------------------------
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if self._client is None or not self._config["auto_recall"]:
+            return
+        if self._is_breaker_open() or not (query or "").strip():
+            return
+        cleaned = _clean_text_for_capture(query)[:2000]
+        if not cleaned:
+            return
+
+        def _recall():
+            try:
+                memories = self._client.search(
+                    cleaned,
+                    limit=self._config["max_recall_results"],
+                    score_threshold=self._config["score_threshold"],
+                )
+                with self._lock:
+                    self._prefetch_result = _format_prefetch_context(
+                        memories, self._config["max_recall_results"]
+                    )
+                self._record_success()
+            except Exception:
+                logger.debug("TiMEM prefetch failed", exc_info=True)
+                self._record_failure()
+                with self._lock:
+                    self._prefetch_result = ""
+
+        with self._lock:
+            if self._prefetch_thread and self._prefetch_thread.is_alive():
+                return
+            self._prefetch_thread = threading.Thread(
+                target=_recall, daemon=True, name="timem-prefetch"
+            )
+            self._prefetch_thread.start()
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._client is None or not self._config["auto_recall"]:
+            return ""
+        thread = self._prefetch_thread
+        if thread is None:
+            # No queued recall yet (first turn) — kick one off and wait briefly.
+            self.queue_prefetch(query, session_id=session_id)
+            thread = self._prefetch_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=_PREFETCH_WAIT_SECS)
+        with self._lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+            self._prefetch_thread = None
+        return result
+
+    # -- Capture (sync_turn / mirror) -------------------------------------------
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        if self._client is None or self._read_only or not self._config["auto_capture"]:
+            return
+        if self._is_breaker_open():
+            return
+        user_text = _clean_text_for_capture(user_content)
+        assistant_text = _clean_text_for_capture(assistant_content)
+        if len(user_text) < _MIN_CAPTURE_LENGTH or _is_trivial_message(user_text):
+            return
+        payload = [
+            {"role": "user", "content": user_text},
+            {"role": "assistant", "content": assistant_text},
+        ]
+        sid = session_id or self._session_id
+
+        def _sync():
+            try:
+                self._client.ingest_turn(sid, payload, metadata={"source": "hermes"})
+                self._record_success()
+            except Exception:
+                logger.debug("TiMEM sync_turn failed", exc_info=True)
+                self._record_failure()
+
+        with self._lock:
+            if self._sync_thread and self._sync_thread.is_alive():
+                # Don't stack threads; drop this turn rather than block.
+                return
+            self._sync_thread = threading.Thread(
+                target=_sync, daemon=True, name="timem-sync"
+            )
+            self._sync_thread.start()
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if self._client is None or self._read_only or not self._config["auto_capture"]:
+            return
+        if action == "remove" or self._is_breaker_open():
+            return
+        text = (content or "").strip()
+        if len(text) < _MIN_CAPTURE_LENGTH:
+            return
+
+        def _mirror():
+            try:
+                self._client.add_fact(
+                    {
+                        "type": "hermes_builtin_memory",
+                        "action": action,
+                        "target": target,
+                        "text": text,
+                    },
+                    tags=["hermes", "builtin-memory"],
+                    session_id=self._session_id or None,
+                )
+                self._record_success()
+            except Exception:
+                logger.debug("TiMEM on_memory_write mirror failed", exc_info=True)
+                self._record_failure()
+
+        threading.Thread(target=_mirror, daemon=True, name="timem-mirror").start()
+
+    # -- Tools -------------------------------------------------------------------
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [SEARCH_SCHEMA, ADD_SCHEMA, PROFILE_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if self._client is None:
+            err = self._init_error or "not initialized"
+            return json.dumps({"error": f"TiMEM client not initialized: {err}"})
+        if self._is_breaker_open():
+            return json.dumps({
+                "error": "TiMEM temporarily unavailable (multiple consecutive "
+                         "failures). Will retry automatically."
+            })
+
+        if tool_name == "timem_search":
+            query = (args.get("query") or "").strip()
+            if not query:
+                return tool_error("Missing required parameter: query")
+            try:
+                limit = max(1, min(int(args.get("limit", self._config["max_recall_results"])), 20))
+            except Exception:
+                limit = self._config["max_recall_results"]
+            try:
+                memories = self._client.search(
+                    query, limit=limit,
+                    score_threshold=self._config["score_threshold"],
+                )
+                self._record_success()
+                if not memories:
+                    return json.dumps({"result": "No relevant memories found."})
+                return json.dumps(
+                    {"results": memories, "count": len(memories)},
+                    ensure_ascii=False,
+                )
+            except Exception as e:
+                self._record_failure()
+                return tool_error(f"TiMEM search failed: {str(e)[:200]}")
+
+        elif tool_name == "timem_add":
+            content = (args.get("content") or "").strip()
+            if not content:
+                return tool_error("Missing required parameter: content")
+            tags = args.get("tags")
+            if not isinstance(tags, list):
+                tags = None
+            else:
+                tags = [str(t) for t in tags if t][:10]
+            try:
+                result = self._client.add_fact(
+                    {"type": "explicit_fact", "text": content},
+                    tags=(tags or []) + ["hermes"],
+                    session_id=self._session_id or None,
+                )
+                self._record_success()
+                memory_id = ""
+                if isinstance(result, dict):
+                    memory_id = str(result.get("id") or result.get("memory_id") or "")
+                return json.dumps({"result": "Fact stored.", "id": memory_id})
+            except Exception as e:
+                self._record_failure()
+                return tool_error(f"TiMEM store failed: {str(e)[:200]}")
+
+        elif tool_name == "timem_profile":
+            try:
+                profile = self._client.get_profile()
+                self._record_success()
+                if not profile:
+                    return json.dumps({"result": "No profile computed yet."})
+                return json.dumps({"profile": profile}, ensure_ascii=False)
+            except Exception as e:
+                self._record_failure()
+                return tool_error(f"TiMEM profile fetch failed: {str(e)[:200]}")
+
+        return tool_error(f"Unknown tool: {tool_name}")
+
+    # -- Setup / config -----------------------------------------------------------
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "api_key",
+                "description": "TiMEM API key (from the TiMEM console)",
+                "secret": True,
+                "required": True,
+                "env_var": "TIMEM_API_KEY",
+                "url": _API_KEY_URL,
+            },
+            {
+                "key": "base_url",
+                "description": "TiMEM Engine URL (leave default for TiMEM Cloud)",
+                "default": _DEFAULT_BASE_URL,
+            },
+            {
+                "key": "user_id",
+                "description": "Stable user identifier for memory scoping",
+                "default": _DEFAULT_USER_ID,
+            },
+            {
+                "key": "character_id",
+                "description": "Agent/character identifier (memory namespace per agent)",
+                "default": _DEFAULT_CHARACTER_ID,
+            },
+            {
+                "key": "domain",
+                "description": "Business domain tag for memories",
+                "default": _DEFAULT_DOMAIN,
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        allowed = {"base_url", "user_id", "character_id", "domain",
+                   "max_recall_results", "score_threshold",
+                   "auto_recall", "auto_capture", "api_timeout"}
+        filtered = {k: v for k, v in (values or {}).items() if k in allowed}
+        if filtered:
+            _save_timem_config(filtered, hermes_home)
+
+    def shutdown(self) -> None:
+        for t in (self._prefetch_thread, self._sync_thread):
+            if t and t.is_alive():
+                t.join(timeout=5.0)
+        if self._client:
+            self._client.close()
+            self._client = None
+
+
+def register(ctx) -> None:
+    """Register TiMEM as a memory provider plugin."""
+    ctx.register_memory_provider(TimemMemoryProvider())

--- a/plugins/memory/timem/__init__.py
+++ b/plugins/memory/timem/__init__.py
@@ -20,6 +20,7 @@ The SDK (timem-ai) is lazy-installed on first use via tools/lazy_deps.py.
 from __future__ import annotations
 
 import json
+import inspect
 import logging
 import os
 import re
@@ -39,8 +40,8 @@ _DEFAULT_CHARACTER_ID = "hermes"
 _DEFAULT_USER_ID = "hermes-user"
 _DEFAULT_MAX_RECALL_RESULTS = 8
 _DEFAULT_SCORE_THRESHOLD = 0.5
-_DEFAULT_API_TIMEOUT = 10.0
-_PREFETCH_WAIT_SECS = 3.0
+_DEFAULT_API_TIMEOUT = 60.0
+_PREFETCH_WAIT_SECS = 10.0
 _BREAKER_THRESHOLD = 5
 _BREAKER_COOLDOWN_SECS = 120.0
 _MIN_CAPTURE_LENGTH = 10
@@ -251,7 +252,16 @@ def _is_trivial_message(text: str) -> bool:
 # ─── SDK wrapper ─────────────────────────────────────────────────────────────
 
 class _TimemClient:
-    """Thin wrapper around the timem-ai SDK, lazy-installed on first use."""
+    """Thin, thread-safe wrapper around ONE timem-ai sync client.
+
+    The timem-ai synchronous client wraps an internal asyncio event loop
+    that is NOT thread-safe: concurrent calls from different threads race on
+    the same loop and time out.  We therefore (a) give every ``_TimemClient``
+    its own ``TiMEMClient`` instance (own loop) and (b) serialize calls on
+    this client with a lock.  The provider uses two ``_TimemClient``
+    instances -- one for reads, one for writes -- so a slow write never
+    blocks a recall.
+    """
 
     def __init__(self, api_key: str, base_url: str, timeout: float,
                  user_id: str, character_id: str, domain: str):
@@ -262,66 +272,80 @@ class _TimemClient:
         try:
             from tools.lazy_deps import ensure as _lazy_ensure
             _lazy_ensure("memory.timem", prompt=False)
-        except ImportError:
-            pass
         except Exception:
             pass
         from timem import TiMEMClient
+        # The timem-ai SDK logs verbose Chinese retry/timeout noise to the
+        # console ("请求最终失败 ...") at ERROR level. We own the circuit
+        # breaking and best-effort semantics and log failures ourselves, so
+        # silence the SDK entirely (CRITICAL suppresses even its .error()).
+        logging.getLogger("timem").setLevel(logging.CRITICAL)
 
         self._user_id = user_id
         self._character_id = character_id
         self._domain = domain
+        self._lock = threading.Lock()
         self._client = TiMEMClient(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             max_retries=0,
             verify_ssl=True,
+            enable_monitoring=False,
+            enable_circuit_breaker=False,
         )
 
     def search(self, query: str, *, limit: int, score_threshold: float) -> List[dict]:
-        response = self._client.search_memories(
-            user_id=self._user_id,
-            query_text=query,
-            character_id=self._character_id,
-            score_threshold=score_threshold,
-            limit=limit,
-        )
+        with self._lock:
+            response = self._client.search_memories(
+                user_id=self._user_id,
+                query_text=query,
+                character_id=self._character_id,
+                score_threshold=score_threshold,
+                limit=limit,
+            )
         return _extract_memories(response)
 
     def ingest_turn(self, session_id: str, messages: List[dict],
                     metadata: Optional[dict] = None) -> dict:
         # Async on the server: returns an acceptance with task_id. We do NOT
-        # poll — memory generation completes in the background server-side.
-        return self._client.generate_memory(
-            character_id=self._character_id,
-            session_id=session_id,
-            messages=messages,
-            user_id=self._user_id,
-            domain=self._domain,
-            metadata=metadata,
-        )
+        # poll -- memory generation completes in the background server-side.
+        with self._lock:
+            return self._client.generate_memory(
+                character_id=self._character_id,
+                session_id=session_id,
+                messages=messages,
+                user_id=self._user_id,
+                domain=self._domain,
+                metadata=metadata,
+            )
 
     def add_fact(self, content: dict, *, tags: Optional[List[str]] = None,
                  session_id: Optional[str] = None) -> dict:
-        return self._client.add_memory(
-            user_id=self._user_id,
-            domain=self._domain,
-            content=content,
-            layer_type="L1",
-            tags=tags,
-            session_id=session_id,
-        )
+        with self._lock:
+            return self._client.add_memory(
+                user_id=self._user_id,
+                domain=self._domain,
+                content=content,
+                layer_type="L1",
+                tags=tags,
+                session_id=session_id,
+            )
 
     def get_profile(self) -> dict:
-        result = self._client.get_profile(
-            user_id=self._user_id, expert_id=self._character_id,
-        )
+        with self._lock:
+            result = self._client.get_profile(
+                user_id=self._user_id, expert_id=self._character_id,
+            )
         return result if isinstance(result, dict) else {}
 
     def close(self) -> None:
         try:
-            self._client.close()
+            cl = getattr(self._client, "close", None)
+            # The timem-ai sync client exposes an async close(); calling it
+            # without awaiting emits a RuntimeWarning and leaks the coroutine.
+            if cl is not None and not inspect.iscoroutinefunction(cl):
+                cl()
         except Exception:
             pass
 
@@ -381,7 +405,8 @@ class TimemMemoryProvider(MemoryProvider):
     """TiMEM temporal-hierarchical memory provider."""
 
     def __init__(self):
-        self._client: Optional[_TimemClient] = None
+        self._read_client: Optional[_TimemClient] = None
+        self._write_client: Optional[_TimemClient] = None
         self._config: dict = _default_config()
         self._session_id = ""
         self._read_only = False
@@ -428,7 +453,17 @@ class TimemMemoryProvider(MemoryProvider):
 
         api_key = os.environ.get("TIMEM_API_KEY", "").strip()
         try:
-            self._client = _TimemClient(
+            self._read_client = _TimemClient(
+                api_key=api_key,
+                base_url=_resolve_base_url(self._config["base_url"]),
+                timeout=self._config["api_timeout"],
+                user_id=user_id,
+                character_id=character_id,
+                domain=self._config["domain"],
+            )
+            # Writes use a SEPARATE client/event loop so a slow server-side
+            # generation never blocks recalls on the read client.
+            self._write_client = _TimemClient(
                 api_key=api_key,
                 base_url=_resolve_base_url(self._config["base_url"]),
                 timeout=self._config["api_timeout"],
@@ -438,12 +473,13 @@ class TimemMemoryProvider(MemoryProvider):
             )
             self._init_error = ""
         except Exception as exc:
-            self._client = None
+            self._read_client = None
+            self._write_client = None
             self._init_error = str(exc).strip()[:200] or "client construction failed"
             logger.warning("TiMEM client init failed: %s", self._init_error)
 
     def system_prompt_block(self) -> str:
-        if self._client is None:
+        if self._read_client is None:
             return ""
         return (
             "## TiMEM Long-Term Memory\n"
@@ -478,7 +514,7 @@ class TimemMemoryProvider(MemoryProvider):
     # -- Recall (prefetch) -----------------------------------------------------
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
-        if self._client is None or not self._config["auto_recall"]:
+        if self._read_client is None or not self._config["auto_recall"]:
             return
         if self._is_breaker_open() or not (query or "").strip():
             return
@@ -488,7 +524,7 @@ class TimemMemoryProvider(MemoryProvider):
 
         def _recall():
             try:
-                memories = self._client.search(
+                memories = self._read_client.search(
                     cleaned,
                     limit=self._config["max_recall_results"],
                     score_threshold=self._config["score_threshold"],
@@ -513,7 +549,7 @@ class TimemMemoryProvider(MemoryProvider):
             self._prefetch_thread.start()
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        if self._client is None or not self._config["auto_recall"]:
+        if self._read_client is None or not self._config["auto_recall"]:
             return ""
         thread = self._prefetch_thread
         if thread is None:
@@ -538,7 +574,7 @@ class TimemMemoryProvider(MemoryProvider):
         session_id: str = "",
         messages: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
-        if self._client is None or self._read_only or not self._config["auto_capture"]:
+        if self._write_client is None or self._read_only or not self._config["auto_capture"]:
             return
         if self._is_breaker_open():
             return
@@ -554,7 +590,7 @@ class TimemMemoryProvider(MemoryProvider):
 
         def _sync():
             try:
-                self._client.ingest_turn(sid, payload, metadata={"source": "hermes"})
+                self._write_client.ingest_turn(sid, payload, metadata={"source": "hermes"})
                 self._record_success()
             except Exception:
                 logger.debug("TiMEM sync_turn failed", exc_info=True)
@@ -576,7 +612,7 @@ class TimemMemoryProvider(MemoryProvider):
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        if self._client is None or self._read_only or not self._config["auto_capture"]:
+        if self._write_client is None or self._read_only or not self._config["auto_capture"]:
             return
         if action == "remove" or self._is_breaker_open():
             return
@@ -586,7 +622,7 @@ class TimemMemoryProvider(MemoryProvider):
 
         def _mirror():
             try:
-                self._client.add_fact(
+                self._write_client.add_fact(
                     {
                         "type": "hermes_builtin_memory",
                         "action": action,
@@ -609,7 +645,7 @@ class TimemMemoryProvider(MemoryProvider):
         return [SEARCH_SCHEMA, ADD_SCHEMA, PROFILE_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
-        if self._client is None:
+        if self._read_client is None and self._write_client is None:
             err = self._init_error or "not initialized"
             return json.dumps({"error": f"TiMEM client not initialized: {err}"})
         if self._is_breaker_open():
@@ -622,12 +658,14 @@ class TimemMemoryProvider(MemoryProvider):
             query = (args.get("query") or "").strip()
             if not query:
                 return tool_error("Missing required parameter: query")
+            if self._read_client is None:
+                return tool_error("TiMEM read client not initialized")
             try:
                 limit = max(1, min(int(args.get("limit", self._config["max_recall_results"])), 20))
             except Exception:
                 limit = self._config["max_recall_results"]
             try:
-                memories = self._client.search(
+                memories = self._read_client.search(
                     query, limit=limit,
                     score_threshold=self._config["score_threshold"],
                 )
@@ -646,29 +684,40 @@ class TimemMemoryProvider(MemoryProvider):
             content = (args.get("content") or "").strip()
             if not content:
                 return tool_error("Missing required parameter: content")
+            if self._write_client is None:
+                return tool_error("TiMEM write client not initialized")
             tags = args.get("tags")
             if not isinstance(tags, list):
                 tags = None
             else:
                 tags = [str(t) for t in tags if t][:10]
-            try:
-                result = self._client.add_fact(
-                    {"type": "explicit_fact", "text": content},
-                    tags=(tags or []) + ["hermes"],
-                    session_id=self._session_id or None,
-                )
-                self._record_success()
-                memory_id = ""
-                if isinstance(result, dict):
-                    memory_id = str(result.get("id") or result.get("memory_id") or "")
-                return json.dumps({"result": "Fact stored.", "id": memory_id})
-            except Exception as e:
-                self._record_failure()
-                return tool_error(f"TiMEM store failed: {str(e)[:200]}")
+            # Fired into the background: TiMEM generates memory server-side
+            # (async, can be slow), so we never block the turn on it.
+            sid = self._session_id or None
+
+            def _add():
+                try:
+                    self._write_client.add_fact(
+                        {"type": "explicit_fact", "text": content},
+                        tags=(tags or []) + ["hermes"],
+                        session_id=sid,
+                    )
+                    self._record_success()
+                except Exception:
+                    logger.debug("TiMEM add_fact failed", exc_info=True)
+                    self._record_failure()
+
+            threading.Thread(target=_add, daemon=True, name="timem-add").start()
+            return json.dumps({
+                "result": "Fact submitted to TiMEM for async generation.",
+                "queued": True,
+            })
 
         elif tool_name == "timem_profile":
+            if self._read_client is None:
+                return tool_error("TiMEM read client not initialized")
             try:
-                profile = self._client.get_profile()
+                profile = self._read_client.get_profile()
                 self._record_success()
                 if not profile:
                     return json.dumps({"result": "No profile computed yet."})
@@ -725,9 +774,11 @@ class TimemMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        if self._client:
-            self._client.close()
-            self._client = None
+        for client in (self._read_client, self._write_client):
+            if client:
+                client.close()
+        self._read_client = None
+        self._write_client = None
 
 
 def register(ctx) -> None:

--- a/plugins/memory/timem/plugin.yaml
+++ b/plugins/memory/timem/plugin.yaml
@@ -1,0 +1,5 @@
+name: timem
+version: 1.0.0
+description: "TiMEM — temporal-hierarchical layered memory (L1 raw interactions to L5 persona) with server-side memory generation, semantic recall, and computed user profiles."
+pip_dependencies:
+  - timem-ai==0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,12 +177,13 @@ voice = [
 ]
 honcho = ["honcho-ai==2.2.0"]
 # Cloud memory providers — opt-in, lazy-installed via tools/lazy_deps.py
-# (memory.supermemory / memory.mem0) at first use. Exact pins MUST match the
+# (memory.supermemory / memory.mem0 / memory.timem) at first use. Exact pins MUST match the
 # LAZY_DEPS pins (enforced by tests/test_project_metadata.py). Deliberately
 # excluded from [all] like honcho/hindsight so a quarantined upstream release
 # can't break fresh installs.
 supermemory = ["supermemory==3.50.0"]
 mem0 = ["mem0ai==2.0.10"]
+timem = ["timem-ai==0.4.0"]
 # Image resize recovery for the vision tools. Pillow is now a CORE dependency
 # (see the main `dependencies` list above) since the byte/pixel shrink paths are on
 # the default vision-embed path and the mid-session lazy install deadlocked the

--- a/tests/plugins/memory/test_timem_provider.py
+++ b/tests/plugins/memory/test_timem_provider.py
@@ -1,0 +1,299 @@
+import json
+import threading
+
+import pytest
+
+from plugins.memory.timem import (
+    TimemMemoryProvider,
+    _clean_text_for_capture,
+    _extract_memories,
+    _format_prefetch_context,
+    _load_timem_config,
+    _save_timem_config,
+)
+
+
+class FakeClient:
+    def __init__(self, api_key: str, base_url: str, timeout: float,
+                 user_id: str, character_id: str, domain: str):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.timeout = timeout
+        self.user_id = user_id
+        self.character_id = character_id
+        self.domain = domain
+        self.search_results = []
+        self.search_calls = []
+        self.ingest_calls = []
+        self.add_calls = []
+        self.profile_response = {}
+        self.closed = False
+
+    def search(self, query, *, limit, score_threshold):
+        self.search_calls.append({"query": query, "limit": limit,
+                                  "score_threshold": score_threshold})
+        return self.search_results
+
+    def ingest_turn(self, session_id, messages, metadata=None):
+        self.ingest_calls.append({"session_id": session_id,
+                                  "messages": messages, "metadata": metadata})
+        return {"task_id": "task_1"}
+
+    def add_fact(self, content, *, tags=None, session_id=None):
+        self.add_calls.append({"content": content, "tags": tags,
+                               "session_id": session_id})
+        return {"id": "mem_1"}
+
+    def get_profile(self):
+        return self.profile_response
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def provider(monkeypatch, tmp_path):
+    monkeypatch.setenv("TIMEM_API_KEY", "test-key")
+    monkeypatch.setattr("plugins.memory.timem._TimemClient", FakeClient)
+    p = TimemMemoryProvider()
+    p.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    return p
+
+
+def _join_worker_threads(p):
+    for t in (p._prefetch_thread, p._sync_thread):
+        if t and t.is_alive():
+            t.join(timeout=5.0)
+    # mirror threads are fire-and-forget; give them a beat
+    for t in threading.enumerate():
+        if t.name == "timem-mirror":
+            t.join(timeout=5.0)
+
+
+# ─── Availability ────────────────────────────────────────────────────────────
+
+def test_is_available_false_without_api_key(monkeypatch):
+    monkeypatch.delenv("TIMEM_API_KEY", raising=False)
+    assert TimemMemoryProvider().is_available() is False
+
+
+def test_is_available_true_when_import_missing_but_key_set(monkeypatch):
+    # is_available() must NOT gate on the timem SDK being importable — the
+    # SDK is lazy-installed at client construction. Mirrors supermemory/mem0.
+    monkeypatch.setenv("TIMEM_API_KEY", "test-key")
+
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "timem" or name.startswith("timem."):
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert TimemMemoryProvider().is_available() is True
+
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+
+def test_load_and_save_config_round_trip(tmp_path):
+    _save_timem_config({"user_id": "u-42", "auto_capture": False,
+                        "score_threshold": 0.7}, str(tmp_path))
+    cfg = _load_timem_config(str(tmp_path))
+    assert cfg["user_id"] == "u-42"
+    assert cfg["auto_capture"] is False
+    assert cfg["auto_recall"] is True
+    assert cfg["score_threshold"] == 0.7
+
+
+def test_config_clamps_bad_values(tmp_path):
+    _save_timem_config({"max_recall_results": 999, "score_threshold": 5,
+                        "api_timeout": -3}, str(tmp_path))
+    cfg = _load_timem_config(str(tmp_path))
+    assert cfg["max_recall_results"] == 20
+    assert cfg["score_threshold"] == 1.0
+    assert cfg["api_timeout"] == 1.0
+
+
+def test_save_config_filters_unknown_keys(provider, tmp_path):
+    provider.save_config({"user_id": "u-1", "api_key": "should-not-persist",
+                          "evil": "x"}, str(tmp_path))
+    cfg = _load_timem_config(str(tmp_path))
+    assert cfg["user_id"] == "u-1"
+    raw = json.loads((tmp_path / "timem.json").read_text(encoding="utf-8"))
+    assert "api_key" not in raw
+    assert "evil" not in raw
+
+
+# ─── Result normalization ────────────────────────────────────────────────────
+
+def test_extract_memories_handles_shape_variants():
+    assert _extract_memories(None) == []
+    assert _extract_memories({}) == []
+    # {"memories": [...]} with dict content and layer/score aliases
+    out = _extract_memories({"memories": [
+        {"id": "1", "content": {"text": "likes tea"}, "layer": "L3", "retrieval_score": 0.9},
+        {"memory": "works at ACME", "layer_type": "L1", "similarity": 0.6},
+        {"content": ""},  # dropped: no text
+    ]})
+    assert [m["text"] for m in out] == ["likes tea", "works at ACME"]
+    assert out[0]["layer"] == "L3" and out[0]["score"] == 0.9
+    assert out[1]["layer"] == "L1" and out[1]["score"] == 0.6
+    # {"results": [...]} and nested {"data": {"memories": [...]}}
+    assert _extract_memories({"results": ["plain string"]})[0]["text"] == "plain string"
+    assert _extract_memories({"data": {"memories": [{"text": "nested"}]}})[0]["text"] == "nested"
+
+
+def test_format_prefetch_context_dedupes_and_caps():
+    memories = [{"text": "fact A", "layer": "L2", "score": 0.8},
+                {"text": "fact A"},
+                {"text": "fact B"}]
+    block = _format_prefetch_context(memories, max_results=8)
+    assert block.startswith("<timem-context>")
+    assert block.count("fact A") == 1
+    assert "fact B" in block
+    assert "[L2]" in block and "[80%]" in block
+    assert _format_prefetch_context([], 8) == ""
+
+
+def test_clean_text_strips_injected_context():
+    text = "hello\n<timem-context>ignore me</timem-context>\nworld"
+    assert _clean_text_for_capture(text) == "hello\nworld"
+
+
+# ─── Recall / capture ────────────────────────────────────────────────────────
+
+def test_prefetch_returns_formatted_context(provider):
+    provider._client.search_results = [{"text": "user prefers dark mode",
+                                        "layer": "L4", "score": 0.75}]
+    provider.queue_prefetch("what theme should I use for the app?")
+    result = provider.prefetch("what theme should I use for the app?")
+    assert "user prefers dark mode" in result
+    assert provider._client.search_calls  # search actually ran
+
+
+def test_prefetch_strips_previous_injection_from_query(provider):
+    provider.queue_prefetch("<timem-context>old</timem-context>real question here")
+    provider.prefetch("real question here")
+    assert provider._client.search_calls
+    assert "old" not in provider._client.search_calls[0]["query"]
+
+
+def test_sync_turn_submits_cleaned_exchange(provider):
+    provider.sync_turn("I moved to Berlin last month", "Noted — congrats!",
+                       session_id="session-1")
+    _join_worker_threads(provider)
+    assert len(provider._client.ingest_calls) == 1
+    call = provider._client.ingest_calls[0]
+    assert call["session_id"] == "session-1"
+    assert call["messages"][0]["role"] == "user"
+    assert call["messages"][1]["role"] == "assistant"
+
+
+def test_sync_turn_skips_trivial_messages(provider):
+    provider.sync_turn("ok", "Anything else?")
+    provider.sync_turn("short", "too short to capture")
+    _join_worker_threads(provider)
+    assert provider._client.ingest_calls == []
+
+
+def test_sync_turn_skipped_for_non_primary_context(monkeypatch, tmp_path):
+    monkeypatch.setenv("TIMEM_API_KEY", "test-key")
+    monkeypatch.setattr("plugins.memory.timem._TimemClient", FakeClient)
+    p = TimemMemoryProvider()
+    p.initialize("cron-1", hermes_home=str(tmp_path), platform="cron",
+                 agent_context="cron")
+    p.sync_turn("scheduled system prompt content here", "done")
+    _join_worker_threads(p)
+    assert p._client.ingest_calls == []
+
+
+def test_on_memory_write_mirrors_add(provider):
+    provider.on_memory_write("add", "user", "User's birthday is March 3rd")
+    _join_worker_threads(provider)
+    assert len(provider._client.add_calls) == 1
+    call = provider._client.add_calls[0]
+    assert call["content"]["text"] == "User's birthday is March 3rd"
+    assert "builtin-memory" in call["tags"]
+
+
+def test_on_memory_write_ignores_remove(provider):
+    provider.on_memory_write("remove", "user", "some removed entry content")
+    _join_worker_threads(provider)
+    assert provider._client.add_calls == []
+
+
+# ─── Tools ───────────────────────────────────────────────────────────────────
+
+def test_tool_schemas_exposed(provider):
+    names = [s["name"] for s in provider.get_tool_schemas()]
+    assert names == ["timem_search", "timem_add", "timem_profile"]
+
+
+def test_timem_search_tool(provider):
+    provider._client.search_results = [{"text": "fact", "score": 0.9}]
+    result = json.loads(provider.handle_tool_call("timem_search", {"query": "fact"}))
+    assert result["count"] == 1
+    assert result["results"][0]["text"] == "fact"
+
+
+def test_timem_search_tool_requires_query(provider):
+    result = provider.handle_tool_call("timem_search", {})
+    assert "query" in result
+
+
+def test_timem_add_tool(provider):
+    result = json.loads(provider.handle_tool_call(
+        "timem_add", {"content": "likes espresso", "tags": ["prefs"]}))
+    assert result["result"] == "Fact stored."
+    call = provider._client.add_calls[0]
+    assert call["content"]["text"] == "likes espresso"
+    assert "prefs" in call["tags"] and "hermes" in call["tags"]
+
+
+def test_timem_profile_tool(provider):
+    provider._client.profile_response = {"persona": "engineer"}
+    result = json.loads(provider.handle_tool_call("timem_profile", {}))
+    assert result["profile"] == {"persona": "engineer"}
+
+
+def test_unknown_tool_returns_error(provider):
+    result = provider.handle_tool_call("timem_bogus", {})
+    assert "Unknown tool" in result
+
+
+# ─── Circuit breaker ─────────────────────────────────────────────────────────
+
+def test_circuit_breaker_opens_after_failures(provider):
+    def boom(*args, **kwargs):
+        raise RuntimeError("api down")
+
+    provider._client.search = boom
+    for _ in range(5):
+        provider.handle_tool_call("timem_search", {"query": "x"})
+    result = provider.handle_tool_call("timem_search", {"query": "x"})
+    assert "temporarily unavailable" in result
+
+
+def test_circuit_breaker_resets_after_cooldown(provider, monkeypatch):
+    provider._consecutive_failures = 5
+    provider._breaker_opened_at = 0.0  # long ago in monotonic terms
+    monkeypatch.setattr("plugins.memory.timem.time.monotonic", lambda: 1e9)
+    assert provider._is_breaker_open() is False
+
+
+# ─── Setup schema ────────────────────────────────────────────────────────────
+
+def test_config_schema_has_secret_api_key(provider):
+    schema = provider.get_config_schema()
+    by_key = {f["key"]: f for f in schema}
+    assert by_key["api_key"]["secret"] is True
+    assert by_key["api_key"]["env_var"] == "TIMEM_API_KEY"
+    assert by_key["base_url"]["default"] == "https://api.timem.cloud"
+
+
+def test_shutdown_closes_client(provider):
+    client = provider._client
+    provider.shutdown()
+    assert client.closed is True
+    assert provider._client is None

--- a/tests/plugins/memory/test_timem_provider.py
+++ b/tests/plugins/memory/test_timem_provider.py
@@ -64,9 +64,9 @@ def _join_worker_threads(p):
     for t in (p._prefetch_thread, p._sync_thread):
         if t and t.is_alive():
             t.join(timeout=5.0)
-    # mirror threads are fire-and-forget; give them a beat
+    # fire-and-forget mirror / add threads are daemon; give them a beat
     for t in threading.enumerate():
-        if t.name == "timem-mirror":
+        if t.name and t.name.startswith("timem-"):
             t.join(timeout=5.0)
 
 
@@ -164,27 +164,27 @@ def test_clean_text_strips_injected_context():
 # ─── Recall / capture ────────────────────────────────────────────────────────
 
 def test_prefetch_returns_formatted_context(provider):
-    provider._client.search_results = [{"text": "user prefers dark mode",
-                                        "layer": "L4", "score": 0.75}]
+    provider._read_client.search_results = [{"text": "user prefers dark mode",
+                                             "layer": "L4", "score": 0.75}]
     provider.queue_prefetch("what theme should I use for the app?")
     result = provider.prefetch("what theme should I use for the app?")
     assert "user prefers dark mode" in result
-    assert provider._client.search_calls  # search actually ran
+    assert provider._read_client.search_calls  # search actually ran
 
 
 def test_prefetch_strips_previous_injection_from_query(provider):
     provider.queue_prefetch("<timem-context>old</timem-context>real question here")
     provider.prefetch("real question here")
-    assert provider._client.search_calls
-    assert "old" not in provider._client.search_calls[0]["query"]
+    assert provider._read_client.search_calls
+    assert "old" not in provider._read_client.search_calls[0]["query"]
 
 
 def test_sync_turn_submits_cleaned_exchange(provider):
     provider.sync_turn("I moved to Berlin last month", "Noted — congrats!",
                        session_id="session-1")
     _join_worker_threads(provider)
-    assert len(provider._client.ingest_calls) == 1
-    call = provider._client.ingest_calls[0]
+    assert len(provider._write_client.ingest_calls) == 1
+    call = provider._write_client.ingest_calls[0]
     assert call["session_id"] == "session-1"
     assert call["messages"][0]["role"] == "user"
     assert call["messages"][1]["role"] == "assistant"
@@ -194,7 +194,7 @@ def test_sync_turn_skips_trivial_messages(provider):
     provider.sync_turn("ok", "Anything else?")
     provider.sync_turn("short", "too short to capture")
     _join_worker_threads(provider)
-    assert provider._client.ingest_calls == []
+    assert provider._write_client.ingest_calls == []
 
 
 def test_sync_turn_skipped_for_non_primary_context(monkeypatch, tmp_path):
@@ -205,14 +205,14 @@ def test_sync_turn_skipped_for_non_primary_context(monkeypatch, tmp_path):
                  agent_context="cron")
     p.sync_turn("scheduled system prompt content here", "done")
     _join_worker_threads(p)
-    assert p._client.ingest_calls == []
+    assert p._write_client.ingest_calls == []
 
 
 def test_on_memory_write_mirrors_add(provider):
     provider.on_memory_write("add", "user", "User's birthday is March 3rd")
     _join_worker_threads(provider)
-    assert len(provider._client.add_calls) == 1
-    call = provider._client.add_calls[0]
+    assert len(provider._write_client.add_calls) == 1
+    call = provider._write_client.add_calls[0]
     assert call["content"]["text"] == "User's birthday is March 3rd"
     assert "builtin-memory" in call["tags"]
 
@@ -220,7 +220,7 @@ def test_on_memory_write_mirrors_add(provider):
 def test_on_memory_write_ignores_remove(provider):
     provider.on_memory_write("remove", "user", "some removed entry content")
     _join_worker_threads(provider)
-    assert provider._client.add_calls == []
+    assert provider._write_client.add_calls == []
 
 
 # ─── Tools ───────────────────────────────────────────────────────────────────
@@ -231,7 +231,7 @@ def test_tool_schemas_exposed(provider):
 
 
 def test_timem_search_tool(provider):
-    provider._client.search_results = [{"text": "fact", "score": 0.9}]
+    provider._read_client.search_results = [{"text": "fact", "score": 0.9}]
     result = json.loads(provider.handle_tool_call("timem_search", {"query": "fact"}))
     assert result["count"] == 1
     assert result["results"][0]["text"] == "fact"
@@ -242,17 +242,18 @@ def test_timem_search_tool_requires_query(provider):
     assert "query" in result
 
 
-def test_timem_add_tool(provider):
+def test_timem_add_tool_queues_write(provider):
     result = json.loads(provider.handle_tool_call(
         "timem_add", {"content": "likes espresso", "tags": ["prefs"]}))
-    assert result["result"] == "Fact stored."
-    call = provider._client.add_calls[0]
+    assert result["queued"] is True
+    _join_worker_threads(provider)
+    call = provider._write_client.add_calls[0]
     assert call["content"]["text"] == "likes espresso"
     assert "prefs" in call["tags"] and "hermes" in call["tags"]
 
 
 def test_timem_profile_tool(provider):
-    provider._client.profile_response = {"persona": "engineer"}
+    provider._read_client.profile_response = {"persona": "engineer"}
     result = json.loads(provider.handle_tool_call("timem_profile", {}))
     assert result["profile"] == {"persona": "engineer"}
 
@@ -268,7 +269,7 @@ def test_circuit_breaker_opens_after_failures(provider):
     def boom(*args, **kwargs):
         raise RuntimeError("api down")
 
-    provider._client.search = boom
+    provider._read_client.search = boom
     for _ in range(5):
         provider.handle_tool_call("timem_search", {"query": "x"})
     result = provider.handle_tool_call("timem_search", {"query": "x"})
@@ -292,8 +293,11 @@ def test_config_schema_has_secret_api_key(provider):
     assert by_key["base_url"]["default"] == "https://api.timem.cloud"
 
 
-def test_shutdown_closes_client(provider):
-    client = provider._client
+def test_shutdown_closes_clients(provider):
+    read_client = provider._read_client
+    write_client = provider._write_client
     provider.shutdown()
-    assert client.closed is True
-    assert provider._client is None
+    assert read_client.closed is True
+    assert write_client.closed is True
+    assert provider._read_client is None
+    assert provider._write_client is None

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -152,6 +152,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # instance and the provider silently reports itself unavailable.
     "memory.supermemory": ("supermemory==3.50.0",),
     "memory.mem0": ("mem0ai==2.0.10",),
+    "memory.timem": ("timem-ai==0.4.0",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),


### PR DESCRIPTION
## Summary

Adds a new opt-in memory provider for [TiMEM](https://docs.timem.cloud) (temporal-hierarchical memory engine). This is the 9th bundled `plugins/memory` provider, following the existing `MemoryProvider` contract and the same opt-in / lazy-install policy as `mem0`, `supermemory`, `hindsight`, and `honcho`.

TiMEM ingests conversations server-side into a five-level Temporal Memory Tree (L1 raw interactions -> L5 persona); Hermes turns are submitted for generation and recalled via semantic search, injected as `<timem-context>` before each turn.

## What the plugin does

- **Auto recall** — `prefetch()` runs a semantic search over layered memories and injects relevant results as background context. Best-effort: TiMEM serializes generation and retrieval server-side, so a recall concurrent with an in-flight write may be skipped for that one turn; the explicit `timem_search` tool is the reliable path.
- **Auto capture** — `sync_turn()` submits the completed user/assistant exchange for async L1–L5 generation (non-blocking, fire-and-forget).
- **Built-in mirror** — `on_memory_write()` mirrors Hermes built-in memory-tool writes into TiMEM as tagged L1 facts.
- **Tools** — `timem_search` (semantic search), `timem_add` (store explicit fact, also fire-and-forget), `timem_profile` (fetch the computed L5 user profile).
- **Safety** — non-primary agent contexts (cron/flush/subagents) are read-only; a circuit breaker opens after 5 consecutive failures (120s cooldown); trivial turns are not captured.

## Key implementation notes

- The `timem-ai` sync SDK wraps a single asyncio event loop that is **not thread-safe**, so the provider uses two separate `TiMEMClient` instances (read vs write), each internally locked — a slow background write never blocks a recall.
- All writes are fire-and-forget because the server-side `/api/v1/memory/batch` generation is slow but does persist (verified: written turns are later recalled).
- The SDK's verbose timeout logging is silenced (`timem` logger set to CRITICAL; its monitoring/circuit-breaker disabled) since the plugin owns those semantics.

## Config & setup

- `TIMEM_API_KEY` (from console.timem.cloud) — required, read from env / `$HERMES_HOME/.env`.
- Optional `$HERMES_HOME/timem.json`: `user_id`, `character_id`, `domain`, `base_url`, `max_recall_results`, `score_threshold`, `auto_recall`, `auto_capture`, `api_timeout`.
- Works with the generic `hermes memory setup` flow (`get_config_schema()` + `save_config()`); no custom `post_setup` needed.
- `timem-ai` is pinned `==0.4.0` in `tools/lazy_deps.py` (`memory.timem`) and mirrored by the `timem` extra in `pyproject.toml` (excluded from `[all]`, same policy as the other cloud providers).

## Testing

- 25 unit tests (`tests/plugins/memory/test_timem_provider.py`) with a fake client covering availability, config round-trip, result-shape normalization, capture gating, tools, circuit breaker, and the read/write client split.
- Validated `lazy_deps`/`pyproject` pin consistency and that plugin discovery still lists `timem`.
- Live-tested against api.timem.cloud with a real key: writes persist and are recalled; reads return in ~1–2s when no generation is in flight.

🤖 Generated with WorkBuddy
