### PR TITLE
feat(tui): render reasoning in italic for clearer visual distinction

### DIFF
--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -640,7 +640,7 @@ export const Thinking = memo(function Thinking({
         {preview ? (
           mode === 'full' ? (
             lines.map((line, index) => (
-              <Text color={t.color.muted} key={index} wrap="wrap-trim">
+              <Text color={t.color.muted} italic key={index} wrap="wrap-trim">
                 {line || ' '}
                 {index === lines.length - 1 ? (
                   <StreamCursor color={t.color.muted} streaming={streaming} visible={active} />
@@ -648,13 +648,13 @@ export const Thinking = memo(function Thinking({
               </Text>
             ))
           ) : (
-            <Text color={t.color.muted} wrap="truncate-end">
+            <Text color={t.color.muted} italic wrap="truncate-end">
               {preview}
               <StreamCursor color={t.color.muted} streaming={streaming} visible={active} />
             </Text>
           )
         ) : (
-          <Text color={t.color.muted}>
+          <Text color={t.color.muted} italic>
             <StreamCursor color={t.color.muted} streaming={streaming} visible={active} />
           </Text>
         )}


### PR DESCRIPTION
## Summary
The thinking/reasoning panel now renders in **italic + muted grey** instead of
only dim grey. Streamed reasoning is then visually distinct from normal graded
output at a glance — no more guessing whether a block is reasoning or response.

## Why
Currently reasoning and response are both dark-on-light; only a subtle dim/grey
tone separates them. Italic makes the distinction immediate and matches the
convention users already expect from reasoning/thought blocks in other UIs.

## Changes
- `ui-tui/src/components/thinking.tsx`: add `italic` to the three reasoning
  `<Text>` renders (full mode, truncated preview, empty placeholder).
- No behaviour change — only text style. Prompt-cache safe (no schema/system
  prompt touch).

## Test plan
- `npx tsc --noEmit` clean, `npm run build` succeeds.
- Manual: `hermes --tui` with a reasoning-capable model shows italic reasoning.