### PR TITLE
fix: ensure web_tools module is imported early

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -24,6 +24,7 @@ Usage:
 """
 
 from typing import List, Dict, Any, Set, Optional
+from tools import web_tools  # ensure web_search/web_extract handlers are registered early
 
 
 # Shared tool list for CLI and all messaging platform toolsets.


### PR DESCRIPTION
## Problem

When the gateway server (`hermes serve`) starts, `model_tools.py` is not always imported. This means `discover_builtin_tools()` never runs and `tools/web_tools.py`'s `registry.register()` calls are never executed.

Result: `web_search` and `web_extract` handlers are missing from the tool registry, causing them to return empty results while the underlying backend (bocha, firecrawl, etc.) is fully configured.

## Fix

Add `from tools import web_tools` as an early import in `toolsets.py`. Since `toolsets.py` is a dependency of `model_tools.py`, this ensures the web tools module is imported and its handlers registered before any tool dispatch occurs.

## Verification

- `registry.get_entry("web_search")` returns the registered handler after importing `toolsets`
- `registry.dispatch("web_search", {"query": "test", "limit": 3})` returns real results
- Single line addition, no side effects on existing functionality