### PR TITLE
chore: add * text=auto to .gitattributes for cross-platform line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Normalise all text files to LF in the repo (platform-native on checkout).
+* text=auto
+
 # Auto-generated files — collapse diffs and exclude from language stats
 web/package-lock.json linguist-generated=true
 


### PR DESCRIPTION
Sets the standard Git attribute for cross-platform repos — auto-detects text vs binary files and normalises text files to LF in the index while preserving platform-native line endings on checkout.

Prevents the 500-file CRLF → LF false-diff that occurs when Windows tools rewrite tracked files.