### PR TITLE
fix(desktop): reuse global remote backend across profiles

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -35,6 +35,7 @@ import {
   profileHasRemoteConnection,
   profileRemoteOverride,
   profileSshOverride,
+  profileUsesPrimaryBackend,
   resolveAuthMode,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
@@ -185,6 +186,44 @@ test('saved SSH drafts are inactive and explicit overrides take precedence', () 
   config.profiles.coder = { mode: 'ssh', host: 'active' }
   assert.deepEqual(profileSshOverride(config, 'coder'), { mode: 'ssh', host: 'active' })
   assert.equal(profileHasRemoteConnection(config, 'coder'), true)
+})
+
+// --- profileUsesPrimaryBackend ---
+
+test('profileUsesPrimaryBackend keeps primary and empty scopes on the window backend', () => {
+  assert.equal(profileUsesPrimaryBackend('default', { primaryProfile: 'default' }), true)
+  assert.equal(profileUsesPrimaryBackend(' coder ', { primaryProfile: 'coder' }), true)
+  assert.equal(profileUsesPrimaryBackend('', { primaryProfile: 'default' }), true)
+})
+
+test('profileUsesPrimaryBackend shares one app-global remote across profiles', () => {
+  assert.equal(
+    profileUsesPrimaryBackend('coder', {
+      primaryProfile: 'default',
+      globalRemote: true,
+      profileRemoteOverride: false
+    }),
+    true
+  )
+})
+
+test('profileUsesPrimaryBackend preserves profile overrides and local profile backends', () => {
+  assert.equal(
+    profileUsesPrimaryBackend('coder', {
+      primaryProfile: 'default',
+      globalRemote: true,
+      profileRemoteOverride: true
+    }),
+    false
+  )
+  assert.equal(
+    profileUsesPrimaryBackend('coder', {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false
+    }),
+    false
+  )
 })
 
 // --- pathWithGlobalRemoteProfile ---

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -351,6 +351,24 @@ function profileRemoteOverride(config, profile) {
 }
 
 /**
+ * Decide whether a profile should reuse the primary backend connection.
+ *
+ * The primary profile always owns the window backend. In app-global remote
+ * mode, that same backend serves every profile through request-level profile
+ * scoping, unless a profile has its own remote connection override.
+ */
+function profileUsesPrimaryBackend(profile, opts: any = {}) {
+  const scopedProfile = connectionScopeKey(profile)
+  const primaryProfile = connectionScopeKey(opts.primaryProfile) || 'default'
+
+  if (!scopedProfile || scopedProfile === primaryProfile) {
+    return true
+  }
+
+  return Boolean(opts.globalRemote) && !opts.profileRemoteOverride
+}
+
+/**
  * In global-remote mode one backend serves every Desktop profile, so REST calls
  * that are scoped by renderer-side `request.profile` must carry that scope as a
  * query parameter. Local pooled backends and per-profile remote overrides do not
@@ -505,6 +523,7 @@ export {
   profileHasRemoteConnection,
   profileRemoteOverride,
   profileSshOverride,
+  profileUsesPrimaryBackend,
   resolveAuthMode,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -63,6 +63,7 @@ import {
   profileHasRemoteConnection,
   profileRemoteOverride,
   profileSshOverride,
+  profileUsesPrimaryBackend,
   resolveAuthMode,
   resolveTestWsUrl,
   savedProfileSsh,
@@ -7726,15 +7727,33 @@ function primaryProfileKey() {
   return readActiveDesktopProfile() || 'default'
 }
 
-// Resolve a backend connection for the given profile. Routes the primary
-// profile to startHermes() (the window backend: boot UI, bootstrap, remote
-// mode), and any OTHER profile to a lazily-spawned pool backend. An empty /
-// unknown profile resolves to the primary, so all legacy callers are unchanged.
+// Resolve a backend connection for the given profile. The primary profile uses
+// startHermes() (the window backend: boot UI, bootstrap, remote mode). Profiles
+// inheriting an app-global remote share that same connection because the remote
+// backend scopes their requests by profile. Other profiles use lazily-spawned
+// pool backends. An empty / unknown profile resolves to the primary.
 async function ensureBackend(profile) {
-  const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
+  const primaryProfile = primaryProfileKey()
+  const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfile
 
-  if (key === primaryProfileKey()) {
+  if (key === primaryProfile) {
     return startHermes()
+  }
+
+  if (
+    globalRemoteActive() &&
+    profileUsesPrimaryBackend(key, {
+      primaryProfile,
+      globalRemote: true,
+      profileRemoteOverride: profileHasRemoteOverride(key)
+    })
+  ) {
+    const connection = await startHermes()
+
+    // Non-primary global-remote profiles still need their scope on the
+    // descriptor so renderer-side WebSocket, filesystem, and cache routing use
+    // the selected profile while sharing the one underlying backend.
+    return { ...connection, profile: key }
   }
 
   const existing = backendPool.get(key)


### PR DESCRIPTION
## What does this PR do?

App-global remote mode uses one backend for every Desktop profile, with the selected profile carried separately on scoped requests and the connection descriptor. `ensureBackend()` still put every non-primary profile into `backendPool`, though, even when the profile inherited that one global remote. Those processless pool entries were later reaped as idle, causing repeated remote probes, ready logs, and `Reaping idle profile backend` churn.

This ports the remaining global-remote pool behavior from #58108 onto the current TypeScript Electron main process. Non-primary profiles that inherit the app-global remote now reuse `startHermes()` and receive a descriptor tagged with their selected profile. Local profiles and profiles with explicit remote overrides keep their existing pool behavior.

The routing decision is extracted into a pure helper with behavioral coverage. Rodrigo Fernandez's contribution from #58108 is preserved in the commit trailer.

## Related Issue

Related: #58108

Complements #61033. That PR avoids local profile REST backend spawns but intentionally keeps app-global remote profiles routed by profile descriptor; this PR makes those inherited global-remote descriptors share the primary backend without absorbing the local-routing change.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Added `profileUsesPrimaryBackend()` in `apps/desktop/electron/connection-config.ts` to make the shared-backend routing contract explicit and testable.
- Updated `apps/desktop/electron/main.ts` so non-primary profiles inheriting an app-global remote reuse the primary connection before any `backendPool` lookup or registration.
- Preserved the requested profile on the shared descriptor so WebSocket, filesystem, and cache routing retain the active profile scope.
- Added behavioral coverage for primary, inherited global-remote, explicit remote-override, and local profile routes.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. From `apps/desktop`, run `npx vitest run --project electron electron/connection-config.test.ts --maxWorkers=4`.
2. Run `npm run typecheck`.
3. Run `npx eslint electron/connection-config.ts electron/connection-config.test.ts electron/main.ts` and `npx prettier --check electron/connection-config.ts electron/connection-config.test.ts electron/main.ts`.
4. In app-global remote mode, request a non-primary profile connection and verify it retains that profile on the descriptor without creating a reapable pool backend. Confirm local profiles and explicit per-profile remote overrides still take their dedicated routes.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused local validation on Windows 11:

- `connection-config.test.ts`: 67 tests passed
- Full Desktop `npm run typecheck`: passed
- Changed-file Electron TypeScript check: passed
- Changed-file ESLint: passed
- Changed-file Prettier check: passed

The full repository suite is left to GitHub CI.
