### PR TITLE
fix(install): warn before Homebrew package changes

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,6 +70,7 @@ DETECTED_BROWSER_EXECUTABLE=""
 USE_VENV=true
 RUN_SETUP=true
 SKIP_BROWSER=false
+SKIP_SYSTEM_PACKAGES=false
 NO_SKILLS=false
 BRANCH="main"
 INSTALL_COMMIT=""
@@ -103,6 +104,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-browser|--no-playwright)
             SKIP_BROWSER=true
+            shift
+            ;;
+        --skip-system-packages)
+            SKIP_SYSTEM_PACKAGES=true
             shift
             ;;
         --no-skills)
@@ -160,6 +165,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --no-venv      Don't create virtual environment"
             echo "  --skip-setup   Skip interactive setup wizard"
             echo "  --skip-browser Skip Playwright/Chromium install (browser tools won't work)"
+            echo "  --skip-system-packages  Don't install optional OS packages (ripgrep/ffmpeg)"
             echo "  --no-skills    Start with a blank slate — seed no bundled skills, and"
             echo "                   write \$HERMES_HOME/.no-bundled-skills so future"
             echo "                   'hermes update' runs never inject bundled skills either"
@@ -1039,9 +1045,19 @@ install_system_packages() {
     local description
     description=$(IFS=" and "; echo "${desc_parts[*]}")
 
+    if [ "$SKIP_SYSTEM_PACKAGES" = true ]; then
+        log_warn "Skipping automatic installation of optional system packages: ${pkgs[*]}"
+        [ "$need_ripgrep" = true ] && show_manual_install_hint "ripgrep"
+        [ "$need_ffmpeg" = true ] && show_manual_install_hint "ffmpeg"
+        return 0
+    fi
+
     # ── macOS: brew ──
     if [ "$OS" = "macos" ]; then
         if command -v brew &> /dev/null; then
+            log_warn "Homebrew is about to install missing optional packages: ${pkgs[*]}"
+            log_info "Homebrew may also install or update transitive dependencies."
+            log_info "Re-run with --skip-system-packages to manage these packages yourself."
             log_info "Installing ${pkgs[*]} via Homebrew..."
             if brew install "${pkgs[@]}"; then
                 [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"

--- a/tests/test_install_sh_macos_system_packages.py
+++ b/tests/test_install_sh_macos_system_packages.py
@@ -1,0 +1,89 @@
+"""Behavior coverage for macOS optional-package installation (#72730)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+@pytest.fixture
+def macos_package_harness(tmp_path: Path) -> tuple[str, dict[str, str], Path]:
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise install.sh")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    brew_log = tmp_path / "brew.log"
+
+    _write_executable(fake_bin / "uname", "printf 'Darwin\\n'")
+    _write_executable(fake_bin / "tr", "IFS= read -r line; printf '%s\\n' \"$line\"")
+    _write_executable(
+        fake_bin / "brew",
+        "printf '%s\\n' \"$*\" >> \"$BREW_LOG\"",
+    )
+
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "HERMES_HOME": str(tmp_path / "hermes-home"),
+        "PATH": str(fake_bin),
+        "BREW_LOG": str(brew_log),
+    }
+    return bash, env, brew_log
+
+
+def _run_ensure_ripgrep(
+    harness: tuple[str, dict[str, str], Path], *args: str
+) -> subprocess.CompletedProcess[str]:
+    bash, env, _ = harness
+    return subprocess.run(
+        [bash, str(INSTALL_SH), "--ensure", "ripgrep", *args],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def test_macos_warns_before_homebrew_installs_optional_packages(
+    macos_package_harness: tuple[str, dict[str, str], Path],
+) -> None:
+    result = _run_ensure_ripgrep(macos_package_harness)
+    _, _, brew_log = macos_package_harness
+
+    assert result.returncode == 0, result.stderr
+    assert "Homebrew is about to install missing optional packages" in result.stdout
+    assert "may also install or update transitive dependencies" in result.stdout
+    assert "--skip-system-packages" in result.stdout
+    assert brew_log.read_text(encoding="utf-8").strip() == "install ripgrep ffmpeg"
+
+
+def test_skip_system_packages_prevents_homebrew_changes(
+    macos_package_harness: tuple[str, dict[str, str], Path],
+) -> None:
+    result = _run_ensure_ripgrep(
+        macos_package_harness,
+        "--skip-system-packages",
+    )
+    _, _, brew_log = macos_package_harness
+
+    assert result.returncode == 0, result.stderr
+    assert "Skipping automatic installation of optional system packages" in result.stdout
+    assert "brew install ripgrep" in result.stdout
+    assert "brew install ffmpeg" in result.stdout
+    assert not brew_log.exists()

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -98,6 +98,22 @@ That logs you in, sets Nous as your provider, and turns on the Tool Gateway in o
 You do **not** need to install Python, Node.js, ripgrep, or ffmpeg manually. The installer detects what's missing and installs it for you. Just make sure `git` is available (`git --version`). On Linux, ensure `curl` and `xz-utils` are installed (`sudo apt install curl xz-utils` on Debian/Ubuntu). For the desktop app, also install `build-essential` (`sudo apt install build-essential`).
 :::
 
+:::tip Managing macOS packages yourself
+On macOS, the installer prints the missing optional packages before running
+Homebrew because `brew install` may also install or update transitive
+dependencies. To keep `ripgrep` and `ffmpeg` under your own package manager's
+control, skip those optional changes:
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-system-packages
+```
+
+The installer will continue and print manual install commands. This option only
+skips the optional OS packages; Git remains a prerequisite. Existing compatible
+Python and Node.js installations (including pyenv/fnm-managed versions available
+on `PATH`) are reused instead of replaced.
+:::
+
 :::tip Nix users
 Nix is **no longer an explicitly supported install path** (best-effort only). If you already use Nix (on NixOS, macOS, or Linux), there's a dedicated setup path with a Nix flake, declarative NixOS module, and optional container mode. See the **[Nix & NixOS Setup](./nix-setup.md)** guide.
 :::


### PR DESCRIPTION
## What does this PR do?

Warns macOS users before the installer invokes Homebrew for missing optional packages, and adds an explicit opt-out for users who manage those dependencies themselves.

## Root cause

`install_system_packages()` detected missing `ripgrep` / `ffmpeg` and immediately ran `brew install` on macOS. Unlike the sudo-based Linux path, it did not explain that Homebrew may install or update transitive dependencies, and the installer exposed no way to skip those optional package-manager changes.

## Changes

- Print the exact missing optional packages before invoking Homebrew.
- Warn that Homebrew may install or update transitive dependencies.
- Add `--skip-system-packages` to leave `ripgrep` and `ffmpeg` under the user's package-management control.
- Keep the existing default install behavior for compatibility.
- Add behavioral regression tests that execute the real `install.sh --ensure ripgrep` path against an isolated fake macOS/Homebrew environment.
- Document the macOS package-management behavior, opt-out command, and interaction with existing compatible pyenv/fnm environments.

## User impact

Users with Homebrew, fnm, pyenv, or other environment-management preferences can see the package-manager impact before it happens and can re-run with `--skip-system-packages` to avoid optional OS-package changes. When skipped, the installer prints manual install commands and continues because these packages are optional.

Fixes #72730

## Validation

- `bash -n scripts/install.sh`
- `scripts/run_tests.sh tests/test_install_sh_macos_system_packages.py -q` — 2 passed
- `python -m ruff check tests/test_install_sh_macos_system_packages.py`
- `git diff --check`

The broader `tests/test_install_sh_*.py` run is blocked on this zh-CN Windows host by pre-existing tests that call `Path.read_text()` without an encoding and therefore decode the UTF-8 installer as GBK; the new behavior tests pass under the same runner.
