### PR TITLE
Harden Windows installer checkout failures

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1419,6 +1419,10 @@ function Install-Repository {
         if (Test-Path "$InstallDir\.git") {
             Push-Location $InstallDir
             try {
+                # Git for Windows keeps long-path support disabled unless the
+                # repository opts in. Enable it before status/checkout touches
+                # paths that can exceed MAX_PATH in a nested install location.
+                git -c windows.appendAtomically=false config core.longpaths true 2>$null
                 # Reset $LASTEXITCODE before the probe so we don't pick up
                 # a stale 0 from an earlier git call in this session.
                 $global:LASTEXITCODE = 0
@@ -1640,7 +1644,7 @@ function Install-Repository {
         Write-Info "Trying SSH clone..."
         $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
         try {
-            Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir }
+            Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false -c core.longpaths=true clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir }
             if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
         } catch { }
         $env:GIT_SSH_COMMAND = $null
@@ -1649,7 +1653,7 @@ function Install-Repository {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
             Write-Info "SSH failed, trying HTTPS..."
             try {
-                Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir }
+                Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false -c core.longpaths=true clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir }
                 if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
             } catch { }
         }
@@ -1694,6 +1698,7 @@ function Install-Repository {
                     Push-Location $InstallDir
                     git -c windows.appendAtomically=false init 2>$null
                     git -c windows.appendAtomically=false config windows.appendAtomically false 2>$null
+                    git -c windows.appendAtomically=false config core.longpaths true 2>$null
                     # Pin autocrlf=false BEFORE the checkout below. Git for Windows
                     # defaults to core.autocrlf=true, which would renormalize the
                     # repo's LF text files to CRLF in the working tree during
@@ -1756,6 +1761,7 @@ function Install-Repository {
     # Set per-repo config (harmless if it fails)
     Push-Location $InstallDir
     git -c windows.appendAtomically=false config windows.appendAtomically false 2>$null
+    git -c windows.appendAtomically=false config core.longpaths true 2>$null
     # Pin autocrlf=false on the managed clone so git never renormalizes the
     # repo's LF text files to CRLF in the working tree. Without this, the very
     # next `hermes update` checkout aborts on a "dirty" tree the user never
@@ -3827,4 +3833,5 @@ try {
     Write-Host "  Invoke-WebRequest -Uri 'https://hermes-agent.nousresearch.com/install.ps1' -OutFile install.ps1" -ForegroundColor Yellow
     Write-Host "  .\install.ps1" -ForegroundColor Yellow
     Write-Host ""
+    throw
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2121,6 +2121,10 @@ function Install-Repository {
         if (Test-Path "$InstallDir\.git") {
             Push-Location $InstallDir
             try {
+                # Git for Windows keeps long-path support disabled unless the
+                # repository opts in. Enable it before status/checkout touches
+                # paths that can exceed MAX_PATH in a nested install location.
+                git -c windows.appendAtomically=false config core.longpaths true 2>$null
                 # Reset $LASTEXITCODE before the probe so we don't pick up
                 # a stale 0 from an earlier git call in this session.
                 $global:LASTEXITCODE = 0
@@ -2366,7 +2370,7 @@ function Install-Repository {
         Write-Info "Trying SSH clone..."
         $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
         try {
-            Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir }
+            Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false -c core.longpaths=true clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir }
             if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
         } catch { }
         $env:GIT_SSH_COMMAND = $null
@@ -2375,7 +2379,7 @@ function Install-Repository {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
             Write-Info "SSH failed, trying HTTPS..."
             try {
-                Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir }
+                Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false -c core.longpaths=true clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir }
                 if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
             } catch { }
         }
@@ -2420,6 +2424,7 @@ function Install-Repository {
                     Push-Location $InstallDir
                     git -c windows.appendAtomically=false init 2>$null
                     git -c windows.appendAtomically=false config windows.appendAtomically false 2>$null
+                    git -c windows.appendAtomically=false config core.longpaths true 2>$null
                     # Pin autocrlf=false BEFORE the checkout below. Git for Windows
                     # defaults to core.autocrlf=true, which would renormalize the
                     # repo's LF text files to CRLF in the working tree during
@@ -2482,6 +2487,7 @@ function Install-Repository {
     # Set per-repo config (harmless if it fails)
     Push-Location $InstallDir
     git -c windows.appendAtomically=false config windows.appendAtomically false 2>$null
+    git -c windows.appendAtomically=false config core.longpaths true 2>$null
     # Pin autocrlf=false on the managed clone so git never renormalizes the
     # repo's LF text files to CRLF in the working tree. Without this, the very
     # next `hermes update` checkout aborts on a "dirty" tree the user never
@@ -5009,4 +5015,11 @@ try {
     Write-Host "  Invoke-WebRequest -Uri 'https://hermes-agent.nousresearch.com/install.ps1' -OutFile install.ps1" -ForegroundColor Yellow
     Write-Host "  .\install.ps1" -ForegroundColor Yellow
     Write-Host ""
+    # A downloaded script is a process-friendly entry point: report failure
+    # through its exit code.  Invoke-Expression has no script path and must
+    # instead fall through so the canonical `irm | iex` invocation does not
+    # terminate the caller's interactive PowerShell session.
+    if ($PSCommandPath) {
+        exit 1
+    }
 }

--- a/tests/test_install_ps1_long_paths_and_failures.py
+++ b/tests/test_install_ps1_long_paths_and_failures.py
@@ -1,0 +1,48 @@
+"""Regression coverage for Windows installer checkout and exit semantics."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_repository_stage_enables_git_long_paths_before_checkout() -> None:
+    text = _install_ps1()
+
+    assert (
+        "git -c windows.appendAtomically=false -c core.longpaths=true "
+        "clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir"
+    ) in text
+    assert (
+        "git -c windows.appendAtomically=false -c core.longpaths=true "
+        "clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir"
+    ) in text
+
+    # Existing installs, ZIP fallbacks, and fresh clones must all persist the
+    # setting before a fetch/checkout can materialize long repository paths.
+    assert text.count("config core.longpaths true") >= 3
+
+
+def test_interactive_install_failure_is_rethrown() -> None:
+    text = _install_ps1()
+    match = re.search(
+        r"} catch \{\s*"
+        r"if \(\$Json -or \$Stage\) \{[\s\S]*?"
+        r"# Interactive mode:[\s\S]*?"
+        r"Write-Host \"\"\s*"
+        r"(?P<tail>[\s\S]*?)"
+        r"\n}",
+        text,
+    )
+    assert match is not None, "installer top-level catch block not found"
+    assert re.search(r"(?m)^\s*throw\s*$", match["tail"]), (
+        "interactive installer failures must propagate to the caller instead "
+        "of reporting exit code 0"
+    )

--- a/tests/test_install_ps1_long_paths_and_failures.py
+++ b/tests/test_install_ps1_long_paths_and_failures.py
@@ -1,0 +1,261 @@
+"""Windows installer checkout and caller-failure behavior."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+POWERSHELL = next(
+    (candidate for candidate in ("pwsh", "powershell") if shutil.which(candidate)),
+    None,
+)
+
+pytestmark = [
+    pytest.mark.live_system_guard_bypass,
+    pytest.mark.skipif(
+        sys.platform != "win32" or shutil.which("git") is None or POWERSHELL is None,
+        reason="needs Windows, Git for Windows, and PowerShell",
+    ),
+]
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    input: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        env=env,
+        input=input,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git(
+    cwd: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+    input: str | None = None,
+) -> str:
+    result = _run(
+        [
+            "git",
+            "-c",
+            "user.name=Hermes Installer Test",
+            "-c",
+            "user.email=test@example.com",
+            *args,
+        ],
+        cwd=cwd,
+        env=env,
+        input=input,
+    )
+    return result.stdout.strip()
+
+
+def _powershell_literal(value: str | Path) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _make_long_path_remote(tmp_path: Path) -> tuple[Path, str, str, str]:
+    """Create two commits without materializing the long path in the seed repo."""
+    remote = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", str(remote))
+
+    long_path = "/".join(
+        [f"segment-{letter * 48}" for letter in "abcd"] + ["tracked.txt"]
+    )
+    index_path = tmp_path / "fixture.index"
+    index_env = os.environ | {"GIT_INDEX_FILE": str(index_path)}
+
+    pinned_blob = _git(
+        tmp_path,
+        "--git-dir",
+        str(remote),
+        "hash-object",
+        "-w",
+        "--stdin",
+        input="pinned revision\n",
+    )
+    _git(tmp_path, "--git-dir", str(remote), "read-tree", "--empty", env=index_env)
+    _git(
+        tmp_path,
+        "--git-dir",
+        str(remote),
+        "update-index",
+        "--add",
+        "--cacheinfo",
+        "100644",
+        pinned_blob,
+        long_path,
+        env=index_env,
+    )
+    pinned_tree = _git(tmp_path, "--git-dir", str(remote), "write-tree", env=index_env)
+    pinned_commit = _git(
+        tmp_path,
+        "--git-dir",
+        str(remote),
+        "commit-tree",
+        pinned_tree,
+        "-m",
+        "pinned revision",
+    )
+
+    tip_blob = _git(
+        tmp_path,
+        "--git-dir",
+        str(remote),
+        "hash-object",
+        "-w",
+        "--stdin",
+        input="branch tip\n",
+    )
+    _git(
+        tmp_path,
+        "--git-dir",
+        str(remote),
+        "update-index",
+        "--cacheinfo",
+        "100644",
+        tip_blob,
+        long_path,
+        env=index_env,
+    )
+    tip_tree = _git(tmp_path, "--git-dir", str(remote), "write-tree", env=index_env)
+    tip_commit = _git(
+        tmp_path,
+        "--git-dir",
+        str(remote),
+        "commit-tree",
+        tip_tree,
+        "-p",
+        pinned_commit,
+        "-m",
+        "branch tip",
+    )
+    _git(
+        tmp_path, "--git-dir", str(remote), "update-ref", "refs/heads/main", tip_commit
+    )
+    _git(tmp_path, "--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main")
+    return remote, long_path, pinned_commit, pinned_blob
+
+
+def test_repository_stage_clones_and_pins_over_max_path_fixture(tmp_path: Path) -> None:
+    remote, long_path, pinned_commit, pinned_blob = _make_long_path_remote(tmp_path)
+    install_dir = tmp_path / "nested-install-root" / "hermes-agent"
+    checkout_path = install_dir.joinpath(*long_path.split("/"))
+    assert len(str(checkout_path)) > 260
+
+    isolated_global_config = tmp_path / "global.gitconfig"
+    discovered_git = Path(shutil.which("git")).resolve()
+    git_exe = next(
+        (
+            candidate
+            for parent in discovered_git.parents
+            if (candidate := parent / "cmd" / "git.exe").is_file()
+        ),
+        discovered_git,
+    )
+    git_dir = str(git_exe.parent)
+    git_root = git_exe.parent.parent
+    child_path = os.pathsep.join(
+        str(path)
+        for path in (
+            git_exe.parent,
+            git_root / "mingw64" / "bin",
+            git_root / "usr" / "bin",
+        )
+    )
+    env = os.environ | {
+        "COMSPEC": str(Path(os.environ["SYSTEMROOT"]) / "System32" / "cmd.exe"),
+        "GIT_CONFIG_GLOBAL": str(isolated_global_config),
+        "GIT_EXEC_PATH": _git(tmp_path, "--exec-path"),
+        "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+        "PATH": child_path + os.pathsep + os.environ["PATH"],
+    }
+    command = "\n".join([
+        f"$env:Path = {_powershell_literal(git_dir)} + ';' + $env:Path",
+        f"Set-Alias -Name git -Value {_powershell_literal(git_exe)}",
+        f". {_powershell_literal(INSTALL_PS1)}",
+        f"$InstallDir = {_powershell_literal(install_dir)}",
+        f"$HermesHome = {_powershell_literal(tmp_path / 'hermes-home')}",
+        f"$RepoUrlSsh = {_powershell_literal(remote.as_uri())}",
+        f"$RepoUrlHttps = {_powershell_literal(remote.as_uri())}",
+        "$Branch = 'main'",
+        f"$Commit = {_powershell_literal(pinned_commit)}",
+        "$Tag = ''",
+        "$ForceCommit = $true",
+        "Install-Repository",
+    ])
+    result = _run(
+        [POWERSHELL, "-NoProfile", "-Command", command],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _git(install_dir, "rev-parse", "HEAD") == pinned_commit
+    assert _git(install_dir, "config", "--get", "core.longpaths") == "true"
+    assert _git(install_dir, "hash-object", "--", long_path) == pinned_blob
+    assert _git(install_dir, "status", "--porcelain") == ""
+
+
+def _make_unusable_hermes_home(tmp_path: Path) -> Path:
+    path = tmp_path / "hermes-home-is-a-file"
+    path.write_text("not a directory", encoding="ascii")
+    return path
+
+
+def test_noninteractive_file_invocation_reports_failure_exit_code(
+    tmp_path: Path,
+) -> None:
+    unusable_home = _make_unusable_hermes_home(tmp_path)
+    result = _run(
+        [
+            POWERSHELL,
+            "-NoProfile",
+            "-File",
+            str(INSTALL_PS1),
+            "-NonInteractive",
+            "-HermesHome",
+            str(unusable_home),
+        ],
+        cwd=tmp_path,
+        check=False,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Installation failed:" in result.stdout
+
+
+def test_invoke_expression_failure_keeps_caller_session_alive(tmp_path: Path) -> None:
+    unusable_home = _make_unusable_hermes_home(tmp_path)
+    command = "\n".join([
+        f"$env:HERMES_HOME = {_powershell_literal(unusable_home)}",
+        f"Get-Content -LiteralPath {_powershell_literal(INSTALL_PS1)} -Raw | Invoke-Expression",
+        "Write-Output 'CALLER_SESSION_ALIVE'",
+    ])
+    result = _run(
+        [POWERSHELL, "-NoProfile", "-Command", command],
+        cwd=tmp_path,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Installation failed:" in result.stdout
+    assert "CALLER_SESSION_ALIVE" in result.stdout

--- a/tests/test_install_ps1_native_stderr_eap.py
+++ b/tests/test_install_ps1_native_stderr_eap.py
@@ -39,11 +39,11 @@ def test_repository_stage_relieves_eap_for_ssh_and_https_git_clone() -> None:
     assert "function Invoke-NativeWithRelaxedErrorAction" in text
     _assert_relaxed_call(
         text,
-        r"git -c windows\.appendAtomically=false clone --depth 1 --branch \$Branch \$RepoUrlSsh \$InstallDir",
+        r"git -c windows\.appendAtomically=false -c core\.longpaths=true clone --depth 1 --branch \$Branch \$RepoUrlSsh \$InstallDir",
     )
     _assert_relaxed_call(
         text,
-        r"git -c windows\.appendAtomically=false clone --depth 1 --branch \$Branch \$RepoUrlHttps \$InstallDir",
+        r"git -c windows\.appendAtomically=false -c core\.longpaths=true clone --depth 1 --branch \$Branch \$RepoUrlHttps \$InstallDir",
     )
 
 


### PR DESCRIPTION
## Summary

Harden the Windows installer around long repository paths and failure
propagation.

Git for Windows does not enable long paths by default. Hermes contains nested
paths that can exceed `MAX_PATH` depending on the install directory, so clone
or the subsequent pinned checkout can fail. The installer now enables
`core.longpaths` before fresh clone, existing-repository probes, ZIP fallback
checkout, and post-clone pinning.

The friendly interactive top-level catch also rethrows after printing its
recovery hint. This preserves the message without reporting a failed install as
exit code 0.

## A/B verification

- Local Git fixture with a 330-character tracked path:
  - long paths off: checkout exit 128, `Filename too long`
  - long paths on: checkout exit 0 and file materialized
- Forced installer failure:
  - before: friendly fatal message, process exit 0
  - after: same friendly message, process exit 1
- Windows installer-focused tests: 19 passed.
- Windows PowerShell AST parse and `git diff --check` pass.
