### PR TITLE
feat(dashboard): add profile web app icons

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1889,6 +1889,9 @@ DEFAULT_CONFIG = {
     "display": {
         "compact": False,
         "personality": "",
+        # Optional profile-local PNG/JPEG used for Safari's Add to Home Screen
+        # icon. Relative paths resolve within this profile's HERMES_HOME.
+        "web_app_icon": "",
         "resume_display": "full",
         # Recap tuning for /resume and startup resume. The defaults match the
         # historical hardcoded values; expose them as config so power users can

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -59,6 +59,10 @@ _GATE_PUBLIC_PREFIXES: tuple[str, ...] = (
     "/api/mcp/oauth/callback/",
     "/assets/",
     "/favicon.ico",
+    # Safari/iPadOS fetches the Home Screen icon outside the SPA's fetch
+    # wrapper and may not preserve the Dashboard session cookie. Keep it
+    # alongside the generic favicon as a public static asset.
+    "/apple-touch-icon.png",
     "/ds-assets/",
     "/fonts/",
     "/fonts-terminal/",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18749,6 +18749,85 @@ def _render_active_theme_bootstrap_css() -> str:
         return ""
 
 
+_WEB_APP_ICON_MAX_BYTES = 5 * 1024 * 1024
+
+
+def _resolve_web_app_icon(profile: Optional[str] = None) -> Optional[tuple[bytes, str, str]]:
+    """Return the configured profile web-app icon or ``None``.
+
+    Safari reads ``apple-touch-icon`` while adding the Dashboard to the Home
+    Screen. The resulting request has no filename chosen by the browser, so
+    resolve the configured profile asset here instead of exposing a generic
+    file-serving route. Absolute values are accepted only when they still live
+    within the active profile home; symlinks and ``..`` traversal are therefore
+    rejected after ``resolve()``.
+
+    The returned bytes are a bounded, descriptor-verified snapshot rather than
+    a pathname. This prevents a local file replacement between validation and
+    response delivery from exposing bytes outside the profile home. The third
+    tuple item is a stable content version used in the document link to bypass
+    stale icon fetches during a fresh Home Screen install.
+    """
+    try:
+        with _config_profile_scope(profile):
+            config = load_config() or {}
+            if not isinstance(config, dict):
+                return None
+            display = config.get("display") or {}
+            if not isinstance(display, dict):
+                return None
+            raw_path = display.get("web_app_icon")
+            if not isinstance(raw_path, str) or not raw_path.strip():
+                return None
+
+            home = get_hermes_home().expanduser().resolve(strict=True)
+            candidate = Path(raw_path).expanduser()
+            if not candidate.is_absolute():
+                candidate = home / candidate
+            candidate = candidate.resolve(strict=True)
+            if not candidate.is_relative_to(home):
+                return None
+
+            # lstat refuses a final-component symlink. Re-resolving after the
+            # lstat catches a replaced parent directory before the open. The
+            # descriptor inode/device check below closes the remaining window
+            # between those checks and opening the file.
+            file_stat = candidate.lstat()
+            if not stat.S_ISREG(file_stat.st_mode):
+                return None
+            if candidate.resolve(strict=True) != candidate:
+                return None
+            if file_stat.st_size <= 0 or file_stat.st_size > _WEB_APP_ICON_MAX_BYTES:
+                return None
+            with candidate.open("rb") as handle:
+                opened_stat = os.fstat(handle.fileno())
+                if (
+                    not stat.S_ISREG(opened_stat.st_mode)
+                    or (opened_stat.st_dev, opened_stat.st_ino)
+                    != (file_stat.st_dev, file_stat.st_ino)
+                ):
+                    return None
+                icon_bytes = handle.read(_WEB_APP_ICON_MAX_BYTES + 1)
+            if (
+                len(icon_bytes) != file_stat.st_size
+                or len(icon_bytes) > _WEB_APP_ICON_MAX_BYTES
+            ):
+                return None
+            if icon_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+                media_type = "image/png"
+            elif icon_bytes.startswith(b"\xff\xd8\xff"):
+                media_type = "image/jpeg"
+            else:
+                return None
+            return icon_bytes, media_type, (
+                f"{file_stat.st_mtime_ns:x}-{file_stat.st_size:x}"
+            )
+    except (HTTPException, OSError, RuntimeError, TypeError, ValueError):
+        # The icon is cosmetic. A malformed, disappearing, or inaccessible
+        # setting must not prevent the Dashboard itself from loading.
+        return None
+
+
 def mount_spa(application: FastAPI):
     """Mount the built SPA. Falls back to index.html for client-side routing.
 
@@ -18782,7 +18861,7 @@ def mount_spa(application: FastAPI):
 
     _index_path = WEB_DIST / "index.html"
 
-    def _serve_index(prefix: str = ""):
+    def _serve_index(prefix: str = "", profile: Optional[str] = None):
         """Return index.html with the session token + base-path injected.
 
         ``prefix`` is the normalised ``X-Forwarded-Prefix`` (e.g. ``/hermes``)
@@ -18834,6 +18913,17 @@ def mount_spa(application: FastAPI):
             html = html.replace('href="/fonts/', f'href="{prefix}/fonts/')
             html = html.replace('href="/ds-assets/', f'href="{prefix}/ds-assets/')
             html = html.replace('src="/ds-assets/', f'src="{prefix}/ds-assets/')
+        web_app_icon = _resolve_web_app_icon(profile)
+        if web_app_icon:
+            _, _, icon_version = web_app_icon
+            profile_query = (
+                f"&profile={urllib.parse.quote(profile, safe='')}" if profile else ""
+            )
+            icon_link = (
+                '<link rel="apple-touch-icon" '
+                f'href="{prefix}/apple-touch-icon.png?v={icon_version}{profile_query}" />'
+            )
+            html = html.replace("</head>", f"{icon_link}</head>", 1)
         # Theme flash mitigation: when the active theme is a user theme
         # (``HERMES_HOME/dashboard-themes/<name>.yaml``), inject a minimal
         # critical-CSS block so the first paint uses the target palette.
@@ -18873,11 +18963,25 @@ def mount_spa(application: FastAPI):
                 css = css.replace(f"url('{asset_dir}", f"url('{prefix}{asset_dir}")
         return Response(content=css, media_type="text/css")
 
+    @application.get("/apple-touch-icon.png", include_in_schema=False)
+    async def serve_web_app_icon(profile: Optional[str] = None):
+        """Serve the configured profile image for Safari Home Screen installs."""
+        web_app_icon = _resolve_web_app_icon(profile)
+        if not web_app_icon:
+            return JSONResponse({"detail": "Web app icon not configured"}, status_code=404)
+        icon_bytes, media_type, _ = web_app_icon
+        return Response(
+            content=icon_bytes,
+            media_type=media_type,
+            headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+        )
+
     application.mount("/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets")
 
     @application.get("/{full_path:path}")
     async def serve_spa(full_path: str, request: Request):
         prefix = _normalise_prefix(request.headers.get("x-forwarded-prefix"))
+        profile = (request.query_params.get("profile") or "").strip() or None
         # An unmatched /api/* path is a missing/renamed endpoint, NOT a
         # client-side route. Falling through to index.html here returns
         # `<!doctype html>` with status 200, which makes JSON clients (the
@@ -18898,7 +19002,7 @@ def mount_spa(application: FastAPI):
             and file_path.is_file()
         ):
             return FileResponse(file_path)
-        return _serve_index(prefix)
+        return _serve_index(prefix, profile)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -142,6 +142,14 @@ def test_gated_static_asset_path_is_public(gated_app):
     assert r.status_code == 404
 
 
+def test_gated_home_screen_icon_path_is_public(gated_app):
+    """iPadOS must fetch the touch icon without a dashboard session cookie."""
+    r = gated_app.get("/apple-touch-icon.png", follow_redirects=False)
+    # 404 means no icon is configured but the public static route was reached.
+    # A 302 would send iPadOS to login and prevent Home Screen icon capture.
+    assert r.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # OAuth round trip
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_web_app_icon.py
+++ b/tests/hermes_cli/test_dashboard_web_app_icon.py
@@ -1,0 +1,194 @@
+"""Regression coverage for profile-scoped iPad Home Screen icons.
+
+Safari's Add to Home Screen flow uses the ``apple-touch-icon`` link in the
+served document.  The icon must be profile-local and must never turn the
+Dashboard into a route for arbitrary local files.
+"""
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+
+_JPEG = b"\xff\xd8\xff\xe0" + b"JFIF\x00" + b"profile-icon" + b"\xff\xd9"
+
+
+def _client_with_profile_icon(tmp_path: Path, monkeypatch, icon_setting: str) -> TestClient:
+    import hermes_cli.web_server as ws
+
+    home = tmp_path / "profile-home"
+    home.mkdir(exist_ok=True)
+    dist = tmp_path / "web-dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text(
+        "<html><head><title>Hermes</title></head><body>Dashboard</body></html>",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ws, "WEB_DIST", dist)
+    monkeypatch.setattr(ws, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(ws, "load_config", lambda: {"display": {"web_app_icon": icon_setting}})
+
+    app = FastAPI()
+    ws.mount_spa(app)
+    return TestClient(app)
+
+
+def test_profile_icon_is_injected_and_served_for_safari_web_clip(tmp_path, monkeypatch):
+    """A profile-local JPEG must drive the iPad Home Screen icon endpoint."""
+    home = tmp_path / "profile-home"
+    icon = home / "reference-images" / "amanda.jpg"
+    icon.parent.mkdir(parents=True)
+    icon.write_bytes(_JPEG)
+
+    client = _client_with_profile_icon(
+        tmp_path, monkeypatch, "reference-images/amanda.jpg"
+    )
+
+    page = client.get("/", headers={"x-forwarded-prefix": "/hermes"})
+    assert page.status_code == 200
+    assert '<link rel="apple-touch-icon"' in page.text
+    assert 'href="/hermes/apple-touch-icon.png?v=' in page.text
+
+    icon_response = client.get("/apple-touch-icon.png")
+    assert icon_response.status_code == 200
+    assert icon_response.content == _JPEG
+    assert icon_response.headers["content-type"].startswith("image/jpeg")
+    assert "no-store" in icon_response.headers["cache-control"]
+
+
+def test_icon_file_swap_cannot_serve_external_bytes(tmp_path, monkeypatch):
+    """A replacement after validation must never turn the route into a file leak."""
+    home = tmp_path / "profile-home"
+    icon = home / "reference-images" / "amanda.jpg"
+    outside = tmp_path / "outside.jpg"
+    icon.parent.mkdir(parents=True)
+    icon.write_bytes(_JPEG)
+    outside.write_bytes(b"\xff\xd8\xffexternal-profile-bytes")
+    client = _client_with_profile_icon(
+        tmp_path, monkeypatch, "reference-images/amanda.jpg"
+    )
+
+    # Render before the swap so this request exercises the endpoint's own
+    # validation-to-response window rather than merely suppressing the link.
+    assert "apple-touch-icon" in client.get("/").text
+    original_open = Path.open
+    swapped = False
+
+    def swap_to_external_file(path, *args, **kwargs):
+        nonlocal swapped
+        if path == icon and not swapped:
+            outside.replace(icon)
+            swapped = True
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", swap_to_external_file)
+    response = client.get("/apple-touch-icon.png")
+
+    assert swapped
+    assert response.status_code == 404
+    assert b"external-profile-bytes" not in response.content
+
+
+def test_malformed_display_config_does_not_break_the_dashboard(tmp_path, monkeypatch):
+    """A non-mapping display setting must disable the icon, not serve a 500."""
+    import hermes_cli.web_server as ws
+
+    client = _client_with_profile_icon(tmp_path, monkeypatch, "unused.jpg")
+    monkeypatch.setattr(ws, "load_config", lambda: {"display": "broken"})
+
+    page = client.get("/")
+    assert page.status_code == 200
+    assert "apple-touch-icon" not in page.text
+    assert client.get("/apple-touch-icon.png").status_code == 404
+
+
+def test_real_profile_config_drives_the_web_clip_icon(tmp_path, monkeypatch):
+    """The real config loader resolves a profile-local image end to end."""
+    from hermes_cli.config import load_config, save_config
+    import hermes_cli.web_server as ws
+
+    home = tmp_path / "profile-home"
+    icon = home / "reference-images" / "amanda.jpg"
+    icon.parent.mkdir(parents=True)
+    icon.write_bytes(_JPEG)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    config = load_config()
+    config.setdefault("display", {})["web_app_icon"] = "reference-images/amanda.jpg"
+    save_config(config)
+
+    dist = tmp_path / "web-dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text(
+        "<html><head></head><body>Dashboard</body></html>", encoding="utf-8"
+    )
+    monkeypatch.setattr(ws, "WEB_DIST", dist)
+    app = FastAPI()
+    ws.mount_spa(app)
+    client = TestClient(app)
+
+    assert "apple-touch-icon" in client.get("/").text
+    assert client.get("/apple-touch-icon.png").content == _JPEG
+
+
+def test_profile_query_is_carried_to_the_icon_request(tmp_path, monkeypatch):
+    """A Dashboard profile switch must not silently use the launch profile icon."""
+    from contextlib import contextmanager
+    import hermes_cli.web_server as ws
+
+    home = tmp_path / "profile-home"
+    icon = home / "reference-images" / "amanda.jpg"
+    icon.parent.mkdir(parents=True)
+    icon.write_bytes(_JPEG)
+    requested_profiles = []
+
+    @contextmanager
+    def fake_profile_scope(profile):
+        requested_profiles.append(profile)
+        yield None
+
+    monkeypatch.setattr(ws, "_config_profile_scope", fake_profile_scope)
+    client = _client_with_profile_icon(
+        tmp_path, monkeypatch, "reference-images/amanda.jpg"
+    )
+
+    page = client.get("/?profile=amanda")
+    assert page.status_code == 200
+    assert "&profile=amanda\"" in page.text
+
+    icon_response = client.get("/apple-touch-icon.png?profile=amanda")
+    assert icon_response.status_code == 200
+    assert requested_profiles == ["amanda", "amanda"]
+
+
+def test_out_of_profile_icon_path_is_not_linked_or_served(tmp_path, monkeypatch):
+    """A config path outside the profile must fail closed instead of exposing bytes."""
+    outside = tmp_path / "outside.jpg"
+    outside.write_bytes(_JPEG)
+    client = _client_with_profile_icon(tmp_path, monkeypatch, str(outside))
+
+    page = client.get("/")
+    assert page.status_code == 200
+    assert "apple-touch-icon" not in page.text
+
+    icon_response = client.get("/apple-touch-icon.png")
+    assert icon_response.status_code == 404
+
+
+def test_non_image_profile_file_is_not_linked_or_served(tmp_path, monkeypatch):
+    """Only image bytes may become a public web-app icon response."""
+    home = tmp_path / "profile-home"
+    not_an_image = home / "reference-images" / "private.txt"
+    not_an_image.parent.mkdir(parents=True)
+    not_an_image.write_text("private profile material", encoding="utf-8")
+    client = _client_with_profile_icon(
+        tmp_path, monkeypatch, "reference-images/private.txt"
+    )
+
+    page = client.get("/")
+    assert page.status_code == 200
+    assert "apple-touch-icon" not in page.text
+
+    icon_response = client.get("/apple-touch-icon.png")
+    assert icon_response.status_code == 404

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -41,6 +41,38 @@ hermes dashboard --host 0.0.0.0
 hermes dashboard --no-open
 ```
 
+## iPad and iPhone Home Screen icon
+
+Safari can add the Dashboard to the Home Screen as a web app. Set
+`display.web_app_icon` to a PNG or JPEG inside the active profile's Hermes
+home to give that installed icon a profile-specific identity:
+
+```yaml
+# ~/.hermes/config.yaml for the default profile
+display:
+  web_app_icon: reference-images/amanda-icon.jpg
+```
+
+The image must be at most 5 MiB and live inside that profile's Hermes home.
+Relative paths are recommended: the default profile resolves them from
+`~/.hermes`, while a named profile resolves them from
+`$HOME/.hermes/profiles/<profile>`. Paths that leave the profile home, including
+through symlinks, are ignored.
+
+The touch-icon endpoint is a public static asset, like `/favicon.ico`, so
+choose an image you are comfortable exposing to anyone who can reach the
+Dashboard hostname. It never exposes a file outside the active profile home.
+
+You can set the same value in **Config → display → web_app_icon**. For a named
+profile, select it in the dashboard first; its `?profile=` URL is retained in
+the icon request so its own configured image is used.
+
+After setting or changing the image, open the dashboard in **Safari**, use
+**Share → Add to Home Screen**, and launch it from the new icon. iPadOS captures
+the Home Screen icon at installation time, so delete the prior shortcut and add
+it again when you change the image. This changes the installed web-app icon;
+the generic Hermes browser-tab favicon is intentionally unchanged.
+
 ## Managing multiple profiles
 
 The dashboard is a **machine-level** management surface: one server manages


### PR DESCRIPTION
## What does this PR do?

Adds a profile-scoped Dashboard Home Screen icon for iPadOS and iOS Safari web apps.

Hermes currently exposes only a generic browser favicon. When a user adds the Dashboard to the Home Screen, there is no way to identify an installed web app with the active profile’s avatar. This adds `display.web_app_icon`: a PNG or JPEG located inside the active profile home. The Dashboard injects a content-versioned `apple-touch-icon` link and serves a bounded, descriptor-verified in-memory snapshot through a narrowly scoped, fail-closed route.

The selected `?profile=` is retained in the icon request, so a machine-level Dashboard does not accidentally install the launch profile’s icon for a different selected profile.

## Related Issue

No existing issue. Searched open/closed issues and PRs for `apple-touch-icon`, `home screen icon`, and `web app icon`.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/config.py`: adds an empty, profile-local `display.web_app_icon` default.
- `hermes_cli/web_server.py`: validates a configured PNG/JPEG after resolved profile-home containment, rejects traversal, symlink escapes, unreadable/missing files, malformed config, files over 5 MiB, and replacement races; injects a versioned Apple touch-icon link; exposes the guarded endpoint before the SPA fallback.
- `hermes_cli/dashboard_auth/middleware.py`: treats the touch icon as a public static asset alongside `/favicon.ico`, so Safari can fetch it outside the SPA session wrapper. Documentation explicitly warns that the selected image is publicly reachable at the Dashboard hostname.
- `tests/hermes_cli/test_dashboard_web_app_icon.py`: covers profile-local serving, real config loading, selected-profile propagation, malformed config, out-of-profile rejection, non-image rejection, and a file-replacement race.
- `website/docs/user-guide/features/web-dashboard.md`: documents configuration, named profiles, supported formats, safety boundary, and iPadOS reinstallation behavior.

## How to Test

1. Put a PNG or JPEG at `~/.hermes/reference-images/avatar.jpg`.
2. Set `display.web_app_icon: reference-images/avatar.jpg` in the active profile’s `config.yaml` (or use Config → display → web_app_icon).
3. Open the Dashboard in Safari, including `?profile=<name>` for a named profile, then use Share → Add to Home Screen.
4. Confirm `GET /apple-touch-icon.png` returns the image with a `Cache-Control: no-store` header and that the installed icon uses it. Delete and re-add an existing shortcut after changing the image.

Automated verification:

- `./scripts/run_tests.sh tests/hermes_cli/test_dashboard_web_app_icon.py tests/hermes_cli/test_dashboard_auth_middleware.py -q` — 42 passed.
- `./scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestThemeBootstrapCSS -q` — 10 passed.
- `python3 -m compileall -q hermes_cli/web_server.py hermes_cli/config.py hermes_cli/dashboard_auth/middleware.py tests/hermes_cli/test_dashboard_web_app_icon.py tests/hermes_cli/test_dashboard_auth_middleware.py` — passed.
- `git diff --check` — passed.
- Full `tests/hermes_cli/test_web_server.py -q`: 519 passed, 1 failed. The same Honcho readiness assertion fails identically in a separate clean `origin/main` worktree on this configured machine (`ready` vs expected `needs_config`), so it is not introduced by this PR.

Tested on macOS 15.7.4.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — blocked by the identical pre-existing environment-sensitive Honcho assertion documented above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no such example file exists in this repository)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (schema is generated from `DEFAULT_CONFIG`)

## Screenshots / Logs

No visual UI change before installation. The server-level regression tests assert the rendered Apple touch-icon link and returned icon bytes.
