### PR TITLE
fix: scan all kanban boards for active workers

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1403,64 +1403,90 @@ except ImportError:
 
 @router.get("/workers/active")
 def list_active_workers(
-    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+    board: Optional[str] = Query(
+        None,
+        description="Kanban board slug; omit to scan all non-archived boards",
+    ),
 ):
-    """Return every currently-running worker on the board.
+    """Return every currently-running worker across the requested board scope.
+
+    When ``board`` is omitted, scan every non-archived board so this endpoint
+    matches gateway-embedded dispatch behavior. Resolved physical database paths
+    are scanned only once because ``HERMES_KANBAN_DB`` can map multiple board
+    slugs to the same SQLite file.
 
     A worker is a ``task_runs`` row whose ``ended_at`` is NULL and whose
-    ``worker_pid`` is non-NULL, belonging to a task with ``status='running'``.
+    ``worker_pid`` is non-NULL, belonging to a task with
+    ``status='running'``.
 
-    Returns ``{workers: [...], count: N, checked_at: <epoch>}``.  Each
-    worker entry carries enough context for the dashboard to link back to
-    its task without a second round-trip.
+    Returns ``{workers: [...], count: N, checked_at: <epoch>}``. Each worker
+    includes its board slug so callers can link a cross-board result back to the
+    correct task.
     """
-    board = _resolve_board(board)
-    conn = _conn(board=board)
-    try:
-        rows = conn.execute(
-            """
-            SELECT
-                r.id          AS run_id,
-                r.task_id,
-                t.title       AS task_title,
-                t.status      AS task_status,
-                t.assignee    AS task_assignee,
-                r.profile,
-                r.worker_pid,
-                r.started_at,
-                r.claim_lock,
-                r.claim_expires,
-                r.last_heartbeat_at,
-                r.max_runtime_seconds
-            FROM task_runs r
-            JOIN tasks t ON t.id = r.task_id
-            WHERE r.ended_at IS NULL
-              AND r.worker_pid IS NOT NULL
-              AND t.status = 'running'
-            ORDER BY r.started_at ASC
-            """,
-        ).fetchall()
-        workers = [
-            {
-                "run_id": row["run_id"],
-                "task_id": row["task_id"],
-                "task_title": row["task_title"],
-                "task_status": row["task_status"],
-                "task_assignee": row["task_assignee"],
-                "profile": row["profile"],
-                "worker_pid": row["worker_pid"],
-                "started_at": row["started_at"],
-                "claim_lock": row["claim_lock"],
-                "claim_expires": row["claim_expires"],
-                "last_heartbeat_at": row["last_heartbeat_at"],
-                "max_runtime_seconds": row["max_runtime_seconds"],
-            }
-            for row in rows
+    if board is None:
+        board_slugs = [
+            str(meta.get("slug") or kanban_db.DEFAULT_BOARD)
+            for meta in kanban_db.list_boards(include_archived=False)
         ]
-        return {"workers": workers, "count": len(workers), "checked_at": int(time.time())}
-    finally:
-        conn.close()
+    else:
+        resolved = _resolve_board(board)
+        board_slugs = [resolved or kanban_db.get_current_board()]
 
+    workers: list[dict[str, Any]] = []
+    seen_db_paths: set[str] = set()
+    for board_slug in board_slugs:
+        db_path = str(kanban_db.kanban_db_path(board_slug).resolve())
+        if db_path in seen_db_paths:
+            continue
+        seen_db_paths.add(db_path)
+
+        conn = _conn(board=board_slug)
+        try:
+            rows = conn.execute(
+                """
+                SELECT
+                    r.id          AS run_id,
+                    r.task_id,
+                    t.title       AS task_title,
+                    t.status      AS task_status,
+                    t.assignee    AS task_assignee,
+                    r.profile,
+                    r.worker_pid,
+                    r.started_at,
+                    r.claim_lock,
+                    r.claim_expires,
+                    r.last_heartbeat_at,
+                    r.max_runtime_seconds
+                FROM task_runs r
+                JOIN tasks t ON t.id = r.task_id
+                WHERE r.ended_at IS NULL
+                  AND r.worker_pid IS NOT NULL
+                  AND t.status = 'running'
+                ORDER BY r.started_at ASC
+                """,
+            ).fetchall()
+            workers.extend(
+                {
+                    "board": board_slug,
+                    "run_id": row["run_id"],
+                    "task_id": row["task_id"],
+                    "task_title": row["task_title"],
+                    "task_status": row["task_status"],
+                    "task_assignee": row["task_assignee"],
+                    "profile": row["profile"],
+                    "worker_pid": row["worker_pid"],
+                    "started_at": row["started_at"],
+                    "claim_lock": row["claim_lock"],
+                    "claim_expires": row["claim_expires"],
+                    "last_heartbeat_at": row["last_heartbeat_at"],
+                    "max_runtime_seconds": row["max_runtime_seconds"],
+                }
+                for row in rows
+            )
+        finally:
+            conn.close()
+
+    return {"workers": workers, "count": len(workers), "checked_at": int(time.time())}
 
 @router.get("/runs/{run_id}")
 def get_run_endpoint(

--- a/tests/plugins/test_kanban_worker_runs.py
+++ b/tests/plugins/test_kanban_worker_runs.py
@@ -92,6 +92,66 @@ def test_workers_active_empty_board(client):
     assert "checked_at" in body
 
 
+def test_workers_active_preserves_open_run_predicate(client):
+    """An open run does not require tasks.current_run_id to be visible."""
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="active-worker", assignee="alice")
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (task_id,))
+        _insert_run(conn, task_id, worker_pid=12345)
+    finally:
+        conn.close()
+
+    body = client.get("/api/plugins/kanban/workers/active").json()
+    assert body["count"] == 1
+    assert body["workers"][0]["task_id"] == task_id
+    assert body["workers"][0]["worker_pid"] == 12345
+
+
+def test_workers_active_scans_all_boards_when_board_is_omitted(client):
+    """Workers on a non-current board are visible in the fleet-wide response."""
+    kb.create_board("other")
+    conn = kb.connect(board="other")
+    try:
+        task_id = kb.create_task(conn, title="other-board-worker", assignee="dana")
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (task_id,))
+        _insert_run(conn, task_id, worker_pid=24680)
+    finally:
+        conn.close()
+
+    body = client.get("/api/plugins/kanban/workers/active").json()
+    assert body["count"] == 1
+    assert body["workers"][0]["board"] == "other"
+    assert body["workers"][0]["task_id"] == task_id
+
+    default_only = client.get(
+        "/api/plugins/kanban/workers/active?board=default"
+    ).json()
+    assert default_only["count"] == 0
+
+
+def test_workers_active_deduplicates_resolved_db_paths(
+    client, kanban_home, monkeypatch
+):
+    """HERMES_KANBAN_DB aliases must not duplicate the same worker."""
+    shared_db = kanban_home / "shared-kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(shared_db))
+    kb.init_db()
+    kb.create_board("shared-alias")
+
+    conn = kb.connect(board="default")
+    try:
+        task_id = kb.create_task(conn, title="shared-db-worker", assignee="erin")
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (task_id,))
+        _insert_run(conn, task_id, worker_pid=13579)
+    finally:
+        conn.close()
+
+    body = client.get("/api/plugins/kanban/workers/active").json()
+    assert body["count"] == 1
+    assert body["workers"][0]["task_id"] == task_id
+
+
 # ---------------------------------------------------------------------------
 # GET /runs/{run_id}
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Scan every non-archived Kanban board when `GET /api/plugins/kanban/workers/active` is called without a `board` parameter.
- Preserve the existing active-worker contract: an open `task_runs` row with a PID still counts without requiring `tasks.current_run_id`.
- Deduplicate resolved SQLite paths so `HERMES_KANBAN_DB` aliases do not report the same worker multiple times.
- Include the board slug on each worker returned by a cross-board scan.

## Root cause

The gateway dispatcher enumerates all boards, but the dashboard endpoint resolved an omitted `board` parameter to only the current board. A worker running on another board was therefore invisible and the endpoint could incorrectly return `count=0`.

## Scope

This is a narrow reimplementation of the worker-visibility fix from #33923 on current `main`. It intentionally excludes the unrelated ledger, review-gate, scripts, generated assets, PID fallback, and diagnostic changes from that PR.

## Validation

Added focused coverage for:

- preserving the existing open-run predicate without requiring `tasks.current_run_id`
- finding an active worker on a non-current board when `board` is omitted
- retaining explicit single-board filtering
- deduplicating multiple board slugs that resolve to the same `HERMES_KANBAN_DB`

The rebased endpoint and test additions pass Python AST syntax validation. Repository CI is awaiting maintainer approval to run for this fork-originated PR.
