### PR TITLE
fix(desktop): latch SSH auth-failed errors to prevent Settings lockout

### DIFF
--- a/apps/desktop/electron/backend-start-failure.ssh-auth.test.ts
+++ b/apps/desktop/electron/backend-start-failure.ssh-auth.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Unit tests for shouldLatchSshAuthFailure — the predicate that prevents
+ * the SSH auth-failed retry loop that locks users out of Settings (#72698).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { shouldLatchSshAuthFailure } from './backend-start-failure'
+
+describe('shouldLatchSshAuthFailure', () => {
+  it('returns false when not remote', () => {
+    expect(shouldLatchSshAuthFailure({ attemptedRemote: false, isSshAuthFailed: true })).toBe(false)
+  })
+
+  it('returns false when remote but not an SSH auth failure', () => {
+    expect(shouldLatchSshAuthFailure({ attemptedRemote: true, isSshAuthFailed: false })).toBe(false)
+  })
+
+  it('returns true when remote AND SSH auth failed', () => {
+    expect(shouldLatchSshAuthFailure({ attemptedRemote: true, isSshAuthFailed: true })).toBe(true)
+  })
+
+  it('returns false when neither is true', () => {
+    expect(shouldLatchSshAuthFailure({ attemptedRemote: false, isSshAuthFailed: false })).toBe(false)
+  })
+})

--- a/apps/desktop/electron/backend-start-failure.ssh-auth.test.ts
+++ b/apps/desktop/electron/backend-start-failure.ssh-auth.test.ts
@@ -1,12 +1,24 @@
 /**
  * Unit tests for shouldLatchSshAuthFailure — the predicate that prevents
  * the SSH auth-failed retry loop that locks users out of Settings (#72698).
+ *
+ * Two layers:
+ *   1. Truth-table tests: the pure predicate for every 2x2 combination.
+ *   2. Behavior-level wiring: production-like error shapes, the latch →
+ *      block → clear cycle, and every recognized SSH_ERROR value.
  */
 
 import { describe, expect, it } from 'vitest'
-import { shouldLatchSshAuthFailure } from './backend-start-failure'
+import {
+  shouldLatchSshAuthFailure,
+  type SshAuthFailureContext,
+} from './backend-start-failure'
 
-describe('shouldLatchSshAuthFailure', () => {
+// ---------------------------------------------------------------------------
+// 1. Truth-table: pure predicate for every combination
+// ---------------------------------------------------------------------------
+
+describe('shouldLatchSshAuthFailure (truth table)', () => {
   it('returns false when not remote', () => {
     expect(shouldLatchSshAuthFailure({ attemptedRemote: false, isSshAuthFailed: true })).toBe(false)
   })
@@ -21,5 +33,175 @@ describe('shouldLatchSshAuthFailure', () => {
 
   it('returns false when neither is true', () => {
     expect(shouldLatchSshAuthFailure({ attemptedRemote: false, isSshAuthFailed: false })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. Behavior-level wiring — production error shapes and latch cycle
+// ---------------------------------------------------------------------------
+
+describe('SshAuthFailureContext — behavior-level wiring', () => {
+  //
+  // Production context derivation
+  //
+  // In main.ts the context is constructed as:
+  //    { attemptedRemote, isSshAuthFailed: error?.sshError === 'auth-failed' }
+  // where error.sshError comes from the ssh-connection layer (SSH_ERROR.*).
+
+  it('derives isSshAuthFailed=true from error with sshError="auth-failed"', () => {
+    const error = new Error('SSH authentication failed') as any
+    error.sshError = 'auth-failed'
+
+    const context: SshAuthFailureContext = {
+      attemptedRemote: true,
+      isSshAuthFailed: error?.sshError === 'auth-failed',
+    }
+
+    expect(shouldLatchSshAuthFailure(context)).toBe(true)
+  })
+
+  it('derives isSshAuthFailed=false from error with sshError="unreachable"', () => {
+    const error = new Error('Host unreachable') as any
+    error.sshError = 'unreachable'
+
+    const context: SshAuthFailureContext = {
+      attemptedRemote: true,
+      isSshAuthFailed: error?.sshError === 'auth-failed',
+    }
+
+    expect(shouldLatchSshAuthFailure(context)).toBe(false)
+  })
+
+  it('derives isSshAuthFailed=false from error with sshError="timeout"', () => {
+    const error = new Error('Connection timed out') as any
+    error.sshError = 'timeout'
+
+    const context: SshAuthFailureContext = {
+      attemptedRemote: true,
+      isSshAuthFailed: error?.sshError === 'auth-failed',
+    }
+
+    expect(shouldLatchSshAuthFailure(context)).toBe(false)
+  })
+
+  it('derives isSshAuthFailed=false from error with sshError="host-key-changed"', () => {
+    const error = new Error('Host key has changed') as any
+    error.sshError = 'host-key-changed'
+
+    const context: SshAuthFailureContext = {
+      attemptedRemote: true,
+      isSshAuthFailed: error?.sshError === 'auth-failed',
+    }
+
+    expect(shouldLatchSshAuthFailure(context)).toBe(false)
+  })
+
+  it('derives isSshAuthFailed=false from error with sshError="unknown"', () => {
+    const error = new Error('Unknown SSH error') as any
+    error.sshError = 'unknown'
+
+    const context: SshAuthFailureContext = {
+      attemptedRemote: true,
+      isSshAuthFailed: error?.sshError === 'auth-failed',
+    }
+
+    expect(shouldLatchSshAuthFailure(context)).toBe(false)
+  })
+
+  it('derives isSshAuthFailed=false when error has no sshError property', () => {
+    const error = new Error('Some non-SSH error')
+
+    const context: SshAuthFailureContext = {
+      attemptedRemote: true,
+      isSshAuthFailed: (error as any)?.sshError === 'auth-failed',
+    }
+
+    expect(shouldLatchSshAuthFailure(context)).toBe(false)
+  })
+
+  /**
+   * In the startup-failure path, the sshError flows through as a literal
+   * string on the thrown error (not through the SSH_ERROR enum), so test
+   * the string value directly — matching the real predicate in main.ts.
+   */
+  it('matches on the string "auth-failed" exactly, not on partial or case variants', () => {
+    // Exact match — this is what the production code expects
+    expect('auth-failed' === 'auth-failed').toBe(true)
+
+    // Partial or case variants must NOT match
+    expect('AuthFailed' === 'auth-failed').toBe(false)
+    expect('auth' === 'auth-failed').toBe(false)
+    expect('auth-failure' === 'auth-failed').toBe(false)
+  })
+
+  //
+  // The "not remote" guard in the predicate
+  //
+  // Even with a genuine auth-failed sshError, setting attemptedRemote=false
+  // must suppress latching (local backends use a different error path).
+
+  it('suppresses latching when attemptedRemote=false even with sshError=auth-failed', () => {
+    const error = new Error('SSH authentication failed') as any
+    error.sshError = 'auth-failed'
+
+    const context: SshAuthFailureContext = {
+      attemptedRemote: false,
+      isSshAuthFailed: error?.sshError === 'auth-failed',
+    }
+
+    expect(shouldLatchSshAuthFailure(context)).toBe(false)
+  })
+
+  //
+  // Latch → block → clear cycle
+  //
+  // This is the core wiring pattern from main.ts: the predicate gates
+  // whether an error is stored in the sshAuthFailure module variable,
+  // which then short-circuits subsequent startHermes() calls, and is
+  // cleared on reset/repair/apply-connection-config.
+
+  it('models the latch → block → clear recovery cycle', () => {
+    // Phase 1 — SET: an auth-failed error arrives, predicate gates true,
+    // and the error is stored as the latched failure.
+    let sshAuthFailure: Error | null = null
+
+    const error = new Error('SSH authentication failed') as any
+    error.sshError = 'auth-failed'
+
+    const shouldLatch = shouldLatchSshAuthFailure({
+      attemptedRemote: true,
+      isSshAuthFailed: error?.sshError === 'auth-failed',
+    })
+
+    if (shouldLatch) {
+      sshAuthFailure = error instanceof Error ? error : new Error(String(error))
+    }
+
+    expect(sshAuthFailure).not.toBeNull()
+    expect(sshAuthFailure!.message).toBe('SSH authentication failed')
+
+    // Phase 2 — BLOCK: a subsequent call mimics the startHermes() early-return
+    // guard (if (sshAuthFailure) throw sshAuthFailure). The latch blocks re-entry.
+    expect(() => {
+      if (sshAuthFailure) {
+        throw sshAuthFailure
+      }
+    }).toThrow('SSH authentication failed')
+
+    // Phase 3 — CLEAR: reset/repair/apply-connection-config sets the latch back
+    // to null (see resetHermesConnection / hermes:bootstrap:reset in main.ts).
+    sshAuthFailure = null
+    expect(sshAuthFailure).toBeNull()
+
+    // Phase 4 — VERIFY clear is durable: after clearing, the guard no longer
+    // blocks, and a non-auth-failed error passes through normally.
+    const unreachableError = new Error('Host unreachable') as any
+    unreachableError.sshError = 'unreachable'
+    expect(
+      shouldLatchSshAuthFailure({
+        attemptedRemote: true,
+        isSshAuthFailed: unreachableError?.sshError === 'auth-failed',
+      })
+    ).toBe(false)
   })
 })

--- a/apps/desktop/electron/backend-start-failure.ts
+++ b/apps/desktop/electron/backend-start-failure.ts
@@ -70,3 +70,30 @@ export interface RemoteReauthFailureContext {
 export function shouldLatchRemoteReauthFailure(context: RemoteReauthFailureContext): boolean {
   return context.attemptedRemote && context.isReauth
 }
+
+export interface SshAuthFailureContext {
+  /** True when the boot that just failed was dialing a REMOTE (or cloud) backend. */
+  attemptedRemote: boolean
+  /**
+   * True when the failure was an SSH authentication error (`kind === 'auth-failed'`).
+   * SSH auth failures cannot self-heal — the key/user/pass is wrong and nothing
+   * will change until the user edits the connection config. Without latching, the
+   * renderer's retry loop re-runs `startHermes` on every `getConnection` call,
+   * re-emitting `running: true` which hides the boot-failure overlay mid-click.
+   */
+  isSshAuthFailed: boolean
+}
+
+/**
+ * Whether a failed SSH auth attempt should latch.
+ *
+ * SSH `auth-failed` is a confirmed credential rejection (wrong key, wrong user,
+ * no key loaded in agent). It is the SSH-layer analogue of a gateway reauth
+ * rejection — transient network glitches get `unreachable`/`timeout`; `auth-failed`
+ * means the server actively refused the credentials. Without latching, the
+ * non-latching remote path causes the overlay to flicker in and out of existence,
+ * making the Settings button unreachable (the exact symptom of #72698).
+ */
+export function shouldLatchSshAuthFailure(context: SshAuthFailureContext): boolean {
+  return context.attemptedRemote && context.isSshAuthFailed
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -39,7 +39,7 @@ import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import { canImportHermesCli, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
-import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
+import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure, shouldLatchSshAuthFailure } from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { runBootstrap } from './bootstrap-runner'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
@@ -1033,6 +1033,14 @@ let backendStartFailure = null
 // the boot-failure overlay, so the "Sign in" button flickers away before it
 // can be clicked. Cleared on every recovery path and on a confirmed sign-in.
 let remoteReauthFailure = null
+// Latched SSH auth-failed errors. SSH `auth-failed` (wrong key/user, key not
+// loaded in agent) is a confirmed credential rejection that cannot self-heal.
+// Without latching, every subsequent getConnection re-runs startHermes,
+// re-emits running:true, and the boot-failure overlay (visible = Boolean(boot.error)
+// && !boot.running) hides itself — so the Settings button flickers away before
+// it can be clicked. This is the root cause of #72698. Cleared on reset,
+// repair, or apply-connection-config.
+let sshAuthFailure = null
 // Active first-launch install, so the renderer's Cancel button (and app quit)
 // can abort the in-flight install.sh/ps1 instead of leaving it running.
 let bootstrapAbortController = null
@@ -7642,6 +7650,7 @@ function stopBackendChild(child) {
 function resetHermesConnection({ soft = false } = {}) {
   backendStartFailure = null
   remoteReauthFailure = null
+  sshAuthFailure = null
   remoteLiveness.clear()
   const hermesProcess = backendConnectionState.invalidate()
   stopBackendChild(hermesProcess)
@@ -8041,6 +8050,14 @@ async function startHermes() {
     throw remoteReauthFailure
   }
 
+  // A confirmed SSH auth-failed error is terminal until the user edits the
+  // connection config. Without this latch, the renderer's getConnection retry
+  // loop re-runs startHermes on every call, toggling boot.running and hiding
+  // the boot-failure overlay — making Settings unreachable (#72698).
+  if (sshAuthFailure) {
+    throw sshAuthFailure
+  }
+
   // E2E: simulate a boot failure without breaking the real backend. The boot
   // progresses a few steps, then fails with the given error message.
   if (BOOT_FAKE_ERROR) {
@@ -8308,6 +8325,14 @@ async function startHermes() {
     // leaving it unlatched hides the overlay's "Sign in" button on every retry.
     if (shouldLatchRemoteReauthFailure({ attemptedRemote, isReauth: isReauthRequiredError(error) })) {
       remoteReauthFailure = error instanceof Error ? error : new Error(message)
+    }
+
+    // SSH auth-failed (wrong key, wrong user, key not in agent) latches for the
+    // same reason as remote reauth — it's a confirmed credential rejection that
+    // can't self-heal. Without this the retry loop toggles boot.running and hides
+    // the boot-failure overlay, locking the user out of Settings (#72698).
+    if (shouldLatchSshAuthFailure({ attemptedRemote, isSshAuthFailed: error?.sshError === 'auth-failed' })) {
+      sshAuthFailure = error instanceof Error ? error : new Error(message)
     }
 
     updateBootProgress(
@@ -9323,6 +9348,7 @@ ipcMain.handle('hermes:bootstrap:reset', async () => {
   bootstrapFailure = null
   backendStartFailure = null
   remoteReauthFailure = null
+  sshAuthFailure = null
   getFirstRunSetupGate().resetForRetry()
   resetBootstrapSnapshot()
 
@@ -9343,6 +9369,7 @@ ipcMain.handle('hermes:bootstrap:repair', async () => {
   bootstrapFailure = null
   backendStartFailure = null
   remoteReauthFailure = null
+  sshAuthFailure = null
   getFirstRunSetupGate().resetForRepair()
   resetHermesConnection()
 


### PR DESCRIPTION
## Background

Fixes #72698: Desktop App SSH authentication failure makes Settings dialog unreachable (window refreshes too fast, clicks ignored).

## Root Cause Analysis

When SSH authentication fails (wrong key/user/key not loaded in agent), the error is NOT latched in `startHermes()` because SSH is classified as a remote connection, and remote failures are normally treated as transient and retryable. This causes the renderer's `getConnection` retry loop to re-run `startHermes` on every call, rapidly toggling `boot.running` between true/false. The boot-failure overlay uses `visible = Boolean(boot.error) && !boot.running`, so it flickers in and out of existence — the user cannot click the Settings button and is locked out of the config UI, forced to manually edit `connection.json`.

## Fix

1. Added `shouldLatchSshAuthFailure()` predicate in `backend-start-failure.ts` to detect SSH `auth-failed` errors
2. In `main.ts` `startHermes()` catch block, latch SSH auth-failed errors the same way `remoteReauthFailure` is latched
3. Clear `sshAuthFailure` latch on reset, repair, and connection reset recovery paths
4. Added 4 unit tests validating the new predicate

After this fix, the boot-failure overlay stays visible and clickable, allowing the user to open Settings and fix their SSH configuration.

## Verification

- [x] Code changes verified locally (4/4 unit tests pass)
- [x] Follows project AGENTS.md contribution guidelines
- [x] No breaking changes

Closes #72698