### PR TITLE
fix(gateway): verify launchd service survivability after restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1156,6 +1156,70 @@ def _wait_for_systemd_service_restart(
     return False
 
 
+def _wait_for_launchd_service_restart(
+    *,
+    previous_pid: int | None = None,
+    timeout: float = 30.0,
+) -> bool:
+    """Wait for the launchd-managed gateway to become healthy after a restart.
+
+    Polls launchd service liveness and the gateway runtime state until the
+    service reports a running gateway with a PID that differs from
+    ``previous_pid`` (when provided).  Returns ``False`` on timeout or
+    ``startup_failed``, surfacing actionable recovery instructions.
+    """
+    import time
+
+    deadline = time.monotonic() + timeout
+    printed_runtime_wait = False
+
+    while time.monotonic() < deadline:
+        if not _probe_launchd_service_running():
+            time.sleep(1)
+            continue
+
+        new_pid = None
+        try:
+            from gateway.status import get_running_pid
+
+            new_pid = get_running_pid()
+        except Exception:
+            new_pid = None
+
+        if new_pid and (previous_pid is None or new_pid != previous_pid):
+            try:
+                runtime_state = _gateway_runtime_status_for_pid(new_pid)
+            except Exception:
+                runtime_state = None
+            gateway_state = (runtime_state or {}).get("gateway_state")
+            if gateway_state == "running":
+                print(f"✓ Launchd service restarted (PID {new_pid})")
+                return True
+            if gateway_state == "startup_failed":
+                reason = (runtime_state or {}).get("exit_reason") or "startup failed"
+                print(
+                    "⚠ Launchd service process restarted "
+                    f"(PID {new_pid}), but gateway startup failed: {reason}"
+                )
+                return False
+            if not printed_runtime_wait:
+                print(
+                    f"⏳ Launchd service process started (PID {new_pid}); "
+                    "waiting for gateway runtime..."
+                )
+                printed_runtime_wait = True
+
+        time.sleep(1)
+
+    print(
+        f"⚠ Launchd service did not relaunch within {int(timeout)}s.\n"
+        "  Check status: hermes gateway status\n"
+        "  Recover manually:\n"
+        f"    launchctl kickstart {_launchd_domain()}/{get_launchd_label()}"
+    )
+    return False
+
+
 def _systemd_unit_is_start_limited(props: dict[str, str]) -> bool:
     result = props.get("Result", "").lower()
     sub_state = props.get("SubState", "").lower()
@@ -4539,10 +4603,38 @@ def launchd_restart():
     try:
         pid = get_running_pid()
         if pid is not None and _request_gateway_self_restart(pid):
+            # The gateway accepted the self-restart signal. It refuses new
+            # turns, waits for in-flight work (up to restart_after_turn_timeout,
+            # then drains within restart_drain_timeout), and exits with code 75
+            # to trigger launchd's KeepAlive respawn (#77184). Wait for the old
+            # process to exit within the full budget — kicking the service while
+            # a turn is still draining would amputate it — then verify launchd
+            # spawned a healthy replacement (#62128).
             print("✓ Service restart requested")
-            _clear_launchd_unsupported_marker()
-            return
-        if pid is not None:
+            exited = _wait_for_gateway_exit(
+                timeout=_get_restart_exit_wait_budget(), force_after=None
+            )
+            if exited:
+                # Old process is gone. Give launchd a brief window for the
+                # automatic KeepAlive respawn (the normal ~1 s path reported in
+                # #62128). If launchd fires the respawn, verify it and return;
+                # if not, escalate to kickstart.
+                if _wait_for_launchd_service_restart(
+                    previous_pid=pid,
+                    timeout=30.0,
+                ):
+                    _clear_launchd_unsupported_marker()
+                    return
+                print(
+                    "⚠ launchd did not respawn the gateway after self-restart "
+                    "— forcing kickstart"
+                )
+            else:
+                print(
+                    "⚠ Gateway did not exit within the restart budget "
+                    "— forcing launchd kickstart"
+                )
+        elif pid is not None:
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway
             # finishes in-flight agent runs, and it streams into surfaces with
@@ -4564,6 +4656,12 @@ def launchd_restart():
                         f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
                     )
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+        if not _wait_for_launchd_service_restart(previous_pid=pid, timeout=30.0):
+            raise subprocess.CalledProcessError(
+                1,
+                ["launchctl", "kickstart", "-k", target],
+                stderr=b"launchd accepted the restart request, but the gateway did not relaunch",
+            )
         print("✓ Service restarted")
         _clear_launchd_unsupported_marker()
     except subprocess.CalledProcessError as e:
@@ -4595,6 +4693,12 @@ def launchd_restart():
                 timeout=30,
             )
             subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+            if not _wait_for_launchd_service_restart(previous_pid=None, timeout=30.0):
+                raise subprocess.CalledProcessError(
+                    1,
+                    ["launchctl", "kickstart", target],
+                    stderr=b"launchd reloaded the job, but the gateway did not relaunch",
+                )
         except subprocess.CalledProcessError as e2:
             if not _launchctl_domain_unsupported(e2.returncode):
                 raise

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -397,6 +397,317 @@ class TestLaunchdServiceRecovery:
         assert "PID 88888" in out
         assert "NOT available" in out
 
+    # ── _wait_for_launchd_service_restart ────────────────────────────────
+
+    def _wait_fixture(self, monkeypatch, *, probe, pids, runtime):
+        """Shared mocks for the launchd restart wait helper."""
+        monkeypatch.setattr(gateway_cli, "_probe_launchd_service_running", probe)
+        if pids is not None:
+            monkeypatch.setattr("gateway.status.get_running_pid", pids)
+        monkeypatch.setattr(
+            gateway_cli, "_gateway_runtime_status_for_pid", runtime
+        )
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(
+            gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway"
+        )
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+    def test_wait_for_launchd_service_restart_times_out_when_service_never_running(
+        self, monkeypatch, capsys
+    ):
+        """launchd probe stays down → poll until timeout → False + recovery text."""
+        ticks = iter([100.0, 100.0, 130.0])
+        monkeypatch.setattr("time.monotonic", lambda: next(ticks))
+        self._wait_fixture(
+            monkeypatch,
+            probe=lambda: False,
+            pids=lambda: None,
+            runtime=lambda pid: None,
+        )
+
+        result = gateway_cli._wait_for_launchd_service_restart(
+            previous_pid=1111, timeout=30.0
+        )
+
+        assert result is False
+        out = capsys.readouterr().out
+        assert "did not relaunch within 30s" in out
+        assert "hermes gateway status" in out
+        assert "launchctl kickstart gui/501/ai.hermes.gateway" in out
+
+    def test_wait_for_launchd_service_restart_returns_true_when_replacement_running(
+        self, monkeypatch, capsys
+    ):
+        """New PID with runtime state 'running' → success on first poll."""
+        ticks = iter([100.0, 100.0])
+        monkeypatch.setattr("time.monotonic", lambda: next(ticks))
+        self._wait_fixture(
+            monkeypatch,
+            probe=lambda: True,
+            pids=lambda: 2222,
+            runtime=lambda pid: {"pid": pid, "gateway_state": "running"},
+        )
+
+        result = gateway_cli._wait_for_launchd_service_restart(
+            previous_pid=1111, timeout=30.0
+        )
+
+        assert result is True
+        assert "Launchd service restarted (PID 2222)" in capsys.readouterr().out
+
+    def test_wait_for_launchd_service_restart_ignores_previous_pid(
+        self, monkeypatch, capsys
+    ):
+        """Same PID as before the restart is NOT treated as a healthy respawn."""
+        pids = iter([1111, 2222])
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: next(pids))
+        ticks = iter([100.0, 100.0, 100.0, 100.0])
+        monkeypatch.setattr("time.monotonic", lambda: next(ticks))
+        self._wait_fixture(
+            monkeypatch,
+            probe=lambda: True,
+            pids=None,
+            runtime=lambda pid: {"pid": pid, "gateway_state": "running"},
+        )
+
+        result = gateway_cli._wait_for_launchd_service_restart(
+            previous_pid=1111, timeout=30.0
+        )
+
+        # Only the replacement PID (2222) counts; the stale 1111 was skipped.
+        assert result is True
+        assert "Launchd service restarted (PID 2222)" in capsys.readouterr().out
+
+    def test_wait_for_launchd_service_restart_reports_startup_failed(
+        self, monkeypatch, capsys
+    ):
+        """Runtime 'startup_failed' → False with the exit reason surfaced."""
+        ticks = iter([100.0, 100.0])
+        monkeypatch.setattr("time.monotonic", lambda: next(ticks))
+        self._wait_fixture(
+            monkeypatch,
+            probe=lambda: True,
+            pids=lambda: 2222,
+            runtime=lambda pid: {
+                "pid": pid,
+                "gateway_state": "startup_failed",
+                "exit_reason": "bad config",
+            },
+        )
+
+        result = gateway_cli._wait_for_launchd_service_restart(
+            previous_pid=1111, timeout=30.0
+        )
+
+        assert result is False
+        out = capsys.readouterr().out
+        assert "startup failed: bad config" in out
+
+    def test_wait_for_launchd_service_restart_waits_for_runtime(
+        self, monkeypatch, capsys
+    ):
+        """Process is up but runtime state not ready → keep polling, then succeed."""
+        states = iter([None, {"pid": 2222, "gateway_state": "running"}])
+        ticks = iter([100.0, 100.0, 100.0, 100.0])
+        monkeypatch.setattr("time.monotonic", lambda: next(ticks))
+
+        def fake_runtime(pid):
+            return next(states)
+
+        self._wait_fixture(
+            monkeypatch,
+            probe=lambda: True,
+            pids=lambda: 2222,
+            runtime=fake_runtime,
+        )
+
+        result = gateway_cli._wait_for_launchd_service_restart(
+            previous_pid=1111, timeout=30.0
+        )
+
+        assert result is True
+        out = capsys.readouterr().out
+        assert "waiting for gateway runtime" in out
+        assert "Launchd service restarted (PID 2222)" in out
+
+    # ── launchd_restart escalation ladder ────────────────────────────────
+
+    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch, capsys):
+        calls = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda: 321,
+        )
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_restart", lambda **kw: True)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ("term", 321, False),
+            ["launchctl", "kickstart", "-k", target],
+        ]
+        # The drain can silently hold for the full budget (180s default); the
+        # desktop updater streams this output as its only progress feedback,
+        # so the stop must be announced BEFORE the wait (#44515).
+        out = capsys.readouterr().out
+        assert "draining in-flight runs" in out
+        assert "up to 12s" in out
+
+    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
+        """SIGUSR1 self-restart accepted → wait for exit + healthy respawn, no kickstart."""
+        calls = []
+        waits = []
+
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda: 321,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append(("self", pid)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_get_restart_exit_wait_budget",
+            lambda: 27.0,
+        )
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout, force_after=None: calls.append(("exit", timeout, force_after)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda **kw: waits.append(kw) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [("self", 321), ("exit", 27.0, None)]
+        # The exit wait uses the full #77184 budget (after-turn + drain +
+        # headroom), so a still-draining gateway is not kicked. The respawn
+        # verification is a short fixed window once the old PID is gone.
+        assert waits == [{"previous_pid": 321, "timeout": 30.0}]
+        assert "restart requested" in capsys.readouterr().out.lower()
+
+    def test_launchd_restart_recovers_stuck_self_restart_with_kickstart(self, monkeypatch, capsys):
+        """When launchd fails to auto-respawn, escalate to kickstart -k."""
+        calls = []
+        waits = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: True)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+
+        # First call: auto-respawn fails.  Second call: kickstart -k succeeds.
+        wait_results = iter([False, True])
+
+        def fake_wait(**kwargs):
+            waits.append(kwargs)
+            return next(wait_results)
+
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_restart", fake_wait)
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert waits == [
+            {"previous_pid": 321, "timeout": 30.0},
+            {"previous_pid": 321, "timeout": 30.0},
+        ]
+        assert calls == [["launchctl", "kickstart", "-k", target]]
+        out = capsys.readouterr().out.lower()
+        assert "forcing kickstart" in out
+
+    def test_launchd_restart_raises_when_gateway_never_relaunches(self, monkeypatch):
+        """After kickstart -k, if the gateway still doesn't become healthy, raise."""
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_restart", lambda **kw: False)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, check=False, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+            gateway_cli.launchd_restart()
+
+    def test_launchd_restart_boots_out_stale_registration_before_bootstrap(
+        self, tmp_path, monkeypatch
+    ):
+        """Unloaded-job kickstart → bootout stale label, bootstrap, verify respawn."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{label}"
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True
+        )
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_restart", lambda **kw: True)
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", "-k", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    3, cmd, stderr="Could not find service"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ["launchctl", "kickstart", "-k", target],
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "kickstart", target],
+        ]
+
 
 class TestLaunchdDomainDetection:
     """Regression tests for _launchd_domain() probing (#40831).


### PR DESCRIPTION
## What does this PR do?

Fixes the launchd restart survivability gap described in #62128. Currently `launchd_restart()` signals a self-restart (SIGUSR1) and returns immediately — if launchd gets stuck in "pended nondemand spawn = semaphore", the gateway stays dead with no error surfaced.

## Changes

### `hermes_cli/gateway.py`
- Added `_wait_for_launchd_service_restart()` — polls launchd liveness + gateway runtime state, analogous to the already-existing `_wait_for_systemd_service_restart()` added by #6631
- Restructured `launchd_restart()` with an escalation ladder on the self-restart path:
  1. Signal self-restart (SIGUSR1) → wait for old PID exit
  2. Wait for launchd automatic KeepAlive respawn → verify
  3. If auto-respawn fails: fall through to `kickstart -k` → verify
  4. If `kickstart -k` still fails: raise `CalledProcessError` so callers stop reporting success for a dead service
- Non-self-restart paths (drain+terminate, bootstrap) also get post-kickstart verification

### `tests/hermes_cli/test_gateway_service.py`
- Updated 3 existing tests for the new wait/verification step
- Added 2 new tests:
  - `test_launchd_restart_recovers_stuck_self_restart_with_kickstart` — auto-respawn fails → kickstart recovery
  - `test_launchd_restart_raises_when_gateway_never_relaunches` — hard failure after kickstart -k

## Related Issue

Closes #62128 (gateway restart half)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

```bash
python -m pytest tests/hermes_cli/test_gateway_service.py -k 'launchd_restart' -v
```

All 7 tests pass.

## Notes

- The desktop app self-relaunch half of #62128 is tracked separately in #66753
- The multi-profile launchd restart gap (#38053) is separate and has its own open PRs
