### PR TITLE
fix(cli): /reasoning shows active fallback model's effort, not the primary's

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2907,8 +2907,16 @@ class CLICommandsMixin:
         parts = cmd.strip().split(maxsplit=1)
 
         if len(parts) < 2:
-            # Show current state
-            rc = self.reasoning_config
+            # Show current state. Prefer the live agent's reasoning_config when
+            # an agent exists: on a fallback swap, try_activate_fallback
+            # re-resolves reasoning_config for the *active* model's per-model
+            # override (agent/chat_completion_helpers.py), while the CLI-level
+            # self.reasoning_config stays pinned to the primary model resolved at
+            # init. Reading it directly would report the primary's effort while a
+            # fallback model is actually answering. Mirrors how the status bar
+            # prefers agent.model over self.model (cli.py _get_status_bar_snapshot).
+            agent = getattr(self, "agent", None)
+            rc = getattr(agent, "reasoning_config", None) if agent is not None else self.reasoning_config
             if rc is None:
                 level = "medium (default)"
             elif rc.get("enabled") is False:

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -154,6 +154,51 @@ class TestHandleReasoningCommand(unittest.TestCase):
         level = rc.get("effort", "medium")
         self.assertEqual(level, "xhigh")
 
+    def test_status_prefers_active_fallback_agent_effort(self):
+        """After a fallback swap the /reasoning status must report the effort of
+        the model actually answering (agent.reasoning_config), not the primary
+        model's effort pinned on the CLI at init.
+
+        Repro: primary gpt-5.6-terra (override high) falls back to
+        deepseek-v4-flash (override max). try_activate_fallback re-resolves
+        agent.reasoning_config to max, but self.reasoning_config stays high.
+        /reasoning must show max.
+        """
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        agent = SimpleNamespace(reasoning_config={"enabled": True, "effort": "max"})
+        stub = SimpleNamespace(
+            reasoning_config={"enabled": True, "effort": "high"},  # primary, stale
+            show_reasoning=True,
+            reasoning_full=True,
+            agent=agent,
+        )
+        printed = []
+        with patch("cli._cprint", side_effect=lambda *a, **k: printed.append(a[0] if a else "")):
+            CLICommandsMixin._handle_reasoning_command(stub, "/reasoning")
+
+        effort_line = next(l for l in printed if "Reasoning effort:" in l)
+        self.assertIn("max", effort_line)
+        self.assertNotIn("high", effort_line)
+
+    def test_status_uses_cli_config_when_no_agent(self):
+        """Before any agent is initialised (self.agent is None), the status
+        falls back to the CLI-level reasoning_config."""
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        stub = SimpleNamespace(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            show_reasoning=False,
+            reasoning_full=False,
+            agent=None,
+        )
+        printed = []
+        with patch("cli._cprint", side_effect=lambda *a, **k: printed.append(a[0] if a else "")):
+            CLICommandsMixin._handle_reasoning_command(stub, "/reasoning")
+
+        effort_line = next(l for l in printed if "Reasoning effort:" in l)
+        self.assertIn("xhigh", effort_line)
+
     def test_effort_defaults_to_session_only(self):
         """Plain /reasoning <level> is session-scoped — no config write."""
         from hermes_cli.cli_commands_mixin import CLICommandsMixin


### PR DESCRIPTION
## Summary

`/reasoning` (no args) reports the wrong effort level after a fallback swap.
The status line reads `self.reasoning_config`, which `HermesCLI` resolves
**once at init for the primary model** (`resolve_reasoning_config(CLI_CONFIG, self.model)`)
and never updates on fallback. Meanwhile `try_activate_fallback`
(`agent/chat_completion_helpers.py`) **does** re-resolve `agent.reasoning_config`
for the active fallback model's per-model override.

Result: after Hermes falls back, the status bar correctly shows the fallback
model (it reads `agent.model`), but `/reasoning` still prints the **primary
model's** effort.

### Repro

Config:
```yaml
model:
  default: gpt-5.6-terra
  provider: openai-codex
fallback_providers:
  - provider: opencode-go
    model: deepseek-v4-flash
    base_url: https://opencode.ai/zen/go/v1
    api_mode: chat_completions
agent:
  reasoning_effort: xhigh
  reasoning_overrides:
    gpt-5.6-terra: high
    deepseek-v4-flash: max
```

Primary fails → fallback to `deepseek-v4-flash`. Logs confirm the swap
re-resolves effort correctly:
```
agent.chat_completion_helpers: Fallback deepseek-v4-flash: reasoning_config resolved: {'enabled': True, 'effort': 'max'}
```
…but the status bar shows `⚕ deepseek-v4-flash` while `/reasoning` prints:
```
Reasoning effort:  high      ← gpt-5.6-terra's override, wrong model
```

## Fix

Read `agent.reasoning_config` when an agent exists, mirroring how the status
bar already prefers `agent.model` over `self.model`
(`cli.py:_get_status_bar_snapshot`). Falls back to `self.reasoning_config`
before the agent is initialised (`self.agent is None`).

This composes cleanly with the existing set path: `/reasoning <level>` sets
`self.reasoning_config` and nulls `self.agent` to force re-init, so the next
`/reasoning` read correctly falls through to the freshly-set CLI value.

## Changes

- `hermes_cli/cli_commands_mixin.py`: `_handle_reasoning_command` status branch
  reads the live agent's `reasoning_config` when present.
- `tests/cli/test_reasoning_command.py`: adds two tests —
  - fallback agent (effort `max`) vs stale CLI (`high`) → status shows `max`;
  - no agent yet → status falls back to the CLI-level `reasoning_config`.

## Testing

```
$ ./venv/bin/python -m unittest tests.cli.test_reasoning_command -v
Ran 62 tests in 0.694s
OK
```

Scope note: the gateway `/reasoning` handler (`gateway/slash_commands.py`) already
re-resolves per active session model, so it is unaffected; this fix is limited to
the CLI/TUI handler.