### PR TITLE
fix(state): index approval history scans

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1291,6 +1291,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_role_timestamp
+    ON messages(role, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3941,6 +3941,74 @@ class TestSchemaInit:
         assert "messages" in tables
         assert "schema_version" in tables
 
+    def test_role_timestamp_index_is_schema_managed_for_fresh_and_legacy_db(
+        self, tmp_path, monkeypatch
+    ):
+        """Schema setup creates, repairs, and preserves the role lookup index."""
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        explicit_db = tmp_path / "role-index.db"
+
+        def assert_index_contract(session_db):
+            assert session_db._conn is not None
+            plans = [
+                session_db._conn.execute(
+                    "EXPLAIN QUERY PLAN "
+                    "SELECT tool_calls FROM messages "
+                    "WHERE role='assistant' AND tool_calls IS NOT NULL "
+                    "AND tool_calls LIKE '%terminal%' AND timestamp >= ?",
+                    (0.0,),
+                ).fetchall(),
+                session_db._conn.execute(
+                    "EXPLAIN QUERY PLAN "
+                    "SELECT tool_call_id, content FROM messages "
+                    "WHERE role='tool' AND tool_call_id IS NOT NULL AND timestamp >= ? "
+                    "AND (content LIKE '%BLOCKED%' OR content LIKE '%approval%')",
+                    (0.0,),
+                ).fetchall(),
+            ]
+            details = [[row[3] for row in plan] for plan in plans]
+            assert all(
+                any("USING INDEX idx_messages_role_timestamp" in detail for detail in plan)
+                for plan in details
+            ), details
+
+            rows = session_db._conn.execute(
+                "PRAGMA index_xinfo('idx_messages_role_timestamp')"
+            ).fetchall()
+            key_columns = [(row[2], row[3]) for row in rows if row[5]]
+            assert key_columns == [("role", 0), ("timestamp", 1)]
+
+        fresh = SessionDB(db_path=explicit_db)
+        try:
+            assert_index_contract(fresh)
+        finally:
+            fresh.close()
+
+        with sqlite3.connect(explicit_db) as legacy:
+            legacy.execute("DROP INDEX idx_messages_role_timestamp")
+
+        reconciled = SessionDB(db_path=explicit_db)
+        try:
+            assert_index_contract(reconciled)
+        finally:
+            reconciled.close()
+
+        reopened = SessionDB(db_path=explicit_db)
+        try:
+            assert_index_contract(reopened)
+            assert reopened._conn is not None
+            count = reopened._conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type = 'index' AND name = 'idx_messages_role_timestamp'"
+            ).fetchone()[0]
+            assert count == 1
+        finally:
+            reopened.close()
+
+        assert not (hermes_home / "state.db").exists()
+
     def test_schema_version(self, db):
         from hermes_state import SCHEMA_VERSION
         cursor = db._conn.execute("SELECT version FROM schema_version")


### PR DESCRIPTION
## What does this PR do?

`hermes approvals suggest` reads approval history through two `messages` queries that constrain both `role` and a timestamp window (`_iter_terminal_calls()` and `_blocked_tool_call_ids()`). On current `main` (`2b0fb72acae67f51652de5c51db556bc15a68f0e`), both queries plan as full table scans:

```text
[['SCAN messages'], ['SCAN messages']]
```

This adds the schema-managed, idempotent index:

```sql
CREATE INDEX IF NOT EXISTS idx_messages_role_timestamp
    ON messages(role, timestamp DESC);
```

Keeping the declaration in `SCHEMA_SQL` means it is created for fresh databases and reconciled whenever an existing `SessionDB` is opened. The change stays inside the existing schema-init mechanism and does not add a new migration framework or config surface.

## Related Issue

No linked issue. The behavior was reproduced against current `main`, and searches across open and closed issues/PRs found no duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: declare `idx_messages_role_timestamp` through the existing idempotent schema setup.
- `tests/test_hermes_state.py`: verify:
  - both production approval-history query shapes use the named index;
  - exact key order is `(role ASC, timestamp DESC)`;
  - fresh database creation;
  - reconciliation after the index is removed from an existing database;
  - idempotent repeated opens produce exactly one index;
  - an explicit test database does not leak into the default `HERMES_HOME/state.db`.

## How to Test

1. Behavioral regression test:
   ```bash
   scripts/run_tests.sh tests/test_hermes_state.py \
     -k role_timestamp_index_is_schema_managed_for_fresh_and_legacy_db -q
   ```
2. Full SessionDB module:
   ```bash
   scripts/run_tests.sh tests/test_hermes_state.py -q
   ```
3. Approval-suggest and related SessionDB/SQLite/WAL/FTS selection through the canonical wrapper.
4. Static checks:
   ```bash
   .venv/bin/ruff check --no-cache hermes_state.py tests/test_hermes_state.py
   .venv/bin/python -m py_compile hermes_state.py tests/test_hermes_state.py
   git diff --check
   ```

Observed locally:

- Before the schema declaration: `1 failed, 465 deselected`; both real query plans reported `SCAN messages`.
- Focused regression: `1 passed`.
- Full `tests/test_hermes_state.py`: `466 passed`.
- Related selection: `26 files, 756 passed, 0 failed`, including all `25` approval-suggest tests.
- Ruff, bytecode compilation, and diff check: pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted canonical suites are green; repository-wide CI is pending
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; no user-facing behavior or configuration changed
- [x] I've updated `cli-config.yaml.example` — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact — standard SQLite DDL/query-plan behavior, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A; no tool surface changed

## Screenshots / Logs

Not applicable. The behavioral RED/GREEN and canonical test totals are included above.
