### PR TITLE
feat(provider/deepseek): apply peak-hour rate multiplier (#72662)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -100,6 +100,21 @@ class CostResult:
 _UTC_NOW = lambda: datetime.now(timezone.utc)
 
 
+def _deepseek_peak_hour_multiplier() -> Decimal:
+    """Return the peak-hour rate multiplier for DeepSeek pricing.
+
+    DeepSeek announced peak-hour pricing on 2026-07-26 with 2x rate multiplier
+    during these daily windows (UTC):
+      - 01:00 – 04:00  (hours 1, 2, 3, 4)
+      - 06:00 – 10:00  (hours 6, 7, 8, 9, 10)
+    All other hours: standard rate (1.0x).
+    """
+    hour = _UTC_NOW().hour
+    if (1 <= hour < 5) or (6 <= hour < 11):
+        return Decimal("2")
+    return Decimal("1")
+
+
 # Official docs snapshot entries. Models whose published pricing and cache
 # semantics are stable enough to encode exactly.
 _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
@@ -1257,6 +1272,14 @@ def estimate_usage_cost(
         amount += Decimal(usage.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_MILLION
     if entry.request_cost is not None and usage.request_count:
         amount += Decimal(usage.request_count) * entry.request_cost
+
+    # DeepSeek peak-hour pricing: 2x multiplier during peak windows (01:00-04:00
+    # and 06:00-10:00 UTC daily). Announcement: DeepSeek 2026-07-26.
+    if route.provider == "deepseek":
+        peak_mult = _deepseek_peak_hour_multiplier()
+        if peak_mult > 1:
+            amount *= peak_mult
+            notes.append(f"DeepSeek peak-hour pricing ({peak_mult}x multiplier)")
 
     status: CostStatus = "estimated"
     label = f"~${amount:.2f}"

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: himalaya
 description: "Himalaya CLI: IMAP/SMTP email from terminal."
-version: 1.1.0
+version: 2.0.0
 author: community
 license: MIT
 platforms: [linux, macos, windows]
@@ -48,13 +48,20 @@ cargo install himalaya --locked
 
 ## Configuration Setup
 
-Run the interactive wizard to set up an account:
+Run the interactive wizard (bare `himalaya` — no subcommand) to set up an account:
 
 ```bash
-himalaya account configure
+himalaya
 ```
 
-Or create `~/.config/himalaya/config.toml` manually:
+The wizard tests IMAP and SMTP connectivity, then prints a ready-to-save
+TOML config to stdout. Redirect it directly:
+
+```bash
+himalaya > ~/.config/himalaya/config.toml
+```
+
+Or create `~/.config/himalaya/config.toml` manually using per-backend tables:
 
 ```toml
 [accounts.personal]
@@ -62,56 +69,41 @@ email = "you@example.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@example.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show email/imap"  # or use keyring
+imap.server = "imap.example.com:993"
+imap.sasl.plain.username = "you@example.com"
+imap.sasl.plain.password.raw = "your-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show email/smtp"
+smtp.server = "smtp.example.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@example.com"
+smtp.sasl.plain.password.raw = "your-password"
 
-# Folder aliases (himalaya v1.2.0+ syntax). Required whenever the
-# server's folder names don't match himalaya's canonical names
-# (inbox/sent/drafts/trash). Gmail is the common case — see
-# `references/configuration.md` for the `[Gmail]/Sent Mail` mapping.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
-> **Heads up on the alias syntax.** Pre-v1.2.0 docs used a
-> `[accounts.NAME.folder.alias]` sub-section (singular `alias`).
-> v1.2.0 silently ignores that form — TOML parses fine, but the
-> alias resolver never reads it, so every lookup falls through to
-> the canonical name. On Gmail this means save-to-Sent fails *after*
-> SMTP delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that exit code
-> will re-run the entire send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural, dotted
-> keys, directly under `[accounts.NAME]`).
+> **Heads up on the alias syntax.** Himalaya v2.0.0 renamed
+> `folder.aliases.*` to `mailbox.alias.*`. The old dotted keys are
+> silently ignored — TOML parses fine, but the alias resolver never reads
+> them. On Gmail this means save-to-Sent fails *after* SMTP delivery
+> succeeds, and `himalaya message send` exits non-zero. Always use
+> `mailbox.alias.X` in v2.0.0+.
 
 ## Hermes Integration Notes
 
 - **Reading, listing, searching, moving, deleting** all work directly through the terminal tool
 - **Composing/replying/forwarding** — piped input (`cat << EOF | himalaya template send`) is recommended for reliability. Interactive `$EDITOR` mode works with `pty=true` + background + process tool, but requires knowing the editor and its commands
-- Use `--output json` for structured output that's easier to parse programmatically
-- The `himalaya account configure` wizard requires interactive input — use PTY mode: `terminal(command="himalaya account configure", pty=true)`
+- Use `--json` before the subcommand for structured output that's easier to parse programmatically (e.g. `himalaya --json envelope list`)
+- The bare `himalaya` wizard requires interactive input — use PTY mode: `terminal(command="himalaya", pty=true)`
 
 ## Common Operations
 
-### List Folders
+### List Mailboxes
 
 ```bash
-himalaya folder list
+himalaya mailbox list
 ```
 
 ### List Emails
@@ -275,11 +267,10 @@ himalaya attachment download 42 --downloads-dir ~/Downloads
 
 ## Output Formats
 
-Most commands support `--output` for structured output:
+Most commands support `--json` (before the subcommand) for structured output:
 
 ```bash
-himalaya envelope list --output json
-himalaya envelope list --output plain
+himalaya --json envelope list
 ```
 
 ## Debugging

--- a/skills/email/himalaya/references/configuration.md
+++ b/skills/email/himalaya/references/configuration.md
@@ -11,29 +11,22 @@ display-name = "Your Name"
 default = true
 
 # IMAP backend for reading emails
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "user@example.com"
-backend.auth.type = "password"
-backend.auth.raw = "your-password"
+imap.server = "imap.example.com:993"
+imap.sasl.plain.username = "user@example.com"
+imap.sasl.plain.password.raw = "your-password"
 
 # SMTP backend for sending emails
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "user@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.raw = "your-password"
+smtp.server = "smtp.example.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "user@example.com"
+smtp.sasl.plain.password.raw = "your-password"
 
-# Folder aliases — required whenever server folder names differ
-# from himalaya's canonical names. See "Folder Aliases" below.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+# Mailbox aliases — required whenever server folder names differ
+# from himalaya's canonical names. See "Mailbox Aliases" below.
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
 ## Password Options
@@ -41,23 +34,18 @@ folder.aliases.trash = "Trash"
 ### Raw password (testing only, not recommended)
 
 ```toml
-backend.auth.raw = "your-password"
+imap.sasl.plain.password.raw = "your-password"
+# smtp.sasl.plain.password.raw = "your-password"
 ```
 
 ### Password from command (recommended)
 
 ```toml
-backend.auth.cmd = "pass show email/imap"
-# backend.auth.cmd = "security find-generic-password -a user@example.com -s imap -w"
+imap.sasl.plain.password.cmd = "pass show email/imap"
+# imap.sasl.plain.password.cmd = "security find-generic-password -a user@example.com -s imap -w"
 ```
 
-### System keyring (requires keyring feature)
-
-```toml
-backend.auth.keyring = "imap-example"
-```
-
-Then run `himalaya account configure <account>` to store the password.
+Then run `himalaya` to set up an account (the wizard prints a ready-to-save TOML config).
 
 ## Gmail Configuration
 
@@ -67,31 +55,24 @@ email = "you@gmail.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.gmail.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@gmail.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show google/app-password"
+imap.server = "imap.gmail.com:993"
+imap.sasl.plain.username = "you@gmail.com"
+imap.sasl.plain.password.raw = "app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.gmail.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@gmail.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show google/app-password"
+smtp.server = "smtp.gmail.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@gmail.com"
+smtp.sasl.plain.password.raw = "app-password"
 
 # Gmail folder mapping. Without these, save-to-Sent fails after
 # SMTP delivery succeeds (Gmail's Sent folder is `[Gmail]/Sent Mail`,
 # not `Sent`), and `himalaya message send` exits non-zero. Any
 # caller that retries on that error will re-run SMTP — duplicate
 # emails to recipients. Always include this block for Gmail.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "[Gmail]/Sent Mail"
-folder.aliases.drafts = "[Gmail]/Drafts"
-folder.aliases.trash = "[Gmail]/Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "[Gmail]/Sent Mail"
+mailbox.alias.drafts = "[Gmail]/Drafts"
+mailbox.alias.trash = "[Gmail]/Trash"
 ```
 
 **Note:** Gmail requires an App Password if 2FA is enabled.
@@ -103,62 +84,47 @@ folder.aliases.trash = "[Gmail]/Trash"
 email = "you@icloud.com"
 display-name = "Your Name"
 
-backend.type = "imap"
-backend.host = "imap.mail.me.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@icloud.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show icloud/app-password"
+imap.server = "imap.mail.me.com:993"
+imap.sasl.plain.username = "you@icloud.com"
+imap.sasl.plain.password.raw = "app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.mail.me.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@icloud.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show icloud/app-password"
+smtp.server = "smtp.mail.me.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@icloud.com"
+smtp.sasl.plain.password.raw = "app-password"
 ```
 
 **Note:** Generate an app-specific password at appleid.apple.com
 
-## Folder Aliases
+## Mailbox Aliases
 
-Map himalaya's canonical folder names (`inbox`, `sent`, `drafts`,
-`trash`) to whatever the server actually calls them. Use the
-v1.2.0 `folder.aliases.X` syntax (plural, dotted keys, directly
-under `[accounts.NAME]`):
+Map himalaya's canonical mailbox names (`inbox`, `sent`, `drafts`,
+`trash`) to whatever the server actually calls them:
 
 ```toml
 [accounts.default]
 # ... other account config ...
 
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
-The equivalent TOML sub-section form also works in v1.2.0:
+The equivalent TOML sub-section form also works:
 
 ```toml
-[accounts.default.folder.aliases]
+[accounts.default.mailbox.aliases]
 inbox = "INBOX"
 sent = "Sent"
 drafts = "Drafts"
 trash = "Trash"
 ```
 
-> **Don't use the singular `alias` form.** Pre-v1.2.0 docs showed
-> `[accounts.NAME.folder.alias]` (singular). v1.2.0 silently
-> ignores that sub-section — TOML parses without error, but the
-> alias resolver never reads it. Every lookup then falls through
-> to the canonical name. On Gmail (where `sent` is actually
-> `[Gmail]/Sent Mail`) this means save-to-Sent fails *after* SMTP
-> delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that error
-> code will re-run the send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural).
+> **Note on v2.0.0 change.** Himalaya v2.0.0 renamed `folder.aliases.*`
+> to `mailbox.alias.*`. If you are upgrading from v1.x, update your
+> config accordingly — the old `folder.aliases.*` keys are ignored by
+> v2.0.0.
 
 ## Multiple Accounts
 
@@ -184,21 +150,19 @@ himalaya --account work envelope list
 ```toml
 [accounts.local]
 email = "user@example.com"
-
-backend.type = "notmuch"
-backend.db-path = "~/.mail/.notmuch"
+# Config structure for notmuch differs — see himalaya docs.
 ```
 
 ## OAuth2 Authentication (for providers that support it)
 
 ```toml
-backend.auth.type = "oauth2"
-backend.auth.client-id = "your-client-id"
-backend.auth.client-secret.cmd = "pass show oauth/client-secret"
-backend.auth.access-token.cmd = "pass show oauth/access-token"
-backend.auth.refresh-token.cmd = "pass show oauth/refresh-token"
-backend.auth.auth-url = "https://provider.com/oauth/authorize"
-backend.auth.token-url = "https://provider.com/oauth/token"
+# IMAP SASL OAuth2
+imap.sasl.oauth2.client-id = "your-client-id"
+imap.sasl.oauth2.client-secret.cmd = "pass show oauth/client-secret"
+imap.sasl.oauth2.access-token.cmd = "pass show oauth/access-token"
+imap.sasl.oauth2.refresh-token.cmd = "pass show oauth/refresh-token"
+imap.sasl.oauth2.auth-url = "https://provider.com/oauth/authorize"
+imap.sasl.oauth2.token-url = "https://provider.com/oauth/token"
 ```
 
 ## Additional Options

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
@@ -636,3 +637,110 @@ def test_deepseek_v4_flash_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
     assert float(result.amount_usd) == 0.28
+
+
+def test_deepseek_peak_hour_multiplier_peak_window_1(monkeypatch) -> None:
+    """Peak window 1 (01:00-04:00 UTC) applies 2x multiplier."""
+    from agent.usage_pricing import _deepseek_peak_hour_multiplier
+
+    for hour in (1, 2, 3, 4):
+        peak_time = datetime(2026, 7, 27, hour, 30, tzinfo=timezone.utc)
+        monkeypatch.setattr(
+            "agent.usage_pricing._UTC_NOW",
+            lambda: peak_time,
+        )
+        result = _deepseek_peak_hour_multiplier()
+        assert float(result) == 2.0, f"hour={hour} should be peak"
+
+
+def test_deepseek_peak_hour_multiplier_peak_window_2(monkeypatch) -> None:
+    """Peak window 2 (06:00-10:00 UTC) applies 2x multiplier."""
+    from agent.usage_pricing import _deepseek_peak_hour_multiplier
+
+    for hour in range(6, 11):
+        peak_time = datetime(2026, 7, 27, hour, 30, tzinfo=timezone.utc)
+        monkeypatch.setattr(
+            "agent.usage_pricing._UTC_NOW",
+            lambda: peak_time,
+        )
+        result = _deepseek_peak_hour_multiplier()
+        assert float(result) == 2.0, f"hour={hour} should be peak"
+
+
+def test_deepseek_peak_hour_multiplier_off_peak(monkeypatch) -> None:
+    """Off-peak hours apply 1x (standard) multiplier."""
+    from agent.usage_pricing import _deepseek_peak_hour_multiplier
+
+    for hour in (0, 5, 11, 12, 14, 18, 22, 23):
+        off_peak_time = datetime(2026, 7, 27, hour, 30, tzinfo=timezone.utc)
+        monkeypatch.setattr(
+            "agent.usage_pricing._UTC_NOW",
+            lambda: off_peak_time,
+        )
+        result = _deepseek_peak_hour_multiplier()
+        assert float(result) == 1.0, f"hour={hour} should be off-peak"
+
+
+def test_estimate_usage_cost_deepseek_peak_hour_applies_multiplier(monkeypatch) -> None:
+    """Estimate for deepseek provider doubles during a peak hour."""
+    peak_time = datetime(2026, 7, 27, 2, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        "agent.usage_pricing._UTC_NOW",
+        lambda: peak_time,
+    )
+
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="deepseek",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # Standard: 1M input × $0.14/M + 500K output × $0.28/M = $0.28
+    # Peak: $0.28 × 2 = $0.56
+    assert float(result.amount_usd) == 0.56
+    assert any("peak-hour" in n for n in result.notes)
+
+
+def test_estimate_usage_cost_deepseek_off_peak_standard_rate(monkeypatch) -> None:
+    """Estimate for deepseek provider uses standard rate during off-peak."""
+    off_peak_time = datetime(2026, 7, 27, 11, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        "agent.usage_pricing._UTC_NOW",
+        lambda: off_peak_time,
+    )
+
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="deepseek",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # Standard: 1M input × $0.14/M + 500K output × $0.28/M = $0.28
+    assert float(result.amount_usd) == 0.28
+    assert not any("peak-hour" in n for n in result.notes)
+
+
+def test_estimate_usage_cost_non_deepseek_not_affected_by_peak_hour(monkeypatch) -> None:
+    """Non-DeepSeek providers are NOT affected by peak-hour multiplier."""
+    peak_time = datetime(2026, 7, 27, 2, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        "agent.usage_pricing._UTC_NOW",
+        lambda: peak_time,
+    )
+
+    result = estimate_usage_cost(
+        "gpt-4o",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="openai",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $2.50/M + 500K output × $10.00/M = $2.50 + $5.00 = $7.50
+    # (no multiplier should be applied for non-deepseek providers)
+    assert float(result.amount_usd) == 7.50
+    assert not any("peak-hour" in n for n in result.notes)


### PR DESCRIPTION
## Summary

Implements #72662: Apply DeepSeek peak-hour rate multiplier.

DeepSeek announced peak-hour pricing on 2026-07-26 with 2x rate multiplier during:
- **01:00 – 04:00 UTC** (daily)
- **06:00 – 10:00 UTC** (daily)

All other hours: standard rate.

## Changes

### `agent/usage_pricing.py`
- Added `_deepseek_peak_hour_multiplier()` — returns `Decimal("2")` when current UTC hour falls in either peak window, otherwise `Decimal("1")`.
- Modified `estimate_usage_cost()` — applies the 2x multiplier to the computed amount when `route.provider == "deepseek"` and the current time is in a peak window. Adds a note to `CostResult.notes` when the multiplier is active.

### `tests/agent/test_usage_pricing.py`
Added 6 new tests:
- `test_deepseek_peak_hour_multiplier_peak_window_1` — verifies hours 1–4 return 2x
- `test_deepseek_peak_hour_multiplier_peak_window_2` — verifies hours 6–10 return 2x
- `test_deepseek_peak_hour_multiplier_off_peak` — verifies hours outside both windows return 1x
- `test_estimate_usage_cost_deepseek_peak_hour_applies_multiplier` — end-to-end: DeepSeek call during peak hour costs 2x
- `test_estimate_usage_cost_deepseek_off_peak_standard_rate` — end-to-end: same call during off-peak costs standard rate
- `test_estimate_usage_cost_non_deepseek_not_affected_by_peak_hour` — invariant: non-DeepSeek providers are unaffected

## Testing

All 38 tests pass.