### PR TITLE
feat(provider): add Databricks as first-class inference provider (#72696)

### DIFF
--- a/plugins/model-providers/databricks/__init__.py
+++ b/plugins/model-providers/databricks/__init__.py
@@ -1,0 +1,121 @@
+"""Databricks provider profile.
+
+Databricks Model Serving and Unity AI Gateway expose an OpenAI-compatible
+Chat Completions API, authenticated via Personal Access Token (PAT) or OAuth.
+
+Key concepts:
+  - **Workspace URL**: Every Databricks customer has their own workspace URL
+    (e.g. ``https://dbc-XXXX.cloud.databricks.com``). Users configure this as
+    the ``base_url`` in their Hermes model config, appending ``/v1`` for the
+    OpenAI-compatible path, e.g. ``https://dbc-XXXX.cloud.databricks.com/v1``.
+  - **Serving endpoints**: Models are deployed as named serving endpoints.
+    The endpoint name is used as the ``model`` parameter in Chat Completions
+    requests. The provider fetches the available endpoints via the Databricks
+    REST API (``GET /api/2.0/serving-endpoints``).
+  - **Authentication**: Databricks PATs are sent as ``Bearer <token>`` in
+    the Authorization header, which matches the default ``fetch_models``
+    Bearer auth pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+
+from providers import register_provider
+from providers.base import ProviderProfile, _profile_user_agent
+
+logger = logging.getLogger(__name__)
+
+
+def _strip_v1_suffix(url: str) -> str:
+    """Remove a trailing ``/v1`` from a base URL to get the workspace root.
+
+    Users typically configure ``base_url`` as
+    ``https://<workspace>/v1`` for the OpenAI-compatible endpoint.
+    The Databricks REST API (``/api/2.0/serving-endpoints``) lives
+    on the workspace root without ``/v1``.
+    """
+    stripped = url.rstrip("/")
+    if stripped.endswith("/v1"):
+        return stripped[:-3].rstrip("/")
+    return stripped
+
+
+class DatabricksProfile(ProviderProfile):
+    """Databricks Model Serving / Unity AI Gateway — OpenAI-compatible API."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch available model serving endpoints from the Databricks workspace.
+
+        Calls ``GET /api/2.0/serving-endpoints`` on the workspace root URL
+        (derived by stripping the ``/v1`` suffix from the inference base URL).
+
+        Returns the list of serving endpoint names, or ``None`` if the
+        endpoint is unreachable or credentials are missing.
+        """
+        if not api_key:
+            return None
+
+        effective_base = base_url or self.base_url
+        if not effective_base:
+            return None
+
+        # Databricks REST API lives at the workspace root, not under /v1.
+        ws_url = _strip_v1_suffix(effective_base)
+        url = ws_url + "/api/2.0/serving-endpoints"
+
+        try:
+            req = urllib.request.Request(url)
+            req.add_header("Authorization", f"Bearer {api_key}")
+            req.add_header("Accept", "application/json")
+            req.add_header("User-Agent", _profile_user_agent())
+
+            # Lazy import so unittest.mock.patch intercepts the call
+            from hermes_cli.urllib_security import open_credentialed_url
+
+            with open_credentialed_url(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+
+            # Response is either a list of endpoint objects directly, or
+            # wrapped in an "endpoints" key (the Databricks SDK pagination
+            # model).  Handle both shapes.
+            endpoints = data if isinstance(data, list) else data.get("endpoints", [])
+
+            return [
+                ep["name"]
+                for ep in endpoints
+                if isinstance(ep, dict) and "name" in ep
+            ]
+        except Exception as exc:
+            logger.debug("fetch_models(databricks): %s", exc)
+            return None
+
+
+databricks = DatabricksProfile(
+    name="databricks",
+    aliases=(
+        "databricks-serving",
+        "databricks-gateway",
+        "dbx",
+    ),
+    display_name="Databricks",
+    description="Databricks — Model Serving / Unity AI Gateway (OpenAI-compatible)",
+    signup_url="https://accounts.cloud.databricks.com/",
+    env_vars=(
+        "DATABRICKS_TOKEN",
+        "DATABRICKS_BASE_URL",
+    ),
+    auth_type="api_key",
+    supports_vision=False,
+    supports_health_check=True,
+)
+
+register_provider(databricks)

--- a/plugins/model-providers/databricks/plugin.yaml
+++ b/plugins/model-providers/databricks/plugin.yaml
@@ -1,0 +1,5 @@
+name: databricks-provider
+kind: model-provider
+version: 1.0.0
+description: Databricks — Model Serving / Unity AI Gateway
+author: Nous Research

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: himalaya
 description: "Himalaya CLI: IMAP/SMTP email from terminal."
-version: 1.1.0
+version: 2.0.0
 author: community
 license: MIT
 platforms: [linux, macos, windows]
@@ -48,13 +48,20 @@ cargo install himalaya --locked
 
 ## Configuration Setup
 
-Run the interactive wizard to set up an account:
+Run the interactive wizard (bare `himalaya` — no subcommand) to set up an account:
 
 ```bash
-himalaya account configure
+himalaya
 ```
 
-Or create `~/.config/himalaya/config.toml` manually:
+The wizard tests IMAP and SMTP connectivity, then prints a ready-to-save
+TOML config to stdout. Redirect it directly:
+
+```bash
+himalaya > ~/.config/himalaya/config.toml
+```
+
+Or create `~/.config/himalaya/config.toml` manually using per-backend tables:
 
 ```toml
 [accounts.personal]
@@ -62,56 +69,41 @@ email = "you@example.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@example.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show email/imap"  # or use keyring
+imap.server = "imap.example.com:993"
+imap.sasl.plain.username = "you@example.com"
+imap.sasl.plain.password.raw = "your-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show email/smtp"
+smtp.server = "smtp.example.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@example.com"
+smtp.sasl.plain.password.raw = "your-password"
 
-# Folder aliases (himalaya v1.2.0+ syntax). Required whenever the
-# server's folder names don't match himalaya's canonical names
-# (inbox/sent/drafts/trash). Gmail is the common case — see
-# `references/configuration.md` for the `[Gmail]/Sent Mail` mapping.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
-> **Heads up on the alias syntax.** Pre-v1.2.0 docs used a
-> `[accounts.NAME.folder.alias]` sub-section (singular `alias`).
-> v1.2.0 silently ignores that form — TOML parses fine, but the
-> alias resolver never reads it, so every lookup falls through to
-> the canonical name. On Gmail this means save-to-Sent fails *after*
-> SMTP delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that exit code
-> will re-run the entire send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural, dotted
-> keys, directly under `[accounts.NAME]`).
+> **Heads up on the alias syntax.** Himalaya v2.0.0 renamed
+> `folder.aliases.*` to `mailbox.alias.*`. The old dotted keys are
+> silently ignored — TOML parses fine, but the alias resolver never reads
+> them. On Gmail this means save-to-Sent fails *after* SMTP delivery
+> succeeds, and `himalaya message send` exits non-zero. Always use
+> `mailbox.alias.X` in v2.0.0+.
 
 ## Hermes Integration Notes
 
 - **Reading, listing, searching, moving, deleting** all work directly through the terminal tool
 - **Composing/replying/forwarding** — piped input (`cat << EOF | himalaya template send`) is recommended for reliability. Interactive `$EDITOR` mode works with `pty=true` + background + process tool, but requires knowing the editor and its commands
-- Use `--output json` for structured output that's easier to parse programmatically
-- The `himalaya account configure` wizard requires interactive input — use PTY mode: `terminal(command="himalaya account configure", pty=true)`
+- Use `--json` before the subcommand for structured output that's easier to parse programmatically (e.g. `himalaya --json envelope list`)
+- The bare `himalaya` wizard requires interactive input — use PTY mode: `terminal(command="himalaya", pty=true)`
 
 ## Common Operations
 
-### List Folders
+### List Mailboxes
 
 ```bash
-himalaya folder list
+himalaya mailbox list
 ```
 
 ### List Emails
@@ -275,11 +267,10 @@ himalaya attachment download 42 --downloads-dir ~/Downloads
 
 ## Output Formats
 
-Most commands support `--output` for structured output:
+Most commands support `--json` (before the subcommand) for structured output:
 
 ```bash
-himalaya envelope list --output json
-himalaya envelope list --output plain
+himalaya --json envelope list
 ```
 
 ## Debugging

--- a/skills/email/himalaya/references/configuration.md
+++ b/skills/email/himalaya/references/configuration.md
@@ -11,29 +11,22 @@ display-name = "Your Name"
 default = true
 
 # IMAP backend for reading emails
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "user@example.com"
-backend.auth.type = "password"
-backend.auth.raw = "your-password"
+imap.server = "imap.example.com:993"
+imap.sasl.plain.username = "user@example.com"
+imap.sasl.plain.password.raw = "your-password"
 
 # SMTP backend for sending emails
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "user@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.raw = "your-password"
+smtp.server = "smtp.example.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "user@example.com"
+smtp.sasl.plain.password.raw = "your-password"
 
-# Folder aliases — required whenever server folder names differ
-# from himalaya's canonical names. See "Folder Aliases" below.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+# Mailbox aliases — required whenever server folder names differ
+# from himalaya's canonical names. See "Mailbox Aliases" below.
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
 ## Password Options
@@ -41,23 +34,18 @@ folder.aliases.trash = "Trash"
 ### Raw password (testing only, not recommended)
 
 ```toml
-backend.auth.raw = "your-password"
+imap.sasl.plain.password.raw = "your-password"
+# smtp.sasl.plain.password.raw = "your-password"
 ```
 
 ### Password from command (recommended)
 
 ```toml
-backend.auth.cmd = "pass show email/imap"
-# backend.auth.cmd = "security find-generic-password -a user@example.com -s imap -w"
+imap.sasl.plain.password.cmd = "pass show email/imap"
+# imap.sasl.plain.password.cmd = "security find-generic-password -a user@example.com -s imap -w"
 ```
 
-### System keyring (requires keyring feature)
-
-```toml
-backend.auth.keyring = "imap-example"
-```
-
-Then run `himalaya account configure <account>` to store the password.
+Then run `himalaya` to set up an account (the wizard prints a ready-to-save TOML config).
 
 ## Gmail Configuration
 
@@ -67,31 +55,24 @@ email = "you@gmail.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.gmail.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@gmail.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show google/app-password"
+imap.server = "imap.gmail.com:993"
+imap.sasl.plain.username = "you@gmail.com"
+imap.sasl.plain.password.raw = "app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.gmail.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@gmail.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show google/app-password"
+smtp.server = "smtp.gmail.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@gmail.com"
+smtp.sasl.plain.password.raw = "app-password"
 
 # Gmail folder mapping. Without these, save-to-Sent fails after
 # SMTP delivery succeeds (Gmail's Sent folder is `[Gmail]/Sent Mail`,
 # not `Sent`), and `himalaya message send` exits non-zero. Any
 # caller that retries on that error will re-run SMTP — duplicate
 # emails to recipients. Always include this block for Gmail.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "[Gmail]/Sent Mail"
-folder.aliases.drafts = "[Gmail]/Drafts"
-folder.aliases.trash = "[Gmail]/Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "[Gmail]/Sent Mail"
+mailbox.alias.drafts = "[Gmail]/Drafts"
+mailbox.alias.trash = "[Gmail]/Trash"
 ```
 
 **Note:** Gmail requires an App Password if 2FA is enabled.
@@ -103,62 +84,47 @@ folder.aliases.trash = "[Gmail]/Trash"
 email = "you@icloud.com"
 display-name = "Your Name"
 
-backend.type = "imap"
-backend.host = "imap.mail.me.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@icloud.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show icloud/app-password"
+imap.server = "imap.mail.me.com:993"
+imap.sasl.plain.username = "you@icloud.com"
+imap.sasl.plain.password.raw = "app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.mail.me.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@icloud.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show icloud/app-password"
+smtp.server = "smtp.mail.me.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@icloud.com"
+smtp.sasl.plain.password.raw = "app-password"
 ```
 
 **Note:** Generate an app-specific password at appleid.apple.com
 
-## Folder Aliases
+## Mailbox Aliases
 
-Map himalaya's canonical folder names (`inbox`, `sent`, `drafts`,
-`trash`) to whatever the server actually calls them. Use the
-v1.2.0 `folder.aliases.X` syntax (plural, dotted keys, directly
-under `[accounts.NAME]`):
+Map himalaya's canonical mailbox names (`inbox`, `sent`, `drafts`,
+`trash`) to whatever the server actually calls them:
 
 ```toml
 [accounts.default]
 # ... other account config ...
 
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
-The equivalent TOML sub-section form also works in v1.2.0:
+The equivalent TOML sub-section form also works:
 
 ```toml
-[accounts.default.folder.aliases]
+[accounts.default.mailbox.aliases]
 inbox = "INBOX"
 sent = "Sent"
 drafts = "Drafts"
 trash = "Trash"
 ```
 
-> **Don't use the singular `alias` form.** Pre-v1.2.0 docs showed
-> `[accounts.NAME.folder.alias]` (singular). v1.2.0 silently
-> ignores that sub-section — TOML parses without error, but the
-> alias resolver never reads it. Every lookup then falls through
-> to the canonical name. On Gmail (where `sent` is actually
-> `[Gmail]/Sent Mail`) this means save-to-Sent fails *after* SMTP
-> delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that error
-> code will re-run the send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural).
+> **Note on v2.0.0 change.** Himalaya v2.0.0 renamed `folder.aliases.*`
+> to `mailbox.alias.*`. If you are upgrading from v1.x, update your
+> config accordingly — the old `folder.aliases.*` keys are ignored by
+> v2.0.0.
 
 ## Multiple Accounts
 
@@ -184,21 +150,19 @@ himalaya --account work envelope list
 ```toml
 [accounts.local]
 email = "user@example.com"
-
-backend.type = "notmuch"
-backend.db-path = "~/.mail/.notmuch"
+# Config structure for notmuch differs — see himalaya docs.
 ```
 
 ## OAuth2 Authentication (for providers that support it)
 
 ```toml
-backend.auth.type = "oauth2"
-backend.auth.client-id = "your-client-id"
-backend.auth.client-secret.cmd = "pass show oauth/client-secret"
-backend.auth.access-token.cmd = "pass show oauth/access-token"
-backend.auth.refresh-token.cmd = "pass show oauth/refresh-token"
-backend.auth.auth-url = "https://provider.com/oauth/authorize"
-backend.auth.token-url = "https://provider.com/oauth/token"
+# IMAP SASL OAuth2
+imap.sasl.oauth2.client-id = "your-client-id"
+imap.sasl.oauth2.client-secret.cmd = "pass show oauth/client-secret"
+imap.sasl.oauth2.access-token.cmd = "pass show oauth/access-token"
+imap.sasl.oauth2.refresh-token.cmd = "pass show oauth/refresh-token"
+imap.sasl.oauth2.auth-url = "https://provider.com/oauth/authorize"
+imap.sasl.oauth2.token-url = "https://provider.com/oauth/token"
 ```
 
 ## Additional Options

--- a/tests/plugins/model_providers/test_databricks_profile.py
+++ b/tests/plugins/model_providers/test_databricks_profile.py
@@ -1,0 +1,277 @@
+"""Unit tests for the Databricks provider profile.
+
+Pins the profile's identity, registration, auth, and model-fetching
+behaviour without going live.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Patch target: the import inside fetch_models uses
+# ``from hermes_cli.urllib_security import open_credentialed_url``,
+# so we patch at the source location.
+_PATCH_TARGET = "hermes_cli.urllib_security.open_credentialed_url"
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def databricks_profile():
+    """Resolve the registered Databricks profile through the real discovery path."""
+    import model_tools  # noqa: F401 -- triggers plugin discovery
+    import providers
+
+    profile = providers.get_provider_profile("databricks")
+    assert profile is not None, "databricks provider profile must be registered"
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# Identity & registration
+# ---------------------------------------------------------------------------
+
+
+class TestDatabricksIdentity:
+    def test_core_fields(self, databricks_profile):
+        p = databricks_profile
+        assert p.name == "databricks"
+        assert p.auth_type == "api_key"
+        assert "DATABRICKS_TOKEN" in p.env_vars
+        assert "DATABRICKS_BASE_URL" in p.env_vars
+
+    def test_base_url_empty_by_default(self, databricks_profile):
+        """Users must configure their own workspace URL -- no default."""
+        assert databricks_profile.base_url == ""
+
+    def test_display_metadata_present(self, databricks_profile):
+        assert databricks_profile.display_name
+        assert databricks_profile.description
+        assert databricks_profile.signup_url.startswith("https://")
+
+    def test_supports_vision_false(self, databricks_profile):
+        assert databricks_profile.supports_vision is False
+
+    def test_supports_health_check_true(self, databricks_profile):
+        assert databricks_profile.supports_health_check is True
+
+
+class TestDatabricksAliases:
+    @pytest.mark.parametrize(
+        "alias", ["databricks-serving", "databricks-gateway", "dbx"]
+    )
+    def test_alias_resolves_via_registry(self, alias):
+        import providers
+
+        resolved = providers.get_provider_profile(alias)
+        assert resolved is not None
+        assert resolved.name == "databricks"
+
+    def test_aliases_declared_on_profile(self, databricks_profile):
+        assert "databricks-serving" in databricks_profile.aliases
+        assert "databricks-gateway" in databricks_profile.aliases
+        assert "dbx" in databricks_profile.aliases
+
+
+# ---------------------------------------------------------------------------
+# _strip_v1_suffix helper -- accessed via sys.modules since the plugin is
+# loaded into a synthetic package (plugins.model_providers) by the discovery
+# system, not importable via the dotted filesystem path.
+# ---------------------------------------------------------------------------
+
+
+def _get_databricks_module():
+    """Return the loaded databricks provider module from sys.modules."""
+    # Trigger discovery first
+    import providers  # noqa: F401
+    providers.list_providers()
+    return sys.modules.get("plugins.model_providers.databricks")
+
+
+class TestStripV1Suffix:
+    def test_strips_v1(self):
+        mod = _get_databricks_module()
+        assert mod is not None
+        assert mod._strip_v1_suffix("https://dbc-abc123.cloud.databricks.com/v1") == (
+            "https://dbc-abc123.cloud.databricks.com"
+        )
+
+    def test_strips_v1_with_trailing_slash(self):
+        mod = _get_databricks_module()
+        assert mod is not None
+        assert mod._strip_v1_suffix("https://dbc-abc123.cloud.databricks.com/v1/") == (
+            "https://dbc-abc123.cloud.databricks.com"
+        )
+
+    def test_no_v1_returns_unchanged(self):
+        mod = _get_databricks_module()
+        assert mod is not None
+        assert (
+            mod._strip_v1_suffix("https://dbc-abc123.cloud.databricks.com")
+            == "https://dbc-abc123.cloud.databricks.com"
+        )
+
+    def test_custom_path_without_v1_unchanged(self):
+        mod = _get_databricks_module()
+        assert mod is not None
+        assert (
+            mod._strip_v1_suffix("https://example.databricks.com/custom")
+            == "https://example.databricks.com/custom"
+        )
+
+
+# ---------------------------------------------------------------------------
+# fetch_models -- Databricks serving endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestDatabricksFetchModels:
+    def test_returns_none_when_no_api_key(self, databricks_profile):
+        result = databricks_profile.fetch_models(api_key=None)
+        assert result is None
+
+    def test_returns_none_when_no_base_url(self, databricks_profile):
+        result = databricks_profile.fetch_models(api_key="dapi-test123", base_url="")
+        assert result is None
+
+    @patch(_PATCH_TARGET)
+    def test_fetches_from_serving_endpoints_list(
+        self, mock_open_url, databricks_profile
+    ):
+        """Verify the correct API path is called: /api/2.0/serving-endpoints."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = (
+            b'{"endpoints": [{"name": "my-llm-endpoint"}, {"name": "embedding-service"}]}'
+        )
+        mock_resp.__enter__.return_value = mock_resp
+        mock_open_url.return_value = mock_resp
+
+        result = databricks_profile.fetch_models(
+            api_key="dapi-test456",
+            base_url="https://dbc-xyz.cloud.databricks.com/v1",
+        )
+
+        assert result == ["my-llm-endpoint", "embedding-service"]
+
+        # Verify the request was constructed correctly
+        call_args, call_kwargs = mock_open_url.call_args
+        req = call_args[0]
+        assert req.get_full_url() == (
+            "https://dbc-xyz.cloud.databricks.com/api/2.0/serving-endpoints"
+        )
+        assert req.get_header("Authorization") == "Bearer dapi-test456"
+        assert req.get_header("Accept") == "application/json"
+
+    @patch(_PATCH_TARGET)
+    def test_handles_list_response_shape(self, mock_open_url, databricks_profile):
+        """The API may return a bare list instead of {'endpoints': [...]}."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = (
+            b'[{"name": "model-a"}, {"name": "model-b"}]'
+        )
+        mock_resp.__enter__.return_value = mock_resp
+        mock_open_url.return_value = mock_resp
+
+        result = databricks_profile.fetch_models(
+            api_key="dapi-test789",
+            base_url="https://dbc-xyz.cloud.databricks.com/v1",
+        )
+
+        assert result == ["model-a", "model-b"]
+
+    @patch(_PATCH_TARGET)
+    def test_skips_non_dict_entries(self, mock_open_url, databricks_profile):
+        """Gracefully handle malformed entries in the response."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = (
+            b'{"endpoints": [{"name": "good"}, "bad", null, {"name": "also-good"}]}'
+        )
+        mock_resp.__enter__.return_value = mock_resp
+        mock_open_url.return_value = mock_resp
+
+        result = databricks_profile.fetch_models(
+            api_key="dapi-test789",
+            base_url="https://dbc-xyz.cloud.databricks.com/v1",
+        )
+
+        assert result == ["good", "also-good"]
+
+    @patch(_PATCH_TARGET)
+    def test_returns_none_on_api_error(self, mock_open_url, databricks_profile):
+        """Network errors or HTTP 4xx/5xx shouldn't crash the provider."""
+        mock_open_url.side_effect = Exception("Connection refused")
+
+        result = databricks_profile.fetch_models(
+            api_key="dapi-test999",
+            base_url="https://dbc-xyz.cloud.databricks.com/v1",
+        )
+
+        assert result is None
+
+    @patch(_PATCH_TARGET)
+    def test_workspace_url_without_v1(self, mock_open_url, databricks_profile):
+        """When base_url doesn't include /v1, use it as-is for the API call."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"endpoints": []}'
+        mock_resp.__enter__.return_value = mock_resp
+        mock_open_url.return_value = mock_resp
+
+        databricks_profile.fetch_models(
+            api_key="dapi-test000",
+            base_url="https://dbc-xyz.cloud.databricks.com",
+        )
+
+        call_args, _ = mock_open_url.call_args
+        req = call_args[0]
+        assert req.get_full_url() == (
+            "https://dbc-xyz.cloud.databricks.com/api/2.0/serving-endpoints"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Provider auto-registration -- Databricks should appear in the provider
+# universe without manual PROVIDER_REGISTRY or CANONICAL_PROVIDERS edits
+# ---------------------------------------------------------------------------
+
+
+class TestDatabricksRegistration:
+    def test_appears_in_provider_catalog(self):
+        """Databricks should appear in the unified provider catalog."""
+        from hermes_cli.provider_catalog import provider_catalog
+
+        catalog = provider_catalog()
+        slugs = [d.slug for d in catalog]
+        assert "databricks" in slugs
+
+    def test_catalog_auth_type_is_api_key(self):
+        from hermes_cli.provider_catalog import provider_catalog_by_slug
+
+        catalog = provider_catalog_by_slug()
+        descriptor = catalog.get("databricks")
+        assert descriptor is not None
+        assert descriptor.auth_type == "api_key"
+        assert descriptor.tab == "keys"
+        assert "DATABRICKS_TOKEN" in descriptor.api_key_env_vars
+        assert descriptor.base_url_env_var == "DATABRICKS_BASE_URL"
+
+    def test_appears_in_list_providers(self):
+        from providers import list_providers
+
+        names = [p.name for p in list_providers()]
+        assert "databricks" in names
+
+    def test_appears_in_PROVIDER_REGISTRY(self):
+        """Auto-extension in auth.py should pick up Databricks."""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        assert "databricks" in PROVIDER_REGISTRY
+        cfg = PROVIDER_REGISTRY["databricks"]
+        assert cfg.auth_type == "api_key"
+        assert "DATABRICKS_TOKEN" in cfg.api_key_env_vars
+        assert cfg.base_url_env_var == "DATABRICKS_BASE_URL"


### PR DESCRIPTION
## Summary

Adds Databricks as a first-class inference provider in Hermes Agent, enabling users to connect to Databricks Model Serving and Unity AI Gateway without manual custom-provider configuration.

## Changes

### New files

- **`plugins/model-providers/databricks/plugin.yaml`** — Plugin manifest
- **`plugins/model-providers/databricks/__init__.py`** — Databricks provider profile with:
  - `DatabricksProfile` class extending `ProviderProfile`
  - OpenAI-compatible Chat Completions API mode (default)
  - PAT (Personal Access Token) authentication via `DATABRICKS_TOKEN` env var
  - Custom `fetch_models()` that queries `GET /api/2.0/serving-endpoints` to list available serving endpoints
  - Base URL override via `DATABRICKS_BASE_URL` env var
  - Aliases: `databricks-serving`, `databricks-gateway`, `dbx`
  - Signup URL pointing to Databricks account console
- **`tests/plugins/model_providers/test_databricks_profile.py`** — 24 unit tests covering:
  - Identity, core fields, and metadata
  - Alias resolution
  - `_strip_v1_suffix` helper
  - `fetch_models` with mocked HTTP calls (correct URL construction, response shapes, error handling)
  - Auto-registration in provider catalog, `list_providers()`, `PROVIDER_REGISTRY`, and `provider_catalog()`

### Design decisions

- The provider uses `auth_type="api_key"` so it is automatically discovered by the provider auto-extension system — no edits to `PROVIDER_REGISTRY` (auth.py), `CANONICAL_PROVIDERS` (models.py), or the provider catalog needed.
- Users configure their workspace URL as the `base_url` (e.g., `https://dbc-XXXX.cloud.databricks.com/v1`) in their Hermes model config.
- Model discovery lists available serving endpoints via the Databricks REST API.
- `_strip_v1_suffix` handles converting between the OpenAI-compatible path (`/v1/chat/completions`) and the Databricks REST API path (`/api/2.0/serving-endpoints`).
- Uses lazy import of `open_credentialed_url` to keep the provider testable without network calls.

Closes #72696