### PR TITLE
fix(honcho): propagate observation config changes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18748,6 +18748,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.pin_peer_name",
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
+        "honcho.observation",
     )
     _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
 
@@ -18779,6 +18780,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "honcho.pin_peer_name": bool(hcfg.pin_peer_name),
                 "honcho.runtime_peer_prefix": hcfg.runtime_peer_prefix or "",
                 "honcho.user_peer_aliases": sorted(aliases.items()) if isinstance(aliases, dict) else [],
+                "honcho.observation": (
+                    bool(hcfg.user_observe_me),
+                    bool(hcfg.user_observe_others),
+                    bool(hcfg.ai_observe_me),
+                    bool(hcfg.ai_observe_others),
+                ),
             }
             cls._HONCHO_CACHE_BUSTING_MEMO = {memo_key: values}
             return dict(values)

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -450,6 +450,8 @@ class HonchoClientConfig:
     user_observe_others: bool = True
     ai_observe_me: bool = True
     ai_observe_others: bool = True
+    # Whether observationMode or observation was explicitly set in config.
+    observation_explicit: bool = False
     # Session resolution
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
@@ -507,6 +509,10 @@ class HonchoClientConfig:
             return cls.from_env(host=resolved_host)
 
         host_block = _host_block(raw, resolved_host)
+        observation_explicit = any(
+            key in host_block or key in raw
+            for key in ("observationMode", "observation")
+        )
         # A hosts.hermes block or explicit enabled flag means the user
         # intentionally configured Honcho for this host.
         _explicitly_configured = bool(host_block) or raw.get("enabled") is True
@@ -727,6 +733,7 @@ class HonchoClientConfig:
                 ),
                 host_block.get("observation") or raw.get("observation"),
             ),
+            observation_explicit=observation_explicit,
             session_strategy=session_strategy,
             session_peer_prefix=session_peer_prefix,
             sessions=raw.get("sessions", {}),

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -209,11 +209,14 @@ class HonchoSessionManager:
 
             session.add_peers([(user_peer, user_config), (assistant_peer, ai_config)])
 
-            # Sync back: server-side config (set via Honcho UI) wins over
-            # local defaults. Read the effective config after add_peers.
-            # Note: observation booleans are manager-scoped, not per-session.
-            # Last session init wins. Fine for CLI; gateway should scope per-session.
-            try:
+            if self._config is not None and self._config.observation_explicit:
+                # add_peers() preserves existing session-peer settings. Apply
+                # explicit local settings so config edits update old sessions.
+                session.set_peer_configuration(user_peer, user_config)
+                session.set_peer_configuration(assistant_peer, ai_config)
+            else:
+                # Without an explicit local policy, retain server-managed values.
+                # Note: these booleans are manager-scoped, not per-session.
                 server_user = session.get_peer_configuration(user_peer)
                 server_ai = session.get_peer_configuration(assistant_peer)
                 if server_user.observe_me is not None:
@@ -229,11 +232,9 @@ class HonchoSessionManager:
                     self._user_observe_me, self._user_observe_others,
                     self._ai_observe_me, self._ai_observe_others,
                 )
-            except Exception as e:
-                logger.debug("Honcho get_peer_configuration failed (using local config): %s", e)
         except Exception as e:
             logger.warning(
-                "Honcho session '%s' add_peers failed (non-fatal): %s",
+                "Honcho session '%s' peer configuration failed (non-fatal): %s",
                 session_id, e,
             )
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -358,6 +358,7 @@ class TestExtractCacheBustingConfig:
                 "honcho.pin_peer_name": True,
                 "honcho.runtime_peer_prefix": "tg_",
                 "honcho.user_peer_aliases": [("123", "eri")],
+                "honcho.observation": (True, False, True, True),
             }
 
         monkeypatch.setattr(GatewayRunner, "_extract_honcho_cache_busting_config", _fake)
@@ -367,6 +368,7 @@ class TestExtractCacheBustingConfig:
         assert calls == [True]
         assert out["honcho.peer_name"] == "eri"
         assert out["honcho.user_peer_aliases"] == [("123", "eri")]
+        assert out["honcho.observation"] == (True, False, True, True)
 
     def test_memory_provider_change_busts_signature(self, monkeypatch):
         """Switching memory.provider must itself change the cache-busting
@@ -404,6 +406,10 @@ class TestExtractCacheBustingConfig:
             pin_peer_name = False
             runtime_peer_prefix = "tg_"
             user_peer_aliases = {"123": "eri"}
+            user_observe_me = True
+            user_observe_others = False
+            ai_observe_me = True
+            ai_observe_others = True
 
             @classmethod
             def from_global_config(cls, config_path=None):
@@ -422,6 +428,7 @@ class TestExtractCacheBustingConfig:
 
         assert first == second
         assert first["honcho.user_peer_aliases"] == [("123", "eri")]
+        assert first["honcho.observation"] == (True, False, True, True)
         assert parse_calls == [config_path]
 
         config_path.write_text("{\n  \"changed\": true\n}")

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -601,6 +601,7 @@ class TestObservationModeMigration:
         }))
         cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
         assert cfg.observation_mode == "unified"
+        assert cfg.observation_explicit is False
 
     def test_new_config_defaults_to_directional(self, tmp_path):
         """Config with no host block and no credentials → 'directional' (new default)."""
@@ -608,6 +609,7 @@ class TestObservationModeMigration:
         cfg_file.write_text(json.dumps({}))
         cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
         assert cfg.observation_mode == "directional"
+        assert cfg.observation_explicit is False
 
     def test_explicit_directional_respected(self, tmp_path):
         """Existing config with explicit observationMode → uses what's set."""
@@ -618,6 +620,7 @@ class TestObservationModeMigration:
         }))
         cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
         assert cfg.observation_mode == "directional"
+        assert cfg.observation_explicit is True
 
     def test_explicit_unified_respected(self, tmp_path):
         """Existing config with explicit observationMode unified → stays unified."""
@@ -629,6 +632,7 @@ class TestObservationModeMigration:
         }))
         cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
         assert cfg.observation_mode == "unified"
+        assert cfg.observation_explicit is True
 
     def test_granular_observation_overrides_preset(self, tmp_path):
         """Explicit observation object overrides both preset and migration default."""
@@ -650,6 +654,7 @@ class TestObservationModeMigration:
         assert cfg.user_observe_others is False
         assert cfg.ai_observe_me is False
         assert cfg.ai_observe_others is True
+        assert cfg.observation_explicit is True
 
 
 class TestGetHonchoClient:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1,9 +1,10 @@
 """Tests for plugins/memory/honcho/session.py — HonchoSession and helpers."""
 
+import sys
 import time
 
 from datetime import datetime
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from plugins.memory.honcho.client import HonchoClientConfig
@@ -100,8 +101,25 @@ class TestHonchoSession:
         assert session.updated_at >= original
 
 
+class _FakeSessionPeerConfig:
+    def __init__(self, *, observe_me, observe_others):
+        self.observe_me = observe_me
+        self.observe_others = observe_others
+
+
+def _install_fake_honcho_sdk(monkeypatch):
+    honcho_module = ModuleType("honcho")
+    honcho_module.__path__ = []
+    session_module = ModuleType("honcho.session")
+    session_module.SessionPeerConfig = _FakeSessionPeerConfig
+    honcho_module.session = session_module
+    monkeypatch.setitem(sys.modules, "honcho", honcho_module)
+    monkeypatch.setitem(sys.modules, "honcho.session", session_module)
+
+
 class TestSessionPeerObservationConfig:
-    def test_explicit_local_config_updates_existing_session(self):
+    def test_explicit_local_config_updates_existing_session(self, monkeypatch):
+        _install_fake_honcho_sdk(monkeypatch)
         cfg = HonchoClientConfig(
             observation_explicit=True,
             user_observe_me=True,
@@ -133,7 +151,8 @@ class TestSessionPeerObservationConfig:
         assert ai_call.args[1].observe_others is True
         remote_session.get_peer_configuration.assert_not_called()
 
-    def test_unspecified_local_config_uses_server_values(self):
+    def test_unspecified_local_config_uses_server_values(self, monkeypatch):
+        _install_fake_honcho_sdk(monkeypatch)
         cfg = HonchoClientConfig(observation_explicit=False)
         mgr = HonchoSessionManager(config=cfg)
         honcho = MagicMock()

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from plugins.memory.honcho.client import HonchoClientConfig
 from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
@@ -97,6 +98,66 @@ class TestHonchoSession:
         original = session.updated_at
         session.clear()
         assert session.updated_at >= original
+
+
+class TestSessionPeerObservationConfig:
+    def test_explicit_local_config_updates_existing_session(self):
+        cfg = HonchoClientConfig(
+            observation_explicit=True,
+            user_observe_me=True,
+            user_observe_others=False,
+            ai_observe_me=True,
+            ai_observe_others=True,
+        )
+        mgr = HonchoSessionManager(config=cfg)
+        honcho = MagicMock()
+        remote_session = honcho.session.return_value
+        remote_session.context.return_value = SimpleNamespace(messages=[])
+        user_peer = MagicMock()
+        assistant_peer = MagicMock()
+
+        with patch.object(
+            HonchoSessionManager,
+            "honcho",
+            new_callable=lambda: property(lambda self: honcho),
+        ):
+            mgr._get_or_create_honcho_session("session", user_peer, assistant_peer)
+
+        assert remote_session.set_peer_configuration.call_count == 2
+        user_call, ai_call = remote_session.set_peer_configuration.call_args_list
+        assert user_call.args[0] is user_peer
+        assert user_call.args[1].observe_me is True
+        assert user_call.args[1].observe_others is False
+        assert ai_call.args[0] is assistant_peer
+        assert ai_call.args[1].observe_me is True
+        assert ai_call.args[1].observe_others is True
+        remote_session.get_peer_configuration.assert_not_called()
+
+    def test_unspecified_local_config_uses_server_values(self):
+        cfg = HonchoClientConfig(observation_explicit=False)
+        mgr = HonchoSessionManager(config=cfg)
+        honcho = MagicMock()
+        remote_session = honcho.session.return_value
+        remote_session.context.return_value = SimpleNamespace(messages=[])
+        remote_session.get_peer_configuration.side_effect = [
+            SimpleNamespace(observe_me=False, observe_others=True),
+            SimpleNamespace(observe_me=True, observe_others=False),
+        ]
+
+        with patch.object(
+            HonchoSessionManager,
+            "honcho",
+            new_callable=lambda: property(lambda self: honcho),
+        ):
+            mgr._get_or_create_honcho_session("session", MagicMock(), MagicMock())
+
+        remote_session.set_peer_configuration.assert_not_called()
+        assert (
+            mgr._user_observe_me,
+            mgr._user_observe_others,
+            mgr._ai_observe_me,
+            mgr._ai_observe_others,
+        ) == (False, True, True, False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- include resolved Honcho observation flags in the gateway agent cache signature
- apply explicitly configured observation flags to existing Honcho sessions
- preserve server-managed session flags when observation policy is not configured locally

This lets observation policy changes reach cached gateway agents and prevents existing session-peer settings from silently undoing an explicit rollout. It does not change the default observation policy or message persistence.

Pairs with plastic-labs/honcho#943, which fixes cross-subject observation attribution while preserving AI self-observation.

## Tests

- `scripts/run_tests.sh tests/gateway/test_agent_cache.py tests/honcho_plugin/test_client.py tests/honcho_plugin/test_session.py`
- `ruff check` on the modified Python files
