### PR TITLE
fix(acp): harden filesystem reads against path races

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -13,7 +13,9 @@ import os
 import queue
 import re
 import shlex
+import stat
 import subprocess
+import sys
 import threading
 import time
 from collections import deque
@@ -380,6 +382,188 @@ def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
     return resolved
 
 
+def _require_secure_posix_fs() -> None:
+    required_flags = ("O_NOFOLLOW", "O_DIRECTORY")
+    if (
+        os.name != "posix"
+        or any(not hasattr(os, name) for name in required_flags)
+        or os.open not in os.supports_dir_fd
+    ):
+        raise PermissionError(
+            "Secure ACP filesystem operations are unavailable on this platform."
+        )
+
+
+def _open_directory_chain(directory: Path) -> int:
+    """Open an absolute directory without following any symlink component."""
+    _require_secure_posix_fs()
+    flags = (
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | os.O_NOFOLLOW
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    current_fd = os.open(directory.anchor, flags)
+    try:
+        for component in directory.parts[1:]:
+            next_fd = os.open(component, flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except Exception:
+        os.close(current_fd)
+        raise
+
+
+def _open_parent_directory(path: Path, cwd: str) -> tuple[int, str]:
+    root = Path(cwd).resolve()
+    try:
+        relative = path.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError(
+            f"Path '{path}' is outside the session cwd '{root}'."
+        ) from exc
+    if not relative.parts:
+        raise PermissionError(
+            "ACP filesystem operations require a file path, not the session cwd."
+        )
+
+    current_fd = _open_directory_chain(root)
+    flags = (
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | os.O_NOFOLLOW
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        for component in relative.parts[:-1]:
+            next_fd = os.open(component, flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd, relative.parts[-1]
+    except Exception:
+        os.close(current_fd)
+        raise
+
+
+def _read_text_file_secure_posix(path: Path, cwd: str) -> str:
+    """Read through a descriptor chain that never follows symlinks."""
+    parent_fd, name = _open_parent_directory(path, cwd)
+    fd = -1
+    try:
+        flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        fd = os.open(name, flags, dir_fd=parent_fd)
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise PermissionError(
+                "ACP filesystem reads require a regular, single-link file."
+            )
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = -1
+            return handle.read()
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        os.close(parent_fd)
+
+
+def _win32_file_api() -> tuple[Any, Any, Any]:
+    try:
+        import pywintypes  # ty: ignore[unresolved-import]
+        import win32con  # ty: ignore[unresolved-import]
+        import win32file  # ty: ignore[unresolved-import]
+    except ImportError as exc:  # pragma: no cover - dependency is Windows-only
+        raise PermissionError(
+            "Secure ACP filesystem reads require pywin32 on Windows."
+        ) from exc
+    return pywintypes, win32con, win32file
+
+
+def _normalize_windows_handle_path(path_text: str) -> str:
+    if path_text.startswith("\\\\?\\UNC\\"):
+        path_text = "\\\\" + path_text[8:]
+    elif path_text.startswith("\\\\?\\"):
+        path_text = path_text[4:]
+    return os.path.normcase(os.path.normpath(path_text))
+
+
+def _read_text_file_secure_windows(path: Path, cwd: str) -> str:
+    """Open the exact non-reparse Windows path validated for this session."""
+    root = Path(cwd).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError(
+            f"Path '{path}' is outside the session cwd '{root}'."
+        ) from exc
+
+    pywintypes, win32con, win32file = _win32_file_api()
+    open_reparse_point = 0x00200000
+    share = (
+        win32con.FILE_SHARE_READ
+        | win32con.FILE_SHARE_WRITE
+        | win32con.FILE_SHARE_DELETE
+    )
+    try:
+        handle = win32file.CreateFile(
+            str(path),
+            win32con.GENERIC_READ,
+            share,
+            None,
+            win32con.OPEN_EXISTING,
+            win32con.FILE_ATTRIBUTE_NORMAL | open_reparse_point,
+            None,
+        )
+    except pywintypes.error as exc:
+        if getattr(exc, "winerror", None) in (2, 3):
+            raise FileNotFoundError(str(path)) from exc
+        raise
+
+    try:
+        actual = _normalize_windows_handle_path(
+            win32file.GetFinalPathNameByHandle(handle, 0)
+        )
+        expected = _normalize_windows_handle_path(os.path.abspath(str(path)))
+        if actual != expected:
+            raise PermissionError(
+                "ACP filesystem read handle escaped its validated path."
+            )
+
+        information = win32file.GetFileInformationByHandle(handle)
+        attributes = int(information[0])
+        number_of_links = int(information[7])
+        file_attribute_reparse_point = 0x00000400
+        if (
+            attributes
+            & (win32con.FILE_ATTRIBUTE_DIRECTORY | file_attribute_reparse_point)
+            or number_of_links != 1
+        ):
+            raise PermissionError(
+                "ACP filesystem reads require a regular, non-reparse, single-link file."
+            )
+
+        chunks: list[bytes] = []
+        while True:
+            try:
+                _, chunk = win32file.ReadFile(handle, 64 * 1024)
+            except pywintypes.error as exc:
+                if getattr(exc, "winerror", None) == 38:
+                    break
+                raise
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks).decode("utf-8")
+    finally:
+        win32file.CloseHandle(handle)
+
+
+def _read_text_file_secure(path: Path, cwd: str) -> str:
+    if sys.platform == "win32":
+        return _read_text_file_secure_windows(path, cwd)
+    return _read_text_file_secure_posix(path, cwd)
+
+
 class _ACPChatCompletions:
     def __init__(self, client: "CopilotACPClient"):
         self._client = client
@@ -708,7 +892,7 @@ class CopilotACPClient:
                 if block_error:
                     raise PermissionError(block_error)
                 try:
-                    content = path.read_text(encoding="utf-8")
+                    content = _read_text_file_secure(path, cwd)
                 except FileNotFoundError:
                     content = ""
                 line = params.get("line")

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -10,12 +10,73 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import agent.copilot_acp_client as acp_client
 from agent.copilot_acp_client import CopilotACPClient
 
 
 class _FakeProcess:
     def __init__(self) -> None:
         self.stdin = io.StringIO()
+
+
+class _FakePyWinTypes:
+    error = OSError
+
+
+class _FakeWin32Con:
+    GENERIC_READ = 0x80000000
+    OPEN_EXISTING = 3
+    FILE_ATTRIBUTE_NORMAL = 0x80
+    FILE_ATTRIBUTE_DIRECTORY = 0x10
+    FILE_SHARE_READ = 1
+    FILE_SHARE_WRITE = 2
+    FILE_SHARE_DELETE = 4
+
+
+class _FakeWin32File:
+    def __init__(
+        self,
+        expected: Path,
+        *,
+        actual: Path | None = None,
+        attributes: int = 0,
+        number_of_links: int = 1,
+        chunks: list[bytes] | None = None,
+    ) -> None:
+        self.expected = expected
+        self.actual = actual or expected
+        self.attributes = attributes
+        self.number_of_links = number_of_links
+        self.chunks = list(chunks or [])
+        self.read_called = False
+        self.closed = False
+
+    def CreateFile(self, *_args):
+        return object()
+
+    def GetFinalPathNameByHandle(self, _handle, _flags):
+        return str(self.actual)
+
+    def GetFileInformationByHandle(self, _handle):
+        return (
+            self.attributes,
+            None,
+            None,
+            None,
+            0,
+            0,
+            0,
+            self.number_of_links,
+            0,
+            0,
+        )
+
+    def ReadFile(self, _handle, _size):
+        self.read_called = True
+        return 0, self.chunks.pop(0) if self.chunks else b""
+
+    def CloseHandle(self, _handle):
+        self.closed = True
 
 
 class CopilotACPClientSafetyTests(unittest.TestCase):
@@ -133,7 +194,213 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertIn("中文标题", content)
         self.assertIn("em dash —", content)
 
+    @unittest.skipUnless(
+        os.name == "posix" and hasattr(os, "O_NOFOLLOW"),
+        "POSIX symlink race",
+    )
+    def test_read_text_file_rejects_target_swapped_to_symlink_after_policy_check(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target = root / "note.txt"
+            target.write_text("inside", encoding="utf-8")
+            outside = root.parent / f"{root.name}-outside-read.txt"
+            outside.write_text("must-not-leak", encoding="utf-8")
 
+            def swap_target(_path: str) -> None:
+                target.unlink()
+                target.symlink_to(outside)
+
+            try:
+                with patch(
+                    "agent.copilot_acp_client.get_read_block_error",
+                    side_effect=swap_target,
+                ):
+                    response = self._dispatch(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 12,
+                            "method": "fs/read_text_file",
+                            "params": {"path": str(target)},
+                        },
+                        cwd=str(root),
+                    )
+            finally:
+                outside.unlink(missing_ok=True)
+
+        self.assertEqual((response.get("error") or {}).get("code"), -32602)
+        self.assertNotIn("must-not-leak", json.dumps(response))
+
+    @unittest.skipUnless(
+        os.name == "posix" and hasattr(os, "O_NOFOLLOW"),
+        "POSIX symlink race",
+    )
+    def test_read_text_file_rejects_parent_swapped_to_symlink_after_policy_check(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            parent = root / "subdir"
+            parent.mkdir()
+            target = parent / "note.txt"
+            target.write_text("inside", encoding="utf-8")
+            outside_dir = root.parent / f"{root.name}-outside-read-dir"
+            outside_dir.mkdir()
+            outside = outside_dir / "note.txt"
+            outside.write_text("must-not-leak-parent", encoding="utf-8")
+
+            def swap_parent(_path: str) -> None:
+                target.unlink()
+                parent.rmdir()
+                parent.symlink_to(outside_dir, target_is_directory=True)
+
+            try:
+                with patch(
+                    "agent.copilot_acp_client.get_read_block_error",
+                    side_effect=swap_parent,
+                ):
+                    response = self._dispatch(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 13,
+                            "method": "fs/read_text_file",
+                            "params": {"path": str(target)},
+                        },
+                        cwd=str(root),
+                    )
+            finally:
+                outside.unlink(missing_ok=True)
+                outside_dir.rmdir()
+
+        self.assertEqual((response.get("error") or {}).get("code"), -32602)
+        self.assertNotIn("must-not-leak-parent", json.dumps(response))
+
+    @unittest.skipUnless(
+        os.name == "posix" and hasattr(os, "link"),
+        "POSIX hardlink",
+    )
+    def test_read_text_file_rejects_hardlinked_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            outside = root.parent / f"{root.name}-outside-hardlink.txt"
+            outside.write_text("must-not-leak-hardlink", encoding="utf-8")
+            target = root / "note.txt"
+            os.link(outside, target)
+
+            try:
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 14,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(target)},
+                    },
+                    cwd=str(root),
+                )
+            finally:
+                outside.unlink(missing_ok=True)
+
+        self.assertEqual((response.get("error") or {}).get("code"), -32602)
+        self.assertNotIn("must-not-leak-hardlink", json.dumps(response))
+
+    def test_read_text_file_uses_secure_windows_reader(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target = root / "note.txt"
+            target.write_text("inside", encoding="utf-8")
+
+            with (
+                patch("sys.platform", "win32"),
+                patch.object(
+                    acp_client,
+                    "_read_text_file_secure_windows",
+                    return_value="inside",
+                    create=True,
+                ) as secure_windows_read,
+            ):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 15,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(target)},
+                    },
+                    cwd=str(root),
+                )
+
+        self.assertNotIn("error", response)
+        self.assertEqual((response.get("result") or {}).get("content"), "inside")
+        secure_windows_read.assert_called_once_with(target.resolve(), str(root))
+
+    def test_windows_secure_reader_rejects_escaped_handle_before_reading(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = (Path(tmpdir) / "note.txt").resolve()
+            target.write_text("inside", encoding="utf-8")
+            fake_file = _FakeWin32File(
+                target,
+                actual=Path(tempfile.gettempdir()) / "escaped" / "secret.txt",
+                chunks=[b"must-not-leak"],
+            )
+            with patch.object(
+                acp_client,
+                "_win32_file_api",
+                return_value=(_FakePyWinTypes, _FakeWin32Con, fake_file),
+            ):
+                with self.assertRaisesRegex(PermissionError, "escaped"):
+                    acp_client._read_text_file_secure_windows(target, tmpdir)
+
+        self.assertFalse(fake_file.read_called)
+        self.assertTrue(fake_file.closed)
+
+    def test_windows_secure_reader_decodes_utf8_from_verified_handle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = (Path(tmpdir) / "note.txt").resolve()
+            target.write_text("ignored by fake handle", encoding="utf-8")
+            fake_file = _FakeWin32File(
+                target,
+                chunks=["中文 — ok".encode(), b""],
+            )
+            with patch.object(
+                acp_client,
+                "_win32_file_api",
+                return_value=(_FakePyWinTypes, _FakeWin32Con, fake_file),
+            ):
+                content = acp_client._read_text_file_secure_windows(target, tmpdir)
+
+        self.assertEqual(content, "中文 — ok")
+        self.assertTrue(fake_file.closed)
+
+    def test_windows_secure_reader_rejects_unsafe_handle_metadata(self) -> None:
+        cases = (
+            ("directory", _FakeWin32Con.FILE_ATTRIBUTE_DIRECTORY, 1),
+            ("reparse-point", 0x400, 1),
+            ("multiple-links", 0, 2),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = (Path(tmpdir) / "note.txt").resolve()
+            target.write_text("inside", encoding="utf-8")
+            for label, attributes, number_of_links in cases:
+                with self.subTest(label=label):
+                    fake_file = _FakeWin32File(
+                        target,
+                        attributes=attributes,
+                        number_of_links=number_of_links,
+                        chunks=[b"must-not-leak"],
+                    )
+                    with patch.object(
+                        acp_client,
+                        "_win32_file_api",
+                        return_value=(_FakePyWinTypes, _FakeWin32Con, fake_file),
+                    ):
+                        with self.assertRaisesRegex(
+                            PermissionError,
+                            "regular, non-reparse, single-link",
+                        ):
+                            acp_client._read_text_file_secure_windows(target, tmpdir)
+
+                    self.assertFalse(fake_file.read_called)
+                    self.assertTrue(fake_file.closed)
 
     def test_write_text_file_respects_safe_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

This revision rebuilds the pull request on current `main` and narrows it to one provider-agnostic ACP hardening change:

- prevent `fs/read_text_file` from following a file or parent directory swapped after policy validation;
- reject non-regular and multi-link files on POSIX;
- on Windows, read from the verified `CreateFile` handle only after checking its final path, reparse/directory attributes, and link count;
- preserve explicit UTF-8 decoding and existing ACP response/redaction behavior.

## Response to maintainer review

The two policy conflicts called out in review have been removed from this PR:

- no model-facing `route` selector or provider-selection surface;
- no in-tree Qoder provider, installer, configuration, routing, or provider-specific tests.

A Qoder integration, if pursued, belongs in a separate standalone plugin proposal. This PR does not publish or route to it.

## Scope

- `agent/copilot_acp_client.py`
- `tests/agent/test_copilot_acp_client.py`

## Validation

- `tests/agent/test_copilot_acp_client.py`: 13 passed
- `tests/agent/test_copilot_acp_deprecation.py`: 14 passed
- `test_aiagent_uses_copilot_acp_client`: 1 passed
- `TestCopilotACPStreamingDecision`: 3 passed
- `ruff check .`: passed (one pre-existing invalid-`noqa` warning)
- `scripts/check-windows-footguns.py --all`: passed, 892 files scanned
- staged-patch Gitleaks scan: 0 findings
- Python 3.11 `py_compile` on both changed files: passed
- `ty`: no new diagnostics versus `upstream/main` (the same 4 pre-existing diagnostics on both trees)

## Known limitations

- Validation was targeted to the ACP client and its integration seams; the full repository suite was not rerun.
- The POSIX race tests exercise real symlink/hardlink filesystem behavior. Windows handle semantics are covered with deterministic API fakes; no native Windows runner was available locally.
- Local tests used the project Python 3.12 environment.
