### PR TITLE
fix(desktop): remove fixed max-w truncation from status-stack rows

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
@@ -121,7 +121,7 @@ export const PreviewStatusRow = memo(function PreviewStatusRow({ item, onDismiss
           </span>
         }
       >
-        <span className="min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4 text-foreground/92">{item.label}</span>
+        <span className="min-w-0 flex-1 truncate text-[0.73rem] leading-4 text-foreground/92">{item.label}</span>
       </Tip>
     </StatusRow>
   )

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -140,7 +140,7 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       >
         <span
           className={cn(
-            'min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4',
+            'min-w-0 flex-1 truncate text-[0.73rem] leading-4',
             failed
               ? 'text-destructive/90'
               : item.todoStatus && item.todoStatus !== 'in_progress'


### PR DESCRIPTION
The status-stack drawer above the chat composer truncates background-process text at a hard-coded `max-w-[18rem]` (~210px at 0.73rem font size), regardless of actual drawer width. In wider windows, text gets ellipsis-truncated at roughly 1/3 of the available space.

**Fix:** Replace `max-w-[18rem]` with `flex-1` in the text span's Tailwind classes. The parent `<div>` is already `flex-1 min-w-0`, so the child naturally fills the allocated space without overflowing. The existing `min-w-0 truncate` still handles genuine overflow with ellipsis when the drawer is narrow.

**Files:** 2 files, 2 lines changed
- `apps/desktop/src/app/chat/composer/status-stack/status-row.tsx:143` — background/subagent/todo/goal row text
- `apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx:124` — preview link row text

**Reviewed:** Cross-vendor — Gemini 3.6 Flash + GPT-OSS 120B, both passed with zero concerns.

| Before | After |
|--------|-------|
| `max-w-[18rem] truncate` — text capped at ~210px | `flex-1 truncate` — text fills available drawer width |

Closes #72775