### PR TITLE
fix(agent): uniquify duplicate tool_call ids and never send an empty assistant turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -51,6 +51,7 @@ from agent.turn_retry_state import TurnRetryState
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
+    sanitize_tool_call_pairing,
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
     _sanitize_messages_surrogates,
@@ -1542,6 +1543,14 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Some providers (Kimi K3 via Moonshot/OpenRouter) reuse tool_call
+        # ids across turns, e.g. `terminal_46` emitted eight times in one
+        # session. Duplicates mispair tool results, strip tool_calls off the
+        # later assistant turns and leave a message with neither content nor
+        # tool_calls, which strict providers reject with a non-retryable 400.
+        # Only the outbound copy is touched; stored history is left intact.
+        sanitize_tool_call_pairing(api_messages)
 
         # Apply Anthropic prompt caching for Claude models on native
         # Anthropic, OpenRouter, and third-party Anthropic-compatible

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -461,6 +461,100 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
     return found
 
 
+def sanitize_tool_call_pairing(messages: list) -> bool:
+    """Make tool_call ids unique and never emit an empty assistant turn.
+
+    Added 27/07/2026 after Marcus wedged permanently on Telegram.
+
+    Kimi K3 (and other Moonshot models) emit tool_call ids of the form
+    ``<tool_name>_<n>`` which REPEAT across turns - one session had
+    ``terminal_46`` emitted eight times, three of them live in the same
+    context window after compression. When two assistant messages carrying the
+    same id are both present, tool results pair to the wrong assistant and the
+    later assistant loses its tool_calls, leaving a message with neither
+    content nor tool_calls. Moonshot rejects that with::
+
+        HTTP 400 Invalid request: the message at position N with role
+        'assistant' must not be empty
+
+    The failed turn is then persisted, so every retry rebuilds the same
+    illegal request and the agent can never recover on its own - it looks like
+    a hang, not an error.
+
+    This runs on the outbound copy only, so stored history is untouched.
+    Returns True if anything was changed.
+    """
+    changed = False
+    seen: set = set()
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        if not isinstance(msg, dict):
+            i += 1
+            continue
+
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            remap = {}
+            for call in msg["tool_calls"]:
+                if not isinstance(call, dict):
+                    continue
+                cid = call.get("id")
+                if not cid:
+                    continue
+                if cid in seen:
+                    new_id = f"{cid}__u{i}"
+                    n = 0
+                    while new_id in seen:
+                        n += 1
+                        new_id = f"{cid}__u{i}_{n}"
+                    remap[cid] = new_id
+                    call["id"] = new_id
+                    seen.add(new_id)
+                    changed = True
+                else:
+                    seen.add(cid)
+
+            # rewrite the matching results, which follow before the next assistant
+            if remap:
+                pending = dict(remap)
+                j = i + 1
+                while j < len(messages) and pending:
+                    nxt = messages[j]
+                    if not isinstance(nxt, dict):
+                        j += 1
+                        continue
+                    if nxt.get("role") == "assistant":
+                        break
+                    if nxt.get("role") == "tool":
+                        tcid = nxt.get("tool_call_id")
+                        if tcid in pending:
+                            nxt["tool_call_id"] = pending.pop(tcid)
+                    j += 1
+                logger.warning(
+                    "Uniquified %d duplicate tool_call id(s) at message %d "
+                    "(provider reuses ids across turns)",
+                    len(remap), i,
+                )
+
+        # An assistant turn with no content AND no tool_calls is illegal.
+        if msg.get("role") == "assistant" and not msg.get("tool_calls"):
+            content = msg.get("content")
+            is_empty = (
+                content is None
+                or (isinstance(content, str) and not content.strip())
+                or (isinstance(content, (list, tuple)) and len(content) == 0)
+            )
+            if is_empty:
+                msg["content"] = "(no output)"
+                changed = True
+                logger.warning(
+                    "Replaced empty assistant message at position %d with a "
+                    "placeholder; providers reject empty assistant turns", i,
+                )
+        i += 1
+
+    return changed
+
 __all__ = [
     "_SURROGATE_RE",
     "close_interrupted_tool_sequence",
@@ -474,4 +568,5 @@ __all__ = [
     "_sanitize_tools_non_ascii",
     "_strip_images_from_messages",
     "_sanitize_structure_non_ascii",
+    "sanitize_tool_call_pairing",
 ]

--- a/tests/agent/test_duplicate_tool_call_ids.py
+++ b/tests/agent/test_duplicate_tool_call_ids.py
@@ -1,0 +1,138 @@
+"""Regression tests for ``sanitize_tool_call_pairing`` (#66429 family).
+
+Some providers reuse tool_call ids across turns instead of emitting globally
+unique ones. Kimi K3 (Moonshot, via OpenRouter) emits ids shaped
+``<tool_name>_<n>``; a single observed session emitted ``terminal_46`` eight
+separate times, and after a compression pass three of them were live in the
+same context window at once.
+
+Duplicate ids break result pairing: the results attach to the first assistant
+carrying that id, the later assistant turns lose their ``tool_calls``, and one
+is left with neither content nor tool_calls. Moonshot rejects that shape with a
+**non-retryable** 400::
+
+    Invalid request: the message at position 30 with role 'assistant'
+    must not be empty
+
+The failed turn is then persisted, so every subsequent request rebuilds the
+same illegal transcript and fails in about a second. The agent never recovers
+on its own - it presents as a hang rather than an error, which is why it was
+originally reported as "it dies and won't come back".
+
+This is a distinct producer of the empty-assistant shape tracked in #66429
+(which is about the builder appending empty turns in a runaway loop) and of the
+phantom ``content:""`` messages in #63200. The guard here covers both shapes on
+the outbound copy.
+"""
+
+from agent.message_sanitization import sanitize_tool_call_pairing
+
+
+def _call(cid, name="terminal"):
+    return {"id": cid, "type": "function",
+            "function": {"name": name, "arguments": "{}"}}
+
+
+def _emitted_ids(messages):
+    out = []
+    for m in messages:
+        for c in m.get("tool_calls") or []:
+            out.append(c["id"])
+    return out
+
+
+def _result_ids(messages):
+    return [m["tool_call_id"] for m in messages if m.get("tool_call_id")]
+
+
+def test_duplicate_ids_are_made_unique_and_results_follow():
+    """The same id reused across two turns must not collide, and each result
+    must stay attached to the call it actually answered."""
+    messages = [
+        {"role": "user", "content": "run it twice"},
+        {"role": "assistant", "content": "first", "tool_calls": [_call("terminal_46")]},
+        {"role": "tool", "tool_call_id": "terminal_46", "content": "first result"},
+        {"role": "assistant", "content": "second", "tool_calls": [_call("terminal_46")]},
+        {"role": "tool", "tool_call_id": "terminal_46", "content": "second result"},
+    ]
+
+    assert sanitize_tool_call_pairing(messages) is True
+
+    ids = _emitted_ids(messages)
+    assert len(ids) == len(set(ids)), f"ids still collide: {ids}"
+
+    # every result still resolves to a call that exists
+    assert set(_result_ids(messages)) <= set(ids)
+
+    # and the pairing is preserved: first result answers the first call
+    assert messages[2]["tool_call_id"] == messages[1]["tool_calls"][0]["id"]
+    assert messages[4]["tool_call_id"] == messages[3]["tool_calls"][0]["id"]
+    assert messages[2]["content"] == "first result"
+    assert messages[4]["content"] == "second result"
+
+
+def test_three_way_collision_in_one_window():
+    """The observed failure had three copies of one id live at once."""
+    messages = [{"role": "user", "content": "go"}]
+    for _ in range(3):
+        messages.append({"role": "assistant", "content": "step",
+                         "tool_calls": [_call("terminal_46")]})
+        messages.append({"role": "tool", "tool_call_id": "terminal_46", "content": "ok"})
+
+    sanitize_tool_call_pairing(messages)
+
+    ids = _emitted_ids(messages)
+    assert len(ids) == 3 and len(set(ids)) == 3, ids
+    for i in (1, 3, 5):
+        assert messages[i + 1]["tool_call_id"] == messages[i]["tool_calls"][0]["id"]
+
+
+def test_empty_assistant_without_tool_calls_gets_a_placeholder():
+    """The exact shape strict providers reject: no content, no tool_calls."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},
+    ]
+    assert sanitize_tool_call_pairing(messages) is True
+    assert messages[1]["content"].strip(), "empty assistant reached the wire"
+
+
+def test_empty_content_with_tool_calls_is_left_alone():
+    """An assistant turn carrying tool_calls is legal with empty content and
+    must not be rewritten - that would change model-visible semantics."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "tool_calls": [_call("terminal_1")]},
+        {"role": "tool", "tool_call_id": "terminal_1", "content": "ok"},
+    ]
+    sanitize_tool_call_pairing(messages)
+    assert messages[1]["content"] == ""
+    assert messages[1]["tool_calls"][0]["id"] == "terminal_1"
+
+
+def test_none_content_assistant_is_handled():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": None},
+    ]
+    assert sanitize_tool_call_pairing(messages) is True
+    assert isinstance(messages[1]["content"], str)
+    assert messages[1]["content"].strip()
+
+
+def test_clean_transcript_is_untouched():
+    """No duplicates and no empty turns means no changes and no churn."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "sure", "tool_calls": [_call("terminal_1")]},
+        {"role": "tool", "tool_call_id": "terminal_1", "content": "ok"},
+        {"role": "assistant", "content": "done"},
+    ]
+    before = [dict(m) for m in messages]
+    assert sanitize_tool_call_pairing(messages) is False
+    assert messages == before
+
+
+def test_non_dict_entries_do_not_crash():
+    messages = [None, {"role": "user", "content": "hi"}, "junk"]
+    sanitize_tool_call_pairing(messages)  # must not raise


### PR DESCRIPTION
## What does this PR do?

Some providers reuse `tool_call` ids across turns instead of emitting globally unique ones. Kimi K3 (Moonshot, via OpenRouter) emits ids shaped `<tool_name>_<n>`. In one observed session `terminal_46` was emitted **eight separate times**, and after a compression pass **three of them were live in the same context window at once**.

Duplicate ids break result pairing. The results attach to the first assistant message carrying that id, the later assistant turns lose their `tool_calls`, and one ends up with neither content nor `tool_calls`. Moonshot rejects that shape with a **non-retryable** 400:

```
Invalid request: the message at position 30 with role 'assistant' must not be empty
```

The failed turn is then persisted, so every subsequent message rebuilds the same illegal transcript and fails in roughly a second with a single API call. **The agent never recovers on its own** — it presents as a hang rather than an error, which is how it was originally reported ("it dies and won't come back"). Restarting the gateway does not help, because the poison is in the session, not the process.

This adds `sanitize_tool_call_pairing()` to the pre-request path, next to the existing surrogate sanitizer. It operates on the **outbound copy only**, so stored history is never mutated. It:

- renames a `tool_call` id already seen earlier in the same request, rewriting the matching `tool` results together so pairing is preserved;
- replaces an assistant turn that has **neither content nor tool_calls** with a short placeholder.

An assistant turn with empty content but real `tool_calls` is deliberately left untouched — that shape is legal, and rewriting it would change what the model sees.

### Why this approach

Fixing it on the outbound copy rather than at persist time means no migration, no mutation of existing sessions, and no behaviour change for providers that already emit unique ids (the sanitizer returns `False` and makes no edits on a clean transcript, which is pinned by a test).

## Related Issue

Relates to #66429.

That issue tracks the same visible shape — empty assistant messages reaching the wire and never appearing in `state.db` — but a different producer: the builder appending `{"role":"assistant","content":"","tool_calls":[]}` in a runaway loop. What I hit is an id collision stripping `tool_calls` off a real turn. **The id-collision cause does not appear to have been identified yet**, so I believe this is complementary rather than a duplicate.

The second guard here (never emit an assistant turn with neither content nor tool_calls) also covers the shape described in #66429 and the phantom `content:""` messages in #63200 at the wire, though it does not address the runaway append site itself — that is still worth fixing separately, since this only stops the bad shape leaving.

Searched open and merged issues and PRs first, per CONTRIBUTING. #31175, #31582 and #47280 sanitize adjacent shapes (empty content with tool_calls, partial-stream empty turns); none covers duplicate ids.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/message_sanitization.py` — new `sanitize_tool_call_pairing()`, exported in `__all__`.
- `agent/conversation_loop.py` — import it and call it immediately after `_sanitize_messages_surrogates(api_messages)`.
- `tests/agent/test_duplicate_tool_call_ids.py` — 7 tests.

## Testing

`pytest tests/agent/test_duplicate_tool_call_ids.py` — 7 passed.

Coverage:

- two turns reusing one id: ids come out unique **and** each result stays attached to the call it actually answered
- the observed three-way collision in a single window
- the exact rejected shape (no content, no tool_calls) gets a placeholder
- empty content **with** tool_calls is left alone (legality guard)
- `content: None` handled
- a clean transcript is returned unchanged and reports `False` (no churn)
- non-dict entries do not raise

Also validated against the real captured request that Moonshot rejected: replaying it through the sanitizer took illegal empty-assistant turns from 1 to 0 with no orphaned tool results introduced. Then ran live against Moonshot for several hours of agent traffic, including multi-tool turns, with no recurrence.

Reproduced on 0.18.2 with `moonshotai/kimi-k3` via OpenRouter, Windows 11, Python 3.11.
