### PR TITLE
fix(delegation): update live-transcript manifest on async completion

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -143,6 +143,59 @@ def test_completion_event_lands_on_shared_queue_with_session_key():
     assert evt["delegation_id"] == res["delegation_id"]
 
 
+def test_single_async_finalization_updates_live_manifest(monkeypatch):
+    calls = []
+    from tools import delegation_live_log
+
+    monkeypatch.setattr(
+        delegation_live_log,
+        "update_manifest_statuses",
+        lambda delegation_id, results: calls.append((delegation_id, results)),
+    )
+    result = {
+        "status": "completed",
+        "summary": "verified handoff",
+        "exit_reason": "completed",
+    }
+    res = ad.dispatch_async_delegation(
+        goal="manifest single", context=None, toolsets=None, role="leaf",
+        model="m", session_key="", runner=lambda: result,
+        max_async_children=1,
+    )
+    assert _drain_for(res["delegation_id"]) is not None
+
+    deadline = time.monotonic() + 2.0
+    while not calls and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert calls == [(res["delegation_id"], [result])]
+
+
+def test_batch_async_finalization_updates_live_manifest(monkeypatch):
+    calls = []
+    from tools import delegation_live_log
+
+    monkeypatch.setattr(
+        delegation_live_log,
+        "update_manifest_statuses",
+        lambda delegation_id, results: calls.append((delegation_id, results)),
+    )
+    results = [
+        {"task_index": 0, "status": "completed", "summary": "one"},
+        {"task_index": 1, "status": "failed", "summary": None},
+    ]
+    res = ad.dispatch_async_delegation_batch(
+        goals=["one", "two"], context=None, toolsets=None, role="leaf",
+        model="m", session_key="", runner=lambda: {"results": results},
+        max_async_children=1,
+    )
+    assert _drain_for(res["delegation_id"]) is not None
+
+    deadline = time.monotonic() + 2.0
+    while not calls and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert calls == [(res["delegation_id"], results)]
+
+
 def test_rich_reinjection_block_is_self_contained():
     def runner():
         return {"status": "completed", "summary": "The answer is 42.",

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -777,6 +777,16 @@ def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
     _push_completion_event(event_record, result, status)
     _finish_finalization(delegation_id, status)
 
+    # Keep the live-transcript manifest in sync after the async worker
+    # finishes.  The synchronous path in delegate_tool already calls
+    # update_manifest_statuses, but the background-pool path was missing it,
+    # so completed tasks appeared as "running" forever in manifest.json.
+    try:
+        from tools.delegation_live_log import update_manifest_statuses
+        update_manifest_statuses(delegation_id, [result])
+    except Exception:
+        logger.debug("Live transcript manifest update failed", exc_info=True)
+
 
 def _begin_finalization(
     delegation_id: str,
@@ -1019,6 +1029,15 @@ def _finalize_batch(
 
     _push_batch_completion_event(event_record, combined, status)
     _finish_finalization(delegation_id, status)
+
+    # Keep the live-transcript manifest in sync (same gap as _finalize above).
+    try:
+        from tools.delegation_live_log import update_manifest_statuses
+        results = combined.get("results") or []
+        if results:
+            update_manifest_statuses(delegation_id, results)
+    except Exception:
+        logger.debug("Live transcript manifest update failed", exc_info=True)
 
 
 def _push_batch_completion_event(


### PR DESCRIPTION
## Summary

Keep live-transcript manifests synchronized when background `delegate_task` workers finish. Both single-child and batch finalization now write terminal per-task statuses through `update_manifest_statuses()`, so Desktop/status consumers no longer see completed children as perpetually running.

The manifest update is best-effort and intentionally occurs after completion delivery; a filesystem/logging failure cannot suppress the result returning to the parent conversation.

## RED proof

The regression tests were copied onto unfixed `origin/main` (`cff972858`) and run there:

```text
$ HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
    tests/tools/test_async_delegation.py -q \
    -k 'single_async_finalization_updates_live_manifest or batch_async_finalization_updates_live_manifest'

FAILED ...::test_single_async_finalization_updates_live_manifest
  AssertionError: assert [] == [('deleg_...', [result])]
FAILED ...::test_batch_async_finalization_updates_live_manifest
  AssertionError: assert [] == [('deleg_...', results)]
2 failed, 40 deselected
```

After the fix:

```text
2 passed, 40 deselected
```

## Code path trace

1. **Symptom:** background children finish and deliver their summaries, but `cache/delegation/live/<id>/manifest.json` can remain `status=running` indefinitely.
2. **Intermediate:** the synchronous aggregation path calls `update_manifest_statuses()`, while `_finalize()` and `_finalize_batch()` only publish completion events and durable state.
3. **Root cause:** the async finalization rail never bridged its terminal result back into the live-transcript manifest owned by `delegation_live_log`.

## Widening audit

- Single background delegation: affected → updates the manifest with `[result]`.
- Background fan-out batch: affected → updates the manifest with `combined.results`.
- Synchronous delegation: already updates manifests; unchanged.
- Empty batch results: no update, preserving the manifest rather than fabricating terminal entries.
- Completion delivery: remains authoritative and occurs before the best-effort manifest write.
- Manifest filesystem/import failure: logged at debug and cannot lose the user-facing completion event.
- Stalled/interrupted async finalization: shares the same finalizers and therefore gets terminal manifest propagation.

## Verification

```text
$ HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
    tests/tools/test_async_delegation.py \
    tests/tools/test_delegation_live_log.py -q
75 passed

$ ruff check tools/async_delegation.py tests/tools/test_async_delegation.py
All checks passed!

$ python3 -m py_compile tools/async_delegation.py tests/tools/test_async_delegation.py
$ git diff --check
```

Validated on PR head `d3f89eb0c`. GitHub reports the branch mergeable with all required checks passing against the current base.

