### PR TITLE
feat: add bounded pre-response hooks

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1983,7 +1983,17 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         "Please provide a final response summarizing what you've found and accomplished so far, "
         "without calling any more tools."
     )
-    messages.append({"role": "user", "content": summary_request})
+    summary_msg = {"role": "user", "content": summary_request}
+    if (
+        messages
+        and isinstance(messages[-1], dict)
+        and messages[-1].get("_pre_response_synthetic")
+    ):
+        # A rejected response exhausted the main-loop budget. The summary call
+        # may use its retry context, but none of that synthetic user scaffolding
+        # belongs in the durable resumed transcript.
+        summary_msg["_pre_response_synthetic"] = True
+    messages.append(summary_msg)
 
     try:
         # Build API messages, stripping internal-only fields

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2032,10 +2032,25 @@ def run_conversation(
                         agent.thinking_callback("")
 
                 _use_streaming = True
+                # A pre_response hook must inspect the whole candidate before
+                # any text reaches the user. Request the response without live
+                # text delivery while the gate is active; the accepted final
+                # result still flows through the normal surface completion
+                # path. This also keeps rejected drafts out of TTS.
+                _response_gate_active = False
+                try:
+                    from hermes_cli.plugins import has_hook as _has_response_hook
+
+                    _response_gate_active = _has_response_hook("pre_response")
+                except Exception:
+                    # Hook discovery failures are fail-open.
+                    _response_gate_active = False
+                if _response_gate_active:
+                    _use_streaming = False
                 # Provider signaled "stream not supported" on a previous
                 # attempt — switch to non-streaming for the rest of this
                 # session instead of re-failing every retry.
-                if getattr(agent, "_disable_streaming", False):
+                elif getattr(agent, "_disable_streaming", False):
                     _use_streaming = False
                 # CopilotACPClient communicates via subprocess stdio and
                 # returns a plain SimpleNamespace — not an iterable
@@ -2077,6 +2092,20 @@ def run_conversation(
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
                         )
+                    if _response_gate_active:
+                        # codex_responses streams internally even through the
+                        # non-streaming entry point. Temporarily detach visible
+                        # text/TTS consumers so it obeys the same response-gate
+                        # buffering contract as chat-completions providers.
+                        _saved_stream_delta = agent.stream_delta_callback
+                        _saved_stream_callback = agent._stream_callback
+                        agent.stream_delta_callback = None
+                        agent._stream_callback = None
+                        try:
+                            return agent._interruptible_api_call(next_api_kwargs)
+                        finally:
+                            agent.stream_delta_callback = _saved_stream_delta
+                            agent._stream_callback = _saved_stream_callback
                     return agent._interruptible_api_call(next_api_kwargs)
 
                 from hermes_cli.middleware import run_llm_execution_middleware
@@ -6633,6 +6662,79 @@ def run_conversation(
                     )
                     final_response = None
                     continue
+
+                # Generic final-response gate: unlike coding-only pre_verify,
+                # this fires for every ordinary non-empty text candidate just
+                # before the shared loop accepts it. Rejected prose and the
+                # revision request are both ephemeral retry context: do not
+                # persist or explicitly emit either one.
+                _response_nudge = None
+                _response_attempt = getattr(agent, "_pre_response_nudges", 0)
+                _response_limit = 0
+                try:
+                    from agent.response_hooks import max_response_continuations
+                    from hermes_cli.plugins import (
+                        get_pre_response_continue_message,
+                        has_hook,
+                    )
+
+                    if final_response and has_hook("pre_response"):
+                        _response_limit = max_response_continuations()
+                        _response_nudge = get_pre_response_continue_message(
+                            response_text=final_response,
+                            user_message=original_user_message,
+                            session_id=getattr(agent, "session_id", None) or "",
+                            task_id=effective_task_id or "",
+                            turn_id=turn_id or "",
+                            platform=getattr(agent, "platform", "") or "",
+                            model=getattr(agent, "model", "") or "",
+                            attempt=_response_attempt,
+                        )
+                except Exception:
+                    logger.debug("pre_response hook check failed", exc_info=True)
+                    _response_nudge = None
+
+                if _response_nudge and _response_attempt < _response_limit:
+                    agent._pre_response_nudges = _response_attempt + 1
+                    # A pre_response rejection supersedes any older
+                    # verification candidate. If this revision consumes the
+                    # remaining budget, use the normal summary fallback; never
+                    # resurrect text that this response gate did not accept.
+                    _pending_verification_response = None
+                    _pending_verification_response_previewed = False
+                    final_msg["finish_reason"] = "response_hook_continue"
+                    final_msg["content"] = final_response
+                    final_msg["_pre_response_synthetic"] = True
+                    messages.append(final_msg)
+                    messages.append({
+                        "role": "user",
+                        "content": _response_nudge,
+                        "_pre_response_synthetic": True,
+                    })
+                    agent._session_messages = messages
+                    logger.debug(
+                        "pre_response nudge issued (attempt %d/%d)",
+                        agent._pre_response_nudges,
+                        _response_limit,
+                    )
+                    final_response = None
+                    continue
+
+                if _response_nudge:
+                    final_response = (
+                        "A response hook rejected the answer after "
+                        f"{_response_limit} revision attempt"
+                        f"{'s' if _response_limit != 1 else ''}. "
+                        "Hermes stopped retrying to prevent a loop."
+                    )
+                    final_msg["content"] = final_response
+                    logger.warning(
+                        "pre_response continuation limit reached "
+                        "(attempt=%d limit=%d session=%s)",
+                        _response_attempt,
+                        _response_limit,
+                        getattr(agent, "session_id", None) or "none",
+                    )
 
                 messages.append(final_msg)
                 

--- a/agent/response_hooks.py
+++ b/agent/response_hooks.py
@@ -1,0 +1,39 @@
+"""Configuration helpers for the bounded ``pre_response`` continuation gate."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+DEFAULT_MAX_RESPONSE_CONTINUATIONS = 1
+
+
+def max_response_continuations(
+    config: Optional[dict[str, Any]] = None,
+) -> int:
+    """Return the per-turn continuation bound for ``pre_response`` (>= 0)."""
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+
+    agent_cfg = (config or {}).get("agent") if isinstance(config, dict) else None
+    raw = (
+        agent_cfg.get("max_response_continuations")
+        if isinstance(agent_cfg, dict)
+        else None
+    )
+    if raw is None:
+        return DEFAULT_MAX_RESPONSE_CONTINUATIONS
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_RESPONSE_CONTINUATIONS
+
+
+__all__ = [
+    "DEFAULT_MAX_RESPONSE_CONTINUATIONS",
+    "max_response_continuations",
+]

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -47,6 +47,10 @@ Wire protocol
     # Inject context for pre_llm_call:
     {"context": "Today is Friday"}
 
+    # Revise a candidate response:
+    {"action": "continue", "message": "Rewrite the answer more clearly"}
+    {"decision": "block", "reason": "Rewrite the answer more clearly"}
+
     # Silent no-op:
     <empty or any non-matching JSON object>
 
@@ -92,6 +96,16 @@ emitted by each built-in hook site.
     interrupted     – bool, True when the user interrupted
     model           – model name
     platform        – platform identifier
+
+``pre_response`` (emitted from ``agent/conversation_loop.py``)::
+
+    response_text   – non-empty candidate assistant response
+    user_message    – original user input for this turn
+    task_id         – current task id
+    turn_id         – current turn id
+    model           – model identifier
+    platform        – platform identifier
+    attempt         – continuations already accepted this turn (0 on first)
 
 ``subagent_stop`` (emitted from ``tools/delegate_tool.py``)::
 
@@ -575,8 +589,12 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     skipping the translation silently breaks every ``pre_tool_call``
     block directive.
 
-    For ``pre_llm_call``, ``{"context": "..."}`` is passed through
-    unchanged to match the existing plugin-hook contract.
+    For ``pre_response`` and ``pre_verify``, Hermes ``continue`` and
+    Stop-compatible ``block`` directives are normalized to a continuation.
+    Directives without a non-empty message are ignored.
+
+    For ``pre_llm_call``, ``{"context": "..."}`` is passed through unchanged
+    to match the existing plugin-hook contract.
 
     Anything else returns ``None``.
     """
@@ -603,7 +621,7 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
             return {"action": "block", "message": _block_message(data.get("reason"), data.get("message"))}
         return None
 
-    if event == "pre_verify":
+    if event in {"pre_response", "pre_verify"}:
         # "continue" (Hermes) / "block" (Claude-Code Stop: block the stop) both
         # mean keep going; the message/reason is the follow-up for the model. A
         # continue with no message is a no-op — let the turn finish.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1108,6 +1108,7 @@ def build_turn_context(
     agent._turn_file_mutation_paths = set()
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
+    agent._pre_response_nudges = 0
 
     # Record the execution thread so interrupt()/clear_interrupt() can scope
     # the tool-level interrupt signal to THIS agent's thread only.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -42,27 +42,29 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
     return not flatten_message_text(msg.get("content")).strip()
 
 
-# Verification continuation scaffolding flags: verify-on-stop / pre_verify
-# inject a synthetic user nudge to keep the agent going one more turn.
-# These nudges must be stripped from returned/live history to avoid
-# role-alternation breaks and poisoning the resumed transcript. The
-# assistant response is real content and is not flagged. (#65919 §7)
-_VERIFICATION_CONTINUATION_FLAGS = (
+# Continuation scaffolding flags. Verification gates keep their assistant
+# candidates as real history and flag only the user nudge. ``pre_response``
+# rejects its candidate, so both halves of that retry pair are synthetic.
+_CONTINUATION_SCAFFOLDING_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_pre_response_synthetic",
 )
 
 
-def _drop_verification_continuation_scaffolding(messages) -> None:
-    """Remove verification-continuation nudge messages from *messages* in place.
+def _drop_continuation_scaffolding(messages) -> None:
+    """Remove synthetic continuation messages from *messages* in place.
 
-    Only the synthetic nudges carry these flags, so this strips just the
-    nudges while preserving the real attempted-final-answer that was
-    persisted to state.db.
+    Verification candidates remain because only their nudges carry a flag.
+    Rejected ``pre_response`` candidates and revision requests both carry the
+    same flag and are removed together.
     """
     messages[:] = [
         m for m in messages
-        if not (isinstance(m, dict) and any(m.get(f) for f in _VERIFICATION_CONTINUATION_FLAGS))
+        if not (
+            isinstance(m, dict)
+            and any(m.get(f) for f in _CONTINUATION_SCAFFOLDING_FLAGS)
+        )
     ]
 
 
@@ -266,11 +268,11 @@ def finalize_turn(
     try:
         agent._drop_trailing_empty_response_scaffolding(messages)
 
-        # Drop verification-continuation nudges (synthetic user messages)
-        # from the live history before the tail-assistant check — only the
-        # nudges need stripping; the assistant candidate persists in
-        # state.db. (#65919 §7)
-        _drop_verification_continuation_scaffolding(messages)
+        # Drop continuation scaffolding before the tail-assistant check.
+        # Verification gates flag only their user nudges, so their real
+        # assistant candidates persist (#65919 §7). pre_response flags both
+        # halves because its candidate was rejected.
+        _drop_continuation_scaffolding(messages)
 
         # When the turn was interrupted and the last message is a tool
         # result, append a synthetic assistant message to close the

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -841,6 +841,13 @@ agent:
   # Default 3.
   # max_verify_nudges: 3
 
+  # A `pre_response` hook (plugin or shell, see Event Hooks docs) can reject a
+  # candidate final text answer and ask the same agent loop to revise it. This
+  # caps accepted continuation directives per turn. The default retries once;
+  # another rejection returns a retry-limit notice instead of the rejected
+  # prose. Set 0 to inspect responses without allowing a continuation.
+  # max_response_continuations: 1
+
   # Enable verbose logging
   verbose: false
   
@@ -1427,13 +1434,14 @@ display:
 # =============================================================================
 # Register shell scripts as plugin-hook callbacks.  Each entry is executed as
 # a subprocess (shell=False, shlex.split) with a JSON payload on stdin.  On
-# stdout the script may return JSON that either blocks the tool call or
-# injects context into the next LLM call.
+# stdout the script may return JSON that blocks a tool call, injects context
+# into the next LLM call, or asks the agent to revise a candidate response.
 #
 # Valid events (mirror hermes_cli.plugins.VALID_HOOKS):
 #   pre_tool_call, post_tool_call, pre_llm_call, post_llm_call,
-#   pre_api_request, post_api_request, on_session_start, on_session_end,
-#   on_session_finalize, on_session_reset, subagent_stop
+#   pre_response, pre_verify, pre_api_request, post_api_request,
+#   on_session_start, on_session_end, on_session_finalize, on_session_reset,
+#   subagent_stop
 #
 # First-use consent: each (event, command) pair prompts once on a TTY, then
 # is persisted to ~/.hermes/shell-hooks-allowlist.json.  Non-interactive
@@ -1453,6 +1461,8 @@ display:
 #       command: "~/.hermes/agent-hooks/auto-format.sh"
 #   pre_llm_call:
 #     - command: "~/.hermes/agent-hooks/inject-cwd-context.sh"
+#   pre_response:
+#     - command: "~/.hermes/agent-hooks/lint-response.py"
 #   subagent_stop:
 #     - command: "~/.hermes/agent-hooks/log-orchestration.sh"
 #

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1060,6 +1060,11 @@ DEFAULT_CONFIG = {
         # Upper bound on consecutive `pre_verify` "continue" nudges in a single
         # turn, so a user/plugin hook can never trap the loop.
         "max_verify_nudges": 3,
+        # Upper bound on `pre_response` continuations in one turn. The hook
+        # still inspects the candidate at the limit; another rejection returns
+        # a user-facing retry-limit notice instead of leaking rejected prose or
+        # trapping the loop.
+        "max_response_continuations": 1,
         # Verification closure: after the agent edits files in a code workspace,
         # do not accept a final answer until fresh verification evidence exists
         # or the agent explains why it cannot run checks. The loop is bounded

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -139,6 +139,16 @@ _DEFAULT_PAYLOADS = {
         "model": "gpt-4",
         "platform": "cli",
     },
+    "pre_response": {
+        "session_id": "test-session",
+        "response_text": "Candidate response.",
+        "user_message": "Original user prompt.",
+        "task_id": "test-task",
+        "turn_id": "test-turn",
+        "platform": "cli",
+        "model": "gpt-4",
+        "attempt": 0,
+    },
     "pre_verify": {
         "session_id": "test-session",
         "platform": "cli",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -141,6 +141,13 @@ VALID_HOOKS: Set[str] = {
     # Plugins return a string to replace the response text, or None/empty to leave unchanged.
     # First non-None string wins. Useful for vocabulary/personality transformation.
     "transform_llm_output",
+    # Final-response gate. Fired for a non-empty candidate text response just
+    # before the shared agent loop accepts it. A callback may ask the same loop
+    # to revise the candidate by returning:
+    #   {"action": "continue", "message": "<revision instruction>"}
+    # The Stop-compatible {"decision": "block", "reason": "..."} shape is
+    # accepted too. Directives without a non-empty message are no-ops.
+    "pre_response",
     "pre_llm_call",
     "post_llm_call",
     # Verification-loop gate. Fired once per turn when the agent has edited code
@@ -2331,6 +2338,49 @@ def get_pre_verify_continue_message(
         attempt=attempt,
         final_response=final_response,
         changed_paths=list(changed_paths or []),
+    )
+
+    for result in hook_results:
+        if not isinstance(result, dict):
+            continue
+        action = str(result.get("action") or result.get("decision") or "").strip().lower()
+        if action not in ("continue", "block"):
+            continue
+        message = result.get("message") or result.get("reason")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+
+    return None
+
+
+def get_pre_response_continue_message(
+    *,
+    response_text: str,
+    user_message: Any = "",
+    session_id: str = "",
+    task_id: str = "",
+    turn_id: str = "",
+    platform: str = "",
+    model: str = "",
+    attempt: int = 0,
+) -> Optional[str]:
+    """Return the first actionable ``pre_response`` continuation message.
+
+    The Hermes ``{"action": "continue", "message": "..."}`` and
+    Stop-compatible ``{"decision": "block", "reason": "..."}`` shapes both
+    keep the shared loop going. Invalid values and directives without a
+    non-empty message fail open.
+    """
+    hook_results = invoke_hook(
+        "pre_response",
+        response_text=response_text,
+        user_message=user_message,
+        session_id=session_id,
+        task_id=task_id,
+        turn_id=turn_id,
+        platform=platform,
+        model=model,
+        attempt=attempt,
     )
 
     for result in hook_results:

--- a/run_agent.py
+++ b/run_agent.py
@@ -237,6 +237,10 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
     # persisted and emitted as an interim message (#65919).
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    # pre_response rejects both the candidate assistant text and its synthetic
+    # revision request. Both exist only for the next API call and must never
+    # enter a resumed transcript.
+    "_pre_response_synthetic",
     # kanban worker stop-guard: narrated exit without kanban_complete/block
     "_kanban_stop_synthetic",
     # dropped tool-call re-prompt pair (finish_reason=tool_calls with an

--- a/tests/agent/test_response_hooks.py
+++ b/tests/agent/test_response_hooks.py
@@ -1,0 +1,24 @@
+from agent.response_hooks import (
+    DEFAULT_MAX_RESPONSE_CONTINUATIONS,
+    max_response_continuations,
+)
+
+
+def test_default_max_response_continuations_is_one():
+    assert DEFAULT_MAX_RESPONSE_CONTINUATIONS == 1
+    assert max_response_continuations({}) == 1
+
+
+def test_configured_max_response_continuations_is_non_negative():
+    assert max_response_continuations(
+        {"agent": {"max_response_continuations": 2}}
+    ) == 2
+    assert max_response_continuations(
+        {"agent": {"max_response_continuations": -1}}
+    ) == 0
+
+
+def test_invalid_max_response_continuations_uses_default():
+    assert max_response_continuations(
+        {"agent": {"max_response_continuations": "invalid"}}
+    ) == DEFAULT_MAX_RESPONSE_CONTINUATIONS

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -115,6 +115,25 @@ class TestParseResponse:
         assert shell_hooks._parse_response("pre_verify", '{"action": "continue"}') is None
         assert shell_hooks._parse_response("pre_verify", '{"decision": "allow"}') is None
 
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (
+                '{"action": "continue", "message": "rewrite this"}',
+                {"action": "continue", "message": "rewrite this"},
+            ),
+            (
+                '{"decision": "block", "reason": "use STE"}',
+                {"action": "continue", "message": "use STE"},
+            ),
+            ('{"action": "continue"}', None),
+            ('{"decision": "block", "reason": "   "}', None),
+            ('{"decision": "allow"}', None),
+        ],
+    )
+    def test_pre_response_directives(self, raw, expected):
+        assert shell_hooks._parse_response("pre_response", raw) == expected
+
     def test_block_action_without_message_uses_default(self):
         """Block is honored even when message/reason is absent."""
         r = shell_hooks._parse_response("pre_tool_call", '{"action": "block"}')
@@ -189,6 +208,34 @@ class TestSerializePayload:
         )
         payload = json.loads(raw)
         assert payload["extra"]["obj"] == "<weird>"
+
+    def test_pre_response_payload_exposes_candidate_and_turn_context(self):
+        raw = shell_hooks._serialize_payload(
+            "pre_response",
+            {
+                "response_text": "candidate answer",
+                "user_message": "original prompt",
+                "session_id": "sess-1",
+                "task_id": "task-1",
+                "turn_id": "turn-1",
+                "model": "test/model",
+                "platform": "desktop",
+                "attempt": 1,
+            },
+        )
+
+        payload = json.loads(raw)
+        assert payload["hook_event_name"] == "pre_response"
+        assert payload["session_id"] == "sess-1"
+        assert payload["extra"] == {
+            "response_text": "candidate answer",
+            "user_message": "original prompt",
+            "task_id": "task-1",
+            "turn_id": "turn-1",
+            "model": "test/model",
+            "platform": "desktop",
+            "attempt": 1,
+        }
 
 
 # ── Matcher behaviour ─────────────────────────────────────────────────────

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -355,7 +355,7 @@ def test_terminal_verification_failure_is_persisted_as_one_correction(monkeypatc
         messages=[
             {"role": "user", "content": "task"},
             {"role": "assistant", "content": report},
-            # Synthetic nudge — should be dropped by _drop_verification_continuation_scaffolding.
+            # Synthetic nudge — should be dropped by _drop_continuation_scaffolding.
             {"role": "user", "content": "[System: run tests]", "_verification_stop_synthetic": True},
         ],
         conversation_history=[],

--- a/tests/agent/test_verification_stop_caching.py
+++ b/tests/agent/test_verification_stop_caching.py
@@ -46,6 +46,27 @@ def test_verification_flags_registered_as_ephemeral(tmp_path, monkeypatch):
     assert not ra._is_ephemeral_scaffolding({"role": "assistant", "content": "premature done"})
 
 
+def test_pre_response_rejected_pair_is_ephemeral(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    ra = _fresh_run_agent(tmp_path)
+
+    assert "_pre_response_synthetic" in ra._EPHEMERAL_SCAFFOLDING_FLAGS
+    assert ra._is_ephemeral_scaffolding(
+        {
+            "role": "assistant",
+            "content": "rejected draft",
+            "_pre_response_synthetic": True,
+        }
+    )
+    assert ra._is_ephemeral_scaffolding(
+        {
+            "role": "user",
+            "content": "rewrite it",
+            "_pre_response_synthetic": True,
+        }
+    )
+
+
 def _make_agent(ra, session_id, tmp_path):
     agent = ra.AIAgent(
         session_id=session_id,
@@ -124,3 +145,41 @@ def test_json_log_drops_only_nudge_keeps_candidate(tmp_path, monkeypatch):
     # Only the nudge is dropped.
     assert "[System: run tests]" not in contents
     assert all(not m.get("_pre_verify_synthetic") for m in data["messages"])
+
+
+def test_db_and_json_drop_rejected_pre_response_pair(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    ra = _fresh_run_agent(tmp_path)
+    agent = _make_agent(ra, "sess_pre_response", tmp_path)
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "rejected draft",
+            "_pre_response_synthetic": True,
+        },
+        {
+            "role": "user",
+            "content": "rewrite it",
+            "_pre_response_synthetic": True,
+        },
+        {"role": "assistant", "content": "accepted answer"},
+    ]
+
+    agent._flush_messages_to_session_db(messages, conversation_history=[])
+    persisted = [
+        kwargs.get("content")
+        for _args, kwargs in agent._session_db.append_message.call_args_list
+    ]
+    assert persisted == ["hi", "accepted answer"]
+
+    agent._save_session_log(messages)
+    data = json.loads(
+        (agent.logs_dir / "session_sess_pre_response.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert [message.get("content") for message in data["messages"]] == [
+        "hi",
+        "accepted answer",
+    ]

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -135,6 +135,36 @@ class TestHooksTest:
         assert '"action": "block"' in out
         assert '"message": "nope"' in out
 
+    def test_pre_response_uses_runtime_payload_shape(self, tmp_path):
+        capture = tmp_path / "pre-response.json"
+        script = _hook_script(
+            tmp_path,
+            f"#!/usr/bin/env bash\ncat - > {capture}\nprintf '{{}}\\n'\n",
+        )
+        cfg = {"hooks": {"pre_response": [{"command": str(script)}]}}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            _run(
+                SimpleNamespace(
+                    hooks_action="test",
+                    event="pre_response",
+                    for_tool=None,
+                    payload_file=None,
+                )
+            )
+
+        seen = json.loads(capture.read_text())
+        assert seen["session_id"] == "test-session"
+        assert seen["extra"] == {
+            "response_text": "Candidate response.",
+            "user_message": "Original user prompt.",
+            "task_id": "test-task",
+            "turn_id": "test-turn",
+            "platform": "cli",
+            "model": "gpt-4",
+            "attempt": 0,
+        }
+
     def test_for_tool_matcher_filters(self, tmp_path):
         script = _hook_script(tmp_path, "#!/usr/bin/env bash\nprintf '{}\\n'\n")
         cfg = {

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -17,6 +17,7 @@ from hermes_cli.plugins import (
     PluginManifest,
     get_plugin_command_handler,
     get_plugin_commands,
+    get_pre_response_continue_message,
     get_pre_tool_call_block_message,
     get_pre_verify_continue_message,
     has_middleware,
@@ -1089,6 +1090,94 @@ class TestGetPreVerifyContinueMessage:
         assert seen["coding"] is True
         assert seen["attempt"] == 2
         assert seen["changed_paths"] == ["a.py"]
+
+
+class TestGetPreResponseContinueMessage:
+    """`pre_response` directives gate any candidate final text response."""
+
+    def test_continue_canonical(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "continue", "message": "rewrite the answer"}
+            ],
+        )
+        assert (
+            get_pre_response_continue_message(response_text="draft")
+            == "rewrite the answer"
+        )
+
+    def test_stop_block_means_continue(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"decision": "block", "reason": "use shorter sentences"}
+            ],
+        )
+        assert (
+            get_pre_response_continue_message(response_text="draft")
+            == "use shorter sentences"
+        )
+
+    def test_first_non_empty_directive_wins(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                "noise",
+                {"action": "continue"},
+                {"decision": "block", "reason": "   "},
+                {"action": "continue", "message": "  revise this  "},
+                {"action": "continue", "message": "ignored"},
+            ],
+        )
+        assert (
+            get_pre_response_continue_message(response_text="draft")
+            == "revise this"
+        )
+
+    def test_allow_and_malformed_values_are_noops(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "allow"},
+                {"decision": "block", "reason": 42},
+                {"action": "continue", "message": None},
+                {"context": "not a directive"},
+            ],
+        )
+        assert get_pre_response_continue_message(response_text="draft") is None
+
+    def test_forwards_candidate_and_turn_context(self, monkeypatch):
+        seen = {}
+
+        def capture(hook_name, **kwargs):
+            seen["hook_name"] = hook_name
+            seen.update(kwargs)
+            return []
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", capture)
+        get_pre_response_continue_message(
+            response_text="candidate",
+            user_message="original prompt",
+            session_id="session-1",
+            task_id="task-1",
+            turn_id="turn-1",
+            platform="desktop",
+            model="test/model",
+            attempt=1,
+        )
+
+        assert seen == {
+            "hook_name": "pre_response",
+            "response_text": "candidate",
+            "user_message": "original prompt",
+            "session_id": "session-1",
+            "task_id": "task-1",
+            "turn_id": "turn-1",
+            "platform": "desktop",
+            "model": "test/model",
+            "attempt": 1,
+        }
 
 
 class TestThreadToolWhitelist:

--- a/tests/run_agent/test_pre_response_continuation.py
+++ b/tests/run_agent/test_pre_response_continuation.py
@@ -1,0 +1,368 @@
+"""Behavior coverage for the shared ``pre_response`` continuation gate."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _response(content):
+    message = SimpleNamespace(content=content, tool_calls=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        model="test/model",
+        usage=None,
+    )
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            session_id="pre-response-test",
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai-compat",
+            model="test/model",
+            max_iterations=3,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="desktop",
+        )
+    instance._cached_system_prompt = "stable test prompt"
+    instance._session_db = None
+    instance._session_json_enabled = False
+    instance.save_trajectories = False
+    instance.compression_enabled = False
+    instance._cleanup_task_resources = lambda *_a, **_kw: None
+    instance._save_trajectory = lambda *_a, **_kw: None
+    return instance
+
+
+def test_non_coding_candidate_is_revised_before_delivery(agent):
+    answers = iter([_response("rejected draft"), _response("corrected answer")])
+    requests = []
+
+    def model_call(api_kwargs):
+        requests.append(api_kwargs["messages"])
+        return next(answers)
+
+    agent._interruptible_api_call = model_call
+    emitted = []
+    agent.interim_assistant_callback = lambda text, **kwargs: emitted.append(text)
+
+    with (
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name == "pre_response",
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_response_continue_message",
+            side_effect=["Invoke the style skill and rewrite.", None],
+        ) as gate,
+        patch(
+            "agent.response_hooks.max_response_continuations",
+            return_value=1,
+        ),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("Explain this simply.")
+
+    assert result["final_response"] == "corrected answer"
+    assert result["completed"] is True
+    assert emitted == []
+    first_gate = gate.call_args_list[0].kwargs
+    assert first_gate == {
+        "response_text": "rejected draft",
+        "user_message": "Explain this simply.",
+        "session_id": "pre-response-test",
+        "task_id": first_gate["task_id"],
+        "turn_id": first_gate["turn_id"],
+        "platform": "desktop",
+        "model": "test/model",
+        "attempt": 0,
+    }
+    assert first_gate["task_id"]
+    assert first_gate["turn_id"]
+    assert gate.call_args_list[1].kwargs["response_text"] == "corrected answer"
+    assert gate.call_args_list[1].kwargs["attempt"] == 1
+
+    # The revision request preserves assistant→user alternation for the next
+    # provider call, but the rejected pair never reaches the returned history.
+    assert [message["role"] for message in requests[1][-2:]] == [
+        "assistant",
+        "user",
+    ]
+    assert requests[1][-2]["content"] == "rejected draft"
+    assert requests[1][-1]["content"] == "Invoke the style skill and rewrite."
+    assert [message["content"] for message in result["messages"]] == [
+        "Explain this simply.",
+        "corrected answer",
+    ]
+    assert all(
+        not message.get("_pre_response_synthetic")
+        for message in result["messages"]
+    )
+
+
+def test_second_rejection_stops_at_bound_without_delivering_candidate(agent):
+    answers = iter([_response("first rejected"), _response("second rejected")])
+    agent._interruptible_api_call = lambda _kwargs: next(answers)
+
+    with (
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name == "pre_response",
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_response_continue_message",
+            return_value="rewrite again",
+        ) as gate,
+        patch(
+            "agent.response_hooks.max_response_continuations",
+            return_value=1,
+        ),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("Answer in the required style.")
+
+    assert gate.call_count == 2
+    assert [call.kwargs["attempt"] for call in gate.call_args_list] == [0, 1]
+    assert "response hook rejected the answer" in result["final_response"].lower()
+    assert "stopped retrying" in result["final_response"].lower()
+    assert "first rejected" not in result["final_response"]
+    assert "second rejected" not in result["final_response"]
+    assert all(
+        message.get("content") not in {"first rejected", "second rejected", "rewrite again"}
+        for message in result["messages"]
+    )
+
+
+def test_allow_or_noop_finishes_without_extra_call(agent):
+    agent._interruptible_api_call = MagicMock(return_value=_response("allowed answer"))
+
+    with (
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name == "pre_response",
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_response_continue_message",
+            return_value=None,
+        ),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("Give me the answer.")
+
+    assert result["final_response"] == "allowed answer"
+    assert agent._interruptible_api_call.call_count == 1
+
+
+def test_hook_exception_fails_open(agent):
+    agent._interruptible_api_call = MagicMock(return_value=_response("keep answer"))
+
+    with (
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name == "pre_response",
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_response_continue_message",
+            side_effect=RuntimeError("hook failed"),
+        ),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("Give me the answer.")
+
+    assert result["final_response"] == "keep answer"
+    assert agent._interruptible_api_call.call_count == 1
+
+
+def test_budget_fallback_does_not_reuse_rejected_candidate(agent):
+    agent.max_iterations = 1
+    agent.iteration_budget.max_total = 1
+    agent._interruptible_api_call = MagicMock(return_value=_response("rejected draft"))
+    agent._handle_max_iterations = MagicMock(return_value="budget fallback answer")
+
+    with (
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name == "pre_response",
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_response_continue_message",
+            return_value="rewrite the draft",
+        ),
+        patch(
+            "agent.response_hooks.max_response_continuations",
+            return_value=1,
+        ),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("Give me the answer.")
+
+    assert result["final_response"].startswith("budget fallback answer")
+    assert result["turn_exit_reason"] == "max_iterations_reached(1/1)"
+    assert agent._handle_max_iterations.call_count == 1
+    assert all(
+        message.get("content") not in {"rejected draft", "rewrite the draft"}
+        for message in result["messages"]
+    )
+
+
+def test_transform_hook_still_runs_after_pre_response_accepts(agent):
+    agent._interruptible_api_call = MagicMock(return_value=_response("accepted answer"))
+
+    def invoke(hook_name, **kwargs):
+        if hook_name == "transform_llm_output":
+            return ["transformed answer"]
+        return []
+
+    with (
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name == "pre_response",
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_response_continue_message",
+            return_value=None,
+        ),
+        patch("hermes_cli.plugins.invoke_hook", side_effect=invoke),
+    ):
+        result = agent.run_conversation("Give me the answer.")
+
+    assert result["final_response"] == "transformed answer"
+    assert result["response_transformed"] is True
+
+
+def test_pre_verify_finishes_before_pre_response_inspects_candidate(agent):
+    answers = iter([_response("unverified answer"), _response("verified answer")])
+
+    def model_call(_api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        return next(answers)
+
+    agent._interruptible_api_call = model_call
+
+    with (
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name in {"pre_verify", "pre_response"},
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_verify_continue_message",
+            side_effect=["run checks", None],
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_response_continue_message",
+            return_value=None,
+        ) as response_gate,
+        patch("agent.verify_hooks.max_verify_nudges", return_value=3),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("Edit changed.py.")
+
+    assert result["final_response"] == "verified answer"
+    assert [call.kwargs["response_text"] for call in response_gate.call_args_list] == [
+        "verified answer"
+    ]
+
+
+def test_active_pre_response_gate_buffers_provider_text_stream(agent):
+    streamed = []
+    agent.stream_delta_callback = streamed.append
+    agent._interruptible_streaming_api_call = MagicMock(
+        return_value=_response("candidate")
+    )
+    agent._interruptible_api_call = MagicMock(return_value=_response("candidate"))
+
+    with (
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name == "pre_response",
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_response_continue_message",
+            return_value=None,
+        ),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("Give me the answer.")
+
+    assert result["final_response"] == "candidate"
+    assert streamed == []
+    agent._interruptible_streaming_api_call.assert_not_called()
+    agent._interruptible_api_call.assert_called_once()
+
+
+def test_response_rejection_does_not_reuse_stale_verification_fallback(agent):
+    agent.max_iterations = 2
+    agent.iteration_budget.max_total = 2
+    answers = iter([_response("unverified draft"), _response("rejected final")])
+
+    def model_call(_api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        return next(answers)
+
+    agent._interruptible_api_call = model_call
+    agent._handle_max_iterations = MagicMock(return_value="safe budget fallback")
+
+    with (
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name in {"pre_verify", "pre_response"},
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_verify_continue_message",
+            side_effect=["run checks", None],
+        ),
+        patch(
+            "hermes_cli.plugins.get_pre_response_continue_message",
+            return_value="rewrite the final answer",
+        ),
+        patch("agent.verify_hooks.max_verify_nudges", return_value=3),
+        patch(
+            "agent.response_hooks.max_response_continuations",
+            return_value=1,
+        ),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("Edit changed.py.")
+
+    assert result["final_response"].startswith("safe budget fallback")
+    assert "unverified draft" not in result["final_response"]
+    assert "rejected final" not in result["final_response"]
+    agent._handle_max_iterations.assert_called_once()
+
+
+def test_budget_summary_request_is_ephemeral_after_response_rejection(agent):
+    agent.client.chat.completions.create.return_value = _response("safe summary")
+    messages = [
+        {"role": "user", "content": "original prompt"},
+        {
+            "role": "assistant",
+            "content": "rejected draft",
+            "_pre_response_synthetic": True,
+        },
+        {
+            "role": "user",
+            "content": "rewrite it",
+            "_pre_response_synthetic": True,
+        },
+    ]
+
+    result = agent._handle_max_iterations(messages, 1)
+
+    assert result == "safe summary"
+    assert messages[-2]["role"] == "user"
+    assert messages[-2]["_pre_response_synthetic"] is True
+    assert messages[-1] == {"role": "assistant", "content": "safe summary"}

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -51,7 +51,7 @@ def _assert_pending_response_survives(agent, result):
     assert result["turn_exit_reason"] == "max_iterations_reached(1/1)"
     assert result["completed"] is False
     assert agent._handle_max_iterations.call_count == 0
-    # The nudge is stripped by _drop_verification_continuation_scaffolding,
+    # The nudge is stripped by _drop_continuation_scaffolding,
     # so the role sequence is [user, assistant] — the candidate is the
     # tail and matches final_response so it is not duplicated. (#65919 §7)
     assert [message["role"] for message in result["messages"]] == [

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -364,6 +364,7 @@ def register(ctx):
     ctx.register_hook("pre_tool_call", my_tool_observer)
     ctx.register_hook("post_tool_call", my_tool_logger)
     ctx.register_hook("pre_llm_call", my_memory_callback)
+    ctx.register_hook("pre_response", my_response_gate)
     ctx.register_hook("post_llm_call", my_sync_callback)
     ctx.register_hook("on_session_start", my_init_callback)
     ctx.register_hook("on_session_end", my_cleanup_callback)
@@ -373,7 +374,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Some hooks have explicit return contracts: [`pre_tool_call`](#pre_tool_call) can **block** a tool, [`pre_llm_call`](#pre_llm_call) can **inject context**, and [`pre_response`](#pre_response) / [`pre_verify`](#pre_verify) can request a bounded continuation. Other hooks either document their own transform contract or ignore return values.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -384,6 +385,7 @@ def register(ctx):
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
+| [`pre_response`](#pre_response) | For each non-empty candidate final text response, just before the shared loop accepts it | `{"action": "continue", "message": str}` to revise it |
 | [`pre_verify`](#pre_verify) | Once per turn when the agent edited code, before it verifies/finishes | `{"action": "continue", "message": str}` to keep going |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
 | [`on_session_end`](#on_session_end) | Session ends | ignored |
@@ -397,6 +399,93 @@ def register(ctx):
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
 | [`transform_terminal_output`](#transform_terminal_output) | Inside the `terminal` tool, before truncation/ANSI-strip/redact | `str` to replace the raw output, `None` to leave unchanged |
 | [`transform_llm_output`](#transform_llm_output) | After the tool-calling loop completes, before the final response is delivered | `str` to replace the response text, `None`/empty to leave unchanged |
+
+---
+
+### `pre_response`
+
+Fires for a non-empty candidate assistant text response when the shared agent
+loop is about to finish normally. It works for ordinary non-coding turns and
+for CLI, gateway, TUI, and desktop callers that use the shared loop.
+
+Use this hook for response validation that needs the model to self-correct.
+Unlike `transform_llm_output`, it can run another inference turn. Unlike
+`pre_verify`, it is not limited to coding turns or file edits.
+
+**Callback signature:**
+
+```python
+def my_callback(response_text: str, user_message, session_id: str,
+                task_id: str, turn_id: str, model: str, platform: str,
+                attempt: int, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `response_text` | `str` | Candidate final assistant text |
+| `user_message` | `str` or message content | Original user input for this turn |
+| `session_id` | `str` | Current session identifier |
+| `task_id` | `str` | Current task identifier |
+| `turn_id` | `str` | Current turn identifier |
+| `model` | `str` | Model identifier |
+| `platform` | `str` | Surface identifier (`cli`, `telegram`, `desktop`, …) |
+| `attempt` | `int` | Continuations already accepted this turn; `0` on the first candidate |
+
+**Return value — revise the candidate:**
+
+```python
+return {
+    "action": "continue",
+    "message": "Load the required style skill and rewrite only your last answer.",
+}
+```
+
+The Stop-compatible shape below has the same meaning:
+
+```python
+return {
+    "decision": "block",
+    "reason": "Load the required style skill and rewrite only your last answer.",
+}
+```
+
+The first directive with a non-empty string `message` or `reason` wins.
+Missing messages, malformed returns, exceptions, shell-hook timeouts, and
+non-directive values fail open.
+
+While this hook is active, Hermes pauses live final-text and TTS streaming so
+the hook can inspect the whole candidate before delivery. Hermes places a
+rejected candidate and continuation instruction in ephemeral assistant→user
+context for the next model call. Both messages are removed from durable and
+returned transcripts before the turn finishes.
+
+**Bounded:** `agent.max_response_continuations` controls how many continuation
+directives Hermes accepts in one turn. The default is `1`. The hook sees the
+next candidate with `attempt=1`; it can return no directive to finish. If it
+rejects again at the limit, Hermes returns a retry-limit notice instead of the
+rejected candidate. Set the value to `0` to inspect candidates without allowing
+a continuation.
+
+**Example — one-shot style validator:**
+
+```python
+def validate_style(response_text, attempt, **kwargs):
+    violations = lint_response(response_text)
+    if not violations:
+        return None
+    if attempt:
+        return None  # The validator owns its second-failure policy.
+    return {
+        "action": "continue",
+        "message": (
+            "Load the style skill. Rewrite only your last answer. "
+            f"Fix these issues: {violations}."
+        ),
+    }
+
+def register(ctx):
+    ctx.register_hook("pre_response", validate_style)
+```
 
 ---
 
@@ -1344,6 +1433,10 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 
 `tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted.
 
+For `pre_response`, `extra` contains `response_text`, `user_message`,
+`task_id`, `turn_id`, `model`, `platform`, and `attempt`. The top-level
+`session_id` uses the same value as the Python callback.
+
 **stdout — optional response:**
 
 ```jsonc
@@ -1354,7 +1447,8 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 // Inject context for pre_llm_call:
 {"context": "Today is Friday, 2026-04-17"}
 
-// Keep the agent going at the verify gate (pre_verify); both shapes accepted:
+// Revise a candidate response (pre_response) or keep going at pre_verify;
+// both shapes are accepted:
 {"action": "continue", "message": "Run the formatter, then finish."}
 {"decision": "block",  "reason":  "Run the formatter, then finish."}
 


### PR DESCRIPTION
## Summary

- add a generic `pre_response` lifecycle hook for plugins and shell hooks
- let hooks accept a candidate response or request one bounded revision before delivery
- suppress rejected drafts from streams, TTS, persisted sessions, and returned transcripts
- document `agent.max_response_continuations` and the new hook payload/return contract

This provides the Hermes core seam needed for STE-style response linting without hard-coding STE policy into the agent loop.

## Behavior

- Supports `{"action":"continue","message":"..."}` and `{"decision":"block","reason":"..."}`.
- Defaults to one continuation attempt.
- Fails open on hook errors, timeouts, malformed output, or empty directives.
- Runs after verification and Kanban stop gates, before `transform_llm_output` and delivery.
- Preserves existing `pre_verify`, verification-stop, Kanban, and transform hook behavior.

## Verification

- `scripts/run_tests.sh tests/run_agent/test_pre_response_continuation.py tests/agent/test_response_hooks.py tests/agent/test_shell_hooks.py tests/hermes_cli/test_hooks_cli.py tests/hermes_cli/test_plugins.py tests/agent/test_verification_stop_caching.py tests/agent/test_turn_finalizer_iteration_limit_exit.py tests/run_agent/test_verification_continuation_budget.py tests/test_transform_llm_output_hook.py -q`
  - 248 passed
- implementation run also covered:
  - 2,923 shared-loop/gateway/TUI tests
  - 92 ACP tests
  - 214 configuration tests
- Ruff passed
- `git diff --check` passed
- independent fail-closed review passed with no security concerns or logic errors

## Notes

The independent reviewer raised two non-blocking optimization suggestions: streaming is disabled for the full loop when this hook is registered, and Codex commentary remains separate from candidate-response buffering. Both preserve the intended correctness and delivery guarantees.
