### PR TITLE
fix(email): preserve unread state during IMAP polling

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -669,7 +669,11 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    # Use BODY.PEEK[] so polling the inbox does not set the
+                    # IMAP \Seen flag. RFC822 fetches mark unread mail as read on
+                    # Gmail and many other providers, which is surprising for a
+                    # passive gateway poller.
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1098,6 +1098,9 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["sender_addr"], "user@test.com")
         self.assertIn(b"3", adapter._seen_uids)
 
+        # Fetch must use BODY.PEEK[] so polling does not mark unread mail read.
+        mock_imap.uid.assert_any_call("fetch", b"3", "(BODY.PEEK[])")
+
     def test_fetch_no_unseen_messages(self):
         """No unseen messages returns empty list."""
         adapter = self._make_adapter()


### PR DESCRIPTION
## Summary
- fetch IMAP messages with `BODY.PEEK[]` instead of `RFC822`
- prevent passive email gateway polling from setting the `\Seen` flag
- add regression coverage for the exact UID fetch command

## Context
This applies the unread-state fix to the current plugin-based email adapter path. Related earlier attempts targeted the pre-refactor `gateway/platforms/email.py` path (#43018, #43017).

Fixes #42997.

## Verification
- `scripts/run_tests.sh tests/gateway/test_email.py` — 88 passed
- `scripts/run_tests.sh tests/gateway/test_email_robustness.py` — 9 passed
- `git diff --check`
- independent review found no security or logic issues