### PR TITLE
fix(cli): stream content in real-time for separate-field reasoning models

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6503,6 +6503,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # reasoning block always appears BEFORE the response in the terminal.
         if self.show_reasoning and getattr(self, "_reasoning_box_opened", False):
             self._deferred_content = getattr(self, "_deferred_content", "") + text
+            # Close reasoning box on first content token so content
+            # renders in real-time instead of deferring until stream end.
+            self._close_reasoning_box()
             return
 
         # Close the live reasoning box before opening the response box


### PR DESCRIPTION
## Summary

Fixes #47116 — CLI content streaming for separate-field reasoning models (DeepSeek, MiniMax-M2.7, etc.)

## Problem

When `show_reasoning: true` and `streaming: true`, reasoning streams live token-by-token, but the final answer is entirely deferred and dumped in one batch at end-of-turn.

Root cause: `_emit_stream_text()` defers all content while `_reasoning_box_opened` is True. For separate-field reasoning models (no inline `</think>` tag), the box is only closed at `_flush_stream()` (stream end).

## Fix

One-line addition in `_emit_stream_text()`: call `self._close_reasoning_box()` immediately when the first content token arrives inside the defer guard. This closes the reasoning box, flushes any accumulated deferred content, and allows subsequent tokens to stream normally through the already-open response box.

For inline-tag models (`<think>...</think>`), behavior is unchanged — the `</think>` tag already triggers `_close_reasoning_box()` mid-stream.

## Change

```diff
         if self.show_reasoning and getattr(self, "_reasoning_box_opened", False):
             self._deferred_content = getattr(self, "_deferred_content", "") + text
+            # Close reasoning box on first content token so content
+            # renders in real-time instead of deferring until stream end.
+            self._close_reasoning_box()
             return
```

## Test Plan

- [x] `tests/cli/test_stream_delta_think_tag.py` — 14 passed (inline-tag behavior preserved)
- [x] `tests/cli/test_stream_partial_line_flush.py` — 6 passed (stream buffering unaffected)
- [x] Manually tested with DeepSeek V4 via custom provider — content streams in real time after reasoning