### PR TITLE
fix(gateway): don't re-home a non-git session onto a repo it only visited

### DIFF
--- a/tests/tui_gateway/test_session_cwd_follow.py
+++ b/tests/tui_gateway/test_session_cwd_follow.py
@@ -29,7 +29,7 @@ def repo_with_worktree(tmp_path):
     _git(repo, "init", "-b", "main")
     _git(repo, "config", "user.email", "t@example.com")
     _git(repo, "config", "user.name", "t")
-    (repo / "README.md").write_text("hi\n")
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "init")
 
@@ -87,6 +87,32 @@ def test_browsing_outside_a_repo_is_not_a_move(session, repo_with_worktree, tmp_
     scratch = tmp_path / "scratch"
     scratch.mkdir()
     terminal_tool.record_session_cwd(session["session_key"], str(scratch))
+
+    assert server._reconcile_session_cwd_from_terminal(session) is False
+    assert session["cwd"] == str(repo)
+
+
+def test_a_non_git_workspace_is_not_hijacked_by_visiting_a_repo(
+    session, repo_with_worktree, tmp_path
+):
+    """A non-git workspace must not be re-homed when a tool call steps into a
+    git repo: browsing in to read a file or run a command is a visit, not a
+    relocation. Otherwise the first git directory the agent touches (e.g. its
+    own install checkout) hijacks a home-directory session.
+    """
+    repo, _ = repo_with_worktree
+    home = tmp_path / "home"  # a plain, non-git workspace
+    home.mkdir()
+    session["cwd"] = str(home)
+    terminal_tool.record_session_cwd(session["session_key"], str(repo))
+
+    assert server._reconcile_session_cwd_from_terminal(session) is False
+    assert session["cwd"] == str(home)
+
+
+def test_a_deleted_directory_is_not_a_move(session, repo_with_worktree, tmp_path):
+    repo, _ = repo_with_worktree
+    terminal_tool.record_session_cwd(session["session_key"], str(tmp_path / "gone"))
 
     assert server._reconcile_session_cwd_from_terminal(session) is False
     assert session["cwd"] == str(repo)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2310,7 +2310,14 @@ def _reconcile_session_cwd_from_terminal(session: dict | None) -> bool:
     # The worktree ROOT, not the common repo root: folding worktrees together
     # here is exactly what hides the move we're looking for.
     landed = _git_repo_root_for_cwd(resolved)
-    if not landed or landed == _git_repo_root_for_cwd(current):
+    current_root = _git_repo_root_for_cwd(current)
+    # A relocation is a move between two DIFFERENT git working trees. When the
+    # session's own workspace is not in a git repo, the agent stepping into one
+    # to read a file or run a command is a browsing visit, not a re-home:
+    # adopting it would hijack a non-git workspace onto whatever repo a tool
+    # call touched first (e.g. a home-directory session pinned to the checkout
+    # it read a file from).
+    if not landed or not current_root or landed == current_root:
         return False
 
     session["cwd"] = resolved


### PR DESCRIPTION
Fixes #72776

## Problem

`_reconcile_session_cwd_from_terminal()` (`tui_gateway/server.py`) re-anchors a session when its settled terminal cwd is in a *different* git working tree than the session's workspace. The "different tree" test is:

```python
landed = _git_repo_root_for_cwd(resolved)
if not landed or landed == _git_repo_root_for_cwd(current):
    return False
```

When the session's workspace is **not** in a git repo (a home directory, or a configured non-git `terminal.cwd`), `_git_repo_root_for_cwd(current)` returns `None`. `landed == None` is `False`, so the guard never fires and the **first** git directory a tool call steps into hijacks the session — its `cwd`/`git_repo_root` flip to that repo, subsequent `terminal`/`file`/`search` tools run from the wrong place, and if that repo has an `AGENTS.md` it gets injected into an unrelated conversation.

This is the regression introduced by `0158569ee` (*follow a session into the worktree it settled in*), reported in detail in #72776.

## Fix

Reconcile only when **both** the current and settled cwds resolve to valid, differing git roots:

```python
landed = _git_repo_root_for_cwd(resolved)
current_root = _git_repo_root_for_cwd(current)
if not landed or not current_root or landed == current_root:
    return False
```

A non-git workspace stepping into a git repo to read a file or run a command is a browsing visit, not a relocation — matching the docstring's own intent that a plain `cd` must not re-home the chat. The intended "follow into a worktree" behavior is unaffected: that path starts from a git checkout, so `current_root` is valid and a move to a different worktree still reconciles.

## Tests

Adds `test_a_non_git_workspace_is_not_hijacked_by_visiting_a_repo` — a session anchored to a non-git dir records a settled cwd inside a git repo and must not move. The existing follow/worktree/subdir/browsing tests still pass (the pre-existing `test_browsing_outside_a_repo_is_not_a_move` only covered the inverse: a *git* workspace browsing to a non-git dir).

```
10 passed in tests/tui_gateway/test_session_cwd_follow.py
```

(The one-token `encoding="utf-8"` on a fixture `write_text` is required by the repo's Windows-footgun gate on the touched file.)

The expected arm64-fork Docker CI failure is unrelated to this change.