### PR TITLE
refactor(skills): dedupe GitHub auth detection across github-* skills

### DIFF
--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -212,25 +212,13 @@ uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/
 
 ### Helper: Detect Auth Method
 
-Use this pattern at the start of any GitHub workflow:
+Use the shared helper script at the start of any GitHub workflow. It exports `GH_AUTH_METHOD` (`"gh"`, `"curl"`, or `"none"`), `GITHUB_TOKEN`, `GH_USER`, and — when inside a repo — `GH_OWNER` / `GH_REPO` / `GH_OWNER_REPO`:
 
 ```bash
-# Try gh first, fall back to git + curl
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  echo "AUTH_METHOD=gh"
-elif [ -n "$GITHUB_TOKEN" ]; then
-  echo "AUTH_METHOD=curl"
-elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-  export GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-  echo "AUTH_METHOD=curl"
-elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-  export GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-  echo "AUTH_METHOD=curl"
-else
-  echo "AUTH_METHOD=none"
-  echo "Need to set up authentication first"
-fi
+source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
 ```
+
+This is the single source of truth. The other `github-*` skills source this same script instead of inlining the detection logic, so any change here (new credential store, renamed env var, different fallback order) propagates to all of them automatically.
 
 ---
 

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -212,7 +212,7 @@ uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/
 
 ### Helper: Detect Auth Method
 
-Use the shared helper script at the start of any GitHub workflow. It exports `GH_AUTH_METHOD` (`"gh"`, `"curl"`, or `"none"`), `GITHUB_TOKEN`, `GH_USER`, and — when inside a repo — `GH_OWNER` / `GH_REPO` / `GH_OWNER_REPO`:
+Use the shared helper script at the start of any GitHub workflow. It always exports `GH_AUTH_METHOD` (`"gh"`, `"curl"`, or `"none"`) and `GH_USER`, and — when inside a repo — `GH_OWNER` / `GH_REPO` / `GH_OWNER_REPO`. It exports `GITHUB_TOKEN` only when one is actually available (i.e. on the `curl` path or when already set in the environment); the `gh`-authenticated branch sets `GH_AUTH_METHOD="gh"` but does not populate a token.
 
 ```bash
 source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -23,23 +23,16 @@ Perform code reviews on local changes before pushing, or review open PRs on GitH
 ### Setup (for PR interactions)
 
 ```bash
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
+# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GITHUB_TOKEN,
+# GH_USER, GH_OWNER, GH_REPO, GH_OWNER_REPO). See github-auth skill for details.
+source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
+# Legacy alias used elsewhere in this skill: gh-env.sh uses "curl" where older
+# skills used "git" for the non-gh fallback path.
+AUTH="$GH_AUTH_METHOD"
+[ "$AUTH" = "curl" ] && AUTH="git"
 
-REMOTE_URL=$(git remote get-url origin)
-OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
-REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
+OWNER="$GH_OWNER"
+REPO="$GH_REPO"
 ```
 
 ---
@@ -336,8 +329,9 @@ When the user asks you to "review PR #N", "look at this PR", or gives you a PR U
 
 ```bash
 source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
-# Or run the inline setup block from the top of this skill
 ```
+
+This is the same setup shown in the `### Setup` block at the top of this skill — sourced once at the start of the review.
 
 ### Step 2: Gather PR context
 

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -23,8 +23,9 @@ Perform code reviews on local changes before pushing, or review open PRs on GitH
 ### Setup (for PR interactions)
 
 ```bash
-# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GITHUB_TOKEN,
-# GH_USER, GH_OWNER, GH_REPO, GH_OWNER_REPO). See github-auth skill for details.
+# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GH_USER,
+# GH_OWNER, GH_REPO, GH_OWNER_REPO; GITHUB_TOKEN only when available on the
+# curl path or pre-set). See github-auth skill for details.
 source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
 # Legacy alias used elsewhere in this skill: gh-env.sh uses "curl" where older
 # skills used "git" for the non-gh fallback path.

--- a/skills/github/github-issues/SKILL.md
+++ b/skills/github/github-issues/SKILL.md
@@ -23,23 +23,16 @@ Create, search, triage, and manage GitHub issues. Each section shows `gh` first,
 ### Setup
 
 ```bash
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
+# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GITHUB_TOKEN,
+# GH_USER, GH_OWNER, GH_REPO, GH_OWNER_REPO). See github-auth skill for details.
+source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
+# Legacy alias used elsewhere in this skill: gh-env.sh uses "curl" where older
+# skills used "git" for the non-gh fallback path.
+AUTH="$GH_AUTH_METHOD"
+[ "$AUTH" = "curl" ] && AUTH="git"
 
-REMOTE_URL=$(git remote get-url origin)
-OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
-REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
+OWNER="$GH_OWNER"
+REPO="$GH_REPO"
 ```
 
 ---

--- a/skills/github/github-issues/SKILL.md
+++ b/skills/github/github-issues/SKILL.md
@@ -23,8 +23,9 @@ Create, search, triage, and manage GitHub issues. Each section shows `gh` first,
 ### Setup
 
 ```bash
-# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GITHUB_TOKEN,
-# GH_USER, GH_OWNER, GH_REPO, GH_OWNER_REPO). See github-auth skill for details.
+# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GH_USER,
+# GH_OWNER, GH_REPO, GH_OWNER_REPO; GITHUB_TOKEN only when available on the
+# curl path or pre-set). See github-auth skill for details.
 source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
 # Legacy alias used elsewhere in this skill: gh-env.sh uses "curl" where older
 # skills used "git" for the non-gh fallback path.

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -23,33 +23,23 @@ Complete guide for managing the PR lifecycle. Each section shows the `gh` way fi
 ### Quick Auth Detection
 
 ```bash
-# Determine which method to use throughout this workflow
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  # Ensure we have a token for API calls
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
+# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GITHUB_TOKEN,
+# GH_USER, GH_OWNER, GH_REPO, GH_OWNER_REPO). See github-auth skill for details.
+source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
+# Legacy alias used elsewhere in this skill: gh-env.sh uses "curl" where older
+# skills used "git" for the non-gh fallback path.
+AUTH="$GH_AUTH_METHOD"
+[ "$AUTH" = "curl" ] && AUTH="git"
 echo "Using: $AUTH"
 ```
 
 ### Extracting Owner/Repo from the Git Remote
 
-Many `curl` commands need `owner/repo`. Extract it from the git remote:
+When you need `OWNER` and `REPO` as separate variables (many `curl` commands do), they are already set by `gh-env.sh` as `GH_OWNER` and `GH_REPO`. Use them directly:
 
 ```bash
-# Works for both HTTPS and SSH remote URLs
-REMOTE_URL=$(git remote get-url origin)
-OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
-REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
+OWNER="$GH_OWNER"
+REPO="$GH_REPO"
 echo "Owner: $OWNER, Repo: $REPO"
 ```
 

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -23,8 +23,9 @@ Complete guide for managing the PR lifecycle. Each section shows the `gh` way fi
 ### Quick Auth Detection
 
 ```bash
-# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GITHUB_TOKEN,
-# GH_USER, GH_OWNER, GH_REPO, GH_OWNER_REPO). See github-auth skill for details.
+# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GH_USER,
+# GH_OWNER, GH_REPO, GH_OWNER_REPO; GITHUB_TOKEN only when available on the
+# curl path or pre-set). See github-auth skill for details.
 source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
 # Legacy alias used elsewhere in this skill: gh-env.sh uses "curl" where older
 # skills used "git" for the non-gh fallback path.

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -22,34 +22,22 @@ Create, clone, fork, configure, and manage GitHub repositories. Each section sho
 ### Setup
 
 ```bash
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
-
-# Get your GitHub username (needed for several operations)
-if [ "$AUTH" = "gh" ]; then
-  GH_USER=$(gh api user --jq '.login')
-else
-  GH_USER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | python3 -c "import sys,json; print(json.load(sys.stdin)['login'])")
-fi
+# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GITHUB_TOKEN,
+# GH_USER, GH_OWNER, GH_REPO, GH_OWNER_REPO). See github-auth skill for details.
+source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
+# Legacy alias used elsewhere in this skill: gh-env.sh uses "curl" where older
+# skills used "git" for the non-gh fallback path.
+AUTH="$GH_AUTH_METHOD"
+[ "$AUTH" = "curl" ] && AUTH="git"
 ```
 
-If you're inside a repo already:
+`GH_USER` is already resolved by `gh-env.sh` (via `gh api user` or the `/user` endpoint), so the separate username lookup that used to live here is no longer needed.
+
+If you're inside a repo already, `GH_OWNER` and `GH_REPO` are also set by `gh-env.sh`:
 
 ```bash
-REMOTE_URL=$(git remote get-url origin)
-OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
-REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
+OWNER="$GH_OWNER"
+REPO="$GH_REPO"
 ```
 
 ---

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -22,8 +22,9 @@ Create, clone, fork, configure, and manage GitHub repositories. Each section sho
 ### Setup
 
 ```bash
-# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GITHUB_TOKEN,
-# GH_USER, GH_OWNER, GH_REPO, GH_OWNER_REPO). See github-auth skill for details.
+# Source the shared auth/repo detection helper (sets GH_AUTH_METHOD, GH_USER,
+# GH_OWNER, GH_REPO, GH_OWNER_REPO; GITHUB_TOKEN only when available on the
+# curl path or pre-set). See github-auth skill for details.
 source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
 # Legacy alias used elsewhere in this skill: gh-env.sh uses "curl" where older
 # skills used "git" for the non-gh fallback path.


### PR DESCRIPTION
## Summary

The five bundled `skills/github/*` skills each inlined the same ~15-line GitHub auth-detection block (try `gh` → read `GITHUB_TOKEN` from `~/.hermes/.env` → extract from `~/.git-credentials` via `git-credential-token.py`). The `github-auth` skill already ships a canonical helper — `scripts/gh-env.sh` — that encapsulates this exact logic **and** resolves `GH_USER`, `GH_OWNER`, `GH_REPO` from the git remote.

This PR replaces every inline copy with:

```bash
source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
```

so the detection logic lives in one place. A future change to credential sourcing (new secret store, renamed env var, different fallback order) now propagates to all five skills automatically instead of requiring five coordinated edits.

**Net: -47 lines** (50 insertions, 97 deletions across 5 files).

## What changed per skill

| Skill | Change |
|---|---|
| `github-auth` | "Helper: Detect Auth Method" section now points at its own `gh-env.sh` as the single source of truth (was a copy-paste inline block) |
| `github-code-review` | Top `### Setup` block sources `gh-env.sh` instead of inlining; removed redundant "or run the inline setup block" comment in §5 Step 1 (which already sourced it) |
| `github-issues` | `### Setup` block sources `gh-env.sh` instead of inlining |
| `github-pr-workflow` | `### Quick Auth Detection` + `### Extracting Owner/Repo` blocks consolidated into one `source` call |
| `github-repo-management` | `### Setup` block sources `gh-env.sh`; removed the separate `GH_USER` lookup (already resolved by the helper) |

## Compatibility

`gh-env.sh` exports `GH_AUTH_METHOD` (`"gh"` / `"curl"` / `"none"`). The older inline blocks used `AUTH` with values `"gh"` / `"git"`. Two skills still reference `$AUTH` later (github-pr-workflow echoes it; github-repo-management branches on `if [ "$AUTH" = "gh" ]`). To preserve that contract, each patched setup block adds:

```bash
AUTH="$GH_AUTH_METHOD"
[ "$AUTH" = "curl" ] && AUTH="git"
```

No behavior change for end users. No new dependencies.

## How to test

1. `source skills/github/github-auth/scripts/gh-env.sh` — runs clean, exports `GH_AUTH_METHOD`, `GITHUB_TOKEN`, `GH_USER`, `GH_OWNER`, `GH_REPO`.
2. Load each patched skill and verify the `### Setup` block reads coherently and the variables it promises (`AUTH`, `OWNER`, `REPO`) are populated.
3. Confirm no remaining references to the removed `REMOTE_URL` / `OWNER_REPO` intermediate variables in the patched sections (verified via `grep`).

```bash
bash -n skills/github/github-auth/scripts/gh-env.sh   # syntax OK
grep -rn 'REMOTE_URL\|OWNER_REPO' skills/github/      # only in unrelated sections, if any
```

## Platforms tested

macOS (arm64). The `gh-env.sh` script and the `source` pattern are POSIX `bash` — no platform-specific primitives introduced or removed.

## Related

Searched open and closed PRs/issues for "github-auth", "gh-env", "dedupe" — no prior PR addressing this duplication found.
