### PR TITLE
fix(timeouts): add claude-fable to reasoning stale-timeout floor table

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -106,6 +106,14 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("claude-sonnet-5", 180),
     ("claude-sonnet-4.5", 180),
     ("claude-sonnet-4.6", 180),
+    # Anthropic Mythos-class named reasoning models (claude-fable-5, …).
+    # 1M context + 128K output — heavier thinking phase than the
+    # numbered Claude line, so the floor is in the deep-reasoning tier
+    # alongside o1 / deepseek-r1 / nemotron-3-ultra.  Without this
+    # entry the stale-stream detector kills fable-5's thinking phase
+    # at the default 180s (300s with context scaling), tripping the
+    # cross-turn circuit breaker after 5 consecutive stale kills.
+    ("claude-fable", 600),
     # xAI Grok reasoning variants.  Explicit reasoning-only keys
     # plus one for the ``non-reasoning`` variant so users picking
     # the fast variant don't get the 300s floor.  Bare ``grok-3``,
@@ -207,6 +215,8 @@ def get_reasoning_stale_timeout_floor(model: object) -> Optional[float]:
     300.0
     >>> get_reasoning_stale_timeout_floor("anthropic/claude-opus-4-6")
     240.0
+    >>> get_reasoning_stale_timeout_floor("anthropic/claude-fable-5")
+    600.0
     >>> get_reasoning_stale_timeout_floor("gpt-4o") is None
     True
     >>> get_reasoning_stale_timeout_floor("olmo-1") is None

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -74,6 +74,10 @@ import pytest
     ("anthropic/claude-opus-4-20250514", 240.0),
     ("anthropic/claude-sonnet-4.5", 180.0),
     ("anthropic/claude-sonnet-4.6", 180.0),
+    # Anthropic Mythos-class named reasoning models — deep-reasoning tier.
+    ("anthropic/claude-fable-5", 600.0),
+    ("claude-fable-5", 600.0),
+    ("claude-fable", 600.0),
     # xAI Grok reasoning variants — explicit, not bare `grok`.
     ("x-ai/grok-4-fast-reasoning", 300.0),
     ("x-ai/grok-4.20-reasoning", 300.0),


### PR DESCRIPTION
## Summary
claude-fable-5's reasoning phase no longer gets killed by the stale-stream detector, which was causing the cross-turn circuit breaker to abort all calls after 5 consecutive stale kills.

## Root cause
`claude-fable-5` is a Mythos-class reasoning model (1M context, 128K output, adaptive thinking) but was missing from the `_REASONING_STALE_TIMEOUT_FLOORS` table in `agent/reasoning_timeouts.py`. Without a floor entry, it got the default 180s stale timeout (300s with context scaling for >100K-token contexts). fable-5's thinking phase on large contexts routinely exceeds that window, so each call was stale-killed, bumping the cross-turn circuit breaker (`_consecutive_stale_streams`). After 5 consecutive kills, `_check_stale_giveup()` fired immediately (`elapsed: 0.00s`) — the "Provider has been unresponsive for 5 consecutive stale attempts" error with no network attempt.

## Changes
- `agent/reasoning_timeouts.py`: add `("claude-fable", 600)` to the reasoning stale-timeout floor table (deep-reasoning tier alongside o1/deepseek-r1/nemotron-3-ultra). The `claude-fable` slug matches `claude-fable-5` and future variants via the existing right-anchor regex.
- Added doctest: `get_reasoning_stale_timeout_floor("anthropic/claude-fable-5")` → `600.0`

## Validation
| Model | Before | After |
|---|---|---|
| `anthropic/claude-fable-5` (191K ctx) | 300s stale timeout | 600s stale timeout |
| `anthropic/claude-opus-4-6` (191K ctx) | 300s (unchanged) | 300s (unchanged) |

- Doctests: 1 passed
- `tests/agent/test_error_classifier.py`: 205 passed
- Stale circuit breaker test: 1 passed
