### PR TITLE
feat(feishu): add history backfill for group @mention context

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -97,6 +97,7 @@ CreateMessageRequest = None  # type: ignore[assignment]
 CreateMessageRequestBody = None  # type: ignore[assignment]
 GetChatRequest = None  # type: ignore[assignment]
 GetMessageRequest = None  # type: ignore[assignment]
+ListMessageRequest = None  # type: ignore[assignment]
 GetMessageResourceRequest = None  # type: ignore[assignment]
 P2ImMessageMessageReadV1 = None  # type: ignore[assignment]
 ReplyMessageRequest = None  # type: ignore[assignment]
@@ -1400,7 +1401,7 @@ def _load_lark_oapi() -> bool:
                 CreateFileRequest, CreateFileRequestBody,
                 CreateImageRequest, CreateImageRequestBody,
                 CreateMessageRequest, CreateMessageRequestBody,
-                GetChatRequest, GetMessageRequest, GetMessageResourceRequest,
+                GetChatRequest, GetMessageRequest, ListMessageRequest, GetMessageResourceRequest,
                 P2ImMessageMessageReadV1,
                 ReplyMessageRequest, ReplyMessageRequestBody,
                 UpdateMessageRequest, UpdateMessageRequestBody,
@@ -1427,6 +1428,7 @@ def _load_lark_oapi() -> bool:
             "CreateMessageRequestBody": CreateMessageRequestBody,
             "GetChatRequest": GetChatRequest,
             "GetMessageRequest": GetMessageRequest,
+            "ListMessageRequest": ListMessageRequest,
             "GetMessageResourceRequest": GetMessageResourceRequest,
             "P2ImMessageMessageReadV1": P2ImMessageMessageReadV1,
             "ReplyMessageRequest": ReplyMessageRequest,
@@ -2438,6 +2440,165 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] Failed to get chat info for %s", chat_id, exc_info=True)
             return fallback
 
+    # =========================================================================
+    # History backfill (modeled on Discord adapter pattern)
+    # =========================================================================
+
+    def _feishu_history_backfill(self) -> bool:
+        """Return whether history backfill is enabled when @mentioned."""
+        _config = getattr(self, "config", None)
+        if _config is None:
+            return True  # default
+        configured = _config.extra.get("history_backfill")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in {"false", "0", "no", "off"}
+            return bool(configured)
+        return True  # default on, matching Discord
+
+    def _feishu_history_backfill_limit(self) -> int:
+        """Return max messages to scan backwards for context."""
+        _config = getattr(self, "config", None)
+        if _config is None:
+            return 50  # default
+        configured = _config.extra.get("history_backfill_limit")
+        if configured is not None:
+            try:
+                return int(configured)
+            except (ValueError, TypeError):
+                pass
+        return 50  # default 50, matching Discord
+
+    async def _fetch_feishu_channel_context(
+        self, chat_id: str, before_message_id: str,
+    ) -> str:
+        """Fetch recent chat messages for conversational context.
+
+        Scans backwards from *before_message_id* and collects messages until
+        it hits a message sent by this bot (the natural partition point between
+        bot turns) or reaches the backfill limit. Handles pagination for
+        configured limits larger than 50.
+
+        Returns a formatted block::
+
+            [Recent channel messages]
+            [sender1] message content
+            [sender2] message content
+
+        Returns empty string if no context available.
+        """
+        limit = self._feishu_history_backfill_limit()
+        if limit <= 0:
+            return ""
+
+        try:
+            collected: List[str] = []
+            page_token: Optional[str] = None
+            partition_hit = False
+
+            for _ in range(20):  # safety cap — 20 pages max
+                if len(collected) >= limit:
+                    break
+
+                builder = (
+                    ListMessageRequest.builder()
+                    .container_id_type("chat")
+                    .container_id(chat_id)
+                    .page_size(min(limit - len(collected), 50))
+                    .sort_type("ByCreateTimeDesc")
+                )
+                if page_token:
+                    builder.page_token(page_token)
+
+                response = await self._run_blocking(
+                    self._client.im.v1.message.list, builder.build()
+                )
+                if not response or not getattr(response, "success", lambda: False)():
+                    break
+
+                data = getattr(response, "data", None)
+                if not data:
+                    break
+
+                items = getattr(data, "items", None) or []
+                if not items:
+                    break
+
+                for msg in items:
+                    msg_id = str(getattr(msg, "message_id", "") or "")
+                    if not msg_id or msg_id == before_message_id:
+                        continue
+
+                    # Stop at our own message — partition point.
+                    sender = getattr(msg, "sender", None)
+                    sender_type = str(getattr(sender, "sender_type", "") or "")
+                    sender_id = str(getattr(sender, "id", "") or "")
+                    if sender_type == "app" and sender_id == self._app_id:
+                        partition_hit = True  # earlier messages belong to previous bot turn
+                        break
+
+                    if len(collected) >= limit:
+                        break
+
+                    # Extract text content.
+                    msg_type = str(getattr(msg, "msg_type", "") or "")
+                    body = getattr(msg, "body", None)
+                    raw_content = str(getattr(body, "content", "") or "")
+                    if not raw_content:
+                        continue
+                    if msg_type == "text":
+                        try:
+                            parsed = json.loads(raw_content)
+                            raw_content = str(parsed.get("text", raw_content))
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                    elif msg_type in ("image", "file", "audio", "video"):
+                        raw_content = f"({msg_type})"
+                    elif msg_type == "post":
+                        raw_content = "(rich text)"
+                    else:
+                        continue
+
+                    # Skip self-mention placeholder suffix like @_user_123.
+                    raw_content = _MENTION_RE.sub("", raw_content).strip()
+                    if not raw_content:
+                        # Only media with no caption.
+                        if msg_type in ("image", "file", "audio", "video"):
+                            raw_content = f"({msg_type})"
+                        else:
+                            continue
+
+                    # Format sender name.
+                    sender_display = (
+                        sender_id.split("_")[-1][:8]
+                        if "_" in sender_id
+                        else sender_id[:12]
+                    )
+                    collected.append(f"[{sender_display}] {raw_content}")
+
+                if partition_hit or not getattr(data, "has_more", False):
+                    break
+                next_token = getattr(data, "page_token", None) or ""
+                if not next_token:
+                    break
+                page_token = next_token
+
+            if not collected:
+                return ""
+
+            # Reverse to chronological order (API returned newest-first).
+            collected.reverse()
+            context = "[Recent channel messages]\n" + "\n".join(collected)
+            logger.debug(
+                "[Feishu] Backfill fetched %d messages for %s",
+                len(collected), chat_id,
+            )
+            return context
+
+        except Exception:
+            logger.debug("[Feishu] Failed to fetch channel context", exc_info=True)
+            return ""
+
     def format_message(self, content: str) -> str:
         """Feishu text messages are plain text by default."""
         return content.strip()
@@ -3363,9 +3524,21 @@ class FeishuAdapter(BasePlatformAdapter):
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
             thread_id=thread_id,
-            user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            user_id_alt=sender_profile["user_id_alt"],
         )
+
+        # ── History backfill: when relevant, fetch recent channel context ──
+        backfill_text: Optional[str] = None
+        if chat_type != "p2p" and self._feishu_history_backfill():
+            # Free-response groups (require_mention=false) always get
+            # backfill; mention-gated groups only get it when @mentioned.
+            needs_mention = self._require_mention_for(chat_id)
+            if not needs_mention or self._mentions_self(message):
+                backfill_text = await self._fetch_feishu_channel_context(
+                    chat_id, message_id
+                )
+
         normalized = MessageEvent(
             text=text,
             message_type=inbound_type,
@@ -3377,6 +3550,7 @@ class FeishuAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
             channel_prompt=self._resolve_channel_prompt(chat_id, thread_id or None),
+            channel_context=backfill_text,
             timestamp=datetime.now(),
         )
         await self._dispatch_inbound_event(normalized)
@@ -4372,10 +4546,11 @@ class FeishuAdapter(BasePlatformAdapter):
         return None
 
     def _require_mention_for(self, chat_id: str) -> bool:
-        rule = self._group_rules.get(chat_id) if chat_id else None
+        _group_rules = getattr(self, '_group_rules', {}) or {}
+        rule = _group_rules.get(chat_id) if chat_id else None
         if rule and rule.require_mention is not None:
             return rule.require_mention
-        return self._require_mention
+        return getattr(self, '_require_mention', True)
 
     # --- Group policy ---------------------------------------------------------
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2302,6 +2302,318 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         self.assertTrue(event.text.startswith("/model"))
 
 
+    # ── History backfill tests ──────────────────────────────────────────
+
+    def test_backfill_fetches_context_when_mentioned_in_group(self):
+        """When @mentioned in a group with backfill default, channel_context is set."""
+        adapter = self._build_adapter()
+        adapter._fetch_feishu_channel_context = AsyncMock(
+            return_value="[Recent channel messages]\n[Alice] hello\n[Bob] world"
+        )
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1 what do you think?"}),
+            message_type="text",
+            message_id="m_b1",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+            root_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m_b1",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertIn("[Recent channel messages]", event.channel_context)
+        self.assertIn("[Alice] hello", event.channel_context)
+        self.assertIn("what do you think?", event.text)
+        self.assertIsNotNone(event.channel_context)
+
+    def test_backfill_skipped_for_p2p_messages(self):
+        """Backfill must not run for direct messages (p2p)."""
+        adapter = self._build_adapter()
+        adapter._fetch_feishu_channel_context = AsyncMock(return_value="[Recent channel messages]\ndata")
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "hi"}),
+            message_type="text",
+            message_id="m_b2",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+            root_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="p2p",
+                message_id="m_b2",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.text, "hi")
+        adapter._fetch_feishu_channel_context.assert_not_called()
+
+    def test_backfill_skipped_when_no_mentions(self):
+        """Backfill must not run for messages without @mentions when require_mention is true."""
+        adapter = self._build_adapter()
+        adapter._require_mention = True
+        adapter._fetch_feishu_channel_context = AsyncMock(return_value="[Recent channel messages]\ndata")
+        message = SimpleNamespace(
+            content=json.dumps({"text": "hello everyone"}),
+            message_type="text",
+            message_id="m_b3",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+            root_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m_b3",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.text, "hello everyone")
+        adapter._fetch_feishu_channel_context.assert_not_called()
+
+    def test_backfill_runs_in_free_response_group(self):
+        """Backfill runs on every message in free-response groups (require_mention=false)."""
+        adapter = self._build_adapter()
+        adapter._require_mention = False
+        adapter._fetch_feishu_channel_context = AsyncMock(
+            return_value="[Recent channel messages]\n[Alice] hi"
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "hello everyone"}),
+            message_type="text",
+            message_id="m_b4",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+            root_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m_b4",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        adapter._fetch_feishu_channel_context.assert_called_once()
+        self.assertIn("[Recent channel messages]", event.channel_context)
+
+    # ── _fetch_feishu_channel_context fixture tests ─────────────────────
+
+    def _make_list_response(self, items, has_more=False, page_token=""):
+        data = Mock()
+        data.items = items
+        data.has_more = has_more
+        if page_token:
+            data.page_token = page_token
+        resp = Mock()
+        resp.success = lambda: True
+        resp.data = data
+        return resp
+
+    def _make_msg(self, msg_id, sender_type, sender_id, msg_type, body_content):
+        msg = Mock()
+        msg.message_id = msg_id
+        msg.sender = Mock()
+        msg.sender.sender_type = sender_type
+        msg.sender.id = sender_id
+        msg.msg_type = msg_type
+        msg.body = Mock()
+        msg.body.content = body_content
+        return msg
+
+    def _build_bare_adapter(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        # CI installs without --extra feishu, so lark_oapi may be missing.
+        # _fetch_feishu_channel_context references ListMessageRequest directly
+        # at module level; inject a chainable mock builder so the pagination
+        # logic under test does not depend on the real SDK being installed.
+        import plugins.platforms.feishu.adapter as feishu_adapter_module
+
+        if getattr(feishu_adapter_module, "ListMessageRequest", None) is None:
+            fake_builder = Mock()
+            fake_builder.container_id_type = Mock(return_value=fake_builder)
+            fake_builder.container_id = Mock(return_value=fake_builder)
+            fake_builder.page_size = Mock(return_value=fake_builder)
+            fake_builder.sort_type = Mock(return_value=fake_builder)
+            fake_builder.page_token = Mock(return_value=fake_builder)
+            fake_builder.build = Mock(return_value=object())
+            fake_request = Mock()
+            fake_request.builder = Mock(return_value=fake_builder)
+            feishu_adapter_module.ListMessageRequest = fake_request
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter._app_id = "ou_bot_app"
+        adapter._client = Mock()
+        adapter._client.im.v1.message.list = AsyncMock()
+        async def _passthrough(_, func, *args):
+            return await func(*args)
+        adapter._run_blocking = _passthrough.__get__(adapter)
+        return adapter
+
+    def test_backfill_single_page(self):
+        adapter = self._build_bare_adapter()
+        items = [
+            self._make_msg("m1", "user", "ou_user1", "text", '{"text":"hello"}'),
+            self._make_msg("m2", "user", "ou_user2", "text", '{"text":"world"}'),
+        ]
+        adapter._client.im.v1.message.list.return_value = self._make_list_response(items)
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m3"))
+        self.assertIn("[Recent channel messages]", result)
+        self.assertIn("[user1] hello", result)
+        self.assertIn("[user2] world", result)
+
+    def test_backfill_trigger_message_excluded(self):
+        adapter = self._build_bare_adapter()
+        items = [
+            self._make_msg("m3", "user", "ou_user1", "text", '{"text":"trigger"}'),
+            self._make_msg("m2", "user", "ou_user2", "text", '{"text":"earlier"}'),
+        ]
+        adapter._client.im.v1.message.list.return_value = self._make_list_response(items)
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m3"))
+        self.assertNotIn("trigger", result)
+        self.assertIn("earlier", result)
+
+    def test_backfill_self_message_cutoff(self):
+        adapter = self._build_bare_adapter()
+        items = [
+            self._make_msg("m3", "user", "ou_user2", "text", '{"text":"after bot"}'),
+            self._make_msg("m2", "app", "ou_bot_app", "text", '{"text":"bot reply"}'),
+            self._make_msg("m1", "user", "ou_user1", "text", '{"text":"before bot"}'),
+        ]
+        adapter._client.im.v1.message.list.return_value = self._make_list_response(items)
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m4"))
+        self.assertIn("after bot", result)
+        self.assertNotIn("before bot", result)
+
+    def test_backfill_limit_enforcement(self):
+        adapter = self._build_bare_adapter()
+        adapter._feishu_history_backfill_limit = Mock(return_value=2)
+        items = [
+            self._make_msg("m1", "user", "ou_u1", "text", '{"text":"a"}'),
+            self._make_msg("m2", "user", "ou_u2", "text", '{"text":"b"}'),
+            self._make_msg("m3", "user", "ou_u3", "text", '{"text":"c"}'),
+        ]
+        adapter._client.im.v1.message.list.return_value = self._make_list_response(items)
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m4"))
+        lines = [l for l in result.strip().split("\n") if l.startswith("[u")]
+        self.assertEqual(len(lines), 2)
+
+    def test_backfill_multi_page_pagination(self):
+        adapter = self._build_bare_adapter()
+        page1 = self._make_list_response(
+            [self._make_msg("m1", "user", "ou_u1", "text", '{"text":"page1 newer"}')],
+            has_more=True, page_token="tok2"
+        )
+        page2 = self._make_list_response(
+            [self._make_msg("m2", "user", "ou_u2", "text", '{"text":"page2 older"}')],
+        )
+        adapter._client.im.v1.message.list = AsyncMock(side_effect=[page1, page2])
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m3"))
+        older_idx = result.index("page2 older")
+        newer_idx = result.index("page1 newer")
+        self.assertLess(older_idx, newer_idx)
+
+    def test_backfill_cross_page_self_message_cutoff(self):
+        adapter = self._build_bare_adapter()
+        page1 = self._make_list_response(
+            [self._make_msg("m1", "user", "ou_u1", "text", '{"text":"after bot"}')],
+            has_more=True, page_token="tok2"
+        )
+        page2 = self._make_list_response([
+            self._make_msg("m2", "app", "ou_bot_app", "text", '{"text":"bot reply"}'),
+            self._make_msg("m3", "user", "ou_u2", "text", '{"text":"before bot"}'),
+        ])
+        adapter._client.im.v1.message.list = AsyncMock(side_effect=[page1, page2])
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m4"))
+        self.assertIn("after bot", result)
+        self.assertNotIn("before bot", result)
+
+    def test_backfill_empty_response(self):
+        adapter = self._build_bare_adapter()
+        adapter._client.im.v1.message.list.return_value = self._make_list_response([])
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m1"))
+        self.assertEqual(result, "")
+
+    def test_backfill_failed_response(self):
+        adapter = self._build_bare_adapter()
+        resp = Mock()
+        resp.success = lambda: False
+        adapter._client.im.v1.message.list.return_value = resp
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m1"))
+        self.assertEqual(result, "")
+
+    def test_backfill_limit_zero(self):
+        adapter = self._build_bare_adapter()
+        adapter._feishu_history_backfill_limit = Mock(return_value=0)
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m1"))
+        self.assertEqual(result, "")
+        adapter._client.im.v1.message.list.assert_not_called()
+
+    def test_backfill_media_messages(self):
+        adapter = self._build_bare_adapter()
+        items = [
+            self._make_msg("m1", "user", "ou_u1", "image", '{"image_key":"img"}'),
+            self._make_msg("m2", "user", "ou_u2", "file", '{"file_key":"f"}'),
+            self._make_msg("m3", "user", "ou_u3", "audio", '{"audio_key":"a"}'),
+            self._make_msg("m4", "user", "ou_u4", "video", '{"video_key":"v"}'),
+        ]
+        adapter._client.im.v1.message.list.return_value = self._make_list_response(items)
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m5"))
+        self.assertIn("(image)", result)
+        self.assertIn("(file)", result)
+        self.assertIn("(audio)", result)
+        self.assertIn("(video)", result)
+
+    def test_backfill_non_bot_partition(self):
+        adapter = self._build_bare_adapter()
+        items = [
+            self._make_msg("m1", "app", "ou_other_bot", "text", '{"text":"other bot msg"}'),
+            self._make_msg("m2", "user", "ou_u1", "text", '{"text":"user msg"}'),
+        ]
+        adapter._client.im.v1.message.list.return_value = self._make_list_response(items)
+        result = asyncio.run(adapter._fetch_feishu_channel_context("oc_chat", "m3"))
+        self.assertIn("other bot msg", result)
+        self.assertIn("user msg", result)
+
+
 class TestFeishuFetchMessageText(unittest.TestCase):
     def _build_adapter(self):
         from plugins.platforms.feishu.adapter import FeishuAdapter


### PR DESCRIPTION
## What does this PR do?

Adds history backfill to the Feishu adapter, modeled on the existing Discord adapter pattern. When the bot is @mentioned in a group chat, it fetches recent channel messages via the Feishu `list_message` API and prepends them as conversational context — so the agent can see what happened before the @mention.

## Related Issue

n/a — new feature request from community feedback

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`plugins/platforms/feishu/adapter.py`**: Added `ListMessageRequest` import; three new methods (`_feishu_history_backfill`, `_feishu_history_backfill_limit`, `_fetch_feishu_channel_context`); wired backfill into `_process_inbound_message` before dispatch
- **`tests/gateway/test_feishu.py`**: Added 3 backfill tests (`test_backfill_fetches_context_when_mentioned_in_group`, `test_backfill_skipped_for_p2p_messages`, `test_backfill_skipped_when_no_mentions`)

Backfill triggers when: group chat + @mention + history_backfill enabled. It calls Feishu `list_message` with `sort_type=ByCreateTimeDesc`, scans backwards until hitting the bot's own last message (natural partition point) or the backfill limit, and prepends as `[Recent channel messages]\n[sender] content...`.

## Configuration

New config keys under `platforms.feishu.extra` in `config.yaml`:

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `history_backfill` | bool | `true` | Enable history backfill when @mentioned in group chats |
| `history_backfill_limit` | int | `50` | Max messages to scan backwards for context |

Backfill pairs with the existing `require_mention` setting — when the bot is @mentioned (`require_mention: true`), backfill pulls the conversation history so the agent has context without needing to be in every message.

Example:
```yaml
platforms:
  feishu:
    extra:
      require_mention: true       # only respond to @mentions
      history_backfill: true      # pull context when @mentioned
      history_backfill_limit: 50  # max messages to scan
```

## How to Test

1. Ensure `history_backfill` is enabled in feishu.extra (default: `true`, no change needed)
2. In a group chat, @mention the bot after some conversation history
3. Verify the bot's response shows awareness of preceding messages wrapped in `[Recent channel messages]`
4. Run tests: `python3 -m pytest tests/gateway/test_feishu.py -q -k "backfill"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_feishu.py -q -k "backfill"` — 15 backfill tests passed, 0 failed
- [x] I've added tests for my changes — 15 tests: 4 gating tests (trigger on @mention, skip p2p, skip no-mention, free-response groups) + 11 fixture-based tests for `_fetch_feishu_channel_context` (single page, trigger exclusion, self-message cutoff single/cross-page, limit enforcement, limit=0, multi-page pagination, empty/failed response, media folding, non-bot partition)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] ✍️ Documentation update — Config section added above
- [ ] N/A — No architecture change requiring CONTRIBUTING.md update
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Feishu adapter only; no cross-platform impact
- [ ] N/A — Tool behavior unchanged