### PR TITLE
fix(xai): use Hermes-Agent User-Agent for chat traffic

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1162,6 +1162,10 @@ def init_agent(
             elif base_url_host_matches(effective_base, "chatgpt.com"):
                 from agent.auxiliary_client import _codex_cloudflare_headers
                 client_kwargs["default_headers"] = _codex_cloudflare_headers(api_key)
+            elif base_url_host_matches(effective_base, "x.ai"):
+                from tools.xai_http import hermes_xai_default_headers
+
+                client_kwargs["default_headers"] = hermes_xai_default_headers()
             elif "default_headers" not in client_kwargs:
                 # Fall back to profile.default_headers for providers that
                 # declare custom headers (e.g. Kimi User-Agent on non-kimi.com

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2794,7 +2794,13 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
         return None, None
     api_key, base_url = resolved
     logger.debug("Auxiliary client: xAI OAuth (%s via Responses API)", model)
-    real_client = _create_openai_client(api_key=api_key, base_url=base_url)
+    from tools.xai_http import hermes_xai_default_headers
+
+    real_client = _create_openai_client(
+        api_key=api_key,
+        base_url=base_url,
+        default_headers=hermes_xai_default_headers(),
+    )
     return CodexAuxiliaryClient(real_client, model), model
 
 
@@ -4892,6 +4898,10 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
     elif base_url_host_matches(sync_base_url, "integrate.api.nvidia.com"):
         async_kwargs["default_headers"] = build_nvidia_nim_headers(sync_base_url)
+    elif base_url_host_matches(sync_base_url, "x.ai"):
+        from tools.xai_http import hermes_xai_default_headers
+
+        async_kwargs["default_headers"] = hermes_xai_default_headers()
     else:
         # Fall back to profile.default_headers for providers that declare
         # client-level headers on their ProviderProfile (e.g. attribution
@@ -5515,6 +5525,10 @@ def resolve_provider_client(
             ))
         elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
             headers.update(build_nvidia_nim_headers(base_url))
+        elif base_url_host_matches(base_url, "x.ai"):
+            from tools.xai_http import hermes_xai_default_headers
+
+            headers.update(hermes_xai_default_headers())
         else:
             # Fall back to profile.default_headers for providers that declare
             # client-level attribution headers on their profile (e.g. GMI

--- a/plugins/model-providers/xai/__init__.py
+++ b/plugins/model-providers/xai/__init__.py
@@ -11,10 +11,6 @@ xai = ProviderProfile(
     env_vars=("XAI_API_KEY",),
     base_url="https://api.x.ai/v1",
     auth_type="api_key",
-    # Attribution so xAI can identify Hermes chat/completions traffic.
-    # Must match tools.xai_http.hermes_xai_user_agent() (Hermes-Agent/<ver>).
-    # Host-based api.x.ai matching in run_agent / auxiliary_client also
-    # covers provider=xai-oauth.
     default_headers={"User-Agent": f"Hermes-Agent/{_HERMES_VERSION}"},
 )
 

--- a/plugins/model-providers/xai/__init__.py
+++ b/plugins/model-providers/xai/__init__.py
@@ -1,5 +1,6 @@
 """xAI (Grok) provider profile."""
 
+from hermes_cli import __version__ as _HERMES_VERSION
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -10,6 +11,11 @@ xai = ProviderProfile(
     env_vars=("XAI_API_KEY",),
     base_url="https://api.x.ai/v1",
     auth_type="api_key",
+    # Attribution so xAI can identify Hermes chat/completions traffic.
+    # Must match tools.xai_http.hermes_xai_user_agent() (Hermes-Agent/<ver>).
+    # Host-based api.x.ai matching in run_agent / auxiliary_client also
+    # covers provider=xai-oauth.
+    default_headers={"User-Agent": f"Hermes-Agent/{_HERMES_VERSION}"},
 )
 
 register_provider(xai)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5077,6 +5077,11 @@ class AIAgent:
             self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
                 self._client_kwargs.get("api_key", "")
             )
+        elif base_url_host_matches(base_url, "x.ai"):
+            # Cover both provider=xai and provider=xai-oauth (api.x.ai).
+            from tools.xai_http import hermes_xai_default_headers
+
+            self._client_kwargs["default_headers"] = hermes_xai_default_headers()
         else:
             # No URL-specific headers — check profile.default_headers before clearing.
             _ph_headers = None

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -160,6 +160,46 @@ def test_gmi_base_url_picks_up_profile_user_agent(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_xai_base_url_applies_hermes_user_agent(mock_openai):
+    """Direct xAI chat must send Hermes-Agent/* instead of OpenAI/Python."""
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.x.ai/v1",
+        model="grok-4",
+        provider="xai",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://api.x.ai/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["User-Agent"].startswith("Hermes-Agent/")
+
+
+@patch("run_agent.OpenAI")
+def test_xai_oauth_base_url_applies_hermes_user_agent(mock_openai):
+    """xai-oauth uses the same api.x.ai host and must get the Hermes UA."""
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="oauth-token",
+        base_url="https://api.x.ai/v1",
+        model="grok-4",
+        provider="xai-oauth",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://api.x.ai/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["User-Agent"].startswith("Hermes-Agent/")
+
+
+@patch("run_agent.OpenAI")
 def test_unknown_base_url_clears_default_headers(mock_openai):
     mock_openai.return_value = MagicMock()
     agent = AIAgent(

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -97,6 +97,16 @@ def hermes_xai_user_agent() -> str:
     return f"Hermes-Agent/{__version__}"
 
 
+def hermes_xai_default_headers() -> Dict[str, str]:
+    """Default headers for OpenAI-SDK and raw HTTP clients talking to xAI.
+
+    Replaces the OpenAI Python SDK's identifying ``User-Agent: OpenAI/Python …``
+    so chat/completions and Responses traffic is attributed as Hermes Agent,
+    matching the direct HTTP integrations (search, TTS, STT, image, video).
+    """
+    return {"User-Agent": hermes_xai_user_agent()}
+
+
 def _load_config_section(section_name: str) -> Dict[str, Any]:
     """Return a top-level Hermes config section as a dict, or empty."""
     try:


### PR DESCRIPTION
## What does this PR do?

adds user-agent headers to xAI adapter

## Related Issue

N/A. discovered while auditing Hermes → xAI request headers.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/xai_http.py` — add `hermes_xai_default_headers()` helper (`User-Agent: Hermes-Agent/<ver>`)
- `plugins/model-providers/xai/__init__.py` — declare `default_headers` on the xAI provider profile
- `run_agent.py` / `agent/agent_init.py` — host-match `*.x.ai` so both `provider=xai` and `provider=xai-oauth` get the Hermes UA
- `agent/auxiliary_client.py` — apply the same headers for aux OAuth client, `resolve_provider_client`, and async conversion
- `tests/run_agent/test_provider_attribution_headers.py` — coverage for xAI + xAI OAuth base URLs

## How to Test

1. `uv run --extra dev pytest tests/run_agent/test_provider_attribution_headers.py -q`
2. (Optional smoke) Configure `provider: xai` or `xai-oauth`, send a chat turn, and confirm the outbound request `User-Agent` starts with `Hermes-Agent/` (not `OpenAI/Python`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux x86_64), Python 3.12.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — header-only change; verified via unit tests (`17 passed` in `tests/run_agent/test_provider_attribution_headers.py`).