### PR TITLE
fix(desktop): measure adaptive stream flush through the deferred commit frame

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
@@ -1,10 +1,13 @@
 import { QueryClient } from '@tanstack/react-query'
 import { act, cleanup, render } from '@testing-library/react'
-import { useEffect, useRef } from 'react'
+import { type MutableRefObject, useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
+import type { ChatMessage } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+
+import { useSessionStateCache } from '../use-session-state-cache'
 
 import { useMessageStream } from './index'
 
@@ -107,5 +110,276 @@ describe('useMessageStream delta flush scheduling', () => {
 
     expect(updateSessionState).toHaveBeenCalledTimes(updatesAfterUnmount)
     expect(window.requestAnimationFrame).not.toHaveBeenCalled()
+  })
+
+  it('stretches the flush gap when the deferred commit frame is expensive', async () => {
+    // The streaming-path $messages publish (React commit + Streamdown
+    // re-parse) is deferred to a view-sync rAF inside updateSessionState, so
+    // the flush cost must be measured through that frame. Simulate one
+    // expensive frame and expect the next gap to adapt to 3x the frame cost.
+    let now = 1000
+    vi.mocked(performance.now).mockImplementation(() => now)
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.mocked(window.requestAnimationFrame).mockImplementation(cb => {
+      rafCallbacks.push(cb)
+
+      return rafCallbacks.length
+    })
+
+    mountStream()
+
+    act(() => appendAssistantDelta!(SID, 'first'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(assistantText()).toBe('first')
+    expect(rafCallbacks).toHaveLength(1)
+
+    // Frame started at 1040, the measurement callback runs at 1100: 60ms of
+    // in-frame work (view sync + commit), so the next floor is 180ms.
+    now = 1100
+    act(() => rafCallbacks[0](1040))
+
+    act(() => appendAssistantDelta!(SID, 'second'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(79)
+    })
+
+    expect(assistantText()).toBe('first')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+
+    expect(assistantText()).toBe('firstsecond')
+  })
+
+  it('keeps the write-cost floor when no frame fires (hidden renderer)', async () => {
+    // A parked renderer never runs rAF callbacks. The cost must stay at the
+    // synchronous store-write measurement so the gap falls back to the fixed
+    // 33ms floor instead of waiting on a frame that will never come.
+    let now = 1000
+    vi.mocked(performance.now).mockImplementation(() => now)
+    vi.mocked(window.requestAnimationFrame).mockImplementation(() => 1)
+
+    mountStream()
+
+    act(() => appendAssistantDelta!(SID, 'first'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(assistantText()).toBe('first')
+
+    // 100ms later (well past the 33ms floor): the next flush is immediate.
+    now = 1100
+    act(() => appendAssistantDelta!(SID, 'second'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(assistantText()).toBe('firstsecond')
+  })
+
+  it('ignores a late frame measurement once a newer flush has started', async () => {
+    let now = 1000
+    vi.mocked(performance.now).mockImplementation(() => now)
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.mocked(window.requestAnimationFrame).mockImplementation(cb => {
+      rafCallbacks.push(cb)
+
+      return rafCallbacks.length
+    })
+
+    mountStream()
+
+    act(() => appendAssistantDelta!(SID, 'a'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // A second flush starts before the first flush's frame lands.
+    now = 1010
+    act(() => appendAssistantDelta!(SID, 'b'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(23)
+    })
+
+    expect(assistantText()).toBe('ab')
+    expect(rafCallbacks).toHaveLength(2)
+
+    // The stale callback must not overwrite the newer flush's cost. If it
+    // did, cost would read 30ms and the next gap would stretch to 70ms.
+    now = 1030
+    act(() => rafCallbacks[0](1000))
+
+    act(() => appendAssistantDelta!(SID, 'c'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(13)
+    })
+
+    expect(assistantText()).toBe('abc')
+  })
+})
+
+describe('useMessageStream composed with the real useSessionStateCache', () => {
+  // The tests above mock updateSessionState, so they validate the adaptive
+  // arithmetic but not the production ordering contract: runFlush's
+  // measurement rAF must be registered AFTER the view-sync rAF that the real
+  // updateSessionState schedules inside syncSessionStateToView, so the
+  // measured frame cost includes the deferred $messages commit it adapts to.
+  let cache: ReturnType<typeof useSessionStateCache> | null = null
+  let published: ChatMessage[]
+
+  function ComposedHarness() {
+    const busyRef: MutableRefObject<boolean> = { current: false }
+    const queryClientRef = useRef(new QueryClient())
+
+    const sessionCache = useSessionStateCache({
+      activeSessionId: SID,
+      busyRef,
+      selectedStoredSessionId: null,
+      setAwaitingResponse: () => undefined,
+      setBusy: () => undefined,
+      setMessages: messages => {
+        published = messages
+      }
+    })
+
+    const stream = useMessageStream({
+      activeSessionIdRef: sessionCache.activeSessionIdRef,
+      hydrateFromStoredSession: vi.fn(async () => undefined),
+      queryClient: queryClientRef.current,
+      refreshHermesConfig: vi.fn(async () => undefined),
+      refreshSessions: vi.fn(async () => undefined),
+      sessionStateByRuntimeIdRef: sessionCache.sessionStateByRuntimeIdRef,
+      updateSessionState: sessionCache.updateSessionState
+    })
+
+    useEffect(() => {
+      appendAssistantDelta = stream.appendAssistantDelta
+      cache = sessionCache
+    }, [stream.appendAssistantDelta, sessionCache])
+
+    return null
+  }
+
+  function cachedText() {
+    const message = cache?.sessionStateByRuntimeIdRef.current.get(SID)?.messages.at(-1)
+    const part = message?.parts.at(-1)
+
+    return part?.type === 'text' ? part.text : ''
+  }
+
+  function publishedText() {
+    const part = published.at(-1)?.parts.at(-1)
+
+    return part?.type === 'text' ? part.text : ''
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    appendAssistantDelta = null
+    cache = null
+    published = []
+    vi.spyOn(performance, 'now').mockReturnValue(100)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('measures the frame cost through the real view-sync rAF and adapts the next gap', async () => {
+    let now = 1000
+    vi.mocked(performance.now).mockImplementation(() => now)
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.mocked(window.requestAnimationFrame).mockImplementation(cb => {
+      rafCallbacks.push(cb)
+
+      return rafCallbacks.length
+    })
+
+    render(<ComposedHarness />)
+    expect(appendAssistantDelta).not.toBeNull()
+
+    // Mid-turn state: busy keeps the view sync on the deferred rAF path
+    // (terminal/needing-input states flush synchronously instead).
+    act(() => {
+      cache!.updateSessionState(SID, state => ({ ...state, busy: true }))
+    })
+    expect(rafCallbacks).toHaveLength(1)
+    // Drain the seed's own view-sync rAF so the flush below starts clean.
+    act(() => rafCallbacks.shift()!(now))
+
+    act(() => appendAssistantDelta!(SID, 'first'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // The store write landed synchronously, but the $messages publish is
+    // deferred: exactly two rAF callbacks are pending — first the cache's
+    // view-sync, then runFlush's measurement.
+    expect(cachedText()).toBe('first')
+    expect(publishedText()).toBe('')
+    expect(rafCallbacks).toHaveLength(2)
+
+    // Draining the FIRST registered callback must be what publishes the
+    // deferred commit; that identity is the ordering contract. It runs until
+    // 60ms into the frame (React commit + Streamdown re-parse).
+    now = 1100
+    act(() => rafCallbacks[0](1040))
+    expect(publishedText()).toBe('first')
+
+    // The measurement callback closes the same frame: 60ms of in-frame work,
+    // so the next adaptive floor is 3x = 180ms.
+    act(() => rafCallbacks[1](1040))
+
+    act(() => appendAssistantDelta!(SID, 'second'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(79)
+    })
+
+    expect(cachedText()).toBe('first')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+
+    expect(cachedText()).toBe('firstsecond')
+  })
+
+  it('keeps the write-cost fallback when the parked renderer never fires rAF', async () => {
+    let now = 1000
+    vi.mocked(performance.now).mockImplementation(() => now)
+    // Parked renderer: rAF callbacks are accepted but never run.
+    vi.mocked(window.requestAnimationFrame).mockImplementation(() => 1)
+
+    render(<ComposedHarness />)
+
+    act(() => {
+      cache!.updateSessionState(SID, state => ({ ...state, busy: true }))
+    })
+
+    act(() => appendAssistantDelta!(SID, 'first'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(cachedText()).toBe('first')
+
+    // 100ms later (well past the 33ms floor): the next flush is immediate.
+    now = 1100
+    act(() => appendAssistantDelta!(SID, 'second'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(cachedText()).toBe('firstsecond')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -256,6 +256,8 @@ export function useMessageStream({
     // keeps the thread ~75% idle for input at any load: cheap flushes stay at
     // 30fps of text growth, expensive multi-stream flushes degrade text fps
     // instead of interactivity — capped so text never updates slower than 4/s.
+    // The cost has to include the deferred view-sync frame where the commit
+    // actually happens; see runFlush below.
     const sinceLast = performance.now() - lastFlushAtRef.current
 
     const adaptiveFloor = Math.min(
@@ -268,7 +270,27 @@ export function useMessageStream({
       const startedAt = performance.now()
       lastFlushAtRef.current = startedAt
       flushQueuedDeltas()
-      lastFlushCostRef.current = performance.now() - startedAt
+      // The store write above is only the cheap half of a flush. While a
+      // session streams, syncSessionStateToView defers the $messages publish
+      // (and with it the React commit + Streamdown re-parse the floor is meant
+      // to account for) to its own rAF inside updateSessionState, which runs
+      // after this timer task. Stopping the clock here pins lastFlushCostRef
+      // near zero and collapses the adaptive floor to 33ms no matter the load.
+      // Our rAF is registered after the view-sync one, so it runs in the same
+      // frame right after that commit; its timestamp marks frame start, so
+      // (now - frameStart) counts only work done inside the frame, not the
+      // vsync wait. A hidden renderer never fires rAF, so the write cost
+      // stays as the fallback.
+      const writeCost = performance.now() - startedAt
+      lastFlushCostRef.current = writeCost
+      window.requestAnimationFrame(frameStart => {
+        // A newer flush already started; its own measurement wins.
+        if (lastFlushAtRef.current !== startedAt) {
+          return
+        }
+
+        lastFlushCostRef.current = writeCost + Math.max(0, performance.now() - frameStart)
+      })
     }
 
     // Always a timer, never requestAnimationFrame. Chromium pauses rAF for a

--- a/apps/desktop/src/app/session/hooks/use-message-stream/stream-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/stream-flush.test.tsx
@@ -87,7 +87,10 @@ describe('stream delta delivery', () => {
     })
 
     expect(states.get(SID)?.messages.at(-1)?.parts).toEqual([{ type: 'text', text: 'first and the rest' }])
-    // The flush must not have depended on a frame at all.
-    expect(rafSpy).not.toHaveBeenCalled()
+    // The flush must not have depended on a frame: this mock parks every rAF
+    // callback, yet the text arrived. runFlush still registers its
+    // adaptive-floor measurement callback here; that one is allowed to wait
+    // for a frame that may never come.
+    expect(rafSpy).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What does this PR do?

The adaptive stream-flush floor from #72504 never engaged on the streaming path. `runFlush` timed only `flushQueuedDeltas()`, the synchronous store write. While a session streams, the `$messages` publish (React commit + Streamdown re-parse) is deferred to a view-sync rAF in `syncSessionStateToView`, so it lands in a later frame, after the measurement. The measured cost stayed near zero, the adaptive branch needs more than ~11ms to engage, and the floor collapsed to the fixed 33ms gap at any load. Multi-stream streaming could still starve the main thread of idle frames and hitch typing, the failure mode the floor was built to prevent.

`runFlush` now keeps the write cost as a fallback and extends the measurement through a rAF registered after the view-sync one. It runs in the same frame right after the deferred commit, and the rAF timestamp marks frame start so only in-frame work is counted, not the vsync wait. A stale callback from before a newer flush is ignored. A hidden renderer that never fires rAF keeps the write-cost fallback, so delivery in parked renderers is unchanged (still timer-driven, never frame-gated).

## Related Issue

Fixes #72799

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/index.ts`: measure flush cost through the deferred view-sync frame (write cost + in-frame work via the rAF timestamp), keep the write-cost fallback for hidden renderers, ignore a stale measurement once a newer flush has started.
- `apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx`: cover the frame-measured adaptive floor, the no-frame fallback, and the stale-callback guard.
- `apps/desktop/src/app/session/hooks/use-message-stream/stream-flush.test.tsx`: update the parked-frame test. The flush still never waits on a frame, but `runFlush` now registers a measurement callback that is allowed to wait.

## How to Test

1. `npx vitest run --project ui src/app/session/hooks/use-message-stream/`
   - 14 files, 59 tests passed (3 new in delta-flush.test.tsx)
2. Proof of the bug on main: with `index.ts` reverted, the new tests "stretches the flush gap when the deferred commit frame is expensive" and "ignores a late frame measurement once a newer flush has started" fail because no frame measurement exists. With this branch, all pass.
3. Wider net: `npx vitest run --project ui src/app/session/hooks/`
   - 30 files, 352 tests passed. `npm run typecheck` clean. `npx eslint` on the touched files clean (one pre-existing `no-restricted-globals` warning in delta-flush.test.tsx).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the vitest suites above and they pass. Full desktop e2e not run here. Change is isolated to the stream flush scheduler + tests.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A (code comments on the measurement path only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - rAF + timer only, no platform API. Reproduced and tested on Windows.
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

```shell
# On main (index.ts reverted): the new tests prove no frame measurement exists
 Tests  2 failed | 3 passed (5)

# With this branch
 Test Files  14 passed (14)
      Tests  59 passed (59)

# Wider session hooks
 Test Files  30 passed (30)
      Tests  352 passed (352)
```
