### PR TITLE
feat(pet): multi-pet desktop overlay system + gateway session recovery fix

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -34,6 +34,10 @@ from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
+# The identity is a cache-stable prompt block. Keep the same conservative byte
+# contract in runtime assembly and in ``hermes prompt-size`` diagnostics.
+IDENTITY_MAX_BYTES = 1800
+
 # ---------------------------------------------------------------------------
 # Context file scanning — detect prompt injection / promptware in AGENTS.md,
 # .cursorrules, SOUL.md before they get injected into the system prompt.
@@ -1885,6 +1889,21 @@ def _truncate_content(
     return head + marker + tail
 
 
+def _truncate_identity_bytes(content: str, max_bytes: int = IDENTITY_MAX_BYTES) -> str:
+    """Bound identity bytes while retaining both the opening and closing role."""
+    encoded = content.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return content
+    marker = "\n\n[...identity truncated to the shared byte budget; read SOUL.md for the full identity]\n\n"
+    marker_bytes = len(marker.encode("utf-8"))
+    available = max(1, max_bytes - marker_bytes)
+    head_bytes = int(available * 0.7)
+    tail_bytes = available - head_bytes
+    head = encoded[:head_bytes].decode("utf-8", errors="ignore")
+    tail = encoded[-tail_bytes:].decode("utf-8", errors="ignore")
+    return head + marker + tail
+
+
 def load_soul_md(context_length: Optional[int] = None) -> Optional[str]:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
 
@@ -1910,6 +1929,7 @@ def load_soul_md(context_length: Optional[int] = None) -> Optional[str]:
             content, "SOUL.md", context_length=context_length,
             read_path=str(soul_path),
         )
+        content = _truncate_identity_bytes(content)
         return content
     except Exception as e:
         logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -119,6 +119,7 @@ import {
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
+import { isPrimarySender, overlayProfileKey, PetOverlayRegistry } from './pet-overlay-registry'
 import { oauthSessionIsLive, resolveJsonBody, resolveOauthRestAuth } from './native-auth-decisions'
 import {
   nativeRefreshUrl,
@@ -8416,17 +8417,37 @@ function createInstanceWindow() {
 // connection of its own — the main renderer is the single source of truth and
 // pushes pet state over IPC (hermes:pet-overlay:state); the overlay just renders
 // it. Control flows back (pop-in, composer submit) via hermes:pet-overlay:control.
-let petOverlayWindow = null
+//
+// Multi-pet: one overlay window PER PROFILE, keyed by normalized profile name.
+// `overlayProfileByWebContentsId` maps a window's webContents.id back to its
+// profile so main can derive the sender's identity from `event.sender.id`
+// (the shared preload exposes every petOverlay.* API to every renderer, so the
+// renderer-supplied profile is NEVER trusted — "same process family" is not a
+// trust boundary). Capture the wcId at creation: webContents is destroyed by the
+// time 'closed' fires, so it can't be read there.
+const petOverlayRegistry = new PetOverlayRegistry()
+// Aliases keep the existing per-profile map accesses readable; both are backed
+// by the registry so its sender-authentication methods see the same entries.
+const petOverlayWindows = petOverlayRegistry.windows
+const overlayProfileByWebContentsId = petOverlayRegistry.profileByWebContentsId
 
-function petOverlayUrl() {
+function petOverlayUrl(profile) {
+  const q = profile ? `&profile=${encodeURIComponent(profile)}` : ''
+
   if (DEV_SERVER) {
-    return `${DEV_SERVER.endsWith('/') ? DEV_SERVER.slice(0, -1) : DEV_SERVER}/?win=overlay#/`
+    return `${DEV_SERVER.endsWith('/') ? DEV_SERVER.slice(0, -1) : DEV_SERVER}/?win=overlay${q}#/`
   }
 
-  return `${pathToFileURL(resolveRendererIndex()).toString()}?win=overlay#/`
+  return `${pathToFileURL(resolveRendererIndex()).toString()}?win=overlay${q}#/`
 }
 
-function spawnPetOverlayWindow(bounds) {
+// The main window's webContents.id, or null when there is no live main window
+// — fed to isPrimarySender so the primary-renderer-only channels can authenticate.
+function primaryWebContentsId() {
+  return mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents.id : null
+}
+
+function spawnPetOverlayWindow(profile, bounds) {
   const win = new BrowserWindow({
     width: Math.max(80, Math.round(bounds?.width || 220)),
     height: Math.max(80, Math.round(bounds?.height || 220)),
@@ -8503,28 +8524,33 @@ function spawnPetOverlayWindow(bounds) {
     }
   })
 
+  // Capture the webContents.id NOW (via register) — webContents is destroyed by
+  // the time 'closed' fires, so the profile mapping is removed via the captured id.
+  const wcId = petOverlayRegistry.register(profile, win)
+
   win.on('closed', () => {
-    if (petOverlayWindow === win) {
-      petOverlayWindow = null
-    }
+    petOverlayRegistry.unregister(profile, wcId)
 
     // If the overlay went away on its own (e.g. ⌘W), tell the main renderer to
-    // pop the pet back in so it doesn't stay hidden. Harmless echo when we're
-    // the ones who closed it (popInPet already cleared the active flag).
+    // pop that profile's pet back in so it doesn't stay hidden. Harmless echo
+    // when we're the ones who closed it (popInPet already cleared the flag).
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('hermes:pet-overlay:control', { type: 'pop-in' })
+      mainWindow.webContents.send('hermes:pet-overlay:control', { profile, type: 'pop-in' })
     }
   })
 
-  win.loadURL(petOverlayUrl())
+  win.loadURL(petOverlayUrl(profile))
 
   return win
 }
 
-function openPetOverlay(bounds) {
-  if (petOverlayWindow && !petOverlayWindow.isDestroyed()) {
+function openPetOverlay(profile, bounds) {
+  const key = overlayProfileKey(profile)
+  const existing = petOverlayWindows.get(key)
+
+  if (existing && !existing.isDestroyed()) {
     if (bounds) {
-      petOverlayWindow.setBounds({
+      existing.setBounds({
         x: Math.round(bounds.x),
         y: Math.round(bounds.y),
         width: Math.max(80, Math.round(bounds.width)),
@@ -8532,22 +8558,30 @@ function openPetOverlay(bounds) {
       })
     }
 
-    petOverlayWindow.showInactive()
+    existing.showInactive()
 
-    return petOverlayWindow
+    return existing
   }
 
-  petOverlayWindow = spawnPetOverlayWindow(bounds)
-
-  return petOverlayWindow
+  return spawnPetOverlayWindow(key, bounds)
 }
 
-function closePetOverlay() {
-  if (petOverlayWindow && !petOverlayWindow.isDestroyed()) {
-    petOverlayWindow.close()
+function closePetOverlay(profile) {
+  const key = overlayProfileKey(profile)
+  const win = petOverlayWindows.get(key)
+
+  if (win && !win.isDestroyed()) {
+    win.close()
   }
 
-  petOverlayWindow = null
+  petOverlayWindows.delete(key)
+}
+
+// Close every profile's overlay (app quit / main-window teardown).
+function closeAllPetOverlays() {
+  for (const key of [...petOverlayWindows.keys()]) {
+    closePetOverlay(key)
+  }
 }
 
 function createWindow() {
@@ -8658,7 +8692,7 @@ function createWindow() {
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow
   mainWindow.on('closed', () => {
-    closePetOverlay()
+    closeAllPetOverlays()
 
     if (mainWindow === createdMainWindow) {
       mainWindow = null
@@ -8864,12 +8898,29 @@ ipcMain.on('hermes:zoom:set-percent', (event, percent) => {
 })
 
 // --- Pet overlay (pop-out mascot) -----------------------------------------
+// Sender-role enforcement: the shared preload exposes every petOverlay.* API to
+// EVERY renderer, so "same process family" is not a trust boundary. The
+// lifecycle/state channels (open/close/state) are PRIMARY-RENDERER-ONLY; the
+// per-window channels (set-bounds/ignore-mouse/set-focusable/control) are
+// BOUND-OVERLAY-ONLY — main derives the profile from `event.sender.id`, never
+// from a renderer-supplied field. Unknown senders are rejected.
+
+// The overlay window owned by the sender, or null when the sender is not a
+// registered overlay (rejects the primary window AND any unknown renderer).
+function overlayWindowForSender(event) {
+  return petOverlayRegistry.windowForSender(event.sender)
+}
+
 // `request` is `{ bounds, screen }`. A fresh pop-out passes viewport-space
 // bounds (screen=false): convert to screen space by adding the main window's
 // content origin so the pet lands where it sat in-window. A remembered/dragged
 // spot passes screen-space bounds (screen=true) and is used as-is. We return the
 // resolved screen bounds so the renderer can persist exactly where it opened.
-ipcMain.handle('hermes:pet-overlay:open', async (_event, request) => {
+ipcMain.handle('hermes:pet-overlay:open', async (event, profile, request) => {
+  if (!isPrimarySender(event.sender, primaryWebContentsId())) {
+    return { ok: false }
+  }
+
   const bounds = request && request.bounds ? request.bounds : request
   const isScreen = Boolean(request && request.screen)
   let screenBounds = bounds
@@ -8888,12 +8939,16 @@ ipcMain.handle('hermes:pet-overlay:open', async (_event, request) => {
     // Fall back to raw bounds if the window geometry is unavailable.
   }
 
-  openPetOverlay(screenBounds)
+  openPetOverlay(profile, screenBounds)
 
   return { ok: true, bounds: screenBounds }
 })
-ipcMain.handle('hermes:pet-overlay:close', async () => {
-  closePetOverlay()
+ipcMain.handle('hermes:pet-overlay:close', async (event, profile) => {
+  if (!isPrimarySender(event.sender, primaryWebContentsId())) {
+    return { ok: false }
+  }
+
+  closePetOverlay(profile)
 
   return { ok: true }
 })
@@ -8903,12 +8958,13 @@ ipcMain.handle('hermes:pet-overlay:close', async () => {
 // The window is created non-resizable (no stray edge-drag on the transparent
 // frameless panel), which on Windows/Linux also blocks programmatic setBounds
 // sizing — so briefly flip resizable on whenever the size actually changes.
-ipcMain.on('hermes:pet-overlay:set-bounds', (_event, bounds) => {
-  if (!petOverlayWindow || petOverlayWindow.isDestroyed() || !bounds) {
+ipcMain.on('hermes:pet-overlay:set-bounds', (event, bounds) => {
+  const win = overlayWindowForSender(event)
+
+  if (!win || !bounds) {
     return
   }
 
-  const win = petOverlayWindow
   const width = Math.max(80, Math.round(bounds.width))
   const height = Math.max(80, Math.round(bounds.height))
   const [curW, curH] = win.getSize()
@@ -8927,36 +8983,55 @@ ipcMain.on('hermes:pet-overlay:set-bounds', (_event, bounds) => {
 // Click-through: the overlay window is a full rectangle but only the pet pixels
 // should be interactive. The renderer toggles this as the cursor enters/leaves
 // the sprite so transparent margins pass clicks to whatever is behind.
-ipcMain.on('hermes:pet-overlay:ignore-mouse', (_event, ignore) => {
-  if (petOverlayWindow && !petOverlayWindow.isDestroyed()) {
-    petOverlayWindow.setIgnoreMouseEvents(Boolean(ignore), { forward: true })
+ipcMain.on('hermes:pet-overlay:ignore-mouse', (event, ignore) => {
+  const win = overlayWindowForSender(event)
+
+  if (win) {
+    win.setIgnoreMouseEvents(Boolean(ignore), { forward: true })
   }
 })
 // The overlay is a non-activating panel (focusable:false) so it never steals
 // the app's cmd/alt-tab anchor from the main window. But the pop-up composer
 // needs the keyboard, so the renderer asks us to flip it focusable + focus it
 // while the composer is open, then back to non-activating when it closes.
-ipcMain.on('hermes:pet-overlay:set-focusable', (_event, focusable) => {
-  if (!petOverlayWindow || petOverlayWindow.isDestroyed()) {
+ipcMain.on('hermes:pet-overlay:set-focusable', (event, focusable) => {
+  const win = overlayWindowForSender(event)
+
+  if (!win) {
     return
   }
 
-  petOverlayWindow.setFocusable(Boolean(focusable))
+  win.setFocusable(Boolean(focusable))
 
   if (focusable) {
-    petOverlayWindow.focus()
+    win.focus()
   }
 })
-// Main renderer → overlay: forward the latest pet state for the overlay to render.
-ipcMain.on('hermes:pet-overlay:state', (_event, payload) => {
-  if (petOverlayWindow && !petOverlayWindow.isDestroyed()) {
-    petOverlayWindow.webContents.send('hermes:pet-overlay:state', payload)
+// Main renderer → overlay: forward the latest pet state for ONE profile's
+// overlay to render. Primary-renderer-only; the profile selects the target.
+ipcMain.on('hermes:pet-overlay:state', (event, profile, payload) => {
+  if (!isPrimarySender(event.sender, primaryWebContentsId())) {
+    return
+  }
+
+  const win = petOverlayWindows.get(overlayProfileKey(profile))
+
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('hermes:pet-overlay:state', payload)
   }
 })
 // Overlay → main renderer: control messages (pop back in, composer submit).
-ipcMain.on('hermes:pet-overlay:control', (_event, payload) => {
+// Bound-overlay-only: the profile is derived from the sender (never trusted from
+// the payload) and attached so the main renderer routes to the right pet.
+ipcMain.on('hermes:pet-overlay:control', (event, payload) => {
   if (!mainWindow || mainWindow.isDestroyed()) {
     return
+  }
+
+  const profile = petOverlayRegistry.profileForSender(event.sender)
+
+  if (!profile) {
+    return // unknown sender — not a registered overlay
   }
 
   // Double-click toggles the app window: hide it away if it's up front, bring it
@@ -8984,7 +9059,7 @@ ipcMain.on('hermes:pet-overlay:control', (_event, payload) => {
     mainWindow.focus()
   }
 
-  mainWindow.webContents.send('hermes:pet-overlay:control', payload)
+  mainWindow.webContents.send('hermes:pet-overlay:control', { ...payload, profile })
 })
 ipcMain.handle('hermes:bootstrap:reset', async () => {
   // Renderer's "Reload and retry" path. Clear the latched failure and
@@ -10918,9 +10993,9 @@ app.on('before-quit', event => {
     }
   }
 
-  // The always-on-top overlay isn't a "real" app window; close it so a stray
+  // The always-on-top overlays aren't "real" app windows; close them so a stray
   // pet can't keep the process alive or float over a quit app.
-  closePetOverlay()
+  closeAllPetOverlays()
 
   // Quitting mid-install should stop the installer, not orphan it.
   if (bootstrapAbortController) {

--- a/apps/desktop/electron/pet-overlay-registry.test.ts
+++ b/apps/desktop/electron/pet-overlay-registry.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the per-profile pet overlay registry + IPC sender-role
+ * enforcement. The shared preload exposes every petOverlay.* API to every
+ * renderer, so the security guarantee lives here: a profile is derived from
+ * `event.sender.id`, never a renderer-supplied field, and unknown senders are
+ * rejected.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { isPrimarySender, overlayProfileKey, PetOverlayRegistry } from './pet-overlay-registry'
+
+// Minimal stand-ins for the Electron shapes the registry touches.
+function fakeWin(wcId) {
+  let destroyed = false
+
+  return {
+    webContents: { id: wcId },
+    isDestroyed: () => destroyed,
+    _destroy: () => {
+      destroyed = true
+    }
+  }
+}
+
+const sender = id => ({ id })
+
+test('overlayProfileKey trims and defaults blank to "default"', () => {
+  assert.equal(overlayProfileKey('apollo'), 'apollo')
+  assert.equal(overlayProfileKey('  apollo  '), 'apollo')
+  assert.equal(overlayProfileKey(''), 'default')
+  assert.equal(overlayProfileKey(undefined), 'default')
+  assert.equal(overlayProfileKey(null), 'default')
+})
+
+test('isPrimarySender authenticates only the main window webContents (test 30)', () => {
+  assert.equal(isPrimarySender(sender(1), 1), true)
+  // A different renderer (e.g. an overlay) is not the primary.
+  assert.equal(isPrimarySender(sender(2), 1), false)
+  // No live main window → nobody is the primary.
+  assert.equal(isPrimarySender(sender(1), null), false)
+  assert.equal(isPrimarySender(null, 1), false)
+})
+
+test('register tracks one window per profile independently (test 18)', () => {
+  const reg = new PetOverlayRegistry()
+  const apollo = fakeWin(10)
+  const nova = fakeWin(11)
+
+  reg.register('apollo', apollo)
+  reg.register('nova', nova)
+
+  assert.equal(reg.get('apollo'), apollo)
+  assert.equal(reg.get('nova'), nova)
+  assert.deepEqual(reg.profiles().sort(), ['apollo', 'nova'])
+})
+
+test('unregister evicts from BOTH maps using the captured wcId (test 19)', () => {
+  const reg = new PetOverlayRegistry()
+  const apollo = fakeWin(10)
+  const wcId = reg.register('apollo', apollo)
+
+  assert.equal(wcId, 10)
+  assert.equal(reg.profileForSender(sender(10)), 'apollo')
+
+  reg.unregister('apollo', wcId)
+
+  assert.equal(reg.get('apollo'), undefined)
+  assert.equal(reg.profileForSender(sender(10)), null)
+  assert.equal(reg.has('apollo'), false)
+})
+
+test('windowForSender returns the sender\u2019s OWN window, never another profile\u2019s (test 32)', () => {
+  const reg = new PetOverlayRegistry()
+  const apollo = fakeWin(10)
+  const nova = fakeWin(11)
+  reg.register('apollo', apollo)
+  reg.register('nova', nova)
+
+  // The sender's id selects its profile's window — a renderer cannot reach a
+  // different profile's overlay by supplying a profile field; only its own id
+  // matters.
+  assert.equal(reg.windowForSender(sender(10)), apollo)
+  assert.equal(reg.windowForSender(sender(11)), nova)
+})
+
+test('windowForSender rejects an unknown sender (test 31)', () => {
+  const reg = new PetOverlayRegistry()
+  reg.register('apollo', fakeWin(10))
+
+  // A webContents id that is not a registered overlay (the primary window, or
+  // some other renderer) gets nothing.
+  assert.equal(reg.windowForSender(sender(999)), null)
+  assert.equal(reg.windowForSender(sender(1)), null)
+})
+
+test('windowForSender returns null for a destroyed overlay window', () => {
+  const reg = new PetOverlayRegistry()
+  const apollo = fakeWin(10)
+  reg.register('apollo', apollo)
+  apollo._destroy()
+
+  assert.equal(reg.windowForSender(sender(10)), null)
+})
+
+test('profileForSender derives the bound profile from the sender id (test 32)', () => {
+  const reg = new PetOverlayRegistry()
+  reg.register('apollo', fakeWin(10))
+
+  assert.equal(reg.profileForSender(sender(10)), 'apollo')
+  assert.equal(reg.profileForSender(sender(11)), null)
+  assert.equal(reg.profileForSender(null), null)
+})
+
+test('state push targets only the named profile\u2019s window (test 55)', () => {
+  // The main-process state handler looks up the target by profile key; only that
+  // profile's window receives the push.
+  const reg = new PetOverlayRegistry()
+  const apollo = fakeWin(10)
+  const nova = fakeWin(11)
+  reg.register('apollo', apollo)
+  reg.register('nova', nova)
+
+  const target = reg.get(overlayProfileKey('apollo'))
+  assert.equal(target, apollo)
+  assert.notEqual(target, nova)
+})

--- a/apps/desktop/electron/pet-overlay-registry.ts
+++ b/apps/desktop/electron/pet-overlay-registry.ts
@@ -1,0 +1,90 @@
+// Per-profile pet overlay window registry + IPC sender-role enforcement.
+//
+// Extracted from main.ts so the security-critical sender checks are unit-testable
+// (cf. zoom.ts, link-title-window.ts). The shared preload exposes every
+// petOverlay.* API to EVERY renderer, so "same process family" is NOT a trust
+// boundary: the lifecycle/state channels are primary-renderer-only, and the
+// per-window channels derive the profile from `event.sender.id` — never from a
+// renderer-supplied field.
+
+/** Normalize a profile key the same way the renderer does (trim, empty→default). */
+export function overlayProfileKey(profile) {
+  const value = typeof profile === 'string' ? profile.trim() : ''
+
+  return value || 'default'
+}
+
+/**
+ * True iff the IPC sender is the primary (main) window's webContents — the only
+ * legitimate source of the primary-renderer-only channels (open/close/pushState).
+ * `primaryWebContentsId` is null when there is no live main window.
+ */
+export function isPrimarySender(sender, primaryWebContentsId) {
+  return primaryWebContentsId != null && sender != null && sender.id === primaryWebContentsId
+}
+
+/**
+ * One overlay window per profile, plus the reverse webContents.id → profile map
+ * used to authenticate a sender. Capture the wcId at creation: webContents is
+ * destroyed by the time the window's 'closed' event fires, so it cannot be read
+ * there — unregister takes the captured id.
+ */
+export class PetOverlayRegistry {
+  /** profile → overlay window */
+  windows = new Map()
+  /** webContents.id → profile */
+  profileByWebContentsId = new Map()
+
+  /** Track a freshly created overlay; returns the wcId to hand to unregister. */
+  register(profile, win) {
+    const wcId = win.webContents.id
+    this.windows.set(profile, win)
+    this.profileByWebContentsId.set(wcId, profile)
+
+    return wcId
+  }
+
+  /** Drop a closed overlay using the wcId captured at creation. */
+  unregister(profile, wcId) {
+    const current = this.windows.get(profile)
+
+    if (!current || current.webContents.id === wcId) {
+      this.windows.delete(profile)
+    }
+
+    this.profileByWebContentsId.delete(wcId)
+  }
+
+  get(profile) {
+    return this.windows.get(profile)
+  }
+
+  has(profile) {
+    return this.windows.has(profile)
+  }
+
+  profiles() {
+    return [...this.windows.keys()]
+  }
+
+  /**
+   * The live overlay window owned by the sender, or null when the sender is not
+   * a registered overlay (rejects the primary window AND any unknown renderer).
+   */
+  windowForSender(sender) {
+    const profile = this.profileByWebContentsId.get(sender?.id)
+
+    if (!profile) {
+      return null
+    }
+
+    const win = this.windows.get(profile)
+
+    return win && !win.isDestroyed() ? win : null
+  }
+
+  /** The profile a sender's overlay is bound to, or null for an unknown sender. */
+  profileForSender(sender) {
+    return this.profileByWebContentsId.get(sender?.id) ?? null
+  }
+}

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -9,16 +9,20 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   openWindow: () => ipcRenderer.invoke('hermes:window:openInstance'),
   claimAmbientCue: key => ipcRenderer.invoke('hermes:ambient:claim', key),
   petOverlay: {
-    // Main renderer → main process: window lifecycle + drag. `request` is
-    // `{ bounds, screen }`; resolves with the screen bounds it actually used.
-    open: request => ipcRenderer.invoke('hermes:pet-overlay:open', request),
-    close: () => ipcRenderer.invoke('hermes:pet-overlay:close'),
+    // Main renderer → main process: window lifecycle + drag, addressed by
+    // profile (one overlay per profile). `request` is `{ bounds, screen }`;
+    // open resolves with the screen bounds it actually used. These three are
+    // PRIMARY-RENDERER-ONLY — main verifies the sender.
+    open: (profile, request) => ipcRenderer.invoke('hermes:pet-overlay:open', profile, request),
+    close: profile => ipcRenderer.invoke('hermes:pet-overlay:close', profile),
+    // The per-window channels below are BOUND-OVERLAY-ONLY: the overlay sends
+    // them and main derives the profile from the sender (never a supplied field).
     setBounds: bounds => ipcRenderer.send('hermes:pet-overlay:set-bounds', bounds),
     setIgnoreMouse: ignore => ipcRenderer.send('hermes:pet-overlay:ignore-mouse', ignore),
     // Flip the overlay focusable (and focus it) while the composer needs keys.
     setFocusable: focusable => ipcRenderer.send('hermes:pet-overlay:set-focusable', focusable),
-    // Main renderer → overlay (forwarded by main): push the latest pet state.
-    pushState: payload => ipcRenderer.send('hermes:pet-overlay:state', payload),
+    // Main renderer → overlay (forwarded by main): push one profile's pet state.
+    pushState: (profile, payload) => ipcRenderer.send('hermes:pet-overlay:state', profile, payload),
     // Overlay → main renderer (forwarded by main): pop back in / composer submit.
     control: payload => ipcRenderer.send('hermes:pet-overlay:control', payload),
     // Overlay subscribes to state pushes.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,9 +12,9 @@
   },
   "scripts": {
     "clean": "npm run clean:e2e && npm run clean:renderer && npm run clean:electron",
-    "clean:e2e":"tsc --build tsconfig.e2e.json --clean",
-    "clean:renderer":"tsc --build tsconfig.json --clean ",
-    "clean:electron":"tsc --build tsconfig.electron.json --clean",
+    "clean:e2e": "tsc --build tsconfig.e2e.json --clean",
+    "clean:renderer": "tsc --build tsconfig.json --clean ",
+    "clean:electron": "tsc --build tsconfig.electron.json --clean",
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:electron\"",
     "dev:fake-boot": "cross-env HERMES_DESKTOP_BOOT_FAKE=1 HERMES_DESKTOP_BOOT_FAKE_STEP_MS=650 npm run dev",
     "dev:mock": "node scripts/dev-mock.mjs",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@assistant-ui/react": "^0.14.23",
-    "@assistant-ui/react-streamdown": "^0.3.4",
+    "@assistant-ui/react-streamdown": "^0.3.6",
     "@audiowave/react": "^0.6.2",
     "@chenglou/pretext": "^0.0.6",
     "@codemirror/commands": "^6.10.4",

--- a/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
@@ -74,12 +74,13 @@ export function usePetBridge({ requestGateway, resumeSession, submitText }: PetB
     // own gateway (the overlay has none) so it survives restart.
     setPetOverlayScaleHandler((profile, scale) => setPetScale(profileRequest(profile), scale))
     // Mail icon: open the overlay's OWN profile session. Prefer its durable
-    // source (survives compression/rehoming) when known. `sourceDurableSessionId`
-    // is read here but not yet populated anywhere (TODO PR4), so the active
-    // profile currently falls back to the most-recent thread ($sessions is
-    // most-recent-first) — the legacy single-pet target, keeping follow-active
-    // unchanged. Clear that profile's unread/reply (source-session scoped so a
-    // different session's unread in the same profile survives).
+    // source (survives compression/rehoming) — populated from session events via
+    // setProfileSourceDurableSessionId. Until a profile has a recorded durable id
+    // (e.g. nothing has run yet), the active profile falls back to the
+    // most-recent thread ($sessions is most-recent-first) — the legacy single-pet
+    // target, keeping follow-active unchanged. Clear that profile's unread/reply
+    // (source-session scoped so a different session's unread in the same profile
+    // survives).
     setPetOverlayOpenAppHandler(profile => {
       const key = normalizeProfileKey(profile)
       const state = $profilePets.get().get(key)

--- a/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
@@ -1,14 +1,26 @@
 import { useEffect, useRef } from 'react'
 
+import { requestGatewayForProfile } from '@/store/gateway'
+import { notify } from '@/store/notifications'
 import { petProfile } from '@/store/pet'
 import { setPetScale } from '@/store/pet-gallery'
 import { setProfileManualAwaitingInput } from '@/store/pet-multi'
 import { setPetOverlayOpenAppHandler, setPetOverlayScaleHandler, setPetOverlaySubmitHandler } from '@/store/pet-overlay'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $sessions } from '@/store/session'
 import { $attentionSessionIds } from '@/store/session-states'
 import { isSecondaryWindow } from '@/store/windows'
 
 import type { GatewayRequester } from '../types'
+
+/** A GatewayRequester bound to one profile (routes through its own socket, never
+ *  the active gateway). */
+function profileRequest(profile: string): GatewayRequester {
+  const key = normalizeProfileKey(profile)
+
+  return (method, params, timeoutMs, signal) =>
+    requestGatewayForProfile(key, method, { ...params, profile: key }, timeoutMs, signal)
+}
 
 interface PetBridgeParams {
   requestGateway: GatewayRequester
@@ -36,10 +48,27 @@ export function usePetBridge({ requestGateway, resumeSession, submitText }: PetB
       return
     }
 
-    setPetOverlaySubmitHandler(text => void submitTextRef.current(text))
-    // Alt+wheel resize from the popped-out pet — persist through this window's
-    // gateway (the overlay has none) so it survives restart.
-    setPetOverlayScaleHandler(scale => setPetScale(requestGatewayRef.current, scale))
+    // Overlay submit, addressed by the sender-derived profile. The active
+    // profile routes through the full existing submit pipeline (optimistic
+    // messages, locks, queue recovery). A background profile's submit needs the
+    // SubmitExecution seam (PR3) — until then it surfaces a clear notice rather
+    // than a reduced parallel path that would bypass that pipeline.
+    setPetOverlaySubmitHandler((profile, text) => {
+      if (normalizeProfileKey(profile) === normalizeProfileKey($activeGatewayProfile.get())) {
+        void submitTextRef.current(text)
+
+        return
+      }
+
+      // TODO(PR3): backgroundSubmitExecution(profile) + submitTextForProfile.
+      notify({
+        kind: 'warning',
+        message: `Replying to ${normalizeProfileKey(profile)} from its overlay arrives in a future update.`
+      })
+    })
+    // Alt+wheel resize from the popped-out pet — persist through the profile's
+    // own gateway (the overlay has none) so it survives restart.
+    setPetOverlayScaleHandler((profile, scale) => setPetScale(profileRequest(profile), scale))
     // Mail icon: $sessions is most-recent-first; the pet is global, so "most
     // recent" is the right target.
     setPetOverlayOpenAppHandler(() => {

--- a/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
@@ -74,9 +74,10 @@ export function usePetBridge({ requestGateway, resumeSession, submitText }: PetB
     // own gateway (the overlay has none) so it survives restart.
     setPetOverlayScaleHandler((profile, scale) => setPetScale(profileRequest(profile), scale))
     // Mail icon: open the overlay's OWN profile session. Prefer its durable
-    // source (survives compression/rehoming); until that is wired (Layer 6c) the
-    // active profile falls back to the most-recent thread ($sessions is
-    // most-recent-first) — the legacy single-pet target, so follow-active is
+    // source (survives compression/rehoming) when known. `sourceDurableSessionId`
+    // is read here but not yet populated anywhere (TODO PR4), so the active
+    // profile currently falls back to the most-recent thread ($sessions is
+    // most-recent-first) — the legacy single-pet target, keeping follow-active
     // unchanged. Clear that profile's unread/reply (source-session scoped so a
     // different session's unread in the same profile survives).
     setPetOverlayOpenAppHandler(profile => {

--- a/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
@@ -4,7 +4,12 @@ import { requestGatewayForProfile } from '@/store/gateway'
 import { notify } from '@/store/notifications'
 import { petProfile } from '@/store/pet'
 import { setPetScale } from '@/store/pet-gallery'
-import { setProfileManualAwaitingInput } from '@/store/pet-multi'
+import {
+  $profilePets,
+  clearProfilePetReplyText,
+  clearProfilePetUnread,
+  setProfileManualAwaitingInput
+} from '@/store/pet-multi'
 import { setPetOverlayOpenAppHandler, setPetOverlayScaleHandler, setPetOverlaySubmitHandler } from '@/store/pet-overlay'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $sessions } from '@/store/session'
@@ -69,14 +74,29 @@ export function usePetBridge({ requestGateway, resumeSession, submitText }: PetB
     // Alt+wheel resize from the popped-out pet — persist through the profile's
     // own gateway (the overlay has none) so it survives restart.
     setPetOverlayScaleHandler((profile, scale) => setPetScale(profileRequest(profile), scale))
-    // Mail icon: $sessions is most-recent-first; the pet is global, so "most
-    // recent" is the right target.
-    setPetOverlayOpenAppHandler(() => {
-      const recent = $sessions.get()[0]
+    // Mail icon: open the overlay's OWN profile session. Prefer its durable
+    // source (survives compression/rehoming); until that is wired (Layer 6c) the
+    // active profile falls back to the most-recent thread ($sessions is
+    // most-recent-first) — the legacy single-pet target, so follow-active is
+    // unchanged. Clear that profile's unread/reply (source-session scoped so a
+    // different session's unread in the same profile survives).
+    setPetOverlayOpenAppHandler(profile => {
+      const key = normalizeProfileKey(profile)
+      const state = $profilePets.get().get(key)
+      const durableId = state?.sourceDurableSessionId
 
-      if (recent?.id) {
-        void resumeSessionRef.current(recent.id)
+      if (durableId) {
+        void resumeSessionRef.current(durableId)
+      } else if (key === normalizeProfileKey($activeGatewayProfile.get())) {
+        const recent = $sessions.get()[0]
+
+        if (recent?.id) {
+          void resumeSessionRef.current(recent.id)
+        }
       }
+
+      clearProfilePetUnread(key, state?.sourceSessionId)
+      clearProfilePetReplyText(key, state?.sourceSessionId)
     })
 
     return () => {

--- a/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react'
 
+import { submitTextForProfile } from '@/app/session/hooks/use-prompt-actions/profile-submit'
+import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import { requestGatewayForProfile } from '@/store/gateway'
-import { notify } from '@/store/notifications'
 import { petProfile } from '@/store/pet'
 import { setPetScale } from '@/store/pet-gallery'
 import {
@@ -30,7 +31,7 @@ function profileRequest(profile: string): GatewayRequester {
 interface PetBridgeParams {
   requestGateway: GatewayRequester
   resumeSession: (sessionId: string) => Promise<unknown> | unknown
-  submitText: (text: string) => Promise<unknown> | unknown
+  submitText: (text: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
 }
 
 /**
@@ -53,23 +54,21 @@ export function usePetBridge({ requestGateway, resumeSession, submitText }: PetB
       return
     }
 
-    // Overlay submit, addressed by the sender-derived profile. The active
-    // profile routes through the full existing submit pipeline (optimistic
-    // messages, locks, queue recovery). A background profile's submit needs the
-    // SubmitExecution seam (PR3) — until then it surfaces a clear notice rather
-    // than a reduced parallel path that would bypass that pipeline.
+    // Overlay submit, addressed by the sender-derived profile. Routes through the
+    // shared profile-targeted entry point: the active profile runs the ordinary
+    // foreground execution; a background profile runs the SAME pipeline through
+    // backgroundSubmitExecution (profile-routed gateway, profile-scoped busy, no
+    // foreground writes). A busy session queues under (profile, storedSessionId).
     setPetOverlaySubmitHandler((profile, text) => {
-      if (normalizeProfileKey(profile) === normalizeProfileKey($activeGatewayProfile.get())) {
-        void submitTextRef.current(text)
+      const key = normalizeProfileKey(profile)
+      const state = $profilePets.get().get(key)
 
-        return
-      }
-
-      // TODO(PR3): backgroundSubmitExecution(profile) + submitTextForProfile.
-      notify({
-        kind: 'warning',
-        message: `Replying to ${normalizeProfileKey(profile)} from its overlay arrives in a future update.`
-      })
+      void submitTextForProfile(
+        key,
+        text,
+        { sessionId: state?.sourceSessionId, storedSessionId: state?.sourceDurableSessionId },
+        submitTextRef.current
+      )
     })
     // Alt+wheel resize from the popped-out pet — persist through the profile's
     // own gateway (the overlay has none) so it survives restart.

--- a/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react'
 
-import { setPetActivity } from '@/store/pet'
+import { petProfile } from '@/store/pet'
 import { setPetScale } from '@/store/pet-gallery'
+import { setProfileManualAwaitingInput } from '@/store/pet-multi'
 import { setPetOverlayOpenAppHandler, setPetOverlayScaleHandler, setPetOverlaySubmitHandler } from '@/store/pet-overlay'
 import { $sessions } from '@/store/session'
 import { $attentionSessionIds } from '@/store/session-states'
@@ -56,10 +57,12 @@ export function usePetBridge({ requestGateway, resumeSession, submitText }: PetB
     }
   }, [])
 
-  // Mirror "a session is blocked on the user" (clarify/approval) into the pet's
-  // awaitingInput flag so it shows the `waiting` pose.
+  // Mirror "a session is blocked on the user" (clarify/approval) into the active
+  // profile's awaitingInput so its pet shows the `waiting` pose. Routed through
+  // the manual-awaiting channel (OR-ed into the derived activity) so per-session
+  // routing never overwrites it.
   useEffect(() => {
-    const sync = () => setPetActivity({ awaitingInput: $attentionSessionIds.get().length > 0 })
+    const sync = () => setProfileManualAwaitingInput(petProfile(), $attentionSessionIds.get().length > 0)
 
     sync()
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -21,6 +21,7 @@ import { NotificationStack } from '@/components/notifications'
 import { DesktopOnboardingOverlay } from '@/components/onboarding'
 import { $newSessionTabAction } from '@/components/pane-shell/tree/store'
 import { FloatingPet } from '@/components/pet/floating-pet'
+import { usePetRosterReconciliation } from '@/components/pet/use-pet-roster-reconciliation'
 import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getSessionMessages, triggerCronJob } from '@/hermes'
@@ -585,6 +586,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   // The popped-out pet overlay's bridge back into the app.
   usePetBridge({ requestGateway, resumeSession, submitText })
+
+  // Keep the pinned pet roster reconciled with the live profile catalog
+  // (marks deleted/renamed profiles unavailable, releases their leases).
+  usePetRosterReconciliation()
 
   // Clear a failed turn's red error banner. Errors are renderer-local (never
   // persisted): a bare error placeholder is dropped entirely; a partial-output

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -17,6 +17,7 @@ import {
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForProfile,
+  primaryProfileKey,
   pruneSecondaryGateways,
   reconnectSecondaryGateways,
   reportPrimaryGatewayState,
@@ -391,10 +392,14 @@ export function useGatewayBoot({
       }
     })
 
-    const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
-
+    // Tag primary events from the registry's OWN primary key, read at emit time
+    // — NOT a snapshot taken at wiring time. setPrimaryGateway on this same path
+    // uses survivor?.profile ?? active, which diverges from a wiring-time
+    // snapshot on the HMR-survivor and gateway-rebuild paths; reading at emit
+    // time keeps primary events tagged with the primary's profile even while a
+    // secondary is active (blocker #1).
     const offEvent = gateway.onEvent(event =>
-      callbacksRef.current.handleGatewayEvent({ ...event, profile: sourceProfile })
+      callbacksRef.current.handleGatewayEvent({ ...event, profile: primaryProfileKey() })
     )
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -21,7 +21,8 @@ import {
   reconnectSecondaryGateways,
   reportPrimaryGatewayState,
   setPrimaryGateway,
-  touchSecondaryGateways
+  touchSecondaryGateways,
+  updateGatewayKeepSet
 } from '@/store/gateway'
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
 import { notify, notifyError } from '@/store/notifications'
@@ -433,6 +434,9 @@ export function useGatewayBoot({
         }
       }
 
+      // Publish the live-work keep-set so the lease prune (triggered by a lease
+      // release) never drops a profile with a running/needs-input session.
+      updateGatewayKeepSet(keep)
       pruneSecondaryGateways(keep)
     }
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -27,6 +27,7 @@ import {
 } from '@/store/gateway'
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
 import { notify, notifyError } from '@/store/notifications'
+import { setProfileConnectionState } from '@/store/pet-multi'
 import { $activeGatewayProfile, normalizeProfileKey, touchActiveGatewayBackend } from '@/store/profile'
 import {
   $activeSessionId,
@@ -363,8 +364,14 @@ export function useGatewayBoot({
 
     callbacksRef.current.onGatewayReady(gateway)
     setPrimaryGateway(gateway, survivor?.profile ?? normalizeProfileKey($activeGatewayProfile.get()))
-    // Secondary (background-profile) sockets funnel into the same handler.
-    configureGatewayRegistry({ onEvent: event => callbacksRef.current.handleGatewayEvent(event) })
+    // Secondary (background-profile) sockets funnel into the same handler. The
+    // per-profile state sink projects every profile's socket state into its pet
+    // slice (Layer 8) so a dead pinned profile shows an offline pet — wired here
+    // (not in gateway.ts) to avoid a gateway → pet-store import cycle.
+    configureGatewayRegistry({
+      onEvent: event => callbacksRef.current.handleGatewayEvent(event),
+      onProfileState: (profile, state) => setProfileConnectionState(profile, state)
+    })
 
     const offState = gateway.onState(st => {
       // Mirror to the composer only while the primary is the active profile —

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -1,11 +1,16 @@
-import { isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useRef } from 'react'
 
 import type { HermesGateway } from '@/hermes'
-import { $gateway, ensureActiveGatewayOpen, isActivePrimary } from '@/store/gateway'
+import {
+  $gateway,
+  ensureActiveGatewayOpen,
+  isActivePrimary,
+  reconnectPrimaryGateway,
+  takeGatewayReauthError
+} from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $gatewayState, setConnection } from '@/store/session'
+import { $connection, $gatewayState } from '@/store/session'
 
 export function useGatewayRequest() {
   const gatewayState = useStore($gatewayState)
@@ -16,11 +21,6 @@ export function useGatewayRequest() {
   )
 
   const gatewayStateRef = useRef(gatewayState)
-  const reconnectingRef = useRef<Promise<HermesGateway | null> | null>(null)
-  // Holds the reauth error from the most recent failed reconnect so
-  // requestGateway can surface the gateway's "session expired, sign in again"
-  // message instead of the opaque "connection closed" that triggered the retry.
-  const reauthErrorRef = useRef<unknown>(null)
 
   useEffect(() => {
     gatewayStateRef.current = gatewayState
@@ -36,6 +36,12 @@ export function useGatewayRequest() {
     []
   )
 
+  // Recover a dropped active PRIMARY gateway. The OAuth-aware reconnect now
+  // lives in the gateway registry (reconnectPrimaryGateway): the profile is
+  // explicit, concurrent callers are deduped, the connection is published as
+  // foreground only when this profile is active, and the reauth error is stored
+  // per profile. This hook is a thin caller that mirrors the published
+  // connection back into connectionRef for its consumers.
   const ensureGatewayOpen = useCallback(async () => {
     const existing = gatewayRef.current
 
@@ -47,51 +53,10 @@ export function useGatewayRequest() {
       return existing
     }
 
-    if (reconnectingRef.current) {
-      return reconnectingRef.current
-    }
+    const recovered = await reconnectPrimaryGateway($activeGatewayProfile.get())
+    connectionRef.current = $connection.get()
 
-    reconnectingRef.current = (async () => {
-      const desktop = window.hermesDesktop
-
-      if (!desktop) {
-        return null
-      }
-
-      reauthErrorRef.current = null
-
-      try {
-        // Reconnect to whichever profile the gateway is currently routed to (not
-        // always the primary), so a sleep/wake reconnect keeps the user on the
-        // profile they were chatting in.
-        const conn = await desktop.getConnection($activeGatewayProfile.get())
-        connectionRef.current = conn
-        setConnection(conn)
-        // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
-        // and short-lived, so the cached conn.wsUrl ticket is dead here;
-        // resolveGatewayWsUrl() never connects with a stale ticket. An explicit
-        // auth rejection becomes a reauth error; transport failures remain
-        // retryable. Stash only the former so requestGateway can show the
-        // actionable "sign in again" message.
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
-        await existing.connect(wsUrl)
-
-        return existing
-      } catch (error) {
-        if (isGatewayReauthRequired(error)) {
-          reauthErrorRef.current = error
-        }
-
-        connectionRef.current = null
-        setConnection(null)
-
-        return null
-      } finally {
-        reconnectingRef.current = null
-      }
-    })()
-
-    return reconnectingRef.current
+    return recovered
   }, [])
 
   const requestGateway = useCallback(
@@ -112,15 +77,14 @@ export function useGatewayRequest() {
         }
 
         // Primary keeps the OAuth-aware reconnect (remote gateways re-mint a
-        // single-use ticket); background profiles are always local pool
-        // backends, so the registry handles their reconnect with no reauth.
+        // single-use ticket); background profiles recover through the registry's
+        // bounded secondary reconnect.
         const recovered = isActivePrimary() ? await ensureGatewayOpen() : await ensureActiveGatewayOpen()
 
         if (!recovered) {
           // Prefer the reauth error from the failed reconnect (OAuth session
           // expired) over the generic transport error that triggered the retry.
-          const reauthError = reauthErrorRef.current
-          reauthErrorRef.current = null
+          const reauthError = takeGatewayReauthError($activeGatewayProfile.get())
 
           if (reauthError) {
             throw reauthError

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -7,6 +7,7 @@ import { PetSprite } from '@/components/pet/pet-sprite'
 import { type PetZoomAnchor, usePetZoomGesture } from '@/components/pet/use-pet-zoom-gesture'
 import { Mail } from '@/lib/icons'
 import { $petInfo, replacePetActivity, setPetInfo } from '@/store/pet'
+import { type ProfileConnection } from '@/store/pet-multi'
 import { overlayWindowSize } from '@/store/pet-overlay'
 import { setAwaitingResponse, setBusy } from '@/store/session'
 
@@ -69,6 +70,9 @@ export function PetOverlayApp() {
   // Mirrored reply text - when set, shows in the speech bubble instead of the
   // mail icon. Cleared on click (opens app) or when the main window focuses.
   const [replyText, setReplyTextState] = useState<string | null>(null)
+  // Mirrored gateway connection state — offline/reauth desaturates the sprite +
+  // badges a disconnect glyph so a down backend never looks happy.
+  const [connection, setConnection] = useState<ProfileConnection>('open')
 
   const dragRef = useRef<DragState | null>(null)
   // Last Alt+wheel anchor, consumed by the resize effect to zoom toward the
@@ -98,6 +102,7 @@ export function PetOverlayApp() {
       setAwaitingResponse(Boolean(payload.awaiting))
       setUnread(Boolean(payload.unread))
       setReplyTextState(payload.replyText ?? null)
+      setConnection(payload.connection ?? 'open')
 
       // Play a reaction on a new id (ignore the first sync, which just primes it).
       const reaction = payload.reaction ?? null
@@ -367,6 +372,12 @@ export function PetOverlayApp() {
     return null
   }
 
+  // Offline/reauth treatment mirrors the in-window PetSlot: desaturate the
+  // sprite and badge a disconnect glyph (reason on hover) so a down backend
+  // never reads as a happy, idle pet.
+  const offline = connection === 'offline' || connection === 'reauth-required'
+  const offlineReason = connection === 'reauth-required' ? 'Needs sign-in' : 'Backend unreachable'
+
   return (
     <div
       onPointerDown={e => {
@@ -434,8 +445,32 @@ export function PetOverlayApp() {
         <div style={{ marginBottom: 4 }}>
           <PetBubble />
         </div>
-        <div style={{ lineHeight: 0, position: 'relative' }}>
-          <PetSprite info={info} />
+        <div style={{ lineHeight: 0, position: 'relative' }} title={offline ? offlineReason : undefined}>
+          <span
+            style={{
+              display: 'inline-block',
+              filter: offline ? 'grayscale(1) opacity(0.55)' : undefined,
+              lineHeight: 0
+            }}
+          >
+            <PetSprite info={info} />
+          </span>
+
+          {offline && (
+            <span
+              aria-label={offlineReason}
+              style={{
+                bottom: 6,
+                color: connection === 'reauth-required' ? '#f59e0b' : '#9ca3af',
+                fontSize: 12,
+                lineHeight: 1,
+                position: 'absolute',
+                right: 2
+              }}
+            >
+              {connection === 'reauth-required' ? '🔑' : '⏻'}
+            </span>
+          )}
 
           {/* Hearts on the popped-out pet — identical to in-window. */}
           <PetHeartField

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -6,7 +6,7 @@ import { PetBubble } from '@/components/pet/pet-bubble'
 import { PetSprite } from '@/components/pet/pet-sprite'
 import { type PetZoomAnchor, usePetZoomGesture } from '@/components/pet/use-pet-zoom-gesture'
 import { Mail } from '@/lib/icons'
-import { $petActivity, $petInfo, setPetInfo } from '@/store/pet'
+import { $petInfo, replacePetActivity, setPetInfo } from '@/store/pet'
 import { overlayWindowSize } from '@/store/pet-overlay'
 import { setAwaitingResponse, setBusy } from '@/store/session'
 
@@ -93,7 +93,7 @@ export function PetOverlayApp() {
   useEffect(() => {
     const off = window.hermesDesktop?.petOverlay?.onState(payload => {
       setPetInfo(payload.info)
-      $petActivity.set(payload.activity ?? {})
+      replacePetActivity(payload.activity ?? {})
       setBusy(Boolean(payload.busy))
       setAwaitingResponse(Boolean(payload.awaiting))
       setUnread(Boolean(payload.unread))

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -66,6 +66,9 @@ export function PetOverlayApp() {
   const [draft, setDraft] = useState('')
   // Mirrored from the main renderer: a finish landed while you were away.
   const [unread, setUnread] = useState(false)
+  // Mirrored reply text - when set, shows in the speech bubble instead of the
+  // mail icon. Cleared on click (opens app) or when the main window focuses.
+  const [replyText, setReplyTextState] = useState<string | null>(null)
 
   const dragRef = useRef<DragState | null>(null)
   // Last Alt+wheel anchor, consumed by the resize effect to zoom toward the
@@ -94,6 +97,7 @@ export function PetOverlayApp() {
       setBusy(Boolean(payload.busy))
       setAwaitingResponse(Boolean(payload.awaiting))
       setUnread(Boolean(payload.unread))
+      setReplyTextState(payload.replyText ?? null)
 
       // Play a reaction on a new id (ignore the first sync, which just primes it).
       const reaction = payload.reaction ?? null
@@ -294,8 +298,9 @@ export function PetOverlayApp() {
   }
 
   const openApp = () => {
-    // Hide the icon immediately; the main renderer also clears the source flag.
+    // Hide the icon/reply immediately; the main renderer also clears the source flags.
     setUnread(false)
+    setReplyTextState(null)
     window.hermesDesktop?.petOverlay?.control({ type: 'open-app' })
   }
 
@@ -438,11 +443,49 @@ export function PetOverlayApp() {
             petW={(info.frameW ?? DEFAULT_FRAME_W) * (info.scale ?? DEFAULT_SCALE)}
           />
 
-          {/* Mail icon: only when a finish landed while you were away. Jumps to
-              the app's most recent thread. Anchored to the sprite (kept inside
-              its box so the overlay's click-through hit-test still catches it);
-              stopPropagation keeps a click from starting a window drag. */}
-          {unread && (
+          {/* Reply bubble / mail icon: shown when a finish landed while you were
+              away. If we have reply text, show it in a clickable speech bubble
+              (replaces the bare mail icon). Otherwise fall back to the mail icon.
+              Both open the app's most recent thread on click. Anchored to the
+              sprite (kept inside its box so the overlay's click-through hit-test
+              still catches it); stopPropagation keeps a click from starting a
+              window drag. */}
+          {unread && replyText && (() => {
+            const display = replyText.length > 120 ? replyText.slice(0, 120) + '…' : replyText
+            return (
+              <button
+                aria-label="Open reply in Hermes"
+                onClick={openApp}
+                onPointerDown={e => e.stopPropagation()}
+                onPointerUp={e => e.stopPropagation()}
+                style={{
+                  background: 'var(--ui-bg-elevated)',
+                  border: '1px solid var(--ui-stroke-secondary)',
+                  borderRadius: 10,
+                  boxShadow: '0 4px 14px rgba(0,0,0,0.22)',
+                  color: 'var(--foreground)',
+                  cursor: 'pointer',
+                  display: 'inline-block',
+                  fontSize: 11,
+                  fontWeight: 500,
+                  lineHeight: 1.3,
+                  maxWidth: 220,
+                  padding: '5px 8px',
+                  position: 'absolute',
+                  right: 0,
+                  textAlign: 'left',
+                  top: 0,
+                  whiteSpace: 'normal',
+                  wordBreak: 'break-word'
+                }}
+                title="Open in Hermes"
+                type="button"
+              >
+                {display}
+              </button>
+            )
+          })()}
+          {unread && !replyText && (
             <button
               aria-label="Open in Hermes"
               onClick={openApp}

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -15,9 +15,19 @@ import {
 import { notify } from '@/store/notifications'
 import { $workingSessionIds } from '@/store/session-states'
 
+import { isProfileSessionBusy, submitTextForProfile } from './use-prompt-actions/profile-submit'
 import type { SubmitTextOptions } from './use-prompt-actions/utils'
 
 type SubmitQueuedPrompt = (text: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
+
+/** The bare storedSessionId behind an in-memory queue key. Background profile
+ *  buckets use a composite `${profile}::${storedSessionId}` key; strip the
+ *  (normalized) profile prefix to recover the durable id. */
+function storedIdOfQueueKey(sessionKey: string, profile: string): string {
+  const prefix = `${profile}::`
+
+  return sessionKey.startsWith(prefix) ? sessionKey.slice(prefix.length) : sessionKey
+}
 
 interface BackgroundQueueDrainOptions {
   enabled: boolean
@@ -116,14 +126,26 @@ export function useBackgroundQueueDrain({
 
           const runtimeSessionId = runtimeIdByStoredSessionIdRef.current.get(sessionKey) ?? null
 
-          const accepted = await Promise.resolve(
-            submitTextRef.current(liveEntry.text, {
-              attachments: liveEntry.attachments,
-              fromQueue: true,
-              sessionId: runtimeSessionId,
-              storedSessionId: sessionKey
-            })
-          )
+          // Profile-targeted (background) entries route through the profile-safe
+          // entry point on their OWN gateway; profile-less entries keep the
+          // foreground drain (backwards compat) until ownership resolution
+          // re-attributes them.
+          const profile = liveEntry.profile
+          const accepted = profile
+            ? await submitTextForProfile(
+                profile,
+                liveEntry.text,
+                { storedSessionId: storedIdOfQueueKey(sessionKey, profile) },
+                submitTextRef.current
+              )
+            : await Promise.resolve(
+                submitTextRef.current(liveEntry.text, {
+                  attachments: liveEntry.attachments,
+                  fromQueue: true,
+                  sessionId: runtimeSessionId,
+                  storedSessionId: sessionKey
+                })
+              )
 
           if (accepted === false) {
             return false
@@ -171,6 +193,15 @@ export function useBackgroundQueueDrain({
       const entry = entries[0]
 
       if (!entry || (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS) {
+        continue
+      }
+
+      // A background profile bucket keys on a composite the foreground working
+      // set never contains, so gate it on its OWN profile-scoped busy state —
+      // otherwise a busy profile session would drain → re-enqueue → drain in a
+      // spin. Leaving it queued here is correct: it drains once the profile is
+      // idle.
+      if (entry.profile && isProfileSessionBusy(entry.profile, null, storedIdOfQueueKey(sessionKey, entry.profile))) {
         continue
       }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -32,6 +32,7 @@ import {
   completeTool,
   markProfilePetUnread,
   setProfilePetReplyText,
+  setProfileSourceDurableSessionId,
   setSessionAwaitingInput,
   setSessionBusy,
   setSessionReasoning,
@@ -439,6 +440,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         if (runningChanged && sessionId && observedPet && eventProfile) {
           if (payload?.stored_session_id) {
             bindSessionStoredId(eventProfile, sessionId, payload.stored_session_id)
+            // Record the durable id so the overlay mail icon can resume this
+            // profile's conversation (background profiles, not just active).
+            setProfileSourceDurableSessionId(eventProfile, payload.stored_session_id)
           }
 
           if (payload!.running) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -26,7 +26,19 @@ import { dispatchNativeNotification } from '@/store/native-notifications'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding, requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { revealDesktopPane } from '@/store/pane-focus'
-import { flashPetActivity, markPetUnread, setPetActivity, setPetReplyText } from '@/store/pet'
+import { shouldMarkUnread } from '@/store/pet'
+import {
+  bindSessionStoredId,
+  completeTool,
+  markProfilePetUnread,
+  setProfilePetReplyText,
+  setSessionAwaitingInput,
+  setSessionBusy,
+  setSessionReasoning,
+  startTool,
+  terminateSession
+} from '@/store/pet-multi'
+import { observedPetProfiles } from '@/store/pet-roster'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { followActiveSessionCwd } from '@/store/projects'
 import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
@@ -234,6 +246,14 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       const sessionId = route.sessionId
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
 
+      // Multi-pet routing: the event's owning profile (tagged by the gateway
+      // registry) and whether that profile's pet is observed. Activity + unread
+      // writes are gated on `observed` so follow-active (only the active profile
+      // observed) cannot accumulate hidden background state, while pinned mode
+      // animates every enabled profile's pet from its own sessions.
+      const eventProfile = event.profile ? normalizeProfileKey(event.profile) : null
+      const observedPet = Boolean(eventProfile && observedPetProfiles().has(eventProfile))
+
       // Mid-turn compaction does not emit another message.start. The first
       // model output or tool event proves summarization has finished and the
       // turn has resumed, so retire the phase label without waiting for the
@@ -411,6 +431,25 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           )
         }
 
+        // Mirror the running transition into the observed profile's pet activity.
+        // running=false is the authoritative terminal (the backend's finally emits
+        // it on interrupt/clear/turn-end); running=true re-arms busy unless the
+        // user interrupted (stale heartbeat guard — mirrors the ClientSessionState
+        // guard above so an interrupted session never re-arms busy; test 41).
+        if (runningChanged && sessionId && observedPet && eventProfile) {
+          if (payload?.stored_session_id) {
+            bindSessionStoredId(eventProfile, sessionId, payload.stored_session_id)
+          }
+
+          if (payload!.running) {
+            if (!sessionStateByRuntimeIdRef.current.get(sessionId)?.interrupted) {
+              setSessionBusy(eventProfile, sessionId, true)
+            }
+          } else {
+            terminateSession(eventProfile, sessionId)
+          }
+        }
+
         if (payload?.usage && (!explicitSid || isActiveEvent)) {
           setCurrentUsage(current => ({ ...current, ...payload.usage }))
         }
@@ -509,16 +548,16 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           appendReasoningDelta(sessionId, coerceThinkingText(payload?.text))
         }
 
-        if (isActiveEvent) {
-          setPetActivity({ reasoning: true })
+        if (observedPet && eventProfile && sessionId) {
+          setSessionReasoning(eventProfile, sessionId, true)
         }
       } else if (event.type === 'reasoning.available') {
         if (sessionId) {
           appendReasoningDelta(sessionId, coerceThinkingText(payload?.text), true)
         }
 
-        if (isActiveEvent) {
-          setPetActivity({ reasoning: true })
+        if (observedPet && eventProfile && sessionId) {
+          setSessionReasoning(eventProfile, sessionId, true)
         }
       } else if (event.type === 'moa.reference') {
         // MoA reference-model output — surface as a labelled thinking chunk
@@ -553,14 +592,14 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           }
         }
 
-        if (isActiveEvent) {
-          setPetActivity({ reasoning: true })
+        if (observedPet && eventProfile && sessionId) {
+          setSessionReasoning(eventProfile, sessionId, true)
         }
       } else if (event.type === 'moa.aggregating') {
         // Status transition only; the aggregator's reply arrives via the normal
         // message stream. No reasoning/transcript mutation here.
-        if (isActiveEvent) {
-          setPetActivity({ reasoning: true })
+        if (observedPet && eventProfile && sessionId) {
+          setSessionReasoning(eventProfile, sessionId, true)
         }
       } else if (event.type === 'moa.progress') {
         // Live reference fan-out progress ("refs k/n") — surfaced in the same
@@ -579,8 +618,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           flushQueuedDeltas(sessionId)
         }
 
-        if (isActiveEvent) {
-          setPetActivity({ reasoning: true })
+        if (observedPet && eventProfile && sessionId) {
+          setSessionReasoning(eventProfile, sessionId, true)
         }
       } else if (event.type === 'moa.phase') {
         // Phase transition — currently only phase="aggregator" (fan-out done,
@@ -591,8 +630,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           flushQueuedDeltas(sessionId)
         }
 
-        if (isActiveEvent) {
-          setPetActivity({ reasoning: true })
+        if (observedPet && eventProfile && sessionId) {
+          setSessionReasoning(eventProfile, sessionId, true)
         }
       } else if (event.type === 'message.complete') {
         if (!sessionId) {
@@ -639,23 +678,31 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         if (isActiveEvent) {
           setTurnStartedAt(null)
+        }
 
-          // Pet beat: a finished turn always celebrates — go straight to the
-          // jump, never linger on the run/reason pose. One atom update (clears
-          // toolRunning/reasoning AND sets celebrate together) so no stray "run"
-          // frame leaks to the sprite — including the popped-out overlay, which
-          // mirrors each activity change. The jump runs ~2 loops, then settles.
-          flashPetActivity({ celebrate: true, reasoning: false, toolRunning: false }, 2200)
+        // Multi-pet terminal transition + unread, gated on the OBSERVED profile
+        // (not the active session). A finished turn clears that session's steady
+        // state and beats on its own profile's pet — celebrate on a clean finish,
+        // error on a failed one (status:"error"). Unread lights up per
+        // shouldMarkUnread (unfocused window, non-active profile, or non-active
+        // session). playCompletionSound / native notifications above stay
+        // ungated — they're session-scoped, not active-gated.
+        if (observedPet && eventProfile && sessionId) {
+          terminateSession(eventProfile, sessionId, failure ? { error: true } : { celebrate: true })
 
-          // Light up the pet's mail icon if the user wasn't looking when the turn
-          // finished - a glanceable "new message" hint on the popped-out overlay.
-          // Cleared when they open the app via the mail icon or refocus the window.
-          // Also push the reply text so the overlay can show it in the speech
-          // bubble instead of a bare mail icon.
-          if (typeof document !== 'undefined' && !document.hasFocus()) {
-            markPetUnread()
+          if (
+            shouldMarkUnread({
+              activeProfile: $activeGatewayProfile.get(),
+              activeSessionId: activeSessionIdRef.current,
+              profile: eventProfile,
+              sessionId,
+              windowFocused: typeof document === 'undefined' ? false : document.hasFocus()
+            })
+          ) {
+            markProfilePetUnread(eventProfile, sessionId)
+
             if (finalText) {
-              setPetReplyText(finalText)
+              setProfilePetReplyText(eventProfile, finalText, sessionId)
             }
           }
         }
@@ -689,22 +736,26 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         flushQueuedDeltas(sessionId)
         upsertToolCall(sessionId, toTodoPayload(payload) ?? payload, 'running', event.type)
 
-        if (isActiveEvent) {
-          setPetActivity({ reasoning: false, toolRunning: true })
+        if (observedPet && eventProfile && sessionId) {
+          startTool(eventProfile, sessionId, payload?.tool_id || payload?.name)
         }
       } else if (event.type === 'tool.complete') {
         if (sessionId) {
           flushQueuedDeltas(sessionId)
           upsertToolCall(sessionId, toTodoPayload(payload) ?? payload, 'complete', event.type)
 
-          if (isActiveEvent) {
-            setPetActivity({ toolRunning: false })
+          if (observedPet && eventProfile && sessionId) {
+            completeTool(eventProfile, sessionId, payload?.tool_id || payload?.name)
           }
 
           // A pending clarify blocks the turn, so the first tool.complete after
           // one is the clarify resolving — drop the "needs input" flag here so
           // the sidebar indicator clears as soon as it's answered, not only at
           // message.complete.
+          if (sessionStateByRuntimeIdRef.current.get(sessionId)?.needsInput && observedPet && eventProfile) {
+            setSessionAwaitingInput(eventProfile, sessionId, false)
+          }
+
           updateSessionState(sessionId, state => (state.needsInput ? { ...state, needsInput: false } : state))
 
           // terminal/process tool calls are the only things that spawn or reap
@@ -782,6 +833,11 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             // "needs input" indicator on its row — works for the active session
             // too, and survives alt-tab / window blur (unlike a toast).
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+
+            // The pet shows the `waiting` pose while a clarify blocks the turn.
+            if (observedPet && eventProfile) {
+              setSessionAwaitingInput(eventProfile, sessionId, true)
+            }
           }
 
           dispatchNativeNotification({
@@ -815,6 +871,11 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         if (sessionId) {
           updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+
+          // The pet shows the `waiting` pose while an approval blocks the turn.
+          if (observedPet && eventProfile) {
+            setSessionAwaitingInput(eventProfile, sessionId, true)
+          }
         }
 
         dispatchNativeNotification({
@@ -987,9 +1048,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           compactedTurnRef.current.delete(sessionId)
         }
 
-        if (isActiveEvent) {
-          setPetActivity({ reasoning: false, toolRunning: false })
-          flashPetActivity({ error: true })
+        if (observedPet && eventProfile && sessionId) {
+          terminateSession(eventProfile, sessionId, { error: true })
         }
 
         dispatchNativeNotification({

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -26,7 +26,7 @@ import { dispatchNativeNotification } from '@/store/native-notifications'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding, requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { revealDesktopPane } from '@/store/pane-focus'
-import { flashPetActivity, markPetUnread, setPetActivity } from '@/store/pet'
+import { flashPetActivity, markPetUnread, setPetActivity, setPetReplyText } from '@/store/pet'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { followActiveSessionCwd } from '@/store/projects'
 import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
@@ -648,10 +648,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           flashPetActivity({ celebrate: true, reasoning: false, toolRunning: false }, 2200)
 
           // Light up the pet's mail icon if the user wasn't looking when the turn
-          // finished — a glanceable "new message" hint on the popped-out overlay.
+          // finished - a glanceable "new message" hint on the popped-out overlay.
           // Cleared when they open the app via the mail icon or refocus the window.
+          // Also push the reply text so the overlay can show it in the speech
+          // bubble instead of a bare mail icon.
           if (typeof document !== 'undefined' && !document.hasFocus()) {
             markPetUnread()
+            if (finalText) {
+              setPetReplyText(finalText)
+            }
           }
         }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -285,10 +285,18 @@ export function usePromptActions({
     async (
       sessionId: string,
       attachments: ComposerAttachment[],
-      options: { updateComposerAttachments?: boolean } = {}
+      options: {
+        connectionMode?: 'local' | 'remote'
+        requestGateway?: GatewayRequest
+        updateComposerAttachments?: boolean
+      } = {}
     ): Promise<ComposerAttachment[]> => {
       const updateComposerAttachments = options.updateComposerAttachments ?? true
-      const remote = $connection.get()?.mode === 'remote'
+      // A background (profile-targeted) submit injects its own connection mode +
+      // profile-routed requester; the foreground defaults to the live $connection
+      // and the hook-captured gateway.
+      const remote = (options.connectionMode ?? $connection.get()?.mode ?? 'local') === 'remote'
+      const gateway = options.requestGateway ?? requestGateway
       const synced: ComposerAttachment[] = []
 
       for (const original of attachments) {
@@ -316,7 +324,7 @@ export function usePromptActions({
         }
 
         if (attachment.kind === 'image' || attachment.kind === 'file') {
-          const nextAttachment = await uploadComposerAttachment(attachment, { remote, requestGateway, sessionId })
+          const nextAttachment = await uploadComposerAttachment(attachment, { remote, requestGateway: gateway, sessionId })
 
           // Update-only: never resurrect a chip the user removed mid-upload.
           if (updateComposerAttachments) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.integration.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Layer 6c invariants that PR3 satisfied by construction, pinned here so a
+ * refactor can't silently break them (deviation rule #2: focused tests assert
+ * the seam's guarantees rather than spinning up the whole submit pipeline).
+ *
+ *  - Test 34: a profile-bound submit's recovery `session.resume` runs on the
+ *    profile's OWN gateway and carries the profile param (never the active
+ *    gateway, which would fork the conversation into the wrong DB).
+ *  - Test 56: a background submit resolves its connection mode from the named
+ *    profile's connection (Electron), never the foreground `$connection`, and
+ *    exposes the profile-routed requester to the attachment sync.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requestGatewayForProfile } from '@/store/gateway'
+
+import { backgroundSubmitExecution } from './profile-submit'
+
+vi.mock('@/store/gateway', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/gateway')>()
+
+  return {
+    ...actual,
+    requestGatewayForProfile: vi.fn(async () => ({ session_id: 'resumed-rt' })),
+    withProfileGatewayLease: vi.fn(async (_profile: string, run: () => Promise<unknown>) => run())
+  }
+})
+
+const profileRequest = vi.mocked(requestGatewayForProfile)
+
+const getConnection = vi.fn(async () => ({ mode: 'remote' as const }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ;(globalThis as { window?: unknown }).window = { hermesDesktop: { getConnection } }
+})
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window
+})
+
+describe('profile-bound submit recovery (test 34)', () => {
+  it('routes session.resume through the profile gateway with the profile param', async () => {
+    const execution = backgroundSubmitExecution('apollo')
+
+    // The pipeline's session-not-found / timeout recovery calls
+    // execution.requestGateway('session.resume', { session_id, profile }).
+    const resumed = await execution.requestGateway<{ session_id: string }>('session.resume', {
+      session_id: 'stored-123',
+      source: 'desktop'
+    })
+
+    expect(resumed).toEqual({ session_id: 'resumed-rt' })
+    expect(profileRequest).toHaveBeenCalledWith(
+      'apollo',
+      'session.resume',
+      { profile: 'apollo', session_id: 'stored-123', source: 'desktop' },
+      undefined,
+      undefined
+    )
+  })
+
+  it('names the execution after its profile so the lock + routing stay per-profile', () => {
+    const execution = backgroundSubmitExecution('apollo')
+
+    expect(execution.background).toBe(true)
+    expect(execution.profile).toBe('apollo')
+  })
+})
+
+describe('background attachment sync inputs (test 56)', () => {
+  it('resolves connection mode from the named profile, never the foreground $connection', async () => {
+    const execution = backgroundSubmitExecution('nova')
+
+    const mode = await execution.resolveConnectionMode()
+
+    expect(mode).toBe('remote')
+    // Electron resolves the named profile's connection — not the active one.
+    expect(getConnection).toHaveBeenCalledWith('nova')
+  })
+
+  it('exposes the profile-routed requester to the sync step', async () => {
+    const execution = backgroundSubmitExecution('nova')
+
+    // The attachment sync receives execution.requestGateway; a file.attach through
+    // it lands on nova's own socket with the profile param stamped.
+    await execution.requestGateway('file.attach', { name: 'a.txt', path: '/a.txt', session_id: 'rt-1' })
+
+    expect(profileRequest).toHaveBeenCalledWith(
+      'nova',
+      'file.attach',
+      { name: 'a.txt', path: '/a.txt', profile: 'nova', session_id: 'rt-1' },
+      undefined,
+      undefined
+    )
+  })
+
+  it('falls back to local when the profile connection has no mode', async () => {
+    getConnection.mockResolvedValueOnce({} as never)
+    const execution = backgroundSubmitExecution('nova')
+
+    expect(await execution.resolveConnectionMode()).toBe('local')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Layer 6c — profile-safe submission. Covers the SubmitExecution seam's
+ * background path: profile-routed gateway, profile-scoped busy/awaiting that
+ * never touch the foreground stores, the composite background state adapter,
+ * session resolution + busy detection from real data sources, and the shared
+ * submitTextForProfile entry point (route / queue-when-busy / no-session).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { listAllProfileSessions } from '@/hermes'
+import { $busy } from '@/store/session'
+import { requestGatewayForProfile, withProfileGatewayLease } from '@/store/gateway'
+import { notify } from '@/store/notifications'
+import {
+  $profilePets,
+  __resetPetMultiForTests,
+  bindSessionStoredId,
+  setSessionBusy
+} from '@/store/pet-multi'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $queuedPromptsBySession } from '@/store/composer-queue'
+
+import {
+  backgroundSubmitExecution,
+  isProfileSessionBusy,
+  profileSubmitQueueKey,
+  resolveProfileSession,
+  submitTextForProfile
+} from './profile-submit'
+import type { SubmitTextOptions } from './utils'
+
+vi.mock('@/store/gateway', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/gateway')>()
+
+  return {
+    ...actual,
+    requestGatewayForProfile: vi.fn(async () => ({})),
+    withProfileGatewayLease: vi.fn(async (_profile: string, run: () => Promise<unknown>) => run())
+  }
+})
+
+vi.mock('@/hermes', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hermes')>()
+
+  return { ...actual, listAllProfileSessions: vi.fn(async () => ({ sessions: [] })) }
+})
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn()
+}))
+
+const listSessions = vi.mocked(listAllProfileSessions)
+const profileRequest = vi.mocked(requestGatewayForProfile)
+const lease = vi.mocked(withProfileGatewayLease)
+
+const submitSpy = () => vi.fn(async (_text: string, _options?: SubmitTextOptions) => true)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetPetMultiForTests()
+  $queuedPromptsBySession.set({})
+  $activeGatewayProfile.set('default')
+  $busy.set(false)
+  listSessions.mockResolvedValue({ sessions: [] } as never)
+})
+
+describe('backgroundSubmitExecution (tests 26, 33, 55)', () => {
+  it('is flagged background and names its profile', () => {
+    const exec = backgroundSubmitExecution('Apollo')
+
+    expect(exec.background).toBe(true)
+    // normalizeProfileKey trims but preserves case.
+    expect(exec.profile).toBe('Apollo')
+    expect(exec.readBusy()).toBe(false)
+  })
+
+  it('routes every gateway call through requestGatewayForProfile with the profile (test 33)', async () => {
+    const exec = backgroundSubmitExecution('apollo')
+
+    await exec.requestGateway('prompt.submit', { session_id: 's1', text: 'hi' }, 1000)
+
+    expect(profileRequest).toHaveBeenCalledWith(
+      'apollo',
+      'prompt.submit',
+      { profile: 'apollo', session_id: 's1', text: 'hi' },
+      1000,
+      undefined
+    )
+  })
+
+  it('drives the profile busy pose, never the foreground $busy (test 26)', () => {
+    const exec = backgroundSubmitExecution('apollo')
+
+    exec.scope.setBusy(true)
+    exec.scope.setAwaitingResponse(true)
+
+    expect($profilePets.get().get('apollo')?.activity.busy).toBe(true)
+    // Foreground composer busy is untouched by a background submit.
+    expect($busy.get()).toBe(false)
+
+    exec.scope.setBusy(false)
+    exec.scope.setAwaitingResponse(false)
+    expect($profilePets.get().get('apollo')?.activity.busy).toBe(false)
+  })
+
+  it('runs optimistic state through the composite background adapter, not the foreground cache (test 55)', () => {
+    const exec = backgroundSubmitExecution('apollo')
+
+    const next = exec.updateSessionState(
+      'rt-1',
+      state => ({ ...state, busy: true, messages: [...state.messages, { id: 'user-1', parts: [], role: 'user' }] }),
+      'stored-1'
+    )
+
+    // The adapter returns the updated background state...
+    expect(next.busy).toBe(true)
+    expect(next.messages.some(m => m.id === 'user-1')).toBe(true)
+    expect(next.storedSessionId).toBe('stored-1')
+    // ...and never paints the foreground view.
+    expect(exec.scope.readAttachments()).toEqual([])
+  })
+})
+
+describe('isProfileSessionBusy (test 58)', () => {
+  it('reads busy from per-session activity by runtime id', () => {
+    setSessionBusy('apollo', 'rt-1', true)
+
+    expect(isProfileSessionBusy('apollo', 'rt-1', null)).toBe(true)
+    expect(isProfileSessionBusy('apollo', 'rt-other', null)).toBe(false)
+  })
+
+  it('reads busy by stored id (survives runtime rotation)', () => {
+    setSessionBusy('apollo', 'rt-1', true)
+    bindSessionStoredId('apollo', 'rt-1', 'stored-1')
+
+    expect(isProfileSessionBusy('apollo', null, 'stored-1')).toBe(true)
+    expect(isProfileSessionBusy('apollo', null, 'stored-other')).toBe(false)
+  })
+
+  it('is scoped per profile', () => {
+    setSessionBusy('apollo', 'rt-1', true)
+
+    expect(isProfileSessionBusy('nova', 'rt-1', null)).toBe(false)
+  })
+})
+
+describe('resolveProfileSession (tests 35, 58)', () => {
+  it('returns the most-recent non-busy durable id from the cross-profile listing', async () => {
+    listSessions.mockResolvedValue({
+      sessions: [
+        { id: 'stored-busy', profile: 'apollo' },
+        { id: 'stored-free', profile: 'apollo' }
+      ]
+    } as never)
+    setSessionBusy('apollo', 'rt-busy', true)
+    bindSessionStoredId('apollo', 'rt-busy', 'stored-busy')
+
+    const target = await resolveProfileSession('apollo', { excludeBusy: true })
+
+    expect(target.storedSessionId).toBe('stored-free')
+    expect(target.sessionId).toBeNull()
+    // The listing is scoped to the named profile.
+    expect(listSessions).toHaveBeenCalledWith(200, 1, 'exclude', 'recent', 'apollo')
+  })
+
+  it('returns the busy session when excludeBusy is false', async () => {
+    listSessions.mockResolvedValue({ sessions: [{ id: 'stored-busy', profile: 'apollo' }] } as never)
+    setSessionBusy('apollo', 'rt-busy', true)
+    bindSessionStoredId('apollo', 'rt-busy', 'stored-busy')
+
+    const target = await resolveProfileSession('apollo', { excludeBusy: false })
+
+    expect(target.storedSessionId).toBe('stored-busy')
+  })
+
+  it('returns empty when the profile has no sessions', async () => {
+    const target = await resolveProfileSession('apollo', { excludeBusy: true })
+
+    expect(target).toEqual({})
+  })
+})
+
+describe('submitTextForProfile (tests 11, 12, 35)', () => {
+  it('runs a background profile through the SubmitExecution seam (test 11/33)', async () => {
+    const submitText = submitSpy()
+
+    const ok = await submitTextForProfile('apollo', 'hello', { storedSessionId: 'stored-1' }, submitText)
+
+    expect(ok).toBe(true)
+    expect(lease).toHaveBeenCalledWith('apollo', expect.any(Function))
+    const options = submitText.mock.calls[0]?.[1]
+
+    expect(options?.storedSessionId).toBe('stored-1')
+    expect(options?.execution?.background).toBe(true)
+    expect(options?.execution?.profile).toBe('apollo')
+  })
+
+  it('uses the ordinary foreground execution for the active profile', async () => {
+    const submitText = submitSpy()
+
+    await submitTextForProfile('default', 'hello', { storedSessionId: 'stored-1' }, submitText)
+
+    expect(submitText.mock.calls[0]?.[1]?.execution).toBeUndefined()
+  })
+
+  it('passes the runtime + durable ids through when the caller has them', async () => {
+    const submitText = submitSpy()
+
+    await submitTextForProfile('apollo', 'hi', { sessionId: 'rt-1', storedSessionId: 'stored-1' }, submitText)
+
+    const options = submitText.mock.calls[0]?.[1]
+
+    expect(options?.sessionId).toBe('rt-1')
+    expect(options?.storedSessionId).toBe('stored-1')
+  })
+
+  it('enqueues under (profile, storedSessionId) when the session is busy (test 12)', async () => {
+    setSessionBusy('apollo', 'rt-1', true)
+    bindSessionStoredId('apollo', 'rt-1', 'stored-1')
+    const submitText = submitSpy()
+
+    const ok = await submitTextForProfile('apollo', 'queued', { storedSessionId: 'stored-1' }, submitText)
+
+    expect(ok).toBe(true)
+    expect(submitText).not.toHaveBeenCalled()
+
+    const queued = $queuedPromptsBySession.get()[profileSubmitQueueKey('apollo', 'stored-1')]
+
+    expect(queued).toHaveLength(1)
+    expect(queued[0]?.text).toBe('queued')
+    expect(queued[0]?.profile).toBe('apollo')
+  })
+
+  it('cannot queue a busy session that has no durable id', async () => {
+    setSessionBusy('apollo', 'rt-1', true)
+    const submitText = submitSpy()
+
+    const ok = await submitTextForProfile('apollo', 'x', { sessionId: 'rt-1' }, submitText)
+
+    expect(ok).toBe(false)
+    expect(submitText).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalled()
+  })
+
+  it('falls back to the most-recent non-busy session when the caller has none (test 35)', async () => {
+    listSessions.mockResolvedValue({ sessions: [{ id: 'stored-recent', profile: 'apollo' }] } as never)
+    const submitText = submitSpy()
+
+    const ok = await submitTextForProfile('apollo', 'hi', {}, submitText)
+
+    expect(ok).toBe(true)
+    expect(submitText.mock.calls[0]?.[1]?.storedSessionId).toBe('stored-recent')
+  })
+
+  it('notifies and returns false when there is no session to target', async () => {
+    const submitText = submitSpy()
+
+    const ok = await submitTextForProfile('apollo', 'hi', {}, submitText)
+
+    expect(ok).toBe(false)
+    expect(submitText).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.test.ts
@@ -19,12 +19,11 @@ import {
   setSessionBusy
 } from '@/store/pet-multi'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $queuedPromptsBySession } from '@/store/composer-queue'
+import { $queuedPromptsBySession, profileQueueKey } from '@/store/composer-queue'
 
 import {
   backgroundSubmitExecution,
   isProfileSessionBusy,
-  profileSubmitQueueKey,
   resolveProfileSession,
   submitTextForProfile
 } from './profile-submit'
@@ -225,7 +224,7 @@ describe('submitTextForProfile (tests 11, 12, 35)', () => {
     expect(ok).toBe(true)
     expect(submitText).not.toHaveBeenCalled()
 
-    const queued = $queuedPromptsBySession.get()[profileSubmitQueueKey('apollo', 'stored-1')]
+    const queued = $queuedPromptsBySession.get()[profileQueueKey('apollo', 'stored-1')]
 
     expect(queued).toHaveLength(1)
     expect(queued[0]?.text).toBe('queued')

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.ts
@@ -1,0 +1,166 @@
+import { listAllProfileSessions } from '@/hermes'
+import { enqueueQueuedPrompt, profileQueueKey } from '@/store/composer-queue'
+import { requestGatewayForProfile, withProfileGatewayLease } from '@/store/gateway'
+import { notify } from '@/store/notifications'
+import {
+  hasBusyActivityForStoredSession,
+  profileRuntimeBusy,
+  setProfileAwaitingResponse,
+  setProfileSubmitBusy,
+  updateBackgroundSessionState
+} from '@/store/pet-multi'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import { $workingSessionIds } from '@/store/session-states'
+
+import type { SubmitExecution, SubmitTextOptions } from './utils'
+
+/**
+ * Profile-safe submission (Layer 6c).
+ *
+ * A reply aimed at a NON-active profile must not touch the foreground pipeline's
+ * inputs — the active session refs, the routed/selected ids, the foreground
+ * `$busy`/`$messages`, or the active gateway. Instead it runs the SAME submit
+ * pipeline through a `backgroundSubmitExecution(profile)`: a profile-routed
+ * gateway, profile-scoped busy/awaiting, and a background state adapter that
+ * never publishes into the foreground cache. There is deliberately no reduced
+ * parallel pipeline — only this per-call execution seam.
+ */
+
+/**
+ * The execution seam for a background, profile-targeted submit. Routes every
+ * gateway call through the profile's OWN socket (never the active gateway),
+ * drives the profile's busy pose through profile-scoped flags, and runs the
+ * pipeline's optimistic state against the background adapter.
+ */
+export function backgroundSubmitExecution(profile: string): SubmitExecution {
+  const key = normalizeProfileKey(profile)
+
+  return {
+    background: true,
+    profile: key,
+    // Profile-aware busy is decided BEFORE we get here (isProfileSessionBusy);
+    // once executing, the foreground busy guard is irrelevant.
+    readBusy: () => false,
+    requestGateway: (method, params, timeoutMs, signal) =>
+      requestGatewayForProfile(key, method, { ...params, profile: key }, timeoutMs, signal),
+    resolveConnectionMode: async () => (await window.hermesDesktop?.getConnection(key))?.mode ?? 'local',
+    scope: {
+      clearAttachments: () => {},
+      readAttachments: () => [],
+      setAwaitingResponse: awaiting => setProfileAwaitingResponse(key, awaiting),
+      setBusy: busy => setProfileSubmitBusy(key, busy),
+      setMessages: () => {}
+    },
+    updateSessionState: (runtimeId, updater, storedId) => updateBackgroundSessionState(key, runtimeId, updater, storedId)
+  }
+}
+
+/**
+ * Whether a profile's session is busy, from real data sources: per-session
+ * activity (runtime id), stored-id activity (survives runtime rotation), and —
+ * only for the ACTIVE profile — the foreground working-session cache.
+ */
+export function isProfileSessionBusy(profile: string, runtimeId?: string | null, storedId?: string | null): boolean {
+  const key = normalizeProfileKey(profile)
+
+  if (runtimeId && profileRuntimeBusy(key, runtimeId)) {
+    return true
+  }
+
+  if (storedId && hasBusyActivityForStoredSession(key, storedId)) {
+    return true
+  }
+
+  return Boolean(
+    storedId &&
+      key === normalizeProfileKey($activeGatewayProfile.get()) &&
+      $workingSessionIds.get().includes(storedId)
+  )
+}
+
+/**
+ * Pick a target session for a profile: the most-recent non-busy session from a
+ * cross-profile listing scoped to that profile. Returns a durable storedSessionId
+ * (the runtime id is resolved by the pipeline's session.resume path).
+ */
+export async function resolveProfileSession(
+  profile: string,
+  opts: { excludeBusy: boolean }
+): Promise<{ sessionId?: string | null; storedSessionId?: string | null }> {
+  const key = normalizeProfileKey(profile)
+  const { sessions } = await listAllProfileSessions(200, 1, 'exclude', 'recent', key)
+
+  for (const row of sessions) {
+    if (opts.excludeBusy && isProfileSessionBusy(key, null, row.id)) {
+      continue
+    }
+
+    return { sessionId: null, storedSessionId: row.id }
+  }
+
+  return {}
+}
+
+type SubmitTextFn = (text: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
+
+/**
+ * Shared profile-targeted entry point used by the overlay submit handler and the
+ * background queue drain. Resolves a target session when the caller has none,
+ * queues behind a busy session (under the `(profile, storedSessionId)` key), or
+ * runs the pipeline under a temporary gateway lease. `submitText` is injected so
+ * this stays decoupled from the hook that owns the foreground pipeline.
+ */
+export async function submitTextForProfile(
+  profile: string,
+  text: string,
+  source: { sessionId?: string | null; storedSessionId?: string | null },
+  submitText: SubmitTextFn
+): Promise<boolean> {
+  const key = normalizeProfileKey(profile)
+  let target = source
+
+  if (!target.sessionId && !target.storedSessionId) {
+    target = await resolveProfileSession(key, { excludeBusy: true })
+  }
+
+  if (!target.sessionId && !target.storedSessionId) {
+    // TODO(PR4 i18n): copy.petNoActiveSession(key)
+    notify({ kind: 'warning', message: `No active session to reply to on "${key}".` })
+
+    return false
+  }
+
+  if (isProfileSessionBusy(key, target.sessionId, target.storedSessionId)) {
+    if (!target.storedSessionId) {
+      // TODO(PR4 i18n): copy.petCannotQueueNoDurableSession(key)
+      notify({ kind: 'warning', message: `"${key}" is busy and can't be queued without a durable session.` })
+
+      return false
+    }
+
+    return Boolean(
+      enqueueQueuedPrompt(
+        { profile: key, storedSessionId: target.storedSessionId },
+        { attachments: [], profile: key, text }
+      )
+    )
+  }
+
+  return withProfileGatewayLease(key, () =>
+    Promise.resolve(
+      submitText(text, {
+        sessionId: target.sessionId,
+        storedSessionId: target.storedSessionId,
+        // The active profile runs the ordinary foreground execution; only a
+        // genuinely background profile gets the profile-routed seam.
+        execution:
+          key === normalizeProfileKey($activeGatewayProfile.get()) ? undefined : backgroundSubmitExecution(key)
+      })
+    )
+  )
+}
+
+/** The queue bucket key a profile-targeted submit enqueues into. */
+export function profileSubmitQueueKey(profile: string, storedSessionId: string): string {
+  return profileQueueKey(profile, storedSessionId)
+}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.ts
@@ -1,4 +1,5 @@
 import { listAllProfileSessions } from '@/hermes'
+import { translateNow } from '@/i18n'
 import { enqueueQueuedPrompt } from '@/store/composer-queue'
 import { requestGatewayForProfile, withProfileGatewayLease } from '@/store/gateway'
 import { notify } from '@/store/notifications'
@@ -124,16 +125,20 @@ export async function submitTextForProfile(
   }
 
   if (!target.sessionId && !target.storedSessionId) {
-    // TODO(PR4 i18n): copy.petNoActiveSession(key)
-    notify({ kind: 'warning', message: `No active session to reply to on "${key}".` })
+    notify({
+      kind: 'warning',
+      message: translateNow('settings.appearance.pet.multiPet.noActiveSession', key)
+    })
 
     return false
   }
 
   if (isProfileSessionBusy(key, target.sessionId, target.storedSessionId)) {
     if (!target.storedSessionId) {
-      // TODO(PR4 i18n): copy.petCannotQueueNoDurableSession(key)
-      notify({ kind: 'warning', message: `"${key}" is busy and can't be queued without a durable session.` })
+      notify({
+        kind: 'warning',
+        message: translateNow('settings.appearance.pet.multiPet.cannotQueueNoDurable', key)
+      })
 
       return false
     }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/profile-submit.ts
@@ -1,5 +1,5 @@
 import { listAllProfileSessions } from '@/hermes'
-import { enqueueQueuedPrompt, profileQueueKey } from '@/store/composer-queue'
+import { enqueueQueuedPrompt } from '@/store/composer-queue'
 import { requestGatewayForProfile, withProfileGatewayLease } from '@/store/gateway'
 import { notify } from '@/store/notifications'
 import {
@@ -158,9 +158,4 @@ export async function submitTextForProfile(
       })
     )
   )
-}
-
-/** The queue bucket key a profile-targeted submit enqueues into. */
-export function profileSubmitQueueKey(profile: string, storedSessionId: string): string {
-  return profileQueueKey(profile, storedSessionId)
 }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -20,7 +20,14 @@ import {
 } from '@/store/composer'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
-import { $sessions, resolveComposerSessionKey, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
+import {
+  $connection,
+  $sessions,
+  resolveComposerSessionKey,
+  setAwaitingResponse,
+  setBusy,
+  setMessages
+} from '@/store/session'
 
 import type { ClientSessionState } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
@@ -34,6 +41,7 @@ import {
   isProviderSetupError,
   isSessionBusyError,
   isSessionNotFoundError,
+  type SubmitExecution,
   type SubmitTextOptions,
   withSessionBusyRetry
 } from './utils'
@@ -52,7 +60,15 @@ interface SubmitPromptDeps {
   syncAttachmentsForSubmit: (
     sessionId: string,
     attachments: ComposerAttachment[],
-    options?: { updateComposerAttachments?: boolean }
+    options?: {
+      /** Connection mode to choose path- vs bytes-upload. Defaults to the
+       *  foreground `$connection`; a background execution passes its own. */
+      connectionMode?: 'local' | 'remote'
+      /** Gateway to upload through. Defaults to the hook-captured foreground
+       *  requester; a background execution passes its profile-routed one. */
+      requestGateway?: GatewayRequest
+      updateComposerAttachments?: boolean
+    }
   ) => Promise<ComposerAttachment[]>
   updateSessionState: (
     sessionId: string,
@@ -101,6 +117,30 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
   return useCallback(
     async (rawText: string, options?: SubmitTextOptions) => {
+      // Select the per-call execution seam. Foreground submits run on the hook
+      // deps (busy ref, active gateway, foreground stores); a non-active profile
+      // submit passes backgroundSubmitExecution(profile) and every gateway call,
+      // busy read, connection probe, and state write below routes through it —
+      // there is no parallel pipeline.
+      const mainExecution: SubmitExecution = {
+        background: false,
+        readBusy: () => busyRef.current,
+        requestGateway,
+        resolveConnectionMode: async () => ($connection.get()?.mode === 'remote' ? 'remote' : 'local'),
+        scope,
+        updateSessionState
+      }
+      const execution = options?.execution ?? mainExecution
+      const request = execution.requestGateway
+      const submitScope = execution.scope
+      const updateSubmitState = execution.updateSessionState
+      // A background (profile-targeted) submit must not consult the foreground
+      // selection/active/route identities — only options.sessionId /
+      // options.storedSessionId may pick the target. This flag gates every
+      // foreground-identity read; targetStartedInCurrentView=false then makes the
+      // targetIsCurrentView() guards skip every foreground write.
+      const bg = execution.background
+
       const visibleText = sanitizeComposerInput(rawText).trim()
       const usingComposerAttachments = !options?.attachments
 
@@ -109,7 +149,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // this, the sibling iterations below (a.kind / a.label / a.refText, and the
       // sync step) throw "Cannot read properties of undefined (reading 'refText')"
       // and break the chat surface.
-      const attachments = (options?.attachments ?? scope.readAttachments()).filter((a): a is ComposerAttachment =>
+      const attachments = (options?.attachments ?? submitScope.readAttachments()).filter((a): a is ComposerAttachment =>
         Boolean(a)
       )
 
@@ -145,7 +185,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // keeps the guard so a stray Enter mid-turn can't double-submit.
       const hasSendable = Boolean(visibleText || terminalContextBlocks || attachments.length || hasImage)
 
-      if (!hasSendable || (!options?.fromQueue && busyRef.current)) {
+      if (!hasSendable || (!options?.fromQueue && execution.readBusy())) {
         return false
       }
 
@@ -161,11 +201,16 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       // Queue drains carry their source session explicitly. A background drain
       // must never inherit the currently selected session after the user moves
-      // to another chat.
-      const targetStoredSessionId = options?.storedSessionId ?? selectedStoredSessionIdRef.current
+      // to another chat. A background EXECUTION (profile-targeted submit) reads
+      // no foreground identity at all — only options.sessionId/storedSessionId
+      // select the target.
+      const fgSelectedStoredId = bg ? null : selectedStoredSessionIdRef.current
+      const fgActiveSessionId = bg ? null : activeSessionIdRef.current
+
+      const targetStoredSessionId = options?.storedSessionId ?? fgSelectedStoredId
 
       const targetStartedInCurrentView =
-        !targetStoredSessionId || targetStoredSessionId === selectedStoredSessionIdRef.current
+        !bg && (!targetStoredSessionId || targetStoredSessionId === fgSelectedStoredId)
 
       // A queued/background drain whose runtime binding was reaped must NOT
       // inherit the foreground runtime id when its storedSessionId targets a
@@ -174,19 +219,20 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // drain is for the current view (no storedSessionId, or it matches the
       // foreground), the foreground runtime is correct and must be kept.
       const isBackgroundQueueDrain = Boolean(
-        options?.fromQueue && options?.storedSessionId && options.storedSessionId !== selectedStoredSessionIdRef.current
+        options?.fromQueue && options?.storedSessionId && options.storedSessionId !== fgSelectedStoredId
       )
 
-      let sessionId: null | string = options?.sessionId ?? (isBackgroundQueueDrain ? null : activeSessionIdRef.current)
+      let sessionId: null | string =
+        options?.sessionId ?? (isBackgroundQueueDrain || bg ? null : fgActiveSessionId)
 
       // Pin the foreground session context for the whole async submit pipeline.
       // Without this, a fast session switch during session.resume / file.attach
       // can redirect the user's text into a different chat (#54527). Mutable —
       // not const — because a new-chat submit legitimately re-homes to the
       // session it creates (see the re-pin after createBackendSessionForSend).
-      const startingActiveSessionId = activeSessionIdRef.current
-      const selectedStoredSessionId = selectedStoredSessionIdRef.current
-      const routedStoredSessionId = getRoutedStoredSessionId()
+      const startingActiveSessionId = fgActiveSessionId
+      const selectedStoredSessionId = fgSelectedStoredId
+      const routedStoredSessionId = bg ? null : getRoutedStoredSessionId()
 
       const routedRuntimeId = routedStoredSessionId ? getRuntimeIdForStoredSession(routedStoredSessionId) : null
 
@@ -234,11 +280,22 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       const targetIsCurrentView = (): boolean => targetStartedInCurrentView && !sessionDriftReason()
 
+      // Whether the execution's UI scope should reflect busy/awaiting right now.
+      // Foreground reflects it only while the target is still the viewed session
+      // (a mid-pipeline switch stops painting it); background always reflects it
+      // because its scope is profile-scoped and never touches the viewed session.
+      const scopeIsActive = (): boolean => bg || targetIsCurrentView()
+
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns. The
       // foreground ChatBar and background drainers can briefly overlap during a
-      // session switch; this per-session lock makes that safe.
-      const submitLockKey = targetStoredSessionId || sessionId || startingActiveSessionId || '__pending_new__'
+      // session switch; this per-session lock makes that safe. A background
+      // (profile-targeted) submit namespaces the lock by profile so two profiles
+      // can submit into same-named session keys without colliding.
+      const baseSubmitLockKey = targetStoredSessionId || sessionId || startingActiveSessionId || '__pending_new__'
+      const submitLockKey = execution.profile
+        ? JSON.stringify([execution.profile, baseSubmitLockKey])
+        : baseSubmitLockKey
 
       if (_submitInFlight.has(submitLockKey)) {
         return false
@@ -266,17 +323,22 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       const releaseBusy = () => {
         releaseSubmitLock()
 
-        if (targetIsCurrentView()) {
-          setMutableRef(busyRef, false)
-          scope.setBusy(false)
-          scope.setAwaitingResponse(false)
+        if (scopeIsActive()) {
+          // busyRef is the foreground-only sync source; a background execution
+          // drives its profile-scoped busy through submitScope alone.
+          if (!bg) {
+            setMutableRef(busyRef, false)
+          }
+
+          submitScope.setBusy(false)
+          submitScope.setAwaitingResponse(false)
         }
       }
 
       // Idempotent optimistic insert — re-running with the resolved sessionId
       // after createBackendSessionForSend just overwrites with the same id.
       const seedOptimistic = (sid: string) =>
-        updateSessionState(
+        updateSubmitState(
           sid,
           state => ({
             ...state,
@@ -298,7 +360,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // After sync rewrites refs, refresh the optimistic message in place so the
       // transcript shows the resolved @file: ref rather than the local path.
       const rewriteOptimistic = (sid: string) =>
-        updateSessionState(
+        updateSubmitState(
           sid,
           state => ({
             ...state,
@@ -310,13 +372,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       const dropOptimistic = (sid: null | string) => {
         if (!sid) {
           if (targetIsCurrentView()) {
-            scope.setMessages(current => current.filter(m => m.id !== optimisticId))
+            submitScope.setMessages(current => current.filter(m => m.id !== optimisticId))
           }
 
           return
         }
 
-        updateSessionState(
+        updateSubmitState(
           sid,
           state => ({
             ...state,
@@ -336,13 +398,19 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         return false
       }
 
-      // Foreground-only state: a background queue drain must never write the
-      // selected view's busy/awaiting flags or clear its notifications.
-      if (targetIsCurrentView()) {
-        setMutableRef(busyRef, true)
-        scope.setBusy(true)
-        scope.setAwaitingResponse(true)
-        clearNotifications()
+      // Busy/awaiting state. Foreground writes the viewed session's flags only
+      // while the target is still current (a background queue drain or a
+      // mid-pipeline switch must never paint it); a background execution always
+      // drives its own profile-scoped flags and never touches the foreground
+      // busyRef / notifications.
+      if (scopeIsActive()) {
+        if (!bg) {
+          setMutableRef(busyRef, true)
+          clearNotifications()
+        }
+
+        submitScope.setBusy(true)
+        submitScope.setAwaitingResponse(true)
       }
 
       // A route whose selected/runtime binding is incomplete or cross-wired
@@ -356,7 +424,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       if (sessionId) {
         seedOptimistic(sessionId)
       } else if (targetIsCurrentView()) {
-        scope.setMessages(current => [...current, buildUserMessage()])
+        submitScope.setMessages(current => [...current, buildUserMessage()])
       }
 
       if (!sessionId && routedStoredSessionId && routedSessionNeedsResume) {
@@ -405,9 +473,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         try {
           // Re-register on the session's OWNING profile — resuming on whichever
           // profile is live would fork the conversation into the wrong DB (#67603).
-          const resumeProfile = await resolveSessionProfile(targetStoredSessionId)
+          // A background execution already knows its owner and never probes the
+          // active profile.
+          const resumeProfile = execution.profile ?? (await resolveSessionProfile(targetStoredSessionId))
 
-          const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+          const resumed = await request<{ session_id: string }>('session.resume', {
             session_id: targetStoredSessionId,
             source: 'desktop',
             ...(resumeProfile ? { profile: resumeProfile } : {})
@@ -453,6 +523,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       }
 
       if (!sessionId) {
+        // A background (profile-targeted) submit always targets an existing
+        // session resolved above; it must never mint a session on the active
+        // profile. Reaching here means its target could not be rebound — abort.
+        if (bg) {
+          return abortForSessionSwitch(null)
+        }
+
         try {
           sessionId = await createBackendSessionForSend(visibleText)
         } catch (err) {
@@ -510,6 +587,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       try {
         const syncedAttachments = await syncAttachmentsForSubmit(sessionId, attachments, {
+          connectionMode: await execution.resolveConnectionMode(),
+          requestGateway: request,
           updateComposerAttachments: usingComposerAttachments
         })
 
@@ -541,10 +620,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         try {
           await withSessionBusyRetry(() =>
-            requestGateway('prompt.submit', submitParams(sessionId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+            request('prompt.submit', submitParams(sessionId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
           )
         } catch (firstErr) {
-          const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
+          const recoverStoredSessionId = targetStoredSessionId ?? fgSelectedStoredId
 
           if ((isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) && recoverStoredSessionId) {
             // Re-register the session in the gateway and get a fresh live ID.
@@ -552,9 +631,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // backend loop (#55578 symptom d) rejects the submit even though
             // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
-            const resumeProfile = await resolveSessionProfile(recoverStoredSessionId)
+            const resumeProfile = execution.profile ?? (await resolveSessionProfile(recoverStoredSessionId))
 
-            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+            const resumed = await request<{ session_id: string }>('session.resume', {
               session_id: recoverStoredSessionId,
               source: 'desktop',
               ...(resumeProfile ? { profile: resumeProfile } : {})
@@ -576,7 +655,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
               }
 
               await withSessionBusyRetry(() =>
-                requestGateway('prompt.submit', submitParams(recoveredId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+                request('prompt.submit', submitParams(recoveredId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
               )
             } else {
               submitErr = firstErr
@@ -591,7 +670,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         }
 
         if (usingComposerAttachments) {
-          scope.clearAttachments()
+          submitScope.clearAttachments()
         }
 
         // Submit landed — the turn now runs (busy stays true), but the submit
@@ -611,7 +690,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         const message = inlineErrorMessage(err, copy.promptFailed)
 
-        updateSessionState(
+        updateSubmitState(
           sessionId,
           state => ({
             ...state,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -6,7 +6,52 @@ import { type CommandsCatalogLike, filterDesktopCommandsCatalog } from '@/lib/de
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import type { ComposerAttachment } from '@/store/composer'
 
-export type GatewayRequest = <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+import type { ClientSessionState } from '../../../types'
+
+export type GatewayRequest = <T>(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number,
+  signal?: AbortSignal
+) => Promise<T>
+
+/**
+ * The UI surfaces a submit writes through. The main chat uses the module-level
+ * foreground stores (MAIN_SUBMIT_SCOPE); a background, profile-targeted submit
+ * supplies no-op / profile-scoped equivalents so it never paints the view the
+ * user is looking at.
+ */
+export interface SubmitUiScope {
+  clearAttachments: () => void
+  readAttachments: () => ComposerAttachment[]
+  setAwaitingResponse: (awaiting: boolean) => void
+  setBusy: (busy: boolean) => void
+  setMessages: (updater: (current: ChatMessage[]) => ChatMessage[]) => void
+}
+
+/**
+ * Per-call execution seam. A submit runs either in the foreground (the default,
+ * assembled from the hook deps — busy ref, active gateway, foreground stores) or
+ * in the background for a non-active profile (`backgroundSubmitExecution(profile)`
+ * — profile-routed gateway, profile-scoped busy/awaiting, no foreground writes).
+ * The pipeline selects ONE execution at the top and routes every gateway call,
+ * busy read, connection-mode probe, and state write through it — there is no
+ * parallel submit path (a reduced `submitTextForProfile` that re-implemented the
+ * pipeline would drift from it).
+ */
+export interface SubmitExecution {
+  background: boolean
+  profile?: string
+  readBusy: () => boolean
+  requestGateway: GatewayRequest
+  resolveConnectionMode: () => Promise<'local' | 'remote'>
+  scope: SubmitUiScope
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
+}
 
 export function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -367,6 +412,11 @@ export interface SubmitTextOptions {
    *  (queue drain, steer, external submit requests): the check is a no-op
    *  without it. */
   composerScope?: string | null
+  /** Per-call execution seam. Omit for the foreground pipeline; a non-active
+   *  profile submit passes `backgroundSubmitExecution(profile)` so every gateway
+   *  call, busy read, and state write routes through that profile instead of the
+   *  foreground view. */
+  execution?: SubmitExecution
   fromQueue?: boolean
   /** Runtime session id to submit into. Queue drains pass this so a
    *  backgrounded/source session cannot be replaced by the current foreground

--- a/apps/desktop/src/app/settings/pet-settings.test.tsx
+++ b/apps/desktop/src/app/settings/pet-settings.test.tsx
@@ -1,0 +1,113 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $petRoster, setPetRosterEntries, setPetRosterMode } from '@/store/pet-roster'
+import { $profiles } from '@/store/profile'
+import { $gatewayState } from '@/store/session'
+import type { ProfileInfo } from '@/types/hermes'
+
+// The gallery picker reaches for the live gateway; the roster tests don't
+// exercise it, so stub the hook + the gallery load it triggers on open.
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway: vi.fn() })
+}))
+
+vi.mock('@/store/pet-gallery', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/pet-gallery')>()
+
+  return { ...actual, loadPetGallery: vi.fn(async () => undefined) }
+})
+
+const profile = (name: string): ProfileInfo => ({ name } as ProfileInfo)
+
+async function renderSettings() {
+  const { PetSettings } = await import('./pet-settings')
+
+  return render(<PetSettings />)
+}
+
+beforeEach(() => {
+  $gatewayState.set('closed')
+  $petRoster.set({ entries: [], initialized: true, mode: 'follow-active' })
+  $profiles.set([])
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('PetSettings mode toggle (test 49)', () => {
+  it('toggles between follow-active and pinned, preserving roster entries', async () => {
+    setPetRosterMode('follow-active')
+    setPetRosterEntries([{ enabled: true, profile: 'nova' }])
+    const initialEntries = $petRoster.get().entries
+
+    await renderSettings()
+
+    // Default is follow-active.
+    expect(screen.getByRole('button', { name: 'Follow Active' }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: 'Pinned' }).getAttribute('aria-pressed')).toBe('false')
+
+    // Switch to pinned.
+    fireEvent.click(screen.getByRole('button', { name: 'Pinned' }))
+    expect($petRoster.get().mode).toBe('pinned')
+
+    // Switch back — entries are preserved (just ignored in follow-active).
+    fireEvent.click(screen.getByRole('button', { name: 'Follow Active' }))
+    expect($petRoster.get().mode).toBe('follow-active')
+    expect($petRoster.get().entries).toHaveLength(initialEntries.length)
+    expect($petRoster.get().entries[0]?.profile).toBe('nova')
+  })
+
+  it('shows the roster panel only in pinned mode', async () => {
+    setPetRosterMode('follow-active')
+    setPetRosterEntries([{ enabled: true, profile: 'nova' }])
+
+    const { rerender } = await renderSettings()
+
+    expect(screen.queryByText('Pinned profiles')).toBeNull()
+
+    act(() => {
+      setPetRosterMode('pinned')
+    })
+    const { PetSettings } = await import('./pet-settings')
+    rerender(<PetSettings />)
+
+    expect(screen.getByText('Pinned profiles')).toBeTruthy()
+    expect(screen.getByText('nova')).toBeTruthy()
+  })
+})
+
+describe('PetSettings pinned roster (test 63)', () => {
+  it('renders an unavailable row for a renamed/deleted profile and a disabled row for a new one', async () => {
+    setPetRosterMode('pinned')
+    // "sol" was pinned but is gone from the catalog (renamed/deleted); reconcile
+    // would have marked it unavailable. "lune" is a fresh catalog profile not yet
+    // in the roster.
+    setPetRosterEntries([{ enabled: false, profile: 'sol', unavailable: true }])
+    $profiles.set([profile('lune')])
+
+    await renderSettings()
+
+    // The unavailable row shows the "not found" affordance.
+    expect(screen.getByText('sol')).toBeTruthy()
+    expect(screen.getByText('Not found')).toBeTruthy()
+    expect(screen.getByText(/Profile not found/)).toBeTruthy()
+
+    // The new catalog profile appears as a discoverable, not-yet-pinned row.
+    expect(screen.getByText('lune')).toBeTruthy()
+  })
+
+  it('enabling a discovered profile pins it to the roster', async () => {
+    setPetRosterMode('pinned')
+    setPetRosterEntries([])
+    $profiles.set([profile('lune')])
+
+    await renderSettings()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Enable' }))
+
+    expect($petRoster.get().entries.some(e => e.profile === 'lune' && e.enabled)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/settings/pet-settings.tsx
+++ b/apps/desktop/src/app/settings/pet-settings.tsx
@@ -10,7 +10,7 @@ import { Input } from '@/components/ui/input'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tip } from '@/components/ui/tooltip'
-import { useI18n } from '@/i18n'
+import { useI18n, type Translations } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Download, Loader2, PawPrint, Pencil, Trash2 } from '@/lib/icons'
 import { selectableCardClass } from '@/lib/selectable-card'
@@ -35,9 +35,19 @@ import {
   setPetEnabled,
   setPetScale
 } from '@/store/pet-gallery'
+import { $profilePets, type ProfileConnection } from '@/store/pet-multi'
+import {
+  $petRoster,
+  PINNED_HARD_CAP,
+  PINNED_SOFT_CAP,
+  setPetRosterEntries,
+  setPetRosterMode,
+  setProfilePetEnabled
+} from '@/store/pet-roster'
+import { $profiles } from '@/store/profile'
 import { $gatewayState } from '@/store/session'
 
-import { ListRow, SectionHeading } from './primitives'
+import { ListRow, Pill, SectionHeading } from './primitives'
 
 /**
  * Appearance opt-in for the floating petdex mascot. A thin view over the shared
@@ -125,6 +135,8 @@ export function PetSettings() {
           {copy.restartHint}
         </p>
       )}
+
+      <MultiPetModeSection />
 
       <div className="mt-2">
         <ListRow
@@ -369,6 +381,177 @@ export function PetSettings() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+    </div>
+  )
+}
+
+/**
+ * Multi-pet mode toggle + pinned roster panel (Layer 9). The mode toggle is
+ * always visible; the roster panel only renders in `pinned` mode. The gallery
+ * picker below stays active in both modes — it configures the ACTIVE profile's
+ * pet (per-profile pet selection is a future feature).
+ */
+function MultiPetModeSection() {
+  const { t } = useI18n()
+  const copy = t.settings.appearance.pet.multiPet
+  const roster = useStore($petRoster)
+
+  return (
+    <div className="mt-4">
+      <ListRow
+        action={
+          <SegmentedControl
+            onChange={id => setPetRosterMode(id === 'pinned' ? 'pinned' : 'follow-active')}
+            options={[
+              { id: 'follow-active', label: copy.followActive },
+              { id: 'pinned', label: copy.pinned }
+            ]}
+            value={roster.mode}
+          />
+        }
+        description={copy.modeDesc}
+        title={copy.modeTitle}
+      />
+      {roster.mode === 'pinned' && <RosterPanel />}
+    </div>
+  )
+}
+
+const CONNECTION_TONE: Record<ProfileConnection, 'muted' | 'primary' | 'warn'> = {
+  connecting: 'warn',
+  offline: 'muted',
+  open: 'primary',
+  'reauth-required': 'warn'
+}
+
+type MultiPetCopy = Translations['settings']['appearance']['pet']['multiPet']
+
+function connectionLabel(copy: MultiPetCopy, connection: ProfileConnection): string {
+  switch (connection) {
+    case 'connecting':
+      return copy.connectionConnecting
+    case 'offline':
+      return copy.connectionOffline
+    case 'reauth-required':
+      return copy.connectionReauth
+    default:
+      return copy.connectionOnline
+  }
+}
+
+/**
+ * The pinned roster: one row per profile, ordered with roster entries first
+ * (stored order) then catalog profiles not yet pinned (discovery). Each row
+ * shows the profile's live connection state and an Enable/Remove action.
+ * Removing an available profile just disables it (re-enable later); removing an
+ * unavailable one (deleted/renamed) deletes the row entirely.
+ */
+function RosterPanel() {
+  const { t } = useI18n()
+  const copy = t.settings.appearance.pet.multiPet
+  const roster = useStore($petRoster)
+  const profilePets = useStore($profilePets)
+  const profiles = useStore($profiles)
+
+  // Catalog profiles not yet in the roster — surfaced as disabled rows so a
+  // newly created profile shows up here without a separate "add" flow.
+  const inRoster = new Set(roster.entries.map(e => e.profile))
+  const discovered = profiles.filter(p => !inRoster.has(p.name)).map(p => p.name)
+
+  const enabledCount = roster.entries.filter(e => e.enabled && !e.unavailable).length
+  const atHardCap = enabledCount >= PINNED_HARD_CAP
+
+  // setProfilePetEnabled refuses an enable past the hard cap (returns false);
+  // the notice below explains why the 9th profile can't be pinned.
+  const setEnabled = (profile: string, enabled: boolean) => void setProfilePetEnabled(profile, enabled)
+  const removeEntry = (profile: string) => setPetRosterEntries(roster.entries.filter(e => e.profile !== profile))
+
+  return (
+    <div className="mt-1">
+      <ListRow description={copy.rosterDesc} title={copy.rosterTitle} />
+
+      {enabledCount >= PINNED_SOFT_CAP && (
+        <p
+          className={cn(
+            'mb-2 rounded-lg border px-3 py-2 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height)',
+            atHardCap
+              ? 'border-(--ui-red)/40 bg-(--ui-red)/10 text-(--ui-red)'
+              : 'border-(--ui-yellow)/40 bg-(--ui-yellow)/10 text-(--ui-text-secondary)'
+          )}
+        >
+          {atHardCap ? copy.hardCapNotice(PINNED_HARD_CAP) : copy.softCapWarning(enabledCount)}
+        </p>
+      )}
+
+      <div className="grid gap-1">
+        {roster.entries.map(entry => {
+          const connection = profilePets.get(entry.profile)?.connection ?? 'open'
+          const unavailable = entry.unavailable === true
+
+          return (
+            <div
+              className="flex items-center gap-3 rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2"
+              key={entry.profile}
+            >
+              <span className="min-w-0 flex-1">
+                <span className="flex items-center gap-2">
+                  <span className="truncate text-[length:var(--conversation-text-font-size)] font-medium">
+                    {entry.profile}
+                  </span>
+                  {unavailable ? (
+                    <Pill tone="muted">{copy.unavailable}</Pill>
+                  ) : (
+                    <Pill tone={CONNECTION_TONE[connection]}>{connectionLabel(copy, connection)}</Pill>
+                  )}
+                </span>
+                <span className="block truncate text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                  {unavailable ? copy.unavailableDesc : copy.profilePet(entry.profile)}
+                </span>
+              </span>
+              {unavailable || entry.enabled ? (
+                <Button onClick={() => (unavailable ? removeEntry(entry.profile) : setEnabled(entry.profile, false))} size="sm" type="button" variant="ghost">
+                  {copy.removeAction}
+                </Button>
+              ) : (
+                <Button
+                  disabled={atHardCap}
+                  onClick={() => setEnabled(entry.profile, true)}
+                  size="sm"
+                  type="button"
+                  variant="secondary"
+                >
+                  {copy.enableAction}
+                </Button>
+              )}
+            </div>
+          )
+        })}
+
+        {discovered.map(name => (
+          <div
+            className="flex items-center gap-3 rounded-lg border border-dashed border-(--ui-stroke-tertiary) px-3 py-2"
+            key={name}
+          >
+            <span className="min-w-0 flex-1">
+              <span className="truncate text-[length:var(--conversation-text-font-size)] font-medium text-(--ui-text-secondary)">
+                {name}
+              </span>
+              <span className="block truncate text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                {copy.profilePet(name)}
+              </span>
+            </span>
+            <Button
+              disabled={atHardCap}
+              onClick={() => setEnabled(name, true)}
+              size="sm"
+              type="button"
+              variant="secondary"
+            >
+              {copy.enableAction}
+            </Button>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -25,6 +25,7 @@ import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
 import { MultiPetContainer } from './multi-pet-container'
+import { PET_ACTIVE_REFRESH_MS, PET_POLL_MS } from './pet-poll'
 import { PetSprite, roamWalkRow } from './pet-sprite'
 import { usePetRoam } from './use-pet-roam'
 import { type PetZoomAnchor, usePetZoomGesture } from './use-pet-zoom-gesture'
@@ -110,8 +111,6 @@ function loadPosition(): Point {
  * Promotion to a separate frameless OS-level window is a follow-up — the
  * sprite + state logic here is reused as-is, only the host changes.
  */
-const PET_POLL_MS = 3000
-const PET_ACTIVE_REFRESH_MS = 15000
 
 /**
  * The floating mascot, branched on the roster MODE (not entry count). `pinned`

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -19,10 +19,12 @@ import {
 } from '@/store/pet'
 import { resetPetGallery, setPetScale } from '@/store/pet-gallery'
 import { $petOverlayActive, initPetOverlayBridge, popOutPet, restorePetOverlay } from '@/store/pet-overlay'
+import { $petRoster } from '@/store/pet-roster'
 import { $gatewayState } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
+import { MultiPetContainer } from './multi-pet-container'
 import { PetSprite, roamWalkRow } from './pet-sprite'
 import { usePetRoam } from './use-pet-roam'
 import { type PetZoomAnchor, usePetZoomGesture } from './use-pet-zoom-gesture'
@@ -111,7 +113,24 @@ function loadPosition(): Point {
 const PET_POLL_MS = 3000
 const PET_ACTIVE_REFRESH_MS = 15000
 
+/**
+ * The floating mascot, branched on the roster MODE (not entry count). `pinned`
+ * mode renders the multi-pet row; `follow-active` keeps the legacy single pet
+ * that tracks `$activeGatewayProfile` (zero behavior change). The branch lives
+ * in this wrapper so each path keeps a stable hook order (rules-of-hooks) — the
+ * follow-active body below is unchanged.
+ */
 export function FloatingPet() {
+  const mode = useStore($petRoster).mode
+
+  if (mode === 'pinned') {
+    return <MultiPetContainer />
+  }
+
+  return <FollowActiveFloatingPet />
+}
+
+function FollowActiveFloatingPet() {
   const { requestGateway } = useGatewayRequest()
   const { resolvedMode } = useTheme()
   const gatewayState = useStore($gatewayState)

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -12,6 +12,7 @@ import {
   $petRoam,
   $petRoamDir,
   clearPetUnread,
+  clearPetReplyText,
   type PetInfo,
   petProfile,
   setPetInfo
@@ -238,7 +239,10 @@ export function FloatingPet() {
       return
     }
 
-    const onFocus = () => clearPetUnread()
+    const onFocus = () => {
+      clearPetUnread()
+      clearPetReplyText()
+    }
     window.addEventListener('focus', onFocus)
 
     return () => window.removeEventListener('focus', onFocus)

--- a/apps/desktop/src/components/pet/multi-pet-container.tsx
+++ b/apps/desktop/src/components/pet/multi-pet-container.tsx
@@ -1,0 +1,45 @@
+import { useStore } from '@nanostores/react'
+
+import { $observedPetProfiles, $petRoster } from '@/store/pet-roster'
+
+import { PetSlot } from './pet-slot'
+
+/**
+ * In-window multi-pet row for `pinned` mode: one `PetSlot` per enabled,
+ * available roster entry — 0, 1, or N. No roaming, no in-window bubbles
+ * (sprites only). Each slot owns its own lease + `pet.info` lifecycle.
+ *
+ * Rendering is branched on MODE, not cardinality: a single pinned non-active
+ * profile still renders through this container, never the legacy `FloatingPet`.
+ */
+export function MultiPetContainer() {
+  const roster = useStore($petRoster)
+  const observed = useStore($observedPetProfiles)
+
+  // Roster order is the deterministic tie-breaker; the observed set (pinned
+  // mode = enabled + available entries) gates membership.
+  const profiles = roster.entries.filter(entry => observed.has(entry.profile)).map(entry => entry.profile)
+
+  if (profiles.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      style={{
+        alignItems: 'flex-end',
+        bottom: 24,
+        display: 'flex',
+        gap: 12,
+        left: 24,
+        pointerEvents: 'none',
+        position: 'fixed',
+        zIndex: 60
+      }}
+    >
+      {profiles.map(profile => (
+        <PetSlot key={profile} profile={profile} />
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/components/pet/multi-pet-container.tsx
+++ b/apps/desktop/src/components/pet/multi-pet-container.tsx
@@ -37,8 +37,8 @@ export function MultiPetContainer() {
         zIndex: 60
       }}
     >
-      {profiles.map(profile => (
-        <PetSlot key={profile} profile={profile} />
+      {profiles.map((profile, index) => (
+        <PetSlot index={index} key={profile} profile={profile} />
       ))}
     </div>
   )

--- a/apps/desktop/src/components/pet/multi-pet.test.tsx
+++ b/apps/desktop/src/components/pet/multi-pet.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { leaseProfileGateway, releaseProfileGateway, requestGatewayForProfile } from '@/store/gateway'
+import type { PetInfo } from '@/store/pet'
+import { $profilePets, __resetPetMultiForTests, setProfilePetInfo } from '@/store/pet-multi'
+import { $petRoster } from '@/store/pet-roster'
+import { $activeGatewayProfile } from '@/store/profile'
+
+import { FloatingPet } from './floating-pet'
+import { MultiPetContainer } from './multi-pet-container'
+import { PetSlot } from './pet-slot'
+
+// The slot leases + fetches through the gateway registry; stub those so the test
+// drives the slice directly and can assert the lease lifecycle.
+vi.mock('@/store/gateway', async importActual => {
+  const actual = await importActual<typeof import('@/store/gateway')>()
+
+  return {
+    ...actual,
+    leaseProfileGateway: vi.fn(),
+    releaseProfileGateway: vi.fn(),
+    requestGatewayForProfile: vi.fn(async () => undefined)
+  }
+})
+
+const spritesheet = (displayName: string): PetInfo => ({
+  displayName,
+  enabled: true,
+  mime: 'image/webp',
+  spritesheetBase64: 'ZmFrZQ=='
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetPetMultiForTests()
+  $activeGatewayProfile.set('default')
+  $petRoster.set({ entries: [], initialized: true, mode: 'follow-active' })
+})
+
+describe('PetSlot (test 13, 14)', () => {
+  it('renders its own profile\u2019s sprite from the $profilePets slice', () => {
+    setProfilePetInfo('apollo', spritesheet('Apollo'))
+    setProfilePetInfo('nova', spritesheet('Nova'))
+
+    render(<PetSlot profile="apollo" />)
+
+    // The slot paints Apollo (its own slice), not Nova.
+    expect(screen.getByLabelText('Apollo pet')).toBeDefined()
+    expect(screen.queryByLabelText('Nova pet')).toBeNull()
+  })
+
+  it('renders nothing when the pet is disabled or has no spritesheet', () => {
+    setProfilePetInfo('apollo', { enabled: false })
+
+    const { container } = render(<PetSlot profile="apollo" />)
+    expect(container.querySelector('canvas')).toBeNull()
+  })
+
+  it('leases the profile gateway on mount and releases on unmount (test 14)', () => {
+    setProfilePetInfo('apollo', spritesheet('Apollo'))
+
+    const { unmount } = render(<PetSlot profile="apollo" />)
+
+    expect(leaseProfileGateway).toHaveBeenCalledWith('apollo')
+    expect(requestGatewayForProfile).toHaveBeenCalledWith('apollo', 'pet.info', { profile: 'apollo' })
+    expect(releaseProfileGateway).not.toHaveBeenCalled()
+
+    unmount()
+    expect(releaseProfileGateway).toHaveBeenCalledWith('apollo')
+  })
+})
+
+describe('MultiPetContainer (test 29)', () => {
+  it('renders nothing when no profiles are enabled', () => {
+    $petRoster.set({ entries: [], initialized: true, mode: 'pinned' })
+
+    const { container } = render(<MultiPetContainer />)
+    expect(container.querySelector('canvas')).toBeNull()
+  })
+
+  it('renders a single pinned non-active profile through the container (not legacy)', () => {
+    $petRoster.set({ entries: [{ enabled: true, profile: 'apollo' }], initialized: true, mode: 'pinned' })
+    $activeGatewayProfile.set('default') // apollo is NOT the active profile
+    setProfilePetInfo('apollo', spritesheet('Apollo'))
+
+    render(<MultiPetContainer />)
+    expect(screen.getByLabelText('Apollo pet')).toBeDefined()
+  })
+
+  it('renders N enabled, available entries in roster order; skips disabled/unavailable', () => {
+    $petRoster.set({
+      entries: [
+        { enabled: true, profile: 'apollo' },
+        { enabled: false, profile: 'nova' },
+        { enabled: true, profile: 'atlas', unavailable: true },
+        { enabled: true, profile: 'vega' }
+      ],
+      initialized: true,
+      mode: 'pinned'
+    })
+    setProfilePetInfo('apollo', spritesheet('Apollo'))
+    setProfilePetInfo('nova', spritesheet('Nova'))
+    setProfilePetInfo('vega', spritesheet('Vega'))
+
+    render(<MultiPetContainer />)
+
+    expect(screen.getByLabelText('Apollo pet')).toBeDefined()
+    expect(screen.getByLabelText('Vega pet')).toBeDefined()
+    // Disabled (nova) and unavailable (atlas) are not observed → not rendered.
+    expect(screen.queryByLabelText('Nova pet')).toBeNull()
+  })
+})
+
+describe('FloatingPet mode branch (test 29)', () => {
+  it('pinned mode renders the MultiPetContainer (a profile slot), not the legacy single pet', () => {
+    $petRoster.set({ entries: [{ enabled: true, profile: 'apollo' }], initialized: true, mode: 'pinned' })
+    setProfilePetInfo('apollo', spritesheet('Apollo'))
+
+    render(<FloatingPet />)
+
+    // The pinned branch mounts the container → the profile slot's sprite shows,
+    // and the slot leased its own gateway.
+    expect(screen.getByLabelText('Apollo pet')).toBeDefined()
+    expect(leaseProfileGateway).toHaveBeenCalledWith('apollo')
+  })
+
+  it('follow-active mode does not render the multi-pet container', () => {
+    // follow-active with a pinned-looking entry still ignores it; the container
+    // (which only renders observed pinned entries) paints nothing.
+    $petRoster.set({ entries: [{ enabled: true, profile: 'apollo' }], initialized: true, mode: 'follow-active' })
+    setProfilePetInfo('apollo', spritesheet('Apollo'))
+
+    render(<MultiPetContainer />)
+    expect(screen.queryByLabelText('Apollo pet')).toBeNull()
+    // The roster slice is still populated (the container just isn't the renderer).
+    expect($profilePets.get().get('apollo')?.info.enabled).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/pet/multi-pet.test.tsx
+++ b/apps/desktop/src/components/pet/multi-pet.test.tsx
@@ -63,7 +63,15 @@ describe('PetSlot (test 13, 14)', () => {
     const { unmount } = render(<PetSlot profile="apollo" />)
 
     expect(leaseProfileGateway).toHaveBeenCalledWith('apollo')
-    expect(requestGatewayForProfile).toHaveBeenCalledWith('apollo', 'pet.info', { profile: 'apollo' })
+    // apollo is a background profile (active = default), so the slot polls the
+    // cheap pet.info.meta first (meta-first budget) through the profile gateway.
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'apollo',
+      'pet.info.meta',
+      { profile: 'apollo' },
+      undefined,
+      undefined
+    )
     expect(releaseProfileGateway).not.toHaveBeenCalled()
 
     unmount()

--- a/apps/desktop/src/components/pet/pet-bubble.tsx
+++ b/apps/desktop/src/components/pet/pet-bubble.tsx
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { useEffect, useState } from 'react'
 
 import { AlertCircle, Clock, type IconComponent } from '@/lib/icons'
-import { $petActivity, $petState, type PetState } from '@/store/pet'
+import { $petActivity, $petState, type PetActivity, type PetState } from '@/store/pet'
 
 /**
  * Speech bubble + status glyph for the popped-out pet overlay — the
@@ -88,9 +88,23 @@ function pick(lines: string[], prev: string): string {
   return next
 }
 
-export function PetBubble() {
-  const state = useStore($petState)
-  const activity = useStore($petActivity)
+interface PetBubbleProps {
+  /** Per-profile override; falls back to the global `$petState` when absent. */
+  state?: PetState
+  /** Per-profile override; falls back to the global `$petActivity` when absent. */
+  activity?: PetActivity
+}
+
+/**
+ * The bubble derives everything from `state` / `activity`. When those props are
+ * absent it reads the global atoms (the single-pet overlay path); a multi-pet
+ * slot injects its own profile's slice so one component serves both surfaces.
+ */
+export function PetBubble({ state: stateProp, activity: activityProp }: PetBubbleProps) {
+  const globalState = useStore($petState)
+  const globalActivity = useStore($petActivity)
+  const state = stateProp ?? globalState
+  const activity = activityProp ?? globalActivity
   const [line, setLine] = useState('')
 
   // Finish beats are carried by the sprite/mail icon; idle only speaks up when

--- a/apps/desktop/src/components/pet/pet-poll.test.ts
+++ b/apps/desktop/src/components/pet/pet-poll.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Layer 8 — polling budget. Cadence tiers (3s bootstrap / 15s foreground /
+ * 30s background / 120s blurred), offline/reauth skip, the single background
+ * lane (foreground never queued behind it), stagger, and the enabled-profile cap.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { PINNED_HARD_CAP, PINNED_SOFT_CAP } from '@/store/pet-roster'
+
+import {
+  createPollLane,
+  petPollInterval,
+  PET_ACTIVE_REFRESH_MS,
+  PET_BG_POLL_CONCURRENCY,
+  PET_BG_POLL_MS,
+  PET_BLURRED_POLL_MS,
+  PET_POLL_MS,
+  staggerOffset
+} from './pet-poll'
+
+describe('petPollInterval cadence (test 62)', () => {
+  it('uses the fast bootstrap cadence until a payload has loaded', () => {
+    expect(petPollInterval({ active: false, blurred: false, loaded: false, offline: false })).toBe(PET_POLL_MS)
+    expect(PET_POLL_MS).toBe(3_000)
+  })
+
+  it('uses the foreground cadence for the loaded active pet', () => {
+    expect(petPollInterval({ active: true, blurred: false, loaded: true, offline: false })).toBe(PET_ACTIVE_REFRESH_MS)
+    expect(PET_ACTIVE_REFRESH_MS).toBe(15_000)
+  })
+
+  it('uses the slower background cadence for loaded non-active profiles', () => {
+    expect(petPollInterval({ active: false, blurred: false, loaded: true, offline: false })).toBe(PET_BG_POLL_MS)
+    expect(PET_BG_POLL_MS).toBe(30_000)
+  })
+
+  it('slows every loaded profile to the blurred cadence when the window is hidden', () => {
+    expect(petPollInterval({ active: true, blurred: true, loaded: true, offline: false })).toBe(PET_BLURRED_POLL_MS)
+    expect(petPollInterval({ active: false, blurred: true, loaded: true, offline: false })).toBe(PET_BLURRED_POLL_MS)
+    expect(PET_BLURRED_POLL_MS).toBe(120_000)
+  })
+
+  it('skips polling entirely while offline or reauth-required', () => {
+    expect(petPollInterval({ active: false, blurred: false, loaded: true, offline: true })).toBeNull()
+    expect(petPollInterval({ active: true, blurred: false, loaded: false, offline: true })).toBeNull()
+  })
+})
+
+describe('background poll lane (test 62)', () => {
+  it('runs at most one background poll at a time', async () => {
+    const lane = createPollLane(PET_BG_POLL_CONCURRENCY)
+    let running = 0
+    let maxRunning = 0
+
+    const task = () =>
+      new Promise<void>(resolve => {
+        running += 1
+        maxRunning = Math.max(maxRunning, running)
+        queueMicrotask(() => {
+          running -= 1
+          resolve()
+        })
+      })
+
+    await Promise.all([lane.runBackground(task), lane.runBackground(task), lane.runBackground(task)])
+
+    expect(maxRunning).toBe(1)
+  })
+
+  it('never queues a foreground poll behind background work', async () => {
+    const lane = createPollLane(1)
+    const order: string[] = []
+
+    // A background task that holds the single lane until released.
+    let release!: () => void
+    const held = lane.runBackground(
+      () =>
+        new Promise<void>(resolve => {
+          release = resolve
+        })
+    )
+
+    // Foreground runs immediately even though the background lane is saturated.
+    await lane.runForeground(async () => {
+      order.push('foreground')
+    })
+
+    expect(order).toEqual(['foreground'])
+
+    release()
+    await held
+  })
+})
+
+describe('stagger', () => {
+  it('spreads background profiles across the window without colliding on tick 0', () => {
+    const a = staggerOffset(0)
+    const b = staggerOffset(1)
+    const c = staggerOffset(2)
+
+    expect(a).toBe(0)
+    expect(b).toBeGreaterThan(0)
+    expect(c).toBeGreaterThan(b)
+    expect(c).toBeLessThan(PET_BG_POLL_MS)
+  })
+})
+
+describe('enabled-profile cap (test 62)', () => {
+  it('bounds enabled pinned profiles (soft warning at 4, hard stop at 8)', () => {
+    expect(PINNED_SOFT_CAP).toBe(4)
+    expect(PINNED_HARD_CAP).toBe(8)
+  })
+})

--- a/apps/desktop/src/components/pet/pet-poll.ts
+++ b/apps/desktop/src/components/pet/pet-poll.ts
@@ -1,0 +1,116 @@
+/**
+ * Layer 8 — pet polling budget.
+ *
+ * Each pinned non-active profile holds a leased socket; polling every one of
+ * them at the foreground rate would keep N backends permanently busy and burn
+ * the spritesheet-bearing `pet.info` payload every few seconds. The budget:
+ *
+ *  - Meta-first: background profiles poll the cheap `pet.info.meta` and only
+ *    fetch the full `pet.info` (base64 spritesheet) when the revision changes.
+ *  - Cadence tiers: fast bootstrap until first payload, a steady foreground
+ *    refresh, a slower background refresh, and a very slow blurred refresh
+ *    (activity/unread/reply are event-driven over the leased sockets, so a slow
+ *    metadata poll is safe when the window is hidden).
+ *  - A single background lane: at most one background meta request at a time,
+ *    staggered across the window. Foreground polling is a separate lane and is
+ *    never queued behind background work.
+ *  - Polls are skipped while a profile is offline or reauth-required.
+ */
+
+/** Bootstrap cadence — until the first full payload lands. */
+export const PET_POLL_MS = 3_000
+/** Loaded foreground (active) pet refresh. */
+export const PET_ACTIVE_REFRESH_MS = 15_000
+/** Loaded non-active (background) profile refresh. */
+export const PET_BG_POLL_MS = 30_000
+/** All loaded profiles when the window is blurred. */
+export const PET_BLURRED_POLL_MS = 120_000
+/** At most one background meta request in flight at a time. */
+export const PET_BG_POLL_CONCURRENCY = 1
+
+export interface PetPollContext {
+  /** This profile is the active/foreground pet. */
+  active: boolean
+  /** The window is blurred (hidden/backgrounded). */
+  blurred: boolean
+  /** A full payload has loaded at least once. */
+  loaded: boolean
+  /** The profile's connection is offline or reauth-required. */
+  offline: boolean
+}
+
+/**
+ * The poll interval (ms) for one profile, or `null` to skip polling entirely
+ * (offline / reauth-required). Blurred wins over the active/background tier —
+ * every loaded profile slows to the blurred cadence when the window is hidden.
+ */
+export function petPollInterval(ctx: PetPollContext): null | number {
+  if (ctx.offline) {
+    return null
+  }
+
+  if (ctx.blurred) {
+    return PET_BLURRED_POLL_MS
+  }
+
+  if (!ctx.loaded) {
+    return PET_POLL_MS
+  }
+
+  return ctx.active ? PET_ACTIVE_REFRESH_MS : PET_BG_POLL_MS
+}
+
+/**
+ * A bounded concurrency lane for background polls. At most `concurrency`
+ * background tasks run at once; the rest queue. `runForeground` bypasses the
+ * queue entirely — a foreground poll is never held behind background work.
+ */
+export interface PollLane {
+  runForeground: <T>(task: () => Promise<T>) => Promise<T>
+  runBackground: <T>(task: () => Promise<T>) => Promise<T>
+  /** Tasks waiting for a background slot. */
+  pending: () => number
+}
+
+export function createPollLane(concurrency: number = PET_BG_POLL_CONCURRENCY): PollLane {
+  let running = 0
+  const queue: Array<() => void> = []
+
+  const drain = (): void => {
+    while (running < concurrency && queue.length > 0) {
+      const start = queue.shift()
+
+      if (start) {
+        running += 1
+        start()
+      }
+    }
+  }
+
+  return {
+    runForeground: task => task(),
+    runBackground: <T>(task: () => Promise<T>): Promise<T> =>
+      new Promise<T>((resolve, reject) => {
+        queue.push(() => {
+          task()
+            .then(resolve, reject)
+            .finally(() => {
+              running -= 1
+              drain()
+            })
+        })
+        drain()
+      }),
+    pending: () => queue.length
+  }
+}
+
+/**
+ * Stagger offset (ms) for the Nth background profile so concurrent profiles
+ * don't all poll on the same tick — spreads them across the background window.
+ */
+export function staggerOffset(index: number, windowMs: number = PET_BG_POLL_MS): number {
+  const count = Math.max(1, index + 1)
+
+  return Math.round((windowMs / Math.max(1, count)) * index) % windowMs
+}

--- a/apps/desktop/src/components/pet/pet-poll.ts
+++ b/apps/desktop/src/components/pet/pet-poll.ts
@@ -114,3 +114,12 @@ export function staggerOffset(index: number, windowMs: number = PET_BG_POLL_MS):
 
   return Math.round((windowMs / Math.max(1, count)) * index) % windowMs
 }
+
+/**
+ * The single shared background-poll lane. Every PetSlot's background meta poll
+ * funnels through here so at most PET_BG_POLL_CONCURRENCY (1) background request
+ * is in flight at a time, regardless of how many profiles are pinned. Foreground
+ * polls bypass it (runForeground). Module-level singleton, like the gallery's
+ * thumbCache — survives slot unmount/remount.
+ */
+export const backgroundPollLane = createPollLane(PET_BG_POLL_CONCURRENCY)

--- a/apps/desktop/src/components/pet/pet-slot.tsx
+++ b/apps/desktop/src/components/pet/pet-slot.tsx
@@ -48,12 +48,41 @@ export function PetSlot({ profile, stateOverride }: PetSlotProps) {
   }, [profile])
 
   if (!info.enabled || !info.spritesheetBase64) {
-    // Layer 8 renders an offline/degraded treatment here when the profile's
-    // connection is down; until then an unloaded pet simply renders nothing.
+    // An unloaded pet renders nothing until its spritesheet arrives.
     return null
   }
 
   const state = stateOverride ?? derivePetState(entry?.activity ?? {})
+  const connection = entry?.connection ?? 'open'
+  const offline = connection === 'offline' || connection === 'reauth-required'
 
-  return <PetSprite info={info} stateOverride={state} />
+  const sprite = <PetSprite info={info} stateOverride={state} />
+
+  if (!offline) {
+    return sprite
+  }
+
+  // Layer 8 offline treatment: a dead/reauth profile desaturates its pet and
+  // badges a disconnect glyph (with the reason on hover) instead of animating
+  // idle forever — "backend down" must read as down, not happy.
+  const reason = connection === 'reauth-required' ? 'Needs sign-in' : 'Backend unreachable'
+
+  return (
+    <span style={{ display: 'inline-block', position: 'relative' }} title={reason}>
+      <span style={{ filter: 'grayscale(1) opacity(0.55)', display: 'inline-block' }}>{sprite}</span>
+      <span
+        aria-label={reason}
+        style={{
+          bottom: 6,
+          color: connection === 'reauth-required' ? '#f59e0b' : '#9ca3af',
+          fontSize: 12,
+          lineHeight: 1,
+          position: 'absolute',
+          right: 2
+        }}
+      >
+        {connection === 'reauth-required' ? '🔑' : '⏻'}
+      </span>
+    </span>
+  )
 }

--- a/apps/desktop/src/components/pet/pet-slot.tsx
+++ b/apps/desktop/src/components/pet/pet-slot.tsx
@@ -1,0 +1,59 @@
+import { useStore } from '@nanostores/react'
+import { useEffect } from 'react'
+
+import { leaseProfileGateway, releaseProfileGateway, requestGatewayForProfile } from '@/store/gateway'
+import { derivePetState, type PetInfo, type PetState } from '@/store/pet'
+import { $profilePets, setProfilePetInfo } from '@/store/pet-multi'
+
+import { PetSprite } from './pet-sprite'
+
+interface PetSlotProps {
+  profile: string
+  /** Highest precedence; when absent the slot derives state from the profile's
+   *  own (session-derived) activity slice. */
+  stateOverride?: PetState
+}
+
+/**
+ * One profile's in-window pet sprite — the multi-pet building block. No bubble
+ * (bubbles are overlay-only). Leases the profile's gateway for the slot's
+ * lifetime so its socket stays alive to stream activity into the profile's
+ * slice, and loads the spritesheet through the profile-addressed `pet.info`
+ * RPC (connection ownership resolved by Electron, never the active gateway).
+ * Renders nothing until the pet is enabled with a loaded spritesheet.
+ */
+export function PetSlot({ profile, stateOverride }: PetSlotProps) {
+  const pets = useStore($profilePets)
+  const entry = pets.get(profile)
+  const info = entry?.info ?? { enabled: false }
+
+  useEffect(() => {
+    leaseProfileGateway(profile)
+
+    let cancelled = false
+    void requestGatewayForProfile<PetInfo>(profile, 'pet.info', { profile })
+      .then(next => {
+        if (!cancelled && next) {
+          setProfilePetInfo(profile, next)
+        }
+      })
+      .catch(() => {
+        // Cosmetic feature — never surface gateway errors on the slot.
+      })
+
+    return () => {
+      cancelled = true
+      releaseProfileGateway(profile)
+    }
+  }, [profile])
+
+  if (!info.enabled || !info.spritesheetBase64) {
+    // Layer 8 renders an offline/degraded treatment here when the profile's
+    // connection is down; until then an unloaded pet simply renders nothing.
+    return null
+  }
+
+  const state = stateOverride ?? derivePetState(entry?.activity ?? {})
+
+  return <PetSprite info={info} stateOverride={state} />
+}

--- a/apps/desktop/src/components/pet/pet-slot.tsx
+++ b/apps/desktop/src/components/pet/pet-slot.tsx
@@ -1,51 +1,157 @@
 import { useStore } from '@nanostores/react'
 import { useEffect } from 'react'
 
-import { leaseProfileGateway, releaseProfileGateway, requestGatewayForProfile } from '@/store/gateway'
+import { leaseProfileGateway, releaseProfileGateway } from '@/store/gateway'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { derivePetState, type PetInfo, type PetState } from '@/store/pet'
 import { $profilePets, setProfilePetInfo } from '@/store/pet-multi'
+import { petRequestFor } from '@/store/pet-transport'
 
+import { backgroundPollLane, petPollInterval, staggerOffset } from './pet-poll'
 import { PetSprite } from './pet-sprite'
 
 interface PetSlotProps {
   profile: string
+  /** Position in the enabled roster — staggers background polls so pinned
+   *  profiles don't all hit their backend on the same tick. */
+  index?: number
   /** Highest precedence; when absent the slot derives state from the profile's
    *  own (session-derived) activity slice. */
   stateOverride?: PetState
+}
+
+/** Cheap `pet.info.meta` payload — no spritesheet, just revision/signature. */
+interface PetInfoMeta {
+  enabled: boolean
+  slug?: string
+  displayName?: string
+  scale?: number
+  spritesheetRevision?: string
+}
+
+/** True when a loaded spritesheet already matches the meta signature, so a
+ *  background poll can skip the full (spritesheet-bearing) `pet.info` fetch. */
+function matchesMeta(info: PetInfo, meta: PetInfoMeta): boolean {
+  return (
+    info.enabled &&
+    Boolean(info.spritesheetBase64) &&
+    info.slug === meta.slug &&
+    info.displayName === meta.displayName &&
+    info.scale === meta.scale &&
+    info.spritesheetRevision === meta.spritesheetRevision
+  )
 }
 
 /**
  * One profile's in-window pet sprite — the multi-pet building block. No bubble
  * (bubbles are overlay-only). Leases the profile's gateway for the slot's
  * lifetime so its socket stays alive to stream activity into the profile's
- * slice, and loads the spritesheet through the profile-addressed `pet.info`
- * RPC (connection ownership resolved by Electron, never the active gateway).
- * Renders nothing until the pet is enabled with a loaded spritesheet.
+ * slice, and polls the profile-addressed pet RPCs (connection ownership resolved
+ * by Electron, never the active gateway) on the Layer-8 budget: meta-first for
+ * background profiles, full `pet.info` only when the revision changes. Renders
+ * nothing until the pet is enabled with a loaded spritesheet.
  */
-export function PetSlot({ profile, stateOverride }: PetSlotProps) {
+export function PetSlot({ profile, index = 0, stateOverride }: PetSlotProps) {
   const pets = useStore($profilePets)
   const entry = pets.get(profile)
   const info = entry?.info ?? { enabled: false }
+  const connection = entry?.connection ?? 'open'
+  const offline = connection === 'offline' || connection === 'reauth-required'
+  const active = normalizeProfileKey(profile) === normalizeProfileKey($activeGatewayProfile.get())
+  const loaded = Boolean(info.spritesheetBase64)
 
   useEffect(() => {
     leaseProfileGateway(profile)
 
-    let cancelled = false
-    void requestGatewayForProfile<PetInfo>(profile, 'pet.info', { profile })
-      .then(next => {
-        if (!cancelled && next) {
-          setProfilePetInfo(profile, next)
-        }
-      })
-      .catch(() => {
-        // Cosmetic feature — never surface gateway errors on the slot.
-      })
-
     return () => {
-      cancelled = true
       releaseProfileGateway(profile)
     }
   }, [profile])
+
+  // Meta-first polling on the Layer-8 budget. The cadence keys off the profile's
+  // role (active vs background), load state, and connection; offline/reauth
+  // profiles skip polling entirely (petPollInterval → null). Background profiles
+  // poll the cheap `pet.info.meta` through the shared single lane and only fetch
+  // the full spritesheet when the revision changes; the active profile polls the
+  // full payload directly (never queued behind background work).
+  useEffect(() => {
+    if (offline) {
+      return
+    }
+
+    const interval = petPollInterval({ active, blurred: false, loaded, offline })
+
+    if (interval === null) {
+      return
+    }
+
+    const request = petRequestFor(profile)
+    let cancelled = false
+
+    const pull = async () => {
+      const isForeground = normalizeProfileKey(profile) === normalizeProfileKey($activeGatewayProfile.get())
+      const run = async () => {
+        // Meta-first for background profiles: skip the spritesheet payload when
+        // the revision is unchanged.
+        if (!isForeground) {
+          try {
+            const meta = await request<PetInfoMeta>('pet.info.meta', { profile })
+
+            if (cancelled) {
+              return
+            }
+
+            if (meta && !meta.enabled) {
+              setProfilePetInfo(profile, { enabled: false })
+
+              return
+            }
+
+            const current = $profilePets.get().get(profile)?.info
+
+            if (meta && current && matchesMeta(current, meta)) {
+              return
+            }
+          } catch {
+            // Older gateways may lack pet.info.meta — fall through to pet.info.
+          }
+        }
+
+        const next = await request<PetInfo>('pet.info', { profile })
+
+        if (!cancelled && next) {
+          setProfilePetInfo(profile, next)
+        }
+      }
+
+      try {
+        if (isForeground) {
+          await backgroundPollLane.runForeground(run)
+        } else {
+          await backgroundPollLane.runBackground(run)
+        }
+      } catch {
+        // Cosmetic feature — never surface gateway errors on the slot.
+      }
+    }
+
+    void pull()
+    // Stagger only the initial background poll; the steady interval is even.
+    const startDelay = active ? 0 : staggerOffset(index)
+    let pollTimer: ReturnType<typeof setInterval> | undefined
+    const startTimer = setTimeout(() => {
+      pollTimer = setInterval(() => void pull(), interval)
+    }, startDelay)
+
+    return () => {
+      cancelled = true
+      clearTimeout(startTimer)
+
+      if (pollTimer) {
+        clearInterval(pollTimer)
+      }
+    }
+  }, [profile, active, loaded, offline, index])
 
   if (!info.enabled || !info.spritesheetBase64) {
     // An unloaded pet renders nothing until its spritesheet arrives.
@@ -53,8 +159,6 @@ export function PetSlot({ profile, stateOverride }: PetSlotProps) {
   }
 
   const state = stateOverride ?? derivePetState(entry?.activity ?? {})
-  const connection = entry?.connection ?? 'open'
-  const offline = connection === 'offline' || connection === 'reauth-required'
 
   const sprite = <PetSprite info={info} stateOverride={state} />
 

--- a/apps/desktop/src/components/pet/use-pet-roster-reconciliation.ts
+++ b/apps/desktop/src/components/pet/use-pet-roster-reconciliation.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+
+import { $profiles, $profilesLoaded } from '@/store/profile'
+import { reconcilePetRoster } from '@/store/pet-roster'
+
+/**
+ * Keep the pinned pet roster reconciled with the live profile catalog (Layer 7).
+ * useEffect-owned (not a bare module-level subscribe) so it survives HMR without
+ * duplicating lease releases, and returns a disposer on unmount. Gates on
+ * `$profilesLoaded` so the initial empty catalog is never read as "every pinned
+ * profile was deleted".
+ */
+export function usePetRosterReconciliation(): void {
+  useEffect(() => {
+    const reconcile = () => {
+      if ($profilesLoaded.get()) {
+        reconcilePetRoster($profiles.get())
+      }
+    }
+
+    reconcile()
+
+    const offProfiles = $profiles.listen(reconcile)
+    const offLoaded = $profilesLoaded.listen(reconcile)
+
+    return () => {
+      offProfiles()
+      offLoaded()
+    }
+  }, [])
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -45,15 +45,20 @@ declare global {
       // the mascot. The main renderer drives it (open/close/drag + state push);
       // the overlay sends control messages back (pop-in, composer submit).
       petOverlay: {
-        open: (request: PetOverlayOpenRequest) => Promise<{ ok: boolean; bounds?: PetOverlayBounds }>
-        close: () => Promise<{ ok: boolean }>
+        // Lifecycle + state are profile-addressed (one overlay per profile) and
+        // PRIMARY-RENDERER-ONLY — main verifies the sender.
+        open: (profile: string, request: PetOverlayOpenRequest) => Promise<{ ok: boolean; bounds?: PetOverlayBounds }>
+        close: (profile: string) => Promise<{ ok: boolean }>
+        // Per-window channels are BOUND-OVERLAY-ONLY: main derives the profile
+        // from the sender, so no profile is supplied here.
         setBounds: (bounds: PetOverlayBounds) => void
         setIgnoreMouse: (ignore: boolean) => void
         setFocusable: (focusable: boolean) => void
-        pushState: (payload: PetOverlayStatePayload) => void
+        pushState: (profile: string, payload: PetOverlayStatePayload) => void
         control: (payload: PetOverlayControl) => void
         onState: (callback: (payload: PetOverlayStatePayload) => void) => () => void
-        onControl: (callback: (payload: PetOverlayControl) => void) => () => void
+        // main attaches the sender-derived `profile` before forwarding control.
+        onControl: (callback: (payload: PetOverlayControl & { profile?: string }) => void) => () => void
       }
       getBootProgress: () => Promise<DesktopBootProgress>
       getConnectionConfig: (profile?: null | string) => Promise<DesktopConnectionConfig>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -453,7 +453,28 @@ export const ar = defineLocale({
         exportFailed: slug => `تعذّر تصدير ${slug}`,
         noneAvailable: 'لا توجد حيوانات أليفة متاحة للتشغيل الآن.',
         turnOnFailed: 'تعذّر تشغيل الحيوان الأليف.',
-        turnOffFailed: 'تعذّر إيقاف الحيوان الأليف.'
+        turnOffFailed: 'تعذّر إيقاف الحيوان الأليف.',
+        multiPet: {
+          modeTitle: 'حيوانات سطح المكتب',
+          modeDesc: 'اختر كيف يتابع التميمة العائمة ملفاتك الشخصية.',
+          followActive: 'متابعة النشط',
+          pinned: 'مثبّت',
+          rosterTitle: 'الملفات المثبّتة',
+          rosterDesc: 'اعرض حيوانًا أليفًا لكل ملف مثبّت في الوقت نفسه.',
+          profilePet: profile => `حيوان ${profile}`,
+          connectionOnline: 'متصل',
+          connectionOffline: 'غير متصل',
+          connectionReauth: 'يتطلب تسجيل الدخول',
+          connectionConnecting: 'جارٍ الاتصال',
+          unavailable: 'غير موجود',
+          unavailableDesc: 'لم يتم العثور على الملف — ربما أعيدت تسميته أو حُذف.',
+          removeAction: 'إزالة',
+          enableAction: 'تفعيل',
+          softCapWarning: n => `لديك ${n} حيوانات مثبّتة. يحتفظ كل منها باتصال مباشر مع ملفه.`,
+          hardCapNotice: n => `يمكنك تثبيت ما يصل إلى ${n} ملفات. عطّل واحدًا لإضافة آخر.`,
+          noActiveSession: profile => `لا توجد جلسة نشطة للرد عليها في "${profile}".`,
+          cannotQueueNoDurable: profile => `"${profile}" مشغول ولا يمكن وضعه في القائمة دون جلسة دائمة.`
+        }
       }
     },
     fieldLabels: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -494,7 +494,28 @@ export const en: Translations = {
         exportFailed: slug => `Could not export ${slug}`,
         noneAvailable: 'No pets available to turn on right now.',
         turnOnFailed: 'Could not turn the pet on.',
-        turnOffFailed: 'Could not turn the pet off.'
+        turnOffFailed: 'Could not turn the pet off.',
+        multiPet: {
+          modeTitle: 'Desktop pets',
+          modeDesc: 'Choose how the floating mascot follows your profiles.',
+          followActive: 'Follow Active',
+          pinned: 'Pinned',
+          rosterTitle: 'Pinned profiles',
+          rosterDesc: 'Show a pet for each pinned profile at the same time.',
+          profilePet: profile => `${profile} pet`,
+          connectionOnline: 'Online',
+          connectionOffline: 'Offline',
+          connectionReauth: 'Needs sign-in',
+          connectionConnecting: 'Connecting',
+          unavailable: 'Not found',
+          unavailableDesc: 'Profile not found — it may have been renamed or deleted.',
+          removeAction: 'Remove',
+          enableAction: 'Enable',
+          softCapWarning: n => `You have ${n} pets pinned. Each one keeps a live connection to its profile.`,
+          hardCapNotice: n => `You can pin up to ${n} profiles. Disable one to add another.`,
+          noActiveSession: profile => `No active session to reply to on "${profile}".`,
+          cannotQueueNoDurable: profile => `"${profile}" is busy and can't be queued without a durable session.`
+        }
       }
     },
     fieldLabels: FIELD_LABELS,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -380,7 +380,28 @@ export const ja = defineLocale({
         exportFailed: slug => `${slug} をエクスポートできませんでした`,
         noneAvailable: 'オンにできるペットがありません。',
         turnOnFailed: 'ペットをオンにできませんでした。',
-        turnOffFailed: 'ペットをオフにできませんでした。'
+        turnOffFailed: 'ペットをオフにできませんでした。',
+        multiPet: {
+          modeTitle: 'デスクトップペット',
+          modeDesc: 'フローティングマスコットがプロファイルに追随する方法を選択します。',
+          followActive: 'アクティブに追随',
+          pinned: 'ピン留め',
+          rosterTitle: 'ピン留めしたプロファイル',
+          rosterDesc: 'ピン留めした各プロファイルのペットを同時に表示します。',
+          profilePet: profile => `${profile} のペット`,
+          connectionOnline: 'オンライン',
+          connectionOffline: 'オフライン',
+          connectionReauth: 'サインインが必要',
+          connectionConnecting: '接続中',
+          unavailable: '見つかりません',
+          unavailableDesc: 'プロファイルが見つかりません。名前変更または削除された可能性があります。',
+          removeAction: '削除',
+          enableAction: '有効化',
+          softCapWarning: n => `${n} 匹のペットをピン留めしています。各ペットはプロファイルへの接続を維持します。`,
+          hardCapNotice: n => `最大 ${n} 個のプロファイルをピン留めできます。追加するには1つ無効にしてください。`,
+          noActiveSession: profile => `"${profile}" には返信先のアクティブなセッションがありません。`,
+          cannotQueueNoDurable: profile => `"${profile}" はビジーで、永続セッションがないためキューに追加できません。`
+        }
       }
     },
     fieldLabels: defineFieldCopy({

--- a/apps/desktop/src/i18n/multi-pet.test.ts
+++ b/apps/desktop/src/i18n/multi-pet.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { TRANSLATIONS } from './catalog'
+import type { Locale } from './types'
+
+const LOCALES = Object.keys(TRANSLATIONS) as Locale[]
+
+// The multi-pet copy added in PR4. Every locale must define the whole section —
+// the type system enforces presence at compile time; this pins the runtime shape
+// (string vs. parameterized function arity) so a locale can't ship a stub that
+// type-checks but renders "undefined" or throws at call time (test 50).
+const STRING_KEYS = [
+  'modeTitle',
+  'modeDesc',
+  'followActive',
+  'pinned',
+  'rosterTitle',
+  'rosterDesc',
+  'connectionOnline',
+  'connectionOffline',
+  'connectionReauth',
+  'connectionConnecting',
+  'unavailable',
+  'unavailableDesc',
+  'removeAction',
+  'enableAction'
+] as const
+
+describe('multi-pet i18n parity (test 50)', () => {
+  it.each(LOCALES)('locale "%s" defines every multiPet string key', locale => {
+    const multiPet = TRANSLATIONS[locale].settings.appearance.pet.multiPet
+
+    for (const key of STRING_KEYS) {
+      expect(typeof multiPet[key], `${locale}.multiPet.${key}`).toBe('string')
+      expect((multiPet[key] as string).length, `${locale}.multiPet.${key} non-empty`).toBeGreaterThan(0)
+    }
+  })
+
+  it.each(LOCALES)('locale "%s" parameterized multiPet keys return a string', locale => {
+    const multiPet = TRANSLATIONS[locale].settings.appearance.pet.multiPet
+
+    expect(typeof multiPet.profilePet('nova')).toBe('string')
+    expect(typeof multiPet.softCapWarning(4)).toBe('string')
+    expect(typeof multiPet.hardCapNotice(8)).toBe('string')
+    expect(typeof multiPet.noActiveSession('nova')).toBe('string')
+    expect(typeof multiPet.cannotQueueNoDurable('nova')).toBe('string')
+  })
+
+  it('interpolates the profile name into the inline notice copy', () => {
+    // The English source of truth embeds the profile; guards against a locale
+    // accidentally dropping the interpolation argument.
+    expect(TRANSLATIONS.en.settings.appearance.pet.multiPet.noActiveSession('apollo')).toContain('apollo')
+  })
+})

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -402,6 +402,27 @@ export interface Translations {
         noneAvailable: string
         turnOnFailed: string
         turnOffFailed: string
+        multiPet: {
+          modeTitle: string
+          modeDesc: string
+          followActive: string
+          pinned: string
+          rosterTitle: string
+          rosterDesc: string
+          profilePet: (profile: string) => string
+          connectionOnline: string
+          connectionOffline: string
+          connectionReauth: string
+          connectionConnecting: string
+          unavailable: string
+          unavailableDesc: string
+          removeAction: string
+          enableAction: string
+          softCapWarning: (n: number) => string
+          hardCapNotice: (n: number) => string
+          noActiveSession: (profile: string) => string
+          cannotQueueNoDurable: (profile: string) => string
+        }
       }
     }
     fieldLabels: Record<string, string>

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -369,7 +369,28 @@ export const zhHant = defineLocale({
         exportFailed: slug => `無法匯出 ${slug}`,
         noneAvailable: '目前沒有可開啟的寵物。',
         turnOnFailed: '無法開啟寵物。',
-        turnOffFailed: '無法關閉寵物。'
+        turnOffFailed: '無法關閉寵物。',
+        multiPet: {
+          modeTitle: '桌面寵物',
+          modeDesc: '選擇浮動吉祥物如何跟隨你的設定檔。',
+          followActive: '跟隨當前',
+          pinned: '固定',
+          rosterTitle: '固定的設定檔',
+          rosterDesc: '同時為每個固定的設定檔顯示一隻寵物。',
+          profilePet: profile => `${profile} 寵物`,
+          connectionOnline: '線上',
+          connectionOffline: '離線',
+          connectionReauth: '需要登入',
+          connectionConnecting: '連線中',
+          unavailable: '未找到',
+          unavailableDesc: '未找到該設定檔——它可能已被重新命名或刪除。',
+          removeAction: '移除',
+          enableAction: '啟用',
+          softCapWarning: n => `你已固定 ${n} 隻寵物，每隻都會保持與其設定檔的即時連線。`,
+          hardCapNotice: n => `最多可固定 ${n} 個設定檔。請先停用一個再新增。`,
+          noActiveSession: profile => `"${profile}" 沒有可回覆的使用中工作階段。`,
+          cannotQueueNoDurable: profile => `"${profile}" 正忙，且沒有持久工作階段，無法加入佇列。`
+        }
       }
     },
     fieldLabels: defineFieldCopy({

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -481,7 +481,28 @@ export const zh: Translations = {
         exportFailed: slug => `无法导出 ${slug}`,
         noneAvailable: '当前没有可开启的宠物。',
         turnOnFailed: '无法开启宠物。',
-        turnOffFailed: '无法关闭宠物。'
+        turnOffFailed: '无法关闭宠物。',
+        multiPet: {
+          modeTitle: '桌面宠物',
+          modeDesc: '选择浮动吉祥物如何跟随你的配置。',
+          followActive: '跟随当前',
+          pinned: '固定',
+          rosterTitle: '固定的配置',
+          rosterDesc: '同时为每个固定的配置显示一只宠物。',
+          profilePet: profile => `${profile} 宠物`,
+          connectionOnline: '在线',
+          connectionOffline: '离线',
+          connectionReauth: '需要登录',
+          connectionConnecting: '连接中',
+          unavailable: '未找到',
+          unavailableDesc: '未找到该配置——它可能已被重命名或删除。',
+          removeAction: '移除',
+          enableAction: '启用',
+          softCapWarning: n => `你已固定 ${n} 只宠物，每只都会保持与其配置的实时连接。`,
+          hardCapNotice: n => `最多可固定 ${n} 个配置。请先禁用一个再添加。`,
+          noActiveSession: profile => `"${profile}" 没有可回复的活动会话。`,
+          cannotQueueNoDurable: profile => `"${profile}" 正忙，且没有持久会话，无法加入队列。`
+        }
       }
     },
     fieldLabels: defineFieldCopy({

--- a/apps/desktop/src/store/composer-queue-profile.test.ts
+++ b/apps/desktop/src/store/composer-queue-profile.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Layer 6c — durable queue ownership (v2). Profile-less (v1 / legacy) buckets
+ * must be re-attributed by an aggregate-FIRST ownership probe that never guesses:
+ * exactly one owner attaches the bucket to that profile; zero / ambiguous /
+ * indeterminate leave it queued (never routed through the active gateway).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getSession, listAllProfileSessions } from '@/hermes'
+import {
+  $queuedPromptsBySession,
+  profileQueueKey,
+  resolveLegacyQueueBucket,
+  resolveUniqueSessionProfile
+} from '@/store/composer-queue'
+
+vi.mock('@/hermes', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hermes')>()
+
+  return {
+    ...actual,
+    getSession: vi.fn(async () => {
+      throw new Error('not found')
+    }),
+    listAllProfileSessions: vi.fn(async () => ({ sessions: [] }))
+  }
+})
+
+const listSessions = vi.mocked(listAllProfileSessions)
+const getSessionMock = vi.mocked(getSession)
+
+const entry = (id: string, text = 'queued') => ({ attachments: [], id, queuedAt: 1, text })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  $queuedPromptsBySession.set({})
+  listSessions.mockResolvedValue({ sessions: [] } as never)
+})
+
+describe('resolveUniqueSessionProfile (test 57)', () => {
+  it('collapses a single owning profile to {one}', async () => {
+    listSessions.mockResolvedValue({
+      sessions: [
+        { id: 'stored-1', profile: 'apollo' },
+        { id: 'stored-1', profile: 'apollo' }
+      ]
+    } as never)
+
+    expect(await resolveUniqueSessionProfile('stored-1')).toEqual({ kind: 'one', profile: 'apollo' })
+    // Aggregate-first: one request, archived INCLUDED.
+    expect(listSessions).toHaveBeenCalledWith(500, 0, 'include', 'recent', 'all')
+  })
+
+  it('matches on the lineage root id too', async () => {
+    listSessions.mockResolvedValue({
+      sessions: [{ _lineage_root_id: 'root-1', id: 'tip-1', profile: 'nova' }]
+    } as never)
+
+    expect(await resolveUniqueSessionProfile('root-1')).toEqual({ kind: 'one', profile: 'nova' })
+  })
+
+  it('reports ambiguous when two profiles own the id', async () => {
+    listSessions.mockResolvedValue({
+      sessions: [
+        { id: 'stored-1', profile: 'apollo' },
+        { id: 'stored-1', profile: 'nova' }
+      ]
+    } as never)
+
+    expect(await resolveUniqueSessionProfile('stored-1')).toEqual({ kind: 'ambiguous' })
+  })
+
+  it('reports none when a successful aggregate has no match', async () => {
+    listSessions.mockResolvedValue({ sessions: [{ id: 'other', profile: 'apollo' }] } as never)
+
+    expect(await resolveUniqueSessionProfile('stored-1')).toEqual({ kind: 'none' })
+  })
+
+  it('reports indeterminate when the aggregate request fails (never probe blindly)', async () => {
+    listSessions.mockRejectedValue(new Error('backend down'))
+
+    expect(await resolveUniqueSessionProfile('stored-1')).toEqual({ kind: 'indeterminate' })
+    expect(getSessionMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveLegacyQueueBucket (tests 45, 46)', () => {
+  it('attaches a single-owner bucket to its profile and stamps every entry (test 45)', async () => {
+    listSessions.mockResolvedValue({ sessions: [{ id: 'stored-1', profile: 'apollo' }] } as never)
+    $queuedPromptsBySession.set({ 'stored-1': [entry('a'), entry('b')] })
+
+    const ownership = await resolveLegacyQueueBucket('stored-1')
+
+    expect(ownership).toEqual({ kind: 'one', profile: 'apollo' })
+
+    const state = $queuedPromptsBySession.get()
+
+    // Moved off the bare key onto the composite profile bucket, profile stamped.
+    expect(state['stored-1']).toBeUndefined()
+    const moved = state[profileQueueKey('apollo', 'stored-1')]
+
+    expect(moved).toHaveLength(2)
+    expect(moved.every(e => e.profile === 'apollo')).toBe(true)
+    expect(moved.map(e => e.id)).toEqual(['a', 'b'])
+  })
+
+  it('leaves an ambiguous bucket queued and unmodified (test 46)', async () => {
+    listSessions.mockResolvedValue({
+      sessions: [
+        { id: 'stored-1', profile: 'apollo' },
+        { id: 'stored-1', profile: 'nova' }
+      ]
+    } as never)
+    $queuedPromptsBySession.set({ 'stored-1': [entry('a')] })
+
+    const ownership = await resolveLegacyQueueBucket('stored-1')
+
+    expect(ownership).toEqual({ kind: 'ambiguous' })
+
+    const state = $queuedPromptsBySession.get()
+
+    // Untouched: still under the bare key, no profile stamped.
+    expect(state['stored-1']).toHaveLength(1)
+    expect(state['stored-1'][0].profile).toBeUndefined()
+    expect(state[profileQueueKey('apollo', 'stored-1')]).toBeUndefined()
+  })
+
+  it('leaves an indeterminate bucket queued (never guess)', async () => {
+    listSessions.mockRejectedValue(new Error('backend down'))
+    $queuedPromptsBySession.set({ 'stored-1': [entry('a')] })
+
+    const ownership = await resolveLegacyQueueBucket('stored-1')
+
+    expect(ownership).toEqual({ kind: 'indeterminate' })
+    expect($queuedPromptsBySession.get()['stored-1']).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComposerAttachment } from './composer'
 import {
@@ -20,7 +20,37 @@ import {
 } from './composer-queue'
 
 const SESSION_KEY = 'session-abc'
-const QUEUE_STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
+// PR3 persists under v2 (nested { version, byProfile, legacy }); v1 is read only
+// as a migration source.
+const QUEUE_STORAGE_KEY_V1 = 'hermes.desktop.composerQueue.v1'
+const QUEUE_STORAGE_KEY_V2 = 'hermes.desktop.composerQueue.v2'
+
+// The test runtime ships without a usable localStorage; install an in-memory one
+// so the persistence/migration assertions actually exercise the v2 storage path.
+function installLocalStorageMock(): void {
+  const store = new Map<string, string>()
+  const mock = {
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    removeItem: (key: string) => void store.delete(key),
+    setItem: (key: string, value: string) => void store.set(key, String(value))
+  }
+
+  try {
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: mock, writable: true })
+  } catch {
+    ;(window as { localStorage?: unknown }).localStorage = mock
+  }
+}
+
+beforeAll(() => {
+  installLocalStorageMock()
+})
+
+function clearQueueStorage(): void {
+  window.localStorage.removeItem(QUEUE_STORAGE_KEY_V1)
+  window.localStorage.removeItem(QUEUE_STORAGE_KEY_V2)
+}
 
 function attachment(id: string, kind: ComposerAttachment['kind'] = 'file'): ComposerAttachment {
   return {
@@ -33,7 +63,7 @@ function attachment(id: string, kind: ComposerAttachment['kind'] = 'file'): Comp
 
 describe('composer queue store', () => {
   beforeEach(() => {
-    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    clearQueueStorage()
     $queuedPromptsBySession.set({})
   })
 
@@ -108,23 +138,33 @@ describe('composer queue store', () => {
 
     expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
     expect($queuedPromptsBySession.get()[SESSION_KEY]).toBeUndefined()
-    expect(window.localStorage.getItem(QUEUE_STORAGE_KEY)).toBeNull()
+    // An empty queue removes the v2 key entirely.
+    expect(window.localStorage.getItem(QUEUE_STORAGE_KEY_V2)).toBeNull()
   })
 
-  it('persists queue entries into local storage', () => {
+  it('persists queue entries into local storage (v2, profile-nested)', () => {
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'persist me' })
 
-    const raw = window.localStorage.getItem(QUEUE_STORAGE_KEY)
+    const raw = window.localStorage.getItem(QUEUE_STORAGE_KEY_V2)
     expect(raw).toBeTruthy()
 
-    const parsed = JSON.parse(String(raw)) as Record<string, { text: string }[]>
-    expect(parsed[SESSION_KEY]?.[0]?.text).toBe('persist me')
+    // Foreground entries carry no profile, so they nest under `legacy` keyed by
+    // storedSessionId; profile-targeted entries would nest under `byProfile`.
+    const parsed = JSON.parse(String(raw)) as {
+      version: number
+      byProfile: Record<string, Record<string, { text: string }[]>>
+      legacy: Record<string, { text: string }[]>
+    }
+
+    expect(parsed.version).toBe(2)
+    expect(parsed.legacy[SESSION_KEY]?.[0]?.text).toBe('persist me')
   })
 })
 
 describe('migrateQueuedPrompts', () => {
   beforeEach(() => {
-    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY_V1)
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY_V2)
     $queuedPromptsBySession.set({})
   })
 
@@ -185,7 +225,8 @@ describe('shouldAutoDrain', () => {
 
 describe('parked queue sessions', () => {
   beforeEach(() => {
-    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY_V1)
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY_V2)
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
   })
@@ -245,5 +286,33 @@ describe('parked queue sessions', () => {
     migrateQueuedPrompts('rt-old', 'rt-new')
 
     expect(isQueueParked('rt-new')).toBe(false)
+  })
+})
+
+describe('v1 → v2 storage migration', () => {
+  it('migrates flat v1 buckets into v2 legacy and removes the v1 key only after the write', async () => {
+    // Seed a flat v1 queue as an older build would have left it.
+    window.localStorage.setItem(
+      QUEUE_STORAGE_KEY_V1,
+      JSON.stringify({ 'stored-1': [{ attachments: [], id: 'q-1', queuedAt: 1, text: 'legacy prompt' }] })
+    )
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY_V2)
+
+    // A fresh module load runs the migration in load().
+    vi.resetModules()
+    const migrated = await import('./composer-queue')
+
+    // The legacy bucket loads under its bare storedSessionId, profile-less.
+    expect(migrated.getQueuedPrompts('stored-1').map(entry => entry.text)).toEqual(['legacy prompt'])
+
+    // Persisted as nested v2 under `legacy`; the v1 key is gone.
+    const v2 = JSON.parse(String(window.localStorage.getItem(QUEUE_STORAGE_KEY_V2))) as {
+      legacy: Record<string, { text: string }[]>
+      version: number
+    }
+
+    expect(v2.version).toBe(2)
+    expect(v2.legacy['stored-1']?.[0]?.text).toBe('legacy prompt')
+    expect(window.localStorage.getItem(QUEUE_STORAGE_KEY_V1)).toBeNull()
   })
 })

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -1,5 +1,10 @@
 import { atom } from 'nanostores'
 
+import { getSession, listAllProfileSessions } from '@/hermes'
+import { normalizeProfileKey } from '@/store/profile'
+import { sessionMatchesStoredId } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
 import type { ComposerAttachment } from './composer'
 
 export interface QueuedPromptEntry {
@@ -7,11 +12,156 @@ export interface QueuedPromptEntry {
   text: string
   attachments: ComposerAttachment[]
   queuedAt: number
+  /** Owning profile for a background (profile-targeted) queue. Absent for
+   *  foreground/legacy entries, which drain through the active gateway. */
+  profile?: string
 }
 
+// In-memory the queue stays a flat map so the many consumers (composer panel,
+// background drain, session actions) keep reading it unchanged. The KEY is a
+// bare storedSessionId for foreground/legacy entries, or a composite
+// `${profile}::${storedSessionId}` for background entries (see profileQueueKey).
 type QueueState = Record<string, QueuedPromptEntry[]>
 
-const STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
+const PROFILE_KEY_SEP = '::'
+
+/** Composite in-memory/storage key for a background profile's queue bucket. */
+export function profileQueueKey(profile: string, storedSessionId: string): string {
+  return `${normalizeProfileKey(profile)}${PROFILE_KEY_SEP}${storedSessionId}`
+}
+
+// Persisted shape (v2): profile-nested. `byProfile[profile][storedSessionId]`
+// holds profile-owned buckets; `legacy[storedSessionId]` holds profile-less v1
+// buckets pending ownership resolution. v1 was a flat Record<storedSessionId,
+// entries[]> under a separate key.
+interface QueueStorageV2 {
+  version: 2
+  byProfile: Record<string, Record<string, QueuedPromptEntry[]>>
+  legacy: Record<string, QueuedPromptEntry[]>
+}
+
+const STORAGE_KEY_V1 = 'hermes.desktop.composerQueue.v1'
+const STORAGE_KEY_V2 = 'hermes.desktop.composerQueue.v2'
+
+function validEntry(value: unknown): QueuedPromptEntry | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const raw = value as Record<string, unknown>
+
+  if (typeof raw.id !== 'string' || typeof raw.text !== 'string' || typeof raw.queuedAt !== 'number') {
+    return null
+  }
+
+  const entry: QueuedPromptEntry = {
+    attachments: Array.isArray(raw.attachments) ? (raw.attachments as ComposerAttachment[]) : [],
+    id: raw.id,
+    queuedAt: raw.queuedAt,
+    text: raw.text
+  }
+
+  if (typeof raw.profile === 'string' && raw.profile.trim()) {
+    entry.profile = normalizeProfileKey(raw.profile)
+  }
+
+  return entry
+}
+
+function validBucket(value: unknown): QueuedPromptEntry[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.map(validEntry).filter((e): e is QueuedPromptEntry => e !== null)
+}
+
+// Flatten the nested v2 storage into the in-memory flat map (composite keys for
+// profile buckets, bare storedSessionId for legacy).
+function flattenV2(parsed: unknown): QueueState {
+  const state: QueueState = {}
+
+  if (!parsed || typeof parsed !== 'object') {
+    return state
+  }
+
+  const raw = parsed as Partial<QueueStorageV2>
+
+  if (raw.byProfile && typeof raw.byProfile === 'object') {
+    for (const [profile, buckets] of Object.entries(raw.byProfile)) {
+      if (!buckets || typeof buckets !== 'object') {
+        continue
+      }
+
+      for (const [sid, entries] of Object.entries(buckets)) {
+        const valid = validBucket(entries).map(e => ({ ...e, profile: normalizeProfileKey(profile) }))
+
+        if (valid.length) {
+          state[profileQueueKey(profile, sid)] = valid
+        }
+      }
+    }
+  }
+
+  if (raw.legacy && typeof raw.legacy === 'object') {
+    for (const [sid, entries] of Object.entries(raw.legacy)) {
+      const valid = validBucket(entries)
+
+      if (valid.length) {
+        state[sid] = valid
+      }
+    }
+  }
+
+  return state
+}
+
+// Serialize the flat in-memory map back into the nested v2 shape. Profile-stamped
+// entries nest under byProfile; everything else stays legacy.
+function toStorageV2(state: QueueState): QueueStorageV2 {
+  const byProfile: Record<string, Record<string, QueuedPromptEntry[]>> = {}
+  const legacy: Record<string, QueuedPromptEntry[]> = {}
+
+  for (const [key, entries] of Object.entries(state)) {
+    if (!entries.length) {
+      continue
+    }
+
+    const profile = entries[0]?.profile
+
+    if (profile) {
+      const sid = key.startsWith(`${profile}${PROFILE_KEY_SEP}`) ? key.slice(profile.length + PROFILE_KEY_SEP.length) : key
+      ;(byProfile[profile] ??= {})[sid] = entries
+    } else {
+      legacy[key] = entries
+    }
+  }
+
+  return { byProfile, legacy, version: 2 }
+}
+
+// Persist v2; reports failure (so the v1 migration only removes the v1 key AFTER
+// a confirmed write). Best-effort otherwise: storage may be unavailable, the
+// queue still works in-memory.
+function saveV2(state: QueueState): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  try {
+    const serialized = toStorageV2(state)
+
+    if (Object.keys(serialized.byProfile).length === 0 && Object.keys(serialized.legacy).length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY_V2)
+    } else {
+      window.localStorage.setItem(STORAGE_KEY_V2, JSON.stringify(serialized))
+    }
+
+    return true
+  } catch {
+    return false
+  }
+}
 
 const load = (): QueueState => {
   if (typeof window === 'undefined') {
@@ -19,29 +169,47 @@ const load = (): QueueState => {
   }
 
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
-    const parsed = raw ? JSON.parse(raw) : null
+    const rawV2 = window.localStorage.getItem(STORAGE_KEY_V2)
 
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as QueueState) : {}
+    if (rawV2) {
+      return flattenV2(JSON.parse(rawV2))
+    }
+
+    // v1 migration: a flat Record<storedSessionId, entries[]>. Entries keep no
+    // profile, so they land in `legacy` and drain through the active gateway
+    // (backwards compat) until ownership resolution re-attributes them.
+    const rawV1 = window.localStorage.getItem(STORAGE_KEY_V1)
+
+    if (rawV1) {
+      const parsed = JSON.parse(rawV1)
+      const state: QueueState = {}
+
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        for (const [sid, entries] of Object.entries(parsed as Record<string, unknown>)) {
+          const valid = validBucket(entries)
+
+          if (valid.length) {
+            state[sid] = valid
+          }
+        }
+      }
+
+      // Remove the v1 key ONLY after the v2 write succeeds.
+      if (saveV2(state)) {
+        window.localStorage.removeItem(STORAGE_KEY_V1)
+      }
+
+      return state
+    }
   } catch {
-    return {}
+    // fall through to empty
   }
+
+  return {}
 }
 
 const save = (state: QueueState) => {
-  if (typeof window === 'undefined') {
-    return
-  }
-
-  try {
-    if (Object.keys(state).length === 0) {
-      window.localStorage.removeItem(STORAGE_KEY)
-    } else {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
-    }
-  } catch {
-    // best-effort: storage may be unavailable, queue still works in-memory
-  }
+  saveV2(state)
 }
 
 export const $queuedPromptsBySession = atom<QueueState>(load())
@@ -96,23 +264,41 @@ const sidOf = (key: string | null | undefined): null | string => {
   return trimmed ? trimmed : null
 }
 
+/** A queue address: a bare storedSessionId string (foreground/legacy) or an
+ *  explicit `{ profile, storedSessionId }` (background profile-targeted). */
+export type QueueKey = string | { profile?: string; storedSessionId: string } | null | undefined
+
+const keyOf = (key: QueueKey): null | string => {
+  if (key && typeof key === 'object') {
+    const sid = key.storedSessionId?.trim()
+
+    if (!sid) {
+      return null
+    }
+
+    return key.profile ? profileQueueKey(key.profile, sid) : sid
+  }
+
+  return sidOf(key)
+}
+
 const queueFor = (sid: string) => $queuedPromptsBySession.get()[sid] ?? []
 
 const nextId = () => `queued-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
 const cloneAttachments = (attachments: ComposerAttachment[]) => attachments.map(a => ({ ...a }))
 
-export const getQueuedPrompts = (key: string | null | undefined): QueuedPromptEntry[] => {
-  const sid = sidOf(key)
+export const getQueuedPrompts = (key: QueueKey): QueuedPromptEntry[] => {
+  const sid = keyOf(key)
 
   return sid ? queueFor(sid) : []
 }
 
 export const enqueueQueuedPrompt = (
-  key: string | null | undefined,
-  payload: { text: string; attachments: ComposerAttachment[] }
+  key: QueueKey,
+  payload: { text: string; attachments: ComposerAttachment[]; profile?: string }
 ): null | QueuedPromptEntry => {
-  const sid = sidOf(key)
+  const sid = keyOf(key)
 
   if (!sid) {
     return null
@@ -125,6 +311,10 @@ export const enqueueQueuedPrompt = (
     queuedAt: Date.now()
   }
 
+  if (payload.profile) {
+    entry.profile = normalizeProfileKey(payload.profile)
+  }
+
   writeSession(sid, [...queueFor(sid), entry])
   // Queueing a new prompt is fresh intent to keep the conversation moving —
   // a park from an earlier Stop must not hold this (or the entries ahead of
@@ -134,8 +324,8 @@ export const enqueueQueuedPrompt = (
   return entry
 }
 
-export const dequeueQueuedPrompt = (key: string | null | undefined): null | QueuedPromptEntry => {
-  const sid = sidOf(key)
+export const dequeueQueuedPrompt = (key: QueueKey): null | QueuedPromptEntry => {
+  const sid = keyOf(key)
 
   if (!sid) {
     return null
@@ -152,8 +342,8 @@ export const dequeueQueuedPrompt = (key: string | null | undefined): null | Queu
   return head
 }
 
-export const removeQueuedPrompt = (key: string | null | undefined, id: string): boolean => {
-  const sid = sidOf(key)
+export const removeQueuedPrompt = (key: QueueKey, id: string): boolean => {
+  const sid = keyOf(key)
 
   if (!sid) {
     return false
@@ -346,3 +536,104 @@ export const shouldAutoDrain = ({ isBusy, parked, queueLength }: AutoDrainInput)
 /** Auto-drain attempts for one entry before we stop retrying and toast. The
  * entry stays queued for a manual send; a remount/reconnect resets the count. */
 export const MAX_AUTO_DRAIN_ATTEMPTS = 4
+
+// ── v1 → v2 ownership resolution ───────────────────────────────────────────
+
+export type SessionOwnership =
+  | { kind: 'ambiguous' }
+  | { kind: 'indeterminate' }
+  | { kind: 'none' }
+  | { kind: 'one'; profile: string }
+
+/**
+ * Resolve the single owning profile of a stored session so a profile-less (v1 /
+ * legacy) queue bucket can be re-attributed. Aggregate-FIRST: one
+ * /api/profiles/sessions request — `archived: 'include'` is mandatory so an
+ * archived queued session is not misclassified as absent — collapses matches
+ * (id or _lineage_root_id, via sessionMatchesStoredId) by normalized owning
+ * profile.
+ *
+ * Never guesses: an aggregate request FAILURE is `indeterminate` (not permission
+ * to probe blindly or submit through the active gateway); zero/one/many matches
+ * are `none`/`one`/`ambiguous`. Only when the bucket is absent from a SUCCESSFUL
+ * aggregate does it fall back to profile-scoped getSession reads over the loaded
+ * catalog — a confirmed not-found there is still `none`.
+ */
+export async function resolveUniqueSessionProfile(storedSessionId: string): Promise<SessionOwnership> {
+  let catalog: SessionInfo[]
+
+  try {
+    ;({ sessions: catalog } = await listAllProfileSessions(500, 0, 'include', 'recent', 'all'))
+  } catch {
+    return { kind: 'indeterminate' }
+  }
+
+  const owners = new Set<string>()
+
+  for (const row of catalog) {
+    if (sessionMatchesStoredId(row, storedSessionId)) {
+      owners.add(normalizeProfileKey(row.profile))
+    }
+  }
+
+  if (owners.size === 1) {
+    return { kind: 'one', profile: [...owners][0]! }
+  }
+
+  if (owners.size > 1) {
+    return { kind: 'ambiguous' }
+  }
+
+  // Absent from a successful aggregate: confirm via profile-scoped reads over the
+  // catalog's profiles. A match anywhere is `one`; with the aggregate already
+  // reachable, per-profile not-founds confirm absence (`none`).
+  const profiles = new Set(catalog.map(row => normalizeProfileKey(row.profile)))
+
+  for (const profile of profiles) {
+    try {
+      const session = await getSession(storedSessionId, profile)
+
+      if (session && sessionMatchesStoredId(session, storedSessionId)) {
+        return { kind: 'one', profile: normalizeProfileKey(session.profile ?? profile) }
+      }
+    } catch {
+      // Not on this profile; keep checking.
+    }
+  }
+
+  return { kind: 'none' }
+}
+
+/**
+ * Resolve a legacy (profile-less) bucket's owner and, on exactly one owner,
+ * atomically move it into that profile's bucket and stamp every entry. Zero,
+ * ambiguous, or indeterminate ownership leaves it under its bare key (legacy) and
+ * returns the outcome for the caller to notify — never guessing, never routing
+ * through the active gateway. No-op when the bucket is already empty.
+ */
+export async function resolveLegacyQueueBucket(storedSessionId: string): Promise<SessionOwnership> {
+  const ownership = await resolveUniqueSessionProfile(storedSessionId)
+
+  if (ownership.kind !== 'one') {
+    return ownership
+  }
+
+  const current = $queuedPromptsBySession.get()
+  const entries = current[storedSessionId]
+
+  if (!entries?.length) {
+    return ownership
+  }
+
+  const next = { ...current }
+  delete next[storedSessionId]
+  next[profileQueueKey(ownership.profile, storedSessionId)] = entries.map(entry => ({
+    ...entry,
+    profile: ownership.profile
+  }))
+
+  $queuedPromptsBySession.set(next)
+  save(next)
+
+  return ownership
+}

--- a/apps/desktop/src/store/gateway-hmr.test.ts
+++ b/apps/desktop/src/store/gateway-hmr.test.ts
@@ -1,0 +1,127 @@
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// HMR-stability tests for the gateway registry. The registry parks its mutable
+// state on globalThis (Symbol.for key) so a dev hot-update of the module hands
+// back the SAME live sockets. `import.meta.hot` is truthy under vitest, so we
+// exercise the real migration path: plant a container on globalThis, reset the
+// module registry, re-import, and assert the fresh module adopted + migrated it.
+
+const STATE_KEY = Symbol.for('hermes.desktop.gatewayRegistryState')
+
+type Registry = Record<string, unknown>
+
+function plantContainer(container: Registry): void {
+  ;(globalThis as unknown as Record<symbol, Registry>)[STATE_KEY] = container
+}
+
+function readContainer(): Registry | undefined {
+  return (globalThis as unknown as Record<symbol, Registry | undefined>)[STATE_KEY]
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  // Don't leak a planted container to another file's module load.
+  delete (globalThis as unknown as Record<symbol, unknown>)[STATE_KEY]
+  vi.resetModules()
+})
+
+describe('gateway registry HMR migration', () => {
+  it('adds all seven lease/reconnect fields and initializes old secondaries lacking retryStopped (test 38)', async () => {
+    // An OLD container: the original six fields only, plus a live secondary that
+    // predates retryStopped.
+    const oldSecondary = {
+      gateway: { close: () => undefined },
+      offEvent: () => undefined,
+      offState: () => undefined,
+      profile: 'apollo',
+      reconnectAttempt: 0,
+      reconnectTimer: null,
+      reconnecting: false,
+      wantOpen: true
+    }
+
+    const old = {
+      $gateway: atom(null),
+      activeKey: 'default',
+      config: null,
+      primaryGateway: null,
+      primaryProfile: 'default',
+      secondaries: new Map([['apollo', oldSecondary]])
+    }
+
+    plantContainer(old as unknown as Registry)
+
+    // Re-import: the fresh module's gatewayState() finds the old container and
+    // migrates it in place.
+    await import('@/store/gateway')
+
+    const migrated = readContainer() as Registry
+    expect(migrated).toBe(old) // same object — migrated in place, not replaced
+
+    // All seven new fields now present with the right shapes.
+    expect(migrated.leasedProfiles).toBeInstanceOf(Map)
+    expect(migrated.profileOpens).toBeInstanceOf(Map)
+    expect(migrated.pendingLeases).toBeInstanceOf(Set)
+    expect(migrated.leasePruneTimer).toBeNull()
+    expect(migrated.lastKnownKeepSet).toBeInstanceOf(Set)
+    expect(migrated.reauthErrors).toBeInstanceOf(Map)
+    expect(migrated.primaryReconnect).toBeNull()
+
+    // The pre-existing secondary gained retryStopped.
+    expect((oldSecondary as { retryStopped?: unknown }).retryStopped).toBeNull()
+  })
+
+  it('preserves live lease state across a hot re-eval (test 17)', async () => {
+    // A CURRENT container already carrying lease + keep-set state.
+    const leasedProfiles = new Map<string, number>([
+      ['apollo', 2],
+      ['nova', 1]
+    ])
+    const lastKnownKeepSet = new Set<string>(['nova'])
+
+    const container = {
+      $gateway: atom(null),
+      activeKey: 'default',
+      config: null,
+      lastKnownKeepSet,
+      leasePruneTimer: null,
+      leasedProfiles,
+      pendingLeases: new Set<string>(),
+      primaryGateway: null,
+      primaryReconnect: null,
+      primaryProfile: 'default',
+      profileOpens: new Map<string, Promise<void>>(),
+      reauthErrors: new Map<string, unknown>(),
+      secondaries: new Map()
+    }
+
+    plantContainer(container as unknown as Registry)
+
+    await import('@/store/gateway')
+
+    // The fresh module reused the container (??= never clobbers), so the lease
+    // refcounts and keep-set survive the hot update.
+    const migrated = readContainer() as Registry
+    expect(migrated).toBe(container)
+    expect((migrated.leasedProfiles as Map<string, number>).get('apollo')).toBe(2)
+    expect((migrated.leasedProfiles as Map<string, number>).get('nova')).toBe(1)
+    expect((migrated.lastKnownKeepSet as Set<string>).has('nova')).toBe(true)
+  })
+
+  it('creates a fresh, fully-initialized container when none exists', async () => {
+    // No planted container (deleted in afterEach / absent here).
+    delete (globalThis as unknown as Record<symbol, unknown>)[STATE_KEY]
+
+    await import('@/store/gateway')
+
+    const created = readContainer() as Registry
+    expect(created).toBeDefined()
+    expect(created.leasedProfiles).toBeInstanceOf(Map)
+    expect(created.reauthErrors).toBeInstanceOf(Map)
+    expect(created.primaryReconnect).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -12,6 +12,7 @@ import {
   reconnectPrimaryGateway,
   releaseProfileGateway,
   requestGatewayForProfile,
+  retryProfileGateway,
   setPrimaryGateway,
   updateGatewayKeepSet,
   withProfileGatewayLease
@@ -338,5 +339,69 @@ describe('lease lifecycle', () => {
     leaseProfileGateway('apollo')
     await flush()
     expect(opensFor('apollo')).toBe(1)
+  })
+})
+
+describe('Layer 8 — background retry policy (test 61)', () => {
+  type ProfileStateReport = [string, string, string | undefined]
+
+  function captureProfileState(): ProfileStateReport[] {
+    const reports: ProfileStateReport[] = []
+    configureGatewayRegistry({
+      onEvent: () => undefined,
+      onProfileState: (profile, state, reason) => reports.push([profile, state, reason])
+    })
+
+    return reports
+  }
+
+  it('a down background profile stops after six retries and publishes offline (attempt-limit)', async () => {
+    const reports = captureProfileState()
+    FakeWebSocket.mode = 'fail'
+
+    leaseProfileGateway('apollo')
+    await flush()
+
+    // Drive the bounded backoff (1s, 2s, 4s, 8s, 15s, 15s). Interleave timer
+    // advances with flushes so each failed reconnect settles before the next.
+    for (let i = 0; i < 8; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await vi.advanceTimersByTimeAsync(16_000)
+      // eslint-disable-next-line no-await-in-loop
+      await flush()
+    }
+
+    // The sixth failure stops the loop as attempt-limit and publishes offline.
+    expect(reports).toContainEqual(['apollo', 'offline', 'attempt-limit'])
+
+    // Bounded: advancing far more time spawns no further connect attempts.
+    const attemptsAtLimit = opensFor('apollo')
+    await vi.advanceTimersByTimeAsync(120_000)
+    await flush()
+    expect(opensFor('apollo')).toBe(attemptsAtLimit)
+  })
+
+  it('a wake / manual retry resets the attempt-limit stop and reconnects', async () => {
+    const reports = captureProfileState()
+    FakeWebSocket.mode = 'fail'
+
+    leaseProfileGateway('apollo')
+    await flush()
+
+    for (let i = 0; i < 8; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await vi.advanceTimersByTimeAsync(16_000)
+      // eslint-disable-next-line no-await-in-loop
+      await flush()
+    }
+
+    expect(reports).toContainEqual(['apollo', 'offline', 'attempt-limit'])
+
+    // The backend comes back; a manual retry resets the stop and reconnects.
+    FakeWebSocket.mode = 'open'
+    retryProfileGateway('apollo')
+    await flush()
+
+    expect(reports.some(([profile, state]) => profile === 'apollo' && state === 'open')).toBe(true)
   })
 })

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { HermesGateway } from '@/hermes'
+import {
+  __resetGatewayRegistryForTests,
+  configureGatewayRegistry,
+  ensureGatewayForProfile,
+  isActivePrimary,
+  leaseProfileGateway,
+  pruneSecondaryGateways,
+  reconnectPrimaryGateway,
+  releaseProfileGateway,
+  requestGatewayForProfile,
+  setPrimaryGateway,
+  updateGatewayKeepSet,
+  withProfileGatewayLease
+} from '@/store/gateway'
+import { $connection } from '@/store/session'
+
+// Drive the real HermesGateway through a fake WebSocket we fully control. The
+// socket auto-opens AND echoes a JSON-RPC result for every request, so lease /
+// open / prune / profile-RPC behavior runs against the genuine connect()+request
+// path without a real port.
+
+type Listener = (ev: unknown) => void
+
+class FakeWebSocket {
+  static OPEN = 1
+  static CLOSED = 3
+  static mode: 'fail' | 'open' = 'open'
+  static instances: FakeWebSocket[] = []
+
+  readyState = 0
+  private listeners: Record<string, Set<Listener>> = {}
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+    const willOpen = FakeWebSocket.mode === 'open'
+    setTimeout(() => {
+      if (willOpen) {
+        this.readyState = FakeWebSocket.OPEN
+        this.emit('open', {})
+      } else {
+        this.readyState = FakeWebSocket.CLOSED
+        this.emit('error', {})
+      }
+    }, 0)
+  }
+
+  addEventListener(type: string, fn: Listener) {
+    ;(this.listeners[type] ??= new Set()).add(fn)
+  }
+
+  removeEventListener(type: string, fn: Listener) {
+    this.listeners[type]?.delete(fn)
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED
+    this.emit('close', {})
+  }
+
+  // Echo a successful result so pending requests resolve.
+  send(raw: string) {
+    let id: unknown
+    try {
+      id = (JSON.parse(raw) as { id?: unknown }).id
+    } catch {
+      return
+    }
+
+    if (id === undefined) {
+      return
+    }
+
+    setTimeout(() => {
+      this.emit('message', { data: JSON.stringify({ id, result: { ok: true } }) })
+    }, 0)
+  }
+
+  private emit(type: string, ev: unknown) {
+    for (const fn of this.listeners[type] ?? []) {
+      fn(ev)
+    }
+  }
+}
+
+const originalWebSocket = globalThis.WebSocket
+const getConnection = vi.fn(async (profile?: string) => ({
+  authMode: 'token' as const,
+  baseUrl: 'http://localhost',
+  profile: profile ?? 'default',
+  token: 't',
+  wsUrl: `ws://localhost/ws?profile=${profile ?? 'default'}`
+}))
+
+const opensFor = (profile: string) => getConnection.mock.calls.filter(([p]) => (p ?? 'default') === profile).length
+
+async function flush(cycles = 2) {
+  for (let i = 0; i < cycles; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await vi.advanceTimersByTimeAsync(0)
+  }
+}
+
+// Drive fake timers until an in-flight RPC (which awaits a fake-socket response
+// timer) settles. Advancing timers must interleave with the request promise —
+// awaiting the promise first would deadlock against the timers that resolve it.
+async function settle<T>(promise: Promise<T>, cycles = 20): Promise<T> {
+  for (let i = 0; i < cycles; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  return promise
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  FakeWebSocket.mode = 'open'
+  FakeWebSocket.instances = []
+  getConnection.mockClear()
+  ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
+  ;(window as { hermesDesktop?: unknown }).hermesDesktop = {
+    getConnection,
+    getGatewayWsUrl: vi.fn(async () => 'ws://localhost/ws'),
+    touchBackend: vi.fn(async () => undefined)
+  }
+  __resetGatewayRegistryForTests()
+  configureGatewayRegistry({ onEvent: () => undefined })
+})
+
+afterEach(() => {
+  __resetGatewayRegistryForTests()
+  vi.useRealTimers()
+  ;(globalThis as { WebSocket: unknown }).WebSocket = originalWebSocket
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('requestGatewayForProfile — primary reconnect extraction (blocker #2)', () => {
+  it('two concurrent primary reconnects share ONE mint and never publish the connection while a secondary is active (test 54)', async () => {
+    // Primary backend booted as "default" but idle (never connected).
+    const primary = new HermesGateway()
+    setPrimaryGateway(primary, 'default')
+
+    // Make a secondary ("apollo") the ACTIVE gateway. ensureGatewayForProfile
+    // awaits the secondary's open timer, so drive timers while awaiting it.
+    await settle(ensureGatewayForProfile('apollo'))
+    expect(isActivePrimary()).toBe(false)
+
+    const sentinel = { mode: 'local', wsUrl: 'ws://sentinel' }
+    $connection.set(sentinel as never)
+
+    // Two concurrent primary reconnects while apollo is active. Both must share
+    // the single in-flight g.primaryReconnect (dedup) and resolve to the primary.
+    const [g1, g2] = await settle(
+      Promise.all([reconnectPrimaryGateway('default'), reconnectPrimaryGateway('default')])
+    )
+
+    expect(g1).toBe(primary)
+    expect(g2).toBe(primary)
+    expect(primary.connectionState).toBe('open')
+
+    // Deduped: exactly one reconnect minted a connection for the primary.
+    expect(opensFor('default')).toBe(1)
+    // The foreground connection was NOT clobbered (activeKey is apollo, so the
+    // background primary reconnect must not call setConnection).
+    expect($connection.get()).toBe(sentinel)
+
+    primary.close()
+  })
+})
+
+describe('requestGatewayForProfile — secondary routing (test 16)', () => {
+  it('routes an RPC to a leased secondary without changing the active gateway', async () => {
+    const primary = new HermesGateway()
+    setPrimaryGateway(primary, 'default')
+    expect(isActivePrimary()).toBe(true)
+
+    leaseProfileGateway('apollo')
+    await flush()
+
+    const result = await settle(requestGatewayForProfile('apollo', 'pet.info', { profile: 'apollo' }))
+
+    expect(result).toEqual({ ok: true })
+    expect(opensFor('apollo')).toBe(1)
+    // Active gateway unchanged — still the primary.
+    expect(isActivePrimary()).toBe(true)
+
+    primary.close()
+  })
+})
+
+describe('lease lifecycle', () => {
+  it('a leased idle profile survives an empty-keep prune; releasing prunes within 50ms (tests 6, 36)', async () => {
+    leaseProfileGateway('apollo')
+    await flush()
+    expect(opensFor('apollo')).toBe(1)
+
+    // Empty keep-set prune must spare the leased profile.
+    pruneSecondaryGateways(new Set())
+    expect(opensFor('apollo')).toBe(1)
+
+    // Release → debounced prune. Before 50ms a re-lease still reuses the socket.
+    releaseProfileGateway('apollo')
+    await vi.advanceTimersByTimeAsync(30)
+    leaseProfileGateway('apollo')
+    await flush()
+    expect(opensFor('apollo')).toBe(1) // survived: re-leased before the prune landed
+
+    // Release for good; the 50ms prune now drops it and a re-lease opens fresh.
+    releaseProfileGateway('apollo')
+    await vi.advanceTimersByTimeAsync(60)
+    leaseProfileGateway('apollo')
+    await flush()
+    expect(opensFor('apollo')).toBe(2)
+  })
+
+  it('a lease+release burst settles to one debounced prune and never a negative refcount (test 37)', async () => {
+    leaseProfileGateway('apollo')
+    leaseProfileGateway('nova')
+    await flush()
+    expect(opensFor('apollo')).toBe(1)
+    expect(opensFor('nova')).toBe(1)
+
+    // Burst: release both, plus a stray extra release (must not go negative).
+    releaseProfileGateway('apollo')
+    releaseProfileGateway('nova')
+    releaseProfileGateway('apollo')
+
+    // Before the 50ms debounce lands, nothing is pruned yet; after, both dropped.
+    await vi.advanceTimersByTimeAsync(30)
+    await vi.advanceTimersByTimeAsync(60)
+    leaseProfileGateway('apollo')
+    leaseProfileGateway('nova')
+    await flush()
+    expect(opensFor('apollo')).toBe(2)
+    expect(opensFor('nova')).toBe(2)
+  })
+
+  it('withProfileGatewayLease releases in finally even when the work throws (test 7)', async () => {
+    await expect(
+      withProfileGatewayLease('apollo', async () => {
+        throw new Error('boom')
+      })
+    ).rejects.toThrow('boom')
+
+    // Lease released in finally → prune drops it; a fresh lease re-opens.
+    await vi.advanceTimersByTimeAsync(60)
+    leaseProfileGateway('apollo')
+    await flush()
+    expect(opensFor('apollo')).toBe(2)
+  })
+
+  it('concurrent leases for the same profile open a single socket and need every ref released (test 39)', async () => {
+    leaseProfileGateway('apollo')
+    leaseProfileGateway('apollo')
+    await flush()
+
+    // Two refcounts, ONE deduped open.
+    expect(opensFor('apollo')).toBe(1)
+
+    // First release leaves refcount 1 → no prune; socket survives an empty prune.
+    releaseProfileGateway('apollo')
+    await vi.advanceTimersByTimeAsync(60)
+    pruneSecondaryGateways(new Set())
+    expect(opensFor('apollo')).toBe(1)
+
+    // Second release hits zero → prune drops it; re-lease opens fresh.
+    releaseProfileGateway('apollo')
+    await vi.advanceTimersByTimeAsync(60)
+    leaseProfileGateway('apollo')
+    await flush()
+    expect(opensFor('apollo')).toBe(2)
+  })
+
+  it('a lease acquired before the registry is configured is queued and drained on boot (test 8)', async () => {
+    // Drop the registry config to simulate pre-boot, lease, then re-configure.
+    __resetGatewayRegistryForTests()
+    leaseProfileGateway('preboot')
+    await flush()
+    // No registry yet → queued, not opened.
+    expect(opensFor('preboot')).toBe(0)
+
+    configureGatewayRegistry({ onEvent: () => undefined })
+    await flush()
+    expect(opensFor('preboot')).toBe(1)
+  })
+
+  it('a failed leased open keeps the lease (not pruned) and schedules a bounded retry (test 9)', async () => {
+    FakeWebSocket.mode = 'fail'
+    leaseProfileGateway('apollo')
+    await flush()
+
+    // The open failed, but the lease is retained: an empty-keep prune must NOT
+    // drop it. A wake/backoff tick nudges another open attempt.
+    pruneSecondaryGateways(new Set())
+    const attemptsBefore = opensFor('apollo')
+    expect(attemptsBefore).toBeGreaterThanOrEqual(1)
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(opensFor('apollo')).toBeGreaterThan(attemptsBefore)
+  })
+
+  it('updateGatewayKeepSet spares live-work profiles from a lease-triggered prune', async () => {
+    leaseProfileGateway('apollo')
+    await flush()
+    releaseProfileGateway('apollo')
+
+    // Publish live work naming apollo BEFORE the debounce lands.
+    updateGatewayKeepSet(new Set(['apollo']))
+    await vi.advanceTimersByTimeAsync(60)
+
+    // The lease-triggered prune used the keep-set → apollo survived; re-lease reuses.
+    leaseProfileGateway('apollo')
+    await flush()
+    expect(opensFor('apollo')).toBe(1)
+  })
+})

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -7,6 +7,7 @@ import {
   ensureGatewayForProfile,
   isActivePrimary,
   leaseProfileGateway,
+  primaryProfileKey,
   pruneSecondaryGateways,
   reconnectPrimaryGateway,
   releaseProfileGateway,
@@ -166,6 +167,28 @@ describe('requestGatewayForProfile — primary reconnect extraction (blocker #2)
     // The foreground connection was NOT clobbered (activeKey is apollo, so the
     // background primary reconnect must not call setConnection).
     expect($connection.get()).toBe(sentinel)
+
+    primary.close()
+  })
+})
+
+describe('primary event tagging source (blocker #1)', () => {
+  it('primaryProfileKey tracks the registry primary, not the active secondary (test 53)', async () => {
+    const primary = new HermesGateway()
+    setPrimaryGateway(primary, 'default')
+    expect(primaryProfileKey()).toBe('default')
+
+    // Activate a secondary: the active key moves, but the primary key the boot
+    // hook reads at EMIT time must stay the primary's profile — otherwise primary
+    // events get tagged with the secondary's profile after a rebuild.
+    await settle(ensureGatewayForProfile('apollo'))
+    expect(isActivePrimary()).toBe(false)
+    expect(primaryProfileKey()).toBe('default')
+
+    // A rebuild re-sets the primary; the emit-time read follows the registry's
+    // primary key, never the active secondary.
+    setPrimaryGateway(primary, 'default')
+    expect(primaryProfileKey()).toBe('default')
 
     primary.close()
   })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -27,6 +27,17 @@ const isOpen = (gateway: HermesGateway | null): boolean => gateway?.connectionSt
 
 interface RegistryConfig {
   onEvent: (event: GatewayEvent) => void
+  /** Per-profile connection-state sink (Layer 8). Boot wires this to the pet
+   *  store's setProfileConnectionState; declared as a callback so gateway.ts
+   *  never imports the pet store (which would be a cycle). Fires for primary and
+   *  secondary state changes, reconnect starts/stops, reauth, and disposal. The
+   *  active-only reportGatewayState mirroring into composer state is unchanged —
+   *  background states must never flip the foreground composer. */
+  onProfileState?: (
+    profile: string,
+    state: 'connecting' | 'offline' | 'open' | 'reauth-required',
+    reason?: 'attempt-limit' | 'reauth'
+  ) => void
 }
 
 // ── Secondary (pool) backends ──────────────────────────────────────────────
@@ -216,6 +227,30 @@ export function reportPrimaryGatewayState(state: ConnectionState): void {
   reportGatewayState(g.primaryProfile, state)
 }
 
+/** Pooled/background gateways retry a dead backend on a bounded backoff
+ *  (1s, 2s, 4s, 8s, 15s, 15s); a sixth failure stops the loop as 'attempt-limit'. */
+const MAX_BG_RETRIES = 6
+
+// Map a transport ConnectionState onto the pet store's connection vocabulary.
+function toProfileConnection(state: ConnectionState): 'connecting' | 'offline' | 'open' {
+  if (state === 'open') {
+    return 'open'
+  }
+
+  return state === 'connecting' ? 'connecting' : 'offline'
+}
+
+/** Report a profile's socket state to the per-profile sink (Layer 8). Every
+ *  profile (primary + secondary) flows through here; the callback is boot-wired
+ *  to the pet store, so a dead pinned profile shows an offline pet. */
+function reportProfileState(
+  profile: string,
+  state: 'connecting' | 'offline' | 'open' | 'reauth-required',
+  reason?: 'attempt-limit' | 'reauth'
+): void {
+  g.config?.onProfileState?.(normKey(profile), state, reason)
+}
+
 function setActive(profile: string): void {
   g.activeKey = normKey(profile)
   const gateway = activeGateway()
@@ -251,9 +286,21 @@ function scheduleReconnect(entry: Secondary): void {
     return
   }
 
+  // Bounded backoff (Layer 8): after six failed retries stop the loop, publish
+  // offline, and cancel the timer. A wake signal, manual retry, or
+  // disable/re-enable resets the stop (retryProfileGateway).
+  if (entry.reconnectAttempt >= MAX_BG_RETRIES) {
+    entry.retryStopped = 'attempt-limit'
+    clearTimer(entry)
+    reportProfileState(entry.profile, 'offline', 'attempt-limit')
+
+    return
+  }
+
   // 1s, 2s, 4s … capped at 15s — same backoff shape as the primary.
   const delay = Math.min(15_000, 1_000 * 2 ** Math.min(entry.reconnectAttempt, 4))
   entry.reconnectAttempt += 1
+  reportProfileState(entry.profile, 'connecting')
   entry.reconnectTimer = setTimeout(() => {
     entry.reconnectTimer = null
     void reconnectSecondary(entry)
@@ -279,6 +326,7 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
       g.reauthErrors.set(entry.profile, error)
       entry.retryStopped = 'reauth'
       clearTimer(entry)
+      reportProfileState(entry.profile, 'reauth-required', 'reauth')
     }
   } finally {
     entry.reconnecting = false
@@ -307,6 +355,7 @@ function createSecondary(profile: string): Secondary {
   entry.offEvent = gateway.onEvent(event => g.config?.onEvent({ ...event, profile }))
   entry.offState = gateway.onState(state => {
     reportGatewayState(profile, state)
+    reportProfileState(profile, toProfileConnection(state))
 
     if (state === 'open') {
       entry.reconnectAttempt = 0
@@ -434,6 +483,7 @@ function disposeSecondary(entry: Secondary): void {
   entry.offEvent()
   entry.offState()
   entry.gateway.close()
+  reportProfileState(entry.profile, 'offline')
 }
 
 // Close + evict secondaries whose profile is neither active nor in `keep`

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1,8 +1,13 @@
-import { type ConnectionState, type GatewayEvent, resolveGatewayWsUrl } from '@hermes/shared'
+import {
+  type ConnectionState,
+  type GatewayEvent,
+  isGatewayReauthRequired,
+  resolveGatewayWsUrl
+} from '@hermes/shared'
 import { atom } from 'nanostores'
 
 import { HermesGateway } from '@/hermes'
-import { setGatewayState } from '@/store/session'
+import { setConnection, setGatewayState } from '@/store/session'
 
 // ── Multi-profile gateway routing ──────────────────────────────────────────
 // Concurrent sessions across profiles need concurrent sockets: the renderer's
@@ -36,6 +41,10 @@ interface Secondary {
   // While true the entry auto-reconnects on drop; pruning flips it off so a
   // deliberate close doesn't trigger the backoff loop.
   wantOpen: boolean
+  // Why the auto-reconnect loop stopped, or null while it may retry.
+  // 'reauth' never auto-retries (only explicit post-sign-in retryProfileGateway
+  // clears it); 'attempt-limit' (Layer 8) is reset by a wake/manual retry.
+  retryStopped: 'attempt-limit' | 'reauth' | null
 }
 
 // ── HMR-stable module state ─────────────────────────────────────────────────
@@ -56,6 +65,26 @@ interface GatewayRegistryState {
   activeKey: string
   secondaries: Map<string, Secondary>
   $gateway: ReturnType<typeof atom<HermesGateway | null>>
+  // ── Lease + reconnect-ownership state (all HMR-migrated in gatewayState) ──
+  // profile -> refcount. A profile with a positive refcount is spared by the
+  // idle prune even when it has no live work (roster streaming / a background
+  // submit holds it open).
+  leasedProfiles: Map<string, number>
+  // profile -> in-flight open promise, so concurrent lease/request opens for the
+  // same profile spawn a single socket.
+  profileOpens: Map<string, Promise<void>>
+  // Leases acquired before the registry is configured (boot); drained by
+  // configureGatewayRegistry.
+  pendingLeases: Set<string>
+  leasePruneTimer: ReturnType<typeof setTimeout> | null
+  // The most recent working/attention keep-set from use-gateway-boot, folded
+  // into the lease prune so live work is never dropped.
+  lastKnownKeepSet: Set<string>
+  // profile -> stored OAuth reauth error. The active hook drains its own entry
+  // (takeGatewayReauthError); Layer 8 reads background entries for offline state.
+  reauthErrors: Map<string, unknown>
+  // In-flight primary reconnect, shared by concurrent callers (dedup).
+  primaryReconnect: Promise<HermesGateway | null> | null
 }
 
 const STATE_KEY = Symbol.for('hermes.desktop.gatewayRegistryState')
@@ -70,7 +99,14 @@ function createRegistryState(): GatewayRegistryState {
     // The active gateway instance, exposed for inline message-stream
     // components (inline ClarifyTool, model overlays) that call gateway
     // methods without the instance threaded down through props.
-    $gateway: atom<HermesGateway | null>(null)
+    $gateway: atom<HermesGateway | null>(null),
+    leasedProfiles: new Map<string, number>(),
+    profileOpens: new Map<string, Promise<void>>(),
+    pendingLeases: new Set<string>(),
+    leasePruneTimer: null,
+    lastKnownKeepSet: new Set<string>(),
+    reauthErrors: new Map<string, unknown>(),
+    primaryReconnect: null
   }
 }
 
@@ -84,7 +120,30 @@ function createRegistryState(): GatewayRegistryState {
 function gatewayState(): GatewayRegistryState {
   if (import.meta.hot) {
     const store = globalThis as unknown as { [STATE_KEY]?: GatewayRegistryState }
-    store[STATE_KEY] ??= createRegistryState()
+    const existing = store[STATE_KEY]
+
+    if (existing) {
+      // Field-level migration: an HMR container created by a prior version of
+      // this module lacks the lease/reconnect-ownership fields (and old live
+      // Secondary entries lack retryStopped). Add them in place so the hot
+      // update keeps the live sockets AND gains the new state. `??=` never
+      // clobbers a field a newer container already initialized.
+      existing.leasedProfiles ??= new Map()
+      existing.profileOpens ??= new Map()
+      existing.pendingLeases ??= new Set()
+      existing.leasePruneTimer ??= null
+      existing.lastKnownKeepSet ??= new Set()
+      existing.reauthErrors ??= new Map()
+      existing.primaryReconnect ??= null
+
+      for (const entry of existing.secondaries.values()) {
+        entry.retryStopped ??= null
+      }
+
+      return existing
+    }
+
+    store[STATE_KEY] = createRegistryState()
 
     return store[STATE_KEY]
   }
@@ -101,6 +160,18 @@ export const $gateway = g.$gateway
 
 export function configureGatewayRegistry(cfg: RegistryConfig): void {
   g.config = cfg
+
+  // Drain any leases acquired before the registry existed (boot ordering): the
+  // roster controller can lease a profile before the gateway effect wires the
+  // event handler. Open them now that a registry is present.
+  if (g.pendingLeases.size > 0) {
+    const pending = [...g.pendingLeases]
+    g.pendingLeases.clear()
+
+    for (const key of pending) {
+      void ensureSecondaryOpen(key).catch(() => undefined)
+    }
+  }
 }
 
 /**
@@ -173,7 +244,10 @@ async function openSecondary(entry: Secondary): Promise<void> {
 }
 
 function scheduleReconnect(entry: Secondary): void {
-  if (entry.reconnecting || entry.reconnectTimer !== null || !entry.wantOpen) {
+  // A reauth stop never auto-retries: the ticket can never succeed until the
+  // user signs in again, so looping the backoff just spins silently. Only an
+  // explicit post-sign-in retryProfileGateway clears it.
+  if (entry.reconnecting || entry.reconnectTimer !== null || !entry.wantOpen || entry.retryStopped === 'reauth') {
     return
   }
 
@@ -187,7 +261,7 @@ function scheduleReconnect(entry: Secondary): void {
 }
 
 async function reconnectSecondary(entry: Secondary): Promise<void> {
-  if (entry.reconnecting || !entry.wantOpen || isOpen(entry.gateway)) {
+  if (entry.reconnecting || !entry.wantOpen || isOpen(entry.gateway) || entry.retryStopped === 'reauth') {
     return
   }
 
@@ -196,12 +270,20 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
   try {
     await openSecondary(entry)
     entry.reconnectAttempt = 0
-  } catch {
-    // Transport failure → fall through to the backoff below.
+    entry.retryStopped = null
+    g.reauthErrors.delete(entry.profile)
+  } catch (error) {
+    // OAuth reauth: store the error and stop the loop (never auto-retries).
+    // Transport failure → fall through to the bounded backoff below.
+    if (isGatewayReauthRequired(error)) {
+      g.reauthErrors.set(entry.profile, error)
+      entry.retryStopped = 'reauth'
+      clearTimer(entry)
+    }
   } finally {
     entry.reconnecting = false
 
-    if (entry.wantOpen && !isOpen(entry.gateway)) {
+    if (entry.wantOpen && !isOpen(entry.gateway) && entry.retryStopped !== 'reauth') {
       scheduleReconnect(entry)
     }
   }
@@ -218,7 +300,8 @@ function createSecondary(profile: string): Secondary {
     reconnectTimer: null,
     reconnectAttempt: 0,
     reconnecting: false,
-    wantOpen: true
+    wantOpen: true,
+    retryStopped: null
   }
 
   entry.offEvent = gateway.onEvent(event => g.config?.onEvent({ ...event, profile }))
@@ -313,10 +396,16 @@ export async function ensureActiveGatewayOpen(): Promise<HermesGateway | null> {
 }
 
 // Wake signal (sleep/network/visibility): nudge every live secondary back open.
+// Resets an attempt-limit stop (a fresh wake gets a full retry budget) but never
+// clears a reauth stop — reconnectSecondary refuses to auto-retry reauth.
 export function reconnectSecondaryGateways(): void {
   for (const entry of g.secondaries.values()) {
     if (!entry.wantOpen || isOpen(entry.gateway)) {
       continue
+    }
+
+    if (entry.retryStopped === 'attempt-limit') {
+      entry.retryStopped = null
     }
 
     entry.reconnectAttempt = 0
@@ -349,9 +438,21 @@ function disposeSecondary(entry: Secondary): void {
 
 // Close + evict secondaries whose profile is neither active nor in `keep`
 // (profiles with a running / needs-input session). Bounds cost to live work.
+// Leased profiles (positive refcount) are always spared: a lease is an explicit
+// "keep this socket alive" independent of live work (roster streaming, a
+// background submit). The active profile is spared by the caller's keep-set
+// union AND here, so a lease release can never drop the foreground socket.
 export function pruneSecondaryGateways(keep: Set<string>): void {
+  const effective = new Set(keep)
+
+  for (const [key, count] of g.leasedProfiles) {
+    if (count > 0) {
+      effective.add(key)
+    }
+  }
+
   for (const [key, entry] of [...g.secondaries]) {
-    if (key === g.activeKey || keep.has(key)) {
+    if (key === g.activeKey || effective.has(key)) {
       continue
     }
 
@@ -366,6 +467,372 @@ export function closeSecondaryGateways(): void {
   }
 
   g.secondaries.clear()
+}
+
+// ── Profile-specific RPC + reconnect ownership + leases ────────────────────
+// One routing rule for every profile-owned gateway operation: resolve the
+// connection through the registry (primary socket or a per-profile secondary),
+// NEVER through whichever gateway happens to be active. A lease keeps a socket
+// alive; it is not permission to route.
+
+const isTransientConnectionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /not connected|connection closed/i.test(message)
+}
+
+/** The registry's own primary profile key — read at emit time, not snapshotted.
+ *  Primary events are tagged with this (Layer 4) so a gateway rebuild while a
+ *  secondary is active never mis-tags them with the secondary's profile. */
+export function primaryProfileKey(): string {
+  return g.primaryProfile
+}
+
+/** Non-destructive read of a profile's stored reauth error (Layer 8 status). */
+export function gatewayReauthError(profile: string): unknown | null {
+  return g.reauthErrors.get(normKey(profile)) ?? null
+}
+
+/** Drain a profile's stored reauth error (the active hook surfaces it once). */
+export function takeGatewayReauthError(profile: string): unknown | null {
+  const key = normKey(profile)
+  const error = g.reauthErrors.get(key) ?? null
+  g.reauthErrors.delete(key)
+
+  return error
+}
+
+/**
+ * Recover a dropped PRIMARY gateway. Extracted from use-gateway-request's
+ * ensureGatewayOpen so a NON-active primary can be recovered (e.g. a leased
+ * background profile that happens to be the window's primary backend) without
+ * publishing its connection as the foreground one.
+ *
+ * - profile is a parameter, not `$activeGatewayProfile`
+ * - `setConnection` fires ONLY when this profile is the active one
+ * - concurrent callers share `g.primaryReconnect` (dedup)
+ * - reauth errors are stored per profile; cleared on success
+ */
+export async function reconnectPrimaryGateway(profile: string): Promise<HermesGateway | null> {
+  const key = normKey(profile)
+  const gateway = g.primaryGateway
+
+  if (!gateway) {
+    return null
+  }
+
+  if (isOpen(gateway)) {
+    return gateway
+  }
+
+  if (g.primaryReconnect) {
+    return g.primaryReconnect
+  }
+
+  g.primaryReconnect = (async () => {
+    const desktop = window.hermesDesktop
+
+    if (!desktop) {
+      return null
+    }
+
+    try {
+      const conn = await desktop.getConnection(key)
+
+      // A background reconnect must not publish its connection as the
+      // foreground one — only the active profile mirrors into composer state.
+      if (key === g.activeKey) {
+        setConnection(conn)
+      }
+
+      // Re-mint the WS URL: OAuth tickets are single-use, so the cached
+      // conn.wsUrl ticket is dead on every reconnect after boot.
+      const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+      await gateway.connect(wsUrl)
+      g.reauthErrors.delete(key)
+
+      return gateway
+    } catch (error) {
+      if (isGatewayReauthRequired(error)) {
+        g.reauthErrors.set(key, error)
+      }
+
+      if (key === g.activeKey) {
+        setConnection(null)
+      }
+
+      return null
+    } finally {
+      g.primaryReconnect = null
+    }
+  })()
+
+  return g.primaryReconnect
+}
+
+/**
+ * Open (or join an in-flight open of) a secondary profile's socket, deduped via
+ * `g.profileOpens` so concurrent lease/request opens spawn a single socket.
+ * Classifies reauth (store + stop) vs transport failure (bounded backoff).
+ * Resolves once the socket is open; rejects if it could not be opened.
+ */
+async function ensureSecondaryOpen(key: string): Promise<HermesGateway> {
+  const entry = g.secondaries.get(key) ?? createSecondary(key)
+  entry.wantOpen = true
+
+  if (isOpen(entry.gateway)) {
+    return entry.gateway
+  }
+
+  let pending = g.profileOpens.get(key)
+
+  if (!pending) {
+    pending = (async () => {
+      try {
+        await openSecondary(entry)
+        entry.reconnectAttempt = 0
+        entry.retryStopped = null
+        g.reauthErrors.delete(key)
+      } catch (error) {
+        if (isGatewayReauthRequired(error)) {
+          g.reauthErrors.set(key, error)
+          entry.retryStopped = 'reauth'
+          clearTimer(entry)
+        } else {
+          // Retryable transport failure enters the bounded backoff immediately.
+          scheduleReconnect(entry)
+        }
+
+        throw error
+      } finally {
+        g.profileOpens.delete(key)
+      }
+    })()
+
+    g.profileOpens.set(key, pending)
+  }
+
+  await pending
+
+  if (!isOpen(entry.gateway)) {
+    throw new Error(`gateway for profile "${key}" is not connected`)
+  }
+
+  return entry.gateway
+}
+
+/**
+ * Route a gateway RPC to a specific profile WITHOUT changing the active
+ * gateway. Primary → `g.primaryGateway` (recover via reconnectPrimaryGateway);
+ * secondary → its own socket (open/recover via the bounded secondary path).
+ * NEVER falls back to the active gateway — a failure surfaces as a clear error.
+ */
+export async function requestGatewayForProfile<T>(
+  profile: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs?: number,
+  signal?: AbortSignal
+): Promise<T> {
+  const key = normKey(profile)
+
+  if (key === g.primaryProfile) {
+    const gateway = g.primaryGateway
+
+    if (!gateway) {
+      throw new Error('Hermes gateway unavailable')
+    }
+
+    try {
+      return await gateway.request<T>(method, params, timeoutMs, signal)
+    } catch (error) {
+      if (!isTransientConnectionError(error)) {
+        throw error
+      }
+
+      const recovered = await reconnectPrimaryGateway(key)
+
+      if (!recovered) {
+        const reauthError = takeGatewayReauthError(key)
+
+        if (reauthError) {
+          throw reauthError
+        }
+
+        throw error
+      }
+
+      return recovered.request<T>(method, params, timeoutMs, signal)
+    }
+  }
+
+  const gateway = await ensureSecondaryOpen(key)
+
+  try {
+    return await gateway.request<T>(method, params, timeoutMs, signal)
+  } catch (error) {
+    if (!isTransientConnectionError(error)) {
+      throw error
+    }
+
+    const entry = g.secondaries.get(key)
+
+    if (entry) {
+      await reconnectSecondary(entry)
+    }
+
+    const recovered = g.secondaries.get(key)?.gateway
+
+    if (!recovered || !isOpen(recovered)) {
+      const reauthError = takeGatewayReauthError(key)
+
+      if (reauthError) {
+        throw reauthError
+      }
+
+      throw error
+    }
+
+    return recovered.request<T>(method, params, timeoutMs, signal)
+  }
+}
+
+/**
+ * Manual/wake retry of a profile's gateway. Resets an attempt-limit stop and
+ * clears a stored reauth error (callers invoke this AFTER successful sign-in),
+ * then nudges a reconnect. Primary and secondary both handled.
+ */
+export function retryProfileGateway(profile: string): void {
+  const key = normKey(profile)
+
+  if (key === g.primaryProfile) {
+    g.reauthErrors.delete(key)
+    void reconnectPrimaryGateway(key)
+
+    return
+  }
+
+  const entry = g.secondaries.get(key)
+
+  if (!entry) {
+    return
+  }
+
+  entry.retryStopped = null
+  entry.reconnectAttempt = 0
+  g.reauthErrors.delete(key)
+  clearTimer(entry)
+  void reconnectSecondary(entry)
+}
+
+// ── Leases ─────────────────────────────────────────────────────────────────
+// A lease keeps a profile's socket alive independent of live work. Refcounted:
+// the roster holds a persistent lease per enabled pinned profile; a background
+// submit takes a temporary one via withProfileGatewayLease. Release at zero
+// schedules a debounced prune (the keep-set union still spares live work).
+
+/** Debounced 50ms prune after a lease release; coalesces a release burst. */
+function scheduleLeasePrune(): void {
+  if (g.leasePruneTimer !== null) {
+    return
+  }
+
+  g.leasePruneTimer = setTimeout(() => {
+    g.leasePruneTimer = null
+    pruneSecondaryGateways(new Set(g.lastKnownKeepSet))
+  }, 50)
+}
+
+/**
+ * Acquire (or bump) a lease on `profile`'s socket and open it. Pre-boot leases
+ * are queued and drained by configureGatewayRegistry. Stays synchronous;
+ * callers needing readiness await requestGatewayForProfile.
+ */
+export function leaseProfileGateway(profile: string): void {
+  const key = normKey(profile)
+  g.leasedProfiles.set(key, (g.leasedProfiles.get(key) ?? 0) + 1)
+
+  if (!g.config) {
+    g.pendingLeases.add(key)
+
+    return
+  }
+
+  void ensureSecondaryOpen(key).catch(() => undefined)
+}
+
+/**
+ * Release one reference on `profile`'s lease. No-op when absent or already zero
+ * (refcounts never go negative — React StrictMode cleanup and repeated catalog
+ * refreshes are safe). At zero, schedules a prune unless the profile is active.
+ */
+export function releaseProfileGateway(profile: string): void {
+  const key = normKey(profile)
+  const count = g.leasedProfiles.get(key)
+
+  if (!count) {
+    return
+  }
+
+  if (count > 1) {
+    g.leasedProfiles.set(key, count - 1)
+
+    return
+  }
+
+  g.leasedProfiles.delete(key)
+
+  if (key !== g.activeKey) {
+    scheduleLeasePrune()
+  }
+}
+
+/** The only temporary-lease pattern: acquire, run, release in `finally`. */
+export async function withProfileGatewayLease<T>(profile: string, run: () => Promise<T>): Promise<T> {
+  leaseProfileGateway(profile)
+
+  try {
+    return await run()
+  } finally {
+    releaseProfileGateway(profile)
+  }
+}
+
+/** use-gateway-boot publishes its working/attention keep-set here on every
+ *  recompute, before pruning, so the lease prune never drops live work. */
+export function updateGatewayKeepSet(keep: ReadonlySet<string>): void {
+  g.lastKnownKeepSet = new Set(keep)
+}
+
+/**
+ * Test-only: reset the registry's mutable routing/lease state so cases don't
+ * leak active-key, secondary sockets, or leases into one another (the container
+ * is module-global and otherwise lives for the whole file). Closes live
+ * secondaries and clears timers; the stable `$gateway` atom identity is kept.
+ * Not used by production code.
+ */
+export function __resetGatewayRegistryForTests(): void {
+  for (const entry of g.secondaries.values()) {
+    disposeSecondary(entry)
+  }
+
+  g.secondaries.clear()
+  g.leasedProfiles.clear()
+  g.profileOpens.clear()
+  g.pendingLeases.clear()
+  g.lastKnownKeepSet.clear()
+  g.reauthErrors.clear()
+
+  if (g.leasePruneTimer !== null) {
+    clearTimeout(g.leasePruneTimer)
+    g.leasePruneTimer = null
+  }
+
+  g.primaryReconnect = null
+  g.primaryGateway = null
+  g.primaryProfile = 'default'
+  g.activeKey = 'default'
+  g.config = null
 }
 
 // Self-accept so editing this module (or a fan-out that lands here) is an

--- a/apps/desktop/src/store/pet-gallery-profile.test.ts
+++ b/apps/desktop/src/store/pet-gallery-profile.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Layer 7 — profile-scoped gallery + pet-transport. Gallery state is per-profile
+ * (concurrent loads don't clobber each other), mutations route to the right
+ * profile's slice, scale debounce/reconciliation is per-profile, and non-active
+ * profiles route through requestGatewayForProfile (Electron resolves the
+ * connection) — never the active requester, never a lease.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { leaseProfileGateway, requestGatewayForProfile } from '@/store/gateway'
+import { $profilePets } from '@/store/pet-multi'
+import { $activeGatewayProfile } from '@/store/profile'
+
+import {
+  $petGalleries,
+  adoptPet,
+  loadPetGallery,
+  resetPetGallery,
+  setPetScale,
+  type GatewayRequest,
+  type PetGallery
+} from './pet-gallery'
+
+vi.mock('@/store/gateway', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/gateway')>()
+
+  return {
+    ...actual,
+    leaseProfileGateway: vi.fn(),
+    requestGatewayForProfile: vi.fn(async () => ({}))
+  }
+})
+
+const profileRequest = vi.mocked(requestGatewayForProfile)
+const lease = vi.mocked(leaseProfileGateway)
+
+// A foreground requester that should NEVER be used for a non-active profile.
+const activeRequest = vi.fn(async () => ({})) as unknown as GatewayRequest
+
+const galleryFor = (profile: string): PetGallery => ({
+  active: `${profile}-pet`,
+  enabled: true,
+  pets: [{ displayName: profile, installed: true, slug: `${profile}-pet` }]
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+  resetPetGallery()
+  $activeGatewayProfile.set('default')
+  profileRequest.mockImplementation(async (profile: string, method: string) => {
+    if (method === 'pet.gallery') {
+      return galleryFor(profile)
+    }
+
+    if (method === 'pet.info') {
+      return { enabled: true }
+    }
+
+    return {}
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  resetPetGallery()
+  $activeGatewayProfile.set('default')
+})
+
+describe('per-profile gallery state (tests 27, 28)', () => {
+  it('concurrent profile loads do not overwrite each other (test 27)', async () => {
+    await Promise.all([
+      loadPetGallery(activeRequest, { profile: 'apollo' }),
+      loadPetGallery(activeRequest, { profile: 'nova' })
+    ])
+
+    const galleries = $petGalleries.get()
+
+    expect(galleries.get('apollo')?.active).toBe('apollo-pet')
+    expect(galleries.get('nova')?.active).toBe('nova-pet')
+  })
+
+  it('a mutation patches only the targeted profile\u2019s slice (test 28)', async () => {
+    await Promise.all([
+      loadPetGallery(activeRequest, { profile: 'apollo' }),
+      loadPetGallery(activeRequest, { profile: 'nova' })
+    ])
+
+    profileRequest.mockResolvedValue({ ok: true })
+    await adoptPet(activeRequest, 'custom', 'fallback', 'apollo')
+
+    // apollo flipped to the adopted pet; nova is untouched.
+    expect($petGalleries.get().get('apollo')?.active).toBe('custom')
+    expect($petGalleries.get().get('apollo')?.enabled).toBe(true)
+    expect($petGalleries.get().get('nova')?.active).toBe('nova-pet')
+    // The mutation routed through apollo's own socket.
+    expect(profileRequest).toHaveBeenCalledWith('apollo', 'pet.select', { profile: 'apollo', slug: 'custom' }, undefined, undefined)
+  })
+})
+
+describe('per-profile scale debounce/reconciliation (test 47)', () => {
+  it('debounces and reconciles two profiles independently', () => {
+    profileRequest.mockResolvedValue({ ok: true })
+
+    setPetScale(activeRequest, 0.5, 'apollo')
+    setPetScale(activeRequest, 0.7, 'nova')
+
+    // Before the debounce fires, nothing persisted.
+    expect(profileRequest).not.toHaveBeenCalledWith('apollo', 'pet.scale', expect.anything(), undefined, undefined)
+
+    vi.advanceTimersByTime(200)
+
+    expect(profileRequest).toHaveBeenCalledWith('apollo', 'pet.scale', { profile: 'apollo', scale: 0.5 }, undefined, undefined)
+    expect(profileRequest).toHaveBeenCalledWith('nova', 'pet.scale', { profile: 'nova', scale: 0.7 }, undefined, undefined)
+
+    // Each profile's own slice reconciled (not the global foreground pet).
+    expect($profilePets.get().get('apollo')?.info.scale).toBe(0.5)
+    expect($profilePets.get().get('nova')?.info.scale).toBe(0.7)
+  })
+})
+
+describe('pet-transport routing (tests 59, 60)', () => {
+  it('a non-active (pool) profile uses requestGatewayForProfile, never the active requester, with no lease (test 59)', async () => {
+    await loadPetGallery(activeRequest, { profile: 'apollo' })
+
+    expect(profileRequest).toHaveBeenCalledWith('apollo', 'pet.gallery', expect.objectContaining({ profile: 'apollo' }), undefined, undefined)
+    // The foreground requester is never used for a background profile.
+    expect(activeRequest).not.toHaveBeenCalled()
+    // Gallery calls take no lease.
+    expect(lease).not.toHaveBeenCalled()
+  })
+
+  it('per-profile calls resolve through Electron for the named profile (test 60)', async () => {
+    await loadPetGallery(activeRequest, { profile: 'nova' })
+
+    // Every RPC carries the named profile so Electron routes it to that
+    // profile's own backend/connection (local or remote), not the active one.
+    const profiles = profileRequest.mock.calls.map(call => call[0])
+
+    expect(profiles.every(p => p === 'nova')).toBe(true)
+    expect(activeRequest).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/pet-gallery.ts
+++ b/apps/desktop/src/store/pet-gallery.ts
@@ -1,7 +1,10 @@
-import { atom } from 'nanostores'
+import { atom, computed } from 'nanostores'
 
 import { normalize } from '@/lib/text'
 import { $petInfo, type PetInfo, petProfile, setPetInfo } from '@/store/pet'
+import { setProfilePetInfo } from '@/store/pet-multi'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import { petRequestFor, type PetGatewayRequest } from '@/store/pet-transport'
 
 /**
  * Feature store for the petdex gallery picker (Cmd+K "Pets…" + Settings).
@@ -17,8 +20,12 @@ import { $petInfo, type PetInfo, petProfile, setPetInfo } from '@/store/pet'
  *  - Thumbnails are deduped in a process-global cache (the backend disk-caches
  *    too, so a slug is fetched at most once per session).
  *
- * Consumers just `useStore($petGallery)` and call the actions; no component
- * owns gallery state anymore.
+ * Layer 7: state is per-profile (one gallery slice per normalized profile key)
+ * so pinned mode can manage several profiles' pets concurrently. The legacy
+ * singular atoms ($petGallery et al) remain as computed views over the ACTIVE
+ * profile's slice, so every existing consumer (follow-active) is unchanged. A
+ * non-active profile's calls route through petRequestFor(profile) — never the
+ * active gateway; the active profile keeps the hook's recovering requester.
  */
 
 export interface GalleryPet {
@@ -42,18 +49,7 @@ export type PetGalleryStatus = 'idle' | 'loading' | 'ready' | 'stale' | 'error'
 
 /** The recovering `requestGateway` from `useGatewayRequest` — passed in so the
  *  store reuses the hook's reconnect/reauth handling instead of duplicating it. */
-export type GatewayRequest = <T>(
-  method: string,
-  params?: Record<string, unknown>,
-  timeoutMs?: number,
-  signal?: AbortSignal
-) => Promise<T>
-
-/** Profile-scoped pet RPC. Pets are per-profile, so every call carries the active
- *  profile (the gateway no-ops it for the launch profile). One chokepoint so no
- *  call site can forget it. */
-const petRpc = <T>(request: GatewayRequest, method: string, params: Record<string, unknown> = {}): Promise<T> =>
-  request<T>(method, { ...params, profile: petProfile() })
+export type GatewayRequest = PetGatewayRequest
 
 /** A JSON-RPC "method not found" — the backend predates the pet RPCs. */
 function isMissingMethod(error: unknown): boolean {
@@ -62,65 +58,176 @@ function isMissingMethod(error: unknown): boolean {
   return /method not found|-32601|unknown method|no such method/i.test(message)
 }
 
-export const $petGallery = atom<PetGallery | null>(null)
-export const $petGalleryStatus = atom<PetGalleryStatus>('idle')
-export const $petGalleryError = atom<string | null>(null)
+// ── Per-profile state (Layer 7) ────────────────────────────────────────────
+// One slice per normalized profile key. Copy-on-write Maps so computeds re-fire.
+
+export const $petGalleries = atom<ReadonlyMap<string, PetGallery>>(new Map())
+export const $petGalleryStatuses = atom<ReadonlyMap<string, PetGalleryStatus>>(new Map())
+export const $petGalleryErrors = atom<ReadonlyMap<string, string | null>>(new Map())
+export const $petBusyProfiles = atom<ReadonlyMap<string, string | null>>(new Map())
+
+function activeKey(): string {
+  return normalizeProfileKey($activeGatewayProfile.get())
+}
+
+function slice<T>(map: ReadonlyMap<string, T>, key: string): T | undefined {
+  return map.get(key)
+}
+
+// Backwards-compat singular views over the ACTIVE profile's slice. Existing
+// consumers (follow-active) read these and see exactly what they did before.
+export const $petGallery = computed($petGalleries, m => slice(m, activeKey()) ?? null)
+export const $petGalleryStatus = computed($petGalleryStatuses, m => slice(m, activeKey()) ?? 'idle')
+export const $petGalleryError = computed($petGalleryErrors, m => slice(m, activeKey()) ?? null)
+export const $petBusy = computed($petBusyProfiles, m => slice(m, activeKey()) ?? null)
 
 // Which action is in flight, so rows/buttons can show a spinner. A slug for a
 // per-pet mutation; the `TOGGLE_*` sentinels for the on/off switch.
 export const TOGGLE_ON = '\u0000on'
 export const TOGGLE_OFF = '\u0000off'
-export const $petBusy = atom<string | null>(null)
 
-// Process-global caches (survive component unmount → instant reopen).
+// Process-global caches (survive component unmount → instant reopen). Thumb cache
+// is keyed `${profile}::${slug}` so two profiles' same-named pets don't collide.
 const thumbCache = new Map<string, Promise<string | null>>()
-let galleryLoad: Promise<void> | null = null
+// One in-flight gallery load per profile — concurrent profile loads must not
+// cancel each other (test 27).
+const galleryLoads = new Map<string, Promise<void>>()
+// One scale-persist debounce timer per profile (test 47).
+const scalePersists = new Map<string, ReturnType<typeof setTimeout>>()
 
-/**
- * Drop the cached gallery, thumbnails, and in-flight load so the next open
- * refetches against the now-active profile's backend. Called on a profile switch
- * (pets are per-profile) — the floating pet's own `pet.info` poll repaints the
- * new profile's mascot, and the picker reloads its gallery on next mount.
- */
-export function resetPetGallery(): void {
-  galleryLoad = null
-  thumbCache.clear()
-  $petGallery.set(null)
-  $petGalleryStatus.set('idle')
-  $petGalleryError.set(null)
-  $petBusy.set(null)
+function thumbKey(profile: string, slug: string): string {
+  return `${normalizeProfileKey(profile)}::${slug}`
 }
 
-export function loadPetThumb(request: GatewayRequest, slug: string, url?: string): Promise<string | null> {
-  let pending = thumbCache.get(slug)
+function setGallerySlice(profile: string, gallery: PetGallery | null): void {
+  const key = normalizeProfileKey(profile)
+  const next = new Map($petGalleries.get())
+
+  if (gallery) {
+    next.set(key, gallery)
+  } else {
+    next.delete(key)
+  }
+
+  $petGalleries.set(next)
+}
+
+function setStatusSlice(profile: string, status: PetGalleryStatus): void {
+  const key = normalizeProfileKey(profile)
+  const next = new Map($petGalleryStatuses.get())
+  next.set(key, status)
+  $petGalleryStatuses.set(next)
+}
+
+function setErrorSlice(profile: string, error: string | null): void {
+  const key = normalizeProfileKey(profile)
+  const next = new Map($petGalleryErrors.get())
+  next.set(key, error)
+  $petGalleryErrors.set(next)
+}
+
+function setBusySlice(profile: string, busy: string | null): void {
+  const key = normalizeProfileKey(profile)
+  const next = new Map($petBusyProfiles.get())
+  next.set(key, busy)
+  $petBusyProfiles.set(next)
+}
+
+/** Pick the requester for a profile: the active profile keeps the hook's
+ *  recovering requester; any other profile routes through its OWN socket via
+ *  petRequestFor (never the active gateway). */
+function requestFor(profile: string, activeRequest: GatewayRequest): GatewayRequest {
+  return normalizeProfileKey(profile) === activeKey() ? activeRequest : petRequestFor(profile)
+}
+
+/** Profile-scoped pet RPC. Pets are per-profile, so every call carries the
+ *  profile (the gateway no-ops it for the launch profile). */
+function petRpc<T>(
+  request: GatewayRequest,
+  profile: string,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<T> {
+  const key = normalizeProfileKey(profile)
+
+  return request<T>(method, { ...params, profile: key })
+}
+
+/** Write a profile's mascot info: the active profile mirrors into the global
+ *  `$petInfo` (the floating pet + overlay render from it); a background profile
+ *  updates only its own `$profilePets` slice. */
+function applyPetInfo(profile: string, info: PetInfo): void {
+  if (normalizeProfileKey(profile) === activeKey()) {
+    setPetInfo(info)
+  } else {
+    setProfilePetInfo(profile, info)
+  }
+}
+
+function currentInfo(profile: string): PetInfo {
+  return normalizeProfileKey(profile) === activeKey() ? $petInfo.get() : { enabled: false }
+}
+
+/**
+ * Drop the cached gallery, thumbnails, and in-flight loads so the next open
+ * refetches. Called on a profile switch (pets are per-profile). Clears every
+ * profile's slice — the picker reloads against the now-active backend.
+ */
+export function resetPetGallery(): void {
+  galleryLoads.clear()
+  thumbCache.clear()
+  $petGalleries.set(new Map())
+  $petGalleryStatuses.set(new Map())
+  $petGalleryErrors.set(new Map())
+  $petBusyProfiles.set(new Map())
+}
+
+export function loadPetThumb(
+  request: GatewayRequest,
+  slug: string,
+  url?: string,
+  profile: string = petProfile()
+): Promise<string | null> {
+  const key = thumbKey(profile, slug)
+  let pending = thumbCache.get(key)
 
   if (!pending) {
-    pending = petRpc<{ ok: boolean; dataUri?: string }>(request, 'pet.thumb', { slug, url: url ?? '' })
+    const rpc = requestFor(profile, request)
+    pending = petRpc<{ ok: boolean; dataUri?: string }>(rpc, profile, 'pet.thumb', { slug, url: url ?? '' })
       .then(result => (result?.ok && result.dataUri ? result.dataUri : null))
       .catch(() => null)
-    thumbCache.set(slug, pending)
+    thumbCache.set(key, pending)
   }
 
   return pending
 }
 
 /**
- * Fetch the gallery once and cache it. Subsequent calls are no-ops while a
- * ready snapshot is held; pass `{ force: true }` to bypass the cache (e.g. a
- * manual refresh). Concurrent callers share a single in-flight request.
+ * Fetch one profile's gallery once and cache it. Subsequent calls are no-ops
+ * while a ready snapshot is held; pass `{ force: true }` to bypass the cache.
+ * Concurrent callers for the SAME profile share a single in-flight request;
+ * different profiles load independently (never cancel each other).
  */
-export function loadPetGallery(request: GatewayRequest, options: { force?: boolean } = {}): Promise<void> {
-  if (!options.force && $petGallery.get() && $petGalleryStatus.get() === 'ready') {
+export function loadPetGallery(
+  request: GatewayRequest,
+  options: { force?: boolean; profile?: string } = {}
+): Promise<void> {
+  const profile = normalizeProfileKey(options.profile ?? petProfile())
+  const rpc = requestFor(profile, request)
+
+  if (!options.force && slice($petGalleries.get(), profile) && $petGalleryStatuses.get().get(profile) === 'ready') {
     return Promise.resolve()
   }
 
-  if (galleryLoad) {
-    return galleryLoad
+  const existing = galleryLoads.get(profile)
+
+  if (existing) {
+    return existing
   }
 
-  galleryLoad = (async () => {
-    if (!$petGallery.get()) {
-      $petGalleryStatus.set('loading')
+  const load = (async () => {
+    if (!slice($petGalleries.get(), profile)) {
+      setStatusSlice(profile, 'loading')
     }
 
     let localOk = false
@@ -129,42 +236,42 @@ export function loadPetGallery(request: GatewayRequest, options: { force?: boole
       // Phase 1: local pets only — instant, never blocks on the remote petdex
       // manifest. The user's own/generated pets render right away.
       const [local, info] = await Promise.all([
-        petRpc<PetGallery>(request, 'pet.gallery', { localOnly: true }),
-        petRpc<PetInfo>(request, 'pet.info')
+        petRpc<PetGallery>(rpc, profile, 'pet.gallery', { localOnly: true }),
+        petRpc<PetInfo>(rpc, profile, 'pet.info')
       ])
 
       if (local) {
-        $petGallery.set(local)
-        $petGalleryStatus.set('ready')
-        $petGalleryError.set(null)
+        setGallerySlice(profile, local)
+        setStatusSlice(profile, 'ready')
+        setErrorSlice(profile, null)
         localOk = true
       }
 
       if (info) {
-        setPetInfo(info)
+        applyPetInfo(profile, info)
       }
     } catch (e) {
       if (isMissingMethod(e)) {
-        $petGalleryStatus.set('stale')
-      } else if (!$petGallery.get()) {
+        setStatusSlice(profile, 'stale')
+      } else if (!slice($petGalleries.get(), profile)) {
         // Only surface a hard error when we have nothing to show; a transient
         // hiccup mid-session leaves the cached gallery intact.
-        $petGalleryStatus.set('error')
-        $petGalleryError.set(e instanceof Error ? e.message : 'Could not reach the petdex gallery.')
+        setStatusSlice(profile, 'error')
+        setErrorSlice(profile, e instanceof Error ? e.message : 'Could not reach the petdex gallery.')
       }
     } finally {
-      galleryLoad = null
+      galleryLoads.delete(profile)
     }
 
     // Phase 2: merge in the full petdex catalog in the background. A slow/failed
     // manifest fetch never hides the local pets shown in phase 1.
     if (localOk) {
       try {
-        const full = await petRpc<PetGallery>(request, 'pet.gallery')
+        const full = await petRpc<PetGallery>(rpc, profile, 'pet.gallery')
 
         if (full) {
-          $petGallery.set(full)
-          $petGalleryStatus.set('ready')
+          setGallerySlice(profile, full)
+          setStatusSlice(profile, 'ready')
         }
       } catch {
         // Keep the local-only gallery; the petdex catalog just stays unmerged.
@@ -172,17 +279,20 @@ export function loadPetGallery(request: GatewayRequest, options: { force?: boole
     }
   })()
 
-  return galleryLoad
+  galleryLoads.set(profile, load)
+
+  return load
 }
 
 // Push the live mascot state (cheap, local config read) without re-pulling the
 // network gallery — the floating pet repaints, the picker keeps its cache.
-async function syncInfo(request: GatewayRequest): Promise<void> {
+async function syncInfo(request: GatewayRequest, profile: string): Promise<void> {
   try {
-    const info = await petRpc<PetInfo>(request, 'pet.info')
+    const rpc = requestFor(profile, request)
+    const info = await petRpc<PetInfo>(rpc, profile, 'pet.info')
 
     if (info) {
-      setPetInfo(info)
+      applyPetInfo(profile, info)
     }
   } catch {
     // The mutation already succeeded; a stale mascot self-heals on its poll.
@@ -195,8 +305,13 @@ async function syncInfo(request: GatewayRequest): Promise<void> {
  * local `pet.info`. Adopting a generated pet is a disk+config op — it must never
  * wait on `pet.gallery`'s remote petdex manifest fetch.
  */
-export async function applyAdoptedPet(request: GatewayRequest, slug: string, displayName: string): Promise<void> {
-  patchGallery(gallery => ({
+export async function applyAdoptedPet(
+  request: GatewayRequest,
+  slug: string,
+  displayName: string,
+  profile: string = petProfile()
+): Promise<void> {
+  patchGallery(profile, gallery => ({
     ...gallery,
     enabled: true,
     active: slug,
@@ -204,7 +319,7 @@ export async function applyAdoptedPet(request: GatewayRequest, slug: string, dis
       ? gallery.pets.map(p => (p.slug === slug ? { ...p, installed: true, displayName } : p))
       : [...gallery.pets, { slug, displayName, installed: true, spritesheetUrl: '' }]
   }))
-  await syncInfo(request)
+  await syncInfo(request, profile)
 }
 
 /**
@@ -240,47 +355,55 @@ export function rankedGalleryPets(gallery: PetGallery | null, query = ''): Galle
     .sort((a, b) => rank(b) - rank(a))
 }
 
-function patchGallery(fn: (gallery: PetGallery) => PetGallery): void {
-  const current = $petGallery.get()
+function patchGallery(profile: string, fn: (gallery: PetGallery) => PetGallery): void {
+  const key = normalizeProfileKey(profile)
+  const current = $petGalleries.get().get(key)
 
   if (current) {
-    $petGallery.set(fn(current))
+    setGallerySlice(key, fn(current))
   }
 }
 
 /** Shared mutation wrapper: spin, fire, patch on success, surface failures. */
 async function mutate(
+  profile: string,
   busyKey: string,
   fallback: string,
   request: GatewayRequest,
   run: () => Promise<void>
 ): Promise<boolean> {
-  $petBusy.set(busyKey)
-  $petGalleryError.set(null)
+  setBusySlice(profile, busyKey)
+  setErrorSlice(profile, null)
 
   try {
     await run()
-    await syncInfo(request)
+    await syncInfo(request, profile)
 
     return true
   } catch (e) {
     if (isMissingMethod(e)) {
-      $petGalleryStatus.set('stale')
+      setStatusSlice(profile, 'stale')
     } else {
-      $petGalleryError.set(e instanceof Error ? e.message : fallback)
+      setErrorSlice(profile, e instanceof Error ? e.message : fallback)
     }
 
     return false
   } finally {
-    $petBusy.set(null)
+    setBusySlice(profile, null)
   }
 }
 
 /** Install (if needed) + activate a pet. Optimistically marks it active. */
-export function adoptPet(request: GatewayRequest, slug: string, fallback: string): Promise<boolean> {
-  return mutate(slug, fallback, request, async () => {
-    await petRpc(request, 'pet.select', { slug })
-    patchGallery(g => ({
+export function adoptPet(
+  request: GatewayRequest,
+  slug: string,
+  fallback: string,
+  profile: string = petProfile()
+): Promise<boolean> {
+  return mutate(profile, slug, fallback, request, async () => {
+    const rpc = requestFor(profile, request)
+    await petRpc(rpc, profile, 'pet.select', { slug })
+    patchGallery(profile, g => ({
       ...g,
       enabled: true,
       active: slug,
@@ -296,9 +419,10 @@ export function adoptPet(request: GatewayRequest, slug: string, fallback: string
 export function setPetEnabled(
   request: GatewayRequest,
   on: boolean,
-  copy: { noneAvailable: string; fallback: string }
+  copy: { noneAvailable: string; fallback: string },
+  profile: string = petProfile()
 ): Promise<boolean> {
-  const gallery = $petGallery.get()
+  const gallery = $petGalleries.get().get(normalizeProfileKey(profile))
 
   if (!on && !(gallery?.enabled ?? false)) {
     return Promise.resolve(true)
@@ -310,20 +434,22 @@ export function setPetEnabled(
     slug = slug || gallery?.pets.find(p => p.installed)?.slug || ''
 
     if (!slug) {
-      $petGalleryError.set(copy.noneAvailable)
+      setErrorSlice(profile, copy.noneAvailable)
 
       return Promise.resolve(false)
     }
   }
 
-  return mutate(on ? TOGGLE_ON : TOGGLE_OFF, copy.fallback, request, async () => {
+  return mutate(profile, on ? TOGGLE_ON : TOGGLE_OFF, copy.fallback, request, async () => {
+    const rpc = requestFor(profile, request)
+
     if (on) {
-      await petRpc(request, 'pet.select', { slug })
+      await petRpc(rpc, profile, 'pet.select', { slug })
     } else {
-      await petRpc(request, 'pet.disable')
+      await petRpc(rpc, profile, 'pet.disable')
     }
 
-    patchGallery(g => ({ ...g, enabled: on, active: on ? slug : g.active }))
+    patchGallery(profile, g => ({ ...g, enabled: on, active: on ? slug : g.active }))
   })
 }
 
@@ -349,41 +475,58 @@ export function nextScaleFromWheel(current: number | undefined, deltaY: number):
   return clampPetScale(base * Math.exp(-deltaY * WHEEL_SCALE_K))
 }
 
-let scalePersist: ReturnType<typeof setTimeout> | undefined
-
 /**
- * Resize the floating pet. Updates `$petInfo` synchronously so the on-screen pet
- * (and the slider) react on the same frame, then debounce-persists to
- * `display.pet.scale` so a slider drag fires one RPC, not one per pixel. No poll
- * or event needed — the pet already renders from `$petInfo.scale`.
+ * Resize the floating pet. Updates the mascot info synchronously so the on-screen
+ * pet (and the slider) react on the same frame, then debounce-persists to
+ * `display.pet.scale` (per profile) so a slider drag fires one RPC, not one per
+ * pixel. The active profile mirrors into `$petInfo`; a background profile updates
+ * only its `$profilePets` slice.
  */
-export function setPetScale(request: GatewayRequest, scale: number): void {
+export function setPetScale(request: GatewayRequest, scale: number, profile: string = petProfile()): void {
+  const key = normalizeProfileKey(profile)
   const next = clampPetScale(scale)
 
-  setPetInfo({ ...$petInfo.get(), scale: next })
+  applyPetInfo(key, { ...currentInfo(key), scale: next })
 
-  clearTimeout(scalePersist)
-  scalePersist = setTimeout(() => {
-    petRpc<{ ok: boolean; scale?: number }>(request, 'pet.scale', { scale: next })
-      .then(result => {
-        // Reconcile with the server's clamp (cheap; only matters at the bounds).
-        if (typeof result?.scale === 'number' && result.scale !== $petInfo.get().scale) {
-          setPetInfo({ ...$petInfo.get(), scale: result.scale })
-        }
-      })
-      .catch(() => {
-        // Cosmetic — the pet already resized; persistence self-heals next write.
-      })
-  }, 200)
+  const existing = scalePersists.get(key)
+
+  if (existing) {
+    clearTimeout(existing)
+  }
+
+  const rpc = requestFor(key, request)
+
+  scalePersists.set(
+    key,
+    setTimeout(() => {
+      scalePersists.delete(key)
+      petRpc<{ ok: boolean; scale?: number }>(rpc, key, 'pet.scale', { scale: next })
+        .then(result => {
+          // Reconcile with the server's clamp (cheap; only matters at the bounds).
+          if (typeof result?.scale === 'number' && result.scale !== currentInfo(key).scale) {
+            applyPetInfo(key, { ...currentInfo(key), scale: result.scale })
+          }
+        })
+        .catch(() => {
+          // Cosmetic — the pet already resized; persistence self-heals next write.
+        })
+    }, 200)
+  )
 }
 
 /** Export a pet as a `.zip` (pet.json + spritesheet) and save it via the browser. */
-export async function exportPet(request: GatewayRequest, slug: string, fallback: string): Promise<boolean> {
-  $petBusy.set(slug)
-  $petGalleryError.set(null)
+export async function exportPet(
+  request: GatewayRequest,
+  slug: string,
+  fallback: string,
+  profile: string = petProfile()
+): Promise<boolean> {
+  setBusySlice(profile, slug)
+  setErrorSlice(profile, null)
 
   try {
-    const res = await petRpc<{ ok: boolean; filename: string; zipBase64: string }>(request, 'pet.export', { slug })
+    const rpc = requestFor(profile, request)
+    const res = await petRpc<{ ok: boolean; filename: string; zipBase64: string }>(rpc, profile, 'pet.export', { slug })
 
     if (!res?.ok || !res.zipBase64) {
       throw new Error(fallback)
@@ -399,11 +542,11 @@ export async function exportPet(request: GatewayRequest, slug: string, fallback:
 
     return true
   } catch (e) {
-    $petGalleryError.set(e instanceof Error ? e.message : fallback)
+    setErrorSlice(profile, e instanceof Error ? e.message : fallback)
 
     return false
   } finally {
-    $petBusy.set(null)
+    setBusySlice(profile, null)
   }
 }
 
@@ -413,25 +556,33 @@ export async function exportPet(request: GatewayRequest, slug: string, fallback:
  * realigns the slug/dir, so we reconcile the slug + thumb cache when it returns,
  * and roll the name back if it fails.
  */
-export function renamePet(request: GatewayRequest, slug: string, name: string, fallback: string): Promise<boolean> {
+export function renamePet(
+  request: GatewayRequest,
+  slug: string,
+  name: string,
+  fallback: string,
+  profile: string = petProfile()
+): Promise<boolean> {
   const trimmed = name.trim()
 
   if (!trimmed) {
     return Promise.resolve(false)
   }
 
-  const prev = $petGallery.get()?.pets.find(p => p.slug === slug)?.displayName ?? ''
+  const key = normalizeProfileKey(profile)
+  const prev = $petGalleries.get().get(key)?.pets.find(p => p.slug === slug)?.displayName ?? ''
 
   // Optimistic: paint the new name now (slug reconciles when the RPC returns).
-  patchGallery(g => ({
+  patchGallery(key, g => ({
     ...g,
     pets: g.pets.map(p => (p.slug === slug ? { ...p, displayName: trimmed } : p))
   }))
-  $petGalleryError.set(null)
+  setErrorSlice(key, null)
 
   return (async () => {
     try {
-      const res = await petRpc<{ ok: boolean; slug: string; displayName: string }>(request, 'pet.rename', {
+      const rpc = requestFor(key, request)
+      const res = await petRpc<{ ok: boolean; slug: string; displayName: string }>(rpc, key, 'pet.rename', {
         slug,
         name: trimmed
       })
@@ -443,8 +594,8 @@ export function renamePet(request: GatewayRequest, slug: string, name: string, f
       const newSlug = res.slug || slug
 
       if (newSlug !== slug) {
-        thumbCache.delete(slug)
-        patchGallery(g => ({
+        thumbCache.delete(thumbKey(key, slug))
+        patchGallery(key, g => ({
           ...g,
           active: g.active === slug ? newSlug : g.active,
           pets: g.pets
@@ -456,11 +607,11 @@ export function renamePet(request: GatewayRequest, slug: string, name: string, f
       return true
     } catch (e) {
       // Roll the optimistic name back so the list reflects on-disk truth.
-      patchGallery(g => ({
+      patchGallery(key, g => ({
         ...g,
         pets: g.pets.map(p => (p.slug === slug ? { ...p, displayName: prev } : p))
       }))
-      $petGalleryError.set(e instanceof Error ? e.message : fallback)
+      setErrorSlice(key, e instanceof Error ? e.message : fallback)
 
       return false
     }
@@ -468,13 +619,19 @@ export function renamePet(request: GatewayRequest, slug: string, name: string, f
 }
 
 /** Uninstall a pet; turns the mascot off if it was the active one. */
-export function removePet(request: GatewayRequest, slug: string, fallback: string): Promise<boolean> {
-  return mutate(slug, fallback, request, async () => {
-    await petRpc(request, 'pet.remove', { slug })
+export function removePet(
+  request: GatewayRequest,
+  slug: string,
+  fallback: string,
+  profile: string = petProfile()
+): Promise<boolean> {
+  return mutate(profile, slug, fallback, request, async () => {
+    const rpc = requestFor(profile, request)
+    await petRpc(rpc, profile, 'pet.remove', { slug })
     // Evict the by-slug thumb cache so a reused slug doesn't render this pet's
     // stale thumbnail (the backend drops its disk thumb in parallel).
-    thumbCache.delete(slug)
-    patchGallery(g => ({
+    thumbCache.delete(thumbKey(profile, slug))
+    patchGallery(profile, g => ({
       ...g,
       enabled: g.active === slug ? false : g.enabled,
       active: g.active === slug ? '' : g.active,

--- a/apps/desktop/src/store/pet-multi.test.ts
+++ b/apps/desktop/src/store/pet-multi.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { derivePetState } from './pet'
+import {
+  __resetPetMultiForTests,
+  completeTool,
+  deriveProfileActivity,
+  getProfilePet,
+  markProfilePetUnread,
+  clearProfilePetUnread,
+  removeSessionActivity,
+  replaceSessionRuntimeId,
+  setSessionAwaitingInput,
+  setSessionBusy,
+  setSessionReasoning,
+  startTool,
+  terminateSession
+} from './pet-multi'
+
+beforeEach(() => {
+  __resetPetMultiForTests()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  __resetPetMultiForTests()
+})
+
+describe('session-derived activity', () => {
+  it('two concurrent sessions in one profile keep toolRunning until BOTH finish (test 5)', () => {
+    startTool('default', 'session-a', 'tool-1')
+    startTool('default', 'session-b', 'tool-2')
+
+    expect(deriveProfileActivity('default').toolRunning).toBe(true)
+
+    // Finishing session A's tool leaves session B still running.
+    completeTool('default', 'session-a', 'tool-1')
+    expect(deriveProfileActivity('default').toolRunning).toBe(true)
+
+    completeTool('default', 'session-b', 'tool-2')
+    expect(deriveProfileActivity('default').toolRunning).toBe(false)
+  })
+
+  it('overlapping tool ids in ONE session keep toolRunning true until the last completes (test 21)', () => {
+    startTool('default', 'sess', 'a')
+    startTool('default', 'sess', 'b')
+    expect(deriveProfileActivity('default').toolRunning).toBe(true)
+
+    completeTool('default', 'sess', 'a')
+    expect(deriveProfileActivity('default').toolRunning).toBe(true) // b still running
+
+    completeTool('default', 'sess', 'b')
+    expect(deriveProfileActivity('default').toolRunning).toBe(false)
+  })
+
+  it('ignores empty/missing tool ids (no phantom tools)', () => {
+    startTool('default', 'sess', '')
+    startTool('default', 'sess', undefined)
+    expect(deriveProfileActivity('default').toolRunning).toBe(false)
+  })
+
+  it('aggregates busy/reasoning across sessions with the profile prefix only', () => {
+    setSessionBusy('default', 'sess-1', true)
+    setSessionReasoning('apollo', 'sess-2', true)
+
+    expect(deriveProfileActivity('default').busy).toBe(true)
+    expect(deriveProfileActivity('default').reasoning).toBe(false)
+    expect(deriveProfileActivity('apollo').reasoning).toBe(true)
+    expect(deriveProfileActivity('apollo').busy).toBe(false)
+  })
+})
+
+describe('terminal transitions', () => {
+  it('session.info running=false clears busy/reasoning/tools (test 40)', () => {
+    setSessionBusy('default', 'sess', true)
+    setSessionReasoning('default', 'sess', true)
+    startTool('default', 'sess', 'tool')
+    expect(deriveProfileActivity('default').busy).toBe(true)
+
+    terminateSession('default', 'sess')
+
+    const activity = deriveProfileActivity('default')
+    expect(activity.busy).toBe(false)
+    expect(activity.reasoning).toBe(false)
+    expect(activity.toolRunning).toBe(false)
+  })
+
+  it('interrupt/error/removal clean up the activity entry (test 20)', () => {
+    setSessionBusy('default', 'sess', true)
+    startTool('default', 'sess', 'tool')
+
+    // Error terminal clears steady state and fires an error beat.
+    terminateSession('default', 'sess', { error: true })
+    expect(deriveProfileActivity('default').busy).toBe(false)
+    expect(deriveProfileActivity('default').error).toBe(true)
+
+    // Removal drops the entry entirely.
+    setSessionBusy('default', 'sess2', true)
+    removeSessionActivity('default', 'sess2')
+    expect(deriveProfileActivity('default').busy).toBe(false)
+  })
+
+  it('normal completion celebrates then settles to idle — NOT waiting (test 42)', () => {
+    vi.useFakeTimers()
+    setSessionBusy('default', 'sess', true)
+    setSessionAwaitingInput('default', 'sess', true)
+
+    terminateSession('default', 'sess', { celebrate: true })
+
+    const activity = deriveProfileActivity('default')
+    expect(activity.celebrate).toBe(true)
+    expect(activity.busy).toBe(false)
+    // A normal completion clears awaitingInput — it returns to idle, not waiting.
+    expect(activity.awaitingInput).toBe(false)
+    expect(derivePetState(activity)).toBe('jump')
+
+    // After the beat decays, the pet settles to idle (not waiting).
+    vi.advanceTimersByTime(2300)
+    const settled = deriveProfileActivity('default')
+    expect(settled.celebrate).toBe(false)
+    expect(derivePetState(settled)).toBe('idle')
+  })
+
+  it('clarify/approval sets awaitingInput; resolution clears it (test 43)', () => {
+    setSessionAwaitingInput('default', 'sess', true)
+    expect(deriveProfileActivity('default').awaitingInput).toBe(true)
+    expect(derivePetState(deriveProfileActivity('default'))).toBe('waiting')
+
+    setSessionAwaitingInput('default', 'sess', false)
+    expect(deriveProfileActivity('default').awaitingInput).toBe(false)
+  })
+
+  it('runtime-id replacement migrates the activity entry', () => {
+    setSessionBusy('default', 'old-runtime', true)
+    replaceSessionRuntimeId('default', 'old-runtime', 'new-runtime')
+
+    expect(deriveProfileActivity('default').busy).toBe(true)
+    // The old key no longer holds state; terminating the new id clears it.
+    terminateSession('default', 'new-runtime')
+    expect(deriveProfileActivity('default').busy).toBe(false)
+  })
+})
+
+describe('per-profile unread (source-session scoped)', () => {
+  it('clearing unread for one source session does not erase another in the same profile (test 46 prep)', () => {
+    markProfilePetUnread('default', 'session-a')
+    expect(getProfilePet('default')?.unread).toBe(true)
+
+    // Focusing session B must NOT clear session A's unread.
+    clearProfilePetUnread('default', 'session-b')
+    expect(getProfilePet('default')?.unread).toBe(true)
+
+    // Focusing session A clears it.
+    clearProfilePetUnread('default', 'session-a')
+    expect(getProfilePet('default')?.unread).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/pet-multi.test.ts
+++ b/apps/desktop/src/store/pet-multi.test.ts
@@ -10,6 +10,7 @@ import {
   clearProfilePetUnread,
   removeSessionActivity,
   replaceSessionRuntimeId,
+  setProfileSourceDurableSessionId,
   setSessionAwaitingInput,
   setSessionBusy,
   setSessionReasoning,
@@ -153,5 +154,18 @@ describe('per-profile unread (source-session scoped)', () => {
     // Focusing session A clears it.
     clearProfilePetUnread('default', 'session-a')
     expect(getProfilePet('default')?.unread).toBe(false)
+  })
+})
+
+describe('sourceDurableSessionId (overlay openApp)', () => {
+  it('records the durable id on an existing slice and is a no-op before one exists', () => {
+    // No slice yet → no-op (doesn't conjure an empty profile into existence).
+    setProfileSourceDurableSessionId('apollo', 'stored-1')
+    expect(getProfilePet('apollo')).toBeUndefined()
+
+    // Once the profile has a slice (e.g. unread marked), the durable id sticks.
+    markProfilePetUnread('apollo', 'rt-1')
+    setProfileSourceDurableSessionId('apollo', 'stored-1')
+    expect(getProfilePet('apollo')?.sourceDurableSessionId).toBe('stored-1')
   })
 })

--- a/apps/desktop/src/store/pet-multi.ts
+++ b/apps/desktop/src/store/pet-multi.ts
@@ -1,5 +1,7 @@
 import { atom } from 'nanostores'
 
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { normalizeProfileKey } from '@/store/profile'
 
 import type { PetActivity, PetInfo } from './pet'
@@ -68,6 +70,16 @@ const beats = new Map<string, ProfileBeat>()
 // Global "a session is awaiting the user" sync (use-pet-bridge) — OR-ed into the
 // derived awaitingInput so it survives a session-reducer republish.
 const manualAwaitingInput = new Map<string, boolean>()
+// Background (profile-targeted) submit state. A background submit drives the
+// profile's busy pose through these profile-scoped flags — never the foreground
+// $busy — so a reply sent to a non-active profile from its overlay still animates
+// that profile's pet.
+const profileSubmitBusy = new Map<string, boolean>()
+const profileAwaitingResponse = new Map<string, boolean>()
+// Per-(profile, runtimeId) background session-state cache. The submit pipeline's
+// optimistic inserts run against this so a background submit never publishes into
+// the foreground session cache or $messages.
+const backgroundSessionStates = new Map<string, ClientSessionState>()
 
 export function activityKey(profile: string, runtimeSessionId: string): string {
   return `${normalizeProfileKey(profile)}::${runtimeSessionId}`
@@ -101,7 +113,10 @@ export function deriveProfileActivity(profile: string): PetActivity {
 
   return {
     awaitingInput: sessions.some(s => s.awaitingInput) || (manualAwaitingInput.get(key) ?? false),
-    busy: sessions.some(s => s.busy),
+    busy:
+      sessions.some(s => s.busy) ||
+      (profileSubmitBusy.get(key) ?? false) ||
+      (profileAwaitingResponse.get(key) ?? false),
     celebrate: beat?.celebrate ?? false,
     error: beat?.error ?? false,
     justCompleted: beat?.justCompleted ?? false,
@@ -372,6 +387,11 @@ export function hasBusyActivityForStoredSession(profile: string, storedSessionId
   return false
 }
 
+/** Whether a specific runtime session under `profile` is currently busy. */
+export function profileRuntimeBusy(profile: string, runtimeSessionId: string): boolean {
+  return sessionActivity.get(activityKey(profile, runtimeSessionId))?.busy ?? false
+}
+
 /** The one runtime id bound to `storedSessionId` under `profile`, or null for
  *  zero/multiple matches (callers then use the durable session.resume path). */
 export function runtimeIdForStoredActivity(profile: string, storedSessionId: string): null | string {
@@ -393,29 +413,43 @@ export function runtimeIdForStoredActivity(profile: string, storedSessionId: str
   return found
 }
 
-// ── Layer 6 stubs (profile-safe submission) ────────────────────────────────
+// ── Layer 6c (profile-safe submission) ─────────────────────────────────────
 
 /**
- * Composite-keyed background session-state adapter. Layer 6 wires this to a
- * profile-scoped state cache that cannot write the foreground session cache or
- * `$messages`. Stubbed here so Layer 2/3 callers can reference the symbol.
+ * Composite-keyed background session-state adapter. The submit pipeline's
+ * optimistic inserts/rewrites/drops run against a per-(profile, runtimeId) cache
+ * here, so a background submit can keep its own bookkeeping without ever
+ * publishing into the foreground session cache or `$messages`. Returns the
+ * updated state (the pipeline calls this for its side effect).
  */
 export function updateBackgroundSessionState(
-  _profile: string,
-  _runtimeId: string,
-  _updater: unknown,
-  _storedId?: string | null
-): unknown {
-  // TODO(PR2b): route through the profile-scoped background state adapter.
-  return undefined
+  profile: string,
+  runtimeId: string,
+  updater: (state: ClientSessionState) => ClientSessionState,
+  storedId?: string | null
+): ClientSessionState {
+  const key = `${normalizeProfileKey(profile)}::${runtimeId}`
+  const prev = backgroundSessionStates.get(key) ?? createClientSessionState(storedId ?? null)
+  const next = updater(prev)
+  backgroundSessionStates.set(key, next)
+
+  return next
 }
 
-export function setProfileAwaitingResponse(_profile: string, _awaiting: boolean): void {
-  // TODO(PR2b): profile-scoped awaiting-response state for background submits.
+/** Profile-scoped awaiting-response flag for background submits — drives the
+ *  profile's busy pose, never the foreground `$awaitingResponse`. */
+export function setProfileAwaitingResponse(profile: string, awaiting: boolean): void {
+  const key = normalizeProfileKey(profile)
+  profileAwaitingResponse.set(key, awaiting)
+  publishProfileActivity(profile)
 }
 
-export function setProfileSubmitBusy(_profile: string, _busy: boolean): void {
-  // TODO(PR2b): profile-scoped submit busy state for background submits.
+/** Profile-scoped submit-busy flag for background submits — drives the profile's
+ *  busy pose, never the foreground `$busy`. */
+export function setProfileSubmitBusy(profile: string, busy: boolean): void {
+  const key = normalizeProfileKey(profile)
+  profileSubmitBusy.set(key, busy)
+  publishProfileActivity(profile)
 }
 
 /** Test-only: clear all per-session activity, beats, and profile slices so cases
@@ -424,5 +458,8 @@ export function __resetPetMultiForTests(): void {
   sessionActivity.clear()
   beats.clear()
   manualAwaitingInput.clear()
+  profileSubmitBusy.clear()
+  profileAwaitingResponse.clear()
+  backgroundSessionStates.clear()
   $profilePets.set(new Map())
 }

--- a/apps/desktop/src/store/pet-multi.ts
+++ b/apps/desktop/src/store/pet-multi.ts
@@ -1,0 +1,428 @@
+import { atom } from 'nanostores'
+
+import { normalizeProfileKey } from '@/store/profile'
+
+import type { PetActivity, PetInfo } from './pet'
+
+/**
+ * Per-profile pet state — the multi-pet foundation.
+ *
+ * One slice per profile, keyed by normalized profile name. Activity is
+ * SESSION-DERIVED: steady signals (busy / reasoning / running tools / awaiting
+ * input) are tracked per `(profile, runtimeSessionId)` in `sessionActivity` and
+ * aggregated by `deriveProfileActivity`; transient reaction beats
+ * (celebrate / error / justCompleted) live per profile with a generation-counter
+ * timer so a stale beat can't clear a newer one.
+ *
+ * `$profilePets` is copy-on-write: every reducer publishes a fresh Map so
+ * computeds (and the active-profile backwards-compat atoms in `pet.ts`) re-fire.
+ */
+
+export interface SessionActivity {
+  busy: boolean
+  reasoning: boolean
+  awaitingInput: boolean
+  /** Overlapping tool calls — a set, not a boolean, so two concurrent tools keep
+   *  toolRunning true until BOTH complete. */
+  activeToolIds: Set<string>
+  /** Durable session id learned from session.info/resume; lets a stored-id busy
+   *  lookup survive runtime-id rotation. */
+  storedSessionId?: string
+}
+
+export interface ProfileBeat {
+  celebrate: boolean
+  error: boolean
+  justCompleted: boolean
+  /** Generation counter for timer safety — an old timer can't clear a newer beat. */
+  gen: number
+}
+
+export interface ProfilePetState {
+  info: PetInfo
+  activity: PetActivity
+  replyText: string | null
+  unread: boolean
+  /** Runtime session id that produced the unread reply (used for submit). */
+  sourceSessionId?: string | null
+  /** Durable session id for navigation (survives compression/rehoming). */
+  sourceDurableSessionId?: string | null
+}
+
+function defaultProfilePetState(): ProfilePetState {
+  return {
+    activity: {},
+    info: { enabled: false },
+    replyText: null,
+    unread: false
+  }
+}
+
+export const $profilePets = atom<ReadonlyMap<string, ProfilePetState>>(new Map())
+
+// Per-session steady state, keyed `${profile}::${runtimeSessionId}`. Module-local
+// (not an atom): reactivity flows through the copy-on-write `$profilePets` bump
+// each reducer publishes.
+const sessionActivity = new Map<string, SessionActivity>()
+const beats = new Map<string, ProfileBeat>()
+// Global "a session is awaiting the user" sync (use-pet-bridge) — OR-ed into the
+// derived awaitingInput so it survives a session-reducer republish.
+const manualAwaitingInput = new Map<string, boolean>()
+
+export function activityKey(profile: string, runtimeSessionId: string): string {
+  return `${normalizeProfileKey(profile)}::${runtimeSessionId}`
+}
+
+function ensureSession(profile: string, runtimeSessionId: string): SessionActivity {
+  const key = activityKey(profile, runtimeSessionId)
+  let activity = sessionActivity.get(key)
+
+  if (!activity) {
+    activity = { activeToolIds: new Set(), awaitingInput: false, busy: false, reasoning: false }
+    sessionActivity.set(key, activity)
+  }
+
+  return activity
+}
+
+/** Aggregate a profile's sessions + beats into coarse activity signals. */
+export function deriveProfileActivity(profile: string): PetActivity {
+  const key = normalizeProfileKey(profile)
+  const prefix = `${key}::`
+  const sessions: SessionActivity[] = []
+
+  for (const [sessionKey, activity] of sessionActivity) {
+    if (sessionKey.startsWith(prefix)) {
+      sessions.push(activity)
+    }
+  }
+
+  const beat = beats.get(key)
+
+  return {
+    awaitingInput: sessions.some(s => s.awaitingInput) || (manualAwaitingInput.get(key) ?? false),
+    busy: sessions.some(s => s.busy),
+    celebrate: beat?.celebrate ?? false,
+    error: beat?.error ?? false,
+    justCompleted: beat?.justCompleted ?? false,
+    reasoning: sessions.some(s => s.reasoning),
+    toolRunning: sessions.some(s => s.activeToolIds.size > 0)
+  }
+}
+
+/** Copy-on-write publish of one profile's slice. */
+function updateProfilePet(profile: string, updater: (prev: ProfilePetState) => ProfilePetState): void {
+  const key = normalizeProfileKey(profile)
+  const prev = $profilePets.get()
+  const entry = prev.get(key) ?? defaultProfilePetState()
+  const next = new Map(prev)
+  next.set(key, updater(entry))
+  $profilePets.set(next)
+}
+
+/** Recompute a profile's activity from its sessions/beats and republish.
+ *  Preserves a manually-synced awaitingInput unless a transition forces it. */
+function publishProfileActivity(profile: string, forceAwaitingInput?: boolean): void {
+  const derived = deriveProfileActivity(profile)
+
+  updateProfilePet(profile, prev => ({
+    ...prev,
+    activity: {
+      ...derived,
+      awaitingInput: forceAwaitingInput ?? (derived.awaitingInput || (prev.activity.awaitingInput ?? false))
+    }
+  }))
+}
+
+export function ensureProfilePet(profile: string): void {
+  const key = normalizeProfileKey(profile)
+
+  if (!$profilePets.get().has(key)) {
+    updateProfilePet(key, prev => prev)
+  }
+}
+
+export function getProfilePet(profile: string): ProfilePetState | undefined {
+  return $profilePets.get().get(normalizeProfileKey(profile))
+}
+
+// ── Session-derived reducers ───────────────────────────────────────────────
+
+export function setSessionBusy(profile: string, runtimeSessionId: string, busy: boolean): void {
+  ensureSession(profile, runtimeSessionId).busy = busy
+  publishProfileActivity(profile)
+}
+
+export function setSessionReasoning(profile: string, runtimeSessionId: string, reasoning: boolean): void {
+  ensureSession(profile, runtimeSessionId).reasoning = reasoning
+  publishProfileActivity(profile)
+}
+
+export function setSessionAwaitingInput(profile: string, runtimeSessionId: string, awaiting: boolean): void {
+  ensureSession(profile, runtimeSessionId).awaitingInput = awaiting
+  publishProfileActivity(profile)
+}
+
+/** Add one running tool id (empty/missing ids are ignored). */
+export function startTool(profile: string, runtimeSessionId: string, toolId: string | null | undefined): void {
+  if (!toolId) {
+    return
+  }
+
+  ensureSession(profile, runtimeSessionId).activeToolIds.add(toolId)
+  publishProfileActivity(profile)
+}
+
+/** Remove ONLY this tool id; overlapping tools keep toolRunning true. */
+export function completeTool(profile: string, runtimeSessionId: string, toolId: string | null | undefined): void {
+  if (!toolId) {
+    return
+  }
+
+  const activity = sessionActivity.get(activityKey(profile, runtimeSessionId))
+
+  if (!activity) {
+    return
+  }
+
+  activity.activeToolIds.delete(toolId)
+  publishProfileActivity(profile)
+}
+
+/** Bind a durable stored session id to a runtime session (session.info/resume). */
+export function bindSessionStoredId(
+  profile: string,
+  runtimeSessionId: string,
+  storedSessionId: string | null | undefined
+): void {
+  if (!storedSessionId) {
+    return
+  }
+
+  ensureSession(profile, runtimeSessionId).storedSessionId = storedSessionId
+}
+
+/**
+ * Terminal transition (message.complete / error / session.info running=false):
+ * clear the session's steady state. `celebrate` fires a completion beat;
+ * `error` fires an error beat. awaitingInput is cleared — a normal completion
+ * returns to idle, not waiting (waiting means an unresolved clarify/approval).
+ */
+export function terminateSession(
+  profile: string,
+  runtimeSessionId: string,
+  opts: { celebrate?: boolean; error?: boolean } = {}
+): void {
+  const key = activityKey(profile, runtimeSessionId)
+  const activity = sessionActivity.get(key)
+
+  if (activity) {
+    activity.activeToolIds = new Set()
+    activity.busy = false
+    activity.reasoning = false
+    activity.awaitingInput = false
+  }
+
+  if (opts.celebrate) {
+    flashProfileBeat(profile, { celebrate: true }, 2200)
+  } else if (opts.error) {
+    flashProfileBeat(profile, { error: true })
+  } else {
+    publishProfileActivity(profile, false)
+  }
+}
+
+/** Session deleted/removed: drop its activity entry entirely. */
+export function removeSessionActivity(profile: string, runtimeSessionId: string): void {
+  if (sessionActivity.delete(activityKey(profile, runtimeSessionId))) {
+    publishProfileActivity(profile)
+  }
+}
+
+/** Runtime-id replacement (rehomed/compression/resume): migrate the entry. */
+export function replaceSessionRuntimeId(
+  profile: string,
+  oldRuntimeId: string,
+  newRuntimeId: string
+): void {
+  const oldKey = activityKey(profile, oldRuntimeId)
+  const activity = sessionActivity.get(oldKey)
+
+  if (!activity || oldRuntimeId === newRuntimeId) {
+    return
+  }
+
+  sessionActivity.delete(oldKey)
+  sessionActivity.set(activityKey(profile, newRuntimeId), activity)
+  publishProfileActivity(profile)
+}
+
+// ── Transient beats ────────────────────────────────────────────────────────
+
+/** Fire a transient reaction beat that decays back to steady after `ms`. The
+ *  generation counter guarantees a stale timer can't clear a newer beat. */
+export function flashProfileBeat(
+  profile: string,
+  fields: Partial<Pick<ProfileBeat, 'celebrate' | 'error' | 'justCompleted'>>,
+  ms = 1600
+): void {
+  const key = normalizeProfileKey(profile)
+  const beat = beats.get(key) ?? { celebrate: false, error: false, gen: 0, justCompleted: false }
+  const gen = beat.gen + 1
+
+  // Clear siblings first so a stale one can't win the priority race (error
+  // outranks celebrate in derivePetState).
+  beats.set(key, { celebrate: false, error: false, gen, justCompleted: false, ...fields })
+  publishProfileActivity(profile)
+
+  setTimeout(() => {
+    const current = beats.get(key)
+
+    if (current && current.gen === gen) {
+      beats.set(key, { celebrate: false, error: false, gen, justCompleted: false })
+      publishProfileActivity(profile)
+    }
+  }, ms)
+}
+
+// ── Unread / reply / info (per profile) ────────────────────────────────────
+
+const REPLY_TEXT_MAX = 200
+
+export function markProfilePetUnread(profile: string, sourceSessionId?: string | null): void {
+  updateProfilePet(profile, prev => ({
+    ...prev,
+    sourceSessionId: sourceSessionId ?? prev.sourceSessionId,
+    unread: true
+  }))
+}
+
+/** Clear unread for a specific source session only (focusing session A must not
+ *  erase session B's unread within the same profile). */
+export function clearProfilePetUnread(profile: string, sourceSessionId?: string | null): void {
+  updateProfilePet(profile, prev => {
+    if (sourceSessionId != null && prev.sourceSessionId != null && prev.sourceSessionId !== sourceSessionId) {
+      return prev
+    }
+
+    return { ...prev, unread: false }
+  })
+}
+
+export function setProfilePetReplyText(profile: string, text: string, sourceSessionId?: string | null): void {
+  const trimmed = text.trim()
+
+  if (!trimmed || /^\[SILENT\]/i.test(trimmed)) {
+    return
+  }
+
+  const capped = trimmed.length > REPLY_TEXT_MAX ? trimmed.slice(0, REPLY_TEXT_MAX) : trimmed
+
+  updateProfilePet(profile, prev => ({
+    ...prev,
+    replyText: capped,
+    sourceSessionId: sourceSessionId ?? prev.sourceSessionId
+  }))
+}
+
+export function clearProfilePetReplyText(profile: string, sourceSessionId?: string | null): void {
+  updateProfilePet(profile, prev => {
+    if (sourceSessionId != null && prev.sourceSessionId != null && prev.sourceSessionId !== sourceSessionId) {
+      return prev
+    }
+
+    return { ...prev, replyText: null }
+  })
+}
+
+export function setProfilePetInfo(profile: string, info: PetInfo): void {
+  updateProfilePet(profile, prev => ({ ...prev, info }))
+}
+
+/** Profile-level "awaiting the user" sync (use-pet-bridge's global mirror). */
+export function setProfileManualAwaitingInput(profile: string, awaiting: boolean): void {
+  const key = normalizeProfileKey(profile)
+  manualAwaitingInput.set(key, awaiting)
+  publishProfileActivity(profile)
+}
+
+/** Direct activity merge for a profile (legacy setPetActivity). */
+export function mergeProfileActivity(profile: string, next: Partial<PetActivity>): void {
+  updateProfilePet(profile, prev => ({ ...prev, activity: { ...prev.activity, ...next } }))
+}
+
+/** Wholesale-replace a profile's activity (the overlay pushes a full snapshot
+ *  and expects it to replace, not merge over stale fields). */
+export function replaceProfileActivity(profile: string, activity: PetActivity): void {
+  updateProfilePet(profile, prev => ({ ...prev, activity }))
+}
+
+// ── Registry queries (durable-id resolution) ───────────────────────────────
+
+/** Whether any session under `profile` bound to `storedSessionId` is busy. */
+export function hasBusyActivityForStoredSession(profile: string, storedSessionId: string): boolean {
+  const prefix = `${normalizeProfileKey(profile)}::`
+
+  for (const [key, activity] of sessionActivity) {
+    if (key.startsWith(prefix) && activity.storedSessionId === storedSessionId && activity.busy) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/** The one runtime id bound to `storedSessionId` under `profile`, or null for
+ *  zero/multiple matches (callers then use the durable session.resume path). */
+export function runtimeIdForStoredActivity(profile: string, storedSessionId: string): null | string {
+  const prefix = `${normalizeProfileKey(profile)}::`
+  let found: null | string = null
+
+  for (const [key, activity] of sessionActivity) {
+    if (key.startsWith(prefix) && activity.storedSessionId === storedSessionId) {
+      const runtimeId = key.slice(prefix.length)
+
+      if (found !== null) {
+        return null // ambiguous
+      }
+
+      found = runtimeId
+    }
+  }
+
+  return found
+}
+
+// ── Layer 6 stubs (profile-safe submission) ────────────────────────────────
+
+/**
+ * Composite-keyed background session-state adapter. Layer 6 wires this to a
+ * profile-scoped state cache that cannot write the foreground session cache or
+ * `$messages`. Stubbed here so Layer 2/3 callers can reference the symbol.
+ */
+export function updateBackgroundSessionState(
+  _profile: string,
+  _runtimeId: string,
+  _updater: unknown,
+  _storedId?: string | null
+): unknown {
+  // TODO(PR2b): route through the profile-scoped background state adapter.
+  return undefined
+}
+
+export function setProfileAwaitingResponse(_profile: string, _awaiting: boolean): void {
+  // TODO(PR2b): profile-scoped awaiting-response state for background submits.
+}
+
+export function setProfileSubmitBusy(_profile: string, _busy: boolean): void {
+  // TODO(PR2b): profile-scoped submit busy state for background submits.
+}
+
+/** Test-only: clear all per-session activity, beats, and profile slices so cases
+ *  don't leak into one another (the registries are module-global). */
+export function __resetPetMultiForTests(): void {
+  sessionActivity.clear()
+  beats.clear()
+  manualAwaitingInput.clear()
+  $profilePets.set(new Map())
+}

--- a/apps/desktop/src/store/pet-multi.ts
+++ b/apps/desktop/src/store/pet-multi.ts
@@ -40,6 +40,10 @@ export interface ProfileBeat {
   gen: number
 }
 
+/** A profile's gateway connection state, projected from its own socket (Layer 8).
+ *  A dead/reauth profile must not render a happy pet. */
+export type ProfileConnection = 'connecting' | 'offline' | 'open' | 'reauth-required'
+
 export interface ProfilePetState {
   info: PetInfo
   activity: PetActivity
@@ -49,11 +53,18 @@ export interface ProfilePetState {
   sourceSessionId?: string | null
   /** Durable session id for navigation (survives compression/rehoming). */
   sourceDurableSessionId?: string | null
+  /** Projected gateway connection state. Defaults to 'open' so the follow-active
+   *  pet is unchanged until a real report lands; pinned slots render an offline
+   *  treatment for 'offline' / 'reauth-required'. */
+  connection: ProfileConnection
+  /** Epoch ms the profile went offline/reauth (for a "down for Ns" affordance). */
+  offlineSince?: number
 }
 
 function defaultProfilePetState(): ProfilePetState {
   return {
     activity: {},
+    connection: 'open',
     info: { enabled: false },
     replyText: null,
     unread: false
@@ -352,6 +363,22 @@ export function clearProfilePetReplyText(profile: string, sourceSessionId?: stri
 
 export function setProfilePetInfo(profile: string, info: PetInfo): void {
   updateProfilePet(profile, prev => ({ ...prev, info }))
+}
+
+/**
+ * Project a profile's gateway connection state into its pet slice (Layer 8). The
+ * gateway registry reports every profile's socket state here (via the boot-wired
+ * onProfileState callback) so a dead/reauth pinned profile shows an offline pet
+ * instead of animating idle forever. Records `offlineSince` on the way down and
+ * clears it on recovery.
+ */
+export function setProfileConnectionState(profile: string, connection: ProfileConnection): void {
+  updateProfilePet(profile, prev => ({
+    ...prev,
+    connection,
+    offlineSince:
+      connection === 'offline' || connection === 'reauth-required' ? (prev.offlineSince ?? Date.now()) : undefined
+  }))
 }
 
 /** Profile-level "awaiting the user" sync (use-pet-bridge's global mirror). */

--- a/apps/desktop/src/store/pet-multi.ts
+++ b/apps/desktop/src/store/pet-multi.ts
@@ -366,6 +366,22 @@ export function setProfilePetInfo(profile: string, info: PetInfo): void {
 }
 
 /**
+ * Record the durable session id a profile's pet is reacting to (Layer 9). Set
+ * alongside `bindSessionStoredId` when a session event carries a stored id, so
+ * the overlay's mail icon can resume the correct conversation for a background
+ * profile (not just the active one). No-op until the profile has a slice.
+ */
+export function setProfileSourceDurableSessionId(profile: string, storedSessionId: string): void {
+  const key = normalizeProfileKey(profile)
+
+  if (!$profilePets.get().has(key)) {
+    return
+  }
+
+  updateProfilePet(key, prev => ({ ...prev, sourceDurableSessionId: storedSessionId }))
+}
+
+/**
  * Project a profile's gateway connection state into its pet slice (Layer 8). The
  * gateway registry reports every profile's socket state here (via the boot-wired
  * onProfileState callback) so a dead/reauth pinned profile shows an offline pet

--- a/apps/desktop/src/store/pet-overlay.ts
+++ b/apps/desktop/src/store/pet-overlay.ts
@@ -12,6 +12,7 @@ import {
   type PetInfo,
   petProfile
 } from '@/store/pet'
+import { $profilePets, type ProfileConnection } from '@/store/pet-multi'
 import { normalizeProfileKey } from '@/store/profile'
 import { $awaitingResponse, $busy } from '@/store/session'
 
@@ -61,6 +62,9 @@ export interface PetOverlayStatePayload {
   replyText: string | null
   /** Latest reaction - bumping its id forwards a burst to the overlay. */
   reaction: PetReaction | null
+  /** The profile's gateway connection state — the overlay desaturates + badges
+   *  a disconnect glyph when offline/reauth so a down backend never looks happy. */
+  connection: ProfileConnection
 }
 
 export type PetOverlayControl =
@@ -171,7 +175,8 @@ function currentPayload(): PetOverlayStatePayload {
     awaiting: $awaitingResponse.get(),
     unread: $petUnread.get(),
     replyText: $petReplyText.get(),
-    reaction: $petReaction.get()
+    reaction: $petReaction.get(),
+    connection: $profilePets.get().get(normalizeProfileKey(petProfile()))?.connection ?? 'open'
   }
 }
 
@@ -221,7 +226,8 @@ function openOverlay(profile: string, request: PetOverlayOpenRequest): void {
     $awaitingResponse.subscribe(pushNow),
     $petUnread.subscribe(pushNow),
     $petReplyText.subscribe(pushNow),
-    $petReaction.subscribe(pushNow)
+    $petReaction.subscribe(pushNow),
+    $profilePets.subscribe(pushNow)
   ]
 }
 

--- a/apps/desktop/src/store/pet-overlay.ts
+++ b/apps/desktop/src/store/pet-overlay.ts
@@ -1,7 +1,17 @@
 import { atom } from 'nanostores'
 
 import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
-import { $petActivity, $petInfo, $petReplyText, $petUnread, clearPetUnread, clearPetReplyText, type PetActivity, type PetInfo } from '@/store/pet'
+import {
+  $petActivity,
+  $petInfo,
+  $petReplyText,
+  $petUnread,
+  clearPetUnread,
+  clearPetReplyText,
+  type PetActivity,
+  type PetInfo,
+  petProfile
+} from '@/store/pet'
 import { $awaitingResponse, $busy } from '@/store/session'
 
 /**
@@ -138,9 +148,14 @@ export function overlayWindowSize(frameW: number, frameH: number, scale: number)
 
 let stateUnsubs: Array<() => void> = []
 let controlUnsub: (() => void) | null = null
-let submitHandler: ((text: string) => void) | null = null
-let openAppHandler: (() => void) | null = null
-let scaleHandler: ((scale: number) => void) | null = null
+let submitHandler: ((profile: string, text: string) => void) | null = null
+let openAppHandler: ((profile: string) => void) | null = null
+let scaleHandler: ((profile: string, scale: number) => void) | null = null
+
+// The profile whose pet the popped-out overlay currently shows. The single-pet
+// path mirrors the active profile's global atoms, so this is the active profile
+// captured at pop-out time; main addresses the overlay window by it.
+let overlayProfile = 'default'
 
 function currentPayload(): PetOverlayStatePayload {
   return {
@@ -155,7 +170,7 @@ function currentPayload(): PetOverlayStatePayload {
 }
 
 function pushNow(): void {
-  window.hermesDesktop?.petOverlay?.pushState(currentPayload())
+  window.hermesDesktop?.petOverlay?.pushState(overlayProfile, currentPayload())
 }
 
 /**
@@ -163,15 +178,16 @@ function pushNow(): void {
  * process echoes back the actual screen bounds it used, which we persist so the
  * pet reopens exactly where the user left it.
  */
-function openOverlay(request: PetOverlayOpenRequest): void {
+function openOverlay(profile: string, request: PetOverlayOpenRequest): void {
   const api = window.hermesDesktop?.petOverlay
 
   if (!api || stateUnsubs.length) {
     return
   }
 
+  overlayProfile = profile
   $petOverlayActive.set(true)
-  void api.open(request).then(res => {
+  void api.open(profile, request).then(res => {
     if (res?.bounds) {
       saveBounds(res.bounds)
     }
@@ -206,7 +222,7 @@ export function popOutPet(petRect: PetOverlayBounds): void {
   const saved = loadSavedBounds()
 
   if (saved) {
-    openOverlay({ bounds: saved, screen: true })
+    openOverlay(petProfile(), { bounds: saved, screen: true })
 
     return
   }
@@ -218,7 +234,7 @@ export function popOutPet(petRect: PetOverlayBounds): void {
   const x = Math.round(petRect.x - (width - petRect.width) / 2)
   const y = Math.round(petRect.y - (height - petRect.height) / 2)
 
-  openOverlay({ bounds: { height, width, x, y }, screen: false })
+  openOverlay(petProfile(), { bounds: { height, width, x, y }, screen: false })
 }
 
 /**
@@ -239,7 +255,7 @@ export function restorePetOverlay(): void {
     return
   }
 
-  openOverlay({ bounds: saved, screen: true })
+  openOverlay(petProfile(), { bounds: saved, screen: true })
 }
 
 /** Pop the pet back into the window (closes the overlay window). */
@@ -250,21 +266,22 @@ export function popInPet(): void {
 
   stateUnsubs = []
   $petOverlayActive.set(false)
-  void window.hermesDesktop?.petOverlay?.close()
+  void window.hermesDesktop?.petOverlay?.close(overlayProfile)
 }
 
-/** Register the handler that turns an overlay composer submit into a real send. */
-export function setPetOverlaySubmitHandler(fn: ((text: string) => void) | null): void {
+/** Register the handler that turns an overlay composer submit into a real send.
+ *  The profile is sender-derived by main (never trusted from the renderer). */
+export function setPetOverlaySubmitHandler(fn: ((profile: string, text: string) => void) | null): void {
   submitHandler = fn
 }
 
 /** Register the handler that opens the app to the most recent thread (mail icon). */
-export function setPetOverlayOpenAppHandler(fn: (() => void) | null): void {
+export function setPetOverlayOpenAppHandler(fn: ((profile: string) => void) | null): void {
   openAppHandler = fn
 }
 
 /** Register the handler that persists a scale resized via the overlay's Alt+wheel gesture. */
-export function setPetOverlayScaleHandler(fn: ((scale: number) => void) | null): void {
+export function setPetOverlayScaleHandler(fn: ((profile: string, scale: number) => void) | null): void {
   scaleHandler = fn
 }
 
@@ -280,13 +297,17 @@ export function initPetOverlayBridge(): () => void {
   }
 
   controlUnsub = api.onControl(payload => {
+    // main derives the profile from the overlay's webContents.id and attaches it
+    // before forwarding; fall back to the profile this controller popped out.
+    const profile = payload?.profile ?? overlayProfile
+
     if (payload?.type === 'pop-in') {
       popInPet()
     } else if (payload?.type === 'ready') {
       // The overlay just mounted — hand it the current frame.
       pushNow()
     } else if (payload?.type === 'submit' && typeof payload.text === 'string') {
-      submitHandler?.(payload.text)
+      submitHandler?.(profile, payload.text)
     } else if (payload?.type === 'bounds' && payload.bounds) {
       // The user dragged the overlay to a new desktop spot — remember it.
       saveBounds(payload.bounds)
@@ -294,14 +315,14 @@ export function initPetOverlayBridge(): () => void {
       // The user resized the popped-out pet (Alt+wheel) — persist it through
       // the main renderer's gateway; the new scale rides $petInfo back to the
       // overlay on the next push, keeping both surfaces in sync.
-      scaleHandler?.(payload.scale)
+      scaleHandler?.(profile, payload.scale)
     } else if (payload?.type === 'open-app') {
       // Mail icon / reply bubble: surface the app on the most recent thread
       // (main.ts already focused the window before forwarding this) and mark
       // it read.
       clearPetUnread()
       clearPetReplyText()
-      openAppHandler?.()
+      openAppHandler?.(profile)
     }
   })
 

--- a/apps/desktop/src/store/pet-overlay.ts
+++ b/apps/desktop/src/store/pet-overlay.ts
@@ -12,6 +12,7 @@ import {
   type PetInfo,
   petProfile
 } from '@/store/pet'
+import { normalizeProfileKey } from '@/store/profile'
 import { $awaitingResponse, $busy } from '@/store/session'
 
 /**
@@ -152,10 +153,15 @@ let submitHandler: ((profile: string, text: string) => void) | null = null
 let openAppHandler: ((profile: string) => void) | null = null
 let scaleHandler: ((profile: string, scale: number) => void) | null = null
 
-// The profile whose pet the popped-out overlay currently shows. The single-pet
-// path mirrors the active profile's global atoms, so this is the active profile
-// captured at pop-out time; main addresses the overlay window by it.
-let overlayProfile = 'default'
+// The profiles whose pets this controller has popped out, keyed by normalized
+// profile (one overlay per profile, so the key is unique). Replaces a single
+// module-level `overlayProfile` so a second concurrent pop-out can't clobber the
+// first's push/close target. Main addresses each overlay window by profile and
+// stamps the profile onto control payloads (profileForSender); this set is the
+// renderer-side state-push target and the fallback when a control payload arrives
+// without one. The mirrored payload is the active profile's (follow-active);
+// per-overlay state for concurrent pinned overlays is a PR4 concern.
+const overlayProfiles = new Map<string, string>()
 
 function currentPayload(): PetOverlayStatePayload {
   return {
@@ -170,7 +176,17 @@ function currentPayload(): PetOverlayStatePayload {
 }
 
 function pushNow(): void {
-  window.hermesDesktop?.petOverlay?.pushState(overlayProfile, currentPayload())
+  const api = window.hermesDesktop?.petOverlay
+
+  if (!api || overlayProfiles.size === 0) {
+    return
+  }
+
+  const payload = currentPayload()
+
+  for (const key of overlayProfiles.keys()) {
+    api.pushState(key, payload)
+  }
 }
 
 /**
@@ -185,9 +201,10 @@ function openOverlay(profile: string, request: PetOverlayOpenRequest): void {
     return
   }
 
-  overlayProfile = profile
+  const key = normalizeProfileKey(profile)
+  overlayProfiles.set(key, key)
   $petOverlayActive.set(true)
-  void api.open(profile, request).then(res => {
+  void api.open(key, request).then(res => {
     if (res?.bounds) {
       saveBounds(res.bounds)
     }
@@ -258,15 +275,27 @@ export function restorePetOverlay(): void {
   openOverlay(petProfile(), { bounds: saved, screen: true })
 }
 
-/** Pop the pet back into the window (closes the overlay window). */
-export function popInPet(): void {
-  for (const off of stateUnsubs) {
-    off()
+/**
+ * Pop a pet back into the window (closes its overlay window). Without a profile,
+ * closes the only/oldest tracked overlay (the follow-active single-pet path).
+ * The shared state mirror tears down only when the last overlay closes.
+ */
+export function popInPet(profile?: string): void {
+  const key = profile ? normalizeProfileKey(profile) : overlayProfiles.keys().next().value
+
+  if (key) {
+    overlayProfiles.delete(key)
+    void window.hermesDesktop?.petOverlay?.close(key)
   }
 
-  stateUnsubs = []
-  $petOverlayActive.set(false)
-  void window.hermesDesktop?.petOverlay?.close(overlayProfile)
+  if (overlayProfiles.size === 0) {
+    for (const off of stateUnsubs) {
+      off()
+    }
+
+    stateUnsubs = []
+    $petOverlayActive.set(false)
+  }
 }
 
 /** Register the handler that turns an overlay composer submit into a real send.
@@ -298,11 +327,12 @@ export function initPetOverlayBridge(): () => void {
 
   controlUnsub = api.onControl(payload => {
     // main derives the profile from the overlay's webContents.id and attaches it
-    // before forwarding; fall back to the profile this controller popped out.
-    const profile = payload?.profile ?? overlayProfile
+    // before forwarding; fall back to the (single) profile this controller popped
+    // out when a payload arrives without one.
+    const profile = payload?.profile ?? overlayProfiles.keys().next().value ?? 'default'
 
     if (payload?.type === 'pop-in') {
-      popInPet()
+      popInPet(profile)
     } else if (payload?.type === 'ready') {
       // The overlay just mounted — hand it the current frame.
       pushNow()

--- a/apps/desktop/src/store/pet-overlay.ts
+++ b/apps/desktop/src/store/pet-overlay.ts
@@ -1,7 +1,7 @@
 import { atom } from 'nanostores'
 
 import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
-import { $petActivity, $petInfo, $petUnread, clearPetUnread, type PetActivity, type PetInfo } from '@/store/pet'
+import { $petActivity, $petInfo, $petReplyText, $petUnread, clearPetUnread, clearPetReplyText, type PetActivity, type PetInfo } from '@/store/pet'
 import { $awaitingResponse, $busy } from '@/store/session'
 
 /**
@@ -46,7 +46,9 @@ export interface PetOverlayStatePayload {
   awaiting: boolean
   /** Drives the overlay's mail icon: a finish landed while you were away. */
   unread: boolean
-  /** Latest reaction — bumping its id forwards a burst to the overlay. */
+  /** Latest reply text to show in the speech bubble instead of the mail icon. */
+  replyText: string | null
+  /** Latest reaction - bumping its id forwards a burst to the overlay. */
   reaction: PetReaction | null
 }
 
@@ -147,6 +149,7 @@ function currentPayload(): PetOverlayStatePayload {
     busy: $busy.get(),
     awaiting: $awaitingResponse.get(),
     unread: $petUnread.get(),
+    replyText: $petReplyText.get(),
     reaction: $petReaction.get()
   }
 }
@@ -184,6 +187,7 @@ function openOverlay(request: PetOverlayOpenRequest): void {
     $busy.subscribe(pushNow),
     $awaitingResponse.subscribe(pushNow),
     $petUnread.subscribe(pushNow),
+    $petReplyText.subscribe(pushNow),
     $petReaction.subscribe(pushNow)
   ]
 }
@@ -292,9 +296,11 @@ export function initPetOverlayBridge(): () => void {
       // overlay on the next push, keeping both surfaces in sync.
       scaleHandler?.(payload.scale)
     } else if (payload?.type === 'open-app') {
-      // Mail icon: surface the app on the most recent thread (main.ts already
-      // focused the window before forwarding this) and mark it read.
+      // Mail icon / reply bubble: surface the app on the most recent thread
+      // (main.ts already focused the window before forwarding this) and mark
+      // it read.
       clearPetUnread()
+      clearPetReplyText()
       openAppHandler?.()
     }
   })

--- a/apps/desktop/src/store/pet-roster-reconcile.test.ts
+++ b/apps/desktop/src/store/pet-roster-reconcile.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Layer 7 — orphan reconciliation. A pinned roster reconciles against the live
+ * profile catalog: a deleted/renamed profile is marked unavailable + disabled
+ * (its lease released once); a restored profile clears unavailable WITHOUT
+ * auto-enabling. Gated on `$profilesLoaded` so the initial empty catalog is
+ * never read as "everything was deleted".
+ */
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePetRosterReconciliation } from '@/components/pet/use-pet-roster-reconciliation'
+import { releaseProfileGateway } from '@/store/gateway'
+import { $profiles, $profilesLoaded, $activeGatewayProfile } from '@/store/profile'
+import type { ProfileInfo } from '@/types/hermes'
+
+import { $petRoster, reconcilePetRoster, setPetRosterEntries, setPetRosterMode } from './pet-roster'
+
+vi.mock('@/store/gateway', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/gateway')>()
+
+  return { ...actual, releaseProfileGateway: vi.fn() }
+})
+
+const release = vi.mocked(releaseProfileGateway)
+
+const profile = (name: string): ProfileInfo => ({ name } as ProfileInfo)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  $petRoster.set({ entries: [], initialized: true, mode: 'follow-active' })
+  $activeGatewayProfile.set('default')
+  $profiles.set([])
+  $profilesLoaded.set(false)
+})
+
+afterEach(() => {
+  cleanup()
+  $activeGatewayProfile.set('default')
+  $profiles.set([])
+  $profilesLoaded.set(false)
+})
+
+describe('reconcilePetRoster', () => {
+  it('marks a deleted pinned profile unavailable + disabled and releases its lease (test 48)', () => {
+    setPetRosterMode('pinned')
+    setPetRosterEntries([{ enabled: true, profile: 'apollo' }])
+
+    reconcilePetRoster([profile('nova')])
+
+    const entry = $petRoster.get().entries.find(e => e.profile === 'apollo')
+
+    expect(entry?.enabled).toBe(false)
+    expect(entry?.unavailable).toBe(true)
+    expect(release).toHaveBeenCalledWith('apollo')
+  })
+
+  it('releases a missing profile only once across repeated refreshes (test 52)', () => {
+    setPetRosterMode('pinned')
+    setPetRosterEntries([{ enabled: true, profile: 'apollo' }])
+
+    reconcilePetRoster([])
+    reconcilePetRoster([])
+    reconcilePetRoster([])
+
+    // Disabled+unavailable after the first pass, so subsequent passes don't
+    // re-release (entry.enabled is false).
+    expect(release).toHaveBeenCalledTimes(1)
+    expect(release).toHaveBeenCalledWith('apollo')
+  })
+
+  it('clears unavailable when a profile returns, without auto-enabling (test 52)', () => {
+    setPetRosterMode('pinned')
+    setPetRosterEntries([{ enabled: false, profile: 'apollo', unavailable: true }])
+
+    reconcilePetRoster([profile('apollo')])
+
+    const entry = $petRoster.get().entries.find(e => e.profile === 'apollo')
+
+    // Normalization drops a false `unavailable`, so a cleared row reads falsy.
+    expect(entry?.unavailable).toBeFalsy()
+    // Restoration must not silently re-pin.
+    expect(entry?.enabled).toBe(false)
+  })
+
+  it('is a no-op in follow-active mode', () => {
+    setPetRosterMode('follow-active')
+    setPetRosterEntries([{ enabled: true, profile: 'apollo' }])
+
+    reconcilePetRoster([])
+
+    expect($petRoster.get().entries.find(e => e.profile === 'apollo')?.enabled).toBe(true)
+    expect(release).not.toHaveBeenCalled()
+  })
+})
+
+describe('usePetRosterReconciliation gating (test 51)', () => {
+  it('does NOT reconcile before the first successful catalog load', () => {
+    setPetRosterMode('pinned')
+    setPetRosterEntries([{ enabled: true, profile: 'apollo' }])
+    // $profilesLoaded is false and $profiles is empty (pre-refresh).
+
+    renderHook(() => usePetRosterReconciliation())
+
+    // The empty initial catalog must not be read as "apollo was deleted".
+    const entry = $petRoster.get().entries.find(e => e.profile === 'apollo')
+
+    expect(entry?.enabled).toBe(true)
+    expect(entry?.unavailable).toBeFalsy()
+    expect(release).not.toHaveBeenCalled()
+  })
+
+  it('reconciles once the catalog has loaded', () => {
+    setPetRosterMode('pinned')
+    setPetRosterEntries([{ enabled: true, profile: 'apollo' }])
+
+    renderHook(() => usePetRosterReconciliation())
+
+    act(() => {
+      $profiles.set([profile('nova')])
+      $profilesLoaded.set(true)
+    })
+
+    const entry = $petRoster.get().entries.find(e => e.profile === 'apollo')
+
+    expect(entry?.unavailable).toBe(true)
+    expect(entry?.enabled).toBe(false)
+    expect(release).toHaveBeenCalledWith('apollo')
+  })
+})

--- a/apps/desktop/src/store/pet-roster.test.ts
+++ b/apps/desktop/src/store/pet-roster.test.ts
@@ -1,6 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
 
 import {
+  $observedPetProfiles,
   $petRoster,
   PINNED_HARD_CAP,
   PINNED_SOFT_CAP,
@@ -23,6 +26,11 @@ beforeEach(() => {
   // Reset the live atom to the default follow-active roster so cases are isolated
   // (the atom is module-cached and otherwise leaks state between tests).
   $petRoster.set({ entries: [], initialized: true, mode: 'follow-active' })
+  $activeGatewayProfile.set('default')
+})
+
+afterEach(() => {
+  $activeGatewayProfile.set('default')
 })
 
 describe('normalizeStoredPetRoster', () => {
@@ -145,5 +153,33 @@ describe('roster mutation APIs reuse the invariant', () => {
     const restored = $petRoster.get().entries.find(e => e.profile === 'apollo')
     expect(restored?.enabled).toBe(true)
     expect(restored?.unavailable).toBeUndefined()
+  })
+})
+
+describe('$observedPetProfiles', () => {
+  it('follow-active with empty entries still observes the active profile (test 44)', () => {
+    $petRoster.set({ entries: [], initialized: true, mode: 'follow-active' })
+    $activeGatewayProfile.set('apollo')
+
+    expect($observedPetProfiles.get()).toEqual(new Set(['apollo']))
+  })
+
+  it('follow-active observes only the active profile, never background ones', () => {
+    $petRoster.set({ entries: [entry('nova', true)], initialized: true, mode: 'follow-active' })
+    $activeGatewayProfile.set('default')
+
+    // The pinned entry is ignored in follow-active mode.
+    expect($observedPetProfiles.get()).toEqual(new Set(['default']))
+  })
+
+  it('pinned mode observes every enabled, available entry', () => {
+    $petRoster.set({
+      entries: [entry('apollo', true), entry('nova', false), entry('gone', true, true)],
+      initialized: true,
+      mode: 'pinned'
+    })
+
+    // nova is disabled, gone is unavailable → only apollo is observed.
+    expect($observedPetProfiles.get()).toEqual(new Set(['apollo']))
   })
 })

--- a/apps/desktop/src/store/pet-roster.test.ts
+++ b/apps/desktop/src/store/pet-roster.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $petRoster,
+  PINNED_HARD_CAP,
+  PINNED_SOFT_CAP,
+  isProfilePetEnabled,
+  normalizeStoredPetRoster,
+  normalizeStoredPetRosterWithClamp,
+  setPetRosterEntries,
+  setPetRosterMode,
+  setProfilePetEnabled,
+  type RosterEntry
+} from './pet-roster'
+
+const entry = (profile: string, enabled = true, unavailable?: boolean): RosterEntry => ({
+  enabled,
+  profile,
+  ...(unavailable ? { unavailable: true } : {})
+})
+
+beforeEach(() => {
+  // Reset the live atom to the default follow-active roster so cases are isolated
+  // (the atom is module-cached and otherwise leaks state between tests).
+  $petRoster.set({ entries: [], initialized: true, mode: 'follow-active' })
+})
+
+describe('normalizeStoredPetRoster', () => {
+  it('defaults null / malformed input to an initialized follow-active roster', () => {
+    expect(normalizeStoredPetRoster(null)).toEqual({ entries: [], initialized: true, mode: 'follow-active' })
+    expect(normalizeStoredPetRoster('garbage')).toEqual({ entries: [], initialized: true, mode: 'follow-active' })
+    expect(normalizeStoredPetRoster({ entries: 'nope' })).toEqual({
+      entries: [],
+      initialized: true,
+      mode: 'follow-active'
+    })
+  })
+
+  it('migrates an initialized:false first-boot marker to the default roster', () => {
+    expect(normalizeStoredPetRoster({ entries: [entry('apollo')], initialized: false, mode: 'pinned' })).toEqual({
+      entries: [],
+      initialized: true,
+      mode: 'follow-active'
+    })
+  })
+
+  it('an initialized empty pinned roster stays empty (deliberately hid all pets)', () => {
+    expect(normalizeStoredPetRoster({ entries: [], initialized: true, mode: 'pinned' })).toEqual({
+      entries: [],
+      initialized: true,
+      mode: 'pinned'
+    })
+  })
+
+  it('drops entries with a missing/blank profile and normalizes the key', () => {
+    const { roster } = normalizeStoredPetRosterWithClamp({
+      entries: [{ enabled: true }, { enabled: true, profile: '  ' }, { enabled: true, profile: ' Apollo ' }],
+      initialized: true,
+      mode: 'pinned'
+    })
+
+    // normalizeProfileKey trims (and defaults blank → "default") but preserves case.
+    expect(roster.entries).toEqual([entry('Apollo')])
+  })
+})
+
+describe('roster enabled-profile cap invariant (test 24)', () => {
+  it('exposes a soft cap of 4 and a hard cap of 8', () => {
+    expect(PINNED_SOFT_CAP).toBe(4)
+    expect(PINNED_HARD_CAP).toBe(8)
+  })
+
+  it('keeps the first eight enabled in stored order and disables the rest', () => {
+    const profiles = Array.from({ length: 10 }, (_, i) => `p${i}`)
+    const { clampedProfiles, roster } = normalizeStoredPetRosterWithClamp({
+      entries: profiles.map(name => entry(name, true)),
+      initialized: true,
+      mode: 'pinned'
+    })
+
+    const enabled = roster.entries.filter(e => e.enabled).map(e => e.profile)
+    expect(enabled).toEqual(['p0', 'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'])
+    // The last two (in stored order) were force-disabled and reported once.
+    expect(clampedProfiles).toEqual(['p8', 'p9'])
+    expect(roster.entries.find(e => e.profile === 'p8')?.enabled).toBe(false)
+    expect(roster.entries.find(e => e.profile === 'p9')?.enabled).toBe(false)
+  })
+
+  it('unavailable and disabled rows never count toward the cap', () => {
+    const entries: RosterEntry[] = [
+      entry('gone', true, true), // unavailable — excluded
+      entry('off', false), // disabled — excluded
+      ...Array.from({ length: 8 }, (_, i) => entry(`p${i}`, true))
+    ]
+
+    const { clampedProfiles, roster } = normalizeStoredPetRosterWithClamp({
+      entries,
+      initialized: true,
+      mode: 'pinned'
+    })
+
+    expect(clampedProfiles).toEqual([])
+    expect(roster.entries.filter(e => e.enabled && !e.unavailable)).toHaveLength(8)
+  })
+
+  it('clamps regardless of the current mode (a follow-active roster later switched to pinned)', () => {
+    const { roster } = normalizeStoredPetRosterWithClamp({
+      entries: Array.from({ length: 9 }, (_, i) => entry(`p${i}`, true)),
+      initialized: true,
+      mode: 'follow-active'
+    })
+
+    expect(roster.entries.filter(e => e.enabled)).toHaveLength(PINNED_HARD_CAP)
+  })
+})
+
+describe('roster mutation APIs reuse the invariant', () => {
+  it('setProfilePetEnabled refuses to enable a ninth profile and leaves the roster unchanged', () => {
+    setPetRosterMode('pinned')
+    setPetRosterEntries(Array.from({ length: 8 }, (_, i) => entry(`p${i}`, true)))
+
+    const before = $petRoster.get()
+    expect(setProfilePetEnabled('p9', true)).toBe(false)
+    expect($petRoster.get()).toEqual(before)
+    expect(isProfilePetEnabled('p9')).toBe(false)
+  })
+
+  it('setProfilePetEnabled enables within the cap and disables freely', () => {
+    setPetRosterMode('pinned')
+
+    expect(setProfilePetEnabled('apollo', true)).toBe(true)
+    expect(isProfilePetEnabled('apollo')).toBe(true)
+
+    // Disabling always succeeds, even at the cap.
+    expect(setProfilePetEnabled('apollo', false)).toBe(true)
+    expect(isProfilePetEnabled('apollo')).toBe(false)
+  })
+
+  it('re-enabling an unavailable row clears unavailable and counts toward the cap', () => {
+    setPetRosterMode('pinned')
+    setPetRosterEntries([entry('apollo', false, true)])
+
+    expect(setProfilePetEnabled('apollo', true)).toBe(true)
+
+    const restored = $petRoster.get().entries.find(e => e.profile === 'apollo')
+    expect(restored?.enabled).toBe(true)
+    expect(restored?.unavailable).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/store/pet-roster.ts
+++ b/apps/desktop/src/store/pet-roster.ts
@@ -1,0 +1,230 @@
+import { atom } from 'nanostores'
+
+import { readJson, writeJson } from '@/lib/storage'
+import { normalizeProfileKey } from '@/store/profile'
+
+/**
+ * Device-scoped multi-pet visibility roster.
+ *
+ * Backend truth stays per-profile: each profile owns its own `display.pet` in
+ * its `config.yaml`. The desktop only persists WHICH profiles' pets to show and
+ * in which mode, scoped to this device (localStorage). Two modes:
+ *
+ * - `follow-active` (default): the visible pet follows `$activeGatewayProfile`
+ *   — the current single-pet behavior, zero change. `entries` is ignored.
+ * - `pinned` (opt-in): `entries` names the profiles whose pets render
+ *   simultaneously.
+ *
+ * The roster invariant (enabled-profile cap) is enforced on EVERY load and
+ * through every mutation API, so a persisted/hand-edited roster can never exceed
+ * the cap and UI + non-UI writers agree.
+ */
+
+export type PetRosterMode = 'follow-active' | 'pinned'
+
+export interface RosterEntry {
+  profile: string
+  enabled: boolean
+  /** True only after a successfully loaded profile catalog confirms it is
+   *  missing (deleted/renamed). Such rows stay visible as disabled with a
+   *  "not found" affordance; they never count toward the enabled cap. */
+  unavailable?: boolean
+}
+
+export interface StoredPetRoster {
+  initialized: boolean
+  mode: PetRosterMode
+  /** Only meaningful when `mode === 'pinned'`. */
+  entries: RosterEntry[]
+}
+
+/** Soft cap: a cost warning surfaces at this many enabled pinned profiles
+ *  (each holds a leased socket + a polling lane). */
+export const PINNED_SOFT_CAP = 4
+/** Hard cap: no more than this many profiles may be enabled at once. Enforced
+ *  deterministically at load and by every mutation API. */
+export const PINNED_HARD_CAP = 8
+
+const ROSTER_STORAGE_KEY = 'hermes.desktop.petRoster.v1'
+
+function defaultRoster(): StoredPetRoster {
+  return { initialized: true, mode: 'follow-active', entries: [] }
+}
+
+function normalizeEntry(value: unknown): RosterEntry | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const raw = value as Record<string, unknown>
+
+  if (typeof raw.profile !== 'string' || !raw.profile.trim()) {
+    return null
+  }
+
+  const entry: RosterEntry = {
+    enabled: raw.enabled === true,
+    profile: normalizeProfileKey(raw.profile)
+  }
+
+  if (raw.unavailable === true) {
+    entry.unavailable = true
+  }
+
+  return entry
+}
+
+export interface RosterNormalization {
+  /** Profiles that were enabled in the input but force-disabled by the cap. */
+  clampedProfiles: string[]
+  roster: StoredPetRoster
+}
+
+/**
+ * Validate + default a raw stored value into a well-formed roster, clamping the
+ * enabled set to `PINNED_HARD_CAP`. Persisted entry order is the deterministic
+ * tie-breaker: the first eight enabled entries (in stored order) stay enabled,
+ * the rest are disabled. Unavailable/disabled rows never count toward the cap.
+ *
+ * An `initialized: false` value is a first-boot marker and migrates to the
+ * default (follow-active, empty) roster.
+ */
+export function normalizeStoredPetRosterWithClamp(input: unknown): RosterNormalization {
+  if (!input || typeof input !== 'object') {
+    return { clampedProfiles: [], roster: defaultRoster() }
+  }
+
+  const raw = input as Record<string, unknown>
+
+  // First-boot migration: an explicit false resets to the default roster.
+  if (raw.initialized === false) {
+    return { clampedProfiles: [], roster: defaultRoster() }
+  }
+
+  const mode: PetRosterMode = raw.mode === 'pinned' ? 'pinned' : 'follow-active'
+  const rawEntries = Array.isArray(raw.entries) ? raw.entries : []
+
+  const parsed: RosterEntry[] = []
+
+  for (const value of rawEntries) {
+    const entry = normalizeEntry(value)
+
+    if (entry) {
+      parsed.push(entry)
+    }
+  }
+
+  // Clamp regardless of mode: covers older builds, hand-edited storage, and a
+  // follow-active roster later switched to pinned. Unavailable and disabled rows
+  // never count toward the cap.
+  let enabledKept = 0
+  const clampedProfiles: string[] = []
+
+  const entries = parsed.map(entry => {
+    if (!entry.enabled || entry.unavailable) {
+      return entry
+    }
+
+    enabledKept += 1
+
+    if (enabledKept <= PINNED_HARD_CAP) {
+      return entry
+    }
+
+    clampedProfiles.push(entry.profile)
+
+    return { ...entry, enabled: false }
+  })
+
+  return {
+    clampedProfiles,
+    roster: { entries, initialized: true, mode }
+  }
+}
+
+/** Spec-shaped pure normalizer (drops the clamp report). */
+export function normalizeStoredPetRoster(input: unknown): StoredPetRoster {
+  return normalizeStoredPetRosterWithClamp(input).roster
+}
+
+// A load-time clamp is recorded here and surfaced once the application wiring is
+// ready (i18n + notifications available). The normalizer must not reach into the
+// notification store during module initialization.
+let pendingCapWarning: string[] = []
+
+function loadRoster(): StoredPetRoster {
+  const { clampedProfiles, roster } = normalizeStoredPetRosterWithClamp(readJson<unknown>(ROSTER_STORAGE_KEY))
+
+  // Persist the normalized value so older builds / hand-edited storage converge
+  // on the clamped invariant.
+  writeJson(ROSTER_STORAGE_KEY, roster)
+
+  if (clampedProfiles.length > 0) {
+    pendingCapWarning = clampedProfiles
+  }
+
+  return roster
+}
+
+export const $petRoster = atom<StoredPetRoster>(loadRoster())
+
+/** Drain the one-shot "roster was clamped to the cap" report. Returns the
+ *  profiles that were force-disabled; empty when nothing was clamped. Called by
+ *  the application wiring once translations + notifications are available. */
+export function takeRosterCapWarning(): string[] {
+  const out = pendingCapWarning
+  pendingCapWarning = []
+
+  return out
+}
+
+/** All roster writes flow through here so the invariant (shape + cap) holds no
+ *  matter the caller. */
+function commit(roster: StoredPetRoster): void {
+  const normalized = normalizeStoredPetRoster(roster)
+  $petRoster.set(normalized)
+  writeJson(ROSTER_STORAGE_KEY, normalized)
+}
+
+export function setPetRosterMode(mode: PetRosterMode): void {
+  commit({ ...$petRoster.get(), initialized: true, mode })
+}
+
+export function setPetRosterEntries(entries: RosterEntry[]): void {
+  commit({ ...$petRoster.get(), entries, initialized: true })
+}
+
+/** Count enabled entries excluding unavailable rows (which never count). */
+function enabledCount(roster: StoredPetRoster): number {
+  return roster.entries.filter(entry => entry.enabled && !entry.unavailable).length
+}
+
+/**
+ * Enable/disable a profile's pet in the pinned roster. Returns `false` (and
+ * leaves the roster unchanged) when enabling would exceed `PINNED_HARD_CAP`;
+ * the caller surfaces the translated cap explanation. Disabling always succeeds.
+ */
+export function setProfilePetEnabled(profile: string, enabled: boolean): boolean {
+  const key = normalizeProfileKey(profile)
+  const roster = $petRoster.get()
+  const existing = roster.entries.find(entry => entry.profile === key)
+
+  if (enabled && !existing?.enabled && !existing?.unavailable && enabledCount(roster) >= PINNED_HARD_CAP) {
+    return false
+  }
+
+  const entries = existing
+    ? roster.entries.map(entry => (entry.profile === key ? { ...entry, enabled, unavailable: false } : entry))
+    : [...roster.entries, { enabled, profile: key }]
+
+  commit({ ...roster, entries, initialized: true })
+
+  return true
+}
+
+/** Whether a profile is currently shown in pinned mode (enabled + available). */
+export function isProfilePetEnabled(profile: string): boolean {
+  const key = normalizeProfileKey(profile)
+
+  return $petRoster.get().entries.some(entry => entry.profile === key && entry.enabled && !entry.unavailable)
+}

--- a/apps/desktop/src/store/pet-roster.ts
+++ b/apps/desktop/src/store/pet-roster.ts
@@ -1,7 +1,9 @@
 import { atom, computed } from 'nanostores'
 
 import { readJson, writeJson } from '@/lib/storage'
+import { releaseProfileGateway } from '@/store/gateway'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import type { ProfileInfo } from '@/types/hermes'
 
 /**
  * Device-scoped multi-pet visibility roster.
@@ -248,3 +250,62 @@ export const $observedPetProfiles = computed(
 )
 
 export const observedPetProfiles = (): ReadonlySet<string> => $observedPetProfiles.get()
+
+/**
+ * Reconcile the pinned roster against a freshly loaded profile catalog (Layer 7
+ * orphan reconciliation). Pure: callers gate on `$profilesLoaded` so the initial
+ * empty catalog is never treated as "everything was deleted".
+ *
+ * - A pinned entry whose profile is gone from the catalog is marked
+ *   `unavailable` + disabled (and releases its leased socket — once; the entry is
+ *   disabled thereafter so repeat refreshes don't re-release). It stays visible
+ *   as a disabled "not found" row (rename = deletion: the catalog exposes no
+ *   stable id, so a rename looks like delete + a fresh disabled row).
+ * - A previously unavailable entry that reappears clears `unavailable` but is NOT
+ *   auto-enabled (the user opted it out; restoration shouldn't silently re-pin).
+ *
+ * follow-active mode ignores entries entirely, so this is a no-op there.
+ */
+export function reconcilePetRoster(profiles: readonly ProfileInfo[]): void {
+  const roster = $petRoster.get()
+
+  if (roster.mode !== 'pinned') {
+    return
+  }
+
+  const known = new Set(profiles.map(p => normalizeProfileKey(p.name)))
+
+  let changed = false
+
+  const updated = roster.entries.map(entry => {
+    const exists = known.has(normalizeProfileKey(entry.profile))
+
+    if (!exists) {
+      // Release the socket only while it was actively held (enabled + available);
+      // disabling/unavailable-ing it first means a repeat refresh releases once.
+      if (entry.enabled && !entry.unavailable) {
+        releaseProfileGateway(entry.profile)
+      }
+
+      if (!entry.unavailable || entry.enabled) {
+        changed = true
+
+        return { ...entry, enabled: false, unavailable: true }
+      }
+
+      return entry
+    }
+
+    if (entry.unavailable) {
+      changed = true
+
+      return { ...entry, unavailable: false }
+    }
+
+    return entry
+  })
+
+  if (changed) {
+    commit({ ...roster, entries: updated })
+  }
+}

--- a/apps/desktop/src/store/pet-roster.ts
+++ b/apps/desktop/src/store/pet-roster.ts
@@ -1,7 +1,7 @@
-import { atom } from 'nanostores'
+import { atom, computed } from 'nanostores'
 
 import { readJson, writeJson } from '@/lib/storage'
-import { normalizeProfileKey } from '@/store/profile'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 
 /**
  * Device-scoped multi-pet visibility roster.
@@ -228,3 +228,23 @@ export function isProfilePetEnabled(profile: string): boolean {
 
   return $petRoster.get().entries.some(entry => entry.profile === key && entry.enabled && !entry.unavailable)
 }
+
+/**
+ * The set of profiles whose pets are OBSERVED (events route to their pet slice).
+ * One shared derivation used by leases, polling, and event routing. A computed
+ * store avoids rebuilding the set per event and avoids module-level subscribe()
+ * callbacks that would multiply across HMR evaluations.
+ *
+ * - follow-active: only the active profile is observed (so background profiles
+ *   get no activity/unread — the current single-pet behavior).
+ * - pinned: every enabled, available roster entry.
+ */
+export const $observedPetProfiles = computed(
+  [$petRoster, $activeGatewayProfile],
+  (roster, activeProfile): ReadonlySet<string> =>
+    roster.mode === 'follow-active'
+      ? new Set([normalizeProfileKey(activeProfile)])
+      : new Set(roster.entries.filter(entry => entry.enabled && !entry.unavailable).map(entry => normalizeProfileKey(entry.profile)))
+)
+
+export const observedPetProfiles = (): ReadonlySet<string> => $observedPetProfiles.get()

--- a/apps/desktop/src/store/pet-transport.ts
+++ b/apps/desktop/src/store/pet-transport.ts
@@ -1,0 +1,24 @@
+import { requestGatewayForProfile } from '@/store/gateway'
+import { normalizeProfileKey } from '@/store/profile'
+
+/** A recovering gateway requester shape (method, params, timeout, signal). */
+export type PetGatewayRequest = <T>(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number,
+  signal?: AbortSignal
+) => Promise<T>
+
+/**
+ * Profile-addressed pet RPC transport (Layer 7). Pets are per-profile, so gallery
+ * calls, scale persistence, and pet config reads/writes all route through the
+ * named profile's OWN socket via requestGatewayForProfile — connection ownership
+ * is resolved by Electron, never guessed in the renderer, and never the active
+ * gateway. Gallery calls take NO lease (only rendering slots/submits lease).
+ */
+export function petRequestFor(profile: string): PetGatewayRequest {
+  const key = normalizeProfileKey(profile)
+
+  return (method, params, timeoutMs, signal) =>
+    requestGatewayForProfile(key, method, { ...params, profile: key }, timeoutMs, signal)
+}

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -11,7 +11,8 @@ import {
   flashPetActivity,
   replacePetActivity,
   setPetActivity,
-  setPetReplyText
+  setPetReplyText,
+  shouldMarkUnread
 } from './pet'
 
 describe('derivePetState', () => {
@@ -116,5 +117,37 @@ describe('replyText', () => {
     const long = 'a'.repeat(250)
     setPetReplyText(long)
     expect($petReplyText.get()?.length).toBe(200)
+  })
+})
+
+describe('shouldMarkUnread (pure)', () => {
+  const base = {
+    activeProfile: 'default',
+    activeSessionId: 's1',
+    profile: 'default',
+    sessionId: 's1',
+    windowFocused: true
+  }
+
+  it('does not mark the active session unread while the window is focused', () => {
+    expect(shouldMarkUnread(base)).toBe(false)
+  })
+
+  it('marks unread when the window is unfocused', () => {
+    expect(shouldMarkUnread({ ...base, windowFocused: false })).toBe(true)
+  })
+
+  it('marks a background profile unread even while focused (pinned mode, test 22)', () => {
+    expect(shouldMarkUnread({ ...base, profile: 'apollo', sessionId: 's2' })).toBe(true)
+  })
+
+  it('marks a non-active session in the active profile unread while focused', () => {
+    expect(shouldMarkUnread({ ...base, sessionId: 's2' })).toBe(true)
+  })
+
+  it('a sessionless event (null sessionId) on the active profile does not mark unread while focused', () => {
+    // The session clause requires sessionId !== null, so a global/sessionless
+    // event on the active profile stays quiet while the window is focused.
+    expect(shouldMarkUnread({ ...base, sessionId: null })).toBe(false)
   })
 })

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -6,8 +6,10 @@ import {
   $petMotion,
   $petReplyText,
   $petState,
+  clearPetReplyText,
   derivePetState,
   flashPetActivity,
+  replacePetActivity,
   setPetActivity,
   setPetReplyText
 } from './pet'
@@ -44,18 +46,18 @@ describe('derivePetState', () => {
 
 describe('roam motion', () => {
   it('only reports at-rest when the agent-driven state is plain idle', () => {
-    $petActivity.set({})
+    replacePetActivity({})
     expect($petAtRest.get()).toBe(true)
 
-    $petActivity.set({ busy: true })
+    replacePetActivity({ busy: true })
     expect($petAtRest.get()).toBe(false)
 
-    $petActivity.set({})
+    replacePetActivity({})
     expect($petAtRest.get()).toBe(true)
   })
 
   it('shows the roam pose while wandering, but never overrides real activity', () => {
-    $petActivity.set({})
+    replacePetActivity({})
     $petMotion.set('run')
     expect($petState.get()).toBe('run')
 
@@ -64,16 +66,16 @@ describe('roam motion', () => {
     expect($petState.get()).toBe('jump')
 
     // Activity wins over a wander in progress.
-    $petActivity.set({ reasoning: true, busy: true })
+    replacePetActivity({ reasoning: true, busy: true })
     expect($petState.get()).toBe('review')
 
     // Back at rest, the wander resumes its pose; clearing it returns to idle.
-    $petActivity.set({})
+    replacePetActivity({})
     expect($petState.get()).toBe('jump')
     $petMotion.set(null)
     expect($petState.get()).toBe('idle')
 
-    $petActivity.set({})
+    replacePetActivity({})
   })
 })
 
@@ -99,13 +101,13 @@ describe('replyText', () => {
   })
 
   it('skips empty / whitespace-only text', () => {
-    $petReplyText.set(null)
+    clearPetReplyText()
     setPetReplyText('   ')
     expect($petReplyText.get()).toBeNull()
   })
 
   it('skips [SILENT] replies', () => {
-    $petReplyText.set(null)
+    clearPetReplyText()
     setPetReplyText('[SILENT] heartbeat sent')
     expect($petReplyText.get()).toBeNull()
   })

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -4,10 +4,12 @@ import {
   $petActivity,
   $petAtRest,
   $petMotion,
+  $petReplyText,
   $petState,
   derivePetState,
   flashPetActivity,
-  setPetActivity
+  setPetActivity,
+  setPetReplyText
 } from './pet'
 
 describe('derivePetState', () => {
@@ -87,5 +89,30 @@ describe('flashPetActivity', () => {
     expect($petState.get()).toBe('jump')
 
     setPetActivity({})
+  })
+})
+
+describe('replyText', () => {
+  it('stores trimmed reply text', () => {
+    setPetReplyText('  hello world  ')
+    expect($petReplyText.get()).toBe('hello world')
+  })
+
+  it('skips empty / whitespace-only text', () => {
+    $petReplyText.set(null)
+    setPetReplyText('   ')
+    expect($petReplyText.get()).toBeNull()
+  })
+
+  it('skips [SILENT] replies', () => {
+    $petReplyText.set(null)
+    setPetReplyText('[SILENT] heartbeat sent')
+    expect($petReplyText.get()).toBeNull()
+  })
+
+  it('truncates to 200 chars', () => {
+    const long = 'a'.repeat(250)
+    setPetReplyText(long)
+    expect($petReplyText.get()?.length).toBe(200)
   })
 })

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -4,6 +4,17 @@ import { persistBoolean, storedBoolean } from '@/lib/storage'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $busy } from '@/store/session'
 
+import {
+  clearProfilePetReplyText,
+  clearProfilePetUnread,
+  markProfilePetUnread,
+  mergeProfileActivity,
+  $profilePets,
+  replaceProfileActivity,
+  setProfilePetInfo,
+  setProfilePetReplyText
+} from './pet-multi'
+
 /**
  * Petdex mascot state for the desktop floating pet.
  *
@@ -89,8 +100,20 @@ export function derivePetState(activity: PetActivity): PetState {
   return 'idle'
 }
 
-export const $petInfo = atom<PetInfo>({ enabled: false })
-export const $petActivity = atom<PetActivity>({})
+// Backwards compat: the foreground (active-profile) pet atoms are computed
+// views over that profile's slice of the per-profile store. Existing components
+// (PetSprite/PetBubble/floating-pet) read these unchanged; in follow-active mode
+// only the active profile is ever populated, so behavior is identical to the old
+// standalone atoms.
+export const $petInfo = computed(
+  [$profilePets, $activeGatewayProfile],
+  (pets, active): PetInfo => pets.get(normalizeProfileKey(active))?.info ?? { enabled: false }
+)
+
+export const $petActivity = computed(
+  [$profilePets, $activeGatewayProfile],
+  (pets, active): PetActivity => pets.get(normalizeProfileKey(active))?.activity ?? {}
+)
 
 /** Pet installed + enabled with a loaded spritesheet (ready to show/react). */
 export const $petActive = computed($petInfo, info => info.enabled && Boolean(info.spritesheetBase64))
@@ -113,9 +136,13 @@ export function petProfile(): string {
  * the app isn't focused, and off when the user opens the app via the mail icon
  * (or returns to the window). No persistence — it's a glance hint, not state.
  */
-export const $petUnread = atom(false)
-export const markPetUnread = () => $petUnread.set(true)
-export const clearPetUnread = () => $petUnread.set(false)
+export const $petUnread = computed(
+  [$profilePets, $activeGatewayProfile],
+  (pets, active): boolean => pets.get(normalizeProfileKey(active))?.unread ?? false
+)
+
+export const markPetUnread = () => markProfilePetUnread(petProfile())
+export const clearPetUnread = () => clearProfilePetUnread(petProfile())
 
 /**
  * Latest agent reply text for the overlay's speech bubble. Set alongside
@@ -126,22 +153,23 @@ export const clearPetUnread = () => $petUnread.set(false)
  * Capped at 200 chars at write time; the overlay further truncates to ~120 for
  * display with an ellipsis.
  */
-export const $petReplyText = atom<string | null>(null)
+export const $petReplyText = computed(
+  [$profilePets, $activeGatewayProfile],
+  (pets, active): string | null => pets.get(normalizeProfileKey(active))?.replyText ?? null
+)
 
-const REPLY_TEXT_MAX = 200
+export const setPetReplyText = (text: string) => setProfilePetReplyText(petProfile(), text)
 
-export const setPetReplyText = (text: string) => {
-  const trimmed = text.trim()
-  if (!trimmed) return
-  // Skip [SILENT] replies - they're internal control signals, not user-facing.
-  if (/^\[SILENT\]/i.test(trimmed)) return
-  $petReplyText.set(trimmed.length > REPLY_TEXT_MAX ? trimmed.slice(0, REPLY_TEXT_MAX) : trimmed)
-}
+export const clearPetReplyText = () => clearProfilePetReplyText(petProfile())
 
-export const clearPetReplyText = () => $petReplyText.set(null)
+/** Steady activity flags (toolRunning / reasoning) set + cleared by the stream.
+ *  Merges into the active profile's slice (the legacy global awaitingInput sync
+ *  writes through here). */
+export const setPetActivity = (next: Partial<PetActivity>) => mergeProfileActivity(petProfile(), next)
 
-/** Steady activity flags (toolRunning / reasoning) set + cleared by the stream. */
-export const setPetActivity = (next: Partial<PetActivity>) => $petActivity.set({ ...$petActivity.get(), ...next })
+/** Wholesale-replace the active profile's activity (the overlay pushes a full
+ *  snapshot). */
+export const replacePetActivity = (next: PetActivity) => replaceProfileActivity(petProfile(), next)
 
 let flashTimer: ReturnType<typeof setTimeout> | undefined
 
@@ -158,7 +186,7 @@ export const flashPetActivity = (next: Partial<PetActivity>, ms = 1600) => {
   flashTimer = setTimeout(() => setPetActivity({ celebrate: false, error: false, justCompleted: false }), ms)
 }
 
-export const setPetInfo = (info: PetInfo) => $petInfo.set(info)
+export const setPetInfo = (info: PetInfo) => setProfilePetInfo(petProfile(), info)
 
 /**
  * Resolve the live activity state from the dedicated activity atom, falling back

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -131,6 +131,30 @@ export function petProfile(): string {
 }
 
 /**
+ * Pure decision for "should this finished turn light up a pet's unread hint?".
+ * Inputs are parameters (not free variables) so it is testable and callable from
+ * the event path without a React ref in scope. Unread fires when the window is
+ * unfocused, OR the turn is on a non-active profile, OR on a non-active session.
+ *
+ * Mode caveat: in follow-active mode only the active profile is observed, so the
+ * profile clause can never fire — background profiles get no unread there. The
+ * "background activity animates its pet" criterion holds in pinned mode only.
+ */
+export function shouldMarkUnread(input: {
+  activeProfile: string
+  activeSessionId: string | null
+  profile: string
+  sessionId: string | null
+  windowFocused: boolean
+}): boolean {
+  return (
+    !input.windowFocused ||
+    normalizeProfileKey(input.profile) !== normalizeProfileKey(input.activeProfile) ||
+    (input.sessionId !== null && input.sessionId !== input.activeSessionId)
+  )
+}
+
+/**
  * Pet-local "you have a new message" flag, surfaced as the overlay's mail icon.
  * Deliberately not real unread tracking: it flips on when a turn finishes while
  * the app isn't focused, and off when the user opens the app via the mail icon

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -117,6 +117,29 @@ export const $petUnread = atom(false)
 export const markPetUnread = () => $petUnread.set(true)
 export const clearPetUnread = () => $petUnread.set(false)
 
+/**
+ * Latest agent reply text for the overlay's speech bubble. Set alongside
+ * $petUnread when a turn finishes while the app isn't focused; cleared when
+ * the user opens the app or clicks the reply bubble. Null = no reply to show
+ * (falls back to the mail icon if $petUnread is also set).
+ *
+ * Capped at 200 chars at write time; the overlay further truncates to ~120 for
+ * display with an ellipsis.
+ */
+export const $petReplyText = atom<string | null>(null)
+
+const REPLY_TEXT_MAX = 200
+
+export const setPetReplyText = (text: string) => {
+  const trimmed = text.trim()
+  if (!trimmed) return
+  // Skip [SILENT] replies - they're internal control signals, not user-facing.
+  if (/^\[SILENT\]/i.test(trimmed)) return
+  $petReplyText.set(trimmed.length > REPLY_TEXT_MAX ? trimmed.slice(0, REPLY_TEXT_MAX) : trimmed)
+}
+
+export const clearPetReplyText = () => $petReplyText.set(null)
+
 /** Steady activity flags (toolRunning / reasoning) set + cleared by the stream. */
 export const setPetActivity = (next: Partial<PetActivity>) => $petActivity.set({ ...$petActivity.get(), ...next })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -34,6 +34,11 @@ export const $activeProfile = atom<string>('default')
 // re-fetches on open so a profile created elsewhere shows up.
 export const $profiles = atom<ProfileInfo[]>([])
 
+// False until refreshProfiles() succeeds at least once. Roster reconciliation
+// gates on this so the initial empty `$profiles` (before the first catalog load)
+// is never mistaken for "every pinned profile was deleted".
+export const $profilesLoaded = atom(false)
+
 export function setActiveProfile(name: string): void {
   $activeProfile.set(name || 'default')
 }
@@ -41,6 +46,7 @@ export function setActiveProfile(name: string): void {
 export async function refreshProfiles(): Promise<ProfileInfo[]> {
   const { profiles } = await getProfiles()
   $profiles.set(profiles)
+  $profilesLoaded.set(true)
 
   return profiles
 }

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -11,6 +11,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 import json
 import logging
+import sqlite3
 import shutil
 import tempfile
 import threading
@@ -67,17 +68,53 @@ HERMES_DIR = get_hermes_home().resolve()
 # These constants remain the default-profile fallback and a compatibility
 # surface for existing callers/tests. Cross-profile callers must scope paths
 # with use_cron_store() instead of mutating them process-wide.
-CRON_DIR = HERMES_DIR / "cron"
-JOBS_FILE = CRON_DIR / "jobs.json"
+def _get_jobs_file() -> Path:
+    """Resolve the default jobs store from the active Hermes home."""
+    return get_hermes_home().resolve() / "cron" / "jobs.json"
+
+
+class _LazyPath:
+    """Path-like compatibility wrapper that resolves its path on use."""
+
+    def __init__(self, resolver):
+        self._resolver = resolver
+
+    def _resolve(self) -> Path:
+        return self._resolver()
+
+    def __fspath__(self):
+        return os.fspath(self._resolve())
+
+    def __getattr__(self, name):
+        return getattr(self._resolve(), name)
+
+    def __str__(self):
+        return str(self._resolve())
+
+    def __repr__(self):
+        return repr(self._resolve())
+
+    def __eq__(self, other):
+        return self is other or self._resolve() == other
+
+    def __hash__(self):
+        return hash(self._resolve())
+
+    def __truediv__(self, other):
+        return self._resolve() / other
+
+
+CRON_DIR = _LazyPath(lambda: get_hermes_home().resolve() / "cron")
+JOBS_FILE = _LazyPath(_get_jobs_file)
 # Heartbeat file the in-process ticker touches on every loop iteration. The
 # gateway process and the (separate) ``hermes cron status`` process share it
 # so status can tell whether the ticker THREAD is alive, not just whether the
 # gateway PROCESS exists — a ticker that dies silently inside a live gateway
 # would otherwise report healthy (#32612, #32895).
-TICKER_HEARTBEAT_FILE = CRON_DIR / "ticker_heartbeat"
+TICKER_HEARTBEAT_FILE = _LazyPath(lambda: CRON_DIR / "ticker_heartbeat")
 # Last tick that completed WITHOUT raising. Distinguishing this from the plain
 # heartbeat lets status detect a ticker that is alive but failing every tick.
-TICKER_SUCCESS_FILE = CRON_DIR / "ticker_last_success"
+TICKER_SUCCESS_FILE = _LazyPath(lambda: CRON_DIR / "ticker_last_success")
 # Default ticker loop interval (seconds). The single source of truth shared by
 # the in-process ticker (cron/scheduler_provider.py) and the staleness
 # threshold in `hermes cron status` (hermes_cli/cron.py), so the two never
@@ -98,7 +135,7 @@ _jobs_lock_state = threading.local()
 # legitimate critical section (field updates only) while keeping the ticker's
 # worst-case stall well under one status-alarm threshold.
 _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
-OUTPUT_DIR = CRON_DIR / "output"
+OUTPUT_DIR = _LazyPath(lambda: CRON_DIR / "output")
 ONESHOT_GRACE_SECONDS = 120
 
 
@@ -115,42 +152,12 @@ _cron_store_override: ContextVar[Optional[_CronStorePaths]] = ContextVar(
 )
 
 
-# Import-time snapshot of the compatibility constants, so deliberate
-# re-pointing of the module surface (monkeypatched CRON_DIR/JOBS_FILE/
-# OUTPUT_DIR — the documented escape hatch existing tests/embedders use)
-# is distinguishable from the constants merely being stale.
-_IMPORT_STORE = _CronStorePaths(CRON_DIR, JOBS_FILE, OUTPUT_DIR)
-
-
 def _current_cron_store() -> _CronStorePaths:
-    """Return paths pinned to this execution context's profile.
-
-    Precedence, most explicit first:
-
-    1. an active use_cron_store() override (ContextVar);
-    2. deliberately re-pointed module constants — if CRON_DIR/JOBS_FILE/
-       OUTPUT_DIR no longer match their import-time values, someone chose
-       the documented process-wide compatibility surface; honor it;
-    3. the ACTIVE profile home, resolved fresh via get_hermes_home()
-       (context-local override, then the HERMES_HOME env var) — so a test
-       or embedder that re-points HERMES_HOME after this module was
-       imported reads/writes ITS OWN store, not whatever jobs.json the
-       import happened to freeze (the filed incident: fixtures that patched
-       the env too late silently rewrote the user's real jobs file);
-    4. the import-time constants (home unchanged since import — the common
-       path, returned unchanged).
-    """
+    """Return paths pinned to this execution context's profile."""
     override = _cron_store_override.get()
     if override is not None:
         return override
-    live_constants = _CronStorePaths(CRON_DIR, JOBS_FILE, OUTPUT_DIR)
-    if live_constants != _IMPORT_STORE:
-        return live_constants
-    home = get_hermes_home().resolve()
-    if home == HERMES_DIR:
-        return live_constants
-    cron_dir = home / "cron"
-    return _CronStorePaths(cron_dir, cron_dir / "jobs.json", cron_dir / "output")
+    return _CronStorePaths(CRON_DIR, Path(JOBS_FILE), OUTPUT_DIR)
 
 
 @contextlib.contextmanager
@@ -239,13 +246,7 @@ def _job_running_in_this_process(job_id: str) -> bool:
         from cron.scheduler import get_running_job_ids
         return job_id in get_running_job_ids()
     except Exception:
-        logger.warning(
-            "Cron running-set liveness check failed for job %r; keeping the "
-            "entry to avoid deleting a possibly live one-shot run",
-            job_id,
-            exc_info=True,
-        )
-        return True
+        return False
 
 
 def _jobs_lock_file() -> Path:
@@ -977,16 +978,13 @@ def load_jobs() -> List[Dict[str, Any]]:
     _strict_retry = False  # track whether we used the strict=False fallback
 
     try:
-        # utf-8-sig: Windows Notepad / PowerShell 5.1 Set-Content -Encoding UTF8
-        # write a leading BOM; json.load under plain utf-8 raises
-        # JSONDecodeError("Unexpected UTF-8 BOM") and takes down cron.
-        with open(jobs_file, 'r', encoding='utf-8-sig') as f:
+        with open(jobs_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         _strict_retry = True
         try:
-            with open(jobs_file, 'r', encoding='utf-8-sig') as f:
+            with open(jobs_file, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)
@@ -1445,14 +1443,6 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
     jobs = [_normalize_job_record(j) for j in load_jobs()]
     if not include_disabled:
         jobs = [j for j in jobs if j.get("enabled", True)]
-    try:
-        from cron.executions import latest_executions
-
-        latest = latest_executions([job.get("id", "") for job in jobs])
-    except Exception:
-        latest = {}
-    for job in jobs:
-        job["latest_execution"] = latest.get(job.get("id", ""))
     return jobs
 
 
@@ -1690,6 +1680,24 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
 
                     # Check if we've hit the repeat limit
                     if times is not None and times > 0 and completed >= times:
+                        if not success and kind == "once":
+                            try:
+                                family_db = Path.home() / ".hermes" / "family" / "family.db"
+                                with sqlite3.connect(str(family_db), timeout=6) as con:
+                                    con.execute(
+                                        "INSERT INTO events (sister, type, detail) VALUES (?, ?, ?)",
+                                        (
+                                            "cron",
+                                            "oneshot_failed",
+                                            f"Job {job['id']} ({job.get('name') or job['id']}) failed: {error or 'unknown error'}",
+                                        ),
+                                    )
+                            except Exception:
+                                logger.warning(
+                                    "Failed to record one-shot cron failure for job %s",
+                                    job["id"],
+                                    exc_info=True,
+                                )
                         # Remove the job (limit reached)
                         jobs.pop(i)
                         save_jobs(jobs)

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -51,7 +51,7 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # `start` is intentionally excluded: starting a gateway from inside a
     # gateway is benign (a no-op or "already running" error), and a
     # legitimate cron job might start a sibling profile's gateway.
-    r"(?:hermes\s+gateway\s+(?:restart|stop))"
+    r"(?:hermes\s+gateway\s+(?:restart|stop|bootout|bootstrap))"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -39,7 +39,7 @@ from typing import Any, List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_cli.fallback_config import get_fallback_chain
@@ -2441,6 +2441,71 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _cron_heartbeat_sister(job: dict) -> str:
+    """Resolve the family sister associated with a heartbeat cron job."""
+    explicit = str(job.get("sister") or "").strip().lower()
+    if explicit:
+        return explicit
+    prompt = str(job.get("prompt") or "")
+    match = re.search(r"\bhb-start\s+([A-Za-z0-9_-]+)\b", prompt)
+    if match:
+        return match.group(1).lower()
+    name = str(job.get("name") or "").lower()
+    for candidate in ("bookkeeper", "lune", "cres", "nova", "apollo", "kai", "vivi", "sol"):
+        if candidate in name:
+            return candidate
+    home = _get_hermes_home()
+    return home.name if home.parent.name == "profiles" else "unknown"
+
+
+def _job_uses_auto_heartbeat(job: dict) -> bool:
+    """Return whether the runner owns this job's heartbeat lifecycle."""
+    toolsets = {str(name).strip().lower() for name in (job.get("enabled_toolsets") or [])}
+    return bool(job.get("auto_heartbeat") is True or "heartbeat" in toolsets or "hb-start" in str(job.get("prompt") or ""))
+
+
+def _run_family_command(args: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a shared-family ``fam`` command from a profile-scoped scheduler."""
+    root = get_default_hermes_root()
+    fam = root / "family" / "fam"
+    env = os.environ.copy()
+    env["FAMILY_DB"] = str(root / "family" / "family.db")
+    env["OPS_DB"] = str(root / "family" / "ops.db")
+    return subprocess.run(
+        [str(fam), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+
+
+def _start_cron_heartbeat(job: dict) -> str:
+    sister = _cron_heartbeat_sister(job)
+    result = _run_family_command(["hb-start", sister, str(job["id"])])
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "fam hb-start failed").strip()
+        raise RuntimeError(f"cron heartbeat start failed for {job['id']}: {detail}")
+    heartbeat_id = next((line.strip() for line in reversed(result.stdout.splitlines()) if line.strip()), "")
+    if not heartbeat_id.isdigit():
+        raise RuntimeError(f"cron heartbeat start returned no heartbeat ID for {job['id']}")
+    return heartbeat_id
+
+
+def _end_cron_heartbeat(heartbeat_id: str, status: str) -> None:
+    result = _run_family_command(["hb-end", heartbeat_id, status])
+    if result.returncode != 0:
+        logger.warning("Cron heartbeat %s close failed: %s", heartbeat_id, (result.stderr or result.stdout).strip())
+
+
+def _strip_legacy_heartbeat_commands(prompt: str) -> str:
+    """Remove prompt-owned hb-start/hb-end shell lines after runner takeover."""
+    return "\n".join(
+        line for line in prompt.splitlines()
+        if not re.search(r"\bhb-(?:start|end)\b", line)
+    )
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -2452,7 +2517,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             result is used for prompt injection. When omitted, the script
             (if any) runs inline as before.
     """
-    user_prompt = str(job.get("prompt") or "")
+    user_prompt = _strip_legacy_heartbeat_commands(str(job.get("prompt") or ""))
     prompt = user_prompt
     skills = job.get("skills")
     # True when runtime-collected DATA (script stdout, upstream-job output)
@@ -2783,6 +2848,10 @@ def run_job(
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    heartbeat_id = None
+    heartbeat_status = "ok"
+    prior_hb_id = os.environ.get("HB_ID")
+    had_hb_id = "HB_ID" in os.environ
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -3129,6 +3198,10 @@ def run_job(
     # (every future job blocks on acquire_*); a leaked reader blocks all
     # future writers.  Acquire itself can't leak (it either blocks or returns).
     try:
+        if _job_uses_auto_heartbeat(job):
+            heartbeat_id = _start_cron_heartbeat(job)
+            os.environ["HB_ID"] = heartbeat_id
+            logger.info("Job '%s': runner-owned heartbeat %s started", job_id, heartbeat_id)
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
@@ -3701,6 +3774,7 @@ def run_job(
         return True, output, final_response, None
         
     except Exception as e:
+        heartbeat_status = "error"
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
         
@@ -3723,6 +3797,12 @@ def run_job(
         return False, output, "", error_msg
 
     finally:
+        if heartbeat_id is not None:
+            _end_cron_heartbeat(heartbeat_id, heartbeat_status)
+        if had_hb_id:
+            os.environ["HB_ID"] = prior_hb_id
+        else:
+            os.environ.pop("HB_ID", None)
         # Restore TERMINAL_CWD to whatever it was before this job ran.  We
         # only ever mutate it when the job has a workdir; see the setup block
         # at the top of run_job for the serialization guarantee.

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -25,6 +25,7 @@ Context dict passed to ``agent:start`` / ``agent:end`` handlers:
   thread_id    -- Telegram forum-topic id / thread root id (string; empty
                   when not in a thread / topic)
   chat_type    -- "dm" | "group" | "forum" (empty if unknown)
+  profile      -- active Hermes profile name (e.g. "default", "apollo")
   session_id   -- Hermes session id
   message      -- inbound message text (truncated to 500 chars)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8133,9 +8133,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         else:
             try:
-                suspended = await self.async_session_store.suspend_recently_active()
+                # Crash-recovery bookkeeping must never prevent messaging
+                # platforms from coming online.  Session storage can be held
+                # by a stale SQLite/file lock after an unclean exit; bound the
+                # recovery attempt and continue startup if it does not return.
+                try:
+                    _session_recovery_timeout = float(
+                        os.getenv("HERMES_GATEWAY_SESSION_RECOVERY_TIMEOUT", "15")
+                    )
+                except (TypeError, ValueError):
+                    _session_recovery_timeout = 15.0
+                _session_recovery_timeout = max(0.1, _session_recovery_timeout)
+                suspended = await asyncio.wait_for(
+                    self.async_session_store.suspend_recently_active(),
+                    timeout=_session_recovery_timeout,
+                )
                 if suspended:
                     logger.info("Marked %d in-flight session(s) as resumable from previous run", suspended)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Session suspension on startup timed out after %.1fs; "
+                    "continuing platform startup",
+                    _session_recovery_timeout,
+                )
             except Exception as e:
                 logger.warning("Session suspension on startup failed: %s", e)
 
@@ -24157,18 +24177,20 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
     _ensure_windows_gateway_venv_imports()
 
-    # MCP tool discovery — run in an executor so the asyncio event loop
-    # stays responsive even when a configured MCP server is slow or
-    # unreachable.  discover_mcp_tools() uses a blocking 120s wait
-    # internally; calling it from the loop thread would freeze platform
-    # heartbeats (Discord shard, Telegram polling) until it returned.
-    # See #16856.
+    # MCP discovery can take up to 120s for a slow or unreachable server.
+    # It must not gate platform startup: a gateway with Telegram configured
+    # still needs to receive messages while optional MCP servers connect.
+    # Reuse the shared daemon-thread launcher used by the CLI/dashboard; the
+    # first tool snapshot takes a separately bounded wait where needed.
     try:
-        from tools.mcp_tool import discover_mcp_tools
-        _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(None, discover_mcp_tools)
-    except Exception as e:
-        logger.debug("MCP tool discovery failed: %s", e)
+        from hermes_cli.mcp_startup import start_background_mcp_discovery
+
+        start_background_mcp_discovery(
+            logger=logger,
+            thread_name="gateway-mcp-discovery",
+        )
+    except Exception:
+        logger.debug("Background MCP tool discovery failed at gateway startup", exc_info=True)
 
     # Start the gateway
     success = await runner.start()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13889,6 +13889,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "chat_id": source.chat_id or "",
                 "thread_id": str(getattr(source, "thread_id", None)) if getattr(source, "thread_id", None) else "",
                 "chat_type": getattr(source, "chat_type", "") or "",
+                "profile": getattr(source, "profile", "") or self._active_profile_name(),
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
             }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13852,7 +13852,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp = (
                     _event_epoch if _event_epoch is not None else _embedded_ts
                 )
-                if _message_timestamps_enabled(_load_gateway_config()):
+                _timestamps_enabled = _message_timestamps_enabled(_load_gateway_config())
+                if _timestamps_enabled:
+                    if persist_user_timestamp is None:
+                        # Some adapters strip event metadata. Preserve the
+                        # temporal-context contract with processing time, and
+                        # make the loss of send-time provenance observable.
+                        persist_user_timestamp = time.time()
+                        logger.warning(
+                            "Message timestamp unavailable for platform=%s; "
+                            "falling back to processing time",
+                            source,
+                        )
                     message_text = _render_msg_ts(
                         _clean_message_text,
                         persist_user_timestamp,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -936,6 +936,14 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    # Retrieval-only exclusions for persona-facing session_search. The
+    # transcripts remain in state.db for admin/debug access and retention.
+    "session_search": {
+        "exclude_patterns": {
+            "session_id": ["bookkeeper"],
+            "messages": ["p_send", "stats-update", "form_scores"],
+        },
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,

--- a/hermes_cli/pets.py
+++ b/hermes_cli/pets.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from contextlib import contextmanager
 
 
 def _print(msg: str = "") -> None:
@@ -25,6 +26,9 @@ def _err(msg: str) -> None:
 def _cmd_list(args) -> int:
     """List gallery pets (or only installed ones with ``--installed``)."""
     from agent.pet import store
+
+    if getattr(args, "profiles", False):
+        return _cmd_list_profiles()
 
     if getattr(args, "installed", False):
         pets = store.installed_pets()
@@ -122,8 +126,55 @@ def _cmd_select(args) -> int:
 
 
 def _cmd_off(args) -> int:
+    if getattr(args, "all", False):
+        return _cmd_off_all()
+
     _set_enabled(False)
     _print("✓ pet disabled (display.pet.enabled=false)")
+    return 0
+
+
+def _cmd_off_all() -> int:
+    """Disable the pet for EVERY profile (``pets off --all``).
+
+    Iterates the profiles catalog and binds each profile's HERMES_HOME the same
+    way the gateway's ``@_profile_scoped`` decorator does, then sets
+    ``display.pet.enabled=false``. Idempotent. An unreadable profile is skipped
+    with a warning rather than aborting the whole run; a per-profile result line
+    is printed either way.
+    """
+    from hermes_cli import profiles as profiles_mod
+
+    for info in profiles_mod.list_profiles():
+        try:
+            with _bound_profile_home(info.path):
+                _set_enabled(False)
+            _print(f"  ✓ {info.name}: pet disabled (display.pet.enabled=false)")
+        except Exception as exc:  # noqa: BLE001 - best-effort per profile
+            _err(f"  ⚠ {info.name}: skipped ({exc})")
+
+    _print("Note: a running desktop picks this up on its next pet poll, not instantly.")
+    return 0
+
+
+def _cmd_list_profiles() -> int:
+    """Per-profile pet status (``pets list --profiles``)."""
+    from hermes_cli import profiles as profiles_mod
+
+    _print("Per-profile pet status:")
+
+    for info in profiles_mod.list_profiles():
+        try:
+            with _bound_profile_home(info.path):
+                cfg = _pet_config()
+            enabled = bool(cfg.get("enabled"))
+            slug = str(cfg.get("slug", "") or "")
+            mark = "✓" if enabled else " "
+            _print(f"  {mark} {info.name:<24} enabled={str(enabled):<5} slug={slug or '(unset)'}")
+        except Exception as exc:  # noqa: BLE001 - best-effort per profile
+            _err(f"  ⚠ {info.name:<24} unreadable ({exc})")
+
+    _print("Note: a running desktop picks up CLI changes on its next pet poll, not instantly.")
     return 0
 
 
@@ -282,13 +333,59 @@ def _cmd_doctor(args) -> int:
         _print("  ✗ Pillow not importable — sprite decoding will be unavailable")
         ok = False
 
+    _print("  profiles:")
+    for line in _profile_pet_summary_lines():
+        _print(f"    {line}")
+
     _print("  ✓ ready" if ok and enabled else "  (run the suggestions above to finish setup)")
     return 0
+
+
+def _profile_pet_summary_lines() -> list[str]:
+    """One status line per profile (``pets doctor`` multi-profile section).
+
+    Best-effort: an unreadable profile yields a warning line rather than raising,
+    so a single broken profile never aborts the doctor report.
+    """
+    from hermes_cli import profiles as profiles_mod
+
+    lines: list[str] = []
+
+    for info in profiles_mod.list_profiles():
+        try:
+            with _bound_profile_home(info.path):
+                cfg = _pet_config()
+            enabled = bool(cfg.get("enabled"))
+            slug = str(cfg.get("slug", "") or "")
+            lines.append(f"{info.name:<24} enabled={str(enabled):<5} slug={slug or '(unset)'}")
+        except Exception as exc:  # noqa: BLE001 - best-effort per profile
+            lines.append(f"{info.name:<24} unreadable ({exc})")
+
+    return lines or ["(no profiles found)"]
 
 
 # ─────────────────────────────────────────────────────────────────────────
 # config helpers
 # ─────────────────────────────────────────────────────────────────────────
+
+
+@contextmanager
+def _bound_profile_home(home):
+    """Bind a profile's HERMES_HOME (context-locally) around a config read/write.
+
+    Mirrors the gateway's ``@_profile_scoped`` decorator: ``load_config`` /
+    ``save_config`` resolve through ``get_hermes_home()``, which honors this
+    override, so the pet helpers below operate on the named profile's
+    ``config.yaml`` rather than the launch profile's.
+    """
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(home)
+    try:
+        yield
+    finally:
+        reset_hermes_home_override(token)
+
 
 def _pet_config() -> dict:
     from hermes_cli.config import load_config
@@ -465,6 +562,7 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
     p_list = subs.add_parser("list", help="Browse the petdex gallery")
     p_list.add_argument("query", nargs="?", default="", help="Filter by slug/name substring")
     p_list.add_argument("--installed", action="store_true", help="Only show installed pets")
+    p_list.add_argument("--profiles", action="store_true", help="Per-profile pet status")
     p_list.add_argument("--limit", type=int, default=40, help="Max rows (0 = all)")
     p_list.set_defaults(func=_cmd_list)
 
@@ -487,7 +585,9 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
     p_show.add_argument("--scale", type=float, default=0, help="Override scale (0 = config)")
     p_show.set_defaults(func=_cmd_show)
 
-    subs.add_parser("off", help="Disable the pet display").set_defaults(func=_cmd_off)
+    p_off = subs.add_parser("off", help="Disable the pet display")
+    p_off.add_argument("--all", action="store_true", help="Disable the pet for every profile")
+    p_off.set_defaults(func=_cmd_off)
 
     p_scale = subs.add_parser("scale", help="Resize the pet everywhere (display.pet.scale)")
     p_scale.add_argument("factor", help="Scale factor, e.g. 0.5 (clamped 0.1–3.0)")

--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -65,6 +65,7 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     of (label, chars, bytes) for the three prompt tiers).
     """
     from agent.system_prompt import build_system_prompt, build_system_prompt_parts
+    from agent.prompt_builder import DEFAULT_AGENT_IDENTITY, IDENTITY_MAX_BYTES, load_soul_md
 
     agent = _build_inspection_agent(platform)
 
@@ -98,6 +99,8 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     # Tool-schema JSON — the other half of the fixed per-call payload.
     tools = getattr(agent, "tools", None) or []
     tools_json = json.dumps(tools, ensure_ascii=False)
+    identity = load_soul_md() or DEFAULT_AGENT_IDENTITY
+    identity_bytes = _bytes(identity)
 
     sections: List[Tuple[str, int, int]] = [
         ("stable (identity/guidance/skills)", len(stable), _bytes(stable)),
@@ -109,6 +112,13 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
         "platform": platform,
         "model": getattr(agent, "model", "") or "",
         "system_prompt": {"chars": len(full), "bytes": _bytes(full)},
+        "identity": {
+            "chars": len(identity),
+            "bytes": identity_bytes,
+            "budget_bytes": IDENTITY_MAX_BYTES,
+            "estimated_tokens": (identity_bytes + 2) // 3,
+            "estimate_contract": "UTF-8 bytes divided by 3; conservative estimate, not an exact tokenizer count",
+        },
         "skills_index": {"chars": len(skills_index), "bytes": _bytes(skills_index)},
         "memory": {"chars": len(memory_block), "bytes": _bytes(memory_block)},
         "user_profile": {"chars": len(user_block), "bytes": _bytes(user_block)},

--- a/hermes_cli/subcommands/prompt_size.py
+++ b/hermes_cli/subcommands/prompt_size.py
@@ -29,6 +29,11 @@ def build_prompt_size_parser(subparsers, *, cmd_prompt_size: Callable) -> None:
         help="Platform to simulate (cli, telegram, discord, ...). Default: cli",
     )
     prompt_size_parser.add_argument(
+        "--profile",
+        default=None,
+        help="Profile name to measure; equivalent to the global --profile selector",
+    )
+    prompt_size_parser.add_argument(
         "--json",
         action="store_true",
         help="Emit the breakdown as JSON",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19807,6 +19807,170 @@ _mount_plugin_api_routes()
 from hermes_cli.dashboard_auth.routes import router as _dashboard_auth_router  # noqa: E402
 app.include_router(_dashboard_auth_router)
 
+
+# --- HERMES_ONE_MODEL_LIBRARY_COMPAT_V1 -------------------------------------
+# Compatibility endpoint installed by Hermes One. Upstream Hermes Agent exposes
+# /api/model/options and /api/model/set, but Hermes One also needs a small
+# configured-model shortcut library for remote/SSH model pickers. The library is
+# deliberately stored in this agent's HERMES_HOME so remote shortcuts stay on
+# the remote host and survive desktop restarts without changing upstream model
+# assignment semantics.
+def _hermes_one_model_library_path():
+    return get_hermes_home() / "models.json"
+
+
+def _hermes_one_short_model_label(model):
+    text = str(model or "").strip()
+    return (text.rsplit("/", 1)[-1] if text else "") or text
+
+
+def _hermes_one_model_key(row):
+    return (
+        str(row.get("provider", "")).strip().lower(),
+        str(row.get("model", "")).strip().lower(),
+        str(row.get("baseUrl", row.get("base_url", ""))).strip().rstrip("/").lower(),
+    )
+
+
+def _hermes_one_normalize_model_row(row, index=0):
+    if not isinstance(row, dict):
+        return None
+    provider = str(row.get("provider", "")).strip()
+    model = str(row.get("model", "")).strip()
+    if not provider or not model:
+        return None
+    base_url = str(row.get("baseUrl", row.get("base_url", "")) or "").strip()
+    return {
+        "id": str(row.get("id") or f"remote:library:{provider}:{index}:{model}"),
+        "name": str(row.get("name") or _hermes_one_short_model_label(model) or provider),
+        "provider": provider,
+        "model": model,
+        "baseUrl": base_url,
+        "createdAt": row.get("createdAt") if isinstance(row.get("createdAt"), (int, float)) else 0,
+    }
+
+
+def _hermes_one_read_model_library():
+    path = _hermes_one_model_library_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8")) if path.exists() else []
+    except Exception:
+        raw = []
+    rows = []
+    seen = set()
+    for index, item in enumerate(raw if isinstance(raw, list) else []):
+        row = _hermes_one_normalize_model_row(item, index)
+        if not row:
+            continue
+        key = _hermes_one_model_key(row)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(row)
+    return rows
+
+
+def _hermes_one_write_model_library(rows):
+    path = _hermes_one_model_library_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _hermes_one_current_model_row():
+    try:
+        cfg = load_config()
+    except Exception:
+        return None
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, dict):
+        provider = str(model_cfg.get("provider", "") or "").strip()
+        model = str(model_cfg.get("default", model_cfg.get("name", "")) or "").strip()
+        base_url = str(model_cfg.get("base_url", "") or "").strip()
+    else:
+        provider = ""
+        model = str(model_cfg or "").strip()
+        base_url = ""
+    if not provider or not model:
+        return None
+    return {
+        "id": f"remote:active:{provider}:{model}",
+        "name": _hermes_one_short_model_label(model) or provider,
+        "provider": provider,
+        "model": model,
+        "baseUrl": base_url,
+        "createdAt": 0,
+    }
+
+
+@app.get("/api/model/library")
+def hermes_one_get_model_library():
+    rows = _hermes_one_read_model_library()
+    current = _hermes_one_current_model_row()
+    if current:
+        current_key = _hermes_one_model_key(current)
+        rows = [current] + [row for row in rows if _hermes_one_model_key(row) != current_key]
+    return {"models": rows}
+
+
+@app.post("/api/model/library")
+def hermes_one_add_model_library_row(body: Dict[str, Any]):
+    provider = str(body.get("provider", "") or "").strip()
+    model = str(body.get("model", "") or "").strip()
+    if not provider or not model:
+        raise HTTPException(status_code=400, detail="provider and model required")
+    base_url = str(body.get("baseUrl", body.get("base_url", "")) or "").strip()
+    name = str(body.get("name", "") or "").strip() or _hermes_one_short_model_label(model) or provider
+    rows = _hermes_one_read_model_library()
+    key = (provider.lower(), model.lower(), base_url.rstrip("/").lower())
+    for row in rows:
+        if _hermes_one_model_key(row) == key:
+            return row
+    row = {
+        "id": f"remote:library:{secrets.token_hex(8)}",
+        "name": name,
+        "provider": provider,
+        "model": model,
+        "baseUrl": base_url,
+        "createdAt": int(time.time() * 1000),
+    }
+    rows.append(row)
+    _hermes_one_write_model_library(rows)
+    return row
+
+
+@app.patch("/api/model/library/{model_id:path}")
+def hermes_one_update_model_library_row(model_id: str, body: Dict[str, Any]):
+    rows = _hermes_one_read_model_library()
+    for index, row in enumerate(rows):
+        if row.get("id") != model_id:
+            continue
+        next_row = dict(row)
+        for key in ("name", "provider", "model"):
+            if key in body:
+                next_row[key] = str(body.get(key, "") or "").strip()
+        if "baseUrl" in body or "base_url" in body:
+            next_row["baseUrl"] = str(body.get("baseUrl", body.get("base_url", "")) or "").strip()
+        normalized = _hermes_one_normalize_model_row(next_row, index)
+        if not normalized:
+            raise HTTPException(status_code=400, detail="provider and model required")
+        rows[index] = normalized
+        _hermes_one_write_model_library(rows)
+        return {"ok": True, "model": normalized}
+    raise HTTPException(status_code=404, detail="model not found")
+
+
+@app.delete("/api/model/library/{model_id:path}")
+def hermes_one_delete_model_library_row(model_id: str):
+    rows = _hermes_one_read_model_library()
+    filtered = [row for row in rows if row.get("id") != model_id]
+    if len(filtered) == len(rows):
+        raise HTTPException(status_code=404, detail="model not found")
+    _hermes_one_write_model_library(filtered)
+    return {"ok": True}
+# --- /HERMES_ONE_MODEL_LIBRARY_COMPAT_V1 ------------------------------------
+
 mount_spa(app)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
       "version": "0.17.0",
       "dependencies": {
         "@assistant-ui/react": "^0.14.23",
-        "@assistant-ui/react-streamdown": "^0.3.4",
+        "@assistant-ui/react-streamdown": "^0.3.6",
         "@audiowave/react": "^0.6.2",
         "@chenglou/pretext": "^0.0.6",
         "@codemirror/commands": "^6.10.4",
@@ -188,150 +188,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "apps/desktop/node_modules/@assistant-ui/core": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.2.19.tgz",
-      "integrity": "sha512-QYwIy+l21rvVsyuc19doblCJ3bfhBzqbuNa/xdts8CIDlw+5LWg1uVGCiVhTRpkysHuJyONDF4TVBAxdMXR7yw==",
-      "license": "MIT",
-      "dependencies": {
-        "assistant-stream": "^0.3.24",
-        "nanoid": "^5.1.15"
-      },
-      "peerDependencies": {
-        "@assistant-ui/store": "^0.2.13",
-        "@assistant-ui/tap": "^0.9.0",
-        "@types/react": "*",
-        "assistant-cloud": "^0.1.31",
-        "react": "^18 || ^19",
-        "zustand": "^5.0.11"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "assistant-cloud": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "zustand": {
-          "optional": true
-        }
-      }
-    },
-    "apps/desktop/node_modules/@assistant-ui/react": {
-      "version": "0.14.24",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.14.24.tgz",
-      "integrity": "sha512-DHUEbJfn3EeApiLXJp6pZfwzGUwQ7aAoGeUfs8bmo1G9uAkRlxF1RKr7MwM/oVSUt+ixSsfWey+OuHJi5gtKCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@assistant-ui/core": "^0.2.19",
-        "@assistant-ui/store": "^0.2.19",
-        "@assistant-ui/tap": "^0.9.3",
-        "@radix-ui/primitive": "^1.1.4",
-        "@radix-ui/react-compose-refs": "^1.1.3",
-        "@radix-ui/react-context": "^1.1.4",
-        "@radix-ui/react-primitive": "^2.1.6",
-        "@radix-ui/react-use-callback-ref": "^1.1.2",
-        "@radix-ui/react-use-escape-keydown": "^1.1.2",
-        "assistant-cloud": "^0.1.34",
-        "assistant-stream": "^0.3.24",
-        "nanoid": "^5.1.15",
-        "radix-ui": "^1.6.0",
-        "react-textarea-autosize": "^8.5.9",
-        "safe-content-frame": "^0.0.21",
-        "zod": "^4.4.3",
-        "zustand": "^5.0.14"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "apps/desktop/node_modules/@assistant-ui/react-streamdown": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react-streamdown/-/react-streamdown-0.3.5.tgz",
-      "integrity": "sha512-xl4UoFGtCfeUk6T/F9d94djE4Vc2KPQ8I3vy7cV0fb8IGN63yHt/rVzehxMSX4XT81Qrpsa0KUQhJOo/8zxdkw==",
-      "license": "MIT",
-      "dependencies": {
-        "rehype-harden": "^1.1.8",
-        "rehype-raw": "^7.0.0",
-        "rehype-sanitize": "^6.0.0",
-        "remend": "^1.3.0",
-        "streamdown": "^2.5.0"
-      },
-      "peerDependencies": {
-        "@assistant-ui/react": "^0.14.18",
-        "@streamdown/cjk": "^1.0.0",
-        "@streamdown/code": "^1.0.0",
-        "@streamdown/math": "^1.0.0",
-        "@streamdown/mermaid": "^1.0.0",
-        "@types/react": "*",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@streamdown/cjk": {
-          "optional": true
-        },
-        "@streamdown/code": {
-          "optional": true
-        },
-        "@streamdown/math": {
-          "optional": true
-        },
-        "@streamdown/mermaid": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "apps/desktop/node_modules/@assistant-ui/store": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.19.tgz",
-      "integrity": "sha512-7GMEoK+H4iINquteLFXqqDB5SAzB19YHBy4KKQprxHseAtDrpkC8w9pTrPfJ1yLvbn3FqjXk645bCt5vDf1sTg==",
-      "license": "MIT",
-      "dependencies": {
-        "use-effect-event": "^2.0.3"
-      },
-      "peerDependencies": {
-        "@assistant-ui/tap": "^0.9.0",
-        "@types/react": "*",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "apps/desktop/node_modules/@assistant-ui/tap": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.9.3.tgz",
-      "integrity": "sha512-IKIgDbaKUPvVt2hMKL+WU2E8oru5J3muO9iSjL/vEVf6TNz5H07wrOKwD+1xhitqR1Nc4WtHK986jqoeGmWRDw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "apps/desktop/node_modules/@nous-research/ui": {
@@ -557,6 +413,152 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@assistant-ui/core": {
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.2.21.tgz",
+      "integrity": "sha512-Kwv9EywvtTsvoSmqFS0uonsQmN9iuo0GaIpqPGkxnfu4o8/slMw8gNDFNc+2+mzAdNCXcwkkLxh52gws7vhf0w==",
+      "license": "MIT",
+      "dependencies": {
+        "assistant-stream": "^0.3.26",
+        "nanoid": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@assistant-ui/store": "^0.2.13",
+        "@assistant-ui/tap": "^0.9.0",
+        "@types/react": "*",
+        "assistant-cloud": "^0.1.31",
+        "react": "^18 || ^19",
+        "zustand": "^5.0.11"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "assistant-cloud": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "zustand": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/react": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.14.27.tgz",
+      "integrity": "sha512-zV49HS6+pxu3BLdTI8TCH2j6vrx7aQtgJFmsPjfs6JVrahKvCojIUDF8dhpfzUtMyfi6VFrrXe496x319bqoDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@assistant-ui/core": "^0.2.21",
+        "@assistant-ui/store": "^0.2.20",
+        "@assistant-ui/tap": "^0.9.4",
+        "@radix-ui/primitive": "^1.1.5",
+        "@radix-ui/react-collection": "^1.1.12",
+        "@radix-ui/react-compose-refs": "^1.1.3",
+        "@radix-ui/react-context": "^1.2.0",
+        "@radix-ui/react-primitive": "^2.1.7",
+        "@radix-ui/react-use-callback-ref": "^1.1.2",
+        "@radix-ui/react-use-controllable-state": "^1.2.3",
+        "@radix-ui/react-use-escape-keydown": "^1.1.3",
+        "assistant-cloud": "^0.1.35",
+        "assistant-stream": "^0.3.26",
+        "nanoid": "^6.0.0",
+        "radix-ui": "^1.6.2",
+        "react-textarea-autosize": "^8.5.9",
+        "safe-content-frame": "^0.0.23",
+        "zod": "^4.4.3",
+        "zustand": "^5.0.14"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/react-streamdown": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react-streamdown/-/react-streamdown-0.3.6.tgz",
+      "integrity": "sha512-yheHLRpk8/coi/DnpQIK3W+f2ccKdiRoL5Srp9SNuJSn4KX2BzQJ4tDZHlFTm0XMfvKrG0jHorsBMs1e+N+Dgw==",
+      "license": "MIT",
+      "dependencies": {
+        "rehype-harden": "^1.1.8",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "remend": "^1.3.0",
+        "streamdown": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@assistant-ui/react": "^0.14.18",
+        "@streamdown/cjk": "^1.0.0",
+        "@streamdown/code": "^1.0.0",
+        "@streamdown/math": "^1.0.0",
+        "@streamdown/mermaid": "^1.0.0",
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@streamdown/cjk": {
+          "optional": true
+        },
+        "@streamdown/code": {
+          "optional": true
+        },
+        "@streamdown/math": {
+          "optional": true
+        },
+        "@streamdown/mermaid": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/store": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.20.tgz",
+      "integrity": "sha512-g+iHnov+JMZmVAPKhfs9YqCXWFcCBWCyi+oqsc/kAR9zMsE0+qbE36iyRYfsJFrhMDm+6Ev7/2UTO+1HwTiZfA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-effect-event": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@assistant-ui/tap": "^0.5.16 || ^0.7.1 || ^0.8.1 || ^0.9.0",
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/tap": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.9.4.tgz",
+      "integrity": "sha512-l44CfXvWrokaXQWBGsFGf574rlM9h5ii9mbcSJ8VoPV6KIpK5zlRqhkSxWWKuke4Q70tQygLaZm1BdiPwIP0bA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@audiowave/core": {
       "version": "0.3.1",
@@ -1486,9 +1488,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1826,9 +1828,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2395,9 +2397,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2493,9 +2495,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3326,12 +3328,12 @@
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-accessible-icon": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.13.tgz",
-      "integrity": "sha512-2/0RrtTngKZVkOFYDlvhe6JIsUravRnYGwH1iJ+qt+wPu8/fPu3HTLRkQptyIkpLovAy8qvHHJs9cvYJ3Uyqqg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.15.tgz",
+      "integrity": "sha512-WTQwcAvQf5sOcuUyi90lKPbhwcvQ+j55cjrSmeaN+L2vKU3DooOvlKw2MDeiJ5IkV5N905KW0/fGojKOBhD11A==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-visually-hidden": "1.2.9"
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3349,20 +3351,20 @@
       }
     },
     "node_modules/@radix-ui/react-accordion": {
-      "version": "1.2.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.18.tgz",
-      "integrity": "sha512-CGuUFvhjScXBF/bhjaU9xlgai2ikYqJRazXhMzngoUaZI7QaxAw24Ae3S/pR0b69p8GqW6i+CKJmx9JPNnZ4QQ==",
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.20.tgz",
+      "integrity": "sha512-jDhG9FvAEnlhnjrsINbNXcUa4G+L1KqSkJSunkbKEzFRcAb52jvM0PjPxPRvhe1HNc5F5yc0yzzWeeqlH4yBIg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collapsible": "1.1.18",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5"
+        "@radix-ui/react-collapsible": "1.1.20",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3380,16 +3382,16 @@
       }
     },
     "node_modules/@radix-ui/react-alert-dialog": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.21.tgz",
-      "integrity": "sha512-VbSR148lNkE8JdWnOsYX72YdivmCAtcrot1dl8UmT0ZZRKNR3hHJUpQxJOw7jWlY/JFemn4oaDXxCxpD594B7Q==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.23.tgz",
+      "integrity": "sha512-VAYOiQRqj3GPpYJE0I9J+X8Ip05cyVlNdKOFeiGS2Ou1HHGfpl0BxOyZm6nmVDyU+W+NF3/XLzmjHmVGydhwgA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-dialog": "1.1.21",
-        "@radix-ui/react-primitive": "2.1.8"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dialog": "1.1.23",
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3407,12 +3409,12 @@
       }
     },
     "node_modules/@radix-ui/react-arrow": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.13.tgz",
-      "integrity": "sha512-0Q310knIY0K+mkmncU9FxLggfW7V49Ok2oY+iu27KkERTsQXxYCIC8XW5QoK4w7Jp1z00vT5xj3oxTcn7QlcTg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.8"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3430,12 +3432,12 @@
       }
     },
     "node_modules/@radix-ui/react-aspect-ratio": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.13.tgz",
-      "integrity": "sha512-dD/EvbOiLskcdBKgNAeUmbTBCJfdCGp85fpFe3lmziE4ASbXuFERQCAB3sR41yvM+P711kJsTBNL9piP60urbA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.15.tgz",
+      "integrity": "sha512-fy+dyVR+90nelK8rqIznFlxzx7uPcGbhxH8Nfr2bHb4UfSe+e3hklOC0luK0hDwVwnRX7xTRySpsrQVeW+/oNQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.8"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3453,17 +3455,17 @@
       }
     },
     "node_modules/@radix-ui/react-avatar": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.4.tgz",
-      "integrity": "sha512-u4Sz6ajq2WobGMqbsNXnFI/3JP/o7TUBkEmQ4BRUYofPDQawdO3WWYy5907c9VgOFX+ETjKI3VxnnrKYAF7Pmg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.6.tgz",
+      "integrity": "sha512-4ULOTJ/mqy2hT9GlWa/MFHxHSvH3nJzHnZM1waNsc5Bonv7i70aNenghXmD97S6OJ81ekXONGGt4nT1r0PfEdA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
-        "@radix-ui/react-use-is-hydrated": "0.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3481,18 +3483,18 @@
       }
     },
     "node_modules/@radix-ui/react-checkbox": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.9.tgz",
-      "integrity": "sha512-YPXZlqjrKVqKtVD2F828CApHwu+PEu30i7x0Y9gg6SbQ3fJbcaQlDkGPT0gW6HjxoCjAEt8uJ494F1S61KpIjQ==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.11.tgz",
+      "integrity": "sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-size": "1.1.3"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3510,19 +3512,19 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.18.tgz",
-      "integrity": "sha512-aNMp8humfYzWERz5gxGb/eLNkB0ZthypLbNlNolzdgzFTeN78e/rnn9rxCdOaSsg/zClTOJ/OkjXYx9PUEPATw==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.20.tgz",
+      "integrity": "sha512-mcGesGplBnzN2sbvJETzpCNfSMyPnb29q1GRLU+Ib7bJrpIG2ywmRoh2V5VbA2uNvKikKUlVbAPks7JDjz4A8Q==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3540,15 +3542,15 @@
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.13.tgz",
-      "integrity": "sha512-Q8xYqNRFObXPmi45bFSkGdM2JA5hjBeYGFqzg6lZR3wp6b+cciraVq8DdneTabtws+uOYqjmsvmKOufk/M9Cyg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-slot": "1.3.1"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3566,9 +3568,9 @@
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.4.tgz",
-      "integrity": "sha512-pWJo6lQAfR6uy1n7ii7PaCc9dLPwTXDYbQpORZU5B548Aqvl2pP1SM1vJGKyxIFqZMHRopRO4CQYX2iXAIB5jA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3581,9 +3583,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.1.tgz",
-      "integrity": "sha512-EraVbFjiIjibpLr6EjvEDmSCYJU2SlKDMiO+qEK/D9GOWnQoAQlpQo2occGYC1UM9MBeEx5Bek3UtW/Qi57vAg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3596,16 +3598,16 @@
       }
     },
     "node_modules/@radix-ui/react-context-menu": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.5.tgz",
-      "integrity": "sha512-wbvSjqc7r0xKmfhrMCiCPxSTv/aSHU0cCAy0tELthJbaIzT7dkAcevKuoGKbDLiPG2VePgMVqLi2sWb6tDnzvQ==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.7.tgz",
+      "integrity": "sha512-CtXP35dxaB5T3zXSd+E3uHe/QpXcpYnZmxp6OaIbfthtfW4wyb77M23BG+bwIJDtsMwEP/YssdsmNyZu7jhWew==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-menu": "2.1.22",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5"
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3623,24 +3625,24 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.21.tgz",
-      "integrity": "sha512-h+7qMDDmZJ8qTSPrwNyKb/PACY0ehtN8QOBlCz+C2C1jgehKekdhmHddG9YQk8BF/sHJqglPjte+jA1Jrp9HcA==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-dismissable-layer": "1.1.17",
-        "@radix-ui/react-focus-guards": "1.1.5",
-        "@radix-ui/react-focus-scope": "1.1.14",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-portal": "1.1.15",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-slot": "1.3.1",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-layout-effect": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
       },
@@ -3660,9 +3662,9 @@
       }
     },
     "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.3.tgz",
-      "integrity": "sha512-OdgAA/xb6WOQMKNn0mtbYoruMG6YMaBOnq+evWxSpMmiEMBdeFZawnIWRfPPeVXCRm+0lnN8jpJLjhD7/UIxWw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3675,16 +3677,16 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.17.tgz",
-      "integrity": "sha512-QAXwa38pG0xNAYh1pjdSaf86NrkqsMoDNmget/Y7X8O8E/C3Iqlj9GAPE4DfX9BPLXc7WH2TWSzMRnIoCdcjzQ==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
-        "@radix-ui/react-use-effect-event": "0.0.4"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3702,18 +3704,18 @@
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.22.tgz",
-      "integrity": "sha512-wZRLTjZaJf1HTxx0YepFKZUuo+SZMi+Cr4kJ2fuA5FxDSUE0vHDTscahUaU+jfz6LFk4OuguwqJs5K0JsIsIBA==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-menu": "2.1.22",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3731,9 +3733,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.5.tgz",
-      "integrity": "sha512-UQvlB7L/BYh3P8MLvwZnQkH521EDos40Rwnbt5+Qpg4Vbk0z3xJjRUmR6+aka4aT1IQQXFdO5bNPoE7cvFl5xQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3746,14 +3748,14 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.14.tgz",
-      "integrity": "sha512-/x4htnJfmW53MplkrePaDpf1o/rN1C++g88WpVobULXbSyC19NtLkXmewuJ/HCaceSmfKDNL5gOXcBGnuAvnvQ==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-callback-ref": "1.1.3"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3771,17 +3773,17 @@
       }
     },
     "node_modules/@radix-ui/react-form": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.14.tgz",
-      "integrity": "sha512-ZCuPb54PQ3ZQEdQ6G1PrMBfXXzAyaVoCI9Fl+bWOwYZKTOcFjPHL7JQ3tCb6CX6Ut81GZLWKgIpV6OS3n5z5Ig==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.16.tgz",
+      "integrity": "sha512-Q4TLEn2A7TAypxwmd6R9EwrlXDvkfYSDMrq9/887AXAGh+G1rH+kYJKSTv+Si9Y0JPKTwKYv6PviAJosysNimA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-label": "2.1.13",
-        "@radix-ui/react-primitive": "2.1.8"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-label": "2.1.15",
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3799,20 +3801,20 @@
       }
     },
     "node_modules/@radix-ui/react-hover-card": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.21.tgz",
-      "integrity": "sha512-ByFLyi+kdTGkObxIt5wKB3Ru3rtJRuYUqPEtqiv1HNYqutqbn1wDuNmVzI6iwus9qfY3vwpNgvx/UVZUGTWC1A==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.23.tgz",
+      "integrity": "sha512-H8qONfZd3ltrU3+jHCIgITbWo6e1iTKvP9DHdrvYbX48ooRM5FjEDTn16AMwdfuOGkWdZEhpl3PLL/Wk/AnHDQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-dismissable-layer": "1.1.17",
-        "@radix-ui/react-popper": "1.3.5",
-        "@radix-ui/react-portal": "1.1.15",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3830,12 +3832,12 @@
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.3.tgz",
-      "integrity": "sha512-f/Wxm0ctyMymUJK0fqTSQlm85rbzdAkoNbPXJQ5+6caowVO8Yx+NWGjGz/oGhs/D+WIbbQpOrU0hU2Li2/42xQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3848,12 +3850,12 @@
       }
     },
     "node_modules/@radix-ui/react-label": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.13.tgz",
-      "integrity": "sha512-kj7BXyM4uG0dyeoEdVmPQAOFN291+iJOtiGTvkXe1ijJWLQbAHpFNkopvqquaMVn+zjqTZRhnefESAinMErHKg==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.15.tgz",
+      "integrity": "sha512-o/rdYEwZTTo5tjknnPeyQFU45kUC4i/XyeDPP+HGyi6XqpOP6Zf5Ya5vh/Yfe9Id5JiuWnnAx2XqIeD3UYZt0g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.8"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3871,27 +3873,27 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.22.tgz",
-      "integrity": "sha512-xCFrVLttGDPwMjIPI6GS+tm3IGUNKsPXffrJQIPpQJuE9Qy1bU9GNUCkwranU/pEqyBlwMxcBIK/FUJFAZ9SqQ==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-dismissable-layer": "1.1.17",
-        "@radix-ui/react-focus-guards": "1.1.5",
-        "@radix-ui/react-focus-scope": "1.1.14",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-popper": "1.3.5",
-        "@radix-ui/react-portal": "1.1.15",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-roving-focus": "1.1.17",
-        "@radix-ui/react-slot": "1.3.1",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
       },
@@ -3911,21 +3913,21 @@
       }
     },
     "node_modules/@radix-ui/react-menubar": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.22.tgz",
-      "integrity": "sha512-jDkcZXd5rN4b/S9nnEv9KZajaQ7+RO98OCWqAxrULTJtkSvODlNOO+EIxNG/d4QIF6QOqK5ZZrTF9MYl6eQdiQ==",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.24.tgz",
+      "integrity": "sha512-eeVs0vf7cuqXaM0qLQCPcufImiJNVBXdJDLu7ZGYl2732UH23Qat/foNGrr6vYV3/DdTsBqASoggUFgH14OcZA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-menu": "2.1.22",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-roving-focus": "1.1.17",
-        "@radix-ui/react-use-controllable-state": "1.2.5"
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3943,25 +3945,25 @@
       }
     },
     "node_modules/@radix-ui/react-navigation-menu": {
-      "version": "1.2.20",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.20.tgz",
-      "integrity": "sha512-in/exCQPatmmBmQZrtQkK4UrysEp8VGEuw5o8Bx3ozxbfg7DBb4H5j3DgxGz4N59J02NRVzhsWFtujZgy5ue3w==",
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.22.tgz",
+      "integrity": "sha512-ou7iLEJ+yrhQndkkA4U21XIdS/CS45F4iXIkTZcb6/Ne9EMsOuDudVmCwmDnfFZZ+y1FZqXRNSIgBy+YMvZVZg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-dismissable-layer": "1.1.17",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-layout-effect": "1.1.3",
-        "@radix-ui/react-use-previous": "1.1.3",
-        "@radix-ui/react-visually-hidden": "1.2.9"
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3979,23 +3981,23 @@
       }
     },
     "node_modules/@radix-ui/react-one-time-password-field": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.14.tgz",
-      "integrity": "sha512-F3vMSK+d+huI3a4Zm6j2hUsS+/gByVbsechJwp/ZCZBCrusXHvBeZZz9aMqXqqYNYu23mtvVMt6AeHDds8EU7w==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.16.tgz",
+      "integrity": "sha512-Tj9P6ntAJEw52oq/F0AGknXR4XncxEt7XU47O3xJQOiWfLzEy3d9gtgKfvjSzGxzHkfL+VzvxGu2KTFsloJqXw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.3",
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-roving-focus": "1.1.17",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-effect-event": "0.0.4",
-        "@radix-ui/react-use-is-hydrated": "0.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4013,19 +4015,19 @@
       }
     },
     "node_modules/@radix-ui/react-password-toggle-field": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.9.tgz",
-      "integrity": "sha512-JFkmnwZFD357odQkpzfxz++bpohQpaGCT/4PK6oRd4R/Rxzg02uFDucFzZDOTIOz6vWSluIlz91zelleg9BheA==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.11.tgz",
+      "integrity": "sha512-4gvFnmDXu3dgj21CqsufzIameRvlRd4SBqaWhcrlrNhRo0Y5i/49AmRJYe1fdAM3G2VNBbmin4b0D6cdQocwgw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-effect-event": "0.0.4",
-        "@radix-ui/react-use-is-hydrated": "0.1.2"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4043,25 +4045,24 @@
       }
     },
     "node_modules/@radix-ui/react-popover": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.21.tgz",
-      "integrity": "sha512-+AJ7P5oRcFqFtv7MaCD8fOuK3l5qQBAMdWEOnUOYd3JfHOeIUe7TnHHSSP15CtWwH4KrotyDCTzodOIoONh8vw==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.23.tgz",
+      "integrity": "sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-dismissable-layer": "1.1.17",
-        "@radix-ui/react-focus-guards": "1.1.5",
-        "@radix-ui/react-focus-scope": "1.1.14",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-popper": "1.3.5",
-        "@radix-ui/react-portal": "1.1.15",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-slot": "1.3.1",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-layout-effect": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
       },
@@ -4081,20 +4082,20 @@
       }
     },
     "node_modules/@radix-ui/react-popper": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.5.tgz",
-      "integrity": "sha512-6hLng2Rs45IZcvZ31BNvMeaFEMMEbtsog4xPcb8LZrGfyoV9fdAXqB9UKhLpTHtL0+E2DhSr6VW54Tehd6ksAQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.3",
-        "@radix-ui/react-use-rect": "1.1.3",
-        "@radix-ui/react-use-size": "1.1.3",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
         "@radix-ui/rect": "1.1.3"
       },
       "peerDependencies": {
@@ -4113,13 +4114,13 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.15.tgz",
-      "integrity": "sha512-kAfBVJUKNNKZuyGQXXG6rKolAV2KAmxxVkPXJgoq9dEFTl39286RufHQFNTL8rzha4vP8159BJ6hMGpB+bqv7A==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4137,12 +4138,12 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.9.tgz",
-      "integrity": "sha512-LTi1v05bprIb8/GSY/GWusI0jfsYjQ3CD3Nin8o7jVxnpHzVQfzjOQJoJTQkE9bdmOnsS7SFdhkXiBv8PrYnxw==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4160,12 +4161,12 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.8.tgz",
-      "integrity": "sha512-DOlK1BdcIeYYUcFkSYFka4v1h95XTov93b0jCgW1EEiZuIhdwHY2NlE1teLIh+p0uBsuZI5A+voay+iVWpprfA==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.3.1"
+        "@radix-ui/react-slot": "1.3.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4183,13 +4184,13 @@
       }
     },
     "node_modules/@radix-ui/react-progress": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.14.tgz",
-      "integrity": "sha512-lq5VXWp/t/b8MaqbRMAItXICc/jwhzJt0ZZ+au/CBtTYkX9EfAsSyGQL5brUVBgf9tUTKCoJEZlDl+uJF/08xQ==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.16.tgz",
+      "integrity": "sha512-5XnomAsoZZCY+KNTxbIghpGqPruZvKFNlvcAljVAOdDRDsH4/OZQxhtwo5wdtoDM5R6MhJBb2sPnDuRFep3lzg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-primitive": "2.1.8"
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4207,20 +4208,20 @@
       }
     },
     "node_modules/@radix-ui/react-radio-group": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.5.tgz",
-      "integrity": "sha512-BM1xQgw1gpgPSw05U4hJCMDX9GmAS6b6vKZANuNQZo0vf/ah7NZDAnjLd4tPg3z2vMvlI0CV+B2CFM9Z19oQDA==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.7.tgz",
+      "integrity": "sha512-cgYFEkntCxppHZgtSZ+7vh0wbZQ+IC7PPMw8DSnRG27B6kDd32/Zw0OJt7dGDigCoprMuWHjg2PvUn3PYvPFoQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-roving-focus": "1.1.17",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-size": "1.1.3"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4238,22 +4239,22 @@
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.17.tgz",
-      "integrity": "sha512-YdJmjETw7Py+4Nziv71jgZ6fH7xQgB5p+pQ5rV8Iufyrm0RHSijec/UV1zPfQoK/YcfzB9nOl/2bi1zf1SjRMQ==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-is-hydrated": "0.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4271,20 +4272,20 @@
       }
     },
     "node_modules/@radix-ui/react-scroll-area": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.16.tgz",
-      "integrity": "sha512-kEcmCenIJ+W5xlCv1u9VKDdPmzzGyfrJwEneY+02GH+lJRXrGpkiTkyjrfkspuRw6DXt4uduwT5c4xD8HTv27Q==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.18.tgz",
+      "integrity": "sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.3",
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4302,31 +4303,31 @@
       }
     },
     "node_modules/@radix-ui/react-select": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.5.tgz",
-      "integrity": "sha512-6CQx0xtdarAkSCsqgLJaz+coYQaru7rt8K6gMItR2rA+WP8/Ig6kRAzP6Zw88RccG98IZnszqJlJx9hejYOL3A==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+      "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.3",
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-dismissable-layer": "1.1.17",
-        "@radix-ui/react-focus-guards": "1.1.5",
-        "@radix-ui/react-focus-scope": "1.1.14",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-popper": "1.3.5",
-        "@radix-ui/react-portal": "1.1.15",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-slot": "1.3.1",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-layout-effect": "1.1.3",
-        "@radix-ui/react-use-previous": "1.1.3",
-        "@radix-ui/react-visually-hidden": "1.2.9",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
       },
@@ -4346,12 +4347,12 @@
       }
     },
     "node_modules/@radix-ui/react-separator": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.13.tgz",
-      "integrity": "sha512-wbagLhy4grekqiT6hU0WNP09FpmemTXbNWg4QEawaw9dix7hRIcrmDNnLDasOsKVLtArEznhgZKe5Gm4U6oPXQ==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.15.tgz",
+      "integrity": "sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.8"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4369,22 +4370,22 @@
       }
     },
     "node_modules/@radix-ui/react-slider": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.5.tgz",
-      "integrity": "sha512-7E8C13SdQKQxYganILiVZGEwM0NSbfbFcnNJ93kP++wD2pMT1SMsG3c04PFUlbPpaSXgicYgPeBndgJTvV3NKg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+      "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.3",
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-layout-effect": "1.1.3",
-        "@radix-ui/react-use-previous": "1.1.3",
-        "@radix-ui/react-use-size": "1.1.3"
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4402,13 +4403,12 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.1.tgz",
-      "integrity": "sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4"
+        "@radix-ui/react-compose-refs": "1.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4421,17 +4421,17 @@
       }
     },
     "node_modules/@radix-ui/react-switch": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.5.tgz",
-      "integrity": "sha512-e1YrvGvEjIqDhqKjQ4Q+IDkMfiY30u3FPz9CZXZMlQ8mU3kZ2PdeBM8Gssc48CDopPizNorKumGhjySBfO7BDQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.7.tgz",
+      "integrity": "sha512-48tB/4dn2UVLBCYhTu9AuR63IHl73l/qLbLgxd86noTUor4/K4LFDAcYjK+isP5313qxaFpjPVogE7+Y0/V3Kw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-size": "1.1.3"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4449,19 +4449,19 @@
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.19.tgz",
-      "integrity": "sha512-4wbGf98pX2ZwYqHMVB/dakeMPyH4xSJ9MSDaCCWXlIpYt0VYY6mtZxKSTiGS/F3tk0yrEYmXE1V8uwG7TxDCcQ==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.21.tgz",
+      "integrity": "sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-roving-focus": "1.1.17",
-        "@radix-ui/react-use-controllable-state": "1.2.5"
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4479,23 +4479,23 @@
       }
     },
     "node_modules/@radix-ui/react-toast": {
-      "version": "1.2.21",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.21.tgz",
-      "integrity": "sha512-/o8uHzH2z6ZM59Dt1UPFj8aYJ0DjPu0EuQXQ7uuYJTQLH5mNqxa1KuBfbpnklgXOOjyAtTp/tll0Nm+Nkz+bEg==",
+      "version": "1.2.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.23.tgz",
+      "integrity": "sha512-ofhyAsYaocRGOs/n0XWdUOSVzEAG6BfrMVM8z0c0kLEWY38w/0WuMFPTJP/HVaZPYkMvHZoKIIhNcjbTCBILPg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-dismissable-layer": "1.1.17",
-        "@radix-ui/react-portal": "1.1.15",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-layout-effect": "1.1.3",
-        "@radix-ui/react-visually-hidden": "1.2.9"
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4513,14 +4513,14 @@
       }
     },
     "node_modules/@radix-ui/react-toggle": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.16.tgz",
-      "integrity": "sha512-pp4TLY3N4osN9IB4TLEaaZRGooBmCi/XJD65gSCs5tvsKofM9WgiBToNtGrmR0k3sG4jFj4Nw4utsIvQraWA9g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+      "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-use-controllable-state": "1.2.5"
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4538,18 +4538,18 @@
       }
     },
     "node_modules/@radix-ui/react-toggle-group": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.17.tgz",
-      "integrity": "sha512-KKsrxb1cZREc2RI5DOGwlUSpaPW40xIaK1/DXXqYDb7slRE8pkRa+iF2aFbYiuMJ+aNWpCSChiN5gFe3bVveaQ==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+      "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-roving-focus": "1.1.17",
-        "@radix-ui/react-toggle": "1.1.16",
-        "@radix-ui/react-use-controllable-state": "1.2.5"
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-toggle": "1.1.18",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4567,18 +4567,18 @@
       }
     },
     "node_modules/@radix-ui/react-toolbar": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.17.tgz",
-      "integrity": "sha512-MjorZ0XQiWfCrrpStNXw/hX0HnG7VEzCgcSV226Ox8/WzS5yq0SiMhsLFE3LlXhdghlakFRFdE6eegtmUQW7Mg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.19.tgz",
+      "integrity": "sha512-Ph0IvtYw4VB12ZnZg+YtrGs8yJQsnizwo/zu0R4Y/nWugtJzA7Pg1eWeuDR9+LSqn+xjamss+UOSOJJJ4gx8jw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-roving-focus": "1.1.17",
-        "@radix-ui/react-separator": "1.1.13",
-        "@radix-ui/react-toggle-group": "1.1.17"
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-separator": "1.1.15",
+        "@radix-ui/react-toggle-group": "1.1.19"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4596,24 +4596,24 @@
       }
     },
     "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.14.tgz",
-      "integrity": "sha512-C/JxCKJJac+wtHPW1yFBSN8Ssuaufy2jYQMgyiJYyW4Fw0WJfDWXQDAly1qsbd1YDznH+sYitaljhf8igPCvmA==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.16.tgz",
+      "integrity": "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-dismissable-layer": "1.1.17",
-        "@radix-ui/react-id": "1.1.3",
-        "@radix-ui/react-popper": "1.3.5",
-        "@radix-ui/react-portal": "1.1.15",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-slot": "1.3.1",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-layout-effect": "1.1.3",
-        "@radix-ui/react-visually-hidden": "1.2.9"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4631,9 +4631,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.3.tgz",
-      "integrity": "sha512-AUS7HoBBAncIsGMLNG+CcpLuJ+JIBbZzmyM8Qdb1eIThX0AlhSSC6wn40xfBlPE+ypx/vSSiRWnklUAjy3U3UA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -4646,14 +4646,14 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.5.tgz",
-      "integrity": "sha512-UB1dXpxvHjR48poyKdKdTm7jT0kp3elkUKdKQiOkirlbYumqXinSJtrjDsr9maXNPvL12bKI4CDSmydms/9Aeg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-use-effect-event": "0.0.4",
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4666,12 +4666,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.4.tgz",
-      "integrity": "sha512-XYcfa6wlXDCwQtePuEiPmXLSAhGL4DWtedSyRgGbG3y10mw+OnrLp6SyeY1gJFMiYF0Dx0nMAX9InylKbLEFQQ==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4684,12 +4684,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.4.tgz",
-      "integrity": "sha512-4MSb5SPbMH02uUn19tLkO5Bav66ZQg/zFbedo7FWLWGFg9r8Z9xSog7QGnq9ZceurzBVIAIwgzANg6ExWc8HkQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.5.tgz",
+      "integrity": "sha512-ge3ipobwSXTj4JyVtswQ7qZj0ZHdtbGuOno/LrgAAeSxtsJ6Vs4Gz5IkPH2bmqpjcLUFoqGhA/mueuIf63UXlA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.3"
+        "@radix-ui/react-use-callback-ref": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4702,9 +4702,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.2.tgz",
-      "integrity": "sha512-2+gAVu9uaSLbopCTvvuWX9MIgEOlyqXC1Ok+KLCO7cZPSHLENs7dL0KbFQUGFIcFKmDW/bmaQRJtd8E3cnMRUw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -4717,9 +4717,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.3.tgz",
-      "integrity": "sha512-rDiah9wvtqihWtWz02XreeRKIxt2EJF8y5D9rtY9l5A2zxePAtcPiOMpDugNRw5bFHz+1/8viVoc7ZVKiJknCw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -4732,9 +4732,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-previous": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.3.tgz",
-      "integrity": "sha512-kbefNKla5AGhgvMqrg/qS7mYVLXTEHQLqoFIS03nKN2dAfQQ5PK5Tp+2LxS7BV6a6l4HHv4jTg6rtV2Uajwe2w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+      "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -4747,9 +4747,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-rect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.3.tgz",
-      "integrity": "sha512-W0GSYZFKEfi6raMiMEfJSngvVbFDIyxtW5JuVg5NoQBY59l0dVQVGLbhog/tOdwq0qtZ+TXuX1ikSNan4/IZXA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/rect": "1.1.3"
@@ -4765,12 +4765,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-size": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.3.tgz",
-      "integrity": "sha512-jJq6tQQLvO/z4uWbztjwPV+1a/+H4rCaWypasLB/ac8DEdd6+p7dIm7o3F6P2KZPGkPMqD4s5424EdAdoU+GLA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.3"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4783,12 +4783,12 @@
       }
     },
     "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.9.tgz",
-      "integrity": "sha512-seuZXNZVCz1kLSQMRO/TdNOSahBI3S5nXE4jzO7u7aFRWQlMAnwyrr8vKMkEU115fCLEyzR2YyjnP+aRMxK34w==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+      "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.8"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -7503,22 +7503,22 @@
       }
     },
     "node_modules/assistant-cloud": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.34.tgz",
-      "integrity": "sha512-kmB9qJmwf1Kb3FoLvVnDV7lsT2vRwaiNX9iDoEs+3Gli8aOQ667DPUIXvEXPyV5zF4gfT0E7GFNEcYWRQTElAA==",
+      "version": "0.1.35",
+      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.35.tgz",
+      "integrity": "sha512-SiMvAXalCwM9GcnyIiJfQTZda00E2VE/jZWqSdX4WPxQyHeVNK7uBzw3AaFpBQT1vXbS1UYdKVlZdUJ3vRftCg==",
       "license": "MIT",
       "dependencies": {
-        "assistant-stream": "^0.3.24"
+        "assistant-stream": "^0.3.26"
       }
     },
     "node_modules/assistant-stream": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.24.tgz",
-      "integrity": "sha512-AmZh8G7QXt2yCZyMZRGfEQRCJKvVYffEhCQQz3tfHixlI20o7zkMHLRpbRUw93gUIzVG+5MHx6j8gy8UHP1mVQ==",
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.26.tgz",
+      "integrity": "sha512-qjYrK9c5Mpuz3U6oG6YDpBbiICANhNTN86MLNcI47iRYXalqvCZL2Tzmh9pQcGWDX3PltSJtGIFAIHdRDXIg+A==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "nanoid": "^5.1.15",
+        "nanoid": "^6.0.0",
         "secure-json-parse": "^4.1.0"
       },
       "peerDependencies": {
@@ -7747,9 +7747,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9390,9 +9390,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10543,9 +10543,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10663,9 +10663,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11011,9 +11011,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11416,9 +11416,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13003,9 +13003,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
       "funding": [
         {
@@ -14838,9 +14838,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
-      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.0.tgz",
+      "integrity": "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ==",
       "funding": [
         {
           "type": "github",
@@ -14852,7 +14852,7 @@
         "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^22 || ^24 || >=26"
       }
     },
     "node_modules/nanostores": {
@@ -15999,66 +15999,66 @@
       }
     },
     "node_modules/radix-ui": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.5.tgz",
-      "integrity": "sha512-HVHPWDoOXBYxxiwvWR45KPcmvrjoa/NTFUbPbGmYoZv7BFYOIpZKiPQZWcpFJTX5z4LeoGenGCUgoafdYHuPWA==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.7.tgz",
+      "integrity": "sha512-QBdhh1arIEUvPC0dQ5+nwWAxt7+N+oP/9jPwjJkGFoSk/sqxg32gJtSXGtFh8frAIcS6oC9cx2Q+7KYCQLOAeA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-accessible-icon": "1.1.13",
-        "@radix-ui/react-accordion": "1.2.18",
-        "@radix-ui/react-alert-dialog": "1.1.21",
-        "@radix-ui/react-arrow": "1.1.13",
-        "@radix-ui/react-aspect-ratio": "1.1.13",
-        "@radix-ui/react-avatar": "1.2.4",
-        "@radix-ui/react-checkbox": "1.3.9",
-        "@radix-ui/react-collapsible": "1.1.18",
-        "@radix-ui/react-collection": "1.1.13",
-        "@radix-ui/react-compose-refs": "1.1.4",
-        "@radix-ui/react-context": "1.2.1",
-        "@radix-ui/react-context-menu": "2.3.5",
-        "@radix-ui/react-dialog": "1.1.21",
-        "@radix-ui/react-direction": "1.1.3",
-        "@radix-ui/react-dismissable-layer": "1.1.17",
-        "@radix-ui/react-dropdown-menu": "2.1.22",
-        "@radix-ui/react-focus-guards": "1.1.5",
-        "@radix-ui/react-focus-scope": "1.1.14",
-        "@radix-ui/react-form": "0.1.14",
-        "@radix-ui/react-hover-card": "1.1.21",
-        "@radix-ui/react-label": "2.1.13",
-        "@radix-ui/react-menu": "2.1.22",
-        "@radix-ui/react-menubar": "1.1.22",
-        "@radix-ui/react-navigation-menu": "1.2.20",
-        "@radix-ui/react-one-time-password-field": "0.1.14",
-        "@radix-ui/react-password-toggle-field": "0.1.9",
-        "@radix-ui/react-popover": "1.1.21",
-        "@radix-ui/react-popper": "1.3.5",
-        "@radix-ui/react-portal": "1.1.15",
-        "@radix-ui/react-presence": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.8",
-        "@radix-ui/react-progress": "1.1.14",
-        "@radix-ui/react-radio-group": "1.4.5",
-        "@radix-ui/react-roving-focus": "1.1.17",
-        "@radix-ui/react-scroll-area": "1.2.16",
-        "@radix-ui/react-select": "2.3.5",
-        "@radix-ui/react-separator": "1.1.13",
-        "@radix-ui/react-slider": "1.4.5",
-        "@radix-ui/react-slot": "1.3.1",
-        "@radix-ui/react-switch": "1.3.5",
-        "@radix-ui/react-tabs": "1.1.19",
-        "@radix-ui/react-toast": "1.2.21",
-        "@radix-ui/react-toggle": "1.1.16",
-        "@radix-ui/react-toggle-group": "1.1.17",
-        "@radix-ui/react-toolbar": "1.1.17",
-        "@radix-ui/react-tooltip": "1.2.14",
-        "@radix-ui/react-use-callback-ref": "1.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.5",
-        "@radix-ui/react-use-effect-event": "0.0.4",
-        "@radix-ui/react-use-escape-keydown": "1.1.4",
-        "@radix-ui/react-use-is-hydrated": "0.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.3",
-        "@radix-ui/react-use-size": "1.1.3",
-        "@radix-ui/react-visually-hidden": "1.2.9"
+        "@radix-ui/react-accessible-icon": "1.1.15",
+        "@radix-ui/react-accordion": "1.2.20",
+        "@radix-ui/react-alert-dialog": "1.1.23",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-aspect-ratio": "1.1.15",
+        "@radix-ui/react-avatar": "1.2.6",
+        "@radix-ui/react-checkbox": "1.3.11",
+        "@radix-ui/react-collapsible": "1.1.20",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-context-menu": "2.3.7",
+        "@radix-ui/react-dialog": "1.1.23",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-dropdown-menu": "2.1.24",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-form": "0.1.16",
+        "@radix-ui/react-hover-card": "1.1.23",
+        "@radix-ui/react-label": "2.1.15",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-menubar": "1.1.24",
+        "@radix-ui/react-navigation-menu": "1.2.22",
+        "@radix-ui/react-one-time-password-field": "0.1.16",
+        "@radix-ui/react-password-toggle-field": "0.1.11",
+        "@radix-ui/react-popover": "1.1.23",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-progress": "1.1.16",
+        "@radix-ui/react-radio-group": "1.4.7",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-scroll-area": "1.2.18",
+        "@radix-ui/react-select": "2.3.7",
+        "@radix-ui/react-separator": "1.1.15",
+        "@radix-ui/react-slider": "1.4.7",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-switch": "1.3.7",
+        "@radix-ui/react-tabs": "1.1.21",
+        "@radix-ui/react-toast": "1.2.23",
+        "@radix-ui/react-toggle": "1.1.18",
+        "@radix-ui/react-toggle-group": "1.1.19",
+        "@radix-ui/react-toolbar": "1.1.19",
+        "@radix-ui/react-tooltip": "1.2.16",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-escape-keydown": "1.1.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -16919,9 +16919,9 @@
       "license": "MIT"
     },
     "node_modules/safe-content-frame": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/safe-content-frame/-/safe-content-frame-0.0.21.tgz",
-      "integrity": "sha512-4LgYcX0lESOg9zVi6QCcqHaNGjZuc86w0IGRJij7lA4YG/6QHBblL2Jwh5OJBtkVSnhDOeARRpD3jvFNGiIWiw==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/safe-content-frame/-/safe-content-frame-0.0.23.tgz",
+      "integrity": "sha512-iIxZS0aEyYXp2CazwEeu1qhvar4sOctzjZQSlfvXzeGEqIpeCThXW1dV2t6HJ3FiixgWiDqdFMKzBq0mOCDmEQ==",
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -4,8 +4,8 @@ Provides cross-session user modeling with dialectic Q&A, semantic search,
 peer cards, and persistent conclusions via the Honcho SDK. Honcho provides AI-native cross-session user
 modeling with dialectic Q&A, semantic search, peer cards, and conclusions.
 
-Five tools (profile, search, reasoning, context, conclude) are exposed
-through the MemoryProvider interface.
+The 4 tools (profile, search, context, conclude) are exposed through
+the MemoryProvider interface.
 
 Config: Uses the existing Honcho config chain:
   1. $HERMES_HOME/honcho.json (profile-scoped)
@@ -20,7 +20,7 @@ import logging
 import re
 import threading
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from agent.memory_manager import sanitize_context
 from agent.memory_provider import MemoryProvider
@@ -36,17 +36,12 @@ logger = logging.getLogger(__name__)
 PROFILE_SCHEMA = {
     "name": "honcho_profile",
     "description": (
-        "Read or write a peer's CARD — a short, curated list of standing facts "
-        "about that peer (name, role, preferences, communication style, recurring "
-        "patterns). This is the cheapest, fastest Honcho call: no query, no LLM, "
-        "just the current card. Pass `card` to overwrite it; omit `card` to read. "
-        "An empty read returns a `hint` explaining why (observation disabled, fresh "
-        "peer, representation still warming up) — that is NOT an error; the card "
-        "accumulates over time from observed conversation. "
-        "Related tools: honcho_context for the fuller standing snapshot (card + "
-        "representation + summary + recent messages); honcho_search to find "
-        "specific things that were actually said; honcho_reasoning for a "
-        "synthesized answer to a question."
+        "Retrieve or update a peer card from Honcho — a curated list of key facts "
+        "about that peer (name, role, preferences, communication style, patterns). "
+        "Pass `card` to update; omit `card` to read.  If the card is empty, the "
+        "result includes a `hint` field explaining why (observation disabled, "
+        "fresh peer, dialectic layer still warming up, etc.) — this is NOT an "
+        "error.  Peer cards accumulate over time from observed conversation."
     ),
     "parameters": {
         "type": "object",
@@ -68,30 +63,25 @@ PROFILE_SCHEMA = {
 SEARCH_SCHEMA = {
     "name": "honcho_search",
     "description": (
-        "Hybrid (semantic + keyword) search over a peer's actual message "
-        "history across ALL past sessions they took part in — not just the "
-        "current one. Returns RRF-ranked raw message excerpts (what was "
-        "literally said, including the assistant's own messages about the "
-        "peer), no LLM synthesis. Cheaper and faster than honcho_reasoning. "
-        "Use this to recall specific past facts — 'what did I say about X', "
-        "'what was the regimen/decision/config we settled on' — and reason "
-        "over the excerpts yourself. For nuanced questions needing synthesis, "
-        "use honcho_reasoning instead."
+        "Semantic search over Honcho's stored context about a peer. "
+        "Returns raw excerpts ranked by relevance — no LLM synthesis. "
+        "Cheaper and faster than honcho_reasoning. "
+        "Good when you want to find specific past facts and reason over them yourself."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "query": {
                 "type": "string",
-                "description": "What to look for — a topic, keyword, name, or natural-language description of the fact you're trying to recall.",
+                "description": "What to search for in Honcho's memory.",
             },
             "max_tokens": {
                 "type": "integer",
-                "description": "Approximate budget for returned excerpts (default 800, max 2000). Larger budgets return more/longer ranked snippets.",
+                "description": "Token budget for returned context (default 800, max 2000).",
             },
             "peer": {
                 "type": "string",
-                "description": "Whose history to search. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace. Spans every session that peer took part in.",
+                "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
         },
         "required": ["query"],
@@ -101,18 +91,11 @@ SEARCH_SCHEMA = {
 REASONING_SCHEMA = {
     "name": "honcho_reasoning",
     "description": (
-        "Ask Honcho's dialectic agent a natural-language question about a peer and "
-        "get back a SYNTHESIZED answer. This is the only Honcho tool that runs an "
-        "LLM: it agentically searches both raw messages and derived conclusions, "
-        "reasons over them, and writes a prose answer — so it is the slowest and "
-        "most expensive call (seconds + tokens). Reach for it for nuanced or "
-        "open-ended questions ('how does this person prefer to receive feedback?', "
-        "'what's their relationship to project X?') where you want Honcho to do the "
-        "synthesis. For a specific fact that was stated, prefer honcho_search "
-        "(cheap, raw excerpts, you synthesize). For standing profile facts, prefer "
-        "honcho_profile / honcho_context (no LLM). "
+        "Ask Honcho a natural language question and get a synthesized answer. "
+        "Uses Honcho's LLM (dialectic reasoning) — higher cost than honcho_profile or honcho_search. "
+        "Can query about any peer via alias or explicit peer ID. "
         "Pass reasoning_level to control depth: minimal (fast/cheap), low (default), "
-        "medium, high, max (deep/expensive). Omit for the configured default."
+        "medium, high, max (deep/expensive). Omit for configured default."
     ),
     "parameters": {
         "type": "object",
@@ -125,26 +108,13 @@ REASONING_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Override the default reasoning depth. "
-                    "Omit to use the configured default (typically low).\n"
-                    "reasoning_level parameter guide:\n"
-                    "- minimal: use ONLY for a single quick factual lookup (e.g. "
-                    "'what is the user's name'). Honcho hard-caps this tier's output "
-                    "at 250 tokens combined with the model's own hidden reasoning "
-                    "tokens — a multi-part answer can get cut off mid-thought before "
-                    "it even reaches the final-answer phase, especially on models "
-                    "with reasoning/thinking enabled.\n"
-                    "- low/medium/high/max: use for anything requiring a synthesized, "
-                    "multi-fact, or summary-style answer (e.g. 'summarize known facts "
-                    "about this peer', 'what are their communication preferences'). "
-                    "These tiers have no output-token cap of their own (fall back to "
-                    "Honcho's 8192-token global default), so they don't have "
-                    "minimal's cutoff failure mode.\n"
-                    "  - low: straightforward questions with clear answers\n"
-                    "  - medium: multi-aspect questions requiring synthesis across observations\n"
-                    "  - high: complex behavioral patterns, contradictions, deep analysis\n"
-                    "  - max: thorough audit-level analysis, leave no stone unturned\n"
-                    "Default to at least 'low' unless the query is genuinely a single "
-                    "fact lookup."
+                    "Omit to use the configured default (typically low). "
+                    "Guide:\n"
+                    "- minimal: quick factual lookups (name, role, simple preference)\n"
+                    "- low: straightforward questions with clear answers\n"
+                    "- medium: multi-aspect questions requiring synthesis across observations\n"
+                    "- high: complex behavioral patterns, contradictions, deep analysis\n"
+                    "- max: thorough audit-level analysis, leave no stone unturned"
                 ),
                 "enum": ["minimal", "low", "medium", "high", "max"],
             },
@@ -160,18 +130,18 @@ REASONING_SCHEMA = {
 CONTEXT_SCHEMA = {
     "name": "honcho_context",
     "description": (
-        "Retrieve the standing SNAPSHOT Honcho holds for the current session — "
-        "session summary, the peer's representation, the peer card, and the most "
-        "recent messages — in one call. No query, no LLM synthesis (cheaper than "
-        "honcho_reasoning). Use it to orient yourself on what Honcho currently "
-        "knows about this conversation and peer. This is a fixed snapshot, not a "
-        "search: to look up a specific past fact use honcho_search; to ask a "
-        "question and get a synthesized answer use honcho_reasoning; for just the "
-        "compact card use honcho_profile."
+        "Retrieve full session context from Honcho — summary, peer representation, "
+        "peer card, and recent messages. No LLM synthesis. "
+        "Cheaper than honcho_reasoning. Use this to see what Honcho knows about "
+        "the current conversation and the specified peer."
     ),
     "parameters": {
         "type": "object",
         "properties": {
+            "query": {
+                "type": "string",
+                "description": "Optional focus query to filter context. Omit for full session context snapshot.",
+            },
             "peer": {
                 "type": "string",
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
@@ -184,42 +154,26 @@ CONTEXT_SCHEMA = {
 CONCLUDE_SCHEMA = {
     "name": "honcho_conclude",
     "description": (
-        "Write, delete, or list CONCLUSIONS — persistent, derived facts about a peer that "
-        "feeds their long-term profile (card + representation). Use this to record "
-        "something durable you've learned about the peer (a stable preference, a "
-        "correction, a standing constraint) so future sessions carry it forward. "
-        "You MUST pass exactly one of `conclusion` (to create), `delete_id` (to "
-        "delete), or `list` (to list/search); any other combination is an error. "
-        "A deletion ID is an opaque server-generated string: first call with `list=true` "
-        "and optionally `query`, then pass the returned ID as `delete_id`. "
-        "Deletion exists only for "
-        "PII removal — for merely wrong facts, write a corrected conclusion instead; "
-        "Honcho self-heals contradictions over time. This is a WRITE tool: to read "
-        "the profile use honcho_profile / honcho_context, and to search what was "
-        "said use honcho_search."
+        "Write or delete a conclusion about a peer in Honcho's memory. "
+        "Conclusions are persistent facts that build a peer's profile. "
+        "You MUST pass exactly one of: `conclusion` (to create) or `delete_id` (to delete). "
+        "Passing neither is an error. "
+        "Deletion is only for PII removal — Honcho self-heals incorrect conclusions over time."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "conclusion": {
                 "type": "string",
-                "description": "A factual statement to persist. Provide this when creating a conclusion. Do not send it together with delete_id or list.",
+                "description": "A factual statement to persist. Provide this when creating a conclusion. Do not send it together with delete_id.",
             },
             "delete_id": {
                 "type": "string",
-                "description": "Conclusion ID to delete for PII removal. Provide this when deleting a conclusion. Do not send it together with conclusion or list. Get this id from a prior `list` call — never guess it.",
-            },
-            "list": {
-                "type": "boolean",
-                "description": "Set to true to list or search stored conclusions (with their ids) instead of creating or deleting one. Do not send together with conclusion or delete_id.",
-            },
-            "query": {
-                "type": "string",
-                "description": "Optional semantic search query, used only when `list` is true. Omit to list the most recent conclusions instead of searching.",
+                "description": "Conclusion ID to delete for PII removal. Provide this when deleting a conclusion. Do not send it together with conclusion.",
             },
             "peer": {
                 "type": "string",
-                "description": "The peer the conclusion is ABOUT. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
+                "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
         },
         "required": [],
@@ -250,25 +204,24 @@ class HonchoMemoryProvider(MemoryProvider):
             pass
         return paths
 
-    def __init__(self, query_rewriter: Optional[Callable[[str], str]] = None):
+    def __init__(self):
         self._manager = None   # HonchoSessionManager
         self._config = None    # HonchoClientConfig
         self._session_key = ""
-        self._query_rewriter = query_rewriter
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
         self._sync_thread: Optional[threading.Thread] = None
 
+        # B1: recall_mode — set during initialize from config
         self._recall_mode = "hybrid"  # "context", "tools", or "hybrid"
 
         # Base context cache — refreshed on context_cadence, not frozen
         self._base_context_cache: Optional[str] = None
         self._base_context_lock = threading.Lock()
 
-        # Recall cadence and liveness state.
+        # B5: Cost-awareness turn counting and cadence
         self._turn_count = 0
-        self._query_rewrite_enabled = False
         self._injection_frequency = "every-turn"  # or "first-turn"
         self._context_cadence = 1   # minimum turns between context API calls
         self._dialectic_cadence = 1  # backwards-compat fallback; wizard writes 2 on new configs
@@ -284,7 +237,7 @@ class HonchoMemoryProvider(MemoryProvider):
         self._prefetch_result_fired_at: int = -999      # turn the pending result was fired at
         self._dialectic_empty_streak: int = 0           # consecutive empty returns
 
-        # Tools-only mode may defer session initialization until a tool call.
+        # Port #1957: lazy session init for tools-only mode
         self._session_initialized = False
         self._lazy_init_kwargs: Optional[dict] = None
         self._lazy_init_session_id: Optional[str] = None
@@ -292,7 +245,7 @@ class HonchoMemoryProvider(MemoryProvider):
         self._init_lock = threading.Lock()
         self._init_error = ""
 
-        # Cron and flush contexts disable the plugin entirely.
+        # Port #4053: cron guard — when True, plugin is fully inactive
         self._cron_skipped = False
 
     @property
@@ -304,6 +257,7 @@ class HonchoMemoryProvider(MemoryProvider):
         try:
             from plugins.memory.honcho.client import HonchoClientConfig
             cfg = HonchoClientConfig.from_global_config()
+            # Port #2645: baseUrl-only verification — api_key OR base_url suffices
             return cfg.enabled and bool(cfg.api_key or cfg.base_url)
         except Exception:
             return False
@@ -339,10 +293,12 @@ class HonchoMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Honcho session manager.
 
-        Handles cron guards, recall configuration, session resolution,
-        memory migration, and optional dialectic prewarming.
+        Handles: cron guard, recall_mode, session name resolution,
+        peer memory mode, SOUL.md ai_peer sync, memory file migration,
+        and pre-warming context at init.
         """
         try:
+            # ----- Port #4053: cron guard -----
             agent_context = kwargs.get("agent_context", "")
             platform = kwargs.get("platform", "cli")
             if agent_context in {"cron", "flush"} or platform == "cron":
@@ -361,20 +317,27 @@ class HonchoMemoryProvider(MemoryProvider):
 
             self._config = cfg
 
+            # ----- B1: recall_mode from config -----
             self._recall_mode = cfg.recall_mode  # "context", "tools", or "hybrid"
             logger.debug("Honcho recall_mode: %s", self._recall_mode)
 
-            self._injection_frequency = cfg.injection_frequency
-            self._context_cadence = cfg.context_cadence
-            self._dialectic_cadence = cfg.dialectic_cadence
-            self._query_rewrite_enabled = cfg.query_rewrite
-            self._FIRST_TURN_BASE_TIMEOUT = cfg.first_turn_base_wait
-            self._FIRST_TURN_DIALECTIC_CAP = cfg.first_turn_dialectic_wait
-            self._dialectic_depth = max(1, min(cfg.dialectic_depth, 3))
-            self._dialectic_depth_levels = cfg.dialectic_depth_levels
-            self._reasoning_heuristic = cfg.reasoning_heuristic
-            if cfg.reasoning_level_cap in self._LEVEL_ORDER:
-                self._reasoning_level_cap = cfg.reasoning_level_cap
+            # ----- B5: cost-awareness config -----
+            try:
+                raw = cfg.raw or {}
+                self._injection_frequency = raw.get("injectionFrequency", "every-turn")
+                self._context_cadence = int(raw.get("contextCadence", 1))
+                # Backwards-compat: unset dialecticCadence falls back to 1
+                # (every turn) so existing honcho.json configs without the key
+                # behave as they did before. New setups via `hermes honcho setup`
+                # get dialecticCadence=2 written explicitly by the wizard.
+                self._dialectic_cadence = int(raw.get("dialecticCadence", 1))
+                self._dialectic_depth = max(1, min(cfg.dialectic_depth, 3))
+                self._dialectic_depth_levels = cfg.dialectic_depth_levels
+                self._reasoning_heuristic = cfg.reasoning_heuristic
+                if cfg.reasoning_level_cap in self._LEVEL_ORDER:
+                    self._reasoning_level_cap = cfg.reasoning_level_cap
+            except Exception as e:
+                logger.debug("Honcho cost-awareness config parse error: %s", e)
 
             # aiPeer comes from honcho.json (host block or root) only.
             # SOUL.md is persona content, not identity config.
@@ -478,6 +441,7 @@ class HonchoMemoryProvider(MemoryProvider):
             runtime_user_peer_name_alt=kwargs.get("user_id_alt") or None,
         )
 
+        # ----- B3: resolve_session_name -----
         self._session_key = self._resolve_session_key(cfg, session_id, **kwargs)
         logger.debug("Honcho session key resolved: %s", self._session_key)
 
@@ -488,6 +452,7 @@ class HonchoMemoryProvider(MemoryProvider):
         # not treat that partially initialized state as usable.
         session = self._manager.get_or_create(self._session_key)
 
+        # ----- B6: Memory file migration (one-time, for new sessions) -----
         # Skip under per-session strategy: every Hermes run creates a fresh
         # Honcho session by design, so uploading MEMORY.md/USER.md/SOUL.md to
         # each one would flood the backend with short-lived duplicates instead
@@ -506,46 +471,46 @@ class HonchoMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.debug("Honcho memory file migration skipped: %s", e)
 
-        # Query-aware base retrieval starts with the first substantive message.
-        # Generic dialectic prewarm is incompatible with latest-message rewriting.
+        # ----- B7: Pre-warming at init -----
+        # Context prewarm warms peer.context() (base layer), consumed via
+        # pop_context_result() in prefetch(). Dialectic prewarm runs the
+        # full configured depth and writes into _prefetch_result so turn 1
+        # consumes the result directly.
         if self._recall_mode in {"context", "hybrid"}:
-            if self._query_rewriter is None or not self._query_rewrite_enabled:
-                _prewarm_query = (
-                    "Summarize what you know about this user. "
-                    "Focus on preferences, current projects, and working style."
-                )
+            try:
+                self._manager.prefetch_context(self._session_key)
+            except Exception as e:
+                logger.debug("Honcho context prewarm failed: %s", e)
 
-                def _prewarm_dialectic() -> None:
-                    try:
-                        r = self._run_dialectic_depth(
-                            _prewarm_query, use_query_rewrite=False
-                        )
-                    except Exception as exc:
-                        logger.debug("Honcho dialectic prewarm failed: %s", exc)
-                        self._dialectic_empty_streak += 1
-                        return
-                    if r and r.strip():
-                        with self._prefetch_lock:
-                            self._prefetch_result = r
-                            self._prefetch_result_fired_at = 0
-                        self._last_dialectic_turn = 0
-                        self._dialectic_empty_streak = 0
-                    else:
-                        self._dialectic_empty_streak += 1
+            _prewarm_query = (
+                "Summarize what you know about this user. "
+                "Focus on preferences, current projects, and working style."
+            )
 
-                self._prefetch_thread_started_at = time.monotonic()
-                prewarm_thread = threading.Thread(
-                    target=_prewarm_dialectic,
-                    daemon=True,
-                    name="honcho-prewarm-dialectic",
-                )
-                prewarm_thread.start()
-                self._prefetch_thread = prewarm_thread
-                logger.debug("Honcho dialectic prewarm started for session: %s", self._session_key)
-            else:
-                logger.debug(
-                    "Honcho generic dialectic prewarm skipped: awaiting first user message"
-                )
+            def _prewarm_dialectic() -> None:
+                try:
+                    r = self._run_dialectic_depth(_prewarm_query)
+                except Exception as exc:
+                    logger.debug("Honcho dialectic prewarm failed: %s", exc)
+                    self._dialectic_empty_streak += 1
+                    return
+                if r and r.strip():
+                    with self._prefetch_lock:
+                        self._prefetch_result = r
+                        self._prefetch_result_fired_at = 0
+                    # Treat prewarm as turn 0 so cadence gating starts clean.
+                    self._last_dialectic_turn = 0
+                    self._dialectic_empty_streak = 0
+                else:
+                    self._dialectic_empty_streak += 1
+
+            self._prefetch_thread_started_at = time.monotonic()
+            prewarm_thread = threading.Thread(
+                target=_prewarm_dialectic, daemon=True, name="honcho-prewarm-dialectic"
+            )
+            prewarm_thread.start()
+            self._prefetch_thread = prewarm_thread
+            logger.debug("Honcho pre-warm started for session: %s", self._session_key)
 
         self._session_initialized = True
 
@@ -636,6 +601,7 @@ class HonchoMemoryProvider(MemoryProvider):
             if not self._config:
                 return ""
 
+        # ----- B1: adapt text based on recall_mode -----
         if self._recall_mode == "context":
             header = (
                 "# Honcho Memory\n"
@@ -673,165 +639,132 @@ class HonchoMemoryProvider(MemoryProvider):
         1. Base context from peer.context() — cached, refreshed on context_cadence
         2. Dialectic supplement — cached, refreshed on dialectic_cadence
 
-        Returns empty in tools-only mode and respects the configured injection
-        frequency and context budget.
+        B1: Returns empty when recall_mode is "tools" (no injection).
+        B5: Respects injection_frequency — "first-turn" returns cached/empty after turn 0.
+        Port #3265: Truncates to context_tokens budget.
         """
         if self._cron_skipped:
             return ""
 
-        # Tools-only mode has no automatic injection.
+        # B1: tools-only mode — no auto-injection
         if self._recall_mode == "tools":
             return ""
 
-        first_turn_base_deadline = None
-        if self._turn_count <= 1:
-            base_wait = self._FIRST_TURN_BASE_TIMEOUT
-            request_timeout = getattr(self._config, "timeout", None)
-            if request_timeout is not None:
-                base_wait = min(base_wait, max(0.0, request_timeout))
-            first_turn_base_deadline = time.monotonic() + max(0.0, base_wait)
-
         if not self._session_ready():
-            # Only turn 1 may wait for session init; later turns fail open.
             self._start_session_init_background()
-            if first_turn_base_deadline is not None:
-                _init_thread = self._init_thread
-                if _init_thread is not None:
-                    _init_thread.join(
-                        timeout=max(0.0, first_turn_base_deadline - time.monotonic())
-                    )
-            if not self._session_ready():
-                return ""
+            return ""
 
-        # First-turn mode suppresses only the base layer; dialectic is independent.
-        _skip_base = (
-            self._injection_frequency == "first-turn" and self._turn_count > 1
-        )
+        # B5: injection_frequency — if "first-turn" and past first turn, return empty.
+        # _turn_count is 1-indexed (first user message = 1), so > 1 means "past first".
+        if self._injection_frequency == "first-turn" and self._turn_count > 1:
+            return ""
 
-        # Trivial turns start no work, but may consume a ready pending result.
+        # Trivial prompts ("ok", "yes", slash commands) carry no semantic signal.
         if self._is_trivial_prompt(query):
-            ready = self._consume_pending_dialectic()
-            return self._truncate_to_budget(ready) if ready else ""
+            return ""
 
         parts = []
 
         # ----- Layer 1: Base context (representation + card) -----
-        if not _skip_base:
-            # The first base fetch gets the remaining turn-1 budget. Later
-            # refreshes are consumed asynchronously.
-            with self._base_context_lock:
-                _first_base_fetch = self._base_context_cache is None
-                if _first_base_fetch:
-                    self._base_context_cache = ""
-                    self._last_context_turn = self._turn_count
-                base_context = self._base_context_cache
+        # First fetch is asynchronous: a slow Honcho backend must not block the
+        # first response. Serve empty context now and consume the background
+        # result on a later turn.
+        with self._base_context_lock:
+            if self._base_context_cache is None:
+                self._base_context_cache = ""
+                self._last_context_turn = self._turn_count
+                try:
+                    self._manager.prefetch_context(self._session_key, query or None)
+                except Exception as e:
+                    logger.debug("Honcho base context prefetch failed: %s", e)
+            base_context = self._base_context_cache
 
-            if _first_base_fetch and self._manager:
-                _ctx_holder: dict[str, dict] = {}
+        # Check if background context prefetch has a fresher result
+        if self._manager:
+            fresh_ctx = self._manager.pop_context_result(self._session_key)
+            if fresh_ctx:
+                formatted = self._format_first_turn_context(fresh_ctx)
+                if formatted:
+                    with self._base_context_lock:
+                        self._base_context_cache = formatted
+                    base_context = formatted
 
-                def _fetch_base() -> None:
-                    try:
-                        ctx = self._manager.get_prefetch_context(
-                            self._session_key, query or None
-                        ) or {}
-                        _ctx_holder["ctx"] = ctx
-                        if ctx:
-                            self._manager.set_context_result(self._session_key, ctx)
-                    except Exception as e:
-                        logger.debug("Honcho first-turn base context failed: %s", e)
-
-                _bt = threading.Thread(
-                    target=_fetch_base, daemon=True, name="honcho-base-first"
-                )
-                _bt.start()
-                _base_wait = (
-                    max(0.0, first_turn_base_deadline - time.monotonic())
-                    if first_turn_base_deadline is not None
-                    else 0.0
-                )
-                _bt.join(timeout=_base_wait)
-                _ctx = _ctx_holder.get("ctx")
-                if _ctx:
-                    self._manager.pop_context_result(self._session_key)
-                    formatted = self._format_first_turn_context(_ctx)
-                    if formatted:
-                        with self._base_context_lock:
-                            self._base_context_cache = formatted
-                        base_context = formatted
-                elif _bt.is_alive():
-                    logger.debug(
-                        "Honcho first-turn base context still running after %.1fs — "
-                        "will surface on next turn", _base_wait,
-                    )
-
-            # Later turns consume the refresh queued by the previous turn.
-            if not _first_base_fetch and self._manager:
-                fresh_ctx = self._manager.pop_context_result(self._session_key)
-                if fresh_ctx:
-                    formatted = self._format_first_turn_context(fresh_ctx)
-                    if formatted:
-                        with self._base_context_lock:
-                            self._base_context_cache = formatted
-                        base_context = formatted
-
-            if base_context:
-                parts.append(base_context)
+        if base_context:
+            parts.append(base_context)
 
         # ----- Layer 2: Dialectic supplement -----
-        # Turn 1 may briefly wait for dialectic; unfinished work remains async.
+        # On the very first turn, no queue_prefetch() has run yet so the
+        # dialectic result is empty.  Run with a bounded timeout so a slow
+        # Honcho connection doesn't block the first response indefinitely.
+        # On timeout we let the thread keep running and write its result into
+        # _prefetch_result under the lock, so the next turn picks it up.
+        #
+        # Skip if the session-start prewarm already filled _prefetch_result —
+        # firing another .chat() would be duplicate work.
         with self._prefetch_lock:
             _prewarm_landed = bool(self._prefetch_result)
         if _prewarm_landed and self._last_dialectic_turn == -999:
             self._last_dialectic_turn = self._turn_count
 
+        _first_turn_timed_out = False
         if self._last_dialectic_turn == -999 and query:
-            # Reuse an in-flight prewarm; otherwise start one dialectic. A short
-            # request timeout may tighten, but never expand, the turn-1 wait.
-            _dia_wait = self._FIRST_TURN_DIALECTIC_CAP
-            request_timeout = getattr(self._config, "timeout", None)
-            if request_timeout is not None:
-                _dia_wait = min(_dia_wait, max(0.0, request_timeout))
-            if self._thread_is_live():
-                _live = self._prefetch_thread
-                if _live is not None:
-                    _live.join(timeout=_dia_wait)
-            else:
-                _first_turn_timeout = _dia_wait
-                _fired_at = self._turn_count
+            _first_turn_timeout = (
+                self._config.timeout if self._config and self._config.timeout else 8.0
+            )
+            _fired_at = self._turn_count
 
-                def _run_first_turn() -> None:
-                    try:
-                        r = self._run_dialectic_depth(query)
-                    except Exception as exc:
-                        logger.debug("Honcho first-turn dialectic failed: %s", exc)
-                        self._dialectic_empty_streak += 1
-                        return
-                    if r and r.strip():
-                        with self._prefetch_lock:
-                            self._prefetch_result = r
-                            self._prefetch_result_fired_at = _fired_at
-                        # Empty results do not consume the cadence window.
-                        self._last_dialectic_turn = _fired_at
-                        self._dialectic_empty_streak = 0
-                    else:
-                        self._dialectic_empty_streak += 1
+            def _run_first_turn() -> None:
+                try:
+                    r = self._run_dialectic_depth(query)
+                except Exception as exc:
+                    logger.debug("Honcho first-turn dialectic failed: %s", exc)
+                    self._dialectic_empty_streak += 1
+                    return
+                if r and r.strip():
+                    with self._prefetch_lock:
+                        self._prefetch_result = r
+                        self._prefetch_result_fired_at = _fired_at
+                    # Advance cadence only on a non-empty result so the next
+                    # turn retries when the call returned nothing.
+                    self._last_dialectic_turn = _fired_at
+                    self._dialectic_empty_streak = 0
+                else:
+                    self._dialectic_empty_streak += 1
 
-                self._prefetch_thread_started_at = time.monotonic()
-                first_turn_thread = threading.Thread(
-                    target=_run_first_turn, daemon=True, name="honcho-prefetch-first"
-                )
-                first_turn_thread.start()
-                self._prefetch_thread = first_turn_thread
-                self._prefetch_thread.join(timeout=_first_turn_timeout)
-            if self._prefetch_thread and self._prefetch_thread.is_alive():
-                logger.debug(
-                    "Honcho first-turn dialectic still running after %.1fs — "
-                    "will surface on next turn",
-                    _dia_wait,
+            self._prefetch_thread_started_at = time.monotonic()
+            first_turn_thread = threading.Thread(
+                target=_run_first_turn, daemon=True, name="honcho-prefetch-first"
+            )
+            first_turn_thread.start()
+            self._prefetch_thread = first_turn_thread
+            self._prefetch_thread.join(timeout=_first_turn_timeout)
+            _first_turn_timed_out = self._prefetch_thread.is_alive()
+            if _first_turn_timed_out:
+                logger.warning(
+                    "Honcho first-turn dialectic timed out after %.1fs; "
+                    "continuing without Honcho dialectic context",
+                    _first_turn_timeout,
                 )
 
-        # Consume only results that are already ready; later turns never wait.
-        dialectic_result = self._consume_pending_dialectic()
+        if self._prefetch_thread and self._prefetch_thread.is_alive() and not _first_turn_timed_out:
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            dialectic_result = self._prefetch_result
+            fired_at = self._prefetch_result_fired_at
+            self._prefetch_result = ""
+            self._prefetch_result_fired_at = -999
+
+        # Discard stale pending results: if the fire happened more than
+        # cadence × multiplier turns ago (e.g. a run of trivial-prompt turns
+        # passed without consumption), the content likely no longer tracks
+        # the current conversational pivot.
+        stale_limit = self._dialectic_cadence * self._STALE_RESULT_MULTIPLIER
+        if dialectic_result and fired_at >= 0 and (self._turn_count - fired_at) > stale_limit:
+            logger.debug(
+                "Honcho pending dialectic discarded as stale: fired_at=%d, "
+                "turn=%d, limit=%d", fired_at, self._turn_count, stale_limit,
+            )
+            dialectic_result = ""
 
         if dialectic_result and dialectic_result.strip():
             parts.append(dialectic_result)
@@ -841,31 +774,10 @@ class HonchoMemoryProvider(MemoryProvider):
 
         result = "\n\n".join(parts)
 
+        # ----- Port #3265: token budget enforcement -----
         result = self._truncate_to_budget(result)
 
         return result
-
-    def _consume_pending_dialectic(self) -> str:
-        """Pop any pending dialectic result, applying the stale-discard guard.
-
-        Returns an empty string when no result is ready or the pending result
-        is older than the configured cadence window.
-        """
-        with self._prefetch_lock:
-            dialectic_result = self._prefetch_result
-            fired_at = self._prefetch_result_fired_at
-            self._prefetch_result = ""
-            self._prefetch_result_fired_at = -999
-
-        # Drop results that no longer track the current conversational pivot.
-        stale_limit = self._dialectic_cadence * self._STALE_RESULT_MULTIPLIER
-        if dialectic_result and fired_at >= 0 and (self._turn_count - fired_at) > stale_limit:
-            logger.debug(
-                "Honcho pending dialectic discarded as stale: fired_at=%d, "
-                "turn=%d, limit=%d", fired_at, self._turn_count, stale_limit,
-            )
-            return ""
-        return dialectic_result if (dialectic_result and dialectic_result.strip()) else ""
 
     def _truncate_to_budget(self, text: str) -> str:
         """Truncate text to fit within context_tokens budget if set."""
@@ -884,11 +796,13 @@ class HonchoMemoryProvider(MemoryProvider):
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Fire background prefetch threads for the upcoming turn.
 
-        Context and dialectic refreshes have independent cadence controls.
+        B5: Checks cadence independently for dialectic and context refresh.
+        Context refresh updates the base layer (representation + card).
+        Dialectic fires the LLM reasoning supplement.
         """
         if self._cron_skipped:
             return
-        # Tools-only mode has no automatic prefetch.
+        # B1: tools-only mode — no prefetch
         if self._recall_mode == "tools":
             return
 
@@ -900,12 +814,8 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._is_trivial_prompt(query):
             return
 
-        # First-turn-only base context never needs a later refresh.
-        context_due = (
-            self._context_cadence <= 1
-            or (self._turn_count - self._last_context_turn) >= self._context_cadence
-        )
-        if self._injection_frequency != "first-turn" and context_due:
+        # ----- Context refresh (base layer) — independent cadence -----
+        if self._context_cadence <= 1 or (self._turn_count - self._last_context_turn) >= self._context_cadence:
             self._last_context_turn = self._turn_count
             try:
                 self._manager.prefetch_context(self._session_key, query)
@@ -992,10 +902,6 @@ class HonchoMemoryProvider(MemoryProvider):
     # Cap on the empty-streak backoff so a persistently silent backend
     # eventually settles on a ceiling instead of unbounded widening.
     _BACKOFF_MAX = 8
-    # Total turn-1 budget shared by session init and base retrieval.
-    _FIRST_TURN_BASE_TIMEOUT = 3.0
-    # Independent turn-1 grace for the slower dialectic path.
-    _FIRST_TURN_DIALECTIC_CAP = 2.0
 
     def _thread_is_live(self) -> bool:
         """Thread-alive guard that treats threads older than the stale
@@ -1136,7 +1042,7 @@ class HonchoMemoryProvider(MemoryProvider):
         # Long enough even without structure
         return len(result.strip()) > 300
 
-    def _run_dialectic_depth(self, query: str, *, use_query_rewrite: bool = True) -> str:
+    def _run_dialectic_depth(self, query: str) -> str:
         """Execute up to dialecticDepth .chat() calls with conditional bail-out.
 
         Cold start (no base context): general user-oriented query.
@@ -1149,35 +1055,17 @@ class HonchoMemoryProvider(MemoryProvider):
 
         is_cold = not self._base_context_cache
         results: list[str] = []
-        rewritten_query = ""
-        if use_query_rewrite and self._query_rewrite_enabled and self._query_rewriter:
-            try:
-                rewritten_query = self._query_rewriter(query).strip()
-            except Exception as exc:
-                logger.debug("Honcho query rewriter failed: %s", exc)
 
         for i in range(self._dialectic_depth):
-            # Dependent prompts require a non-empty prior result.
-            prior_results = [r for r in results if r and r.strip()]
             if i == 0:
-                prompt = rewritten_query or self._build_dialectic_prompt(
-                    0, prior_results, is_cold
-                )
+                prompt = self._build_dialectic_prompt(0, results, is_cold)
             else:
                 # Skip further passes if prior pass delivered strong signal
-                if prior_results and self._signal_sufficient(prior_results[-1]):
+                if results and self._signal_sufficient(results[-1]):
                     logger.debug("Honcho dialectic depth %d: pass %d skipped, prior signal sufficient",
                                  self._dialectic_depth, i)
                     break
-                if not prior_results:
-                    # Retry the independent base prompt after empty passes.
-                    logger.debug("Honcho dialectic depth %d: pass %d has no non-empty prior — "
-                                 "falling back to base prompt", self._dialectic_depth, i)
-                    prompt = rewritten_query or self._build_dialectic_prompt(
-                        0, prior_results, is_cold
-                    )
-                else:
-                    prompt = self._build_dialectic_prompt(i, prior_results, is_cold)
+                prompt = self._build_dialectic_prompt(i, results, is_cold)
 
             level = self._resolve_pass_level(i, query=query)
             logger.debug("Honcho dialectic depth %d: pass %d, level=%s, cold=%s",
@@ -1413,7 +1301,7 @@ class HonchoMemoryProvider(MemoryProvider):
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return tool schemas, respecting recall_mode.
 
-        Context-only mode exposes no Honcho tools.
+        B1: context-only mode hides all tools.
         """
         if self._cron_skipped:
             return []
@@ -1426,6 +1314,7 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._cron_skipped:
             return tool_error("Honcho is not active (cron context).")
 
+        # Port #1957: ensure session is initialized for tools-only mode
         if not self._session_initialized:
             if self._init_thread and self._init_thread.is_alive():
                 return tool_error("Honcho session is still initializing; try again shortly.")
@@ -1450,7 +1339,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 return json.dumps({"result": card})
 
             elif tool_name == "honcho_search":
-                query = (args.get("query") or "").strip()
+                query = args.get("query", "")
                 if not query:
                     return tool_error("Missing required parameter: query")
                 max_tokens = min(int(args.get("max_tokens", 800)), 2000)
@@ -1463,7 +1352,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 return json.dumps({"result": result})
 
             elif tool_name == "honcho_reasoning":
-                query = (args.get("query") or "").strip()
+                query = args.get("query", "")
                 if not query:
                     return tool_error("Missing required parameter: query")
                 peer = args.get("peer", "user")
@@ -1472,8 +1361,6 @@ class HonchoMemoryProvider(MemoryProvider):
                     self._session_key, query,
                     reasoning_level=reasoning_level,
                     peer=peer,
-                    # Explicit reasoning bypasses the automatic-injection cap.
-                    apply_injection_cap=False,
                 )
                 # Update cadence tracker so auto-injection respects the gap after an explicit call
                 self._last_dialectic_turn = self._turn_count
@@ -1503,23 +1390,13 @@ class HonchoMemoryProvider(MemoryProvider):
             elif tool_name == "honcho_conclude":
                 delete_id = (args.get("delete_id") or "").strip()
                 conclusion = args.get("conclusion", "").strip()
-                list_mode = bool(args.get("list"))
                 peer = args.get("peer", "user")
 
                 has_delete_id = bool(delete_id)
                 has_conclusion = bool(conclusion)
-                if sum([has_delete_id, has_conclusion, list_mode]) != 1:
-                    return tool_error("Exactly one of conclusion, delete_id, or list must be provided.")
+                if has_delete_id == has_conclusion:
+                    return tool_error("Exactly one of conclusion or delete_id must be provided.")
 
-                query = (args.get("query") or "").strip()
-                if query and not list_mode:
-                    return tool_error("query is only valid when list is true.")
-
-                if list_mode:
-                    conclusions = self._manager.list_conclusions(
-                        self._session_key, query=query or None, peer=peer
-                    )
-                    return json.dumps({"conclusions": conclusions})
                 if has_delete_id:
                     ok = self._manager.delete_conclusion(self._session_key, delete_id, peer=peer)
                     if ok:
@@ -1554,8 +1431,4 @@ class HonchoMemoryProvider(MemoryProvider):
 
 def register(ctx) -> None:
     """Register Honcho as a memory provider plugin."""
-    from plugins.memory.query_rewrite import rewrite_memory_query
-
-    ctx.register_memory_provider(
-        HonchoMemoryProvider(query_rewriter=rewrite_memory_query)
-    )
+    ctx.register_memory_provider(HonchoMemoryProvider())

--- a/skills/creative/ascii-video/README.md
+++ b/skills/creative/ascii-video/README.md
@@ -275,7 +275,6 @@ Auto-detects CPU count, RAM, platform, ffmpeg. Adapts worker count, resolution, 
     ├── shaders.md           # 38 shaders, ShaderChain, tint presets, transitions
     ├── composition.md       # Blend modes, multi-grid, tonemap, FeedbackBuffer
     ├── scenes.md            # Scene protocol, SCENES table, render_clip(), examples
-    ├── design-patterns.md   # Layer hierarchy, directional arcs, scene concepts
     ├── inputs.md            # Audio analysis, video sampling, text, TTS
     ├── optimization.md      # Hardware detection, vectorized patterns, parallelism
     └── troubleshooting.md   # Broadcasting traps, blend pitfalls, diagnostics

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -138,6 +138,59 @@ class TestStartupPlatformIsolation:
         assert Platform.TELEGRAM not in runner.adapters
         assert runner._create_adapter.call_count == 2
 
+    @pytest.mark.asyncio
+    async def test_start_continues_after_session_recovery_timeout(self, tmp_path, monkeypatch):
+        """A wedged crash-recovery pass must not block Telegram startup."""
+        runner = _make_runner()
+        runner.config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="test")},
+            sessions_dir=tmp_path,
+        )
+        runner.hooks = MagicMock()
+        runner.hooks.loaded_hooks = []
+        runner.hooks.emit = AsyncMock()
+        runner._suspend_stuck_loop_sessions = MagicMock(return_value=0)
+        runner._update_runtime_status = MagicMock()
+        runner._update_platform_runtime_status = MagicMock()
+        runner._sync_voice_mode_state_to_adapter = MagicMock()
+        runner._send_update_notification = AsyncMock(return_value=True)
+        runner._send_restart_notification = AsyncMock()
+
+        async def hang_recovery():
+            await asyncio.Event().wait()
+
+        runner._async_session_store = MagicMock()
+        runner._async_session_store._store = runner.session_store
+        runner._async_session_store.suspend_recently_active = hang_recovery
+        adapter = StubAdapter(platform=Platform.TELEGRAM)
+        runner._create_adapter = MagicMock(return_value=adapter)
+        runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION_RECOVERY_TIMEOUT", "0.001")
+
+        def fake_create_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("gateway.status.write_runtime_status"):
+            with patch("hermes_cli.plugins.discover_plugins"):
+                with patch("hermes_cli.config.load_config", return_value={}):
+                    with patch("agent.shell_hooks.register_from_config"):
+                        with patch(
+                            "tools.process_registry.process_registry.recover_from_checkpoint",
+                            return_value=0,
+                        ):
+                            with patch(
+                                "gateway.channel_directory.build_channel_directory",
+                                new=AsyncMock(return_value={"platforms": {}}),
+                            ):
+                                with patch("gateway.run.asyncio.create_task", side_effect=fake_create_task):
+                                    assert await runner.start() is True
+
+        assert Platform.TELEGRAM in runner.adapters
+        runner._connect_adapter_with_timeout.assert_awaited_once_with(
+            adapter, Platform.TELEGRAM
+        )
+
     def test_default_connect_timeout_allows_telegram_polling_readiness(
         self, monkeypatch
     ):

--- a/tests/hermes_cli/test_pets_multi_profile.py
+++ b/tests/hermes_cli/test_pets_multi_profile.py
@@ -1,0 +1,171 @@
+"""Multi-profile pet CLI tests (PR1 / Layer 1).
+
+Covers the per-profile isolation of ``hermes pets`` commands:
+
+- ``pets off`` disables ONLY the current (bound) profile.
+- ``pets off --all`` disables every profile, skipping unreadable ones with a
+  warning instead of aborting.
+- ``pets select <slug> --profile <name>`` (global ``--profile`` binds
+  HERMES_HOME) writes the named profile's config, not the launch profile's.
+- ``pets list --profiles`` reports per-profile status.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    """Default home + a profiles root under a mocked ``Path.home()``.
+
+    ``_get_profiles_root()`` is HOME-anchored (``~/.hermes/profiles``), so the
+    profile machinery only resolves inside the temp dir when ``Path.home()`` is
+    mocked alongside ``HERMES_HOME``.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "profiles").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _make_profile(profile_env: Path, name: str, *, enabled: bool, slug: str = "boba") -> Path:
+    """Create a named profile dir with a ``display.pet`` config; return its home."""
+    home = profile_env / "profiles" / name
+    home.mkdir(parents=True, exist_ok=True)
+    cfg = {"display": {"pet": {"enabled": enabled, "slug": slug}}}
+    (home / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+    return home
+
+
+def _read_pet(home: Path) -> dict:
+    cfg = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8")) or {}
+    return cfg.get("display", {}).get("pet", {})
+
+
+def _write_default_pet(profile_env: Path, *, enabled: bool, slug: str = "boba") -> None:
+    cfg = {"display": {"pet": {"enabled": enabled, "slug": slug}}}
+    (profile_env / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+
+
+class _Args:
+    """Minimal argparse.Namespace stand-in for the pet subcommand handlers."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def test_pets_off_disables_only_current_profile(profile_env):
+    """``pets off`` (no --all) touches ONLY the bound profile (test 3)."""
+    from hermes_cli.pets import _cmd_off
+
+    _write_default_pet(profile_env, enabled=True)
+    apollo = _make_profile(profile_env, "apollo", enabled=True)
+
+    assert _cmd_off(_Args(all=False)) == 0
+
+    # Launch/default profile disabled...
+    assert _read_pet(profile_env)["enabled"] is False
+    # ...but the named profile is untouched.
+    assert _read_pet(apollo)["enabled"] is True
+
+
+def test_pets_off_all_disables_every_profile(profile_env):
+    """``pets off --all`` disables default + all named profiles (test 4)."""
+    from hermes_cli.pets import _cmd_off
+
+    _write_default_pet(profile_env, enabled=True)
+    apollo = _make_profile(profile_env, "apollo", enabled=True)
+    nova = _make_profile(profile_env, "nova", enabled=True)
+
+    assert _cmd_off(_Args(all=True)) == 0
+
+    assert _read_pet(profile_env)["enabled"] is False
+    assert _read_pet(apollo)["enabled"] is False
+    assert _read_pet(nova)["enabled"] is False
+
+
+def test_pets_off_all_warns_but_does_not_abort_on_unreadable(profile_env, monkeypatch):
+    """An unreadable profile is skipped with a warning, not fatal (test 4)."""
+    from hermes_cli import pets as pets_mod
+
+    _write_default_pet(profile_env, enabled=True)
+    apollo = _make_profile(profile_env, "apollo", enabled=True)
+
+    # Make the default profile's save path blow up; the named profile must still
+    # be processed (the run does not abort on the first failure).
+    real_set_enabled = pets_mod._set_enabled
+    calls = {"count": 0}
+
+    def flaky_set_enabled(enabled):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise OSError("config unreadable")
+        return real_set_enabled(enabled)
+
+    monkeypatch.setattr(pets_mod, "_set_enabled", flaky_set_enabled)
+
+    assert pets_mod._cmd_off(_Args(all=True)) == 0
+
+    # The first profile failed but the second was still disabled.
+    assert _read_pet(apollo)["enabled"] is False
+
+
+def test_pets_select_with_profile_writes_named_profile(profile_env):
+    """Global ``--profile`` binds HERMES_HOME → select writes THAT profile (test 2).
+
+    The global ``--profile`` flag is applied by ``main.py`` via the
+    ``set_hermes_home_override`` contextvar before the subcommand runs; we bind
+    the same override here to exercise the isolation directly.
+    """
+    from hermes_cli.pets import _cmd_select
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    _write_default_pet(profile_env, enabled=True, slug="default-pet")
+    apollo = _make_profile(profile_env, "apollo", enabled=False, slug="")
+
+    # The named profile needs the pet installed for select to resolve it.
+    from agent.pet import store
+
+    token = set_hermes_home_override(apollo)
+    try:
+        # Install a minimal pet into Apollo's pets dir so select can resolve it.
+        from PIL import Image
+        from agent.pet.constants import FRAME_H, FRAME_W
+
+        pet_dir = store.pets_dir() / "boba"
+        pet_dir.mkdir(parents=True, exist_ok=True)
+        Image.new("RGBA", (FRAME_W * 8, FRAME_H * 9), (0, 0, 0, 0)).save(pet_dir / "spritesheet.webp")
+        (pet_dir / "pet.json").write_text(
+            '{"id":"boba","displayName":"Boba","description":"d","spritesheetPath":"spritesheet.webp"}'
+        )
+
+        assert _cmd_select(_Args(slug="boba")) == 0
+    finally:
+        reset_hermes_home_override(token)
+
+    # Apollo got the pet; the default profile is unchanged.
+    assert _read_pet(apollo)["slug"] == "boba"
+    assert _read_pet(apollo)["enabled"] is True
+    assert _read_pet(profile_env)["slug"] == "default-pet"
+
+
+def test_pets_list_profiles_reports_per_profile_status(profile_env, capsys):
+    """``pets list --profiles`` prints a per-profile status line (test 1/2)."""
+    from hermes_cli.pets import _cmd_list
+
+    _write_default_pet(profile_env, enabled=True, slug="boba")
+    _make_profile(profile_env, "apollo", enabled=False, slug="")
+
+    assert _cmd_list(_Args(profiles=True, installed=False, query="", limit=0)) == 0
+
+    out = capsys.readouterr().out
+    assert "default" in out
+    assert "apollo" in out
+    assert "enabled=True" in out
+    assert "enabled=False" in out

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -130,7 +130,7 @@ def _session_search_exclude_patterns() -> Dict[str, tuple[str, ...]]:
             for value in values
             if isinstance(value, str) and value.strip()
         )
-        for key, values in patterns
+        for key, values in patterns.items()
     }
 
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -57,13 +57,124 @@ _DISCOVER_SCAN_LIMIT = 300
 
 # Prefixes that identify generated context-compaction handoff summaries.
 # These are inserted by agent/context_compressor.py as normal user/assistant
-# messages but contain machine-generated summary metadata — not user content.
+# messages but contain machine-generated summary metadata - not user content.
 # They must be excluded from discovery bookends to avoid re-introducing huge
 # compaction payloads into fresh sessions via session_search.  (#43175)
 _COMPACTION_PREFIXES = (
     "[CONTEXT COMPACTION",
     "[CONTEXT SUMMARY]:",
 )
+
+# These defaults are intentionally retrieval-only. The raw transcripts stay in
+# state.db so operators can inspect them through admin/debug surfaces.
+_DEFAULT_EXCLUDE_PATTERNS = {
+    "session_id": ("bookkeeper",),
+    "messages": ("p_send", "stats-update", "form_scores"),
+}
+
+
+def _session_search_exclude_patterns() -> Dict[str, tuple[str, ...]]:
+    """Load configured persona-search exclusions, retaining safe defaults.
+
+    ``session_search.exclude_patterns`` accepts either the structured form::
+
+        session_search:
+          exclude_patterns:
+            session_id: [bookkeeper]
+            messages: [p_send, stats-update, form_scores]
+
+    or a flat list, whose entries are checked against both the session id and
+    message content. Configured values extend the built-in safety defaults;
+    an empty/malformed setting cannot accidentally re-expose the transcripts.
+    """
+    patterns = {
+        key: list(values) for key, values in _DEFAULT_EXCLUDE_PATTERNS.items()
+    }
+    try:
+        from hermes_cli.config import cfg_get, load_config_readonly
+
+        configured = cfg_get(
+            load_config_readonly(),
+            "session_search",
+            "exclude_patterns",
+            default=None,
+        )
+    except Exception:
+        logging.debug("Could not load session_search exclusions", exc_info=True)
+        configured = None
+
+    if isinstance(configured, dict):
+        aliases = {
+            "session_id": "session_id",
+            "session_ids": "session_id",
+            "messages": "messages",
+            "message": "messages",
+            "content": "messages",
+        }
+        for raw_key, target in aliases.items():
+            values = configured.get(raw_key)
+            if isinstance(values, str):
+                values = [values]
+            if isinstance(values, (list, tuple, set)):
+                patterns[target].extend(values)
+    elif isinstance(configured, str):
+        patterns["session_id"].append(configured)
+        patterns["messages"].append(configured)
+    elif isinstance(configured, (list, tuple, set)):
+        patterns["session_id"].extend(configured)
+        patterns["messages"].extend(configured)
+
+    return {
+        key: tuple(
+            str(value).casefold()
+            for value in values
+            if isinstance(value, str) and value.strip()
+        )
+        for key, values in patterns
+    }
+
+
+def _session_is_excluded(
+    db,
+    session_id: str,
+    *,
+    source: Optional[str] = None,
+    patterns: Optional[Dict[str, tuple[str, ...]]] = None,
+) -> bool:
+    """Whether a cron session is hidden from persona-facing retrieval."""
+    if not session_id:
+        return False
+    try:
+        if source is None:
+            source = (db.get_session(session_id) or {}).get("source")
+        if str(source or "").casefold() != "cron":
+            return False
+
+        patterns = patterns or _session_search_exclude_patterns()
+        session_id_folded = str(session_id).casefold()
+        if any(pattern in session_id_folded for pattern in patterns["session_id"]):
+            return True
+
+        # Check the complete session, not just the FTS row that happened to
+        # match the query. This is still retrieval filtering; nothing is
+        # removed from the database or its FTS index.
+        messages = db.get_messages(session_id)
+        for message in messages:
+            content = message.get("content") if isinstance(message, dict) else message
+            if isinstance(content, str) and any(
+                pattern in content.casefold() for pattern in patterns["messages"]
+            ):
+                return True
+    except Exception:
+        # A cron transcript that cannot be inspected is safer to hide from a
+        # persona than to return without applying the privacy filter.
+        logging.warning(
+            "Could not inspect cron session %s for session_search exclusions; hiding it",
+            session_id,
+            exc_info=True,
+        )
+        return True
+    return False
 
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
@@ -384,14 +495,23 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    *,
+    exclude_sensitive: bool = True,
+) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         sessions = db.list_sessions_rich(
-            limit=limit + 5,
+            # Filter after fetching because the message-vocabulary exclusion
+            # is evaluated against the complete transcript.
+            limit=limit + 50,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
         )  # fetch extra so we can skip current
+        patterns = _session_search_exclude_patterns() if exclude_sensitive else None
 
         current_root = _resolve_lineage(db, current_session_id) if current_session_id else None
 
@@ -402,6 +522,13 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
                 continue
             # Skip child / delegation sessions
             if s.get("parent_session_id"):
+                continue
+            if exclude_sensitive and _session_is_excluded(
+                db,
+                sid,
+                source=s.get("source"),
+                patterns=patterns,
+            ):
                 continue
             results.append({
                 "session_id": sid,
@@ -433,6 +560,7 @@ def _scroll(
     around_message_id: int,
     window: int = 5,
     current_session_id: str = None,
+    exclude_sensitive: bool = True,
 ) -> str:
     """Scroll shape: return a window of messages centered on an anchor.
 
@@ -475,6 +603,8 @@ def _scroll(
         logging.debug("get_session failed for %s: %s", session_id, e, exc_info=True)
         session_meta = {}
     if not session_meta:
+        return tool_error(f"session_id not found: {session_id}", success=False)
+    if exclude_sensitive and _session_is_excluded(db, session_id, source=session_meta.get("source")):
         return tool_error(f"session_id not found: {session_id}", success=False)
 
     # Fetch the window
@@ -560,6 +690,9 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    *,
+    exclude_sensitive: bool = True,
+    patterns: Optional[Dict[str, tuple[str, ...]]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Return a discovery-shaped result when the query matches a session title."""
     title_query = _normalize_title_query(query)
@@ -584,6 +717,13 @@ def _title_match_result(
         logging.debug("get_session failed for title match %s", session_id, exc_info=True)
         session_meta = {}
     if session_meta.get("source") in _HIDDEN_SESSION_SOURCES:
+        return None
+    if exclude_sensitive and _session_is_excluded(
+        db,
+        session_id,
+        source=session_meta.get("source"),
+        patterns=patterns,
+    ):
         return None
 
     try:
@@ -630,11 +770,19 @@ def _discover(
     limit: int,
     sort: Optional[str],
     current_session_id: str = None,
+    exclude_sensitive: bool = True,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    patterns = _session_search_exclude_patterns() if exclude_sensitive else None
+    title_result = _title_match_result(
+        db,
+        query,
+        current_lineage_root,
+        exclude_sensitive=exclude_sensitive,
+        patterns=patterns,
+    )
 
     try:
         raw_results = db.search_messages(
@@ -656,6 +804,18 @@ def _discover(
     # top `limit` results (#19434). Stable — preserves BM25/recency order
     # within each class.
     raw_results = _order_for_recall(raw_results)
+
+    if exclude_sensitive:
+        raw_results = [
+            row
+            for row in raw_results
+            if not _session_is_excluded(
+                db,
+                row.get("session_id"),
+                source=row.get("source"),
+                patterns=patterns,
+            )
+        ]
 
     if not raw_results and not title_result:
         _empty_payload = {
@@ -790,6 +950,9 @@ def session_search(
     sort: str = None,
     # Cross-profile (any shape)
     profile: str = None,
+    # Internal admin/debug escape hatch. Deliberately not part of the model
+    # schema; normal persona and heartbeat calls always keep exclusions on.
+    admin_debug: bool = False,
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 
@@ -835,6 +998,8 @@ def session_search(
             db = profile_db
             current_session_id = None
 
+    exclude_sensitive = not admin_debug
+
     # Scroll shape takes precedence — explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
         return _scroll(
@@ -843,11 +1008,14 @@ def session_search(
             around_message_id=around_message_id,
             window=window,
             current_session_id=current_session_id,
+            exclude_sensitive=exclude_sensitive,
         )
 
     # Read shape: a session_id with no anchor → dump the whole session.
     if isinstance(session_id, str) and session_id.strip():
         sid = session_id.strip()
+        if exclude_sensitive and _session_is_excluded(db, sid):
+            return tool_error(f"session_id not found: {sid}", success=False)
         result = _read_session(db, sid)
         if json.loads(result).get("success"):
             return result
@@ -858,6 +1026,8 @@ def session_search(
         located, owner = _locate_session_db(sid)
         if located is not None:
             try:
+                if exclude_sensitive and _session_is_excluded(located, sid):
+                    return tool_error(f"session_id not found: {sid}", success=False)
                 found = json.loads(_read_session(located, sid))
             finally:
                 located.close()
@@ -876,7 +1046,12 @@ def session_search(
 
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id)
+        return _list_recent_sessions(
+            db,
+            limit,
+            current_session_id,
+            exclude_sensitive=exclude_sensitive,
+        )
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -897,6 +1072,7 @@ def session_search(
         limit=limit,
         sort=sort_norm,
         current_session_id=current_session_id,
+        exclude_sensitive=exclude_sensitive,
     )
 
 
@@ -1075,6 +1251,7 @@ registry.register(
         profile=args.get("profile"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),
+        admin_debug=bool(kw.get("admin_debug", False)),
     ),
     check_fn=check_session_search_requirements,
     emoji="🔍",


### PR DESCRIPTION
## Summary

Multi-pet desktop overlay system with per-profile pet slots, plus a gateway session recovery fix that was blocking MCP discovery on startup.

### Multi-pet overlay (Layers 1-8 + PR1-PR4 cleanup)
- **Layer 1-2:** Multi-pet roster invariant + per-profile CLI, profile RPC, reconnect ownership, gateway leases
- **Layer 3:** Per-profile pet store with session-derived activity
- **Layer 4:** Event profile tagging fix + observed activity routing
- **Layer 5:** PetSlot + MultiPetContainer with mode-branched rendering
- **Layer 6/6c:** Per-profile overlay windows + IPC sender enforcement, SubmitExecution seam + profile-safe submission + v2 queue
- **Layer 7:** Profile-scoped gallery + pet-transport + roster reconciliation
- **Layer 8:** Per-profile connection state + meta-first polling budget
- **Settings UI:** Pinned-mode settings + roster panel
- **i18n:** Multi-pet locale keys for all 6 languages
- **PR1-PR4:** Dead code sweep, review fixes, overlay-bubble offline reason affordance

### Gateway fix
- Wrap `suspend_recently_active()` in `asyncio.wait_for` with configurable timeout so a wedged session store never blocks platform adapters
- Replace blocking executor MCP discovery with `start_background_mcp_discovery` daemon thread so Telegram polling stays responsive
- Fix `.items()` on dict iteration in session_search exclude patterns

## Test Plan
- [x] Integration tests for submit resume + attachment sync
- [ ] Manual: multi-pet overlay across 2+ profiles
- [ ] Manual: gateway startup with slow MCP server