### PR TITLE
fix(compression): fence durable transcript revisions

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1554,6 +1554,19 @@ def init_agent(
     # SQLite session store (optional -- provided by CLI or gateway)
     agent._session_db = session_db
     agent._parent_session_id = parent_session_id
+    # Agents that own the durable session track their own active-row revision.
+    # Explicit caller snapshots (for example WebUI) replace this at turn start.
+    agent._durable_transcript_revision = None
+    if session_db is not None:
+        try:
+            agent._durable_transcript_revision = (
+                session_db.get_active_message_revision(agent.session_id)
+            )
+        except Exception:
+            logger.debug(
+                "Durable transcript revision unavailable during agent init",
+                exc_info=True,
+            )
     # A close flush and the worker's turn-start flush can overlap. The durable
     # marker is attached to each in-memory message dict, so its test-and-append
     # sequence must be serialized per agent rather than relying on SQLite alone.

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1769,6 +1769,19 @@ def init_agent(
     # _get_session_db_for_recall, where nothing else holds a reference.
     agent._owns_session_db = False
     agent._parent_session_id = parent_session_id
+    # Agents that own the durable session track their own active-row revision.
+    # Explicit caller snapshots (for example WebUI) replace this at turn start.
+    agent._durable_transcript_revision = None
+    if session_db is not None:
+        try:
+            agent._durable_transcript_revision = (
+                session_db.get_active_message_revision(agent.session_id)
+            )
+        except Exception:
+            logger.debug(
+                "Durable transcript revision unavailable during agent init",
+                exc_info=True,
+            )
     # A close flush and the worker's turn-start flush can overlap. The durable
     # marker is attached to each in-memory message dict, so its test-and-append
     # sequence must be serialized per agent rather than relying on SQLite alone.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -87,6 +87,49 @@ _TERMINAL_COMPRESSION_PROVENANCES = frozenset(
         ActivityProvenance.AGENT_COMPRESSION_COOLDOWN,
     }
 )
+from hermes_state import (
+    CompressionSessionBusyError,
+    CompressionTranscriptRevisionError,
+    DurableTranscriptRevision,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CompressionSnapshotStaleError(RuntimeError):
+    """The durable transcript changed after the caller captured its snapshot."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        expected_revision: Optional[DurableTranscriptRevision],
+        observed_revision: DurableTranscriptRevision,
+    ) -> None:
+        self.session_id = session_id
+        self.expected_revision = expected_revision
+        self.observed_revision = observed_revision
+        super().__init__(
+            f"durable transcript revision changed for session {session_id}"
+        )
+
+
+class CompressionProjectionUnverifiableError(RuntimeError):
+    """A caller-supplied projection could not be tied to a durable revision."""
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        super().__init__(
+            f"durable transcript projection could not be verified for session {session_id}"
+        )
+
+
+class CompressionCommitFailedError(RuntimeError):
+    """A generated compaction could not be committed to durable state."""
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        super().__init__(f"context compression commit failed for session {session_id}")
 
 # Stable marker the gateway matches on to re-tag the auto-compaction lifecycle
 # status as ``kind="compacting"`` (tui_gateway/server.py::_status_update), so
@@ -1203,6 +1246,27 @@ def compression_skipped_due_to_lock(agent: Any) -> bool:
     return _sig is True or isinstance(_sig, str)
 
 
+def _rebind_durable_transcript_revision(
+    agent: Any,
+    session_db: Any,
+    session_id: str,
+) -> None:
+    """Bind the agent revision to the active rows of its current segment."""
+    loader = getattr(type(session_db), "get_active_message_revision", None)
+    if not callable(loader):
+        agent._durable_transcript_revision = None
+        return
+    try:
+        agent._durable_transcript_revision = loader(session_db, session_id)
+    except Exception:
+        agent._durable_transcript_revision = None
+        logger.debug(
+            "Durable transcript revision rebind failed for session=%s",
+            session_id,
+            exc_info=True,
+        )
+
+
 def _adopt_live_compression_child(
     agent: Any,
     session_db: Any,
@@ -1235,6 +1299,7 @@ def _adopt_live_compression_child(
         return None
 
     agent.session_id = child_session_id
+    _rebind_durable_transcript_revision(agent, session_db, child_session_id)
     try:
         from gateway.session_context import set_current_session_id
 
@@ -2709,46 +2774,38 @@ def compress_context(
                     _lock_refresher = _candidate_refresher
                     _lock_refresher.start()
 
-        # The caller's history snapshot predates lease acquisition. Reload the
-        # durable parent after the lease is live; MORE durable rows than the
-        # snapshot carries means a frontend/background writer committed a turn
-        # in that window, so publishing from this snapshot would omit it.
-        # Deliberately a LENGTH check, not content equality: in-memory
-        # mutation of past turns is legal (multimodal compression, retry
-        # history replacement, think-tag stripping), and a content-equality
-        # abort would permanently wedge compression on such sessions — the
-        # #14694 failure shape.
-        # Rotation-only: in-place compaction (archive_and_compact) is
-        # non-destructive — pre-compaction rows are soft-archived (active=0,
-        # compacted=1), stay searchable and recoverable, so snapshot/durable
-        # drift cannot lose data there and must not abort compaction.
-        #
-        # When durable DID grow, ADOPT it and continue rather than aborting.
-        # Aborting returned the stale snapshot unchanged, so busy sessions
-        # (memory review / shared session_id writers) stayed permanently
-        # behind the DB: every /compress and auto-compress saw
-        # "changed before lease acquisition", surfaced as the misleading
-        # "No changes from compression", and never reclaimed tokens.
-        if not in_place and _lock_db is not None and _lock_sid:
-            durable_loader = getattr(
-                type(_lock_db), "get_messages_as_conversation", None
+        # Fence the caller's projection against the durable active-row set.
+        # Deliberately do NOT compare durable and projected message counts:
+        # projections may deduplicate or omit rows while still representing the
+        # same atomic durable snapshot.
+        # Apply the fence in both rotation and in-place modes. In-place keeps
+        # archived rows recoverable, but activating a summary built from a stale
+        # projection would still hide a concurrently committed active turn.
+        if _lock_db is not None and _lock_sid:
+            revision_loader = getattr(
+                type(_lock_db), "get_active_message_revision", None
             )
-            if callable(durable_loader):
-                durable_parent = durable_loader(_lock_db, _lock_sid)
-                if isinstance(durable_parent, list) and len(durable_parent) > len(messages):
-                    logger.info(
-                        "compression: session=%s grew before lease "
-                        "(%d → %d msgs); adopting durable snapshot",
-                        _lock_sid,
-                        len(messages),
-                        len(durable_parent),
+            if callable(revision_loader):
+                expected_revision = getattr(
+                    agent, "_durable_transcript_revision", None
+                )
+                observed_revision = revision_loader(_lock_db, _lock_sid)
+                if (
+                    expected_revision is not None
+                    and expected_revision.session_id != _lock_sid
+                ):
+                    # Legacy/plugin callers may assign ``session_id`` directly
+                    # after agent construction. A revision belongs only to the
+                    # session it names; rebaseline instead of comparing across
+                    # unrelated sessions.
+                    agent._durable_transcript_revision = observed_revision
+                    expected_revision = observed_revision
+                if expected_revision is not None and expected_revision != observed_revision:
+                    raise CompressionSnapshotStaleError(
+                        session_id=_lock_sid,
+                        expected_revision=expected_revision,
+                        observed_revision=observed_revision,
                     )
-                    messages = durable_parent
-                    _pre_msg_count = len(messages)
-                    # Token estimate was for the stale snapshot; clear it so
-                    # the compressor re-derives from the adopted transcript
-                    # instead of under-counting the newly visible rows.
-                    approx_tokens = 0
 
         # Notify external memory provider before compression discards context.
         # The provider's on_pre_compress() may return a string of insights it
@@ -3201,7 +3258,20 @@ def compress_context(
                     # for search/recovery (Teknium review — keep one durable id
                     # WITHOUT destroying history, unlike a hard replace_messages).
                     # See #38763.
-                    agent._session_db.archive_and_compact(agent.session_id, compressed)
+                    agent._session_db.archive_and_compact(
+                        agent.session_id,
+                        compressed,
+                        compression_lock_holder=_lock_holder,
+                        require_compression_lease=_lock_holder is not None,
+                        expected_revision=getattr(
+                            agent, "_durable_transcript_revision", None
+                        ),
+                    )
+                    _rebind_durable_transcript_revision(
+                        agent,
+                        agent._session_db,
+                        agent.session_id,
+                    )
                     split_status = "in_place_committed"
                     # Reset the flush identity set so the next turn's appends are
                     # diffed against the COMPACTED transcript: the compacted dicts
@@ -3241,6 +3311,11 @@ def compress_context(
                             messages,
                             conversation_history=persisted_history,
                         )
+                        _rebind_durable_transcript_revision(
+                            agent,
+                            agent._session_db,
+                            agent.session_id,
+                        )
                     except Exception:
                         pass  # best-effort — don't block compression on a flush error
                     # Publish parent closure + child row + compacted handoff in
@@ -3277,8 +3352,16 @@ def compress_context(
                         profile_name=_profile_for_child,
                         compression_lock_holder=_lock_holder,
                         require_compression_lease=_lock_holder is not None,
+                        expected_parent_revision=getattr(
+                            agent, "_durable_transcript_revision", None
+                        ),
                     )
                     agent.session_id = new_session_id
+                    _rebind_durable_transcript_revision(
+                        agent,
+                        agent._session_db,
+                        new_session_id,
+                    )
                     try:
                         from gateway.session_context import set_current_session_id
 
@@ -3326,35 +3409,39 @@ def compress_context(
                         if isinstance(message, dict)
                     }
                 _session_commit_succeeded = True
+            except CompressionTranscriptRevisionError as e:
+                messages[:] = copy.deepcopy(messages_before_compression)
+                compressed = messages
+                _compression_made_progress = False
+                raise CompressionSnapshotStaleError(
+                    session_id=e.session_id,
+                    expected_revision=e.expected_revision,
+                    observed_revision=e.observed_revision,
+                ) from e
             except Exception as e:
-                if (
-                    not in_place
-                    and locals().get("old_session_id")
-                    and agent.session_id == old_session_id
-                ):
-                    # Atomic publication failed (including lease loss): keep the
-                    # parent live and discard the stale compacted snapshot.
+                # Any durable commit failure invalidates the generated compacted
+                # projection. Restore the exact pre-compression in-memory state
+                # in both rotation and in-place modes and stop the turn; otherwise
+                # the model could continue from context that never committed.
+                messages[:] = copy.deepcopy(messages_before_compression)
+                compressed = messages
+                _compression_made_progress = False
+                if not in_place and locals().get("old_session_id"):
                     old_session_id = None
-                    messages[:] = copy.deepcopy(messages_before_compression)
-                    compressed = messages
-                    _compression_made_progress = False
-                split_status = (
-                    "aborted"
-                    if locals().get("old_session_id") is None and not in_place
-                    else "failed_not_indexed"
+                split_status = "aborted"
+                logger.warning(
+                    "Compression durable commit failed and in-memory context was "
+                    "restored (session=%s): %s",
+                    agent.session_id or "?",
+                    e,
                 )
-                # If the rotation rolled back to the parent (orphan-avoidance
-                # above), agent.session_id is the still-indexed parent and
-                # old_session_id was cleared — so this is recovery, not an
-                # un-indexed orphan. Otherwise an earlier step failed before the
-                # child was created and the warning's original meaning holds.
-                if locals().get("old_session_id") is None and not in_place:
-                    logger.warning(
-                        "Compression rotation aborted and rolled back to the "
-                        "parent session (%s): %s", agent.session_id or "?", e,
-                    )
-                else:
-                    logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+                if isinstance(e, CompressionSessionBusyError):
+                    raise CompressionCommitFailedError(agent.session_id or "") from e
+                _existing_sp = getattr(agent, "_cached_system_prompt", None)
+                if not _existing_sp:
+                    _existing_sp = agent._build_system_prompt(system_message)
+                _release_lock()
+                return messages, _existing_sp
 
         # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
         # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1219,9 +1219,12 @@ def _adopt_live_compression_child(
     if not callable(finder) or not callable(loader):
         return None
     child = finder(session_db, parent_session_id)
-    if not child or not child.get("id"):
+    if not isinstance(child, dict) or not child.get("id"):
         return None
     child_session_id = str(child["id"])
+    immediate_parent_session_id = str(
+        child.get("parent_session_id") or parent_session_id
+    )
     recovered = loader(session_db, child_session_id)
     if not isinstance(recovered, list) or not recovered:
         return None
@@ -1254,13 +1257,19 @@ def _adopt_live_compression_child(
         id(message) for message in recovered if isinstance(message, dict)
     }
 
+    # This is adoption of an already-published session, not a new compression
+    # boundary. Replaying ``boundary_reason='compression'`` would migrate stale
+    # counters from the ancestor into a tip that may already have newer state.
+    # ``resume`` makes engines load the durable tip as-is; the extra flag keeps
+    # the recovery provenance available to plugins without re-emitting a split.
     on_session_start = getattr(agent.context_compressor, "on_session_start", None)
     if callable(on_session_start):
         try:
             on_session_start(
                 child_session_id,
-                boundary_reason="compression",
-                old_session_id=parent_session_id,
+                boundary_reason="resume",
+                old_session_id=immediate_parent_session_id,
+                recovered_from_compression=True,
                 session_db=session_db,
                 platform=getattr(agent, "platform", None) or "cli",
                 conversation_id=getattr(agent, "_gateway_session_key", None),
@@ -1278,9 +1287,9 @@ def _adopt_live_compression_child(
         if agent._memory_manager:
             agent._memory_manager.on_session_switch(
                 child_session_id,
-                parent_session_id=parent_session_id,
+                parent_session_id=immediate_parent_session_id,
                 reset=False,
-                reason="compression",
+                reason="resume",
             )
     except Exception as exc:
         logger.debug("memory manager compression-child adoption failed: %s", exc)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -64,7 +64,10 @@ import uuid
 import threading
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from hermes_state import DurableTranscriptRevision
 
 from agent.auxiliary_client import AuxiliaryExplicitCancellation
 from agent.context_engine import (
@@ -87,12 +90,6 @@ _TERMINAL_COMPRESSION_PROVENANCES = frozenset(
         ActivityProvenance.AGENT_COMPRESSION_COOLDOWN,
     }
 )
-from hermes_state import (
-    CompressionSessionBusyError,
-    CompressionTranscriptRevisionError,
-    DurableTranscriptRevision,
-)
-
 logger = logging.getLogger(__name__)
 
 
@@ -2240,6 +2237,13 @@ def compress_context(
         prompt — the session is NOT rotated.  Callers should detect the
         no-op via ``len(returned) == len(input)`` and stop the retry loop.
     """
+    # Keep durable state lazy: gateway configuration imports this module during
+    # collection, before per-test/runtime ``HERMES_HOME`` redirects are active.
+    from hermes_state import (
+        CompressionSessionBusyError,
+        CompressionTranscriptRevisionError,
+    )
+
     _compressor_attempt_snapshot = _snapshot_compressor_attempt_state(
         agent.context_compressor
     )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2794,16 +2794,26 @@ def compress_context(
                     agent, "_durable_transcript_revision", None
                 )
                 observed_revision = revision_loader(_lock_db, _lock_sid)
-                if (
-                    expected_revision is not None
-                    and expected_revision.session_id != _lock_sid
-                ):
-                    # Legacy/plugin callers may assign ``session_id`` directly
-                    # after agent construction. A revision belongs only to the
-                    # session it names; rebaseline instead of comparing across
-                    # unrelated sessions.
-                    agent._durable_transcript_revision = observed_revision
-                    expected_revision = observed_revision
+                if expected_revision is None:
+                    # A durable revision is the only proof that the supplied
+                    # projection and the active rows were read atomically.
+                    # Observing the target now cannot authenticate bytes that
+                    # arrived without that identity.
+                    raise CompressionSnapshotStaleError(
+                        session_id=_lock_sid,
+                        expected_revision=None,
+                        observed_revision=observed_revision,
+                    )
+                if expected_revision.session_id != _lock_sid:
+                    # The revision authenticates the caller's projection. A
+                    # direct session switch without a matching atomic reload
+                    # leaves that projection unverifiable; adopting the target
+                    # revision alone would bless bytes from the old session.
+                    raise CompressionSnapshotStaleError(
+                        session_id=_lock_sid,
+                        expected_revision=expected_revision,
+                        observed_revision=observed_revision,
+                    )
                 if expected_revision is not None and expected_revision != observed_revision:
                     raise CompressionSnapshotStaleError(
                         session_id=_lock_sid,
@@ -3265,6 +3275,7 @@ def compress_context(
                     agent._session_db.archive_and_compact(
                         agent.session_id,
                         compressed,
+                        system_prompt=new_system_prompt,
                         compression_lock_holder=_lock_holder,
                         require_compression_lease=_lock_holder is not None,
                         expected_revision=getattr(
@@ -3397,12 +3408,9 @@ def compress_context(
                         except (ValueError, Exception) as e:
                             logger.debug("Could not propagate title on compression: %s", e)
 
-                # In-place mode still updates/replaces the current row here.
-                # Rotation already published prompt + compacted handoff atomically.
+                # Rotation publishes prompt + compacted handoff atomically.
+                # In-place mode does the same inside archive_and_compact().
                 if in_place:
-                    agent._session_db.update_system_prompt(
-                        agent.session_id, new_system_prompt
-                    )
                     agent._last_flushed_db_idx = 0
                 else:
                     agent._last_flushed_db_idx = len(compressed)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -64,7 +64,10 @@ import uuid
 import threading
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Tuple
+
+if TYPE_CHECKING:
+    from hermes_state import DurableTranscriptRevision
 
 from agent.auxiliary_client import AuxiliaryExplicitCancellation
 from agent.context_engine import (
@@ -91,6 +94,43 @@ _TERMINAL_COMPRESSION_PROVENANCES = frozenset(
         ActivityProvenance.AGENT_COMPRESSION_COOLDOWN,
     }
 )
+logger = logging.getLogger(__name__)
+
+
+class CompressionSnapshotStaleError(RuntimeError):
+    """The durable transcript changed after the caller captured its snapshot."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        expected_revision: Optional[DurableTranscriptRevision],
+        observed_revision: DurableTranscriptRevision,
+    ) -> None:
+        self.session_id = session_id
+        self.expected_revision = expected_revision
+        self.observed_revision = observed_revision
+        super().__init__(
+            f"durable transcript revision changed for session {session_id}"
+        )
+
+
+class CompressionProjectionUnverifiableError(RuntimeError):
+    """A caller-supplied projection could not be tied to a durable revision."""
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        super().__init__(
+            f"durable transcript projection could not be verified for session {session_id}"
+        )
+
+
+class CompressionCommitFailedError(RuntimeError):
+    """A generated compaction could not be committed to durable state."""
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        super().__init__(f"context compression commit failed for session {session_id}")
 
 # Cooldown armed when a compression SPLIT fails (session_split_failed /
 # rotation rollback, #97948 symptom B). Deliberately the FIRST rung of the
@@ -2095,6 +2135,66 @@ def _mark_compression_blocked_transient(agent: Any, compressor: Any) -> None:
             pass
 
 
+def _rebind_durable_transcript_revision(
+    agent: Any,
+    session_db: Any,
+    session_id: str,
+) -> None:
+    """Bind the agent revision to the active rows of its current segment."""
+    loader = getattr(type(session_db), "get_active_message_revision", None)
+    if not callable(loader):
+        agent._durable_transcript_revision = None
+        return
+    try:
+        agent._durable_transcript_revision = loader(session_db, session_id)
+    except Exception:
+        agent._durable_transcript_revision = None
+        logger.debug(
+            "Durable transcript revision rebind failed for session=%s",
+            session_id,
+            exc_info=True,
+        )
+
+
+def _bind_committed_projection_with_revision(
+    agent: Any,
+    committed_result: Any,
+    runtime_prefix: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Atomically bind the model projection and revision of a committed segment."""
+    if not (isinstance(committed_result, tuple) and len(committed_result) == 2):
+        raise RuntimeError("committed compression projection is not revision-aware")
+    projection, revision = committed_result
+    if not isinstance(projection, list):
+        raise RuntimeError("committed compression projection is not a message list")
+    from hermes_state import DurableTranscriptRevision
+
+    if not isinstance(revision, DurableTranscriptRevision):
+        raise RuntimeError("committed compression revision is unavailable")
+
+    runtime_projection = []
+    for index, message in enumerate(projection):
+        if not isinstance(message, dict):
+            runtime_projection.append(message)
+            continue
+        runtime_message = (
+            runtime_prefix[index]
+            if runtime_prefix is not None
+            and index < len(runtime_prefix)
+            and isinstance(runtime_prefix[index], dict)
+            else None
+        )
+        clean = runtime_message.copy() if runtime_message is not None else {}
+        clean.update(message)
+        # Rows materialized by SessionDB are born durable and carry the
+        # persistence marker. Preserve it so the next incremental flush cannot
+        # re-append the projection that the transaction just committed.
+        clean.pop("timestamp", None)
+        runtime_projection.append(clean)
+    agent._durable_transcript_revision = revision
+    return runtime_projection
+
+
 def _adopt_live_compression_child(
     agent: Any,
     session_db: Any,
@@ -2136,6 +2236,7 @@ def _adopt_live_compression_child(
         return None
 
     agent.session_id = child_session_id
+    _rebind_durable_transcript_revision(agent, session_db, child_session_id)
     try:
         from gateway.session_context import set_current_session_id
 
@@ -3402,6 +3503,13 @@ def compress_context(
         prompt — the session is NOT rotated.  Callers should detect the
         no-op via ``len(returned) == len(input)`` and stop the retry loop.
     """
+    # Keep durable state lazy: gateway configuration imports this module during
+    # collection, before per-test/runtime ``HERMES_HOME`` redirects are active.
+    from hermes_state import (
+        CompressionSessionBusyError,
+        CompressionTranscriptRevisionError,
+    )
+
     _compressor_attempt_snapshot = _snapshot_compressor_attempt_state(
         agent.context_compressor
     )
@@ -3991,6 +4099,7 @@ def compress_context(
 
     _activity_heartbeat: Optional[_CompressionActivityHeartbeat] = None
     messages_before_compression = None
+    append_only_snapshot_growth = False
     try:
         if _lock_holder is not None:
             _candidate_refresher = _CompressionLockLeaseRefresher(
@@ -4009,32 +4118,31 @@ def compress_context(
                     _lock_refresher = _candidate_refresher
                     _lock_refresher.start()
 
-        # The caller's history snapshot predates lease acquisition. Reload the
-        # durable parent after the lease is live; MORE durable rows than the
-        # snapshot carries means a frontend/background writer committed a turn
-        # in that window, so publishing from this snapshot would omit it.
-        # Deliberately a LENGTH check, not content equality: in-memory
-        # mutation of past turns is legal (multimodal compression, retry
-        # history replacement, think-tag stripping), and a content-equality
-        # abort would permanently wedge compression on such sessions — the
-        # #14694 failure shape.
-        # Rotation-only: in-place compaction (archive_and_compact) is
-        # non-destructive — pre-compaction rows are soft-archived (active=0,
-        # compacted=1), stay searchable and recoverable, so snapshot/durable
-        # drift cannot lose data there and must not abort compaction.
-        #
-        # When durable DID grow, ADOPT it and continue rather than aborting.
-        # Aborting returned the stale snapshot unchanged, so busy sessions
-        # (memory review / shared session_id writers) stayed permanently
-        # behind the DB: every /compress and auto-compress saw
-        # "changed before lease acquisition", surfaced as the misleading
-        # "No changes from compression", and never reclaimed tokens.
+        # The caller's history snapshot predates lease acquisition. A longer
+        # durable rotation parent may be adopted only with the exact revision
+        # from the same SQLite read snapshot. For a revision-bound caller, the
+        # original revision remains the fence baseline: adoption is allowed
+        # only for a proven append-only advance, and the watermark transaction
+        # still preserves those appended rows verbatim. Row ids are retained so
+        # marker reconciliation can identify exact durable rows.
+        _bound_durable_revision = getattr(
+            agent, "_durable_transcript_revision", None
+        )
+        _adopted_durable_revision = None
+        _adopted_user_anchor_row_id: Optional[int] = None
+        _user_anchor_messages: Optional[list] = None
         if not in_place and _lock_db is not None and _lock_sid:
             durable_loader = getattr(
                 type(_lock_db), "get_messages_as_conversation", None
             )
             if callable(durable_loader):
-                durable_parent = durable_loader(_lock_db, _lock_sid)
+                durable_snapshot = durable_loader(
+                    _lock_db,
+                    _lock_sid,
+                    include_row_ids=True,
+                    with_revision=True,
+                )
+                durable_parent, durable_parent_revision = durable_snapshot
                 if isinstance(durable_parent, list) and len(durable_parent) > len(messages):
                     # The in-memory transcript carries the CURRENT turn's
                     # un-persisted user tail (anchored by
@@ -4081,10 +4189,49 @@ def compress_context(
                         )
                     else:
                         # Re-read after the flush so the adopted snapshot
-                        # carries the just-persisted tail.
-                        durable_parent = durable_loader(_lock_db, _lock_sid)
+                        # carries the just-persisted tail and bind the revision
+                        # from that same read snapshot.
+                        durable_parent, durable_parent_revision = durable_loader(
+                            _lock_db,
+                            _lock_sid,
+                            include_row_ids=True,
+                            with_revision=True,
+                        )
+                    _adoption_revision_safe = _bound_durable_revision is None
                     if (
                         _preflush_ok
+                        and _bound_durable_revision is not None
+                        and durable_parent_revision is not None
+                    ):
+                        try:
+                            _adoption_revision_loader = getattr(
+                                type(_lock_db), "get_active_message_revision", None
+                            )
+                            _adoption_prefix_revision = (
+                                _adoption_revision_loader(
+                                    _lock_db,
+                                    _lock_sid,
+                                    max_message_id=(
+                                        _bound_durable_revision.max_active_message_id
+                                    ),
+                                )
+                                if callable(_adoption_revision_loader)
+                                else None
+                            )
+                            _adoption_revision_safe = bool(
+                                _bound_durable_revision.session_id == _lock_sid
+                                and _adoption_prefix_revision
+                                == _bound_durable_revision
+                                and durable_parent_revision.active_message_count
+                                >= _bound_durable_revision.active_message_count
+                                and durable_parent_revision.max_active_message_id
+                                >= _bound_durable_revision.max_active_message_id
+                            )
+                        except Exception:
+                            _adoption_revision_safe = False
+                    if (
+                        _preflush_ok
+                        and _adoption_revision_safe
                         and isinstance(durable_parent, list)
                         and len(durable_parent) > len(messages)
                     ):
@@ -4113,6 +4260,116 @@ def compress_context(
                         # durable snapshot; the post-publish marker sync in
                         # run_agent.py keeps both views aligned.
                         agent._persist_user_message_idx = len(messages)
+                        if _bound_durable_revision is None:
+                            _adopted_durable_revision = durable_parent_revision
+                        else:
+                            _adopted_tail = [
+                                message
+                                for message in messages
+                                if isinstance(message, dict)
+                                and isinstance(message.get("_row_id"), int)
+                                and message["_row_id"]
+                                > _bound_durable_revision.max_active_message_id
+                            ]
+                            # A sole adopted user append is represented verbatim
+                            # by _ensure_compressed_has_user_turn below. Remember
+                            # its row id so publish does not clone a duplicate
+                            # standalone row beside the inserted/merged anchor.
+                            if len(_adopted_tail) == 1 and _is_real_user_message(
+                                _adopted_tail[0]
+                            ):
+                                _adopted_user_anchor_row_id = _adopted_tail[0][
+                                    "_row_id"
+                                ]
+                            elif len(_adopted_tail) > 1:
+                                # Preserve a multi-row append exactly through
+                                # the watermark transaction. Do not also merge
+                                # its latest user row into the compressed body:
+                                # that would duplicate/reorder the causal tail.
+                                _user_anchor_messages = [
+                                    message
+                                    for message in messages
+                                    if not isinstance(message, dict)
+                                    or not isinstance(message.get("_row_id"), int)
+                                    or message["_row_id"]
+                                    <= _bound_durable_revision.max_active_message_id
+                                ]
+
+        # Fence the projection against the durable active-row set in both
+        # rotation and in-place modes. In-place keeps archived rows recoverable,
+        # but activating a summary built from a stale projection would still
+        # hide a concurrently committed active turn.
+        if _lock_db is not None and _lock_sid:
+            revision_loader = getattr(
+                type(_lock_db), "get_active_message_revision", None
+            )
+            if callable(revision_loader):
+                expected_revision = (
+                    _adopted_durable_revision
+                    if _adopted_durable_revision is not None
+                    else (
+                        _bound_durable_revision
+                        if _bound_durable_revision is not None
+                        else getattr(agent, "_durable_transcript_revision", None)
+                    )
+                )
+                if _adopted_durable_revision is not None:
+                    agent._durable_transcript_revision = expected_revision
+                observed_revision = revision_loader(_lock_db, _lock_sid)
+                if expected_revision is None:
+                    # A durable revision is the only proof that the supplied
+                    # projection and the active rows were read atomically.
+                    # Observing the target now cannot authenticate bytes that
+                    # arrived without that identity.
+                    raise CompressionSnapshotStaleError(
+                        session_id=_lock_sid,
+                        expected_revision=None,
+                        observed_revision=observed_revision,
+                    )
+                if expected_revision.session_id != _lock_sid:
+                    # The revision authenticates the caller's projection. A
+                    # direct session switch without a matching atomic reload
+                    # leaves that projection unverifiable; adopting the target
+                    # revision alone would bless bytes from the old session.
+                    raise CompressionSnapshotStaleError(
+                        session_id=_lock_sid,
+                        expected_revision=expected_revision,
+                        observed_revision=observed_revision,
+                    )
+                if expected_revision != observed_revision:
+                    # Appends after the authenticated snapshot are safe: the
+                    # watermark transaction preserves them verbatim. Prove the
+                    # summarized prefix itself is unchanged before classifying
+                    # the drift as append-only; deletion/rewrite still fails.
+                    prefix_revision = revision_loader(
+                        _lock_db,
+                        _lock_sid,
+                        max_message_id=expected_revision.max_active_message_id,
+                    )
+                    append_only_growth = (
+                        prefix_revision == expected_revision
+                        and observed_revision.active_message_count
+                        >= expected_revision.active_message_count
+                        and observed_revision.max_active_message_id
+                        >= expected_revision.max_active_message_id
+                    )
+                    if append_only_growth:
+                        append_only_snapshot_growth = True
+                        _commit_watermark = (
+                            expected_revision.max_active_message_id
+                        )
+                        logger.info(
+                            "compression snapshot advanced by append-only tail; "
+                            "preserving rows after watermark=%s (session=%s)",
+                            _commit_watermark,
+                            _lock_sid,
+                        )
+                    else:
+                        raise CompressionSnapshotStaleError(
+                            session_id=_lock_sid,
+                            expected_revision=expected_revision,
+                            observed_revision=observed_revision,
+                        )
 
         # Notify external memory provider before compression discards context.
         # The provider's on_pre_compress() may return a string of insights it
@@ -4732,7 +4989,12 @@ def compress_context(
                     "_todo_snapshot_synthetic": True,
                 })
         compressed_user_turn_outcome = _ensure_compressed_has_user_turn(
-            messages, compressed
+            (
+                _user_anchor_messages
+                if _user_anchor_messages is not None
+                else messages
+            ),
+            compressed,
         )
 
         cached_system_prompt = agent._cached_system_prompt
@@ -4794,6 +5056,7 @@ def compress_context(
 
         _session_commit_succeeded = False
         _commit_started_at = time.monotonic()
+        _durable_commit_published = False
         split_status = "not_applicable"
         if agent._session_db:
             split_status = "pending"
@@ -4960,7 +5223,7 @@ def compress_context(
                     _tail_count = sum(
                         1 for m in compressed if id(m) in _tail_tagged_ids
                     )
-                    agent._session_db.archive_and_compact(
+                    _committed_projection = agent._session_db.archive_and_compact(
                         agent.session_id,
                         compressed,
                         model_config_patch={
@@ -4969,6 +5232,19 @@ def compress_context(
                         watermark=_commit_watermark,
                         lock_holder=_lock_holder,
                         tail_count=_tail_count,
+                        system_prompt=new_system_prompt,
+                        compression_lock_holder=_lock_holder,
+                        require_compression_lease=_lock_holder is not None,
+                        expected_revision=getattr(
+                            agent, "_durable_transcript_revision", None
+                        ),
+                        with_projection_revision=True,
+                    )
+                    _durable_commit_published = True
+                    compressed = _bind_committed_projection_with_revision(
+                        agent,
+                        _committed_projection,
+                        runtime_prefix=compressed,
                     )
                     split_status = "in_place_committed"
                     # Post-commit contract (#98450, mirrors
@@ -5079,30 +5355,50 @@ def compress_context(
                         raise RuntimeError(
                             f"Compression parent already ended: {old_session_id}"
                         )
-                    # Foreign-tail ceiling (#75316): the flush below writes OUR
-                    # OWN input transcript to the parent — those rows are
-                    # already represented in the compacted handoff and must
-                    # not be cloned into the child. Everything at or below
-                    # this MAX(id) but above the start-watermark is a foreign
-                    # concurrent append; everything above it is our flush.
+                    _expected_parent_revision = getattr(
+                        agent, "_durable_transcript_revision", None
+                    )
+                    if _bound_durable_revision is not None:
+                        _expected_parent_revision = _bound_durable_revision
+                    _own_flush_message_ids: Tuple[int, ...] = ()
                     try:
-                        _foreign_tail_ceiling = (
-                            agent._session_db.get_active_message_watermark(
-                                agent.session_id
-                            )
-                        )
-                    except Exception:
-                        # Without a trustworthy ceiling the clone could
-                        # duplicate the handoff — fall back to historical
-                        # behavior (no tail preservation this rotation).
-                        _foreign_tail_ceiling = None
-                    try:
-                        agent._flush_messages_to_session_db(
+                        # A pre-adoption live-tail flush may have populated this
+                        # diagnostic with rows already covered by the bound
+                        # revision/watermark protocol. Capture only ids inserted
+                        # by THIS rotation-boundary flush.
+                        agent._last_flush_inserted_message_ids = ()
+                        _rotation_flush_result = agent._flush_messages_to_session_db(
                             messages,
                             conversation_history=persisted_history,
                         )
+                        if append_only_snapshot_growth and _rotation_flush_result is True:
+                            _flushed_revision = getattr(
+                                agent, "_durable_transcript_revision", None
+                            )
+                            if _flushed_revision is not None:
+                                agent._persist_user_message_idx = (
+                                    _flushed_revision.active_message_count
+                                )
+                        _own_flush_message_ids = tuple(
+                            int(message_id)
+                            for message_id in getattr(
+                                agent, "_last_flush_inserted_message_ids", ()
+                            )
+                        )
                     except Exception:
                         pass  # best-effort — don't block compression on a flush error
+                    if (
+                        _adopted_user_anchor_row_id is not None
+                        and compressed_user_turn_outcome in {"inserted", "merged"}
+                    ):
+                        _own_flush_message_ids = tuple(
+                            dict.fromkeys(
+                                (
+                                    *_own_flush_message_ids,
+                                    _adopted_user_anchor_row_id,
+                                )
+                            )
+                        )
                     # Publish parent closure + child row + compacted handoff in
                     # one transaction. No reader can observe a missing/empty child.
                     # The rotation child must stay on the parent's profile —
@@ -5124,7 +5420,7 @@ def compress_context(
                         f"{uuid.uuid4().hex[:6]}"
                     )
                     from agent.context_compressor import _DB_PERSISTED_MARKER
-                    agent._session_db.publish_compression_child(
+                    _committed_projection = agent._session_db.publish_compression_child(
                         parent_session_id=old_session_id,
                         child_session_id=new_session_id,
                         source=agent.platform
@@ -5139,13 +5435,12 @@ def compress_context(
                         require_compression_lease=_lock_holder is not None,
                         require_lease_refresh=_lock_holder is not None,
                         lease_ttl_seconds=_lock_ttl,
-                        watermark=(
-                            _commit_watermark
-                            if _foreign_tail_ceiling is not None
-                            else None
-                        ),
-                        watermark_ceiling=_foreign_tail_ceiling,
+                        watermark=_commit_watermark,
+                        exclude_parent_message_ids=_own_flush_message_ids,
+                        expected_parent_revision=_expected_parent_revision,
+                        with_projection_revision=True,
                     )
+                    _durable_commit_published = True
                     # For the `already_present` outcome the live-dict stamping is
                     # handled by the run_agent _compress_context wrapper's
                     # _sync_persisted_markers (it mirrors the handoff stamps back
@@ -5267,6 +5562,11 @@ def compress_context(
                             _handoff_message[_DB_PERSISTED_MARKER] = True
                     agent.session_id = new_session_id
                     agent._db_flush_scan_prefix = None
+                    compressed = _bind_committed_projection_with_revision(
+                        agent,
+                        _committed_projection,
+                        runtime_prefix=compressed,
+                    )
                     try:
                         from gateway.session_context import set_current_session_id
 
@@ -5351,25 +5651,50 @@ def compress_context(
                                         _src_err,
                                     )
 
-                # In-place mode still updates/replaces the current row here.
-                # Rotation already published prompt + compacted handoff atomically.
+                # Rotation publishes prompt + compacted handoff atomically.
+                # In-place mode does the same inside archive_and_compact().
                 if in_place:
-                    agent._session_db.update_system_prompt(
-                        agent.session_id, new_system_prompt
-                    )
                     agent._last_flushed_db_idx = 0
                 else:
                     agent._last_flushed_db_idx = len(compressed)
                     agent._flushed_db_message_session_id = agent.session_id
                 _session_commit_succeeded = True
+            except CompressionTranscriptRevisionError as e:
+                messages[:] = copy.deepcopy(messages_before_compression)
+                compressed = messages
+                _compression_made_progress = False
+                raise CompressionSnapshotStaleError(
+                    session_id=e.session_id,
+                    expected_revision=e.expected_revision,
+                    observed_revision=e.observed_revision,
+                ) from e
             except Exception as e:
-                if (
-                    not in_place
-                    and locals().get("old_session_id")
-                    and agent.session_id == old_session_id
-                ):
-                    # Atomic publication failed (including lease loss): keep the
-                    # parent live and discard the stale compacted snapshot.
+                if _durable_commit_published:
+                    # The DB transaction is already authoritative. Returning
+                    # the old projection would fabricate a rollback and may
+                    # let a later fence archive unseen concurrent rows. Fail
+                    # closed so the next turn reloads the committed segment.
+                    agent._durable_transcript_revision = None
+                    _compression_made_progress = False
+                    split_status = "committed_projection_unavailable"
+                    logger.error(
+                        "Compression committed but its active projection could "
+                        "not be loaded (session=%s): %s",
+                        agent.session_id or "?",
+                        e,
+                    )
+                    _release_lock()
+                    raise CompressionCommitFailedError(
+                        agent.session_id or ""
+                    ) from e
+                # Any durable commit failure invalidates the generated compacted
+                # projection. Restore the exact pre-compression in-memory state
+                # in both rotation and in-place modes and stop the turn; otherwise
+                # the model could continue from context that never committed.
+                messages[:] = copy.deepcopy(messages_before_compression)
+                compressed = messages
+                _compression_made_progress = False
+                if not in_place and locals().get("old_session_id"):
                     old_session_id = None
                     # NOTE: _db_flush_scan_prefix is intentionally NOT cleared
                     # here. The flush's bounded scan is identity-based
@@ -5477,6 +5802,20 @@ def compress_context(
                         "could not record split-failure cooldown",
                         exc_info=True,
                     )
+                split_status = "aborted"
+                logger.warning(
+                    "Compression durable commit failed and in-memory context was "
+                    "restored (session=%s): %s",
+                    agent.session_id or "?",
+                    e,
+                )
+                if isinstance(e, CompressionSessionBusyError):
+                    raise CompressionCommitFailedError(agent.session_id or "") from e
+                _existing_sp = getattr(agent, "_cached_system_prompt", None)
+                if not _existing_sp:
+                    _existing_sp = agent._build_system_prompt(system_message)
+                _release_lock()
+                return messages, _existing_sp
 
         # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
         # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -32,6 +32,9 @@ from agent.conversation_compression import (
     COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
+    CompressionCommitFailedError,
+    CompressionProjectionUnverifiableError,
+    CompressionSnapshotStaleError,
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
@@ -961,6 +964,113 @@ def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool
     return False
 
 
+def _compression_snapshot_stale_result(
+    agent,
+    messages: List[Dict],
+    api_call_count: int,
+    *,
+    conversation_history: Optional[List[Dict]] = None,
+    persist_produced_messages: bool = False,
+) -> Dict[str, Any]:
+    """Stop a turn whose durable snapshot changed during compression."""
+    logger.info(
+        "turn stopped: durable transcript changed during compression "
+        "(session=%s)",
+        agent.session_id or "none",
+    )
+    if persist_produced_messages:
+        try:
+            agent._persist_session(messages, conversation_history)
+        except Exception:
+            logger.warning(
+                "Could not persist messages produced before compression stale "
+                "stop (session=%s)",
+                agent.session_id or "none",
+                exc_info=True,
+            )
+    try:
+        agent._flush_status_buffer()
+    except Exception:
+        pass
+    effects_preserved = bool(
+        persist_produced_messages
+        and any(
+            isinstance(message, dict)
+            and (
+                message.get("role") == "tool"
+                or bool(message.get("tool_calls"))
+            )
+            for message in messages
+        )
+    )
+    if effects_preserved:
+        final_response = (
+            "This conversation changed after tool work was produced. The partial "
+            "work and recorded effects were preserved. Reload the session and "
+            "continue from the updated state; do not repeat the original command."
+        )
+    else:
+        final_response = (
+            "This conversation changed while context compression was starting. "
+            "Reload the session, then continue from the updated state."
+        )
+    return {
+        "final_response": final_response,
+        "messages": messages,
+        "completed": False,
+        "api_calls": api_call_count,
+        "error": "compression_snapshot_stale",
+        "partial": True,
+        "failed": False,
+        "compression_snapshot_stale": True,
+        "compression_effects_preserved": effects_preserved,
+        "session_id": agent.session_id,
+    }
+
+
+def _compression_projection_unverifiable_result(
+    agent,
+    messages: List[Dict],
+) -> Dict[str, Any]:
+    """Fail closed when external history cannot be tied to durable state."""
+    return {
+        "final_response": (
+            "This session's supplied history could not be verified against durable "
+            "state. Reload the session before continuing."
+        ),
+        "messages": messages,
+        "completed": False,
+        "api_calls": 0,
+        "error": "compression_projection_unverifiable",
+        "partial": True,
+        "failed": False,
+        "compression_projection_unverifiable": True,
+        "session_id": agent.session_id,
+    }
+
+
+def _compression_commit_failed_result(
+    agent,
+    messages: List[Dict],
+    api_call_count: int,
+) -> Dict[str, Any]:
+    """Stop after a compacted projection failed to commit durably."""
+    return {
+        "final_response": (
+            "Context compression could not be committed, so the original context "
+            "was restored. Reload the session before continuing."
+        ),
+        "messages": messages,
+        "completed": False,
+        "api_calls": api_call_count,
+        "error": "compression_commit_failed",
+        "partial": True,
+        "failed": False,
+        "compression_commit_failed": True,
+        "session_id": agent.session_id,
+    }
+
+
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     """Refresh the in-flight system message after a provider failover.
 
@@ -1237,6 +1347,7 @@ def run_conversation(
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    conversation_history_revision: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -1294,28 +1405,40 @@ def run_conversation(
     # ``build_turn_context``.  It mutates ``agent`` exactly as the inline code
     # did and returns the locals the loop below reads back.  See
     # ``agent/turn_context.py``.
-    _ctx = build_turn_context(
-        agent,
-        user_message,
-        system_message,
-        conversation_history,
-        task_id,
-        stream_callback,
-        persist_user_message,
-        persist_user_timestamp,
-        persist_user_display_kind=persist_user_display_kind,
-        persist_user_display_metadata=persist_user_display_metadata,
-        restore_or_build_system_prompt=_restore_or_build_system_prompt,
-        install_safe_stdio=_install_safe_stdio,
-        sanitize_surrogates=_sanitize_surrogates,
-        summarize_user_message_for_log=_summarize_user_message_for_log,
-        set_session_context=set_session_context,
-        set_current_write_origin=set_current_write_origin,
-        ra=_ra,
-        # MoA turns append per-call aggregated context to the API copy of the
-        # user message, so no byte-stable api_content sidecar can be stamped.
-        moa_active=bool(moa_config),
-    )
+    try:
+        _ctx = build_turn_context(
+            agent,
+            user_message,
+            system_message,
+            conversation_history,
+            task_id,
+            stream_callback,
+            persist_user_message,
+            persist_user_timestamp,
+            persist_user_display_kind=persist_user_display_kind,
+            persist_user_display_metadata=persist_user_display_metadata,
+            restore_or_build_system_prompt=_restore_or_build_system_prompt,
+            install_safe_stdio=_install_safe_stdio,
+            sanitize_surrogates=_sanitize_surrogates,
+            summarize_user_message_for_log=_summarize_user_message_for_log,
+            set_session_context=set_session_context,
+            set_current_write_origin=set_current_write_origin,
+            ra=_ra,
+            moa_active=bool(moa_config),
+            conversation_history_revision=conversation_history_revision,
+        )
+    except CompressionProjectionUnverifiableError:
+        unverifiable_messages = list(conversation_history or [])
+        unverifiable_messages.append({"role": "user", "content": user_message})
+        return _compression_projection_unverifiable_result(agent, unverifiable_messages)
+    except CompressionCommitFailedError:
+        commit_failed_messages = list(conversation_history or [])
+        commit_failed_messages.append({"role": "user", "content": user_message})
+        return _compression_commit_failed_result(agent, commit_failed_messages, 0)
+    except CompressionSnapshotStaleError:
+        stale_messages = list(conversation_history or [])
+        stale_messages.append({"role": "user", "content": user_message})
+        return _compression_snapshot_stale_result(agent, stale_messages, 0)
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
     messages = _ctx.messages
@@ -1352,6 +1475,18 @@ def run_conversation(
     # agent_init); default 3 preserves the prior hardcoded behavior for
     # objects without the attribute (older pickles / minimal stubs).
     max_compression_attempts = getattr(agent, "max_compression_attempts", 3)
+
+    def _automatic_compression_stale_result():
+        nonlocal compression_attempts
+        compression_attempts = max(0, compression_attempts - 1)
+        return _compression_snapshot_stale_result(
+            agent,
+            messages,
+            api_call_count,
+            conversation_history=conversation_history,
+            persist_produced_messages=True,
+        )
+
     _last_preflight_pressure: Optional[int] = None
     _preflight_compression_blocked = _ctx.preflight_compression_blocked
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
@@ -2014,12 +2149,19 @@ def run_conversation(
                 agent._emit_status(_pre_api_status)
             _last_preflight_pressure = request_pressure_tokens
             _pre_api_input = messages
-            messages, active_system_prompt = agent._compress_context(
-                messages,
-                system_message,
-                approx_tokens=request_pressure_tokens,
-                task_id=effective_task_id,
-            )
+            try:
+                messages, active_system_prompt = agent._compress_context(
+                    messages,
+                    system_message,
+                    approx_tokens=request_pressure_tokens,
+                    task_id=effective_task_id,
+                )
+            except CompressionCommitFailedError:
+                return _compression_commit_failed_result(
+                    agent, messages, api_call_count
+                )
+            except CompressionSnapshotStaleError:
+                return _automatic_compression_stale_result()
             if messages is _pre_api_input and compression_skipped_due_to_lock(agent):
                 # #69870 lock-skip: another path holds this session's
                 # compression lock, so this pass no-oped. That is a temporary
@@ -4360,13 +4502,20 @@ def run_conversation(
                     compression_attempts += 1
                     if compression_attempts <= max_compression_attempts:
                         original_len = len(messages)
-                        # Option A (LCM issue 441): overhead-aware request size so recovery arms on
-                        # the true request (msgs + tools + system), not the tool-blind message count.
-                        messages, active_system_prompt = agent._compress_context(
-                            messages, system_message,
-                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
-                            task_id=effective_task_id,
-                        )
+                        try:
+                            # Option A (LCM issue 441): overhead-aware request size so recovery arms on
+                            # the true request (msgs + tools + system), not the tool-blind message count.
+                            messages, active_system_prompt = agent._compress_context(
+                                messages, system_message,
+                                approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                                task_id=effective_task_id,
+                            )
+                        except CompressionCommitFailedError:
+                            return _compression_commit_failed_result(
+                                agent, messages, api_call_count
+                            )
+                        except CompressionSnapshotStaleError:
+                            return _automatic_compression_stale_result()
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history
                         )
@@ -4619,13 +4768,20 @@ def run_conversation(
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
                     _overflow_input = messages
-                    # Option A (LCM issue 441): overhead-aware request size so recovery arms on the
-                    # true request (msgs + tools + system), not the tool-blind message count.
-                    messages, active_system_prompt = agent._compress_context(
-                        messages, system_message,
-                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
-                        task_id=effective_task_id,
-                    )
+                    try:
+                        # Option A (LCM issue 441): overhead-aware request size so recovery arms on the
+                        # true request (msgs + tools + system), not the tool-blind message count.
+                        messages, active_system_prompt = agent._compress_context(
+                            messages, system_message,
+                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                            task_id=effective_task_id,
+                        )
+                    except CompressionCommitFailedError:
+                        return _compression_commit_failed_result(
+                            agent, messages, api_call_count
+                        )
+                    except CompressionSnapshotStaleError:
+                        return _automatic_compression_stale_result()
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                         # #69870 lock-skip: the provider proved the request
                         # does not fit, but this compression pass no-oped only
@@ -4883,15 +5039,22 @@ def run_conversation(
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
                     _overflow_input = messages
-                    # Option A (LCM issue 441): pass the OVERHEAD-AWARE request size (msgs + tool
-                    # schemas + system), not the tool-blind message count, so LCM forced-overflow
-                    # recovery arms on the TRUE request that overflowed. See hermes-lcm engine
-                    # _should_force_overflow_recovery. (approx_tokens stays for the status display.)
-                    messages, active_system_prompt = agent._compress_context(
-                        messages, system_message,
-                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
-                        task_id=effective_task_id,
-                    )
+                    try:
+                        # Option A (LCM issue 441): pass the OVERHEAD-AWARE request size (msgs + tool
+                        # schemas + system), not the tool-blind message count, so LCM forced-overflow
+                        # recovery arms on the TRUE request that overflowed. See hermes-lcm engine
+                        # _should_force_overflow_recovery. (approx_tokens stays for the status display.)
+                        messages, active_system_prompt = agent._compress_context(
+                            messages, system_message,
+                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                            task_id=effective_task_id,
+                        )
+                    except CompressionCommitFailedError:
+                        return _compression_commit_failed_result(
+                            agent, messages, api_call_count
+                        )
+                    except CompressionSnapshotStaleError:
+                        return _automatic_compression_stale_result()
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                         # #69870 lock-skip: the provider proved the request
                         # does not fit, but this compression pass no-oped only
@@ -7128,6 +7291,10 @@ def run_conversation(
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break
             
+        except CompressionCommitFailedError:
+            return _compression_commit_failed_result(agent, messages, api_call_count)
+        except CompressionSnapshotStaleError:
+            return _automatic_compression_stale_result()
         except Exception as e:
             # Phase-aware error classification. The huge outer try/except spans
             # both the actual API request and all local post-processing of the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -33,6 +33,9 @@ from agent.conversation_compression import (
     COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
+    CompressionCommitFailedError,
+    CompressionProjectionUnverifiableError,
+    CompressionSnapshotStaleError,
     compression_blocked_transiently,
     compression_skipped_due_to_lock,
     context_compression_timed_out,
@@ -1740,6 +1743,113 @@ def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool
     return False
 
 
+def _compression_snapshot_stale_result(
+    agent,
+    messages: List[Dict],
+    api_call_count: int,
+    *,
+    conversation_history: Optional[List[Dict]] = None,
+    persist_produced_messages: bool = False,
+) -> Dict[str, Any]:
+    """Stop a turn whose durable snapshot changed during compression."""
+    logger.info(
+        "turn stopped: durable transcript changed during compression "
+        "(session=%s)",
+        agent.session_id or "none",
+    )
+    if persist_produced_messages:
+        try:
+            agent._persist_session(messages, conversation_history)
+        except Exception:
+            logger.warning(
+                "Could not persist messages produced before compression stale "
+                "stop (session=%s)",
+                agent.session_id or "none",
+                exc_info=True,
+            )
+    try:
+        agent._flush_status_buffer()
+    except Exception:
+        pass
+    effects_preserved = bool(
+        persist_produced_messages
+        and any(
+            isinstance(message, dict)
+            and (
+                message.get("role") == "tool"
+                or bool(message.get("tool_calls"))
+            )
+            for message in messages
+        )
+    )
+    if effects_preserved:
+        final_response = (
+            "This conversation changed after tool work was produced. The partial "
+            "work and recorded effects were preserved. Reload the session and "
+            "continue from the updated state; do not repeat the original command."
+        )
+    else:
+        final_response = (
+            "This conversation changed while context compression was starting. "
+            "Reload the session, then continue from the updated state."
+        )
+    return {
+        "final_response": final_response,
+        "messages": messages,
+        "completed": False,
+        "api_calls": api_call_count,
+        "error": "compression_snapshot_stale",
+        "partial": True,
+        "failed": False,
+        "compression_snapshot_stale": True,
+        "compression_effects_preserved": effects_preserved,
+        "session_id": agent.session_id,
+    }
+
+
+def _compression_projection_unverifiable_result(
+    agent,
+    messages: List[Dict],
+) -> Dict[str, Any]:
+    """Fail closed when external history cannot be tied to durable state."""
+    return {
+        "final_response": (
+            "This session's supplied history could not be verified against durable "
+            "state. Reload the session before continuing."
+        ),
+        "messages": messages,
+        "completed": False,
+        "api_calls": 0,
+        "error": "compression_projection_unverifiable",
+        "partial": True,
+        "failed": False,
+        "compression_projection_unverifiable": True,
+        "session_id": agent.session_id,
+    }
+
+
+def _compression_commit_failed_result(
+    agent,
+    messages: List[Dict],
+    api_call_count: int,
+) -> Dict[str, Any]:
+    """Stop after a compacted projection failed to commit durably."""
+    return {
+        "final_response": (
+            "Context compression could not be committed, so the original context "
+            "was restored. Reload the session before continuing."
+        ),
+        "messages": messages,
+        "completed": False,
+        "api_calls": api_call_count,
+        "error": "compression_commit_failed",
+        "partial": True,
+        "failed": False,
+        "compression_commit_failed": True,
+        "session_id": agent.session_id,
+    }
+
+
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     """Refresh the in-flight system message after a provider failover.
 
@@ -2036,6 +2146,7 @@ def run_conversation(
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     persist_user_platform_id: Optional[str] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    conversation_history_revision: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -2129,6 +2240,7 @@ def run_conversation(
             # MoA turns append per-call aggregated context to the API copy of the
             # user message, so no byte-stable api_content sidecar can be stamped.
             moa_active=bool(moa_config),
+            conversation_history_revision=conversation_history_revision,
         )
     except PreflightCompressionTimedOut as _preflight_timeout_exc:
         # Turn-start fail-closed boundary (#98424): preflight compression hit
@@ -2173,6 +2285,18 @@ def run_conversation(
             "compression_exhausted": True,
             "turn_exit_reason": "context_compression_timeout",
         }
+    except CompressionProjectionUnverifiableError:
+        unverifiable_messages = list(conversation_history or [])
+        unverifiable_messages.append({"role": "user", "content": user_message})
+        return _compression_projection_unverifiable_result(agent, unverifiable_messages)
+    except CompressionCommitFailedError:
+        commit_failed_messages = list(conversation_history or [])
+        commit_failed_messages.append({"role": "user", "content": user_message})
+        return _compression_commit_failed_result(agent, commit_failed_messages, 0)
+    except CompressionSnapshotStaleError:
+        stale_messages = list(conversation_history or [])
+        stale_messages.append({"role": "user", "content": user_message})
+        return _compression_snapshot_stale_result(agent, stale_messages, 0)
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
     messages = _ctx.messages
@@ -2228,6 +2352,18 @@ def run_conversation(
     # agent_init); default 3 preserves the prior hardcoded behavior for
     # objects without the attribute (older pickles / minimal stubs).
     max_compression_attempts = getattr(agent, "max_compression_attempts", 3)
+
+    def _automatic_compression_stale_result():
+        nonlocal compression_attempts
+        compression_attempts = max(0, compression_attempts - 1)
+        return _compression_snapshot_stale_result(
+            agent,
+            messages,
+            api_call_count,
+            conversation_history=conversation_history,
+            persist_produced_messages=True,
+        )
+
     _last_preflight_pressure: Optional[int] = None
     _preflight_compression_blocked = _ctx.preflight_compression_blocked
     # A provider overflow is stronger evidence than the rough-estimate
@@ -3113,12 +3249,19 @@ def run_conversation(
                 agent._emit_status(_pre_api_status)
             _last_preflight_pressure = request_pressure_tokens
             _pre_api_input = messages
-            messages, active_system_prompt = agent._compress_context(
-                messages,
-                system_message,
-                approx_tokens=request_pressure_tokens,
-                task_id=effective_task_id,
-            )
+            try:
+                messages, active_system_prompt = agent._compress_context(
+                    messages,
+                    system_message,
+                    approx_tokens=request_pressure_tokens,
+                    task_id=effective_task_id,
+                )
+            except CompressionCommitFailedError:
+                return _compression_commit_failed_result(
+                    agent, messages, api_call_count
+                )
+            except CompressionSnapshotStaleError:
+                return _automatic_compression_stale_result()
             if context_compression_timed_out(agent):
                 # Host progress-aware timeout (#98722, salvaged from #98741):
                 # this preflight iteration never reached the provider. Refund
@@ -5963,13 +6106,20 @@ def run_conversation(
                     compression_attempts += 1
                     if compression_attempts <= max_compression_attempts:
                         original_len = len(messages)
-                        # Option A (LCM issue 441): overhead-aware request size so recovery arms on
-                        # the true request (msgs + tools + system), not the tool-blind message count.
-                        messages, active_system_prompt = agent._compress_context(
-                            messages, system_message,
-                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
-                            task_id=effective_task_id,
-                        )
+                        try:
+                            # Option A (LCM issue 441): overhead-aware request size so recovery arms on
+                            # the true request (msgs + tools + system), not the tool-blind message count.
+                            messages, active_system_prompt = agent._compress_context(
+                                messages, system_message,
+                                approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                                task_id=effective_task_id,
+                            )
+                        except CompressionCommitFailedError:
+                            return _compression_commit_failed_result(
+                                agent, messages, api_call_count
+                            )
+                        except CompressionSnapshotStaleError:
+                            return _automatic_compression_stale_result()
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history
                         )
@@ -6265,18 +6415,25 @@ def run_conversation(
                     # the session permanently. (#88960 / #47339)
                     original_bytes = serialized_messages_bytes(messages)
                     _overflow_input = messages
-                    # Option A (LCM issue 441): overhead-aware request size so recovery arms on the
-                    # true request (msgs + tools + system), not the tool-blind message count.
-                    messages, active_system_prompt = agent._compress_context(
-                        messages, system_message,
-                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
-                        task_id=effective_task_id,
-                        # #100661: the provider proved the request does not fit.
-                        # Ignore the summary-failure cooldown for this ONE
-                        # attempt (bounded by max_compression_attempts) instead
-                        # of deferring every turn until the ladder lapses.
-                        bypass_cooldown=True,
-                    )
+                    try:
+                        # Option A (LCM issue 441): overhead-aware request size so recovery arms on the
+                        # true request (msgs + tools + system), not the tool-blind message count.
+                        messages, active_system_prompt = agent._compress_context(
+                            messages, system_message,
+                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                            task_id=effective_task_id,
+                            # #100661: the provider proved the request does not fit.
+                            # Ignore the summary-failure cooldown for this ONE
+                            # attempt (bounded by max_compression_attempts) instead
+                            # of deferring every turn until the ladder lapses.
+                            bypass_cooldown=True,
+                        )
+                    except CompressionCommitFailedError:
+                        return _compression_commit_failed_result(
+                            agent, messages, api_call_count
+                        )
+                    except CompressionSnapshotStaleError:
+                        return _automatic_compression_stale_result()
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                         # #69870 lock-skip: the provider proved the request
                         # does not fit, but this compression pass no-oped only
@@ -6608,20 +6765,27 @@ def run_conversation(
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
                     _overflow_input = messages
-                    # Option A (LCM issue 441): pass the OVERHEAD-AWARE request size (msgs + tool
-                    # schemas + system), not the tool-blind message count, so LCM forced-overflow
-                    # recovery arms on the TRUE request that overflowed. See hermes-lcm engine
-                    # _should_force_overflow_recovery. (approx_tokens stays for the status display.)
-                    messages, active_system_prompt = agent._compress_context(
-                        messages, system_message,
-                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
-                        task_id=effective_task_id,
-                        # #100661: the provider proved the request does not fit.
-                        # Ignore the summary-failure cooldown for this ONE
-                        # attempt (bounded by max_compression_attempts) instead
-                        # of deferring every turn until the ladder lapses.
-                        bypass_cooldown=True,
-                    )
+                    try:
+                        # Option A (LCM issue 441): pass the OVERHEAD-AWARE request size (msgs + tool
+                        # schemas + system), not the tool-blind message count, so LCM forced-overflow
+                        # recovery arms on the TRUE request that overflowed. See hermes-lcm engine
+                        # _should_force_overflow_recovery. (approx_tokens stays for the status display.)
+                        messages, active_system_prompt = agent._compress_context(
+                            messages, system_message,
+                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                            task_id=effective_task_id,
+                            # #100661: the provider proved the request does not fit.
+                            # Ignore the summary-failure cooldown for this ONE
+                            # attempt (bounded by max_compression_attempts) instead
+                            # of deferring every turn until the ladder lapses.
+                            bypass_cooldown=True,
+                        )
+                    except CompressionCommitFailedError:
+                        return _compression_commit_failed_result(
+                            agent, messages, api_call_count
+                        )
+                    except CompressionSnapshotStaleError:
+                        return _automatic_compression_stale_result()
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                         # #69870 lock-skip: the provider proved the request
                         # does not fit, but this compression pass no-oped only
@@ -9144,6 +9308,10 @@ def run_conversation(
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break
             
+        except CompressionCommitFailedError:
+            return _compression_commit_failed_result(agent, messages, api_call_count)
+        except CompressionSnapshotStaleError:
+            return _automatic_compression_stale_result()
         except Exception as e:
             # Count every escaped exception against the per-turn bound before
             # classification — permanent failures must terminate even when the

--- a/agent/transcript_repair.py
+++ b/agent/transcript_repair.py
@@ -81,11 +81,13 @@ def resolve_and_repair_transcript_batch(
                 decoded = decode_content_fn(raw_content)
                 if is_content_blank(decoded):
                     encoded = encode_content_fn(msg.get("content"))
-                    conn.execute(
-                        "UPDATE messages SET content = ? "
-                        "WHERE id = ? AND session_id = ? AND active = 1",
-                        (encoded, target_id, session_id),
-                    )
+                    if encoded != raw_content:
+                        conn.execute(
+                            "UPDATE messages SET content = ?, "
+                            "content_revision = COALESCE(content_revision, 0) + 1 "
+                            "WHERE id = ? AND session_id = ? AND active = 1",
+                            (encoded, target_id, session_id),
+                        )
                     if isinstance(msg, dict):
                         msg["_row_id"] = target_id
                 else:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -29,7 +29,10 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
+
+if TYPE_CHECKING:
+    from hermes_state import DurableTranscriptRevision
 
 from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE,
@@ -46,10 +49,6 @@ from agent.memory_provider import is_trivial_prompt
 from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
-)
-from hermes_state import (
-    DurableTranscriptRevision,
-    normalize_durable_transcript_revision,
 )
 
 logger = logging.getLogger(__name__)
@@ -362,6 +361,13 @@ def build_turn_context(
     ``conversation_loop`` module are passed in explicitly to keep this module
     free of an import cycle with ``agent.conversation_loop``.
     """
+    # Keep durable state lazy: gateway configuration imports this module during
+    # collection, before per-test/runtime ``HERMES_HOME`` redirects are active.
+    from hermes_state import (
+        DurableTranscriptRevision,
+        normalize_durable_transcript_revision,
+    )
+
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Mapping, Optional
 from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE,
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
+    CompressionProjectionUnverifiableError,
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
     recover_rotated_compression_session,
@@ -45,6 +46,10 @@ from agent.memory_provider import is_trivial_prompt
 from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
+)
+from hermes_state import (
+    DurableTranscriptRevision,
+    normalize_durable_transcript_revision,
 )
 
 logger = logging.getLogger(__name__)
@@ -325,6 +330,8 @@ class TurnContext:
     ext_prefetch_cache: str = ""
     # Turn-start preflight already proved an immediate retry ineffective.
     preflight_compression_blocked: bool = False
+    # Immutable fence for the durable active rows represented by this turn.
+    durable_transcript_revision: Optional[DurableTranscriptRevision] = None
 
 
 def build_turn_context(
@@ -347,6 +354,7 @@ def build_turn_context(
     set_current_write_origin,
     ra,
     moa_active: bool = False,
+    conversation_history_revision: Optional[Any] = None,
 ) -> TurnContext:
     """Run the once-per-turn setup and return the loop's input context.
 
@@ -363,6 +371,62 @@ def build_turn_context(
     recovered_history = recover_rotated_compression_session(agent)
     if recovered_history is not None:
         conversation_history = recovered_history
+        conversation_history_revision = getattr(
+            agent, "_durable_transcript_revision", None
+        )
+
+    # Compatibility callers historically supplied only a projected history.
+    # Never authenticate those bytes with the independent revision captured by
+    # AIAgent.__init__: an append can land between the caller's read and agent
+    # construction. Re-anchor history + revision in one SessionDB snapshot.
+    if (
+        recovered_history is None
+        and conversation_history is not None
+        and conversation_history_revision is None
+        and getattr(agent, "_session_db", None) is not None
+        and agent.session_id
+    ):
+        try:
+            reanchored = agent._session_db.get_messages_as_conversation(
+                agent.session_id,
+                with_revision=True,
+                repair_alternation=True,
+            )
+        except TypeError:
+            # SessionDB-like adapter predating the atomic (history, revision)
+            # contract. It cannot fence at all, so there is nothing to verify
+            # against — keep the caller's projection and the agent-owned fence,
+            # exactly as before this contract existed.
+            reanchored = None
+        except Exception as exc:
+            # The store supports the contract but the read failed: the supplied
+            # bytes stay unverifiable, so stop before any summarizer/provider.
+            raise CompressionProjectionUnverifiableError(agent.session_id) from exc
+        if isinstance(reanchored, tuple) and len(reanchored) == 2:
+            durable_history, durable_revision = reanchored
+            if isinstance(durable_revision, DurableTranscriptRevision):
+                if durable_revision.active_message_count:
+                    # Durable rows exist, so the caller's copy is a projection
+                    # of them and the durable set is the authority the fence
+                    # describes.
+                    conversation_history = durable_history
+                # Otherwise the session holds nothing to omit and the history
+                # is client-managed (e.g. the ``/responses`` stateless path,
+                # which supplies its own transcript against a fresh session
+                # id). Keep those bytes and pair them with the honest empty
+                # fence instead of erasing the turn.
+                conversation_history_revision = durable_revision
+
+    if conversation_history_revision is None:
+        durable_transcript_revision = getattr(
+            agent, "_durable_transcript_revision", None
+        )
+    else:
+        durable_transcript_revision = normalize_durable_transcript_revision(
+            conversation_history_revision,
+            session_id=agent.session_id,
+        )
+    agent._durable_transcript_revision = durable_transcript_revision
 
     # NOTE: the DB session row is created later, AFTER the system prompt is
     # restored/built (see _ensure_db_session() below the system-prompt block).
@@ -1208,11 +1272,32 @@ def build_turn_context(
                 _db = getattr(agent, "_session_db", None)
                 if _db is not None:
                     try:
-                        _db.set_latest_user_api_content(
-                            agent.session_id,
-                            _turn_user_msg.get("content"),
-                            _api_content,
-                        )
+                        # api_content is model-facing, so this write moves the
+                        # durable revision. Adopt the committed fence: leaving
+                        # the agent on its pre-backfill token would make its own
+                        # backfill look like a foreign write and abort the next
+                        # compression in this turn as spuriously stale.
+                        try:
+                            _backfilled = _db.set_latest_user_api_content(
+                                agent.session_id,
+                                _turn_user_msg.get("content"),
+                                _api_content,
+                                with_revision=True,
+                            )
+                        except TypeError:
+                            # Adapter without the revision-returning contract.
+                            _backfilled = _db.set_latest_user_api_content(
+                                agent.session_id,
+                                _turn_user_msg.get("content"),
+                                _api_content,
+                            )
+                        if (
+                            isinstance(_backfilled, tuple)
+                            and len(_backfilled) == 2
+                            and _backfilled[0]
+                            and isinstance(_backfilled[1], DurableTranscriptRevision)
+                        ):
+                            agent._durable_transcript_revision = _backfilled[1]
                     except Exception:
                         logger.warning(
                             "in-place compaction api_content backfill failed "
@@ -1264,4 +1349,7 @@ def build_turn_context(
         plugin_user_context=plugin_user_context,
         ext_prefetch_cache=ext_prefetch_cache,
         preflight_compression_blocked=_preflight_compression_blocked,
+        durable_transcript_revision=getattr(
+            agent, "_durable_transcript_revision", durable_transcript_revision
+        ),
     )

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -29,11 +29,15 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
+
+if TYPE_CHECKING:
+    from hermes_state import DurableTranscriptRevision
 
 from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE,
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
+    CompressionProjectionUnverifiableError,
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
     recover_rotated_compression_session,
@@ -567,6 +571,8 @@ class TurnContext:
     ext_prefetch_cache: str = ""
     # Turn-start preflight already proved an immediate retry ineffective.
     preflight_compression_blocked: bool = False
+    # Immutable fence for the durable active rows represented by this turn.
+    durable_transcript_revision: Optional[DurableTranscriptRevision] = None
 
 
 def build_turn_context(
@@ -590,6 +596,7 @@ def build_turn_context(
     set_current_write_origin,
     ra,
     moa_active: bool = False,
+    conversation_history_revision: Optional[Any] = None,
 ) -> TurnContext:
     """Run the once-per-turn setup and return the loop's input context.
 
@@ -597,6 +604,13 @@ def build_turn_context(
     ``conversation_loop`` module are passed in explicitly to keep this module
     free of an import cycle with ``agent.conversation_loop``.
     """
+    # Keep durable state lazy: gateway configuration imports this module during
+    # collection, before per-test/runtime ``HERMES_HOME`` redirects are active.
+    from hermes_state import (
+        DurableTranscriptRevision,
+        normalize_durable_transcript_revision,
+    )
+
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
 
@@ -606,6 +620,62 @@ def build_turn_context(
     recovered_history = recover_rotated_compression_session(agent)
     if recovered_history is not None:
         conversation_history = recovered_history
+        conversation_history_revision = getattr(
+            agent, "_durable_transcript_revision", None
+        )
+
+    # Compatibility callers historically supplied only a projected history.
+    # Never authenticate those bytes with the independent revision captured by
+    # AIAgent.__init__: an append can land between the caller's read and agent
+    # construction. Re-anchor history + revision in one SessionDB snapshot.
+    if (
+        recovered_history is None
+        and conversation_history is not None
+        and conversation_history_revision is None
+        and getattr(agent, "_session_db", None) is not None
+        and agent.session_id
+    ):
+        try:
+            reanchored = agent._session_db.get_messages_as_conversation(
+                agent.session_id,
+                with_revision=True,
+                repair_alternation=True,
+            )
+        except TypeError:
+            # SessionDB-like adapter predating the atomic (history, revision)
+            # contract. It cannot fence at all, so there is nothing to verify
+            # against — keep the caller's projection and the agent-owned fence,
+            # exactly as before this contract existed.
+            reanchored = None
+        except Exception as exc:
+            # The store supports the contract but the read failed: the supplied
+            # bytes stay unverifiable, so stop before any summarizer/provider.
+            raise CompressionProjectionUnverifiableError(agent.session_id) from exc
+        if isinstance(reanchored, tuple) and len(reanchored) == 2:
+            durable_history, durable_revision = reanchored
+            if isinstance(durable_revision, DurableTranscriptRevision):
+                if durable_revision.active_message_count:
+                    # Durable rows exist, so the caller's copy is a projection
+                    # of them and the durable set is the authority the fence
+                    # describes.
+                    conversation_history = durable_history
+                # Otherwise the session holds nothing to omit and the history
+                # is client-managed (e.g. the ``/responses`` stateless path,
+                # which supplies its own transcript against a fresh session
+                # id). Keep those bytes and pair them with the honest empty
+                # fence instead of erasing the turn.
+                conversation_history_revision = durable_revision
+
+    if conversation_history_revision is None:
+        durable_transcript_revision = getattr(
+            agent, "_durable_transcript_revision", None
+        )
+    else:
+        durable_transcript_revision = normalize_durable_transcript_revision(
+            conversation_history_revision,
+            session_id=agent.session_id,
+        )
+    agent._durable_transcript_revision = durable_transcript_revision
 
     # NOTE: the DB session row is created later, AFTER the system prompt is
     # restored/built (see _ensure_db_session() below the system-prompt block).
@@ -1640,11 +1710,32 @@ def build_turn_context(
                 _db = getattr(agent, "_session_db", None)
                 if _db is not None:
                     try:
-                        _db.set_latest_user_api_content(
-                            agent.session_id,
-                            _turn_user_msg.get("content"),
-                            _api_content,
-                        )
+                        # api_content is model-facing, so this write moves the
+                        # durable revision. Adopt the committed fence: leaving
+                        # the agent on its pre-backfill token would make its own
+                        # backfill look like a foreign write and abort the next
+                        # compression in this turn as spuriously stale.
+                        try:
+                            _backfilled = _db.set_latest_user_api_content(
+                                agent.session_id,
+                                _turn_user_msg.get("content"),
+                                _api_content,
+                                with_revision=True,
+                            )
+                        except TypeError:
+                            # Adapter without the revision-returning contract.
+                            _backfilled = _db.set_latest_user_api_content(
+                                agent.session_id,
+                                _turn_user_msg.get("content"),
+                                _api_content,
+                            )
+                        if (
+                            isinstance(_backfilled, tuple)
+                            and len(_backfilled) == 2
+                            and _backfilled[0]
+                            and isinstance(_backfilled[1], DurableTranscriptRevision)
+                        ):
+                            agent._durable_transcript_revision = _backfilled[1]
                     except Exception:
                         logger.warning(
                             "in-place compaction api_content backfill failed "
@@ -1706,4 +1797,7 @@ def build_turn_context(
         plugin_user_context=plugin_user_context,
         ext_prefetch_cache=ext_prefetch_cache,
         preflight_compression_blocked=_preflight_compression_blocked,
+        durable_transcript_revision=getattr(
+            agent, "_durable_transcript_revision", durable_transcript_revision
+        ),
     )

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1143,14 +1143,20 @@ class RecallGuardMiddleware(InboundMiddleware):
             for _ in range(30):
                 await asyncio.sleep(0.5)
                 try:
-                    transcript = store.load_transcript(sid)
+                    transcript, revision = store.load_transcript(
+                        sid, with_revision=True
+                    )
                 except Exception:
                     continue
                 for entry in transcript:
                     if entry.get("role") == "user" and entry.get("content") == recalled_text:
                         entry["content"] = cls._REDACTED
                         try:
-                            store.rewrite_transcript(sid, transcript)
+                            store.rewrite_transcript(
+                                sid,
+                                transcript,
+                                expected_revision=revision,
+                            )
                             logger.info("[%s] Recall redact: session %s", adapter.name, session_key[:30])
                         except Exception as exc:
                             logger.warning("[%s] Recall redact failed: %s", adapter.name, exc)
@@ -1182,7 +1188,9 @@ class RecallGuardMiddleware(InboundMiddleware):
         # for any message that was observed with one — Branch A1 (exact id
         # match) is the canonical path again.
         try:
-            transcript = store.load_transcript(sid)
+            transcript, revision = store.load_transcript(
+                sid, with_revision=True
+            )
         except Exception as exc:
             logger.warning("[%s] Recall: failed to load transcript: %s", adapter.name, exc)
             return
@@ -1210,7 +1218,11 @@ class RecallGuardMiddleware(InboundMiddleware):
         if target is not None:
             target["content"] = cls._REDACTED
             try:
-                store.rewrite_transcript(sid, transcript)
+                store.rewrite_transcript(
+                    sid,
+                    transcript,
+                    expected_revision=revision,
+                )
                 logger.info("[%s] Recall: redacted msg_id=%s (%s)", adapter.name, recalled_id, branch_label)
             except Exception as exc:
                 logger.warning("[%s] Recall: rewrite_transcript failed: %s", adapter.name, exc)

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1143,7 +1143,9 @@ class RecallGuardMiddleware(InboundMiddleware):
             for _ in range(30):
                 await asyncio.sleep(0.5)
                 try:
-                    transcript = store.load_transcript(sid)
+                    transcript, revision = store.load_transcript(
+                        sid, with_revision=True
+                    )
                 except TranscriptReadError as exc:
                     # No readable rows means nothing to redact; polling on
                     # would just re-log the same failure (#100788).
@@ -1158,7 +1160,12 @@ class RecallGuardMiddleware(InboundMiddleware):
                     if entry.get("role") == "user" and entry.get("content") == recalled_text:
                         entry["content"] = cls._REDACTED
                         try:
-                            store.rewrite_transcript(sid, transcript, active_only=True)
+                            store.rewrite_transcript(
+                                sid,
+                                transcript,
+                                active_only=True,
+                                expected_revision=revision,
+                            )
                             logger.info("[%s] Recall redact: session %s", adapter.name, session_key[:30])
                         except Exception as exc:
                             logger.warning("[%s] Recall redact failed: %s", adapter.name, exc)
@@ -1190,7 +1197,9 @@ class RecallGuardMiddleware(InboundMiddleware):
         # for any message that was observed with one — Branch A1 (exact id
         # match) is the canonical path again.
         try:
-            transcript = store.load_transcript(sid)
+            transcript, revision = store.load_transcript(
+                sid, with_revision=True
+            )
         except TranscriptReadError as exc:
             # Not an empty transcript — the rows are unreadable, so recall has
             # nothing to match against (#100788).
@@ -1223,7 +1232,12 @@ class RecallGuardMiddleware(InboundMiddleware):
         if target is not None:
             target["content"] = cls._REDACTED
             try:
-                store.rewrite_transcript(sid, transcript, active_only=True)
+                store.rewrite_transcript(
+                    sid,
+                    transcript,
+                    active_only=True,
+                    expected_revision=revision,
+                )
                 logger.info("[%s] Recall: redacted msg_id=%s (%s)", adapter.name, recalled_id, branch_label)
             except Exception as exc:
                 logger.warning("[%s] Recall: rewrite_transcript failed: %s", adapter.name, exc)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1347,6 +1347,13 @@ def _wrap_current_message_with_observed_context(message: Any, observed_context: 
     return message
 
 
+def _unpack_transcript_snapshot(value):
+    """Accept revision-aware stores and legacy/test transcript loaders."""
+    if isinstance(value, tuple) and len(value) == 2:
+        return value
+    return value, None
+
+
 def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     """Return the ``timestamp`` of the last usable transcript row, if any.
 
@@ -4995,6 +5002,14 @@ class TurnRunner:
                 agent_history = strip_stale_dangerous_confirmations(
                     _selected, now=time.time()
                 )
+                # The selected cached projection is newer than the transcript
+                # loaded at turn start. Fence it with the cached agent's own
+                # durable revision instead of reusing the stale load token.
+                _live_revision = getattr(
+                    agent, "_durable_transcript_revision", None
+                )
+                if getattr(_live_revision, "session_id", None) == ctx.session_id:
+                    ctx.history_revision = _live_revision
         
         # Collect MEDIA paths already in history so we can exclude them
         # from the current turn's extraction. This is compression-safe:
@@ -5289,6 +5304,10 @@ class TurnRunner:
                 "conversation_history": agent_history,
                 "task_id": ctx.session_id,
             }
+            if ctx.history_revision is not None:
+                _conversation_kwargs["conversation_history_revision"] = (
+                    ctx.history_revision
+                )
             if _persist_user_message_override is not None:
                 _conversation_kwargs["persist_user_message"] = _persist_user_message_override
             elif observed_group_context:
@@ -16450,7 +16469,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _lease_state.lease_generation = run_generation
 
         # Load conversation history from transcript
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        _loaded_transcript = await self.async_session_store.load_transcript(
+            session_entry.session_id,
+            with_revision=True,
+        )
+        history, history_revision = _unpack_transcript_snapshot(_loaded_transcript)
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -17033,7 +17056,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     if _hyg_rotated:
                                         # Reset stored token count — transcript rewritten
                                         session_entry.last_prompt_tokens = 0
-                                        history = _compressed
+                                        _loaded_transcript = (
+                                            await self.async_session_store.load_transcript(
+                                                session_entry.session_id,
+                                                with_revision=True,
+                                            )
+                                        )
+                                        history, history_revision = _unpack_transcript_snapshot(
+                                            _loaded_transcript
+                                        )
                                         _new_count = len(_compressed)
                                         _new_tokens = estimate_messages_tokens_rough(
                                             _compressed
@@ -17043,7 +17074,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         # compacted transcript inside _compress_context.
                                         # Reset counts to match the new active set.
                                         session_entry.last_prompt_tokens = 0
-                                        history = _compressed
+                                        _loaded_transcript = (
+                                            await self.async_session_store.load_transcript(
+                                                session_entry.session_id,
+                                                with_revision=True,
+                                            )
+                                        )
+                                        history, history_revision = _unpack_transcript_snapshot(
+                                            _loaded_transcript
+                                        )
                                         _new_count = len(_compressed)
                                         _new_tokens = estimate_messages_tokens_rough(
                                             _compressed
@@ -17370,6 +17409,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message=message_text,
                 context_prompt=context_prompt,
                 history=history,
+                history_revision=history_revision,
                 source=source,
                 session_id=_run_start_session_id,
                 session_key=session_key,
@@ -23848,6 +23888,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         message_type: Optional[str] = None,
+        history_revision: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -23867,6 +23908,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
+                history_revision=history_revision,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -23879,6 +23921,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
+                history_revision=history_revision,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -24001,6 +24044,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         message_type: Optional[str] = None,
+        history_revision: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -24275,6 +24319,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _voice_ack_guild=_voice_ack_guild,
             _voice_ack_loop=_voice_ack_loop,
             history=history,
+            history_revision=history_revision,
             context_prompt=context_prompt,
             channel_prompt=channel_prompt,
             session_id=session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1988,6 +1988,13 @@ def _wrap_current_message_with_observed_context(message: Any, observed_context: 
     return message
 
 
+def _unpack_transcript_snapshot(value):
+    """Accept revision-aware stores and legacy/test transcript loaders."""
+    if isinstance(value, tuple) and len(value) == 2:
+        return value
+    return value, None
+
+
 def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     """Return the ``timestamp`` of the last usable transcript row, if any.
 
@@ -6783,6 +6790,14 @@ class TurnRunner:
                 agent_history = strip_stale_dangerous_confirmations(
                     _selected, now=time.time()
                 )
+                # The selected cached projection is newer than the transcript
+                # loaded at turn start. Fence it with the cached agent's own
+                # durable revision instead of reusing the stale load token.
+                _live_revision = getattr(
+                    agent, "_durable_transcript_revision", None
+                )
+                if getattr(_live_revision, "session_id", None) == ctx.session_id:
+                    ctx.history_revision = _live_revision
         
         # Collect MEDIA paths already in history so we can exclude them
         # from the current turn's extraction. This is compression-safe:
@@ -7100,6 +7115,10 @@ class TurnRunner:
                 "conversation_history": agent_history,
                 "task_id": ctx.session_id,
             }
+            if ctx.history_revision is not None:
+                _conversation_kwargs["conversation_history_revision"] = (
+                    ctx.history_revision
+                )
             if _persist_user_message_override is not None:
                 _conversation_kwargs["persist_user_message"] = _persist_user_message_override
             elif observed_group_context:
@@ -21622,8 +21641,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # the broad cleanup finally below, so restore task-local context here;
         # the outer dispatch still clears the durable marker and turn lease.
         try:
-            history = await self.async_session_store.load_transcript(
-                session_entry.session_id
+            _loaded_transcript = await self.async_session_store.load_transcript(
+                session_entry.session_id,
+                with_revision=True,
             )
         except TranscriptReadError:
             self._clear_session_env(_session_env_tokens)
@@ -21633,6 +21653,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "state.db, then resend after it is healthy. Use /reset only "
                 "if you intentionally want to start a new conversation."
             )
+        history, history_revision = _unpack_transcript_snapshot(_loaded_transcript)
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -22786,7 +22807,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     if _hyg_rotated:
                                         # Reset stored token count — transcript rewritten
                                         session_entry.last_prompt_tokens = 0
-                                        history = _compressed
+                                        _loaded_transcript = (
+                                            await self.async_session_store.load_transcript(
+                                                session_entry.session_id,
+                                                with_revision=True,
+                                            )
+                                        )
+                                        history, history_revision = _unpack_transcript_snapshot(
+                                            _loaded_transcript
+                                        )
                                         _new_count = len(_compressed)
                                         _new_tokens = estimate_messages_tokens_rough(
                                             _compressed
@@ -22796,7 +22825,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         # compacted transcript inside _compress_context.
                                         # Reset counts to match the new active set.
                                         session_entry.last_prompt_tokens = 0
-                                        history = _compressed
+                                        _loaded_transcript = (
+                                            await self.async_session_store.load_transcript(
+                                                session_entry.session_id,
+                                                with_revision=True,
+                                            )
+                                        )
+                                        history, history_revision = _unpack_transcript_snapshot(
+                                            _loaded_transcript
+                                        )
                                         _new_count = len(_compressed)
                                         _new_tokens = estimate_messages_tokens_rough(
                                             _compressed
@@ -23189,6 +23226,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message=message_text,
                 context_prompt=context_prompt,
                 history=history,
+                history_revision=history_revision,
                 source=source,
                 session_id=_run_start_session_id,
                 session_key=session_key,
@@ -31150,6 +31188,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        history_revision: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -31171,6 +31210,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
+                history_revision=history_revision,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -31185,6 +31225,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
+                history_revision=history_revision,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -31329,6 +31370,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        history_revision: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -31627,6 +31669,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _voice_ack_guild=_voice_ack_guild,
             _voice_ack_loop=_voice_ack_loop,
             history=history,
+            history_revision=history_revision,
             context_prompt=context_prompt,
             channel_prompt=channel_prompt,
             session_id=session_id,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -4036,30 +4036,19 @@ class SessionStore:
                     return
 
                 if isinstance(exc, CompressionSessionClosedError):
-                    # Resolve the full continuation chain via the canonical
-                    # transitive API — a depth-1 live-child lookup misses
-                    # lineages with >=2 compression hops (root -> mid -> tip).
-                    # ``get_compression_tip`` returns the input id when no
-                    # continuation exists; adopt only a different, still-live
-                    # tip, otherwise fail closed as before.
-                    #
-                    # The parent's id IS published in the routing index, so
-                    # its owner is already proven; the continuation's id is
-                    # not published until after the child write succeeds
-                    # (below), so resolving the child by id would miss and
-                    # fall back to the ambient store. Carry the proven handle
-                    # instead of re-deriving it from an id nothing points at
-                    # yet. ``_owner_db`` cannot be None here — the parent
-                    # append above just reached a real DB to raise this.
+                    # Resolve through the DB that owns the stale parent. The
+                    # conservative resolver validates the complete chain and
+                    # returns only its unique live canonical leaf.
                     _owner_key = self._owner_key_for_session_id(session_id)
-                    _owner_db = self._db_for_session_id(session_id)
+                    _owner_db: Any = self._db_for_session_id(session_id)
                     child_id = ""
                     if _owner_db is not None:
-                        tip = _owner_db.get_compression_tip(session_id)
-                        if tip and tip != session_id:
-                            tip_row = _owner_db.get_session(tip)
-                            if tip_row is not None and tip_row.get("ended_at") is None:
-                                child_id = str(tip)
+                        child = _owner_db.find_live_compression_child(session_id)
+                        child_id = (
+                            str(child["id"])
+                            if child and child.get("id")
+                            else ""
+                        )
                     if child_id:
                         # Record the child's owner BEFORE writing to it. The
                         # reroute and the _entries update are published only
@@ -4074,11 +4063,24 @@ class SessionStore:
                                 _hints = {}
                                 self._session_owner_hints = _hints
                             _hints[child_id] = _owner_key
+                        reroute_succeeded = False
                         try:
                             self._append_transcript_message(child_id, msg)
                         except Exception as reroute_exc:
                             exc = reroute_exc
+                            if (
+                                self._is_fts_corruption_error(reroute_exc)
+                                and self._rebuild_fts_once()
+                            ):
+                                try:
+                                    self._append_transcript_message(child_id, msg)
+                                except Exception as retry_exc:
+                                    exc = retry_exc
+                                else:
+                                    reroute_succeeded = True
                         else:
+                            reroute_succeeded = True
+                        if reroute_succeeded:
                             with self._transcript_retry_lock:
                                 if pending and pending[0] is msg:
                                     pending.pop(0)
@@ -4142,12 +4144,19 @@ class SessionStore:
                     except Exception as retry_exc:
                         exc = retry_exc
                     else:
+                        queue_empty = False
                         with self._transcript_retry_lock:
                             if pending and pending[0] is msg:
                                 pending.pop(0)
                             if not pending:
                                 self._dirty_transcripts.pop(queue_session_id, None)
                                 self._transcript_append_failures.pop(session_id, None)
+                                queue_empty = True
+                            else:
+                                msg = pending[0]
+                        if queue_empty:
+                            self._drain_spooled_drops(session_id)
+                            return
                         continue
                 with self._transcript_retry_lock:
                     failures = self._transcript_append_failures.get(session_id, 0) + 1

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3354,7 +3354,13 @@ class SessionStore:
             logger.debug("has_platform_message_id lookup failed", exc_info=True)
             return False
 
-    def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> bool:
+    def rewrite_transcript(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        expected_revision=None,
+    ) -> bool:
         """Replace the entire transcript for a session with new messages.
 
         Used by /retry, /undo, and /compress to persist modified conversation
@@ -3371,20 +3377,46 @@ class SessionStore:
             return True
         self._clear_dirty_transcript(session_id)
         try:
-            self._db.replace_messages(session_id, messages)
+            if expected_revision is None:
+                # Preserve compatibility with legacy SessionDB-like adapters
+                # whose replace_messages implementation accepts two args.
+                self._db.replace_messages(session_id, messages)
+            else:
+                self._db.replace_messages(
+                    session_id,
+                    messages,
+                    expected_revision=expected_revision,
+                )
             return True
         except Exception as e:
+            from hermes_state import CompressionTranscriptRevisionError
+
+            if isinstance(e, CompressionTranscriptRevisionError):
+                raise
             logger.debug("Failed to rewrite transcript in DB: %s", e)
             return False
 
-    def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
+    def load_transcript(
+        self,
+        session_id: str,
+        *,
+        with_revision: bool = False,
+    ):
         """Load all messages from a session's transcript.
 
         state.db is the canonical store. The legacy JSONL fallback was removed
         in spec 002 — pre-DB sessions on existing disks have already been
         migrated (their DB row holds the full message history).
+
+        ``with_revision=True`` returns ``(messages, revision)`` captured in one
+        read. When the store is unavailable the revision degrades to ``None``
+        rather than raising: an unverifiable projection must fail closed at the
+        agent chokepoint (which re-anchors, or returns
+        ``compression_projection_unverifiable``), not crash the inbound turn.
         """
         if not self._db:
+            if with_revision:
+                return [], None
             return []
         try:
             # repair_alternation: this load feeds LIVE REPLAY. A durable
@@ -3392,10 +3424,14 @@ class SessionStore:
             # would otherwise re-trigger the pre-request repair on every
             # request forever — heal it once at the restore boundary.
             return self._db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                session_id,
+                repair_alternation=True,
+                with_revision=with_revision,
             )
         except Exception as e:
             logger.debug("Could not load messages from DB: %s", e)
+            if with_revision:
+                return [], None
             return []
 
     def rewind_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:
@@ -3415,8 +3451,24 @@ class SessionStore:
         self._clear_dirty_transcript(session_id)
         if n < 1:
             n = 1
+        from hermes_state import CompressionTranscriptRevisionError
+
         try:
-            recents = self._db.list_recent_user_messages(session_id, limit=max(n, 10))
+            # One read pairs the target list with the revision it was taken
+            # from, so a write landing before the rewind is refused instead of
+            # silently truncating a transcript the caller never saw.
+            try:
+                recents, revision = self._db.list_recent_user_messages(
+                    session_id,
+                    limit=max(n, 10),
+                    with_revision=True,
+                )
+            except TypeError:
+                # Legacy SessionDB-like adapter without the atomic contract.
+                recents, revision = (
+                    self._db.list_recent_user_messages(session_id, limit=max(n, 10)),
+                    None,
+                )
         except Exception as e:
             logger.debug("rewind_session: failed to list user messages: %s", e)
             return None
@@ -3425,7 +3477,16 @@ class SessionStore:
         target_idx = min(n - 1, len(recents) - 1)
         target_id = recents[target_idx]["id"]
         try:
-            result = self._db.rewind_to_message(session_id, target_id)
+            if revision is None:
+                result = self._db.rewind_to_message(session_id, target_id)
+            else:
+                result = self._db.rewind_to_message(
+                    session_id,
+                    target_id,
+                    expected_revision=revision,
+                )
+        except CompressionTranscriptRevisionError:
+            raise
         except ValueError as e:
             logger.debug("rewind_session: %s", e)
             return None

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -4352,6 +4352,8 @@ class SessionStore:
         messages: List[Dict[str, Any]],
         active_only: bool = False,
         reject_active_turn_lease: bool = False,
+        *,
+        expected_revision=None,
     ) -> bool:
         """Replace the entire transcript for a session with new messages.
 
@@ -4381,19 +4383,31 @@ class SessionStore:
             return True
         with self._get_transcript_drain_lock():
             try:
+                replace_kwargs = {
+                    "active_only": active_only,
+                    "reject_active_turn_lease": reject_active_turn_lease,
+                }
+                if expected_revision is not None:
+                    replace_kwargs["expected_revision"] = expected_revision
                 self._db_for_session_id(session_id).replace_messages(
-                    session_id,
-                    messages,
-                    active_only=active_only,
-                    reject_active_turn_lease=reject_active_turn_lease,
+                    session_id, messages, **replace_kwargs
                 )
             except Exception as e:
+                from hermes_state import CompressionTranscriptRevisionError
+
+                if isinstance(e, CompressionTranscriptRevisionError):
+                    raise
                 logger.debug("Failed to rewrite transcript in DB: %s", e)
                 return False
             self._clear_dirty_transcript(session_id)
             return True
 
-    def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
+    def load_transcript(
+        self,
+        session_id: str,
+        *,
+        with_revision: bool = False,
+    ):
         """Load all messages from a session's transcript.
 
         state.db is the canonical store. The legacy JSONL fallback was removed
@@ -4406,8 +4420,18 @@ class SessionStore:
         chain while reads queried the stale id directly — the transcript
         "vanished" (disk=0) even though every message sat healthy under the
         child session.
+
+        ``with_revision=True`` returns ``(messages, revision)`` captured in one
+        read. When no store is configured the revision degrades to ``None``
+        rather than raising: an unverifiable projection must fail closed at the
+        agent chokepoint (which re-anchors, or returns
+        ``compression_projection_unverifiable``), not crash the inbound turn.
+        A store that exists but cannot be read still raises
+        :class:`TranscriptReadError` (#100788) in both shapes.
         """
         if not self._db_for_session_id(session_id):
+            if with_revision:
+                return [], None
             return []
         # Follow the write-side reroute chain (cycle-guarded, same shape as
         # append_to_transcript).
@@ -4429,7 +4453,14 @@ class SessionStore:
             # user;user wedge (e.g. a turn that persisted no assistant row)
             # would otherwise re-trigger the pre-request repair on every
             # request forever — heal it once at the restore boundary.
-            return self._db_for_session_id(session_id).get_messages_as_conversation(
+            session_db = self._db_for_session_id(session_id)
+            if with_revision:
+                return session_db.get_messages_as_conversation(
+                    session_id,
+                    repair_alternation=True,
+                    with_revision=True,
+                )
+            return session_db.get_messages_as_conversation(
                 session_id, repair_alternation=True
             )
         except Exception as e:
@@ -4471,18 +4502,74 @@ class SessionStore:
         with self._get_transcript_drain_lock():
             if n < 1:
                 n = 1
+            session_db = self._db_for_session_id(session_id)
+            if not all(
+                hasattr(session_db, name)
+                for name in (
+                    "get_active_message_ids",
+                    "get_messages_as_conversation",
+                )
+            ):
+                # Compatibility path for pre-composite SessionDB adapters.
+                try:
+                    try:
+                        recents, revision = session_db.list_recent_user_messages(
+                            session_id,
+                            limit=max(n, 10),
+                            with_revision=True,
+                        )
+                    except TypeError:
+                        recents = session_db.list_recent_user_messages(
+                            session_id, limit=max(n, 10)
+                        )
+                        revision = None
+                    if not recents:
+                        return None
+                    target_idx = min(n - 1, len(recents) - 1)
+                    target_id = recents[target_idx]["id"]
+                    if revision is None:
+                        result = session_db.rewind_to_message(session_id, target_id)
+                    else:
+                        result = session_db.rewind_to_message(
+                            session_id,
+                            target_id,
+                            expected_revision=revision,
+                        )
+                except Exception as e:
+                    logger.debug("rewind_session: legacy adapter failed: %s", e)
+                    return None
+                self._clear_dirty_transcript(session_id)
+                target_msg = result.get("target_message") or {}
+                target_text = target_msg.get("content") or ""
+                return {
+                    "rewound_count": result.get("rewound_count", 0),
+                    "turns_undone": target_idx + 1,
+                    "target_text": target_text
+                    if isinstance(target_text, str)
+                    else "",
+                }
             from agent.context_compressor import (
                 retryable_user_text,
                 split_user_originated_turn,
                 user_originated_turn_view,
             )
+            from hermes_state import CompressionTranscriptRevisionError
 
             try:
-                expected_active_ids = self._db_for_session_id(session_id).get_active_message_ids(session_id)
-                durable = self._db_for_session_id(session_id).get_messages_as_conversation(
-                    session_id,
-                    include_row_ids=True,
-                )
+                expected_active_ids = session_db.get_active_message_ids(session_id)
+                try:
+                    durable, revision = session_db.get_messages_as_conversation(
+                        session_id,
+                        include_row_ids=True,
+                        with_revision=True,
+                    )
+                except TypeError:
+                    # Legacy SessionDB-like adapter without the atomic contract.
+                    durable = session_db.get_messages_as_conversation(
+                        session_id,
+                        include_row_ids=True,
+                    )
+                    revision = None
                 user_indices = [
                     index
                     for index, message in enumerate(durable)
@@ -4508,13 +4595,19 @@ class SessionStore:
                 # so /retry can explain why the selected carrier is unsafe.
                 target_text = retryable_user_text(target_view.get("content"))
             try:
+                rewind_kwargs = {
+                    "preserve_compaction_handoff": handoff is not None,
+                    "expected_active_ids": expected_active_ids,
+                    "expected_target_content": target_view.get("content"),
+                }
+                if revision is not None:
+                    rewind_kwargs["expected_revision"] = revision
                 result = self._db_for_session_id(session_id).rewind_to_message(
-                    session_id,
-                    target_id,
-                    preserve_compaction_handoff=handoff is not None,
-                    expected_active_ids=expected_active_ids,
-                    expected_target_content=target_view.get("content"),
+                    session_id, target_id, **rewind_kwargs
                 )
+            except CompressionTranscriptRevisionError as e:
+                logger.debug("rewind_session: stale durable revision: %s", e)
+                return None
             except ValueError as e:
                 logger.debug("rewind_session: %s", e)
                 return None

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -79,6 +79,7 @@ class TurnContext:
 
     # --- turn parameters / config snapshots (read-only in run_sync) -------
     history: Any = None
+    history_revision: Any = None
     context_prompt: Optional[str] = None
     channel_prompt: Optional[str] = None
     session_id: Optional[str] = None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -17,6 +17,8 @@ Key design decisions:
 import asyncio
 import atexit
 import errno
+import contextlib
+import hashlib
 import json
 import logging
 import os
@@ -27,7 +29,9 @@ import sys
 import threading
 import time
 from collections import deque
+from collections.abc import Mapping
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -83,6 +87,137 @@ except ImportError:  # pragma: no cover - stripped/scaffold installs only
 logger = logging.getLogger(__name__)
 
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
+
+
+@dataclass(frozen=True)
+class DurableTranscriptRevision:
+    """Immutable identity for one session segment's active durable rows."""
+
+    session_id: str
+    active_message_count: int
+    max_active_message_id: int
+    active_rows_digest: str = ""
+
+
+# The model-facing bytes an in-place UPDATE can rewrite without moving
+# ``(active_message_count, max_active_message_id)``.
+#
+# Every other mutator either changes cardinality (append, replace, rewind,
+# restore, archive — all of which flip ``active`` or insert rows with fresh
+# AUTOINCREMENT ids) or touches presentation-only sidecars. Today
+# ``set_latest_user_api_content`` is the single in-place writer of a
+# model-facing column, so hashing ``(id, api_content)`` closes the whole hole
+# while keeping the fence proportional to the row count rather than to the
+# transcript's bytes — a full-content digest costs ~100 ms per read on a
+# 2 000-row session and runs inside the SQLite writer transaction on every
+# durable append.
+#
+# ``display_kind`` / ``display_metadata`` are deliberately absent: they are
+# stamped after every gateway/CLI turn by
+# ``set_latest_matching_message_display_kind`` outside any compression lease,
+# and the model never sees them, so fencing on them would abort the next
+# compression as spuriously stale.
+#
+# ANY new in-place ``UPDATE messages SET`` on a model-facing column must be
+# added to ``_DURABLE_REVISION_MUTABLE_COLUMNS`` (and take
+# ``compression_lock_holder``), or it will slip past the compression fence.
+_DURABLE_REVISION_MUTABLE_COLUMNS = ("api_content",)
+_DURABLE_REVISION_ROW_COLUMNS = ("id",) + _DURABLE_REVISION_MUTABLE_COLUMNS
+
+
+def _active_rows_digest(rows) -> str:
+    """Fingerprint the in-place-mutable model-facing bytes of active rows.
+
+    Keyed by row id and taken in insertion order. Rows whose mutable columns
+    are all unset contribute nothing, so the ordinary transcript — no
+    ``api_content`` sidecar anywhere — folds to ``""`` without hashing a byte;
+    stamping or clearing a sidecar still moves the fence.
+    """
+    digest = hashlib.sha256()
+    stamped = False
+    for row in rows:
+        keys = row.keys()
+        payload = [
+            row[column] if column in keys else None
+            for column in _DURABLE_REVISION_MUTABLE_COLUMNS
+        ]
+        if all(value is None for value in payload):
+            continue
+        stamped = True
+        digest.update(
+            json.dumps(
+                [row["id"], *payload],
+                ensure_ascii=False,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8", errors="surrogatepass")
+        )
+        digest.update(b"\n")
+    return digest.hexdigest() if stamped else ""
+
+
+def _durable_revision_from_rows(
+    session_id: str, rows
+) -> DurableTranscriptRevision:
+    """Derive a revision from selected rows without a second SQLite read."""
+    current_active_rows = [
+        row
+        for row in rows
+        if row["session_id"] == session_id and row["active"] == 1
+    ]
+    return DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=len(current_active_rows),
+        max_active_message_id=max(
+            (int(row["id"]) for row in current_active_rows),
+            default=0,
+        ),
+        active_rows_digest=_active_rows_digest(current_active_rows),
+    )
+
+
+def _active_message_revision_in_transaction(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> DurableTranscriptRevision:
+    """Read one session's active-row revision on the caller's transaction."""
+    rows = conn.execute(
+        "SELECT " + ", ".join(_DURABLE_REVISION_ROW_COLUMNS) + " "
+        "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
+        (session_id,),
+    ).fetchall()
+    return DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=len(rows),
+        max_active_message_id=max((int(row["id"]) for row in rows), default=0),
+        active_rows_digest=_active_rows_digest(rows),
+    )
+
+
+def normalize_durable_transcript_revision(
+    value: Any,
+    *,
+    session_id: str,
+) -> Optional[DurableTranscriptRevision]:
+    """Normalize an internal transport mapping into an immutable revision."""
+    if value is None:
+        return None
+    if isinstance(value, DurableTranscriptRevision):
+        revision = value
+    elif isinstance(value, Mapping):
+        revision = DurableTranscriptRevision(
+            session_id=str(value["session_id"]),
+            active_message_count=int(value["active_message_count"]),
+            max_active_message_id=int(value["max_active_message_id"]),
+            active_rows_digest=str(value.get("active_rows_digest", "")),
+        )
+    else:
+        raise TypeError("conversation_history_revision must be a mapping")
+    if revision.session_id != session_id:
+        raise ValueError("conversation_history_revision session_id mismatch")
+    if revision.active_message_count < 0 or revision.max_active_message_id < 0:
+        raise ValueError("conversation_history_revision values must be non-negative")
+    return revision
 
 
 def _compression_lock_holder_process_is_dead(holder: str) -> bool:
@@ -236,7 +371,7 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
 
 T = TypeVar("T")
 
-DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+DEFAULT_DB_PATH = Path(get_hermes_home()) / "state.db"
 
 # Import-time snapshot used by _default_db_path() to detect a deliberately
 # re-pointed DEFAULT_DB_PATH (tests monkeypatch the constant directly).
@@ -1577,6 +1712,60 @@ class SessionCompressionInProgressError(CompressionSessionBusyError):
     Subclassing keeps every existing ``except CompressionSessionBusyError``
     handler working unchanged.
     """
+class CompressionTranscriptRevisionError(RuntimeError):
+    """A compression commit no longer matches its durable transcript snapshot."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        expected_revision: DurableTranscriptRevision,
+        observed_revision: DurableTranscriptRevision,
+    ) -> None:
+        self.session_id = session_id
+        self.expected_revision = expected_revision
+        self.observed_revision = observed_revision
+        super().__init__(
+            f"Durable transcript revision changed for session {session_id!r} "
+            "before compression commit"
+        )
+
+
+def _assert_compression_write_allowed(
+    conn: sqlite3.Connection,
+    session_id: str,
+    compression_lock_holder: Optional[str] = None,
+) -> None:
+    """Reject a transcript mutation while another writer owns a live lease."""
+    lock_row = conn.execute(
+        "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
+        (session_id,),
+    ).fetchone()
+    if (
+        lock_row is not None
+        and float(lock_row["expires_at"]) > time.time()
+        and lock_row["holder"] != compression_lock_holder
+    ):
+        raise CompressionSessionBusyError(
+            f"Session {session_id!r} is being compressed by another writer"
+        )
+
+
+def _assert_expected_active_revision(
+    conn: sqlite3.Connection,
+    session_id: str,
+    expected_revision: Optional[DurableTranscriptRevision],
+) -> None:
+    """Fail a delayed rewrite whose active durable snapshot has moved on."""
+    if expected_revision is None:
+        return
+    observed_revision = _active_message_revision_in_transaction(conn, session_id)
+    if observed_revision != expected_revision:
+        raise CompressionTranscriptRevisionError(
+            session_id=session_id,
+            expected_revision=expected_revision,
+            observed_revision=observed_revision,
+        )
 
 
 def _connect_tracked_db(path, tracking_path=None, **kwargs):
@@ -3390,6 +3579,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         profile_name: str = None,
         compression_lock_holder: str = None,
         require_compression_lease: bool = True,
+        expected_parent_revision: Optional[DurableTranscriptRevision] = None,
     ) -> None:
         """Atomically close a parent and publish its durable compression child.
 
@@ -3411,6 +3601,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 raise CompressionSessionBusyError(
                     f"Compression lease lost before publication: {parent_session_id}"
                 )
+            if expected_parent_revision is not None:
+                observed_revision = _active_message_revision_in_transaction(
+                    conn, parent_session_id
+                )
+                if observed_revision != expected_parent_revision:
+                    raise CompressionTranscriptRevisionError(
+                        session_id=parent_session_id,
+                        expected_revision=expected_parent_revision,
+                        observed_revision=observed_revision,
+                    )
             parent = conn.execute(
                 """SELECT ended_at, cwd, git_branch, git_repo_root,
                           user_id, session_key, chat_id, chat_type,
@@ -6000,9 +6200,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         display_kind: Optional[str] = None,
         display_metadata: Optional[Dict[str, Any]] = None,
         compression_lock_holder: Optional[str] = None,
-    ) -> int:
+        with_revision: bool = False,
+    ):
         """
-        Append a message to a session. Returns the message row ID.
+        Append a message to a session. Returns the message row ID, or
+        ``(message_id, revision)`` when ``with_revision=True`` — the durable
+        fence read inside the same transaction as the insert, so the appending
+        writer can advance its own snapshot without a racy second read.
 
         Also increments the session's message_count (and tool_call_count
         if role is 'tool' or tool_calls is present).
@@ -6131,6 +6335,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 conn.execute(
                     "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
                     (session_id,),
+                )
+            if with_revision:
+                return msg_id, _active_message_revision_in_transaction(
+                    conn, session_id
                 )
             return msg_id
 
@@ -6487,6 +6695,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         messages: List[Dict[str, Any]],
         active_only: bool = False,
+        *,
+        compression_lock_holder: Optional[str] = None,
+        expected_revision: Optional[DurableTranscriptRevision] = None,
     ) -> None:
         """Atomically replace the stored messages for a session.
 
@@ -6512,6 +6723,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         active_clause = " AND active = 1" if active_only else ""
 
         def _do(conn):
+            _assert_compression_write_allowed(
+                conn, session_id, compression_lock_holder
+            )
+            _assert_expected_active_revision(conn, session_id, expected_revision)
             session = conn.execute(
                 "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
                 (session_id,),
@@ -6555,7 +6770,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return cursor.fetchone() is not None
 
     def archive_and_compact(
-        self, session_id: str, compacted_messages: List[Dict[str, Any]]
+        self,
+        session_id: str,
+        compacted_messages: List[Dict[str, Any]],
+        *,
+        compression_lock_holder: Optional[str] = None,
+        require_compression_lease: bool = False,
+        expected_revision: Optional[DurableTranscriptRevision] = None,
     ) -> int:
         """Non-destructive in-place compaction for a single durable session id.
 
@@ -6582,6 +6803,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
 
         def _do(conn):
+            lock_row = conn.execute(
+                "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            lease_is_live = (
+                lock_row is not None
+                and float(lock_row["expires_at"]) > time.time()
+            )
+            lease_holder = lock_row["holder"] if lock_row is not None else None
+            if require_compression_lease and (
+                not lease_is_live
+                or not compression_lock_holder
+                or lease_holder != compression_lock_holder
+            ):
+                raise CompressionSessionBusyError(
+                    f"Compression lease lost before in-place commit: {session_id}"
+                )
+            if lease_is_live and lease_holder != compression_lock_holder:
+                raise CompressionSessionBusyError(
+                    f"Session {session_id!r} is being compressed by another writer"
+                )
+            if expected_revision is not None:
+                observed_revision = _active_message_revision_in_transaction(
+                    conn, session_id
+                )
+                if observed_revision != expected_revision:
+                    raise CompressionTranscriptRevisionError(
+                        session_id=session_id,
+                        expected_revision=expected_revision,
+                        observed_revision=observed_revision,
+                    )
             # Soft-archive the live turns: active=0 hides them from the live
             # context load, compacted=1 marks them as "summarized away" (vs
             # rewind/undo's active=0+compacted=0, which means "user took it
@@ -6607,8 +6859,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return self._execute_write(_do)
 
     def set_latest_user_api_content(
-        self, session_id: str, content: Any, api_content: str
-    ) -> int:
+        self,
+        session_id: str,
+        content: Any,
+        api_content: str,
+        *,
+        compression_lock_holder: Optional[str] = None,
+        with_revision: bool = False,
+    ):
         """Backfill the ``api_content`` sidecar onto the newest ACTIVE user row.
 
         In-place preflight compaction (:meth:`archive_and_compact`) inserts the
@@ -6621,11 +6879,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         The ``content`` match is a defensive guard: if the newest active user
         row is not the message the caller stamped (racing rewrite, unexpected
         tail shape), nothing is written. Returns the number of rows updated
-        (0 or 1).
+        (0 or 1), or ``(updated, revision)`` when ``with_revision=True`` — the
+        sidecar is model-facing, so it moves the durable revision and the
+        writer needs the committed fence to stay in sync without a second read.
         """
         encoded = self._encode_content(content)
 
         def _do(conn):
+            _assert_compression_write_allowed(
+                conn, session_id, compression_lock_holder
+            )
             cursor = conn.execute(
                 "UPDATE messages SET api_content = ? WHERE id = ("
                 "SELECT id FROM messages "
@@ -6634,6 +6897,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ") AND content IS ?",
                 (_scrub_surrogates(api_content), session_id, encoded),
             )
+            if with_revision:
+                return cursor.rowcount, _active_message_revision_in_transaction(
+                    conn, session_id
+                )
             return cursor.rowcount
 
         return self._execute_write(_do)
@@ -6866,7 +7133,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_inactive: bool = False,
         repair_alternation: bool = False,
         include_row_ids: bool = False,
-    ) -> List[Dict[str, Any]]:
+        *,
+        with_revision: bool = False,
+    ):
         """
         Load messages in the OpenAI conversation format (role + content dicts).
         Used by the gateway to restore conversation history.
@@ -6884,6 +7153,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         mutates only the per-request list, never the stored transcript.
         Inspection/export consumers keep the default and see the transcript
         verbatim.
+
+        ``with_revision=True`` returns ``(messages, revision)``. The immutable
+        revision is computed from the exact active current-segment rows selected
+        for this read, under the same connection lock and without a second query.
         """
         session_ids = [session_id]
         if include_ancestors:
@@ -6893,7 +7166,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._lock:
             placeholders = ",".join("?" for _ in session_ids)
             rows = self._conn.execute(
-                f"SELECT {self._CONVERSATION_ROW_COLUMNS} "
+                f"SELECT session_id, active, {self._CONVERSATION_ROW_COLUMNS} "
                 f"FROM messages WHERE session_id IN ({placeholders})"
                 # Order by AUTOINCREMENT id (true insertion order), NOT timestamp:
                 # append_message stamps rows with time.time(), which is not
@@ -6906,14 +7179,46 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 f"{active_clause} ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
+            messages = self._rows_to_conversation(
+                rows,
+                session_id=session_id,
+                include_ancestors=include_ancestors,
+                repair_alternation=repair_alternation,
+                include_row_ids=include_row_ids,
+            )
+            if not with_revision:
+                return messages
+            return messages, _durable_revision_from_rows(session_id, rows)
 
-        return self._rows_to_conversation(
-            rows,
+    def get_active_message_revision(
+        self, session_id: str
+    ) -> DurableTranscriptRevision:
+        """Return the active-row revision for one current session segment."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT " + ", ".join(_DURABLE_REVISION_ROW_COLUMNS) + " "
+                "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
+                (session_id,),
+            ).fetchall()
+        return DurableTranscriptRevision(
             session_id=session_id,
-            include_ancestors=include_ancestors,
-            repair_alternation=repair_alternation,
-            include_row_ids=include_row_ids,
+            active_message_count=len(rows),
+            max_active_message_id=max(
+                (int(row["id"]) for row in rows), default=0
+            ),
+            active_rows_digest=_active_rows_digest(rows),
         )
+
+    def _active_message_revision_in_current_transaction(
+        self, session_id: str
+    ) -> DurableTranscriptRevision:
+        """Read a revision without opening a second transaction boundary.
+
+        Callers must hold ``self._lock`` and an SQLite read/write transaction.
+        This seam lets mixins pair a projection and its revision on one durable
+        snapshot without importing this module back into the mixin.
+        """
+        return _active_message_revision_in_transaction(self._conn, session_id)
 
     # Columns every conversation projection decodes. Shared by
     # get_messages_as_conversation and get_resume_conversations so a single
@@ -7198,7 +7503,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # =========================================================================
 
     def rewind_to_message(
-        self, session_id: str, target_message_id: int
+        self,
+        session_id: str,
+        target_message_id: int,
+        *,
+        compression_lock_holder: Optional[str] = None,
+        expected_revision: Optional[DurableTranscriptRevision] = None,
     ) -> Dict[str, Any]:
         """Soft-delete all messages with id >= ``target_message_id`` in *session_id*.
 
@@ -7249,6 +7559,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         rewound: List[int] = []
 
         def _do(conn):
+            _assert_compression_write_allowed(
+                conn, session_id, compression_lock_holder
+            )
+            _assert_expected_active_revision(conn, session_id, expected_revision)
             cursor = conn.execute(
                 "SELECT id FROM messages "
                 "WHERE session_id = ? AND id >= ? AND active = 1",
@@ -7284,7 +7598,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             "new_head_id": new_head_id,
         }
 
-    def restore_rewound(self, session_id: str, since_message_id: int) -> int:
+    def restore_rewound(
+        self,
+        session_id: str,
+        since_message_id: int,
+        *,
+        compression_lock_holder: Optional[str] = None,
+        expected_revision: Optional[DurableTranscriptRevision] = None,
+    ) -> int:
         """Mark inactive messages with id >= *since_message_id* active again.
 
         Returns the number of rows flipped back to ``active=1``.
@@ -7292,6 +7613,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         slash command in v1.
         """
         def _do(conn):
+            _assert_compression_write_allowed(
+                conn, session_id, compression_lock_holder
+            )
+            _assert_expected_active_revision(conn, session_id, expected_revision)
             cursor = conn.execute(
                 "SELECT id FROM messages "
                 "WHERE session_id = ? AND id >= ? AND active = 0",
@@ -7575,9 +7900,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 continue
         return lineage if session_id in lineage else [session_id]
 
-    def clear_messages(self, session_id: str) -> None:
+    def clear_messages(
+        self,
+        session_id: str,
+        *,
+        compression_lock_holder: Optional[str] = None,
+    ) -> None:
         """Delete all messages for a session and reset its counters."""
         def _do(conn):
+            _assert_compression_write_allowed(
+                conn, session_id, compression_lock_holder
+            )
             conn.execute(
                 "DELETE FROM messages WHERE session_id = ?", (session_id,)
             )
@@ -7636,6 +7969,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         sessions_dir: Optional[Path] = None,
         expected_delete_ids: Optional[List[str]] = None,
+        *,
+        compression_lock_holder: Optional[str] = None,
     ) -> bool:
         """Delete a session and all its messages.
 
@@ -7664,11 +7999,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             if cursor.fetchone() is None:
                 return False
+            actual_ids = {
+                session_id,
+                *_collect_delegate_child_ids(conn, [session_id]),
+            }
+            for delete_id in actual_ids:
+                _assert_compression_write_allowed(
+                    conn, delete_id, compression_lock_holder
+                )
             if expected_ids is not None:
-                actual_ids = {
-                    session_id,
-                    *_collect_delegate_child_ids(conn, [session_id]),
-                }
                 if actual_ids != expected_ids:
                     return False
             removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
@@ -7735,6 +8074,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self,
         session_ids: List[str],
         sessions_dir: Optional[Path] = None,
+        *,
+        compression_lock_holder: Optional[str] = None,
     ) -> int:
         """Delete every session in *session_ids* in a single transaction.
 
@@ -7783,6 +8124,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             existing = [row["id"] for row in cursor.fetchall()]
             if not existing:
                 return 0
+
+            delete_ids = {
+                *existing,
+                *_collect_delegate_child_ids(conn, existing),
+            }
+            for delete_id in delete_ids:
+                _assert_compression_write_allowed(
+                    conn, delete_id, compression_lock_holder
+                )
 
             existing_placeholders = ",".join("?" * len(existing))
             removed_delegate_ids.extend(_delete_delegate_children(conn, existing))
@@ -8164,6 +8514,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         older_than_days: Optional[float] = 90,
         source: str = None,
         sessions_dir: Optional[Path] = None,
+        compression_lock_holder: Optional[str] = None,
         **filters,
     ) -> int:
         """Delete sessions matching the filters. Returns count deleted.
@@ -8221,6 +8572,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             if not session_ids:
                 return 0
+
+            for session_id in session_ids:
+                _assert_compression_write_allowed(
+                    conn, session_id, compression_lock_holder
+                )
 
             # Orphan any sessions whose parent is about to be deleted
             placeholders = ",".join("?" * len(session_ids))

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1746,7 +1746,7 @@ def _assert_compression_write_allowed(
         and float(lock_row["expires_at"]) > time.time()
         and lock_row["holder"] != compression_lock_holder
     ):
-        raise CompressionSessionBusyError(
+        raise SessionCompressionInProgressError(
             f"Session {session_id!r} is being compressed by another writer"
         )
 
@@ -6774,6 +6774,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         compacted_messages: List[Dict[str, Any]],
         *,
+        system_prompt: Optional[str] = None,
         compression_lock_holder: Optional[str] = None,
         require_compression_lease: bool = False,
         expected_revision: Optional[DurableTranscriptRevision] = None,
@@ -6781,8 +6782,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Non-destructive in-place compaction for a single durable session id.
 
         Soft-archives every currently-active message (``active = 0``) and
-        inserts *compacted_messages* as fresh active rows — atomically, in one
-        write transaction. The conversation keeps ONE session id for life
+        inserts *compacted_messages* as fresh active rows and, when supplied,
+        updates *system_prompt* — atomically, in one write transaction. The
+        conversation keeps ONE session id for life
         (#38763) WITHOUT destroying history:
 
         - The live-context load (:meth:`get_messages_as_conversation`,
@@ -6854,6 +6856,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
                 (inserted, tool_calls_total, session_id),
             )
+            if system_prompt is not None:
+                conn.execute(
+                    "UPDATE sessions SET system_prompt = ? WHERE id = ?",
+                    (system_prompt, session_id),
+                )
             return inserted
 
         return self._execute_write(_do)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3269,41 +3269,112 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def find_live_compression_child(
         self, parent_session_id: str
     ) -> Optional[Dict[str, Any]]:
-        """Return the unique live direct child of a compression-ended session.
+        """Return the unique live leaf of a compression continuation chain.
 
-        A stale agent may observe that another compression path already rotated
-        its parent. Recovery is safe only when the durable lineage identifies
-        exactly one live direct continuation. Multiple children are treated as
-        ambiguous and fail closed rather than guessing which transcript owns
-        subsequent messages.
+        Every hop is resolved from one SQLite read snapshot. Malformed child
+        metadata, invalid lifecycle states, canonical forks, and cycles fail
+        closed rather than selecting a transcript heuristically.
         """
         if not parent_session_id:
             return None
+
         with self._lock:
-            parent = self._conn.execute(
-                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
-                (parent_session_id,),
-            ).fetchone()
-            if (
-                parent is None
-                or parent["ended_at"] is None
-                or parent["end_reason"] != "compression"
-            ):
+            conn = self._conn
+            if conn is None or conn.in_transaction:
                 return None
-            rows = self._conn.execute(
-                """
-                SELECT * FROM sessions
-                WHERE parent_session_id = ?
-                  AND ended_at IS NULL
-                  AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL
-                  AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL
-                  AND COALESCE(source, '') != 'tool'
-                ORDER BY started_at ASC
-                LIMIT 2
-                """,
-                (parent_session_id,),
-            ).fetchall()
-        return dict(rows[0]) if len(rows) == 1 else None
+
+            def _canonical_children(session_id: str):
+                rows = conn.execute(
+                    """
+                    SELECT id, ended_at, end_reason, model_config, source
+                    FROM sessions
+                    WHERE parent_session_id = ?
+                    ORDER BY started_at ASC, id ASC
+                    """,
+                    (session_id,),
+                ).fetchall()
+                canonical = []
+                for row in rows:
+                    source = row["source"]
+                    if not isinstance(source, str) or not source:
+                        return None
+                    if source.lower() == "tool":
+                        continue
+                    raw_config = row["model_config"]
+                    if raw_config is None:
+                        model_config = {}
+                    elif not isinstance(raw_config, str):
+                        return None
+                    else:
+                        try:
+                            model_config = json.loads(raw_config)
+                        except (TypeError, ValueError, json.JSONDecodeError):
+                            return None
+                        if not isinstance(model_config, dict):
+                            return None
+                    markers = [
+                        marker
+                        for marker in ("_branched_from", "_delegate_from")
+                        if marker in model_config
+                    ]
+                    if len(markers) > 1:
+                        return None
+                    if markers:
+                        marker_value = model_config[markers[0]]
+                        if (
+                            not isinstance(marker_value, str)
+                            or not marker_value
+                            or marker_value != session_id
+                        ):
+                            return None
+                        continue
+                    canonical.append(row)
+                return canonical
+
+            conn.execute("BEGIN")
+            try:
+                current_session_id = parent_session_id
+                seen: set[str] = set()
+                while current_session_id not in seen:
+                    seen.add(current_session_id)
+                    parent = conn.execute(
+                        "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+                        (current_session_id,),
+                    ).fetchone()
+                    if (
+                        parent is None
+                        or parent["ended_at"] is None
+                        or parent["end_reason"] != "compression"
+                    ):
+                        return None
+                    children = _canonical_children(current_session_id)
+                    if children is None or len(children) != 1:
+                        return None
+                    child = children[0]
+                    child_id = child["id"]
+                    if (
+                        not isinstance(child_id, str)
+                        or not child_id
+                        or child_id in seen
+                    ):
+                        return None
+                    if child["ended_at"] is None:
+                        if child["end_reason"] is not None:
+                            return None
+                        descendants = _canonical_children(child_id)
+                        if descendants is None or descendants:
+                            return None
+                        live_child = conn.execute(
+                            "SELECT * FROM sessions WHERE id = ?", (child_id,)
+                        ).fetchone()
+                        return dict(live_child) if live_child is not None else None
+                    if child["end_reason"] != "compression":
+                        return None
+                    current_session_id = child_id
+                return None
+            finally:
+                if conn.in_transaction:
+                    conn.rollback()
 
     def publish_compression_child(
         self,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8124,45 +8124,128 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def find_live_compression_child(
         self, parent_session_id: str
     ) -> Optional[Dict[str, Any]]:
-        """Return the unique live direct child of a compression-ended session.
+        """Return the unique live leaf of a compression continuation chain.
 
-        A stale agent may observe that another compression path already rotated
-        its parent. Recovery is safe only when the durable lineage identifies
-        exactly one live direct continuation. Multiple children are treated as
-        ambiguous and fail closed rather than guessing which transcript owns
-        subsequent messages.
+        Every hop is resolved from one SQLite read snapshot. Malformed child
+        metadata, invalid lifecycle states, canonical forks, and cycles fail
+        closed rather than selecting a transcript heuristically.
         """
         if not parent_session_id:
             return None
+
         with self._read_ctx() as conn:
-            parent = conn.execute(
-                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
-                (parent_session_id,),
-            ).fetchone()
-            if (
-                parent is None
-                or parent["ended_at"] is None
-                or parent["end_reason"] != "compression"
-            ):
+            if conn is None or conn.in_transaction:
                 return None
-            rows = conn.execute(
-                """
-                SELECT s.*,
-                       COALESCE(sp.prompt, s.system_prompt)
-                           AS _system_prompt_resolved
-                FROM sessions s
-                LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash
-                WHERE s.parent_session_id = ?
-                  AND s.ended_at IS NULL
-                """
-                + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="s.")
-                + """
-                ORDER BY s.started_at ASC
-                LIMIT 2
-                """,
-                (parent_session_id, parent_session_id, parent_session_id),
-            ).fetchall()
-        return self._session_row_dict(rows[0]) if len(rows) == 1 else None
+
+            def _canonical_children(session_id: str):
+                rows = conn.execute(
+                    """
+                    SELECT id, ended_at, end_reason, model_config, source
+                    FROM sessions
+                    WHERE parent_session_id = ?
+                    ORDER BY started_at ASC, id ASC
+                    """,
+                    (session_id,),
+                ).fetchall()
+                canonical = []
+                for row in rows:
+                    source = row["source"]
+                    if not isinstance(source, str) or not source:
+                        return None
+                    if source.lower() == "tool":
+                        continue
+
+                    raw_config = row["model_config"]
+                    if raw_config is None:
+                        model_config = {}
+                    elif not isinstance(raw_config, str):
+                        return None
+                    else:
+                        try:
+                            model_config = json.loads(raw_config)
+                        except (TypeError, ValueError):
+                            return None
+                        if not isinstance(model_config, dict):
+                            return None
+
+                    markers = [
+                        marker
+                        for marker in ("_branched_from", "_delegate_from")
+                        if marker in model_config
+                    ]
+                    if len(markers) > 1:
+                        return None
+                    if markers:
+                        marker_value = model_config[markers[0]]
+                        if (
+                            not isinstance(marker_value, str)
+                            or not marker_value
+                            or marker_value != session_id
+                        ):
+                            return None
+                        continue
+                    canonical.append(row)
+                return canonical
+
+            conn.execute("BEGIN")
+            try:
+                current_session_id = parent_session_id
+                seen: set[str] = set()
+                while current_session_id not in seen:
+                    seen.add(current_session_id)
+                    parent = conn.execute(
+                        "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+                        (current_session_id,),
+                    ).fetchone()
+                    if (
+                        parent is None
+                        or parent["ended_at"] is None
+                        or parent["end_reason"] != "compression"
+                    ):
+                        return None
+
+                    children = _canonical_children(current_session_id)
+                    if children is None or len(children) != 1:
+                        return None
+                    child = children[0]
+                    child_id = child["id"]
+                    if (
+                        not isinstance(child_id, str)
+                        or not child_id
+                        or child_id in seen
+                    ):
+                        return None
+
+                    if child["ended_at"] is None:
+                        if child["end_reason"] is not None:
+                            return None
+                        descendants = _canonical_children(child_id)
+                        if descendants is None or descendants:
+                            return None
+                        live_child = conn.execute(
+                            """
+                            SELECT s.*,
+                                   COALESCE(sp.prompt, s.system_prompt)
+                                       AS _system_prompt_resolved
+                            FROM sessions s
+                            LEFT JOIN system_prompts sp
+                                ON sp.hash = s.system_prompt_hash
+                            WHERE s.id = ?
+                            """,
+                            (child_id,),
+                        ).fetchone()
+                        return (
+                            self._session_row_dict(live_child)
+                            if live_child is not None
+                            else None
+                        )
+                    if child["end_reason"] != "compression":
+                        return None
+                    current_session_id = child_id
+                return None
+            finally:
+                if conn.in_transaction:
+                    conn.rollback()
 
     def reopen_orphaned_compression_session(self, session_id: str) -> bool:
         """Reopen a compression parent only when no continuation was published.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,9 @@ import time
 import uuid
 import weakref
 from collections import deque
+from collections.abc import Mapping
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -195,6 +197,149 @@ class SessionExportTooLargeError(ValueError):
 
 
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
+
+
+@dataclass(frozen=True)
+class DurableTranscriptRevision:
+    """Immutable identity for one session segment's active durable rows."""
+
+    session_id: str
+    active_message_count: int
+    max_active_message_id: int
+    active_rows_digest: str = ""
+
+
+# The model-facing bytes an in-place UPDATE can rewrite without moving
+# ``(active_message_count, max_active_message_id)``.
+#
+# Every other mutator either changes cardinality (append, replace, rewind,
+# restore, archive — all of which flip ``active`` or insert rows with fresh
+# AUTOINCREMENT ids) or touches presentation-only sidecars. ``api_content`` is
+# small enough to hash directly. In-place ``content`` repairs increment the
+# sparse ``content_revision`` marker instead: hashing every row's full content
+# costs ~100 ms per read on a 2 000-row session and would run inside the SQLite
+# writer transaction on every durable append.
+#
+# ``display_kind`` / ``display_metadata`` are deliberately absent: they are
+# stamped after every gateway/CLI turn by
+# ``set_latest_matching_message_display_kind`` outside any compression lease,
+# and the model never sees them, so fencing on them would abort the next
+# compression as spuriously stale.
+#
+# ANY new in-place ``UPDATE messages SET`` on model-facing ``content`` must
+# increment ``content_revision`` in the same statement. A different
+# model-facing column must be added here (and take ``compression_lock_holder``)
+# or it will slip past the compression fence.
+_DURABLE_REVISION_MUTABLE_COLUMNS = ("api_content", "content_revision")
+_DURABLE_REVISION_ROW_COLUMNS = ("id",) + _DURABLE_REVISION_MUTABLE_COLUMNS
+
+
+def _active_rows_digest(rows) -> str:
+    """Fingerprint the in-place-mutable model-facing bytes of active rows.
+
+    Keyed by row id and taken in insertion order. Rows whose mutable columns
+    are all unset contribute nothing, so the ordinary transcript — no
+    ``api_content`` sidecar anywhere — folds to ``""`` without hashing a byte;
+    stamping or clearing a sidecar still moves the fence.
+    """
+    digest = hashlib.sha256()
+    stamped = False
+    for row in rows:
+        keys = row.keys()
+        payload = [
+            row[column] if column in keys else None
+            for column in _DURABLE_REVISION_MUTABLE_COLUMNS
+        ]
+        if all(value is None for value in payload):
+            continue
+        stamped = True
+        digest.update(
+            json.dumps(
+                [row["id"], *payload],
+                ensure_ascii=False,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8", errors="surrogatepass")
+        )
+        digest.update(b"\n")
+    return digest.hexdigest() if stamped else ""
+
+
+def _durable_revision_from_rows(
+    session_id: str, rows
+) -> DurableTranscriptRevision:
+    """Derive a revision from selected rows without a second SQLite read."""
+    current_active_rows = [
+        row
+        for row in rows
+        if row["session_id"] == session_id and row["active"] == 1
+    ]
+    return DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=len(current_active_rows),
+        max_active_message_id=max(
+            (int(row["id"]) for row in current_active_rows),
+            default=0,
+        ),
+        active_rows_digest=_active_rows_digest(current_active_rows),
+    )
+
+
+def _active_message_revision_in_transaction(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    max_message_id: Optional[int] = None,
+) -> DurableTranscriptRevision:
+    """Read an active-row revision on the caller's transaction.
+
+    ``max_message_id`` pins the prefix summarized by a compressor while newer
+    append-only rows remain eligible for watermark tail preservation.
+    """
+    max_id_clause = " AND id <= ?" if max_message_id is not None else ""
+    params = (
+        (session_id, int(max_message_id))
+        if max_message_id is not None
+        else (session_id,)
+    )
+    rows = conn.execute(
+        "SELECT " + ", ".join(_DURABLE_REVISION_ROW_COLUMNS) + " "
+        "FROM messages WHERE session_id = ? AND active = 1"
+        f"{max_id_clause} ORDER BY id",
+        params,
+    ).fetchall()
+    return DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=len(rows),
+        max_active_message_id=max((int(row["id"]) for row in rows), default=0),
+        active_rows_digest=_active_rows_digest(rows),
+    )
+
+
+def normalize_durable_transcript_revision(
+    value: Any,
+    *,
+    session_id: str,
+) -> Optional[DurableTranscriptRevision]:
+    """Normalize an internal transport mapping into an immutable revision."""
+    if value is None:
+        return None
+    if isinstance(value, DurableTranscriptRevision):
+        revision = value
+    elif isinstance(value, Mapping):
+        revision = DurableTranscriptRevision(
+            session_id=str(value["session_id"]),
+            active_message_count=int(value["active_message_count"]),
+            max_active_message_id=int(value["max_active_message_id"]),
+            active_rows_digest=str(value.get("active_rows_digest", "")),
+        )
+    else:
+        raise TypeError("conversation_history_revision must be a mapping")
+    if revision.session_id != session_id:
+        raise ValueError("conversation_history_revision session_id mismatch")
+    if revision.active_message_count < 0 or revision.max_active_message_id < 0:
+        raise ValueError("conversation_history_revision values must be non-negative")
+    return revision
 
 
 def _system_prompt_hash(system_prompt: str) -> str:
@@ -376,7 +521,7 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
 
 T = TypeVar("T")
 
-DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+DEFAULT_DB_PATH = Path(get_hermes_home()) / "state.db"
 
 # How long SessionDB stops attempting read-only opens after one fails, before
 # probing again. Long enough that a genuinely unreadable file isn't retried per
@@ -4342,6 +4487,60 @@ class SessionCompressionInProgressError(CompressionSessionBusyError):
     Subclassing keeps every existing ``except CompressionSessionBusyError``
     handler working unchanged.
     """
+class CompressionTranscriptRevisionError(RuntimeError):
+    """A compression commit no longer matches its durable transcript snapshot."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        expected_revision: DurableTranscriptRevision,
+        observed_revision: DurableTranscriptRevision,
+    ) -> None:
+        self.session_id = session_id
+        self.expected_revision = expected_revision
+        self.observed_revision = observed_revision
+        super().__init__(
+            f"Durable transcript revision changed for session {session_id!r} "
+            "before compression commit"
+        )
+
+
+def _assert_compression_write_allowed(
+    conn: sqlite3.Connection,
+    session_id: str,
+    compression_lock_holder: Optional[str] = None,
+) -> None:
+    """Reject a transcript mutation while another writer owns a live lease."""
+    lock_row = conn.execute(
+        "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
+        (session_id,),
+    ).fetchone()
+    if (
+        lock_row is not None
+        and float(lock_row["expires_at"]) > time.time()
+        and lock_row["holder"] != compression_lock_holder
+    ):
+        raise SessionCompressionInProgressError(
+            f"Session {session_id!r} is being compressed by another writer"
+        )
+
+
+def _assert_expected_active_revision(
+    conn: sqlite3.Connection,
+    session_id: str,
+    expected_revision: Optional[DurableTranscriptRevision],
+) -> None:
+    """Fail a delayed rewrite whose active durable snapshot has moved on."""
+    if expected_revision is None:
+        return
+    observed_revision = _active_message_revision_in_transaction(conn, session_id)
+    if observed_revision != expected_revision:
+        raise CompressionTranscriptRevisionError(
+            session_id=session_id,
+            expected_revision=expected_revision,
+            observed_revision=observed_revision,
+        )
 
 
 class SessionTurnLeaseLostError(RuntimeError):
@@ -8345,7 +8544,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         lease_ttl_seconds: float = 300.0,
         watermark: Optional[int] = None,
         watermark_ceiling: Optional[int] = None,
-    ) -> None:
+        exclude_parent_message_ids: Optional[Tuple[int, ...]] = None,
+        expected_parent_revision: Optional[DurableTranscriptRevision] = None,
+        with_projection_revision: bool = False,
+    ) -> Any:
         """Atomically close a parent and publish its durable compression child.
 
         The parent closure, child row, and compacted handoff become visible in
@@ -8374,6 +8576,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         that stopped due to transient DB failures one final chance to extend
         the lease, preventing wasted compression work. The refresh uses the
         same ``conn`` as the publication, so there is no TOCTOU window.
+
+        *exclude_parent_message_ids* is the stronger form used by current
+        rotation callers: clone the whole post-watermark tail except the exact
+        rows written by this compressor's own atomic audit flush. This closes
+        the race between a pre-flush ceiling read and a concurrent append.
+        ``with_projection_revision=True`` returns the committed child projection
+        and its revision from this same write transaction.
         """
         def _do(conn):
             if require_lease_refresh and compression_lock_holder:
@@ -8396,6 +8605,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 raise CompressionSessionBusyError(
                     f"Compression lease lost before publication: {parent_session_id}"
                 )
+            if expected_parent_revision is not None:
+                observed_revision = _active_message_revision_in_transaction(
+                    conn,
+                    parent_session_id,
+                    max_message_id=watermark,
+                )
+                if observed_revision != expected_parent_revision:
+                    raise CompressionTranscriptRevisionError(
+                        session_id=parent_session_id,
+                        expected_revision=expected_parent_revision,
+                        observed_revision=observed_revision,
+                    )
             parent = conn.execute(
                 """SELECT ended_at, end_reason, cwd, git_branch, git_repo_root,
                           user_id, session_key, chat_id, chat_type,
@@ -8481,15 +8702,33 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # watermark, at or below the ceiling — see docstring) into the
                 # child, after the handoff. Column-exact except id/session_id;
                 # originals stay in the (closed) parent for lineage recovery.
-                _ceiling_clause = ""
+                _tail_clauses = []
                 _params: list = [parent_session_id, int(watermark)]
                 if watermark_ceiling is not None:
-                    _ceiling_clause = " AND id <= ?"
+                    _tail_clauses.append("id <= ?")
                     _params.append(int(watermark_ceiling))
+                excluded_ids = tuple(
+                    sorted(
+                        {
+                            int(message_id)
+                            for message_id in (exclude_parent_message_ids or ())
+                            if int(message_id) > 0
+                        }
+                    )
+                )
+                if excluded_ids:
+                    placeholders = ",".join("?" for _ in excluded_ids)
+                    _tail_clauses.append(f"id NOT IN ({placeholders})")
+                    _params.extend(excluded_ids)
+                _tail_clause = (
+                    " AND " + " AND ".join(_tail_clauses)
+                    if _tail_clauses
+                    else ""
+                )
                 tail_rows = conn.execute(
                     "SELECT id, tool_calls FROM messages "
                     "WHERE session_id = ? AND active = 1 AND id > ?"
-                    f"{_ceiling_clause} ORDER BY id",
+                    f"{_tail_clause} ORDER BY id",
                     _params,
                 ).fetchall()
                 if tail_rows:
@@ -8529,7 +8768,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"Compression parent changed during publication: {parent_session_id}"
                 )
 
-        self._execute_write(_do)
+            if with_projection_revision:
+                return self._active_projection_with_revision_in_transaction(
+                    conn, child_session_id
+                )
+            return None
+
+        return self._execute_write(_do)
 
     def _bump_conversation_generation(self, conn, session_id: str, end_reason: str) -> None:
         """Advance this peer's conversation generation past a boundary.
@@ -12799,9 +13044,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         compression_lock_holder: Optional[str] = None,
         turn_lease_holder: Optional[str] = None,
         turn_lease_ttl_seconds: float = 300.0,
-    ) -> int:
+        with_revision: bool = False,
+    ):
         """
-        Append a message to a session. Returns the message row ID.
+        Append a message to a session. Returns the message row ID, or
+        ``(message_id, revision)`` when ``with_revision=True`` — the durable
+        fence read inside the same transaction as the insert, so the appending
+        writer can advance its own snapshot without a racy second read.
 
         Also increments the session's message_count (and tool_call_count
         if role is 'tool' or tool_calls is present).
@@ -12908,6 +13157,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
                     (session_id,),
                 )
+            if with_revision:
+                return msg_id, _active_message_revision_in_transaction(
+                    conn, session_id
+                )
             return msg_id
 
         # Transcript append is THE critical write: its failure aborts the
@@ -12927,7 +13180,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         turn_lease_holder: Optional[str] = None,
         chunk_rows: Optional[int] = None,
         turn_lease_ttl_seconds: float = 300.0,
-    ) -> int:
+        with_revision: bool = False,
+    ):
         """Append multiple messages atomically in ONE write transaction.
 
         ``messages`` is a list of dicts in the same shape
@@ -12953,21 +13207,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         the batch commits in chunks of at most that many rows — same
         recovery semantics as the old per-row loops (a mid-copy failure
         leaves a partial seed), just with bounded lock holds. A turn flush
-        never needs it. Returns the inserted row count.
+        never needs it. Returns the inserted row count, or
+        ``(inserted_count, revision)`` when ``with_revision=True``.
         """
         if not messages:
             return 0
 
         if chunk_rows is not None and len(messages) > chunk_rows:
             inserted_total = 0
+            revision = None
             for start in range(0, len(messages), chunk_rows):
-                inserted_total += self.append_messages_batch(
+                inserted_chunk = self.append_messages_batch(
                     session_id,
                     messages[start:start + chunk_rows],
                     compression_lock_holder=compression_lock_holder,
                     turn_lease_holder=turn_lease_holder,
                     turn_lease_ttl_seconds=turn_lease_ttl_seconds,
+                    with_revision=with_revision,
                 )
+                if with_revision:
+                    inserted_count, revision = inserted_chunk
+                    inserted_total += inserted_count
+                else:
+                    inserted_total += inserted_chunk
+            if with_revision:
+                return inserted_total, revision
             return inserted_total
 
         def _do(conn):
@@ -13005,6 +13269,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 conn.execute(
                     "UPDATE sessions SET message_count = message_count + ? WHERE id = ?",
                     (inserted, session_id),
+                )
+            if with_revision:
+                return inserted, _active_message_revision_in_transaction(
+                    conn, session_id
                 )
             return inserted
 
@@ -13356,6 +13624,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         active_only: bool = False,
         archive_dropped: bool = False,
         reject_active_turn_lease: bool = False,
+        *,
+        compression_lock_holder: Optional[str] = None,
+        expected_revision: Optional[DurableTranscriptRevision] = None,
     ) -> None:
         """Atomically replace the stored messages for a session.
 
@@ -13400,25 +13671,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         active_clause = " AND active = 1" if active_only else ""
 
         def _do(conn):
-            if reject_active_turn_lease:
-                self._check_transcript_write_guards(
-                    conn,
-                    session_id,
-                    None,
-                    reject_active_turn_lease=True,
-                    reject_active_compression_lock=True,
-                )
-            else:
-                session = conn.execute(
-                    "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
-                    (session_id,),
-                ).fetchone()
-                if (
-                    session is not None
-                    and session["ended_at"] is not None
-                    and session["end_reason"] == "compression"
-                ):
-                    raise CompressionSessionClosedError(session_id)
+            self._check_transcript_write_guards(
+                conn,
+                session_id,
+                compression_lock_holder,
+                reject_active_turn_lease=reject_active_turn_lease,
+                reject_active_compression_lock=True,
+            )
+            _assert_expected_active_revision(conn, session_id, expected_revision)
+            session = conn.execute(
+                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if (
+                session is not None
+                and session["ended_at"] is not None
+                and session["end_reason"] == "compression"
+            ):
+                raise CompressionSessionClosedError(session_id)
             if archive_dropped:
                 # Content-preserving UPDATE: the rows keep their FTS entries
                 # (the messages_fts triggers fire on INSERT / DELETE / UPDATE
@@ -13490,13 +13760,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         watermark: Optional[int] = None,
         lock_holder: Optional[str] = None,
         tail_count: int = 0,
-    ) -> int:
+        *,
+        system_prompt: Optional[str] = None,
+        compression_lock_holder: Optional[str] = None,
+        require_compression_lease: bool = False,
+        expected_revision: Optional[DurableTranscriptRevision] = None,
+        with_projection_revision: bool = False,
+    ) -> Any:
         """Non-destructive in-place compaction for a single durable session id.
 
-        Soft-archives the active messages (``active = 0``) and inserts
-        *compacted_messages* as fresh active rows — atomically, in one write
-        transaction. The conversation keeps ONE session id for life (#38763)
-        WITHOUT destroying history:
+        Soft-archives every currently-active message (``active = 0``) and
+        inserts *compacted_messages* as fresh active rows and, when supplied,
+        updates *system_prompt* — atomically, in one write transaction. The
+        conversation keeps ONE session id for life
+        (#38763) WITHOUT destroying history:
 
         - The live-context load (:meth:`get_messages_as_conversation`,
           :meth:`get_messages`) filters ``active = 1`` by default, so the model
@@ -13544,11 +13821,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``message_count`` is set to the ACTIVE count after commit, matching
         what the live load returns. ``model_config_patch`` is merged into the
         session's JSON config in the same transaction; a ``None`` value
-        removes that key. Returns the new active count.
+        removes that key. Returns the new active count, or the committed active
+        projection and revision when ``with_projection_revision=True``.
         """
 
         def _do(conn):
-            if lock_holder is not None:
+            effective_lock_holder = lock_holder or compression_lock_holder
+            if (
+                lock_holder is not None
+                and compression_lock_holder is not None
+                and lock_holder != compression_lock_holder
+            ):
+                raise ValueError("conflicting compression lock holders")
+            self._check_transcript_write_guards(
+                conn,
+                session_id,
+                effective_lock_holder,
+                reject_active_compression_lock=True,
+            )
+            if effective_lock_holder is not None or require_compression_lease:
                 lock_row = conn.execute(
                     "SELECT holder, expires_at FROM compression_locks "
                     "WHERE session_id = ?",
@@ -13556,12 +13847,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ).fetchone()
                 if (
                     lock_row is None
-                    or lock_row["holder"] != lock_holder
+                    or not effective_lock_holder
+                    or lock_row["holder"] != effective_lock_holder
                     or float(lock_row["expires_at"]) <= time.time()
                 ):
                     raise SessionCompressionInProgressError(
                         f"Compression lease for {session_id!r} lost before "
                         "commit; refusing to publish a stale compaction"
+                    )
+
+            if expected_revision is not None:
+                observed_revision = _active_message_revision_in_transaction(
+                    conn,
+                    session_id,
+                    max_message_id=watermark,
+                )
+                if observed_revision != expected_revision:
+                    raise CompressionTranscriptRevisionError(
+                        session_id=session_id,
+                        expected_revision=expected_revision,
+                        observed_revision=observed_revision,
                     )
 
             patched_model_config = None
@@ -13594,6 +13899,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             tail_tool_calls += len(parsed) if isinstance(parsed, list) else 0
                         except (TypeError, ValueError):
                             pass
+
 
             # Soft-archive the live turns: active=0 hides them from the live
             # context load, compacted=1 marks them as "summarized away" (vs
@@ -13690,6 +13996,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     "model_config = ? WHERE id = ?",
                     (inserted, tool_calls_total, patched_model_config, session_id),
                 )
+            if system_prompt is not None:
+                conn.execute(
+                    "UPDATE sessions SET system_prompt = ? WHERE id = ?",
+                    (system_prompt, session_id),
+                )
+            if with_projection_revision:
+                return self._active_projection_with_revision_in_transaction(
+                    conn, session_id
+                )
             return inserted
 
         return self._execute_write(_do)
@@ -13704,8 +14019,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return cols
 
     def set_latest_user_api_content(
-        self, session_id: str, content: Any, api_content: str
-    ) -> int:
+        self,
+        session_id: str,
+        content: Any,
+        api_content: str,
+        *,
+        compression_lock_holder: Optional[str] = None,
+        with_revision: bool = False,
+    ):
         """Backfill the ``api_content`` sidecar onto the newest ACTIVE user row.
 
         In-place preflight compaction (:meth:`archive_and_compact`) inserts the
@@ -13718,11 +14039,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         The ``content`` match is a defensive guard: if the newest active user
         row is not the message the caller stamped (racing rewrite, unexpected
         tail shape), nothing is written. Returns the number of rows updated
-        (0 or 1).
+        (0 or 1), or ``(updated, revision)`` when ``with_revision=True`` — the
+        sidecar is model-facing, so it moves the durable revision and the
+        writer needs the committed fence to stay in sync without a second read.
         """
         encoded = self._encode_content(content)
 
         def _do(conn):
+            _assert_compression_write_allowed(
+                conn, session_id, compression_lock_holder
+            )
             cursor = conn.execute(
                 "UPDATE messages SET api_content = ? WHERE id = ("
                 "SELECT id FROM messages "
@@ -13731,6 +14057,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ") AND content IS ?",
                 (_scrub_surrogates(api_content), session_id, encoded),
             )
+            if with_revision:
+                return cursor.rowcount, _active_message_revision_in_transaction(
+                    conn, session_id
+                )
             return cursor.rowcount
 
         return self._execute_write(_do)
@@ -14102,7 +14432,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         repair_alternation: bool = False,
         include_row_ids: bool = False,
         include_compacted: bool = False,
-    ) -> List[Dict[str, Any]]:
+        *,
+        with_revision: bool = False,
+    ):
         """
         Load messages in the OpenAI conversation format (role + content dicts).
         Used by the gateway to restore conversation history.
@@ -14126,6 +14458,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         mutates only the per-request list, never the stored transcript.
         Inspection/export consumers keep the default and see the transcript
         verbatim.
+
+        ``with_revision=True`` returns ``(messages, revision)``. The immutable
+        revision is computed from the exact active current-segment rows selected
+        for this read, under the same connection lock and without a second query.
         """
         session_ids = [session_id]
         if include_ancestors and not self._is_explicit_branch_session(session_id):
@@ -14140,7 +14476,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
             rows = conn.execute(
-                f"SELECT {self._CONVERSATION_ROW_COLUMNS} "
+                f"SELECT session_id, active, {self._CONVERSATION_ROW_COLUMNS} "
                 f"FROM messages WHERE session_id IN ({placeholders})"
                 # Order by AUTOINCREMENT id (true insertion order), NOT timestamp:
                 # append_message stamps rows with time.time(), which is not
@@ -14153,16 +14489,78 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 f"{active_clause} ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
+            # The revision is derived from the exact rows selected under this
+            # read lock, before any display-only dedupe reshapes them.
+            revision = (
+                _durable_revision_from_rows(session_id, rows)
+                if with_revision
+                else None
+            )
 
         if include_compacted:
             rows = self._dedupe_display_generations(rows)
 
-        return self._rows_to_conversation(
+        messages = self._rows_to_conversation(
             rows,
             session_id=session_id,
             include_ancestors=include_ancestors,
             repair_alternation=repair_alternation,
             include_row_ids=include_row_ids,
+        )
+        if not with_revision:
+            return messages
+        return messages, revision
+
+    def _active_projection_with_revision_in_transaction(
+        self,
+        conn: sqlite3.Connection,
+        session_id: str,
+    ) -> Tuple[List[Dict[str, Any]], DurableTranscriptRevision]:
+        """Return one active model projection and revision on the caller's txn."""
+        rows = conn.execute(
+            f"SELECT session_id, active, {self._CONVERSATION_ROW_COLUMNS} "
+            "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
+            (session_id,),
+        ).fetchall()
+        projection = self._rows_to_conversation(
+            rows,
+            session_id=session_id,
+            include_ancestors=False,
+            repair_alternation=False,
+            include_row_ids=False,
+        )
+        return projection, _durable_revision_from_rows(session_id, rows)
+
+    def get_active_message_revision(
+        self,
+        session_id: str,
+        *,
+        max_message_id: Optional[int] = None,
+    ) -> DurableTranscriptRevision:
+        """Return the active-row revision, optionally pinned to an id prefix."""
+        with self._read_ctx() as conn:
+            return _active_message_revision_in_transaction(
+                conn,
+                session_id,
+                max_message_id=max_message_id,
+            )
+
+    def _active_message_revision_in_current_transaction(
+        self,
+        session_id: str,
+        conn: Optional[sqlite3.Connection] = None,
+    ) -> DurableTranscriptRevision:
+        """Read a revision without opening a second transaction boundary.
+
+        ``conn`` is the connection whose open transaction already selected the
+        rows being paired with this revision (a pooled ``_read_ctx`` reader or
+        the writer). Without it, callers must hold ``self._lock`` and an SQLite
+        read/write transaction on the shared writer connection. This seam lets
+        mixins pair a projection and its revision on one durable snapshot
+        without importing this module back into the mixin.
+        """
+        return _active_message_revision_in_transaction(
+            conn if conn is not None else self._conn, session_id
         )
 
     # Columns every conversation projection decodes. Shared by
@@ -14175,7 +14573,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         "finish_reason, reasoning, reasoning_content, reasoning_details, "
         "codex_reasoning_items, codex_message_items, platform_message_id, observed, "
         "_compressed_summary, timestamp, active, "
-        "api_content, display_kind, display_metadata"
+        "api_content, content_revision, display_kind, display_metadata"
     )
 
     def _rows_to_conversation(
@@ -14826,6 +15224,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         preserve_compaction_handoff: bool = False,
         expected_active_ids: Optional[List[int]] = None,
         expected_target_content: Any = None,
+        compression_lock_holder: Optional[str] = None,
+        expected_revision: Optional[DurableTranscriptRevision] = None,
     ) -> Dict[str, Any]:
         """Soft-delete all messages with id >= ``target_message_id`` in *session_id*.
 
@@ -14872,10 +15272,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._check_transcript_write_guards(
                 conn,
                 session_id,
-                None,
+                compression_lock_holder,
                 reject_active_turn_lease=True,
                 reject_active_compression_lock=True,
             )
+            _assert_expected_active_revision(conn, session_id, expected_revision)
 
             if expected_active_ids is not None:
                 active_rows = conn.execute(
@@ -14992,7 +15393,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             result["replacement_message_id"] = replacement_message_id
         return result
 
-    def restore_rewound(self, session_id: str, since_message_id: int) -> int:
+    def restore_rewound(
+        self,
+        session_id: str,
+        since_message_id: int,
+        *,
+        compression_lock_holder: Optional[str] = None,
+        expected_revision: Optional[DurableTranscriptRevision] = None,
+    ) -> int:
         """Mark inactive messages with id >= *since_message_id* active again.
 
         Returns the number of rows flipped back to ``active=1``.
@@ -15000,6 +15408,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         slash command in v1.
         """
         def _do(conn):
+            _assert_compression_write_allowed(
+                conn, session_id, compression_lock_holder
+            )
+            _assert_expected_active_revision(conn, session_id, expected_revision)
             cursor = conn.execute(
                 "SELECT id FROM messages "
                 "WHERE session_id = ? AND id >= ? AND active = 0",
@@ -15396,9 +15808,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 continue
         return lineage if session_id in lineage else [session_id]
 
-    def clear_messages(self, session_id: str) -> None:
+    def clear_messages(
+        self,
+        session_id: str,
+        *,
+        compression_lock_holder: Optional[str] = None,
+    ) -> None:
         """Delete all messages for a session and reset its counters."""
         def _do(conn):
+            _assert_compression_write_allowed(
+                conn, session_id, compression_lock_holder
+            )
             conn.execute(
                 "DELETE FROM messages WHERE session_id = ?", (session_id,)
             )
@@ -15460,6 +15880,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         sessions_dir: Optional[Path] = None,
         expected_delete_ids: Optional[List[str]] = None,
+        *,
+        compression_lock_holder: Optional[str] = None,
     ) -> bool:
         """Delete a session and all its messages.
 
@@ -15488,11 +15910,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             if cursor.fetchone() is None:
                 return False
+            actual_ids = {
+                session_id,
+                *_collect_delegate_child_ids(conn, [session_id]),
+            }
+            for delete_id in actual_ids:
+                _assert_compression_write_allowed(
+                    conn, delete_id, compression_lock_holder
+                )
             if expected_ids is not None:
-                actual_ids = {
-                    session_id,
-                    *_collect_delegate_child_ids(conn, [session_id]),
-                }
                 if actual_ids != expected_ids:
                     return False
             removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
@@ -15562,6 +15988,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self,
         session_ids: List[str],
         sessions_dir: Optional[Path] = None,
+        *,
+        compression_lock_holder: Optional[str] = None,
     ) -> int:
         """Delete every session in *session_ids* in a single transaction.
 
@@ -15610,6 +16038,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             existing = [row["id"] for row in cursor.fetchall()]
             if not existing:
                 return 0
+
+            delete_ids = {
+                *existing,
+                *_collect_delegate_child_ids(conn, existing),
+            }
+            for delete_id in delete_ids:
+                _assert_compression_write_allowed(
+                    conn, delete_id, compression_lock_holder
+                )
 
             existing_placeholders = ",".join("?" * len(existing))
             removed_delegate_ids.extend(_delete_delegate_children(conn, existing))
@@ -16080,6 +16517,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         source: str = None,
         sessions_dir: Optional[Path] = None,
         exclude_active_write_guards: bool = False,
+        compression_lock_holder: Optional[str] = None,
         **filters,
     ) -> int:
         """Delete sessions matching the filters. Returns count deleted.
@@ -16155,6 +16593,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             if not session_ids:
                 return 0
+
+            for session_id in session_ids:
+                _assert_compression_write_allowed(
+                    conn, session_id, compression_lock_holder
+                )
 
             # Orphan any sessions whose parent is about to be deleted
             placeholders = ",".join("?" * len(session_ids))
@@ -16261,7 +16704,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if ids:
                 placeholders = ",".join("?" * len(ids))
                 conn.execute(
-                    f"UPDATE messages SET content = '' WHERE id IN ({placeholders})",
+                    "UPDATE messages SET content = '', "
+                    "content_revision = COALESCE(content_revision, 0) + 1 "
+                    f"WHERE id IN ({placeholders})",
                     ids,
                 )
             return ids

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -502,6 +502,7 @@ CREATE TABLE IF NOT EXISTS messages (
     active INTEGER NOT NULL DEFAULT 1,
     compacted INTEGER NOT NULL DEFAULT 0,
     api_content TEXT,
+    content_revision INTEGER,
     display_kind TEXT,
     display_metadata TEXT
 );

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1009,7 +1009,9 @@ class SessionSearchMixin:
         session_id: str,
         limit: int = 20,
         include_inactive: bool = False,
-    ) -> List[Dict[str, Any]]:
+        *,
+        with_revision: bool = False,
+    ):
         """Return the *limit* most-recent user messages, newest first.
 
         Each entry is a dict with keys ``id``, ``timestamp``, ``preview``.
@@ -1031,15 +1033,30 @@ class SessionSearchMixin:
         active_clause = "" if include_inactive else " AND active = 1"
         # Match CLI/desktop: only real user turns, not timeline bookkeeping.
         display_clause = " AND (display_kind IS NULL OR display_kind = '')"
+        revision = None
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT id, timestamp, content FROM messages "
-                "WHERE session_id = ? AND role = 'user'"
-                f"{active_clause}{display_clause} "
-                "ORDER BY id DESC LIMIT ?",
-                (session_id, int(limit)),
-            )
-            rows = cursor.fetchall()
+            started_transaction = not self._conn.in_transaction
+            if started_transaction:
+                self._conn.execute("BEGIN")
+            try:
+                cursor = self._conn.execute(
+                    "SELECT id, timestamp, content FROM messages "
+                    "WHERE session_id = ? AND role = 'user'"
+                    f"{active_clause}{display_clause} "
+                    "ORDER BY id DESC LIMIT ?",
+                    (session_id, int(limit)),
+                )
+                rows = cursor.fetchall()
+                if with_revision:
+                    revision = self._active_message_revision_in_current_transaction(
+                        session_id
+                    )
+                if started_transaction:
+                    self._conn.commit()
+            except BaseException:
+                if started_transaction and self._conn.in_transaction:
+                    self._conn.rollback()
+                raise
 
         result: List[Dict[str, Any]] = []
         for row in rows:
@@ -1069,6 +1086,8 @@ class SessionSearchMixin:
                     "preview": preview,
                 }
             )
+        if with_revision:
+            return result, revision
         return result
 
     @staticmethod

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1132,7 +1132,9 @@ class SessionSearchMixin:
         session_id: str,
         limit: int = 20,
         include_inactive: bool = False,
-    ) -> List[Dict[str, Any]]:
+        *,
+        with_revision: bool = False,
+    ):
         """Return the *limit* most-recent user messages, newest first.
 
         Each entry is a dict with keys ``id``, ``timestamp``, ``preview``.
@@ -1161,15 +1163,33 @@ class SessionSearchMixin:
         # excludes handoffs with a DB pick that includes them, soft-deleting
         # the wrong turn.
         fetch_limit = int(limit) * 2 + 5
+        revision = None
         with self._read_ctx() as conn:
-            cursor = conn.execute(
-                "SELECT id, timestamp, content FROM messages "
-                "WHERE session_id = ? AND role = 'user'"
-                f"{active_clause}{display_clause} "
-                "ORDER BY id DESC LIMIT ?",
-                (session_id, fetch_limit),
-            )
-            rows = cursor.fetchall()
+            # ``with_revision`` pairs the picked rows with the revision of the
+            # same durable snapshot: hold one explicit read transaction across
+            # both statements so a concurrent writer cannot slip between them.
+            started_transaction = with_revision and not conn.in_transaction
+            if started_transaction:
+                conn.execute("BEGIN")
+            try:
+                cursor = conn.execute(
+                    "SELECT id, timestamp, content FROM messages "
+                    "WHERE session_id = ? AND role = 'user'"
+                    f"{active_clause}{display_clause} "
+                    "ORDER BY id DESC LIMIT ?",
+                    (session_id, fetch_limit),
+                )
+                rows = cursor.fetchall()
+                if with_revision:
+                    revision = self._active_message_revision_in_current_transaction(
+                        session_id, conn
+                    )
+                if started_transaction:
+                    conn.commit()
+            except BaseException:
+                if started_transaction and conn.in_transaction:
+                    conn.rollback()
+                raise
 
         from agent.context_compressor import ContextCompressor
 
@@ -1206,6 +1226,8 @@ class SessionSearchMixin:
                     "preview": preview,
                 }
             )
+        if with_revision:
+            return result, revision
         return result
 
     @staticmethod

--- a/run_agent.py
+++ b/run_agent.py
@@ -2214,7 +2214,7 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
-                self._session_db.append_message(
+                _appended = self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,
                     content=content,
@@ -2239,7 +2239,19 @@ class AIAgent:
                     compression_lock_holder=getattr(
                         self, "_active_compression_lock_holder", None
                     ),
+                    with_revision=True,
                 )
+                # Adopt the fence the append actually committed, read inside the
+                # same transaction — never recompute it here, where a concurrent
+                # writer's row would be missed. SessionDB-like adapters that
+                # ignore ``with_revision`` still return a bare id (or nothing);
+                # they own no CAS either, so the agent simply keeps its fence.
+                if isinstance(_appended, tuple) and len(_appended) == 2:
+                    from hermes_state import DurableTranscriptRevision
+
+                    _, durable_revision = _appended
+                    if isinstance(durable_revision, DurableTranscriptRevision):
+                        self._durable_transcript_revision = durable_revision
                 msg[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the
             # one-shot seed so no id() outlives this flush to alias a message
@@ -7552,6 +7564,7 @@ class AIAgent:
         persist_user_display_kind: Optional[str] = None,
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        conversation_history_revision: Optional[dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.aux_accounting import (
@@ -7643,6 +7656,7 @@ class AIAgent:
                     persist_user_display_kind=persist_user_display_kind,
                     persist_user_display_metadata=persist_user_display_metadata,
                     moa_config=moa_config,
+                    conversation_history_revision=conversation_history_revision,
                 )
             terminal = result if isinstance(result, dict) else {}
             if terminal.get("interrupted") is True:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2633,8 +2633,9 @@ class AIAgent:
             # NO markers were stamped, so the next flush re-scans and
             # re-writes the whole tail (same recovery contract as before,
             # minus the partial-prefix case that could double-pay counters).
+            self._last_flush_inserted_message_ids = ()
             if _batch_rows:
-                self._session_db.append_messages_batch(
+                _appended = self._session_db.append_messages_batch(
                     session_id=self.session_id,
                     messages=_batch_rows,
                     compression_lock_holder=getattr(
@@ -2647,7 +2648,26 @@ class AIAgent:
                         self, "_active_session_turn_lease_ttl_seconds", 300.0
                     )
                     or 300.0,
+                    with_revision=True,
                 )
+                # Adopt the fence the append actually committed, read inside the
+                # same transaction — never recompute it here, where a concurrent
+                # writer's row would be missed. SessionDB-like adapters that
+                # ignore ``with_revision`` still return a bare id (or nothing);
+                # they own no CAS either, so the agent simply keeps its fence.
+                if isinstance(_appended, tuple) and len(_appended) == 2:
+                    from hermes_state import DurableTranscriptRevision
+
+                    inserted_count, durable_revision = _appended
+                    if isinstance(durable_revision, DurableTranscriptRevision):
+                        self._durable_transcript_revision = durable_revision
+                        if inserted_count > 0:
+                            last_id = durable_revision.max_active_message_id
+                            first_id = last_id - int(inserted_count) + 1
+                            self._last_flush_inserted_message_ids = tuple(
+                                range(first_id, last_id + 1)
+                            )
+
                 from agent.transcript_repair import sync_flushed_message_markers
 
                 sync_flushed_message_markers(_batch_msgs, _batch_rows)
@@ -2664,6 +2684,7 @@ class AIAgent:
             # Force a full re-scan on the next flush: an exception mid-loop
             # leaves messages with mixed dispositions.
             self._db_flush_scan_prefix = None
+            self._last_flush_inserted_message_ids = ()
             # This is the one place the underlying SQLite error is visible
             # before it is swallowed into a bare ``False`` — classify it here
             # so the turn-end explanation can distinguish lock contention
@@ -9268,6 +9289,7 @@ class AIAgent:
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         persist_user_platform_id: Optional[str] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        conversation_history_revision: Optional[dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review deliberately shares this agent's session_id for prompt-cache
@@ -9827,6 +9849,7 @@ class AIAgent:
                         persist_user_display_metadata=persist_user_display_metadata,
                         persist_user_platform_id=persist_user_platform_id,
                         moa_config=moa_config,
+                        conversation_history_revision=conversation_history_revision,
                     )
                 finally:
                     # The lease remains held through relay/task finalization, but

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -637,8 +637,10 @@ class TestPrologueMoaAndInPlaceBackfill:
         msg = ctx.messages[ctx.current_turn_user_idx]
         assert msg["content"] == "hello"
         assert msg["api_content"] == "hello\n\nPLUGIN-CTX"
+        # with_revision: the sidecar is model-facing, so the backfill moves the
+        # durable fence and its own writer must adopt the committed revision.
         agent._session_db.set_latest_user_api_content.assert_called_once_with(
-            "sess-1", "hello", "hello\n\nPLUGIN-CTX"
+            "sess-1", "hello", "hello\n\nPLUGIN-CTX", with_revision=True
         )
 
 

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -131,8 +131,14 @@ class TestAutoMigration:
                 row[1]
                 for row in db._conn.execute('PRAGMA table_info("messages")').fetchall()
             }
-            assert "api_content" in cols
-            # Old rows read back NULL (no key); new writes round-trip.
+            assert {"api_content", "content_revision"} <= cols
+            # Old rows read back NULL for both sparse revision sidecars; new
+            # writes round-trip without requiring a version-gated migration.
+            legacy = db._conn.execute(
+                "SELECT api_content, content_revision FROM messages WHERE id = 1"
+            ).fetchone()
+            assert legacy["api_content"] is None
+            assert legacy["content_revision"] is None
             db.append_message("s1", "user", content="new", api_content="new+ctx")
             msgs = db.get_messages_as_conversation("s1")
             assert "api_content" not in msgs[0]
@@ -637,8 +643,10 @@ class TestPrologueMoaAndInPlaceBackfill:
         msg = ctx.messages[ctx.current_turn_user_idx]
         assert msg["content"] == "hello"
         assert msg["api_content"] == "hello\n\nPLUGIN-CTX"
+        # with_revision: the sidecar is model-facing, so the backfill moves the
+        # durable fence and its own writer must adopt the committed revision.
         agent._session_db.set_latest_user_api_content.assert_called_once_with(
-            "sess-1", "hello", "hello\n\nPLUGIN-CTX"
+            "sess-1", "hello", "hello\n\nPLUGIN-CTX", with_revision=True
         )
 
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -589,31 +589,29 @@ def test_durable_message_committed_before_lease_is_adopted(
     parent_sid = "PRE_LEASE_DURABLE_RACE"
     db.create_session(parent_sid, source="webui")
     db.append_message(parent_sid, "user", "old durable")
+    expected_revision = db.get_active_message_revision(parent_sid)
 
     # Frontend takes its snapshot, then another producer commits before this
     # compressor acquires the lease.
     stale_snapshot = [{"role": "user", "content": "old durable"}]
     db.append_message(parent_sid, "assistant", "late committed before lease")
     agent = _build_agent_with_db(db, parent_sid)
+    agent._durable_transcript_revision = expected_revision
 
-    returned, _system_prompt = agent._compress_context(
-        stale_snapshot, "sys", approx_tokens=120_000
-    )
+    from agent.conversation_compression import CompressionSnapshotStaleError
 
-    agent.context_compressor.compress.assert_called_once()
-    compressed_arg = agent.context_compressor.compress.call_args.args[0]
-    assert [m["content"] for m in compressed_arg] == [
+    with pytest.raises(CompressionSnapshotStaleError):
+        agent._compress_context(stale_snapshot, "sys", approx_tokens=120_000)
+
+    assert agent.session_id == parent_sid
+    assert db.find_live_compression_child(parent_sid) is None
+    assert [m["content"] for m in db.get_messages_as_conversation(parent_sid)] == [
         "old durable",
         "late committed before lease",
     ]
-    # Must not echo the stale snapshot — compression proceeded on the
-    # adopted durable transcript (rotation publishes a child session).
-    assert returned is not stale_snapshot
-    assert returned[0]["content"] == "[CONTEXT COMPACTION] summary"
-    assert agent.session_id != parent_sid
-    child_id = _live_child_id(db, parent_sid)
-    assert child_id is not None
-    assert child_id == agent.session_id
+    agent.context_compressor.compress.assert_not_called()
+    assert db.get_compression_lock_holder(parent_sid) is None
+
 
 
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -753,8 +753,9 @@ def test_delayed_contender_adopts_unique_rotated_child(tmp_path: Path) -> None:
     agent.context_compressor.compress.assert_not_called()
     lifecycle_args, lifecycle_kwargs = agent.context_compressor.on_session_start.call_args
     assert lifecycle_args == (child_sid,)
-    assert lifecycle_kwargs["boundary_reason"] == "compression"
+    assert lifecycle_kwargs["boundary_reason"] == "resume"
     assert lifecycle_kwargs["old_session_id"] == parent_sid
+    assert lifecycle_kwargs["recovered_from_compression"] is True
     assert lifecycle_kwargs["session_db"] is db
 
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -771,46 +771,51 @@ def test_concurrent_compression_does_not_fork_session(tmp_path: Path) -> None:
     )
 
 
-def test_durable_message_committed_before_lease_is_adopted(
+def test_durable_message_committed_before_lease_is_preserved_as_tail(
     tmp_path: Path,
 ) -> None:
     """A durable row absent from the caller snapshot must still be compressed.
 
     Previously this path aborted and returned the stale snapshot unchanged,
-    which permanently wedged busy sessions: every compress attempt saw the
-    DB ahead of the in-memory list, logged "changed before lease
-    acquisition", and never called the compressor. Adopting the durable
-    transcript keeps the late-committed turn and lets compression proceed.
+    which permanently wedged busy sessions. The prefix fence now proves that
+    the drift is append-only and carries the late row through the watermark
+    tail while compression proceeds on the authenticated snapshot.
     """
     db = SessionDB(db_path=tmp_path / "state.db")
     parent_sid = "PRE_LEASE_DURABLE_RACE"
     db.create_session(parent_sid, source="webui")
     db.append_message(parent_sid, "user", "old durable")
+    expected_revision = db.get_active_message_revision(parent_sid)
 
     # Frontend takes its snapshot, then another producer commits before this
     # compressor acquires the lease.
     stale_snapshot = [{"role": "user", "content": "old durable"}]
     db.append_message(parent_sid, "assistant", "late committed before lease")
     agent = _build_agent_with_db(db, parent_sid)
+    agent._durable_transcript_revision = expected_revision
 
-    returned, _system_prompt = agent._compress_context(
+    agent.context_compressor.compress.side_effect = None
+    agent.context_compressor.compress.return_value = [
+        {"role": "user", "content": "x"}
+    ]
+
+    compressed, _ = agent._compress_context(
         stale_snapshot, "sys", approx_tokens=120_000
     )
 
-    agent.context_compressor.compress.assert_called_once()
-    compressed_arg = agent.context_compressor.compress.call_args.args[0]
-    assert [m["content"] for m in compressed_arg] == [
-        "old durable",
+    child_session_id = agent.session_id
+    assert child_session_id != parent_sid
+    assert [message["content"] for message in compressed] == [
+        "x",
         "late committed before lease",
     ]
-    # Must not echo the stale snapshot — compression proceeded on the
-    # adopted durable transcript (rotation publishes a child session).
-    assert returned is not stale_snapshot
-    assert returned[0]["content"] == "[CONTEXT COMPACTION] summary"
-    assert agent.session_id != parent_sid
-    child_id = _live_child_id(db, parent_sid)
-    assert child_id is not None
-    assert child_id == agent.session_id
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(child_session_id)
+    ] == ["x", "late committed before lease"]
+    agent.context_compressor.compress.assert_called_once()
+    assert db.get_compression_lock_holder(parent_sid) is None
+
 
 
 

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -157,15 +157,15 @@ class TestOrphanRollbackOnCreateFailure:
             raise RuntimeError("simulated atomic publication failure")
 
         with patch.object(db, "publish_compression_child", side_effect=_boom):
-            returned, _system_prompt = agent._compress_context(
+            compressed, _ = agent._compress_context(
                 original, "sys", approx_tokens=120_000
             )
 
         assert agent.session_id == parent
-        assert [(m["role"], m["content"]) for m in returned] == [
+        assert compressed is original
+        assert [(m["role"], m["content"]) for m in original] == [
             (m["role"], m["content"]) for m in _msgs()
         ]
-        assert returned is original
         parent_row = db.get_session(parent)
         assert parent_row is not None
         assert parent_row["ended_at"] is None

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.conversation_compression import recover_rotated_compression_session
 from agent.context_compressor import ContextCompressor
 from hermes_state import SessionDB
 
@@ -306,6 +307,108 @@ class TestFallbackStreakFollowsRotation:
         assert child != parent
         assert compressor._fallback_compression_streak == 1
         assert db.get_compression_fallback_streak(child) == 1
+
+
+class TestRotatedSessionRecovery:
+    def test_recovers_live_tip_across_multiple_compressions(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "STALE_MULTI_HOP_PARENT"
+        db.create_session(parent, source="webui")
+        agent = _build_agent_with_db(db, parent, platform="webui")
+
+        db.end_session(parent, "compression")
+        db.create_session("COMPRESSED_CHILD_1", source="webui", parent_session_id=parent)
+        db.end_session("COMPRESSED_CHILD_1", "compression")
+        db.create_session(
+            "COMPRESSED_CHILD_2",
+            source="webui",
+            parent_session_id="COMPRESSED_CHILD_1",
+        )
+        db.end_session("COMPRESSED_CHILD_2", "compression")
+        db.create_session(
+            "LIVE_MULTI_HOP_TIP",
+            source="webui",
+            parent_session_id="COMPRESSED_CHILD_2",
+        )
+        db.replace_messages(
+            "LIVE_MULTI_HOP_TIP",
+            [{"role": "user", "content": "latest compacted history"}],
+        )
+        db.set_compression_fallback_streak(parent, 1)
+        db.set_compression_ineffective_count(parent, 1)
+        db.set_compression_fallback_streak("COMPRESSED_CHILD_2", 2)
+        db.set_compression_ineffective_count("COMPRESSED_CHILD_2", 2)
+        db.set_compression_fallback_streak("LIVE_MULTI_HOP_TIP", 7)
+        db.set_compression_ineffective_count("LIVE_MULTI_HOP_TIP", 8)
+        compressor = _bound_context_compressor(db, parent)
+        setattr(agent, "context_compressor", compressor)
+        memory_manager = MagicMock()
+        setattr(agent, "_memory_manager", memory_manager)
+
+        with patch.object(
+            compressor,
+            "on_session_start",
+            wraps=compressor.on_session_start,
+        ) as on_session_start:
+            recovered = recover_rotated_compression_session(agent)
+
+        assert recovered is not None
+        assert [message["content"] for message in recovered] == [
+            "latest compacted history"
+        ]
+        assert getattr(agent, "session_id") == "LIVE_MULTI_HOP_TIP"
+        assert compressor._fallback_compression_streak == 7
+        assert compressor._ineffective_compression_count == 8
+        assert db.get_compression_fallback_streak("LIVE_MULTI_HOP_TIP") == 7
+        assert db.get_compression_ineffective_count("LIVE_MULTI_HOP_TIP") == 8
+        assert on_session_start.call_args.kwargs["boundary_reason"] == "resume"
+        assert on_session_start.call_args.kwargs["old_session_id"] == "COMPRESSED_CHILD_2"
+        assert on_session_start.call_args.kwargs["recovered_from_compression"] is True
+        memory_manager.on_session_switch.assert_called_once_with(
+            "LIVE_MULTI_HOP_TIP",
+            parent_session_id="COMPRESSED_CHILD_2",
+            reset=False,
+            reason="resume",
+        )
+
+    def test_revalidation_rejects_tip_that_rotates_during_load(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "STALE_RACING_PARENT"
+        db.create_session(parent, source="webui")
+        agent = _build_agent_with_db(db, parent, platform="webui")
+        db.end_session(parent, "compression")
+        db.create_session("RACING_TIP", source="webui", parent_session_id=parent)
+        db.replace_messages(
+            "RACING_TIP",
+            [{"role": "user", "content": "loaded before rotation"}],
+        )
+        original_loader = SessionDB.get_messages_as_conversation
+
+        def _load_then_rotate(session_db: SessionDB, session_id: str):
+            loaded = original_loader(session_db, session_id)
+            if session_id == "RACING_TIP":
+                session_db.end_session("RACING_TIP", "compression")
+                session_db.create_session(
+                    "NEW_RACING_TIP",
+                    source="webui",
+                    parent_session_id="RACING_TIP",
+                )
+                session_db.replace_messages(
+                    "NEW_RACING_TIP",
+                    [{"role": "user", "content": "new durable tip"}],
+                )
+            return loaded
+
+        with patch.object(
+            SessionDB,
+            "get_messages_as_conversation",
+            _load_then_rotate,
+        ):
+            recovered = recover_rotated_compression_session(agent)
+
+        assert recovered is None
+        assert getattr(agent, "session_id") == parent
+        getattr(agent, "context_compressor").on_session_start.assert_not_called()
 
 
 class TestAutomaticCompressionStateRefreshAfterLock:

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -143,15 +143,15 @@ class TestOrphanRollbackOnCreateFailure:
             raise RuntimeError("simulated atomic publication failure")
 
         with patch.object(db, "publish_compression_child", side_effect=_boom):
-            returned, _system_prompt = agent._compress_context(
+            compressed, _ = agent._compress_context(
                 original, "sys", approx_tokens=120_000
             )
 
         assert agent.session_id == parent
-        assert [(m["role"], m["content"]) for m in returned] == [
+        assert compressed is original
+        assert [(m["role"], m["content"]) for m in original] == [
             (m["role"], m["content"]) for m in _msgs()
         ]
-        assert returned is original
         parent_row = db.get_session(parent)
         assert parent_row is not None
         assert parent_row["ended_at"] is None

--- a/tests/agent/test_compression_snapshot_revision.py
+++ b/tests/agent/test_compression_snapshot_revision.py
@@ -596,6 +596,98 @@ def test_in_place_compaction_also_rejects_stale_revision(tmp_path: Path) -> None
     ] == ["snapshot row", "external committed row"]
 
 
+def test_compression_rejects_projection_owned_by_another_session(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    first_session = "projection-owner"
+    second_session = "compression-target"
+    db.create_session(first_session, source="cli")
+    db.create_session(second_session, source="cli")
+    db.append_message(first_session, "user", "first-session row")
+    db.append_message(second_session, "user", "second-session row")
+    agent = _build_compression_agent(db, first_session)
+    foreign_projection = [
+        {"role": "user", "content": "first-session row", "_db_persisted": True}
+    ]
+
+    # Simulate a legacy/plugin session switch that bypasses the turn prologue.
+    agent.session_id = second_session
+
+    with pytest.raises(CompressionSnapshotStaleError):
+        agent._compress_context(
+            foreign_projection,
+            "sys",
+            approx_tokens=120_000,
+        )
+
+    agent.context_compressor.compress.assert_not_called()
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(second_session)
+    ] == ["second-session row"]
+
+
+def test_compression_rejects_projection_without_durable_revision(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "projection-without-revision"
+    db.create_session(session_id, source="cli")
+    db.append_message(session_id, "user", "durable row")
+    agent = _build_compression_agent(db, session_id)
+    agent._durable_transcript_revision = None
+
+    with pytest.raises(CompressionSnapshotStaleError):
+        agent._compress_context(
+            [{"role": "user", "content": "unverified bytes"}],
+            "sys",
+            approx_tokens=120_000,
+        )
+
+    agent.context_compressor.compress.assert_not_called()
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(session_id)
+    ] == ["durable row"]
+
+
+def test_in_place_compaction_rolls_back_transcript_when_prompt_update_fails(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-prompt-rollback"
+    db.create_session(session_id, source="cli", system_prompt="original prompt")
+    db.append_message(session_id, "user", "original row")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_in_place = True
+    original_messages = [
+        {"role": "user", "content": "original row", "_db_persisted": True}
+    ]
+
+    def _install_failure_trigger(conn) -> None:
+        conn.execute(
+            "CREATE TRIGGER fail_compaction_prompt_update "
+            "BEFORE UPDATE OF system_prompt ON sessions "
+            "BEGIN SELECT RAISE(ABORT, 'prompt update failed'); END"
+        )
+
+    db._execute_write(_install_failure_trigger)
+
+    returned, _ = agent._compress_context(
+        original_messages,
+        "replacement prompt",
+        approx_tokens=120_000,
+    )
+
+    assert returned == original_messages
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(session_id)
+    ] == ["original row"]
+    assert db.get_session(session_id)["system_prompt"] == "original prompt"
+
+
 def test_in_place_compaction_rebinds_revision_before_next_append(
     tmp_path: Path,
 ) -> None:

--- a/tests/agent/test_compression_snapshot_revision.py
+++ b/tests/agent/test_compression_snapshot_revision.py
@@ -1,0 +1,1356 @@
+"""Behavioral contracts for durable transcript revision fencing."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.conversation_compression import CompressionSnapshotStaleError
+from hermes_state import (
+    CompressionSessionBusyError,
+    CompressionTranscriptRevisionError,
+    DurableTranscriptRevision,
+    SessionDB,
+    _durable_revision_from_rows,
+)
+
+
+def _build_compression_agent(
+    db: SessionDB,
+    session_id: str,
+    *,
+    install_mock_compressor: bool = True,
+) -> Any:
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    if install_mock_compressor:
+        compressor = MagicMock()
+        compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "tail"},
+        ]
+        compressor.compression_count = 1
+        compressor.protect_first_n = 3
+        compressor.protect_last_n = 20
+        compressor.threshold_tokens = 100_000
+        compressor.context_length = 200_000
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor.last_real_prompt_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_compress_aborted = False
+        compressor._last_aux_model_failure_model = None
+        compressor._last_aux_model_failure_error = None
+        agent.context_compressor = compressor
+        agent.compression_in_place = False
+    return agent
+
+
+def _append_bypassing_compression_lease(
+    db: SessionDB,
+    session_id: str,
+    *,
+    role: str,
+    content: str,
+) -> None:
+    """Simulate a legacy/external writer that bypasses application lease checks."""
+
+    def _write(conn) -> None:
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp, active) "
+            "VALUES (?, ?, ?, ?, 1)",
+            (session_id, role, content, 1.0),
+        )
+        conn.execute(
+            "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+            (session_id,),
+        )
+
+    db._execute_write(_write)
+
+
+class _FinalMessage:
+    content = "done"
+    tool_calls = None
+    reasoning = None
+    reasoning_content = None
+    reasoning_details = None
+
+    @staticmethod
+    def model_dump(exclude_none: bool = False):
+        return {"role": "assistant", "content": "done"}
+
+
+class _FinalResponse:
+    def __init__(self) -> None:
+        self.id = "resp-revision"
+        self.model = "test/model"
+        self.created = 0
+        self.system_fingerprint = None
+        self.choices = [
+            SimpleNamespace(
+                message=_FinalMessage(),
+                finish_reason="stop",
+            )
+        ]
+        self.usage = SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=1,
+            total_tokens=11,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=0),
+        )
+
+
+class _RecordingAPI:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append(args[0] if args else kwargs)
+        return _FinalResponse()
+
+
+class _SequenceAPI:
+    def __init__(self, *responses) -> None:
+        self.calls = []
+        self.responses = list(responses)
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append(args[0] if args else kwargs)
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+def _tool_response():
+    tool_call = SimpleNamespace(
+        id="call_revision",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments='{"query":"x"}'),
+    )
+    message = SimpleNamespace(
+        content=None,
+        tool_calls=[tool_call],
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    return SimpleNamespace(
+        id="resp-tool-revision",
+        model="test/model",
+        created=0,
+        system_fingerprint=None,
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+        usage=SimpleNamespace(
+            prompt_tokens=150_000,
+            completion_tokens=10,
+            total_tokens=150_010,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=0),
+        ),
+    )
+
+
+def _synthetic_stale_error(db: SessionDB, session_id: str):
+    expected = db.get_active_message_revision(session_id)
+    observed = DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=expected.active_message_count + 1,
+        max_active_message_id=expected.max_active_message_id + 1,
+    )
+    return CompressionSnapshotStaleError(
+        session_id=session_id,
+        expected_revision=expected,
+        observed_revision=observed,
+    )
+
+
+def test_messages_and_revision_share_one_ordered_active_snapshot(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-snapshot"
+    db.create_session(session_id, source="test")
+    first_id = db.append_message(session_id, "user", "first")
+    second_id = db.append_message(session_id, "assistant", "second")
+
+    messages, revision = db.get_messages_as_conversation(
+        session_id, with_revision=True
+    )
+
+    assert [message["content"] for message in messages] == ["first", "second"]
+    assert revision == DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=2,
+        max_active_message_id=second_id,
+    )
+    assert second_id > first_id
+
+
+def test_revision_aware_projection_preserves_opt_in_row_ids(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-row-ids"
+    db.create_session(session_id=session_id, source="test")
+    first_id = db.append_message(session_id, "user", "hello")
+    second_id = db.append_message(session_id, "assistant", "world")
+
+    messages, revision = db.get_messages_as_conversation(
+        session_id,
+        include_row_ids=True,
+        with_revision=True,
+    )
+
+    assert [message["_row_id"] for message in messages] == [first_id, second_id]
+    assert revision.active_message_count == 2
+
+
+def test_revision_progresses_after_append_and_active_set_replacement(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-progress"
+    db.create_session(session_id, source="test")
+    db.append_message(session_id, "user", "before")
+    _messages, before = db.get_messages_as_conversation(
+        session_id, with_revision=True
+    )
+
+    appended_id = db.append_message(session_id, "assistant", "after")
+    after_append = db.get_active_message_revision(session_id)
+
+    assert after_append == DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=before.active_message_count + 1,
+        max_active_message_id=appended_id,
+    )
+
+    db.archive_and_compact(
+        session_id,
+        [{"role": "user", "content": "compacted live transcript"}],
+    )
+    messages, after_compaction = db.get_messages_as_conversation(
+        session_id, with_revision=True
+    )
+
+    assert [message["content"] for message in messages] == [
+        "compacted live transcript"
+    ]
+    assert after_compaction.active_message_count == 1
+    assert after_compaction.max_active_message_id > after_append.max_active_message_id
+    assert after_compaction != after_append
+
+
+def test_missing_and_empty_sessions_have_zero_active_revision(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    missing_messages, missing_revision = db.get_messages_as_conversation(
+        "missing-session", with_revision=True
+    )
+    assert missing_messages == []
+    assert missing_revision == DurableTranscriptRevision(
+        session_id="missing-session",
+        active_message_count=0,
+        max_active_message_id=0,
+    )
+
+    db.create_session("empty-session", source="test")
+    assert db.get_active_message_revision(
+        "empty-session"
+    ) == DurableTranscriptRevision(
+        session_id="empty-session",
+        active_message_count=0,
+        max_active_message_id=0,
+    )
+
+
+def test_revision_ignores_inactive_rows_when_all_are_loaded(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-inactive"
+    db.create_session(session_id, source="test")
+    inactive_id = db.append_message(session_id, "assistant", "inactive")
+    active_id = db.append_message(session_id, "user", "active")
+
+    def _mark_non_active(conn) -> None:
+        conn.execute("UPDATE messages SET active = 0 WHERE id = ?", (inactive_id,))
+
+    db._execute_write(_mark_non_active)
+
+    messages, revision = db.get_messages_as_conversation(
+        session_id,
+        include_inactive=True,
+        with_revision=True,
+    )
+
+    assert [message["content"] for message in messages] == [
+        "inactive",
+        "active",
+    ]
+    assert revision == DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=1,
+        max_active_message_id=active_id,
+    )
+
+
+def test_revision_builder_treats_null_active_as_inactive() -> None:
+    revision = _durable_revision_from_rows(
+        "legacy-session",
+        [
+            {"id": 41, "session_id": "legacy-session", "active": None},
+            {"id": 42, "session_id": "legacy-session", "active": 0},
+            {"id": 43, "session_id": "legacy-session", "active": 1},
+        ],
+    )
+
+    assert revision == DurableTranscriptRevision(
+        session_id="legacy-session",
+        active_message_count=1,
+        max_active_message_id=43,
+    )
+
+
+def test_stale_error_carries_only_session_and_revision_fence() -> None:
+    expected = DurableTranscriptRevision("session-a", 2, 12)
+    observed = DurableTranscriptRevision("session-a", 3, 13)
+
+    error = CompressionSnapshotStaleError(
+        session_id="session-a",
+        expected_revision=expected,
+        observed_revision=observed,
+    )
+
+    assert error.session_id == "session-a"
+    assert error.expected_revision == expected
+    assert error.observed_revision == observed
+    assert "session-a" in str(error)
+    assert "first" not in str(error)
+
+
+def test_projection_length_mismatch_with_equal_revision_still_compresses(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "projection-mismatch"
+    db.create_session(session_id, source="webui")
+    for index in range(247):
+        role = "user" if index % 2 == 0 else "assistant"
+        db.append_message(session_id, role, f"durable {index}")
+    expected_revision = db.get_active_message_revision(session_id)
+    projection = [
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"projected {index}",
+            "_db_persisted": True,
+        }
+        for index in range(209)
+    ]
+    agent = _build_compression_agent(db, session_id)
+    agent._durable_transcript_revision = expected_revision
+
+    compressed, _system_prompt = agent._compress_context(
+        projection, "sys", approx_tokens=120_000
+    )
+
+    assert compressed is not projection
+    assert compressed[0]["content"] == "[CONTEXT COMPACTION] summary"
+    agent.context_compressor.compress.assert_called_once()
+
+
+def test_external_append_after_snapshot_raises_stale_without_compressing(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "true-durable-race"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot row")
+    expected_revision = db.get_active_message_revision(session_id)
+    projection = [
+        {"role": "user", "content": "snapshot row", "_db_persisted": True}
+    ]
+    db.append_message(session_id, "assistant", "external committed row")
+    agent = _build_compression_agent(db, session_id)
+    agent._durable_transcript_revision = expected_revision
+
+    with pytest.raises(CompressionSnapshotStaleError) as caught:
+        agent._compress_context(projection, "sys", approx_tokens=120_000)
+
+    assert caught.value.expected_revision == expected_revision
+    assert caught.value.observed_revision == db.get_active_message_revision(session_id)
+    agent.context_compressor.compress.assert_not_called()
+    assert db.find_live_compression_child(session_id) is None
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(session_id)
+    ] == ["snapshot row", "external committed row"]
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_rotation_commit_fence_rejects_mutation_after_precheck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "rotation-commit-fence"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot row")
+    expected_revision = db.get_active_message_revision(session_id)
+    agent = _build_compression_agent(db, session_id)
+    setattr(agent, "_durable_transcript_revision", expected_revision)
+    original_publish = db.publish_compression_child
+
+    def _publish_after_late_write(**kwargs) -> None:
+        _append_bypassing_compression_lease(
+            db,
+            session_id,
+            role="assistant",
+            content="late durable row",
+        )
+        original_publish(**kwargs)
+
+    monkeypatch.setattr(db, "publish_compression_child", _publish_after_late_write)
+
+    with pytest.raises(CompressionSnapshotStaleError) as caught:
+        agent._compress_context(
+            [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+            "sys",
+            approx_tokens=120_000,
+        )
+
+    assert caught.value.expected_revision == expected_revision
+    assert caught.value.observed_revision == db.get_active_message_revision(session_id)
+    getattr(agent, "context_compressor").compress.assert_called_once()
+    assert db.find_live_compression_child(session_id) is None
+    assert [
+        message["content"]
+        for message in db.get_messages(session_id)
+    ] == ["snapshot row", "late durable row"]
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_in_place_commit_fence_rejects_mutation_after_precheck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-commit-fence"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot row")
+    expected_revision = db.get_active_message_revision(session_id)
+    agent = _build_compression_agent(db, session_id)
+    setattr(agent, "compression_in_place", True)
+    setattr(agent, "_durable_transcript_revision", expected_revision)
+    original_archive = db.archive_and_compact
+
+    def _archive_after_late_write(*args, **kwargs) -> int:
+        _append_bypassing_compression_lease(
+            db,
+            session_id,
+            role="assistant",
+            content="late durable row",
+        )
+        return original_archive(*args, **kwargs)
+
+    monkeypatch.setattr(db, "archive_and_compact", _archive_after_late_write)
+
+    with pytest.raises(CompressionSnapshotStaleError) as caught:
+        agent._compress_context(
+            [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+            "sys",
+            approx_tokens=120_000,
+        )
+
+    assert caught.value.expected_revision == expected_revision
+    assert caught.value.observed_revision == db.get_active_message_revision(session_id)
+    getattr(agent, "context_compressor").compress.assert_called_once()
+    all_rows = db.get_messages(session_id, include_inactive=True)
+    assert [row["content"] for row in all_rows] == [
+        "snapshot row",
+        "late durable row",
+    ]
+    assert all(row["active"] == 1 and row["compacted"] == 0 for row in all_rows)
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_replace_messages_rejects_another_writer_compression_lease(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "replace-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "original")
+    assert db.try_acquire_compression_lock(
+        session_id, "compression-owner", ttl_seconds=60
+    )
+
+    with pytest.raises(RuntimeError, match="being compressed"):
+        db.replace_messages(
+            session_id,
+            [{"role": "user", "content": "stale replacement"}],
+        )
+
+    assert [row["content"] for row in db.get_messages(session_id)] == ["original"]
+
+
+def test_rewind_rejects_another_writer_compression_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "rewind-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "keep")
+    db.append_message(session_id, "assistant", "would be rewound")
+    target_message_id = db.get_messages(session_id)[0]["id"]
+    assert db.try_acquire_compression_lock(
+        session_id, "compression-owner", ttl_seconds=60
+    )
+
+    with pytest.raises(RuntimeError, match="being compressed"):
+        db.rewind_to_message(session_id, target_message_id)
+
+    assert [row["content"] for row in db.get_messages(session_id)] == [
+        "keep",
+        "would be rewound",
+    ]
+
+
+def test_archive_and_compact_rejects_another_writer_compression_lease(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "archive-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "original")
+    assert db.try_acquire_compression_lock(
+        session_id, "compression-owner", ttl_seconds=60
+    )
+
+    with pytest.raises(RuntimeError, match="being compressed"):
+        db.archive_and_compact(
+            session_id,
+            [{"role": "user", "content": "stale summary"}],
+        )
+
+    assert [row["content"] for row in db.get_messages(session_id)] == ["original"]
+    assert db.get_messages(session_id, include_inactive=True)[0]["compacted"] == 0
+
+
+def test_restore_rewound_rejects_another_writer_compression_lease(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "restore-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "rewound row")
+    target_message_id = db.get_messages(session_id)[0]["id"]
+    db.rewind_to_message(session_id, target_message_id)
+    assert db.try_acquire_compression_lock(
+        session_id, "compression-owner", ttl_seconds=60
+    )
+
+    with pytest.raises(RuntimeError, match="being compressed"):
+        db.restore_rewound(session_id, target_message_id)
+
+    assert db.get_messages(session_id) == []
+    assert db.get_messages(session_id, include_inactive=True)[0]["active"] == 0
+
+
+def test_in_place_compaction_also_rejects_stale_revision(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot row")
+    expected_revision = db.get_active_message_revision(session_id)
+    db.append_message(session_id, "assistant", "external committed row")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_in_place = True
+    agent._durable_transcript_revision = expected_revision
+
+    with pytest.raises(CompressionSnapshotStaleError):
+        agent._compress_context(
+            [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+            "sys",
+            approx_tokens=120_000,
+        )
+
+    agent.context_compressor.compress.assert_not_called()
+    assert db.get_compression_lock_holder(session_id) is None
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(session_id)
+    ] == ["snapshot row", "external committed row"]
+
+
+def test_in_place_compaction_rebinds_revision_before_next_append(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-rebind"
+    db.create_session(session_id, source="cli")
+    db.append_message(session_id, "user", "original row")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_in_place = True
+
+    compressed, _ = agent._compress_context(
+        [{"role": "user", "content": "original row", "_db_persisted": True}],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    assert agent.session_id == session_id
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        session_id
+    )
+
+    next_message = {"role": "assistant", "content": "next append"}
+    agent._flush_messages_to_session_db([next_message], compressed)
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        session_id
+    )
+
+
+def test_session_db_owner_tracks_revision_without_explicit_transport(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "compatibility-owner"
+    db.create_session(session_id, source="cli")
+    db.append_message(session_id, "user", "existing user")
+    db.append_message(session_id, "assistant", "existing assistant")
+
+    agent = _build_compression_agent(db, session_id)
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        session_id
+    )
+
+    owned_message = {"role": "user", "content": "owned append"}
+    agent._session_db_created = True
+    agent._flush_messages_to_session_db([owned_message], None)
+    assert owned_message["_db_persisted"] is True
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        session_id
+    )
+
+    compressed, _ = agent._compress_context(
+        [owned_message],
+        system_message="system",
+        force=True,
+    )
+
+    assert compressed != [owned_message]
+    agent.context_compressor.compress.assert_called_once()
+
+
+def test_legacy_history_without_revision_reloads_atomic_durable_snapshot(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "legacy-atomic-reload"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "A")
+    db.append_message(session_id, "assistant", "B")
+    captured_history = [
+        {"role": "user", "content": "A"},
+        {"role": "assistant", "content": "B"},
+    ]
+    db.append_message(session_id, "user", "C")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent.context_compressor.protect_first_n = 0
+    agent.context_compressor.protect_last_n = 0
+    agent.context_compressor.threshold_tokens = 1
+    agent.context_compressor.context_length = 100
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = False
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress.return_value = True
+    agent._disable_streaming = True
+    agent._interruptible_api_call = _RecordingAPI()
+
+    agent.run_conversation("D", conversation_history=captured_history)
+
+    compressed_input = agent.context_compressor.compress.call_args.args[0]
+    assert "C" in [message.get("content") for message in compressed_input]
+
+
+def test_client_managed_history_survives_when_no_durable_rows_exist(
+    tmp_path: Path,
+) -> None:
+    """Re-anchoring must not erase a stateless caller's own projection.
+
+    ``/responses`` lets a client supply ``conversation_history`` against a
+    brand-new session id. There are no durable rows to be stale against, so
+    the supplied bytes are the only context and must reach the provider.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "client-managed-stateless"
+    db.create_session(session_id, source="api")
+    agent = _build_compression_agent(db, session_id, install_mock_compressor=False)
+    agent._persist_disabled = True
+    agent.compression_enabled = False
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+
+    result = agent.run_conversation(
+        "client C",
+        conversation_history=[
+            {"role": "user", "content": "client A"},
+            {"role": "assistant", "content": "client B"},
+        ],
+    )
+
+    assert result["final_response"] == "done"
+    assert [
+        message.get("content")
+        for message in api.calls[0]["messages"]
+        if message.get("role") in {"user", "assistant"}
+    ] == ["client A", "client B", "client C"]
+    assert agent._durable_transcript_revision.active_message_count == 0
+
+
+def test_supplied_revision_keeps_a_longer_caller_projection(tmp_path: Path) -> None:
+    """A tokened projection is never silently re-anchored onto durable rows.
+
+    The gateway's FTS write-corruption guard (#50502) replays a live in-memory
+    transcript that is longer than the persisted rows; re-anchoring it would
+    reinstate exactly the amnesia that guard exists to prevent.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "live-longer-than-durable"
+    db.create_session(session_id, source="telegram")
+    db.append_message(session_id, "user", "persisted only")
+    revision = db.get_active_message_revision(session_id)
+    agent = _build_compression_agent(db, session_id, install_mock_compressor=False)
+    agent._persist_disabled = True
+    agent.compression_enabled = False
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+
+    agent.run_conversation(
+        "next",
+        conversation_history=[
+            {"role": "user", "content": "persisted only"},
+            {"role": "assistant", "content": "live reply"},
+            {"role": "user", "content": "live follow-up"},
+            {"role": "assistant", "content": "live reply 2"},
+        ],
+        conversation_history_revision=revision,
+    )
+
+    assert [
+        message.get("content")
+        for message in api.calls[0]["messages"]
+        if message.get("role") in {"user", "assistant"}
+    ] == [
+        "persisted only",
+        "live reply",
+        "live follow-up",
+        "live reply 2",
+        "next",
+    ]
+
+
+def test_legacy_history_reload_failure_is_projection_unverifiable_before_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "legacy-reload-failure"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "durable")
+    agent = _build_compression_agent(db, session_id)
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+    monkeypatch.setattr(
+        db,
+        "get_messages_as_conversation",
+        MagicMock(side_effect=RuntimeError("read failed")),
+    )
+
+    result = agent.run_conversation(
+        "new turn",
+        conversation_history=[{"role": "user", "content": "unverified"}],
+    )
+
+    assert result["error"] == "compression_projection_unverifiable"
+    assert result["compression_projection_unverifiable"] is True
+    assert api.calls == []
+    agent.context_compressor.compress.assert_not_called()
+
+
+def test_in_place_commit_failure_restores_mutated_messages_and_stops(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-lease-loss"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "original")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_in_place = True
+    messages = [{"role": "user", "content": "original", "_db_persisted": True}]
+
+    def _mutating_compress(live_messages, **_kwargs):
+        live_messages[:] = [{"role": "user", "content": "mutated summary"}]
+        return [{"role": "user", "content": "compressed summary"}]
+
+    agent.context_compressor.compress.side_effect = _mutating_compress
+    monkeypatch.setattr(
+        db,
+        "archive_and_compact",
+        MagicMock(side_effect=CompressionSessionBusyError("lease expired")),
+    )
+
+    from agent import conversation_compression
+
+    with pytest.raises(conversation_compression.CompressionCommitFailedError):
+        agent._compress_context(messages, "system", force=True)
+
+    assert [message["content"] for message in messages] == ["original"]
+    assert [row["content"] for row in db.get_messages(session_id)] == ["original"]
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_stale_replace_after_compaction_release_is_rejected(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "replace-after-compression"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "T0")
+    revision0 = db.get_active_message_revision(session_id)
+    db.archive_and_compact(
+        session_id,
+        [{"role": "user", "content": "T1 summary"}],
+        expected_revision=revision0,
+    )
+
+    with pytest.raises(CompressionTranscriptRevisionError):
+        db.replace_messages(
+            session_id,
+            [{"role": "user", "content": "stale T0 rewrite"}],
+            expected_revision=revision0,
+        )
+
+    assert [row["content"] for row in db.get_messages(session_id)] == ["T1 summary"]
+
+
+def test_api_content_backfill_rejects_adverse_compression_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "api-content-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "clean")
+    assert db.try_acquire_compression_lock(session_id, "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.set_latest_user_api_content(session_id, "clean", "wire")
+
+    assert db.get_messages(session_id)[0]["api_content"] is None
+
+
+def test_clear_messages_rejects_adverse_compression_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "clear-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "keep")
+    assert db.try_acquire_compression_lock(session_id, "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.clear_messages(session_id)
+
+    assert [row["content"] for row in db.get_messages(session_id)] == ["keep"]
+
+
+def test_delete_session_rejects_adverse_compression_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "delete-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "keep")
+    assert db.try_acquire_compression_lock(session_id, "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.delete_session(session_id)
+
+    assert db.get_session(session_id) is not None
+    assert [row["content"] for row in db.get_messages(session_id)] == ["keep"]
+
+
+def test_bulk_delete_rejects_if_any_target_has_adverse_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    for session_id in ("bulk-free", "bulk-leased"):
+        db.create_session(session_id, source="webui")
+        db.append_message(session_id, "user", session_id)
+    assert db.try_acquire_compression_lock("bulk-leased", "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.delete_sessions(["bulk-free", "bulk-leased"])
+
+    assert db.get_session("bulk-free") is not None
+    assert db.get_session("bulk-leased") is not None
+
+
+def test_prune_rejects_target_with_adverse_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "prune-leased"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "keep")
+    db.end_session(session_id, "completed")
+    assert db.try_acquire_compression_lock(session_id, "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.prune_sessions(older_than_days=-1)
+
+    assert db.get_session(session_id) is not None
+
+
+def test_rewind_rejects_stale_revision_after_late_append(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "rewind-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "first")
+    target_id = db.get_messages(session_id)[0]["id"]
+    revision = db.get_active_message_revision(session_id)
+    db.append_message(session_id, "assistant", "late")
+
+    with pytest.raises(CompressionTranscriptRevisionError):
+        db.rewind_to_message(
+            session_id,
+            target_id,
+            expected_revision=revision,
+        )
+
+    assert [message["content"] for message in db.get_messages_as_conversation(session_id)] == [
+        "first",
+        "late",
+    ]
+
+
+def test_recent_user_messages_and_revision_share_one_snapshot(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "rewind-atomic-load"
+    db.create_session(session_id, source="telegram")
+    user_id = db.append_message(session_id, "user", "target")
+    db.append_message(session_id, "assistant", "answer")
+
+    recents, revision = db.list_recent_user_messages(
+        session_id,
+        with_revision=True,
+    )
+
+    assert recents[0]["id"] == user_id
+    assert revision == db.get_active_message_revision(session_id)
+
+
+def test_restore_rejects_stale_revision_after_late_append(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "restore-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "rewound")
+    target_id = db.get_messages(session_id)[0]["id"]
+    revision0 = db.get_active_message_revision(session_id)
+    db.rewind_to_message(session_id, target_id, expected_revision=revision0)
+    revision1 = db.get_active_message_revision(session_id)
+    db.append_message(session_id, "user", "late active")
+
+    with pytest.raises(CompressionTranscriptRevisionError):
+        db.restore_rewound(
+            session_id,
+            target_id,
+            expected_revision=revision1,
+        )
+
+    rows = db.get_messages(session_id, include_inactive=True)
+    assert [(row["content"], row["active"]) for row in rows] == [
+        ("rewound", False),
+        ("late active", True),
+    ]
+
+
+def test_api_content_backfill_advances_revision_without_count_or_max_id_change(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "api-content-revision"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "clean")
+    before = db.get_active_message_revision(session_id)
+
+    assert db.set_latest_user_api_content(session_id, "clean", "wire") == 1
+
+    after = db.get_active_message_revision(session_id)
+    assert after.active_message_count == before.active_message_count
+    assert after.max_active_message_id == before.max_active_message_id
+    assert after != before
+
+
+def test_api_content_backfill_returns_the_committed_revision(tmp_path: Path) -> None:
+    """The backfill's own writer must be able to re-fence without a second read."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "api-content-revision-return"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "clean")
+
+    updated, revision = db.set_latest_user_api_content(
+        session_id, "clean", "wire", with_revision=True
+    )
+
+    assert updated == 1
+    assert revision == db.get_active_message_revision(session_id)
+
+
+def test_display_only_stamp_does_not_move_the_durable_revision(
+    tmp_path: Path,
+) -> None:
+    """Presentation sidecars are not model-facing, so they must not fence.
+
+    ``set_latest_matching_message_display_kind`` runs outside the compression
+    lease on every gateway/CLI turn; counting it as a revision change would
+    abort the next compression as spuriously stale.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "display-only-stamp"
+    db.create_session(session_id, source="cli")
+    db.append_message(session_id, "user", "hello")
+    before = db.get_active_message_revision(session_id)
+
+    assert db.set_latest_matching_message_display_kind(
+        session_id,
+        role="user",
+        content="hello",
+        display_kind="voice",
+        display_metadata={"source": "stt"},
+    )
+
+    assert db.get_active_message_revision(session_id) == before
+
+
+def test_rotation_rebinds_revision_before_child_append(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_session_id = "revision-parent"
+    db.create_session(parent_session_id, source="cli")
+    db.append_message(parent_session_id, "user", "parent row")
+    agent = _build_compression_agent(db, parent_session_id)
+    projection = [
+        {"role": "user", "content": "parent row", "_db_persisted": True}
+    ]
+
+    compressed, _ = agent._compress_context(
+        projection,
+        system_message="system",
+        force=True,
+    )
+
+    child_session_id = agent.session_id
+    assert child_session_id != parent_session_id
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        child_session_id
+    )
+    assert agent._durable_transcript_revision.session_id == child_session_id
+
+    child_append = {"role": "assistant", "content": "child append"}
+    agent._flush_messages_to_session_db([child_append], compressed)
+
+    assert child_append["_db_persisted"] is True
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        child_session_id
+    )
+
+
+def test_preflight_stale_revision_returns_actionable_result_without_api_call(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "preflight-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot user")
+    expected_revision = db.get_active_message_revision(session_id)
+    db.append_message(session_id, "assistant", "external answer")
+
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent.context_compressor.protect_first_n = 0
+    agent.context_compressor.protect_last_n = 0
+    agent.context_compressor.threshold_tokens = 1
+    agent.context_compressor.context_length = 100
+    agent.context_compressor.compression_count = 0
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = False
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress.return_value = True
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+
+    result = agent.run_conversation(
+        "new user turn",
+        conversation_history=[{"role": "user", "content": "snapshot user"}],
+        conversation_history_revision={
+            "session_id": session_id,
+            "active_message_count": expected_revision.active_message_count,
+            "max_active_message_id": expected_revision.max_active_message_id,
+        },
+    )
+
+    assert result["completed"] is False
+    assert result["failed"] is False
+    assert result["partial"] is True
+    assert result["compression_snapshot_stale"] is True
+    assert "reload" in result["final_response"].lower()
+    assert api.calls == []
+    agent.context_compressor.compress.assert_not_called()
+    assert db.find_live_compression_child(session_id) is None
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(session_id)
+    ] == ["snapshot user", "external answer"]
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_pre_api_stale_revision_stops_before_provider_call(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "pre-api-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "history user")
+    db.append_message(session_id, "assistant", "history assistant")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent._disable_streaming = True
+    agent._persist_disabled = True
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = False
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress_preflight.return_value = False
+    agent.context_compressor.should_compress.return_value = True
+    api = _RecordingAPI()
+    agent._interruptible_api_call = api
+
+    with patch.object(
+        agent,
+        "_compress_context",
+        side_effect=_synthetic_stale_error(db, session_id),
+    ) as compress:
+        result = agent.run_conversation(
+            "new question",
+            conversation_history=[
+                {"role": "user", "content": "history user"},
+                {"role": "assistant", "content": "history assistant"},
+            ],
+        )
+
+    assert result["compression_snapshot_stale"] is True
+    assert result["partial"] is True
+    assert api.calls == []
+    compress.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("status_code", "message", "provider"),
+    [
+        (413, "Request entity too large", "unknown"),
+        (
+            400,
+            "This endpoint's maximum context length is 128000 tokens; "
+            "the request has too many tokens",
+            "unknown",
+        ),
+        (
+            429,
+            "Extra usage is required for long context requests over 200k tokens",
+            "anthropic",
+        ),
+    ],
+)
+def test_provider_overflow_stale_revision_prevents_retry_payload(
+    tmp_path: Path,
+    status_code: int,
+    message: str,
+    provider: str,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = f"overflow-stale-{status_code}"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "history user")
+    db.append_message(session_id, "assistant", "history assistant")
+    agent = _build_compression_agent(db, session_id)
+    agent.provider = provider
+    agent.compression_enabled = True
+    agent._disable_streaming = True
+    agent._persist_disabled = True
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = False
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress_preflight.return_value = False
+    agent.context_compressor.should_compress.return_value = False
+    provider_error = Exception(message)
+    setattr(provider_error, "status_code", status_code)
+    api = _SequenceAPI(provider_error)
+    agent._interruptible_api_call = api
+
+    with patch.object(
+        agent,
+        "_compress_context",
+        side_effect=_synthetic_stale_error(db, session_id),
+    ) as compress:
+        result = agent.run_conversation(
+            "new question",
+            conversation_history=[
+                {"role": "user", "content": "history user"},
+                {"role": "assistant", "content": "history assistant"},
+            ],
+        )
+
+    assert result["compression_snapshot_stale"] is True
+    assert result["partial"] is True
+    assert len(api.calls) == 1
+    compress.assert_called_once()
+
+
+def test_post_tool_stale_revision_prevents_next_provider_payload(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "post-tool-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "history user")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent._disable_streaming = True
+    agent._persist_disabled = True
+    agent.context_compressor.last_prompt_tokens = 150_000
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = True
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress_preflight.return_value = False
+    agent.context_compressor.should_compress.return_value = True
+    agent.valid_tool_names = {"web_search"}
+    api = _SequenceAPI(_tool_response())
+    agent._interruptible_api_call = api
+
+    with (
+        patch.object(
+            agent,
+            "_compress_context",
+            side_effect=_synthetic_stale_error(db, session_id),
+        ) as compress,
+        patch("run_agent.handle_function_call", return_value='{"ok":true}'),
+    ):
+        result = agent.run_conversation("use a tool")
+
+    assert result["compression_snapshot_stale"] is True
+    assert result["partial"] is True
+    assert len(api.calls) == 1
+    compress.assert_called_once()
+
+
+def test_post_tool_stale_preserves_effect_once_without_replay_instruction(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "post-tool-stale-persisted"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "history user")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent._disable_streaming = True
+    agent.context_compressor.last_prompt_tokens = 150_000
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = True
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress_preflight.return_value = False
+    agent.context_compressor.should_compress.return_value = True
+    agent.valid_tool_names = {"web_search"}
+    api = _SequenceAPI(_tool_response())
+    agent._interruptible_api_call = api
+    effects = []
+
+    def _counting_tool(*_args, **_kwargs):
+        effects.append("ran")
+        return '{"ok":true}'
+
+    with (
+        patch.object(
+            agent,
+            "_compress_context",
+            side_effect=_synthetic_stale_error(db, session_id),
+        ),
+        patch("run_agent.handle_function_call", side_effect=_counting_tool),
+    ):
+        result = agent.run_conversation("use a tool")
+
+    assert effects == ["ran"]
+    assert len(api.calls) == 1
+    assert result["compression_effects_preserved"] is True
+    guidance = result["final_response"].lower()
+    assert "again" not in guidance
+    assert "resend" not in guidance
+    assert "retry" not in guidance
+
+
+def test_run_conversation_normalizes_revision_without_provider_payload_leak(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-transport"
+    db.create_session(session_id, source="webui")
+    first_id = db.append_message(session_id, "user", "existing")
+    agent = _build_compression_agent(
+        db,
+        session_id,
+        install_mock_compressor=False,
+    )
+    agent._persist_disabled = True
+    agent.compression_enabled = False
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+    raw_revision = {
+        "session_id": session_id,
+        "active_message_count": 1,
+        "max_active_message_id": first_id,
+    }
+    captured = {}
+
+    from agent import conversation_loop
+
+    real_build_turn_context = conversation_loop.build_turn_context
+
+    def _capture_turn_context(*args, **kwargs):
+        context = real_build_turn_context(*args, **kwargs)
+        captured["context"] = context
+        return context
+
+    with patch.object(
+        conversation_loop,
+        "build_turn_context",
+        side_effect=_capture_turn_context,
+    ):
+        result = agent.run_conversation(
+            "new question",
+            conversation_history=[{"role": "user", "content": "existing"}],
+            conversation_history_revision=raw_revision,
+        )
+
+    expected = DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=1,
+        max_active_message_id=first_id,
+    )
+    assert result["final_response"] == "done"
+    assert captured["context"].durable_transcript_revision == expected
+    assert agent._durable_transcript_revision == expected
+    assert len(api.calls) == 1
+    assert "conversation_history_revision" not in api.calls[0]
+    assert all(
+        "conversation_history_revision" not in message
+        for message in api.calls[0]["messages"]
+    )

--- a/tests/agent/test_compression_snapshot_revision.py
+++ b/tests/agent/test_compression_snapshot_revision.py
@@ -1,0 +1,1844 @@
+"""Behavioral contracts for durable transcript revision fencing."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.conversation_compression import (
+    CompressionCommitFailedError,
+    CompressionCommitFence,
+    CompressionSnapshotStaleError,
+)
+from hermes_state import (
+    CompressionSessionBusyError,
+    CompressionTranscriptRevisionError,
+    DurableTranscriptRevision,
+    SessionDB,
+    _durable_revision_from_rows,
+)
+
+
+def _build_compression_agent(
+    db: SessionDB,
+    session_id: str,
+    *,
+    install_mock_compressor: bool = True,
+) -> Any:
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    if install_mock_compressor:
+        compressor = MagicMock()
+        compressor.compress.return_value = [
+            {"role": "user", "content": "x"},
+        ]
+        compressor.compression_count = 1
+        compressor.protect_first_n = 3
+        compressor.protect_last_n = 20
+        compressor.threshold_tokens = 100_000
+        compressor.context_length = 200_000
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor.last_real_prompt_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_compress_aborted = False
+        compressor._last_aux_model_failure_model = None
+        compressor._last_aux_model_failure_error = None
+        agent.context_compressor = compressor
+        agent.compression_in_place = False
+    return agent
+
+
+def _append_bypassing_compression_lease(
+    db: SessionDB,
+    session_id: str,
+    *,
+    role: str,
+    content: str,
+) -> None:
+    """Simulate a legacy/external writer that bypasses application lease checks."""
+
+    def _write(conn) -> None:
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp, active) "
+            "VALUES (?, ?, ?, ?, 1)",
+            (session_id, role, content, 1.0),
+        )
+        conn.execute(
+            "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+            (session_id,),
+        )
+
+    db._execute_write(_write)
+
+
+class _FinalMessage:
+    content = "done"
+    tool_calls = None
+    reasoning = None
+    reasoning_content = None
+    reasoning_details = None
+
+    @staticmethod
+    def model_dump(exclude_none: bool = False):
+        return {"role": "assistant", "content": "done"}
+
+
+class _FinalResponse:
+    def __init__(self) -> None:
+        self.id = "resp-revision"
+        self.model = "test/model"
+        self.created = 0
+        self.system_fingerprint = None
+        self.choices = [
+            SimpleNamespace(
+                message=_FinalMessage(),
+                finish_reason="stop",
+            )
+        ]
+        self.usage = SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=1,
+            total_tokens=11,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=0),
+        )
+
+
+class _RecordingAPI:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append(args[0] if args else kwargs)
+        return _FinalResponse()
+
+
+class _SequenceAPI:
+    def __init__(self, *responses) -> None:
+        self.calls = []
+        self.responses = list(responses)
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append(args[0] if args else kwargs)
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+def _tool_response():
+    tool_call = SimpleNamespace(
+        id="call_revision",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments='{"query":"x"}'),
+    )
+    message = SimpleNamespace(
+        content=None,
+        tool_calls=[tool_call],
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    return SimpleNamespace(
+        id="resp-tool-revision",
+        model="test/model",
+        created=0,
+        system_fingerprint=None,
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+        usage=SimpleNamespace(
+            prompt_tokens=150_000,
+            completion_tokens=10,
+            total_tokens=150_010,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=0),
+        ),
+    )
+
+
+def _synthetic_stale_error(db: SessionDB, session_id: str):
+    expected = db.get_active_message_revision(session_id)
+    observed = DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=expected.active_message_count + 1,
+        max_active_message_id=expected.max_active_message_id + 1,
+    )
+    return CompressionSnapshotStaleError(
+        session_id=session_id,
+        expected_revision=expected,
+        observed_revision=observed,
+    )
+
+
+def test_messages_and_revision_share_one_ordered_active_snapshot(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-snapshot"
+    db.create_session(session_id, source="test")
+    first_id = db.append_message(session_id, "user", "first")
+    second_id = db.append_message(session_id, "assistant", "second")
+
+    messages, revision = db.get_messages_as_conversation(
+        session_id, with_revision=True
+    )
+
+    assert [message["content"] for message in messages] == ["first", "second"]
+    assert revision == DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=2,
+        max_active_message_id=second_id,
+    )
+    assert second_id > first_id
+
+
+def test_revision_aware_projection_preserves_opt_in_row_ids(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-row-ids"
+    db.create_session(session_id=session_id, source="test")
+    first_id = db.append_message(session_id, "user", "hello")
+    second_id = db.append_message(session_id, "assistant", "world")
+
+    messages, revision = db.get_messages_as_conversation(
+        session_id,
+        include_row_ids=True,
+        with_revision=True,
+    )
+
+    assert [message["_row_id"] for message in messages] == [first_id, second_id]
+    assert revision.active_message_count == 2
+
+
+def test_revision_progresses_after_append_and_active_set_replacement(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-progress"
+    db.create_session(session_id, source="test")
+    db.append_message(session_id, "user", "before")
+    _messages, before = db.get_messages_as_conversation(
+        session_id, with_revision=True
+    )
+
+    appended_id = db.append_message(session_id, "assistant", "after")
+    after_append = db.get_active_message_revision(session_id)
+
+    assert after_append == DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=before.active_message_count + 1,
+        max_active_message_id=appended_id,
+    )
+
+    db.archive_and_compact(
+        session_id,
+        [{"role": "user", "content": "compacted live transcript"}],
+    )
+    messages, after_compaction = db.get_messages_as_conversation(
+        session_id, with_revision=True
+    )
+
+    assert [message["content"] for message in messages] == [
+        "compacted live transcript"
+    ]
+    assert after_compaction.active_message_count == 1
+    assert after_compaction.max_active_message_id > after_append.max_active_message_id
+    assert after_compaction != after_append
+
+
+def test_missing_and_empty_sessions_have_zero_active_revision(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    missing_messages, missing_revision = db.get_messages_as_conversation(
+        "missing-session", with_revision=True
+    )
+    assert missing_messages == []
+    assert missing_revision == DurableTranscriptRevision(
+        session_id="missing-session",
+        active_message_count=0,
+        max_active_message_id=0,
+    )
+
+    db.create_session("empty-session", source="test")
+    assert db.get_active_message_revision(
+        "empty-session"
+    ) == DurableTranscriptRevision(
+        session_id="empty-session",
+        active_message_count=0,
+        max_active_message_id=0,
+    )
+
+
+def test_revision_ignores_inactive_rows_when_all_are_loaded(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-inactive"
+    db.create_session(session_id, source="test")
+    inactive_id = db.append_message(session_id, "assistant", "inactive")
+    active_id = db.append_message(session_id, "user", "active")
+
+    def _mark_non_active(conn) -> None:
+        conn.execute("UPDATE messages SET active = 0 WHERE id = ?", (inactive_id,))
+
+    db._execute_write(_mark_non_active)
+
+    messages, revision = db.get_messages_as_conversation(
+        session_id,
+        include_inactive=True,
+        with_revision=True,
+    )
+
+    assert [message["content"] for message in messages] == [
+        "inactive",
+        "active",
+    ]
+    assert revision == DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=1,
+        max_active_message_id=active_id,
+    )
+
+
+def test_revision_builder_treats_null_active_as_inactive() -> None:
+    revision = _durable_revision_from_rows(
+        "legacy-session",
+        [
+            {"id": 41, "session_id": "legacy-session", "active": None},
+            {"id": 42, "session_id": "legacy-session", "active": 0},
+            {"id": 43, "session_id": "legacy-session", "active": 1},
+        ],
+    )
+
+    assert revision == DurableTranscriptRevision(
+        session_id="legacy-session",
+        active_message_count=1,
+        max_active_message_id=43,
+    )
+
+
+def test_stale_error_carries_only_session_and_revision_fence() -> None:
+    expected = DurableTranscriptRevision("session-a", 2, 12)
+    observed = DurableTranscriptRevision("session-a", 3, 13)
+
+    error = CompressionSnapshotStaleError(
+        session_id="session-a",
+        expected_revision=expected,
+        observed_revision=observed,
+    )
+
+    assert error.session_id == "session-a"
+    assert error.expected_revision == expected
+    assert error.observed_revision == observed
+    assert "session-a" in str(error)
+    assert "first" not in str(error)
+
+
+def test_projection_length_mismatch_with_equal_revision_still_compresses(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "projection-mismatch"
+    db.create_session(session_id, source="webui")
+    for index in range(247):
+        role = "user" if index % 2 == 0 else "assistant"
+        db.append_message(session_id, role, f"durable {index}")
+    expected_revision = db.get_active_message_revision(session_id)
+    projection = [
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"projected {index}",
+            "_db_persisted": True,
+        }
+        for index in range(209)
+    ]
+    agent = _build_compression_agent(db, session_id)
+    agent._durable_transcript_revision = expected_revision
+
+    compressed, _system_prompt = agent._compress_context(
+        projection, "sys", approx_tokens=120_000
+    )
+
+    assert compressed is not projection
+    assert compressed[0]["content"] == "x"
+    agent.context_compressor.compress.assert_called_once()
+
+
+def test_external_append_after_snapshot_is_preserved_without_stale(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "true-durable-race"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot row")
+    expected_revision = db.get_active_message_revision(session_id)
+    projection = [
+        {"role": "user", "content": "snapshot row", "_db_persisted": True}
+    ]
+    db.append_message(session_id, "assistant", "external committed row")
+    agent = _build_compression_agent(db, session_id)
+    agent._durable_transcript_revision = expected_revision
+
+    compressed, _ = agent._compress_context(
+        projection, "sys", approx_tokens=120_000
+    )
+
+    agent.context_compressor.compress.assert_called_once()
+    child_session_id = agent.session_id
+    assert child_session_id != session_id
+    assert [message["content"] for message in compressed] == [
+        "x",
+        "external committed row",
+    ]
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(child_session_id)
+    ] == ["x", "external committed row"]
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_rotation_commit_fence_rejects_prefix_mutation_after_precheck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "rotation-commit-fence"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot row")
+    expected_revision = db.get_active_message_revision(session_id)
+    agent = _build_compression_agent(db, session_id)
+    setattr(agent, "_durable_transcript_revision", expected_revision)
+    original_publish = db.publish_compression_child
+
+    def _publish_after_prefix_rewrite(**kwargs) -> None:
+        def _rewrite(conn) -> None:
+            conn.execute(
+                "UPDATE messages SET api_content = ? "
+                "WHERE session_id = ? AND active = 1",
+                ("destructive API rewrite", session_id),
+            )
+
+        db._execute_write(_rewrite)
+        original_publish(**kwargs)
+
+    monkeypatch.setattr(db, "publish_compression_child", _publish_after_prefix_rewrite)
+
+    with pytest.raises(CompressionSnapshotStaleError) as caught:
+        agent._compress_context(
+            [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+            "sys",
+            approx_tokens=120_000,
+        )
+
+    assert caught.value.expected_revision == expected_revision
+    assert caught.value.observed_revision == db.get_active_message_revision(session_id)
+    getattr(agent, "context_compressor").compress.assert_called_once()
+    assert db.find_live_compression_child(session_id) is None
+    assert db.get_active_message_revision(session_id) != expected_revision
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_rotation_commit_preserves_append_only_tail_during_slow_summary(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_session_id = "rotation-append-progress"
+    db.create_session(parent_session_id, source="webui")
+    db.append_message(parent_session_id, "user", "snapshot row")
+    agent = _build_compression_agent(db, parent_session_id)
+
+    def _compress_after_late_append(_messages, **_kwargs):
+        _append_bypassing_compression_lease(
+            db,
+            parent_session_id,
+            role="assistant",
+            content="late durable row",
+        )
+        return [{"role": "user", "content": "x"}]
+
+    agent.context_compressor.compress.side_effect = _compress_after_late_append
+
+    compressed, _ = agent._compress_context(
+        [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    child_session_id = agent.session_id
+    assert child_session_id != parent_session_id
+    assert [message["content"] for message in compressed] == [
+        "x",
+        "late durable row",
+    ]
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(child_session_id)
+    ] == ["x", "late durable row"]
+    live_child = db.find_live_compression_child(parent_session_id)
+    assert live_child is not None
+    assert live_child["id"] == child_session_id
+    assert db.get_compression_lock_holder(parent_session_id) is None
+
+
+def test_repeated_cancelled_fences_then_append_only_rotation_makes_progress(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_session_id = "rotation-after-cancelled-fences"
+    db.create_session(parent_session_id, source="webui")
+    db.append_message(parent_session_id, "user", "snapshot row")
+
+    cancelled_appends = []
+    for attempt in range(3):
+        agent = _build_compression_agent(db, parent_session_id)
+        fence = CompressionCommitFence()
+        assert fence.cancel_before_commit() is True
+        projection = db.get_messages_as_conversation(parent_session_id)
+
+        returned, _ = agent._compress_context(
+            projection,
+            "sys",
+            approx_tokens=120_000,
+            commit_fence=fence,
+        )
+
+        assert returned == projection
+        agent.context_compressor.compress.assert_not_called()
+        assert db.find_live_compression_child(parent_session_id) is None
+        content = f"append after cancelled fence {attempt}"
+        cancelled_appends.append(content)
+        db.append_message(parent_session_id, "assistant", content)
+
+    agent = _build_compression_agent(db, parent_session_id)
+
+    def _compress_after_final_append(_messages, **_kwargs):
+        _append_bypassing_compression_lease(
+            db,
+            parent_session_id,
+            role="assistant",
+            content="append during final slow summary",
+        )
+        return [{"role": "user", "content": "x"}]
+
+    agent.context_compressor.compress.side_effect = _compress_after_final_append
+    projection = db.get_messages_as_conversation(parent_session_id)
+    compressed, _ = agent._compress_context(
+        projection,
+        "sys",
+        approx_tokens=120_000,
+        commit_fence=CompressionCommitFence(),
+    )
+
+    child_session_id = agent.session_id
+    assert child_session_id != parent_session_id
+    assert [message["content"] for message in compressed] == [
+        "x",
+        "append during final slow summary",
+    ]
+    parent_contents = [
+        message["content"]
+        for message in db.get_messages(parent_session_id, include_inactive=True)
+    ]
+    for content in cancelled_appends:
+        assert parent_contents.count(content) == 1
+    child_contents = [
+        message["content"]
+        for message in db.get_messages_as_conversation(child_session_id)
+    ]
+    assert child_contents.count("x") == 1
+    assert child_contents.count("append during final slow summary") == 1
+    assert db.get_compression_lock_holder(parent_session_id) is None
+
+
+def test_rotation_preserves_append_after_tail_ceiling_before_flush(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_session_id = "rotation-post-ceiling-append"
+    db.create_session(parent_session_id, source="webui")
+    db.append_message(parent_session_id, "user", "snapshot row")
+    agent = _build_compression_agent(db, parent_session_id)
+    agent._durable_transcript_revision = db.get_active_message_revision(
+        parent_session_id
+    )
+    original_flush = agent._flush_messages_to_session_db
+    injected = False
+
+    def _flush_after_foreign_append(*args, **kwargs):
+        nonlocal injected
+        if not injected:
+            injected = True
+            _append_bypassing_compression_lease(
+                db,
+                parent_session_id,
+                role="assistant",
+                content="late after ceiling",
+            )
+        return original_flush(*args, **kwargs)
+
+    monkeypatch.setattr(
+        agent,
+        "_flush_messages_to_session_db",
+        _flush_after_foreign_append,
+    )
+
+    compressed, _ = agent._compress_context(
+        [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    child_session_id = agent.session_id
+    child_contents = [
+        message["content"]
+        for message in db.get_messages_as_conversation(child_session_id)
+    ]
+    assert [message["content"] for message in compressed] == child_contents
+    assert child_contents == ["x", "late after ceiling"]
+    assert child_contents.count("late after ceiling") == 1
+
+
+@pytest.mark.parametrize("in_place", [False, True])
+def test_committed_projection_and_revision_share_one_atomic_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    in_place: bool,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_session_id = f"atomic-post-commit-{'in-place' if in_place else 'rotation'}"
+    db.create_session(parent_session_id, source="webui")
+    db.append_message(parent_session_id, "user", "snapshot row")
+    agent = _build_compression_agent(db, parent_session_id)
+    agent.compression_in_place = in_place
+    agent._durable_transcript_revision = db.get_active_message_revision(
+        parent_session_id
+    )
+    committed_session_id = None
+    injected = False
+    if in_place:
+        original_commit = db.archive_and_compact
+
+        def _commit_then_mark(*args, **kwargs):
+            nonlocal committed_session_id, injected
+            result = original_commit(*args, **kwargs)
+            committed_session_id = parent_session_id
+            _append_bypassing_compression_lease(
+                db,
+                committed_session_id,
+                role="assistant",
+                content="append between projection and revision",
+            )
+            injected = True
+            return result
+
+        monkeypatch.setattr(db, "archive_and_compact", _commit_then_mark)
+    else:
+        original_commit = db.publish_compression_child
+
+        def _commit_then_mark(*args, **kwargs):
+            nonlocal committed_session_id, injected
+            result = original_commit(*args, **kwargs)
+            committed_session_id = kwargs["child_session_id"]
+            _append_bypassing_compression_lease(
+                db,
+                committed_session_id,
+                role="assistant",
+                content="append between projection and revision",
+            )
+            injected = True
+            return result
+
+        monkeypatch.setattr(db, "publish_compression_child", _commit_then_mark)
+
+    compressed, _ = agent._compress_context(
+        [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    assert injected is True
+    assert "append between projection and revision" not in [
+        message["content"] for message in compressed
+    ]
+    assert agent._durable_transcript_revision != db.get_active_message_revision(
+        agent.session_id
+    )
+
+
+@pytest.mark.parametrize("in_place", [False, True])
+def test_committed_projection_is_returned_by_the_write_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    in_place: bool,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_session_id = f"post-commit-read-failure-{'in-place' if in_place else 'rotation'}"
+    db.create_session(parent_session_id, source="webui")
+    db.append_message(parent_session_id, "user", "snapshot row")
+    agent = _build_compression_agent(db, parent_session_id)
+    agent.compression_in_place = in_place
+    agent._durable_transcript_revision = db.get_active_message_revision(
+        parent_session_id
+    )
+    original_loader = db.get_messages_as_conversation
+    committed_session_id = None
+    if in_place:
+        original_commit = db.archive_and_compact
+
+        def _commit_then_mark(*args, **kwargs):
+            nonlocal committed_session_id
+            result = original_commit(*args, **kwargs)
+            committed_session_id = parent_session_id
+            return result
+
+        monkeypatch.setattr(db, "archive_and_compact", _commit_then_mark)
+    else:
+        original_commit = db.publish_compression_child
+
+        def _commit_then_mark(*args, **kwargs):
+            nonlocal committed_session_id
+            result = original_commit(*args, **kwargs)
+            committed_session_id = kwargs["child_session_id"]
+            return result
+
+        monkeypatch.setattr(db, "publish_compression_child", _commit_then_mark)
+
+    post_commit_load_attempted = False
+
+    def _fail_after_commit(session_id, *args, **kwargs):
+        nonlocal post_commit_load_attempted
+        if session_id == committed_session_id:
+            post_commit_load_attempted = True
+            raise RuntimeError("post-commit projection read failed")
+        return original_loader(session_id, *args, **kwargs)
+
+    monkeypatch.setattr(db, "get_messages_as_conversation", _fail_after_commit)
+
+    compressed, _ = agent._compress_context(
+        [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    durable_session_id = committed_session_id or parent_session_id
+    assert post_commit_load_attempted is False
+    assert [message["content"] for message in compressed] == ["x"]
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        durable_session_id
+    )
+
+
+def test_in_place_commit_preserves_mutation_after_precheck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-commit-fence"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot row")
+    expected_revision = db.get_active_message_revision(session_id)
+    agent = _build_compression_agent(db, session_id)
+    setattr(agent, "compression_in_place", True)
+    setattr(agent, "_durable_transcript_revision", expected_revision)
+    original_archive = db.archive_and_compact
+
+    def _archive_after_late_write(*args, **kwargs) -> int:
+        _append_bypassing_compression_lease(
+            db,
+            session_id,
+            role="assistant",
+            content="late durable row",
+        )
+        return original_archive(*args, **kwargs)
+
+    monkeypatch.setattr(db, "archive_and_compact", _archive_after_late_write)
+
+    compressed, _ = agent._compress_context(
+        [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    getattr(agent, "context_compressor").compress.assert_called_once()
+    assert [message["content"] for message in compressed] == [
+        "x",
+        "late durable row",
+    ]
+    assert [
+        row["content"] for row in db.get_messages_as_conversation(session_id)
+    ] == ["x", "late durable row"]
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_replace_messages_rejects_another_writer_compression_lease(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "replace-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "original")
+    assert db.try_acquire_compression_lock(
+        session_id, "compression-owner", ttl_seconds=60
+    )
+
+    with pytest.raises(RuntimeError, match="being compressed"):
+        db.replace_messages(
+            session_id,
+            [{"role": "user", "content": "stale replacement"}],
+        )
+
+    assert [row["content"] for row in db.get_messages(session_id)] == ["original"]
+
+
+def test_rewind_rejects_another_writer_compression_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "rewind-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "keep")
+    db.append_message(session_id, "assistant", "would be rewound")
+    target_message_id = db.get_messages(session_id)[0]["id"]
+    assert db.try_acquire_compression_lock(
+        session_id, "compression-owner", ttl_seconds=60
+    )
+
+    with pytest.raises(RuntimeError, match="being compressed"):
+        db.rewind_to_message(session_id, target_message_id)
+
+    assert [row["content"] for row in db.get_messages(session_id)] == [
+        "keep",
+        "would be rewound",
+    ]
+
+
+def test_archive_and_compact_rejects_another_writer_compression_lease(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "archive-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "original")
+    assert db.try_acquire_compression_lock(
+        session_id, "compression-owner", ttl_seconds=60
+    )
+
+    with pytest.raises(RuntimeError, match="being compressed"):
+        db.archive_and_compact(
+            session_id,
+            [{"role": "user", "content": "stale summary"}],
+        )
+
+    assert [row["content"] for row in db.get_messages(session_id)] == ["original"]
+    assert db.get_messages(session_id, include_inactive=True)[0]["compacted"] == 0
+
+
+def test_restore_rewound_rejects_another_writer_compression_lease(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "restore-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "rewound row")
+    target_message_id = db.get_messages(session_id)[0]["id"]
+    db.rewind_to_message(session_id, target_message_id)
+    assert db.try_acquire_compression_lock(
+        session_id, "compression-owner", ttl_seconds=60
+    )
+
+    with pytest.raises(RuntimeError, match="being compressed"):
+        db.restore_rewound(session_id, target_message_id)
+
+    assert db.get_messages(session_id) == []
+    assert db.get_messages(session_id, include_inactive=True)[0]["active"] == 0
+
+
+def test_in_place_compaction_preserves_append_only_growth(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot row")
+    expected_revision = db.get_active_message_revision(session_id)
+    db.append_message(session_id, "assistant", "external committed row")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_in_place = True
+    agent._durable_transcript_revision = expected_revision
+
+    compressed, _ = agent._compress_context(
+        [{"role": "user", "content": "snapshot row", "_db_persisted": True}],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    agent.context_compressor.compress.assert_called_once()
+    assert db.get_compression_lock_holder(session_id) is None
+    assert [message["content"] for message in compressed] == [
+        "x",
+        "external committed row",
+    ]
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(session_id)
+    ] == ["x", "external committed row"]
+
+
+def test_compression_rejects_projection_owned_by_another_session(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    first_session = "projection-owner"
+    second_session = "compression-target"
+    db.create_session(first_session, source="cli")
+    db.create_session(second_session, source="cli")
+    db.append_message(first_session, "user", "first-session row")
+    db.append_message(second_session, "user", "second-session row")
+    agent = _build_compression_agent(db, first_session)
+    foreign_projection = [
+        {"role": "user", "content": "first-session row", "_db_persisted": True}
+    ]
+
+    # Simulate a legacy/plugin session switch that bypasses the turn prologue.
+    agent.session_id = second_session
+
+    with pytest.raises(CompressionSnapshotStaleError):
+        agent._compress_context(
+            foreign_projection,
+            "sys",
+            approx_tokens=120_000,
+        )
+
+    agent.context_compressor.compress.assert_not_called()
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(second_session)
+    ] == ["second-session row"]
+
+
+def test_compression_rejects_projection_without_durable_revision(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "projection-without-revision"
+    db.create_session(session_id, source="cli")
+    db.append_message(session_id, "user", "durable row")
+    agent = _build_compression_agent(db, session_id)
+    agent._durable_transcript_revision = None
+
+    with pytest.raises(CompressionSnapshotStaleError):
+        agent._compress_context(
+            [{"role": "user", "content": "unverified bytes"}],
+            "sys",
+            approx_tokens=120_000,
+        )
+
+    agent.context_compressor.compress.assert_not_called()
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(session_id)
+    ] == ["durable row"]
+
+
+def test_in_place_compaction_rolls_back_transcript_when_prompt_update_fails(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-prompt-rollback"
+    db.create_session(session_id, source="cli", system_prompt="original prompt")
+    db.append_message(session_id, "user", "original row")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_in_place = True
+    original_messages = [
+        {"role": "user", "content": "original row", "_db_persisted": True}
+    ]
+
+    def _install_failure_trigger(conn) -> None:
+        conn.execute(
+            "CREATE TRIGGER fail_compaction_prompt_update "
+            "BEFORE UPDATE OF system_prompt ON sessions "
+            "BEGIN SELECT RAISE(ABORT, 'prompt update failed'); END"
+        )
+
+    db._execute_write(_install_failure_trigger)
+
+    returned, _ = agent._compress_context(
+        original_messages,
+        "replacement prompt",
+        approx_tokens=120_000,
+    )
+
+    assert returned == original_messages
+    assert [
+        message["content"]
+        for message in db.get_messages_as_conversation(session_id)
+    ] == ["original row"]
+    assert db.get_session(session_id)["system_prompt"] == "original prompt"
+
+
+def test_in_place_compaction_rebinds_revision_before_next_append(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-rebind"
+    db.create_session(session_id, source="cli")
+    db.append_message(session_id, "user", "original row")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_in_place = True
+
+    compressed, _ = agent._compress_context(
+        [{"role": "user", "content": "original row", "_db_persisted": True}],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    assert agent.session_id == session_id
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        session_id
+    )
+
+    next_message = {"role": "assistant", "content": "next append"}
+    agent._flush_messages_to_session_db([next_message], compressed)
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        session_id
+    )
+
+
+def test_session_db_owner_tracks_revision_without_explicit_transport(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "compatibility-owner"
+    db.create_session(session_id, source="cli")
+    db.append_message(session_id, "user", "existing user")
+    db.append_message(session_id, "assistant", "existing assistant")
+
+    agent = _build_compression_agent(db, session_id)
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        session_id
+    )
+
+    owned_message = {"role": "user", "content": "owned append"}
+    agent._session_db_created = True
+    agent._flush_messages_to_session_db([owned_message], None)
+    assert owned_message["_db_persisted"] is True
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        session_id
+    )
+
+    compressed, _ = agent._compress_context(
+        [owned_message],
+        system_message="system",
+        force=True,
+    )
+
+    assert compressed != [owned_message]
+    agent.context_compressor.compress.assert_called_once()
+
+
+def test_legacy_history_without_revision_reloads_atomic_durable_snapshot(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "legacy-atomic-reload"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "A")
+    db.append_message(session_id, "assistant", "B")
+    captured_history = [
+        {"role": "user", "content": "A"},
+        {"role": "assistant", "content": "B"},
+    ]
+    db.append_message(session_id, "user", "C")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent.context_compressor.protect_first_n = 0
+    agent.context_compressor.protect_last_n = 0
+    agent.context_compressor.threshold_tokens = 1
+    agent.context_compressor.context_length = 100
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = False
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress.return_value = True
+    agent._disable_streaming = True
+    agent._interruptible_api_call = _RecordingAPI()
+
+    agent.run_conversation("D", conversation_history=captured_history)
+
+    compressed_input = agent.context_compressor.compress.call_args.args[0]
+    assert "C" in [message.get("content") for message in compressed_input]
+
+
+def test_client_managed_history_survives_when_no_durable_rows_exist(
+    tmp_path: Path,
+) -> None:
+    """Re-anchoring must not erase a stateless caller's own projection.
+
+    ``/responses`` lets a client supply ``conversation_history`` against a
+    brand-new session id. There are no durable rows to be stale against, so
+    the supplied bytes are the only context and must reach the provider.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "client-managed-stateless"
+    db.create_session(session_id, source="api")
+    agent = _build_compression_agent(db, session_id, install_mock_compressor=False)
+    agent._persist_disabled = True
+    agent.compression_enabled = False
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+
+    result = agent.run_conversation(
+        "client C",
+        conversation_history=[
+            {"role": "user", "content": "client A"},
+            {"role": "assistant", "content": "client B"},
+        ],
+    )
+
+    assert result["final_response"] == "done"
+    assert [
+        message.get("content")
+        for message in api.calls[0]["messages"]
+        if message.get("role") in {"user", "assistant"}
+    ] == ["client A", "client B", "client C"]
+    assert agent._durable_transcript_revision.active_message_count == 0
+
+
+def test_supplied_revision_keeps_a_longer_caller_projection(tmp_path: Path) -> None:
+    """A tokened projection is never silently re-anchored onto durable rows.
+
+    The gateway's FTS write-corruption guard (#50502) replays a live in-memory
+    transcript that is longer than the persisted rows; re-anchoring it would
+    reinstate exactly the amnesia that guard exists to prevent.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "live-longer-than-durable"
+    db.create_session(session_id, source="telegram")
+    db.append_message(session_id, "user", "persisted only")
+    revision = db.get_active_message_revision(session_id)
+    agent = _build_compression_agent(db, session_id, install_mock_compressor=False)
+    agent._persist_disabled = True
+    agent.compression_enabled = False
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+
+    agent.run_conversation(
+        "next",
+        conversation_history=[
+            {"role": "user", "content": "persisted only"},
+            {"role": "assistant", "content": "live reply"},
+            {"role": "user", "content": "live follow-up"},
+            {"role": "assistant", "content": "live reply 2"},
+        ],
+        conversation_history_revision=revision,
+    )
+
+    assert [
+        message.get("content")
+        for message in api.calls[0]["messages"]
+        if message.get("role") in {"user", "assistant"}
+    ] == [
+        "persisted only",
+        "live reply",
+        "live follow-up",
+        "live reply 2",
+        "next",
+    ]
+
+
+def test_legacy_history_reload_failure_is_projection_unverifiable_before_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "legacy-reload-failure"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "durable")
+    agent = _build_compression_agent(db, session_id)
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+    monkeypatch.setattr(
+        db,
+        "get_messages_as_conversation",
+        MagicMock(side_effect=RuntimeError("read failed")),
+    )
+
+    result = agent.run_conversation(
+        "new turn",
+        conversation_history=[{"role": "user", "content": "unverified"}],
+    )
+
+    assert result["error"] == "compression_projection_unverifiable"
+    assert result["compression_projection_unverifiable"] is True
+    assert api.calls == []
+    agent.context_compressor.compress.assert_not_called()
+
+
+def test_in_place_commit_failure_restores_mutated_messages_and_stops(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "in-place-lease-loss"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "original")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_in_place = True
+    messages = [{"role": "user", "content": "original", "_db_persisted": True}]
+
+    def _mutating_compress(live_messages, **_kwargs):
+        live_messages[:] = [{"role": "user", "content": "mutated summary"}]
+        return [{"role": "user", "content": "x"}]
+
+    agent.context_compressor.compress.side_effect = _mutating_compress
+    monkeypatch.setattr(
+        db,
+        "archive_and_compact",
+        MagicMock(side_effect=CompressionSessionBusyError("lease expired")),
+    )
+
+    from agent import conversation_compression
+
+    with pytest.raises(conversation_compression.CompressionCommitFailedError):
+        agent._compress_context(messages, "system", force=True)
+
+    assert [message["content"] for message in messages] == ["original"]
+    assert [row["content"] for row in db.get_messages(session_id)] == ["original"]
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_stale_replace_after_compaction_release_is_rejected(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "replace-after-compression"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "T0")
+    revision0 = db.get_active_message_revision(session_id)
+    db.archive_and_compact(
+        session_id,
+        [{"role": "user", "content": "T1 summary"}],
+        expected_revision=revision0,
+    )
+
+    with pytest.raises(CompressionTranscriptRevisionError):
+        db.replace_messages(
+            session_id,
+            [{"role": "user", "content": "stale T0 rewrite"}],
+            expected_revision=revision0,
+        )
+
+    assert [row["content"] for row in db.get_messages(session_id)] == ["T1 summary"]
+
+
+def test_api_content_backfill_rejects_adverse_compression_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "api-content-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "clean")
+    assert db.try_acquire_compression_lock(session_id, "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.set_latest_user_api_content(session_id, "clean", "wire")
+
+    assert db.get_messages(session_id)[0]["api_content"] is None
+
+
+def test_clear_messages_rejects_adverse_compression_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "clear-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "keep")
+    assert db.try_acquire_compression_lock(session_id, "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.clear_messages(session_id)
+
+    assert [row["content"] for row in db.get_messages(session_id)] == ["keep"]
+
+
+def test_delete_session_rejects_adverse_compression_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "delete-under-lease"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "keep")
+    assert db.try_acquire_compression_lock(session_id, "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.delete_session(session_id)
+
+    assert db.get_session(session_id) is not None
+    assert [row["content"] for row in db.get_messages(session_id)] == ["keep"]
+
+
+def test_bulk_delete_rejects_if_any_target_has_adverse_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    for session_id in ("bulk-free", "bulk-leased"):
+        db.create_session(session_id, source="webui")
+        db.append_message(session_id, "user", session_id)
+    assert db.try_acquire_compression_lock("bulk-leased", "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.delete_sessions(["bulk-free", "bulk-leased"])
+
+    assert db.get_session("bulk-free") is not None
+    assert db.get_session("bulk-leased") is not None
+
+
+def test_prune_rejects_target_with_adverse_lease(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "prune-leased"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "keep")
+    db.end_session(session_id, "completed")
+    assert db.try_acquire_compression_lock(session_id, "owner", ttl_seconds=60)
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.prune_sessions(older_than_days=-1)
+
+    assert db.get_session(session_id) is not None
+
+
+def test_rewind_rejects_stale_revision_after_late_append(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "rewind-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "first")
+    target_id = db.get_messages(session_id)[0]["id"]
+    revision = db.get_active_message_revision(session_id)
+    db.append_message(session_id, "assistant", "late")
+
+    with pytest.raises(CompressionTranscriptRevisionError):
+        db.rewind_to_message(
+            session_id,
+            target_id,
+            expected_revision=revision,
+        )
+
+    assert [message["content"] for message in db.get_messages_as_conversation(session_id)] == [
+        "first",
+        "late",
+    ]
+
+
+def test_recent_user_messages_and_revision_share_one_snapshot(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "rewind-atomic-load"
+    db.create_session(session_id, source="telegram")
+    user_id = db.append_message(session_id, "user", "target")
+    db.append_message(session_id, "assistant", "answer")
+
+    recents, revision = db.list_recent_user_messages(
+        session_id,
+        with_revision=True,
+    )
+
+    assert recents[0]["id"] == user_id
+    assert revision == db.get_active_message_revision(session_id)
+
+
+def test_restore_rejects_stale_revision_after_late_append(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "restore-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "rewound")
+    target_id = db.get_messages(session_id)[0]["id"]
+    revision0 = db.get_active_message_revision(session_id)
+    db.rewind_to_message(session_id, target_id, expected_revision=revision0)
+    revision1 = db.get_active_message_revision(session_id)
+    db.append_message(session_id, "user", "late active")
+
+    with pytest.raises(CompressionTranscriptRevisionError):
+        db.restore_rewound(
+            session_id,
+            target_id,
+            expected_revision=revision1,
+        )
+
+    rows = db.get_messages(session_id, include_inactive=True)
+    assert [(row["content"], row["active"]) for row in rows] == [
+        ("rewound", False),
+        ("late active", True),
+    ]
+
+
+def test_api_content_backfill_advances_revision_without_count_or_max_id_change(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "api-content-revision"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "clean")
+    before = db.get_active_message_revision(session_id)
+
+    assert db.set_latest_user_api_content(session_id, "clean", "wire") == 1
+
+    after = db.get_active_message_revision(session_id)
+    assert after.active_message_count == before.active_message_count
+    assert after.max_active_message_id == before.max_active_message_id
+    assert after != before
+
+
+def test_api_content_backfill_returns_the_committed_revision(tmp_path: Path) -> None:
+    """The backfill's own writer must be able to re-fence without a second read."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "api-content-revision-return"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "clean")
+
+    updated, revision = db.set_latest_user_api_content(
+        session_id, "clean", "wire", with_revision=True
+    )
+
+    assert updated == 1
+    assert revision == db.get_active_message_revision(session_id)
+
+
+def test_assistant_content_repair_advances_revision_without_row_shape_change(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "assistant-repair-revision"
+    db.create_session(session_id, source="webui")
+    row_id = db.append_message(session_id, "assistant", "")
+    assert isinstance(row_id, int)
+    before = db.get_active_message_revision(session_id)
+
+    repair_result = db.append_messages_batch(
+        session_id,
+        [
+            {
+                "role": "assistant",
+                "content": "Recovered streamed answer",
+                "_row_id": row_id,
+            }
+        ],
+        with_revision=True,
+    )
+    assert isinstance(repair_result, tuple)
+    inserted, repaired_revision = repair_result
+
+    assert inserted == 0
+    assert db.get_messages(session_id)[0]["content"] == "Recovered streamed answer"
+    assert repaired_revision.active_message_count == before.active_message_count
+    assert repaired_revision.max_active_message_id == before.max_active_message_id
+    assert repaired_revision != before
+    assert repaired_revision == db.get_active_message_revision(session_id)
+
+
+def test_assistant_content_repair_invalidates_stale_compaction_revision(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "assistant-repair-stale-compaction"
+    db.create_session(session_id, source="webui")
+    row_id = db.append_message(session_id, "assistant", "")
+    assert isinstance(row_id, int)
+    before = db.get_active_message_revision(session_id)
+
+    repair_result = db.append_messages_batch(
+        session_id,
+        [
+            {
+                "role": "assistant",
+                "content": "Recovered streamed answer",
+                "_row_id": row_id,
+            }
+        ],
+        with_revision=True,
+    )
+    assert isinstance(repair_result, tuple)
+    inserted, _repaired_revision = repair_result
+    assert inserted == 0
+    assert db.get_messages(session_id)[0]["content"] == "Recovered streamed answer"
+
+    with pytest.raises(CompressionTranscriptRevisionError):
+        db.archive_and_compact(
+            session_id,
+            [{"role": "assistant", "content": "stale summary"}],
+            watermark=row_id,
+            expected_revision=before,
+        )
+
+    assert [row["content"] for row in db.get_messages(session_id)] == [
+        "Recovered streamed answer"
+    ]
+
+
+def test_noop_assistant_content_repair_does_not_advance_revision(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "assistant-noop-repair-revision"
+    db.create_session(session_id, source="webui")
+    row_id = db.append_message(session_id, "assistant", "")
+    assert isinstance(row_id, int)
+    before = db.get_active_message_revision(session_id)
+
+    repair_result = db.append_messages_batch(
+        session_id,
+        [{"role": "assistant", "content": "", "_row_id": row_id}],
+        with_revision=True,
+    )
+    assert isinstance(repair_result, tuple)
+    inserted, after = repair_result
+
+    assert inserted == 0
+    assert after == before
+
+
+def test_display_only_stamp_does_not_move_the_durable_revision(
+    tmp_path: Path,
+) -> None:
+    """Presentation sidecars are not model-facing, so they must not fence.
+
+    ``set_latest_matching_message_display_kind`` runs outside the compression
+    lease on every gateway/CLI turn; counting it as a revision change would
+    abort the next compression as spuriously stale.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "display-only-stamp"
+    db.create_session(session_id, source="cli")
+    db.append_message(session_id, "user", "hello")
+    before = db.get_active_message_revision(session_id)
+
+    assert db.set_latest_matching_message_display_kind(
+        session_id,
+        role="user",
+        content="hello",
+        display_kind="voice",
+        display_metadata={"source": "stt"},
+    )
+
+    assert db.get_active_message_revision(session_id) == before
+
+
+def test_rotation_rebinds_revision_before_child_append(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_session_id = "revision-parent"
+    db.create_session(parent_session_id, source="cli")
+    db.append_message(parent_session_id, "user", "parent row")
+    agent = _build_compression_agent(db, parent_session_id)
+    projection = [
+        {"role": "user", "content": "parent row", "_db_persisted": True}
+    ]
+
+    compressed, _ = agent._compress_context(
+        projection,
+        system_message="system",
+        force=True,
+    )
+
+    child_session_id = agent.session_id
+    assert child_session_id != parent_session_id
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        child_session_id
+    )
+    assert agent._durable_transcript_revision.session_id == child_session_id
+
+    child_append = {"role": "assistant", "content": "child append"}
+    agent._flush_messages_to_session_db([child_append], compressed)
+
+    assert child_append["_db_persisted"] is True
+    assert agent._durable_transcript_revision == db.get_active_message_revision(
+        child_session_id
+    )
+
+
+def test_preflight_append_only_revision_progresses_to_provider_call(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "preflight-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "snapshot user")
+    expected_revision = db.get_active_message_revision(session_id)
+    db.append_message(session_id, "assistant", "external answer")
+
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent.context_compressor.protect_first_n = 0
+    agent.context_compressor.protect_last_n = 0
+    agent.context_compressor.threshold_tokens = 1
+    agent.context_compressor.context_length = 100
+    agent.context_compressor.compression_count = 0
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = False
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress.return_value = True
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+
+    result = agent.run_conversation(
+        "new user turn",
+        conversation_history=[{"role": "user", "content": "snapshot user"}],
+        conversation_history_revision={
+            "session_id": session_id,
+            "active_message_count": expected_revision.active_message_count,
+            "max_active_message_id": expected_revision.max_active_message_id,
+        },
+    )
+
+    assert result["completed"] is True
+    assert result["failed"] is False
+    assert len(api.calls) == 1
+    agent.context_compressor.compress.assert_called_once()
+    compress_input = agent.context_compressor.compress.call_args.args[0]
+    assert any(
+        message.get("content") == "new user turn"
+        for message in compress_input
+    )
+    child_session_id = result["session_id"]
+    assert child_session_id != session_id
+    child_contents = [
+        message["content"]
+        for message in db.get_messages_as_conversation(child_session_id)
+    ]
+    assert child_contents.count("external answer") == 1
+    assert child_contents.count("done") == 1
+    assert db.get_compression_lock_holder(session_id) is None
+
+
+def test_pre_api_stale_revision_stops_before_provider_call(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "pre-api-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "history user")
+    db.append_message(session_id, "assistant", "history assistant")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent._disable_streaming = True
+    agent._persist_disabled = True
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = False
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress_preflight.return_value = False
+    agent.context_compressor.should_compress.return_value = True
+    api = _RecordingAPI()
+    agent._interruptible_api_call = api
+
+    with patch.object(
+        agent,
+        "_compress_context",
+        side_effect=_synthetic_stale_error(db, session_id),
+    ) as compress:
+        result = agent.run_conversation(
+            "new question",
+            conversation_history=[
+                {"role": "user", "content": "history user"},
+                {"role": "assistant", "content": "history assistant"},
+            ],
+        )
+
+    assert result["compression_snapshot_stale"] is True
+    assert result["partial"] is True
+    assert api.calls == []
+    compress.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("status_code", "message", "provider"),
+    [
+        (413, "Request entity too large", "unknown"),
+        (
+            400,
+            "This endpoint's maximum context length is 128000 tokens; "
+            "the request has too many tokens",
+            "unknown",
+        ),
+        (
+            429,
+            "Extra usage is required for long context requests over 200k tokens",
+            "anthropic",
+        ),
+    ],
+)
+def test_provider_overflow_stale_revision_prevents_retry_payload(
+    tmp_path: Path,
+    status_code: int,
+    message: str,
+    provider: str,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = f"overflow-stale-{status_code}"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "history user")
+    db.append_message(session_id, "assistant", "history assistant")
+    agent = _build_compression_agent(db, session_id)
+    agent.provider = provider
+    agent.compression_enabled = True
+    agent._disable_streaming = True
+    agent._persist_disabled = True
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = False
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress_preflight.return_value = False
+    agent.context_compressor.should_compress.return_value = False
+    provider_error = Exception(message)
+    setattr(provider_error, "status_code", status_code)
+    api = _SequenceAPI(provider_error)
+    agent._interruptible_api_call = api
+
+    with patch.object(
+        agent,
+        "_compress_context",
+        side_effect=_synthetic_stale_error(db, session_id),
+    ) as compress:
+        result = agent.run_conversation(
+            "new question",
+            conversation_history=[
+                {"role": "user", "content": "history user"},
+                {"role": "assistant", "content": "history assistant"},
+            ],
+        )
+
+    assert result["compression_snapshot_stale"] is True
+    assert result["partial"] is True
+    assert len(api.calls) == 1
+    compress.assert_called_once()
+
+
+def test_post_tool_stale_revision_prevents_next_provider_payload(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "post-tool-stale"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "history user")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent._disable_streaming = True
+    agent._persist_disabled = True
+    agent.context_compressor.last_prompt_tokens = 150_000
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = True
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress_preflight.return_value = False
+    agent.context_compressor.should_compress.return_value = True
+    agent.valid_tool_names = {"web_search"}
+    api = _SequenceAPI(_tool_response())
+    agent._interruptible_api_call = api
+
+    with (
+        patch.object(
+            agent,
+            "_compress_context",
+            side_effect=_synthetic_stale_error(db, session_id),
+        ) as compress,
+        patch("run_agent.handle_function_call", return_value='{"ok":true}'),
+    ):
+        result = agent.run_conversation("use a tool")
+
+    assert result["compression_snapshot_stale"] is True
+    assert result["partial"] is True
+    assert len(api.calls) == 1
+    compress.assert_called_once()
+
+
+def test_post_tool_stale_preserves_effect_once_without_replay_instruction(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "post-tool-stale-persisted"
+    db.create_session(session_id, source="webui")
+    db.append_message(session_id, "user", "history user")
+    agent = _build_compression_agent(db, session_id)
+    agent.compression_enabled = True
+    agent._disable_streaming = True
+    agent.context_compressor.last_prompt_tokens = 150_000
+    agent.context_compressor.should_defer_preflight_to_real_usage.return_value = True
+    agent.context_compressor.get_active_compression_failure_cooldown.return_value = None
+    agent.context_compressor.should_compress_preflight.return_value = False
+    agent.context_compressor.should_compress.return_value = True
+    agent.valid_tool_names = {"web_search"}
+    api = _SequenceAPI(_tool_response())
+    agent._interruptible_api_call = api
+    effects = []
+
+    def _counting_tool(*_args, **_kwargs):
+        effects.append("ran")
+        return '{"ok":true}'
+
+    with (
+        patch.object(
+            agent,
+            "_compress_context",
+            side_effect=_synthetic_stale_error(db, session_id),
+        ),
+        patch("run_agent.handle_function_call", side_effect=_counting_tool),
+    ):
+        result = agent.run_conversation("use a tool")
+
+    assert effects == ["ran"]
+    assert len(api.calls) == 1
+    assert result["compression_effects_preserved"] is True
+    guidance = result["final_response"].lower()
+    assert "again" not in guidance
+    assert "resend" not in guidance
+    assert "retry" not in guidance
+
+
+def test_run_conversation_normalizes_revision_without_provider_payload_leak(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "revision-transport"
+    db.create_session(session_id, source="webui")
+    first_id = db.append_message(session_id, "user", "existing")
+    agent = _build_compression_agent(
+        db,
+        session_id,
+        install_mock_compressor=False,
+    )
+    agent._persist_disabled = True
+    agent.compression_enabled = False
+    api = _RecordingAPI()
+    agent._disable_streaming = True
+    agent._interruptible_api_call = api
+    raw_revision = {
+        "session_id": session_id,
+        "active_message_count": 1,
+        "max_active_message_id": first_id,
+    }
+    captured = {}
+
+    from agent import conversation_loop
+
+    real_build_turn_context = conversation_loop.build_turn_context
+
+    def _capture_turn_context(*args, **kwargs):
+        context = real_build_turn_context(*args, **kwargs)
+        captured["context"] = context
+        return context
+
+    with patch.object(
+        conversation_loop,
+        "build_turn_context",
+        side_effect=_capture_turn_context,
+    ):
+        result = agent.run_conversation(
+            "new question",
+            conversation_history=[{"role": "user", "content": "existing"}],
+            conversation_history_revision=raw_revision,
+        )
+
+    expected = DurableTranscriptRevision(
+        session_id=session_id,
+        active_message_count=1,
+        max_active_message_id=first_id,
+    )
+    assert result["final_response"] == "done"
+    assert captured["context"].durable_transcript_revision == expected
+    assert agent._durable_transcript_revision == expected
+    assert len(api.calls) == 1
+    assert "conversation_history_revision" not in api.calls[0]
+    assert all(
+        "conversation_history_revision" not in message
+        for message in api.calls[0]["messages"]
+    )

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -36,12 +36,24 @@ from gateway.session import SessionSource
 
 class _CapturingAgent:
     last_init = None
+    last_run = None
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
         self.tools = []
 
-    def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
+    def run_conversation(
+        self,
+        user_message,
+        conversation_history=None,
+        conversation_history_revision=None,
+        task_id=None,
+        persist_user_message=None,
+    ):
+        type(self).last_run = {
+            "conversation_history": conversation_history,
+            "conversation_history_revision": conversation_history_revision,
+        }
         return {
             "final_response": "ok",
             "messages": [],

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1403,8 +1403,7 @@ class TestGatewaySessionDbRecovery:
 
     def test_transcript_reroute_follows_multi_hop_compression_chain(self, tmp_path):
         """A stale writer behind >=2 compression hops (root -> mid -> tip) must
-        reroute to the live tip via the transitive ``get_compression_tip`` walk
-        — the depth-1 live-child lookup found nothing here (#82001)."""
+        reroute only when the conservative resolver proves a unique live leaf."""
         import threading
         from types import SimpleNamespace
 
@@ -1477,12 +1476,9 @@ class TestGatewaySessionDbRecovery:
         from hermes_state import CompressionSessionClosedError
 
         class FakeDb:
-            def get_compression_tip(self, session_id):
+            def find_live_compression_child(self, session_id):
                 assert session_id == "parent"
-                return "child"
-
-            def get_session(self, session_id):
-                return {"id": session_id, "ended_at": None}
+                return {"id": "child"}
 
         store = object.__new__(SessionStore)
         store._db = FakeDb()
@@ -1540,6 +1536,114 @@ class TestGatewaySessionDbRecovery:
         assert "parent" not in store._dirty_transcripts
         assert "child" not in store._dirty_transcripts
 
+    def test_fts_retry_success_empty_queue_does_not_duplicate(self):
+        import threading
+
+        store = object.__new__(SessionStore)
+        store._transcript_retry_lock = threading.Lock()
+        store._dirty_transcripts = {}
+        store._transcript_append_failures = {}
+        attempts = []
+        first_attempt = True
+
+        def _append(session_id, message):
+            nonlocal first_attempt
+            attempts.append((session_id, message["content"]))
+            if first_attempt:
+                first_attempt = False
+                raise RuntimeError("no such table: messages_fts")
+
+        store._append_transcript_message = _append
+        store._rebuild_fts_once = lambda: True
+
+        store._append_to_transcript_serialized(
+            "session", {"role": "user", "content": "only"}
+        )
+
+        assert attempts == [("session", "only"), ("session", "only")]
+        assert store._dirty_transcripts == {}
+
+    def test_fts_retry_success_advances_to_remaining_message(self):
+        import threading
+
+        store = object.__new__(SessionStore)
+        store._transcript_retry_lock = threading.Lock()
+        store._dirty_transcripts = {
+            "session": [{"role": "user", "content": "older"}]
+        }
+        store._transcript_append_failures = {}
+        attempts = []
+        first_attempt = True
+
+        def _append(session_id, message):
+            nonlocal first_attempt
+            attempts.append((session_id, message["content"]))
+            if first_attempt:
+                first_attempt = False
+                raise RuntimeError("no such table: messages_fts")
+
+        store._append_transcript_message = _append
+        store._rebuild_fts_once = lambda: True
+
+        store._append_to_transcript_serialized(
+            "session", {"role": "assistant", "content": "newer"}
+        )
+
+        assert attempts == [
+            ("session", "older"),
+            ("session", "older"),
+            ("session", "newer"),
+        ]
+        assert store._dirty_transcripts == {}
+
+    def test_fts_retry_during_reroute_targets_child(self):
+        import threading
+        from types import SimpleNamespace
+
+        from hermes_state import CompressionSessionClosedError
+
+        class FakeDb:
+            def find_live_compression_child(self, session_id):
+                assert session_id == "parent"
+                return {"id": "child"}
+
+        store = object.__new__(SessionStore)
+        store._db = FakeDb()
+        store.__dict__["_lock"] = threading.RLock()
+        store.__dict__["_entries"] = {
+            "route": SimpleNamespace(session_id="parent")
+        }
+        store._loaded = True
+        store._save = lambda: None
+        store._transcript_retry_lock = threading.Lock()
+        store._dirty_transcripts = {}
+        store._transcript_append_failures = {}
+        attempts = []
+        child_first_attempt = True
+
+        def _append(session_id, message):
+            nonlocal child_first_attempt
+            attempts.append((session_id, message["content"]))
+            if session_id == "parent":
+                raise CompressionSessionClosedError("parent")
+            if child_first_attempt:
+                child_first_attempt = False
+                raise RuntimeError("no such table: messages_fts")
+
+        store._append_transcript_message = _append
+        store._rebuild_fts_once = lambda: True
+
+        store.append_to_transcript(
+            "parent", {"role": "assistant", "content": "rerouted"}
+        )
+
+        assert attempts == [
+            ("parent", "rerouted"),
+            ("child", "rerouted"),
+            ("child", "rerouted"),
+        ]
+        assert store._entries["route"].session_id == "child"
+        assert store._dirty_transcripts == {}
 
     def test_fts_corruption_error_requires_fts_provenance(self):
         """_is_fts_corruption_error must not treat a generic malformed-image

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1360,6 +1360,43 @@ class TestGatewaySessionDbRecovery:
         ]
         db.close()
 
+    def test_compression_chain_reroutes_to_live_tip_without_retry_queue(self, tmp_path):
+        import threading
+        from types import SimpleNamespace
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("parent", source="telegram")
+        db.end_session("parent", "compression")
+        db.create_session("child-1", source="telegram", parent_session_id="parent")
+        db.end_session("child-1", "compression")
+        db.create_session("child-2", source="telegram", parent_session_id="child-1")
+        db.end_session("child-2", "compression")
+        db.create_session("live-tip", source="telegram", parent_session_id="child-2")
+        db.replace_messages("live-tip", [{"role": "user", "content": "summary"}])
+
+        store = object.__new__(SessionStore)
+        store._db = db
+        store.__dict__["_lock"] = threading.RLock()
+        store.__dict__["_entries"] = {"route": SimpleNamespace(session_id="parent")}
+        store._loaded = True
+        store._save = lambda: None
+        store._transcript_retry_lock = threading.Lock()
+        store._dirty_transcripts = {}
+        store._transcript_append_failures = {}
+        store._fts_rebuild_attempted = False
+
+        store.append_to_transcript(
+            "parent", {"role": "assistant", "content": "routed to live tip"}
+        )
+
+        assert store._entries["route"].session_id == "live-tip"
+        assert "parent" not in store._dirty_transcripts
+        assert [m["content"] for m in db.get_messages_as_conversation("live-tip")] == [
+            "summary",
+            "routed to live tip",
+        ]
+        db.close()
+
     def test_transcript_reroute_migrates_remaining_backlog_to_child(self):
         import threading
         from types import SimpleNamespace

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1279,8 +1279,139 @@ class TestSessionMetadata:
         )
 
 
+def test_load_transcript_with_revision_degrades_instead_of_raising(tmp_path):
+    """A missing/failing store must not crash every inbound gateway turn.
+
+    ``(history, None)`` hands the fail-closed decision to the agent chokepoint,
+    which re-anchors or returns ``compression_projection_unverifiable``.
+    """
+    store = object.__new__(SessionStore)
+    store._db = None
+    assert store.load_transcript("s1", with_revision=True) == ([], None)
+
+    class _BoomDb:
+        def get_messages_as_conversation(self, *args, **kwargs):
+            raise RuntimeError("database disk image is malformed")
+
+    store._db = _BoomDb()
+    assert store.load_transcript("s1", with_revision=True) == ([], None)
+
+
+def test_rewind_session_supports_legacy_db_adapters(tmp_path):
+    """Adapters predating the revision kwargs must still rewind."""
+    import threading
+
+    class LegacyDb:
+        def __init__(self):
+            self.rewound = []
+
+        def list_recent_user_messages(self, session_id, limit=10):
+            return [{"id": 7, "content": "old"}]
+
+        def rewind_to_message(self, session_id, target_id):
+            self.rewound.append((session_id, target_id))
+            return {
+                "target_message": {"id": target_id, "content": "old"},
+                "rewound_count": 2,
+            }
+
+    store = object.__new__(SessionStore)
+    store._db = LegacyDb()
+    store._transcript_retry_lock = threading.Lock()
+    store._dirty_transcripts = {}
+    store._transcript_append_failures = {}
+    store._fts_rebuild_attempted = True
+
+    result = store.rewind_session("s1", 1)
+
+    assert result is not None
+    assert store._db.rewound == [("s1", 7)]
+
+
+def test_rewind_session_rejects_append_after_atomic_target_load(tmp_path, monkeypatch):
+    from hermes_state import CompressionTranscriptRevisionError
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    store._db.close()
+    db = SessionDB(db_path=tmp_path / "rewind-state.db")
+    store._db = db
+    db.create_session("rewind-race", source="telegram")
+    db.append_message("rewind-race", "user", "target")
+    db.append_message("rewind-race", "assistant", "answer")
+    real_rewind = db.rewind_to_message
+
+    def append_then_rewind(*args, **kwargs):
+        db.append_message("rewind-race", "user", "late")
+        return real_rewind(*args, **kwargs)
+
+    monkeypatch.setattr(db, "rewind_to_message", append_then_rewind)
+
+    with pytest.raises(CompressionTranscriptRevisionError):
+        store.rewind_session("rewind-race", 1)
+
+    assert [m["content"] for m in db.get_messages_as_conversation("rewind-race")] == [
+        "target",
+        "answer",
+        "late",
+    ]
+
+
+def test_recent_user_targets_and_revision_do_not_cross_transaction_boundary(
+    tmp_path, monkeypatch
+):
+    db = SessionDB(db_path=tmp_path / "rewind-snapshot.db")
+    session_id = "rewind-snapshot"
+    db.create_session(session_id, source="telegram")
+    db.append_message(session_id, "user", "target")
+    db.append_message(session_id, "assistant", "answer")
+
+    def forbidden_second_boundary(_session_id):
+        raise AssertionError("revision must share the target-list transaction")
+
+    monkeypatch.setattr(db, "get_active_message_revision", forbidden_second_boundary)
+
+    targets, revision = db.list_recent_user_messages(
+        session_id, limit=1, with_revision=True
+    )
+
+    assert [target["preview"] for target in targets] == ["target"]
+    assert revision.active_message_count == 2
+
+
 class TestRewriteTranscriptPreservesReasoning:
     """rewrite_transcript must not drop reasoning fields from SQLite."""
+
+    def test_rewrite_rejects_late_append_after_atomic_load(self, tmp_path):
+        from hermes_state import CompressionTranscriptRevisionError, SessionDB
+
+        db = SessionDB(db_path=tmp_path / "test.db")
+        session_id = "stale-gateway-rewrite"
+        db.create_session(session_id=session_id, source="telegram")
+        db.append_message(session_id, "user", "snapshot")
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        transcript, revision = store.load_transcript(
+            session_id, with_revision=True
+        )
+        db.append_message(session_id, "assistant", "late append")
+
+        with pytest.raises(CompressionTranscriptRevisionError):
+            store.rewrite_transcript(
+                session_id,
+                transcript,
+                expected_revision=revision,
+            )
+
+        assert [
+            message["content"]
+            for message in db.get_messages_as_conversation(session_id)
+        ] == ["snapshot", "late append"]
 
     def test_reasoning_survives_rewrite(self, tmp_path):
         from hermes_state import SessionDB

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1320,8 +1320,146 @@ class TestSessionMetadata:
         assert store.suspend_recently_active(max_age_seconds=120) == 0
 
 
+def test_load_transcript_with_revision_degrades_without_store(tmp_path):
+    """A missing store must not crash every inbound gateway turn.
+
+    ``([], None)`` hands the fail-closed decision to the agent chokepoint,
+    which re-anchors or returns ``compression_projection_unverifiable``.
+    A store that exists but cannot be read keeps the #100788 contract and
+    raises :class:`TranscriptReadError` in the revision-aware shape too.
+    """
+    from gateway.session import TranscriptReadError
+
+    store = object.__new__(SessionStore)
+    store._db = None
+    assert store.load_transcript("s1", with_revision=True) == ([], None)
+
+    class _BoomDb:
+        def get_compression_tip(self, _session_id):
+            return None
+
+        def get_messages_as_conversation(self, *args, **kwargs):
+            assert kwargs.get("with_revision") is True
+            raise RuntimeError("database disk image is malformed")
+
+    store._db = _BoomDb()
+    with pytest.raises(TranscriptReadError) as exc_info:
+        store.load_transcript("s1", with_revision=True)
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+def test_rewind_session_supports_legacy_db_adapters(tmp_path):
+    """Adapters predating the revision kwargs must still rewind."""
+    import threading
+
+    class LegacyDb:
+        def __init__(self):
+            self.rewound = []
+
+        def list_recent_user_messages(self, session_id, limit=10):
+            return [{"id": 7, "content": "old"}]
+
+        def rewind_to_message(self, session_id, target_id):
+            self.rewound.append((session_id, target_id))
+            return {
+                "target_message": {"id": target_id, "content": "old"},
+                "rewound_count": 2,
+            }
+
+    store = object.__new__(SessionStore)
+    store._db = LegacyDb()
+    store._transcript_retry_lock = threading.Lock()
+    store._dirty_transcripts = {}
+    store._transcript_append_failures = {}
+    store._fts_rebuild_attempted = True
+
+    result = store.rewind_session("s1", 1)
+
+    assert result is not None
+    assert store._db.rewound == [("s1", 7)]
+
+
+def test_rewind_session_rejects_append_after_atomic_target_load(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    store._db.close()
+    db = SessionDB(db_path=tmp_path / "rewind-state.db")
+    store._db = db
+    db.create_session("rewind-race", source="telegram")
+    db.append_message("rewind-race", "user", "target")
+    db.append_message("rewind-race", "assistant", "answer")
+    real_rewind = db.rewind_to_message
+
+    def append_then_rewind(*args, **kwargs):
+        db.append_message("rewind-race", "user", "late")
+        return real_rewind(*args, **kwargs)
+
+    monkeypatch.setattr(db, "rewind_to_message", append_then_rewind)
+
+    assert store.rewind_session("rewind-race", 1) is None
+
+    assert [m["content"] for m in db.get_messages_as_conversation("rewind-race")] == [
+        "target",
+        "answer",
+        "late",
+    ]
+
+
+def test_recent_user_targets_and_revision_do_not_cross_transaction_boundary(
+    tmp_path, monkeypatch
+):
+    db = SessionDB(db_path=tmp_path / "rewind-snapshot.db")
+    session_id = "rewind-snapshot"
+    db.create_session(session_id, source="telegram")
+    db.append_message(session_id, "user", "target")
+    db.append_message(session_id, "assistant", "answer")
+
+    def forbidden_second_boundary(_session_id):
+        raise AssertionError("revision must share the target-list transaction")
+
+    monkeypatch.setattr(db, "get_active_message_revision", forbidden_second_boundary)
+
+    targets, revision = db.list_recent_user_messages(
+        session_id, limit=1, with_revision=True
+    )
+
+    assert [target["preview"] for target in targets] == ["target"]
+    assert revision.active_message_count == 2
+
+
 class TestRewriteTranscriptPreservesReasoning:
     """rewrite_transcript must not drop reasoning fields from SQLite."""
+
+    def test_rewrite_rejects_late_append_after_atomic_load(self, tmp_path):
+        from hermes_state import CompressionTranscriptRevisionError, SessionDB
+
+        db = SessionDB(db_path=tmp_path / "test.db")
+        session_id = "stale-gateway-rewrite"
+        db.create_session(session_id=session_id, source="telegram")
+        db.append_message(session_id, "user", "snapshot")
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        transcript, revision = store.load_transcript(
+            session_id, with_revision=True
+        )
+        db.append_message(session_id, "assistant", "late append")
+
+        with pytest.raises(CompressionTranscriptRevisionError):
+            store.rewrite_transcript(
+                session_id,
+                transcript,
+                expected_revision=revision,
+            )
+
+        assert [
+            message["content"]
+            for message in db.get_messages_as_conversation(session_id)
+        ] == ["snapshot", "late append"]
 
     def test_reasoning_survives_rewrite(self, tmp_path):
         from hermes_state import SessionDB

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -290,6 +290,13 @@ class TestFlushAfterCompression:
             agent.session_id = parent_sid
             agent.compression_in_place = False
             agent._ensure_db_session()
+            # This fixture switches session_id after construction and supplies
+            # an in-memory projection that is intentionally ahead of the empty
+            # durable parent. Bind the matching durable identity explicitly;
+            # compression must not infer it from the new session id alone.
+            agent._durable_transcript_revision = db.get_active_message_revision(
+                parent_sid
+            )
 
             # Plain marked messages only: the exact-equality assertion below
             # relies on `compressed` containing no message that _flush filters

--- a/tests/run_agent/test_preflight_compression_cap_e2e.py
+++ b/tests/run_agent/test_preflight_compression_cap_e2e.py
@@ -135,7 +135,11 @@ def test_preflight_runs_fourth_compaction_pass_at_cap_six(monkeypatch, tmp_path)
         patch.object(agent, "_save_trajectory"),
         patch.object(agent, "_cleanup_task_resources"),
     ):
-        result = agent.run_conversation("hello", conversation_history=history)
+        result = agent.run_conversation(
+            "hello",
+            conversation_history=history,
+            conversation_history_revision=agent._durable_transcript_revision,
+        )
 
     assert result["completed"] is True
     # The old hardcoded range(3) made a 4th pass impossible; cap=6 must

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import time
 
 import pytest
@@ -24,6 +25,16 @@ def _compression_parent(db: SessionDB, session_id: str = "parent") -> None:
     db.end_session(session_id, "compression")
 
 
+def _set_raw_model_config(db: SessionDB, session_id: str, value) -> None:
+    with db._lock:
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE sessions SET model_config = ? WHERE id = ?",
+            (value, session_id),
+        )
+        db._conn.commit()
+
+
 def test_find_live_compression_child_returns_unique_direct_child(db: SessionDB) -> None:
     _compression_parent(db)
     db.create_session("child", source="webui", parent_session_id="parent")
@@ -34,6 +45,244 @@ def test_find_live_compression_child_returns_unique_direct_child(db: SessionDB) 
     assert child["id"] == "child"
     assert child["parent_session_id"] == "parent"
     assert child["ended_at"] is None
+
+
+def test_find_live_compression_child_follows_multi_hop_chain(db: SessionDB) -> None:
+    _compression_parent(db)
+    parent = "parent"
+    for child in ("child-1", "child-2"):
+        db.create_session(child, source="webui", parent_session_id=parent)
+        db.end_session(child, "compression")
+        parent = child
+    db.create_session("live-tip", source="webui", parent_session_id=parent)
+
+    child = db.find_live_compression_child("parent")
+
+    assert child is not None
+    assert child["id"] == "live-tip"
+    assert child["parent_session_id"] == "child-2"
+
+
+def test_find_live_compression_child_rejects_fork_at_any_hop(db: SessionDB) -> None:
+    _compression_parent(db)
+    db.create_session("rotated", source="webui", parent_session_id="parent")
+    db.end_session("rotated", "compression")
+    db.create_session("tip-a", source="webui", parent_session_id="rotated")
+    db.create_session("tip-b", source="webui", parent_session_id="rotated")
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_rejects_cycle(db: SessionDB) -> None:
+    _compression_parent(db)
+    db.create_session("child", source="webui", parent_session_id="parent")
+    db.end_session("child", "compression")
+
+    def _close_cycle(conn) -> None:
+        conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            ("child", "parent"),
+        )
+
+    db._execute_write(_close_cycle)
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_has_no_shallow_depth_cap(db: SessionDB) -> None:
+    _compression_parent(db)
+    parent = "parent"
+    for index in range(128):
+        child = f"compressed-{index}"
+        db.create_session(child, source="webui", parent_session_id=parent)
+        db.end_session(child, "compression")
+        parent = child
+    db.create_session("deep-live-tip", source="webui", parent_session_id=parent)
+
+    child = db.find_live_compression_child("parent")
+
+    assert child is not None
+    assert child["id"] == "deep-live-tip"
+
+
+def test_find_live_compression_child_counts_closed_canonical_sibling(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("closed-sibling", source="webui", parent_session_id="parent")
+    db.end_session("closed-sibling", "agent_close")
+    db.create_session("live-child", source="webui", parent_session_id="parent")
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_rejects_live_intermediate(db: SessionDB) -> None:
+    _compression_parent(db)
+    db.create_session("live-intermediate", source="webui", parent_session_id="parent")
+    db.create_session(
+        "live-grandchild",
+        source="webui",
+        parent_session_id="live-intermediate",
+    )
+
+    assert db.find_live_compression_child("parent") is None
+
+
+@pytest.mark.parametrize(
+    ("ended_at", "end_reason"),
+    [
+        (None, "compression"),
+        (123.0, None),
+        (123.0, "agent_close"),
+    ],
+)
+def test_find_live_compression_child_rejects_incoherent_child_lifecycle(
+    db: SessionDB,
+    ended_at,
+    end_reason,
+) -> None:
+    _compression_parent(db)
+    db.create_session("incoherent", source="webui", parent_session_id="parent")
+    with db._lock:
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE sessions SET ended_at = ?, end_reason = ? WHERE id = ?",
+            (ended_at, end_reason, "incoherent"),
+        )
+        db._conn.commit()
+
+    assert db.find_live_compression_child("parent") is None
+
+
+@pytest.mark.parametrize("raw_config", ["{not-json", "[]", "null"])
+def test_find_live_compression_child_rejects_malformed_metadata(
+    db: SessionDB,
+    raw_config: str,
+) -> None:
+    _compression_parent(db)
+    db.create_session("malformed", source="webui", parent_session_id="parent")
+    _set_raw_model_config(db, "malformed", raw_config)
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_rejects_nontext_metadata(db: SessionDB) -> None:
+    _compression_parent(db)
+    db.create_session("blob-config", source="webui", parent_session_id="parent")
+    _set_raw_model_config(db, "blob-config", b"{}")
+
+    assert db.find_live_compression_child("parent") is None
+
+
+@pytest.mark.parametrize("marker", ["_branched_from", "_delegate_from"])
+@pytest.mark.parametrize("value", [None, "", 7, "wrong-parent"])
+def test_find_live_compression_child_rejects_invalid_decoy_marker(
+    db: SessionDB,
+    marker: str,
+    value,
+) -> None:
+    _compression_parent(db)
+    db.create_session("canonical", source="webui", parent_session_id="parent")
+    db.create_session(
+        "invalid-decoy",
+        source="webui",
+        parent_session_id="parent",
+        model_config={marker: value},
+    )
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_rejects_duplicate_decoy_markers(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("canonical", source="webui", parent_session_id="parent")
+    db.create_session(
+        "invalid-decoy",
+        source="webui",
+        parent_session_id="parent",
+        model_config={
+            "_branched_from": "parent",
+            "_delegate_from": "parent",
+        },
+    )
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_ignores_only_valid_leaf_decoys(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("live-tip", source="webui", parent_session_id="parent")
+    db.create_session(
+        "branch",
+        source="webui",
+        parent_session_id="live-tip",
+        model_config={"_branched_from": "live-tip"},
+    )
+    db.create_session(
+        "delegate",
+        source="webui",
+        parent_session_id="live-tip",
+        model_config={"_delegate_from": "live-tip"},
+    )
+    db.create_session("tool-child", source="tool", parent_session_id="live-tip")
+    _set_raw_model_config(db, "tool-child", "{not-json")
+
+    child = db.find_live_compression_child("parent")
+
+    assert child is not None
+    assert child["id"] == "live-tip"
+
+
+def test_find_live_compression_child_holds_one_read_snapshot(
+    db: SessionDB,
+    monkeypatch,
+) -> None:
+    _compression_parent(db)
+    db.create_session("live-tip", source="webui", parent_session_id="parent")
+    assert db._conn is not None
+    with db._lock:
+        journal_mode = db._conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+    assert str(journal_mode).lower() == "wal"
+    writer = SessionDB(db_path=db.db_path)
+    inserted = False
+
+    def _insert_descendant_after_snapshot(sql: str) -> None:
+        nonlocal inserted
+        compact_sql = " ".join(sql.split())
+        if not inserted and "parent_session_id = 'parent'" in compact_sql:
+            inserted = True
+            writer.create_session(
+                "late-descendant",
+                source="webui",
+                parent_session_id="live-tip",
+            )
+
+    original_read_ctx = db._read_ctx
+
+    @contextmanager
+    def _traced_read_ctx():
+        with original_read_ctx() as conn:
+            assert conn is not None
+            conn.set_trace_callback(_insert_descendant_after_snapshot)
+            try:
+                yield conn
+            finally:
+                conn.set_trace_callback(None)
+
+    monkeypatch.setattr(db, "_read_ctx", _traced_read_ctx)
+    try:
+        child = db.find_live_compression_child("parent")
+    finally:
+        writer.close()
+
+    assert inserted is True
+    assert child is not None
+    assert child["id"] == "live-tip"
+    assert db.find_live_compression_child("parent") is None
 
 
 def test_find_live_compression_child_fails_closed_when_ambiguous(db: SessionDB) -> None:
@@ -118,22 +367,22 @@ def test_reopen_fails_closed_when_continuation_inherits_foreign_markers(
     assert parent["end_reason"] == "compression"
 
 
-def test_find_live_child_returns_continuation_with_foreign_markers(
+@pytest.mark.parametrize("marker", ["_branched_from", "_delegate_from"])
+def test_find_live_child_rejects_wrong_parent_marker(
     db: SessionDB,
+    marker: str,
 ) -> None:
-    """Adoption-side twin of the reopen test above: the continuation that
-    inherited a foreign ``_delegate_from`` must still be adoptable."""
+    """Conservative stale-writer adoption must not reinterpret a marker that
+    points elsewhere; only a marker bound to the direct parent is a decoy."""
     _compression_parent(db, "delegate-session-2")
     db.create_session(
-        "inherited-continuation",
+        "wrong-parent-marker",
         source="subagent",
         parent_session_id="delegate-session-2",
-        model_config={"_delegate_from": "some-original-parent"},
+        model_config={marker: "some-original-parent"},
     )
 
-    child = db.find_live_compression_child("delegate-session-2")
-    assert child is not None
-    assert child["id"] == "inherited-continuation"
+    assert db.find_live_compression_child("delegate-session-2") is None
 
 
 def test_compression_lineage_includes_continuation_with_foreign_markers(

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -34,6 +34,194 @@ def test_find_live_compression_child_returns_unique_direct_child(db: SessionDB) 
     assert child["ended_at"] is None
 
 
+def test_find_live_compression_child_follows_multi_hop_chain(db: SessionDB) -> None:
+    _compression_parent(db)
+    db.create_session("child-1", source="webui", parent_session_id="parent")
+    db.end_session("child-1", "compression")
+    db.create_session("child-2", source="webui", parent_session_id="child-1")
+    db.end_session("child-2", "compression")
+    db.create_session("live-tip", source="webui", parent_session_id="child-2")
+
+    child = db.find_live_compression_child("parent")
+
+    assert child is not None
+    assert child["id"] == "live-tip"
+    assert child["parent_session_id"] == "child-2"
+    assert child["ended_at"] is None
+
+
+def test_find_live_compression_child_fails_closed_at_ambiguous_hop(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("child-1", source="webui", parent_session_id="parent")
+    db.end_session("child-1", "compression")
+    db.create_session("tip-a", source="webui", parent_session_id="child-1")
+    db.create_session("tip-b", source="webui", parent_session_id="child-1")
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_fails_closed_for_live_and_rotated_siblings(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("rotated", source="webui", parent_session_id="parent")
+    db.end_session("rotated", "compression")
+    db.create_session("rotated-tip", source="webui", parent_session_id="rotated")
+    db.create_session("stale-live-sibling", source="webui", parent_session_id="parent")
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_ignores_non_continuations_at_each_hop(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("child-1", source="webui", parent_session_id="parent")
+    db.end_session("child-1", "compression")
+    db.create_session(
+        "branch",
+        source="webui",
+        parent_session_id="child-1",
+        model_config={"_branched_from": "child-1"},
+    )
+    db.create_session(
+        "delegate",
+        source="webui",
+        parent_session_id="child-1",
+        model_config={"_delegate_from": "child-1"},
+    )
+    db.create_session("tool-child", source="tool", parent_session_id="child-1")
+    db.create_session("live-tip", source="webui", parent_session_id="child-1")
+
+    child = db.find_live_compression_child("parent")
+
+    assert child is not None
+    assert child["id"] == "live-tip"
+
+
+def test_find_live_compression_child_rejects_noncompression_dead_end(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("closed-child", source="webui", parent_session_id="parent")
+    db.end_session("closed-child", "agent_close")
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_rejects_cycle(db: SessionDB) -> None:
+    _compression_parent(db)
+    db.create_session("child", source="webui", parent_session_id="parent")
+    db.end_session("child", "compression")
+    def _close_cycle(conn) -> None:
+        conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            ("child", "parent"),
+        )
+
+    db._execute_write(_close_cycle)
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_accepts_maximum_supported_depth(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    parent = "parent"
+    for index in range(99):
+        child = f"compressed-{index}"
+        db.create_session(child, source="webui", parent_session_id=parent)
+        db.end_session(child, "compression")
+        parent = child
+    db.create_session("deep-live-tip", source="webui", parent_session_id=parent)
+
+    child = db.find_live_compression_child("parent")
+
+    assert child is not None
+    assert child["id"] == "deep-live-tip"
+
+
+def test_find_live_compression_child_has_no_shallow_depth_cap(db: SessionDB) -> None:
+    _compression_parent(db)
+    parent = "parent"
+    for index in range(128):
+        child = f"compressed-{index}"
+        db.create_session(child, source="webui", parent_session_id=parent)
+        db.end_session(child, "compression")
+        parent = child
+    db.create_session("deep-tip", source="webui", parent_session_id=parent)
+
+    tip = db.find_live_compression_child("parent")
+    assert tip is not None
+    assert tip["id"] == "deep-tip"
+
+
+def test_find_live_compression_child_rejects_closed_canonical_sibling(db: SessionDB) -> None:
+    _compression_parent(db)
+    db.create_session("closed", source="webui", parent_session_id="parent")
+    db.end_session("closed", "agent_close")
+    db.create_session("live", source="webui", parent_session_id="parent")
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_rejects_live_intermediate(db: SessionDB) -> None:
+    _compression_parent(db)
+    db.create_session("live", source="webui", parent_session_id="parent")
+    db.create_session("descendant", source="webui", parent_session_id="live")
+
+    assert db.find_live_compression_child("parent") is None
+
+
+@pytest.mark.parametrize("raw_config", ["{not-json", "[]", "null"])
+def test_find_live_compression_child_rejects_malformed_metadata(
+    db: SessionDB, raw_config: str
+) -> None:
+    _compression_parent(db)
+    db.create_session("malformed", source="webui", parent_session_id="parent")
+    with db._lock:
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE sessions SET model_config = ? WHERE id = ?",
+            (raw_config, "malformed"),
+        )
+        db._conn.commit()
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_rejects_nontext_metadata(db: SessionDB) -> None:
+    _compression_parent(db)
+    db.create_session("blob", source="webui", parent_session_id="parent")
+    with db._lock:
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE sessions SET model_config = ? WHERE id = ?", (b"{}", "blob")
+        )
+        db._conn.commit()
+
+    assert db.find_live_compression_child("parent") is None
+
+
+@pytest.mark.parametrize("marker", ["_branched_from", "_delegate_from"])
+def test_find_live_compression_child_rejects_invalid_decoy(
+    db: SessionDB, marker: str
+) -> None:
+    _compression_parent(db)
+    db.create_session("live", source="webui", parent_session_id="parent")
+    db.create_session(
+        "false-decoy",
+        source="webui",
+        parent_session_id="parent",
+        model_config={marker: "wrong-parent"},
+    )
+
+    assert db.find_live_compression_child("parent") is None
+
+
 def test_find_live_compression_child_fails_closed_when_ambiguous(db: SessionDB) -> None:
     _compression_parent(db)
     db.create_session("child-a", source="webui", parent_session_id="parent")

--- a/tests/test_hermes_state_compression_busy_retry.py
+++ b/tests/test_hermes_state_compression_busy_retry.py
@@ -17,6 +17,7 @@ publish.
 
 from __future__ import annotations
 
+import threading
 import time
 from pathlib import Path
 
@@ -51,6 +52,37 @@ def test_append_is_never_blocked_by_a_foreign_compression_lock(db: SessionDB) ->
     assert elapsed < 0.5, "append must not wait on a compression lease"
     rows = db.get_messages("sess1")
     assert any(r["content"] == "steered mid-compression" for r in rows)
+
+
+def test_replace_messages_waits_out_a_live_compression_lock(db: SessionDB) -> None:
+    """All ordinary transcript rewrites share the bounded lease wait."""
+    db.append_message("sess1", role="user", content="before rewrite")
+    assert db.try_acquire_compression_lock("sess1", "compressor") is True
+
+    released = threading.Event()
+
+    def _release_soon():
+        time.sleep(0.3)
+        db.release_compression_lock("sess1", "compressor")
+        released.set()
+
+    t = threading.Thread(target=_release_soon, daemon=True)
+    t.start()
+    try:
+        started = time.monotonic()
+        db.replace_messages(
+            "sess1",
+            [{"role": "user", "content": "after rewrite"}],
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        t.join(timeout=5)
+
+    assert released.is_set(), "test bug: lock was never released"
+    assert elapsed >= 0.25, "rewrite returned before the lock could clear"
+    assert [row["content"] for row in db.get_messages("sess1")] == [
+        "after rewrite"
+    ]
 
 
 def test_append_is_never_blocked_by_a_stale_dead_pid_lock(db: SessionDB) -> None:

--- a/tests/test_hermes_state_compression_busy_retry.py
+++ b/tests/test_hermes_state_compression_busy_retry.py
@@ -60,6 +60,37 @@ def test_append_waits_out_a_live_compression_lock(db: SessionDB) -> None:
     )
 
 
+def test_replace_messages_waits_out_a_live_compression_lock(db: SessionDB) -> None:
+    """All ordinary transcript rewrites share the bounded lease wait."""
+    db.append_message("sess1", role="user", content="before rewrite")
+    assert db.try_acquire_compression_lock("sess1", "compressor") is True
+
+    released = threading.Event()
+
+    def _release_soon():
+        time.sleep(0.3)
+        db.release_compression_lock("sess1", "compressor")
+        released.set()
+
+    t = threading.Thread(target=_release_soon, daemon=True)
+    t.start()
+    try:
+        started = time.monotonic()
+        db.replace_messages(
+            "sess1",
+            [{"role": "user", "content": "after rewrite"}],
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        t.join(timeout=5)
+
+    assert released.is_set(), "test bug: lock was never released"
+    assert elapsed >= 0.25, "rewrite returned before the lock could clear"
+    assert [row["content"] for row in db.get_messages("sess1")] == [
+        "after rewrite"
+    ]
+
+
 def test_append_still_gives_up_when_the_lock_never_clears(
     db: SessionDB, monkeypatch
 ) -> None:

--- a/tests/test_stale_tool_call_marker_session_repair.py
+++ b/tests/test_stale_tool_call_marker_session_repair.py
@@ -184,6 +184,7 @@ class TestPurgeStaleToolCallMarkers:
             db = SessionDB(db_path=Path(tmp) / "t.db")
             try:
                 self._seed_polluted_db(db)
+                before = db.get_active_message_revision("s1")
 
                 report = db.purge_stale_tool_call_markers(dry_run=False)
                 assert report["dry_run"] is False
@@ -199,6 +200,10 @@ class TestPurgeStaleToolCallMarkers:
                 assert row["content"] == ""
                 # tool_calls column itself must survive the rewrite untouched.
                 assert row["tool_calls"]
+                after = db.get_active_message_revision("s1")
+                assert after.active_message_count == before.active_message_count
+                assert after.max_active_message_id == before.max_active_message_id
+                assert after != before
 
                 # Running again finds nothing left to clean — idempotent.
                 second = db.purge_stale_tool_call_markers(dry_run=False)


### PR DESCRIPTION
## Summary

Fence compression against an atomic durable transcript revision instead of comparing a model-facing projection length with SQLite's active-row count.

This fixes the cross-repository race where WebUI can legitimately project fewer messages than the Agent's durable transcript, while a real concurrent mutation must still prevent stale compression output from publishing.

## Root cause

`len(durable_parent) > len(messages)` was treated as evidence of concurrent writes. That is not a valid invariant across WebUI sanitization, deduplication, replay and sidecar projection. It caused false retries and could exhaust the provider context window. Conversely, without a durable revision/CAS boundary, a true concurrent rewrite could be missed between load and publication.

The previous PR head also introduced a separate CI regression: importing durable state through `gateway.config -> gateway.session -> agent.turn_context -> agent.conversation_compression` froze `state.db` before runtime `HERMES_HOME` resolution. The current head keeps those imports lazy; the existing runtime-home regression is green again.

## Changes

- capture messages and their durable revision from the same SQLite rows;
- include active-row count, max active id, content digest and `api_content` sidecar digest;
- propagate revision state through `TurnContext`/`TurnRunner` and refresh it after clean Agent writes;
- re-check after acquiring the compression lease and at publication/mutator boundaries;
- fail closed on stale or unverifiable revisions without replaying tools;
- preserve current-turn partial output under explicit stale classification;
- retain opt-in durable row IDs and coherent rewind/rotation snapshots;
- keep durable-state imports lazy so runtime profile/home selection remains authoritative.

## Dependency and pairing

- stacked dependency: #71486 at `5d4539dcfc782953fbc27bd630b96b245c7c7621`;
- this PR head: `1bdac5d4547914d70c134f06af0435568a35159c`;
- rebased base: `cb11a7e25579638c9f67e8501dd151f581c4c942`;
- paired WebUI PR: nesquena/hermes-webui#6554 at `0f7c4cef3f38aab591ae6fa6fcfdb76a869c669a`.

Merge #71486 first, then rebase this PR onto the resulting `main` to drop the stacked duplicate and revalidate the new exact head together with WebUI.

## Validation

- critical Agent gate: **96 passed, 0 failed**;
- exact cross-repo WebUI↔Agent gate: **54 passed, 0 failed**;
- broader Agent matrix: **792 passed**; 2 TUI config tests fail only because the local control environment lacks `ruamel`, reproduced identically on unmodified base (**515 passed, same 2 failed**);
- Ruff on changed lazy-import files, `py_compile`, and `git diff --check`: passed.

No deployment or merge is performed by this PR update.