### PR TITLE
fix(desktop): retire dead pooled remotes and log main-process faults

### DIFF
--- a/apps/desktop/electron/crash-forensics.test.ts
+++ b/apps/desktop/electron/crash-forensics.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { describeCrashReason, installCrashForensics } from './crash-forensics'
+
+const harness = () => {
+  const listeners = new Map<string, (value: unknown) => void>()
+  const flush = vi.fn()
+  const log = vi.fn()
+
+  installCrashForensics({
+    flush,
+    log,
+    target: { on: (event, listener) => listeners.set(event, listener) }
+  })
+
+  return { flush, listeners, log }
+}
+
+describe('describeCrashReason', () => {
+  it('prefers a stack, then a message, for thrown errors', () => {
+    const withStack = new Error('boom')
+    withStack.stack = 'Error: boom\n    at somewhere'
+
+    expect(describeCrashReason(withStack)).toBe('Error: boom\n    at somewhere')
+
+    const withoutStack = new Error('boom')
+    withoutStack.stack = ''
+
+    expect(describeCrashReason(withoutStack)).toBe('boom')
+  })
+
+  it('renders non-error rejections without throwing', () => {
+    expect(describeCrashReason('plain string')).toBe('plain string')
+    expect(describeCrashReason({ code: 'ECONNRESET' })).toBe('{"code":"ECONNRESET"}')
+    expect(describeCrashReason(undefined)).toBe('undefined')
+
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+
+    expect(describeCrashReason(circular)).toBe('[object Object]')
+  })
+})
+
+describe('installCrashForensics', () => {
+  it('records and synchronously flushes an uncaught exception', () => {
+    const { flush, listeners, log } = harness()
+    const error = new Error('renderer gone')
+    error.stack = 'Error: renderer gone\n    at main'
+
+    listeners.get('uncaughtException')?.(error)
+
+    expect(log).toHaveBeenCalledWith('[main] Uncaught exception: Error: renderer gone\n    at main')
+    expect(flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('records and synchronously flushes an unhandled rejection', () => {
+    const { flush, listeners, log } = harness()
+
+    listeners.get('unhandledRejection')?.('gateway ticket mint failed')
+
+    expect(log).toHaveBeenCalledWith('[main] Unhandled rejection: gateway ticket mint failed')
+    expect(flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('registers both handlers', () => {
+    const { listeners } = harness()
+
+    expect([...listeners.keys()].sort()).toEqual(['uncaughtException', 'unhandledRejection'])
+  })
+})

--- a/apps/desktop/electron/crash-forensics.ts
+++ b/apps/desktop/electron/crash-forensics.ts
@@ -1,0 +1,51 @@
+/**
+ * Last-chance forensics for the Electron main process.
+ *
+ * Electron installs its own `uncaughtException` listener and only warns on
+ * unhandled rejections, so the app usually survives — but the reason lands on
+ * stderr alone, which is discarded entirely when the app is launched from
+ * Finder or the Start menu. Without a record in desktop.log, a main-process
+ * fault is invisible in a `hermes debug share` bundle and the user is left
+ * describing symptoms instead of showing a stack.
+ */
+
+export interface CrashForensicsTarget {
+  on: (event: 'uncaughtException' | 'unhandledRejection', listener: (value: unknown) => void) => unknown
+}
+
+export interface CrashForensicsOptions {
+  flush: () => void
+  log: (message: string) => void
+  target?: CrashForensicsTarget
+}
+
+/** Render a thrown value for the log, preferring a stack over a bare message. */
+export function describeCrashReason(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.stack || reason.message || reason.name || 'Error'
+  }
+
+  if (typeof reason === 'string') {
+    return reason
+  }
+
+  try {
+    return JSON.stringify(reason) ?? String(reason)
+  } catch {
+    return String(reason)
+  }
+}
+
+/**
+ * Record main-process faults to desktop.log and flush synchronously, since a
+ * fault that does prove fatal leaves no chance for the batched async flush.
+ */
+export function installCrashForensics({ flush, log, target = process }: CrashForensicsOptions): void {
+  const record = (label: string) => (reason: unknown) => {
+    log(`[main] ${label}: ${describeCrashReason(reason)}`)
+    flush()
+  }
+
+  target.on('uncaughtException', record('Uncaught exception'))
+  target.on('unhandledRejection', record('Unhandled rejection'))
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -144,7 +144,12 @@ import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import * as remoteLifecycle from './remote-lifecycle'
-import { RemoteLivenessTracker, RemoteRevalidationCoordinator, revalidateRemoteConnection } from './remote-liveness'
+import {
+  RemoteLivenessTracker,
+  RemoteRevalidationCoordinator,
+  revalidatePooledRemoteBackends,
+  revalidateRemoteConnection
+} from './remote-liveness'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -7747,7 +7752,14 @@ async function ensureBackend(profile) {
 
   evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
 
-  const entry = { process: null, port: null, token: null, connectionPromise: null, lastActiveAt: Date.now() }
+  const entry = {
+    process: null,
+    port: null,
+    token: null,
+    connectionPromise: null,
+    lastActiveAt: Date.now(),
+    remoteBaseUrl: null
+  }
   entry.connectionPromise = spawnPoolBackend(key, entry).catch(error => {
     backendPool.delete(key)
     throw error
@@ -7843,6 +7855,10 @@ async function spawnPoolBackend(profile, entry) {
 
   if (remote) {
     await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
+
+    // Recorded on the entry so revalidation can probe this descriptor without
+    // awaiting connectionPromise, which may still be pending for a sibling.
+    entry.remoteBaseUrl = remote.baseUrl
 
     return {
       ...remote,
@@ -9117,6 +9133,8 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
   const connectionPromise = backendConnectionState.getPromise()
 
   if (!connectionPromise) {
+    await revalidatePool()
+
     return { ok: true, rebuilt: false }
   }
 
@@ -9124,14 +9142,17 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
   // share this primary connection. Coalesce simultaneous requests so one outage
   // produces one failure observation rather than exhausting the whole streak.
   return remoteRevalidation.run(connectionPromise, async () => {
-    const result = await revalidateRemoteConnection({
-      connectionPromise,
-      currentConnectionPromise: () => backendConnectionState.getPromise(),
-      log: rememberLog,
-      probe: fetchPublicJson,
-      resetConnection: resetHermesConnection,
-      tracker: remoteLiveness
-    })
+    const [result] = await Promise.all([
+      revalidateRemoteConnection({
+        connectionPromise,
+        currentConnectionPromise: () => backendConnectionState.getPromise(),
+        log: rememberLog,
+        probe: fetchPublicJson,
+        resetConnection: resetHermesConnection,
+        tracker: remoteLiveness
+      }),
+      revalidatePool()
+    ])
 
     // A rebuilt SSH connection must also tear down its tunnel/master before the
     // renderer re-dials (which only happens after this handler resolves), so the
@@ -9149,6 +9170,19 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
     return result
   })
 })
+
+// Pooled remote descriptors get the same treatment as the primary: they have no
+// child process to signal their host's death, and the renderer's keepalive touch
+// spares them from the idle reaper, so nothing else can retire a dead one.
+function revalidatePool() {
+  return revalidatePooledRemoteBackends({
+    entries: backendPool.entries(),
+    log: rememberLog,
+    probe: fetchPublicJson,
+    stopBackend: stopPoolBackend,
+    tracker: remoteLiveness
+  })
+}
 ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
   touchPoolBackend(profile)
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -68,6 +68,7 @@ import {
   savedProfileSsh,
   tokenPreview
 } from './connection-config'
+import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import {
@@ -1215,6 +1216,14 @@ function rememberLog(chunk) {
   }
 
   scheduleDesktopLogFlush()
+}
+
+installCrashForensics({ flush: flushDesktopLogBufferSync, log: rememberLog })
+
+// A rejected loadURL leaves a blank window and, unhandled, no trace anywhere
+// the user can send us. `label` names the surface so the log says which one.
+function loadWindowUrl(win, url, label) {
+  win.loadURL(url).catch(error => rememberLog(`${label} failed to load: ${describeCrashReason(error)}`))
 }
 
 function openExternalUrl(rawUrl) {
@@ -7760,6 +7769,7 @@ async function ensureBackend(profile) {
     lastActiveAt: Date.now(),
     remoteBaseUrl: null
   }
+
   entry.connectionPromise = spawnPoolBackend(key, entry).catch(error => {
     backendPool.delete(key)
     throw error
@@ -8450,12 +8460,14 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
 
   wireCommonWindowHandlers(win, zoomWiringForWindowKind('chat'))
 
-  win.loadURL(
+  loadWindowUrl(
+    win,
     buildSessionWindowUrl(sessionId, {
       devServer: DEV_SERVER,
       rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
       watch
-    })
+    }),
+    'Session window'
   )
 
   return win
@@ -8535,11 +8547,7 @@ function createInstanceWindow() {
     instanceWindows.delete(win)
   })
 
-  if (DEV_SERVER) {
-    win.loadURL(DEV_SERVER)
-  } else {
-    win.loadURL(pathToFileURL(resolveRendererIndex()).toString())
-  }
+  loadWindowUrl(win, DEV_SERVER || pathToFileURL(resolveRendererIndex()).toString(), 'Instance window')
 
   return win
 }
@@ -8651,7 +8659,7 @@ function spawnPetOverlayWindow(bounds) {
     }
   })
 
-  win.loadURL(petOverlayUrl())
+  loadWindowUrl(win, petOverlayUrl(), 'Pet overlay')
 
   return win
 }
@@ -8803,7 +8811,7 @@ function spawnQuickEntryWindow() {
     }
   })
 
-  win.loadURL(quickEntryUrl())
+  loadWindowUrl(win, quickEntryUrl(), 'Quick entry')
 
   return win
 }
@@ -9097,11 +9105,7 @@ function createWindow() {
     rememberLog(`[renderer console] ${text} (${src}:${lineNo})`)
   })
 
-  if (DEV_SERVER) {
-    mainWindow.loadURL(DEV_SERVER)
-  } else {
-    mainWindow.loadURL(pathToFileURL(resolveRendererIndex()).toString())
-  }
+  loadWindowUrl(mainWindow, DEV_SERVER || pathToFileURL(resolveRendererIndex()).toString(), 'Renderer')
 
   // Start the Python backend NOW, in parallel with the renderer load — not on
   // did-finish-load. The backend cold boot (spawn → port announce → /api/status)
@@ -9183,6 +9187,7 @@ function revalidatePool() {
     tracker: remoteLiveness
   })
 }
+
 ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
   touchPoolBackend(profile)
 

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -258,6 +258,7 @@ describe('revalidatePooledRemoteBackends', () => {
     const unreachable = new Set<string>()
     const log = vi.fn()
     const stopBackend = vi.fn()
+
     const probe = vi.fn(async (url: string) => {
       if ([...unreachable].some(base => url.startsWith(base))) {
         throw new Error('unreachable')
@@ -336,6 +337,7 @@ describe('revalidatePooledRemoteBackends', () => {
       ['coder', { process: null, remoteBaseUrl: 'https://dead.example.com' }],
       ['writer', { process: null, remoteBaseUrl: 'https://live.example.com' }]
     ])
+
     pool.unreachable.add('https://dead.example.com')
 
     const tracker = new RemoteLivenessTracker()

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -6,6 +6,7 @@ import {
   REMOTE_LIVENESS_TIMEOUT_MS,
   RemoteLivenessTracker,
   RemoteRevalidationCoordinator,
+  revalidatePooledRemoteBackends,
   revalidateRemoteConnection
 } from './remote-liveness'
 
@@ -249,5 +250,102 @@ describe('revalidateRemoteConnection', () => {
 
     await expect(revalidateRemoteConnection(rejected.options)).resolves.toEqual({ ok: true, rebuilt: false })
     expect(rejected.probe).not.toHaveBeenCalled()
+  })
+})
+
+describe('revalidatePooledRemoteBackends', () => {
+  const harness = (entries: Array<[string, { process?: unknown; remoteBaseUrl?: null | string }]>) => {
+    const unreachable = new Set<string>()
+    const log = vi.fn()
+    const stopBackend = vi.fn()
+    const probe = vi.fn(async (url: string) => {
+      if ([...unreachable].some(base => url.startsWith(base))) {
+        throw new Error('unreachable')
+      }
+
+      return {}
+    })
+
+    return {
+      log,
+      probe,
+      stopBackend,
+      unreachable,
+      run: (tracker: RemoteLivenessTracker) =>
+        revalidatePooledRemoteBackends({ entries, log, probe, stopBackend, tracker })
+    }
+  }
+
+  it('probes only pooled entries backed by a remote host', async () => {
+    const local = { process: {}, remoteBaseUrl: null }
+    const spawning = { process: null, remoteBaseUrl: null }
+    const remote = { process: null, remoteBaseUrl: 'https://remote.example.com' }
+
+    const pool = harness([
+      ['local', local],
+      ['spawning', spawning],
+      ['remote', remote]
+    ])
+
+    await pool.run(new RemoteLivenessTracker())
+
+    expect(pool.probe).toHaveBeenCalledTimes(1)
+    expect(pool.probe).toHaveBeenCalledWith('https://remote.example.com/api/status', {
+      timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS
+    })
+    expect(pool.stopBackend).not.toHaveBeenCalled()
+  })
+
+  it('drops a descriptor only after the shared failure limit', async () => {
+    const pool = harness([['coder', { process: null, remoteBaseUrl: 'https://remote.example.com/' }]])
+    pool.unreachable.add('https://remote.example.com')
+
+    const tracker = new RemoteLivenessTracker()
+
+    for (let attempt = 1; attempt < REMOTE_LIVENESS_FAILURE_LIMIT; attempt += 1) {
+      await expect(pool.run(tracker)).resolves.toEqual({ dropped: [] })
+      expect(pool.stopBackend).not.toHaveBeenCalled()
+    }
+
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder'] })
+    expect(pool.stopBackend).toHaveBeenCalledWith('coder')
+  })
+
+  it('clears the streak when the host answers again', async () => {
+    const pool = harness([['coder', { process: null, remoteBaseUrl: 'https://remote.example.com' }]])
+    const tracker = new RemoteLivenessTracker()
+
+    pool.unreachable.add('https://remote.example.com')
+    await pool.run(tracker)
+
+    pool.unreachable.clear()
+    await pool.run(tracker)
+
+    pool.unreachable.add('https://remote.example.com')
+
+    for (let attempt = 1; attempt < REMOTE_LIVENESS_FAILURE_LIMIT; attempt += 1) {
+      await expect(pool.run(tracker)).resolves.toEqual({ dropped: [] })
+    }
+
+    expect(pool.stopBackend).not.toHaveBeenCalled()
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder'] })
+  })
+
+  it('keeps a healthy sibling when another profile on a different host dies', async () => {
+    const pool = harness([
+      ['coder', { process: null, remoteBaseUrl: 'https://dead.example.com' }],
+      ['writer', { process: null, remoteBaseUrl: 'https://live.example.com' }]
+    ])
+    pool.unreachable.add('https://dead.example.com')
+
+    const tracker = new RemoteLivenessTracker()
+
+    for (let attempt = 1; attempt < REMOTE_LIVENESS_FAILURE_LIMIT; attempt += 1) {
+      await pool.run(tracker)
+    }
+
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder'] })
+    expect(pool.stopBackend).toHaveBeenCalledTimes(1)
+    expect(pool.stopBackend).toHaveBeenCalledWith('coder')
   })
 })

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -117,6 +117,68 @@ export class RemoteLivenessTracker {
   }
 }
 
+export interface PooledRemoteEntry {
+  process?: unknown
+  remoteBaseUrl?: null | string
+}
+
+export interface RevalidatePooledRemoteBackendsOptions {
+  entries: Iterable<[string, PooledRemoteEntry]>
+  log: (message: string) => void
+  probe: (url: string, options: { timeoutMs: number }) => Promise<unknown>
+  stopBackend: (profile: string) => void
+  tracker: RemoteLivenessTracker
+}
+
+/**
+ * Probe pooled REMOTE descriptors and drop the dead ones.
+ *
+ * A pooled entry backed by a remote host has no child process, so the 'exit'
+ * handler that clears a dead local backend never fires, and the renderer's
+ * keepalive touch keeps the idle reaper off it. Without this the pool serves a
+ * descriptor for an unreachable host indefinitely.
+ *
+ * Entries share the primary's failure policy, keyed per base URL, so a profile
+ * pointing at the same host as another does not burn the streak twice as fast.
+ */
+export async function revalidatePooledRemoteBackends({
+  entries,
+  log,
+  probe,
+  stopBackend,
+  tracker
+}: RevalidatePooledRemoteBackendsOptions): Promise<{ dropped: string[] }> {
+  const remotes = [...entries].filter(([, entry]) => !entry.process && entry.remoteBaseUrl)
+  const dropped: string[] = []
+
+  await Promise.all(
+    remotes.map(async ([profile, entry]) => {
+      const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
+
+      try {
+        await probe(`${baseUrl}/api/status`, { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
+        tracker.recordSuccess(baseUrl)
+      } catch {
+        const failure = tracker.recordFailure(baseUrl)
+
+        if (!failure.shouldReset) {
+          log(
+            `Pooled remote backend for profile "${profile}" failed liveness probe (${failure.failures}/${REMOTE_LIVENESS_FAILURE_LIMIT}); keeping descriptor for retry.`
+          )
+
+          return
+        }
+
+        log(`Pooled remote backend for profile "${profile}" failed liveness probe; dropping stale descriptor.`)
+        stopBackend(profile)
+        dropped.push(profile)
+      }
+    })
+  )
+
+  return { dropped }
+}
+
 /**
  * Probe the cached primary remote connection and apply the failure policy.
  * The caller owns single-flight coordination; identity checks here ensure an


### PR DESCRIPTION
## What does this PR do?

The last two pieces of #58108 that no port has picked up. #68250 took the liveness and auth-classification work, #72740 takes the global-remote pool routing, and #67578 takes the OAuth session aggregate. These two remain.

**Pooled remote backends are never retired when their host dies.** A pool entry backed by a remote host has `entry.process === null`, so the `'exit'` handler that clears a dead *local* backend never fires, and the renderer's 60s keepalive touch keeps the idle reaper off it. Revalidation only ever probed the primary. Nothing was left to notice the host had gone, so the pool served a dead descriptor until the app restarted and every profile bound to that host stayed broken. Pooled remotes now share the primary's liveness policy — same probe on the same revalidate tick, keyed per base URL, dropped only after the same consecutive-failure limit, so `ensureBackend()` rebuilds on the next call.

**A main-process fault leaves no trace we can read.** Electron pre-installs its own `uncaughtException` listener and only warns on unhandled rejections, so the app typically survives and the reason goes to stderr — discarded entirely when launched from Finder or the Start menu. It never reaches `desktop.log`, so it is absent from `hermes debug share` and the user can only describe symptoms. Both are now recorded and flushed synchronously, since a fault that does prove fatal leaves no chance for the batched async flush. Five `loadURL` calls were unhandled too, each able to leave a blank window with nothing to explain it; they now name the surface that failed.

The second half is diagnostics rather than a behavior fix, and it is here because it is what the current round of remote-desktop reports keeps costing us: users spend hours guessing because the bundle is silent about what actually broke.

## Related Issue

Related: #58108. Completes the four defects listed in that PR's review — the other two land in #72740 and #67578.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/remote-liveness.ts` — added `revalidatePooledRemoteBackends()`, reusing the existing `RemoteLivenessTracker` policy rather than introducing a second one.
- `apps/desktop/electron/main.ts` — record `entry.remoteBaseUrl` when a pool entry resolves to a remote, and probe the pool on the same `hermes:connection:revalidate` tick as the primary.
- `apps/desktop/electron/crash-forensics.ts` (new) — `describeCrashReason()` and `installCrashForensics()`, dependency-injected so the handlers are tested for real rather than by reading source.
- `apps/desktop/electron/main.ts` — install the handlers, and route the five unhandled `loadURL` calls through a labelled helper.
- Behavioral coverage for both: pooled probe selection, the shared failure limit, streak reset on recovery, per-host isolation between profiles, and crash-record formatting and flushing.

## How to Test

1. From `apps/desktop`: `npx vitest run --project electron`
2. From `apps/desktop`: `npm run typecheck`
3. Point a named profile at a per-profile remote override, open it so it enters the pool, then stop the remote host. Before this change the pool serves that descriptor until restart; after it, the profile is dropped after the standard failure streak and rebuilds when the host returns.
4. Throw from a main-process handler and confirm the stack lands in `desktop.log` and survives into `hermes debug share`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, Desktop-only
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local validation on macOS, branched from `c2e45b555`:

- `npx vitest run --project electron`: 803 passed, 2 skipped
- `npm run typecheck`: passed
- ESLint and Prettier on the changed files: passed

Original diagnosis and the `main.cjs` implementation of both pieces are @rod-nxtlevel's in #58108; credited in the commit trailers.
