### PR TITLE
refactor(desktop): simplify free-text slash mode check

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.ts
@@ -139,10 +139,12 @@ export function useComposerTrigger({
   // Space/Tab — neither should dead-end on a popover.
   const argStageEmpty = trigger?.kind === '/' && slashArgStage(trigger.query) && !triggerLoading && !triggerItems.length
 
-  const slashFreeTextArgStage =
-    trigger?.kind === '/' &&
-    slashArgStage(trigger.query) &&
-    ['mixed', 'text'].includes(desktopSlashCommandArgumentMode(slashCommandToken(trigger.query)) ?? '')
+  const slashArgumentMode =
+    trigger?.kind === '/' && slashArgStage(trigger.query)
+      ? desktopSlashCommandArgumentMode(slashCommandToken(trigger.query))
+      : null
+
+  const slashFreeTextArgStage = slashArgumentMode === 'mixed' || slashArgumentMode === 'text'
 
   const closeTrigger = () => {
     setTrigger(null)


### PR DESCRIPTION
## What does this PR do?

Simplifies the free-text slash argument-mode check introduced by #72768. The hot composer render path now derives the guarded `DesktopSlashArgumentMode` once and compares the `mixed | text` union directly instead of allocating an array for `includes()` on every render.

This is the optional non-blocking follow-up requested in https://github.com/NousResearch/hermes-agent/pull/72768#pullrequestreview-4789919552. It preserves the existing trigger guard and behavior.

## Related Issue

Follow-up to #72768.

Review comment: https://github.com/NousResearch/hermes-agent/pull/72768#pullrequestreview-4789919552

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.ts`
  - derive the guarded slash argument mode once
  - replace the per-render array membership check with direct union comparisons

## How to Test

1. Run `npx vitest run --project ui src/app/chat/composer/hooks/use-composer-trigger.test.ts --maxWorkers=4` from `apps/desktop`: 9 passed.
2. Run `npm run typecheck` from `apps/desktop`: clean across renderer, Electron, and E2E TypeScript configs.
3. Run file-scoped ESLint and Prettier checks, then `git diff --check`: all clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this refactor
- [x] `pytest` is N/A because this is a Desktop TypeScript-only refactor; the focused Desktop test is green
- [x] Existing composer-trigger regression coverage exercises the unchanged behavior; no new test is needed for the direct-comparison refactor
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation is N/A; there is no user-facing behavior change
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact is N/A; this is a platform-neutral TypeScript expression cleanup
- [x] Tool descriptions and schemas are N/A

## Screenshots / Logs

N/A; no visual or behavioral change.
