### PR TITLE
fix(auth): let profiles disable global credential fallback

### DIFF
--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -108,6 +108,25 @@ If no route matches, the message uses the default/active profile.
 Because `gateway_runner` is injected for **all** adapters (declared on `BasePlatformAdapter`),
 every platform goes through this path — not just Discord.
 
+## Credential inheritance
+
+Named profiles inherit credentials from the global/root `auth.json` by default when the
+profile has no usable local entry for a provider. This preserves the historical convenience
+of authenticating once and using that provider across profiles.
+
+Security-sensitive service profiles can disable that fallback in the profile's own
+`config.yaml`:
+
+```yaml
+auth:
+  global_fallback: false
+```
+
+With fallback disabled, provider singleton state and credential-pool entries are resolved
+only from the profile. Global OAuth refresh/write-through paths are also unavailable to that
+profile. Configure the profile's required provider locally; otherwise credential resolution
+fails rather than borrowing root credentials.
+
 ## Relationship to multiplexing
 
 `profile_routes` requires `gateway.multiplex_profiles: true`. Multiplexing is what

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -46,6 +46,7 @@ import httpx
 from hermes_cli.config import (
     get_hermes_home,
     get_config_path,
+    load_config_readonly,
     read_raw_config,
     require_readable_config_before_write,
 )
@@ -934,6 +935,28 @@ def _global_auth_file_path() -> Optional[Path]:
 
     See issue #18594 follow-up (credential_pool shadowing).
     """
+    # Named profiles inherit root credentials by default for backward
+    # compatibility. Security-sensitive/service profiles can opt out in their
+    # own config.yaml:
+    #
+    #   auth:
+    #     global_fallback: false
+    #
+    # Keep this gate at the path resolver so every global read and OAuth
+    # refresh write-through observes the same boundary.
+    try:
+        resolved_config = load_config_readonly()
+        auth_config = (
+            resolved_config.get("auth") if isinstance(resolved_config, dict) else None
+        )
+        if isinstance(auth_config, dict) and not is_truthy_value(
+            auth_config.get("global_fallback"), default=True
+        ):
+            return None
+    except Exception:
+        # A malformed/unreadable config must preserve the historical default.
+        logger.debug("Failed to read auth.global_fallback; preserving fallback", exc_info=True)
+
     try:
         from hermes_constants import get_default_hermes_root
         global_root = get_default_hermes_root()

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -57,10 +57,63 @@ def _write(path: Path, payload: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_profile_can_disable_global_credential_pool_fallback(profile_env):
+    """Security-sensitive profiles can refuse every root pool credential."""
+    from hermes_cli.auth import read_credential_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "xai-oauth": [{
+            "id": "global-xai",
+            "label": "global-xai",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "global-access",
+            "refresh_token": "global-refresh",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+    (profile_env["profile"] / "config.yaml").write_text(
+        "auth:\n  global_fallback: false\n"
+    )
+
+    assert read_credential_pool("xai-oauth") == []
+    assert read_credential_pool(None) == {}
 
 
+def test_managed_config_can_disable_global_credential_pool_fallback(
+    profile_env, monkeypatch
+):
+    """An administrator-pinned false value overrides the profile config."""
+    from hermes_cli import managed_scope
+    from hermes_cli.auth import read_credential_pool
+    import hermes_cli.config as config_module
 
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "xai-oauth": [{
+            "id": "global-xai",
+            "label": "global-xai",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "global-access",
+            "refresh_token": "global-refresh",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+    (profile_env["profile"] / "config.yaml").write_text(
+        "auth:\n  global_fallback: true\n"
+    )
+    managed_dir = profile_env["global"] / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(
+        "auth:\n  global_fallback: false\n"
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    config_module._LOAD_CONFIG_CACHE.clear()
+    managed_scope.invalidate_managed_cache()
 
+    assert read_credential_pool("xai-oauth") == []
 
 
 def test_missing_global_auth_file_is_safe(profile_env):
@@ -125,6 +178,21 @@ def test_provider_auth_state_falls_back_to_global_when_profile_has_none(profile_
     state = get_provider_auth_state("nous")
     assert state is not None
     assert state["access_token"] == "nous-global"
+
+
+def test_profile_can_disable_global_provider_state_fallback(profile_env):
+    """The same opt-out covers singleton provider state, not only pools."""
+    from hermes_cli.auth import get_provider_auth_state
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "nous": {"access_token": "nous-global", "refresh_token": "rt-global"},
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+    (profile_env["profile"] / "config.yaml").write_text(
+        "auth:\n  global_fallback: false\n"
+    )
+
+    assert get_provider_auth_state("nous") is None
 
 
 def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):

--- a/tests/hermes_cli/test_xai_oauth_writethrough.py
+++ b/tests/hermes_cli/test_xai_oauth_writethrough.py
@@ -14,6 +14,7 @@ boundary, so they exercise the actual atomic write path.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -88,3 +89,54 @@ def test_write_through_failure_does_not_break_profile_save(profile_and_root, mon
 
     profile = _read_store(profile_path)
     assert profile["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "r"
+
+
+def test_disabled_global_fallback_rejects_root_xai_and_prevents_write_through(
+    tmp_path, monkeypatch
+):
+    """Profile isolation covers both xAI root reads and refresh write-through."""
+    from hermes_cli import managed_scope
+    import hermes_cli.config as config_module
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root_dir = tmp_path / ".hermes"
+    profile_dir = root_dir / "profiles" / "isolated"
+    profile_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+    (profile_dir / "config.yaml").write_text(
+        "auth:\n  global_fallback: false\n", encoding="utf-8"
+    )
+    config_module._LOAD_CONFIG_CACHE.clear()
+    config_module._RAW_CONFIG_CACHE.clear()
+    managed_scope.invalidate_managed_cache()
+
+    profile_path = profile_dir / "auth.json"
+    root_path = root_dir / "auth.json"
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(root_path, {
+        "version": 1,
+        "providers": {
+            "xai-oauth": {
+                "tokens": {
+                    "access_token": "root-access",
+                    "refresh_token": "root-refresh",
+                }
+            }
+        },
+    })
+
+    with pytest.raises(auth.AuthError, match="No xAI OAuth credentials stored"):
+        auth._read_xai_oauth_tokens()
+
+    auth._save_xai_oauth_tokens({
+        "access_token": "profile-access",
+        "refresh_token": "profile-refresh",
+    })
+    assert _read_store(profile_path)["providers"]["xai-oauth"]["tokens"] == {
+        "access_token": "profile-access",
+        "refresh_token": "profile-refresh",
+    }
+    assert _read_store(root_path)["providers"]["xai-oauth"]["tokens"] == {
+        "access_token": "root-access",
+        "refresh_token": "root-refresh",
+    }


### PR DESCRIPTION
## Summary

- add profile-local `auth.global_fallback: false`
- stop global provider-state and credential-pool inheritance at the shared global auth path resolver
- stop OAuth refresh/write-through from reaching the root store when fallback is disabled
- preserve the existing fallback default for every profile that omits the setting

## Problem

Hermes intentionally lets named profiles borrow credentials from the global/root `auth.json`. That is convenient for ordinary personal profiles, but there is no opt-out for service profiles with a strict trust boundary.

A real profile-backed ACP integration reproduced the failure class: the root profile held xAI OAuth credentials, the isolated service profile had no credentials, and ACP initialization materialized root access/refresh tokens into the service profile's credential pool. Changing `HOME` around the subprocess kept `acp --check` clean but did not protect a real session.

This is related to the fallback contract discussed in #34143 and #6653, but it preserves that contract by default rather than removing it.

## Configuration

```yaml
auth:
  global_fallback: false
```

When disabled, the profile resolves provider singleton state and credential pools locally only. Missing local credentials fail closed.

## Tests

```text
python -m pytest \
  tests/hermes_cli/test_auth_profile_fallback.py \
  tests/hermes_cli/test_xai_oauth_profile_auth.py \
  tests/agent/test_credential_pool.py -q

127 passed
```

The new regressions prove both credential-pool and singleton-provider fallback are disabled while existing default fallback tests remain green.
