### PR TITLE
fix(telegram): preserve text batch dispatch order

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8756,13 +8756,27 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # Cancel any pending flush and restart the timer
         prior_task = self._pending_text_batch_tasks.get(key)
+        predecessor_task = None
         if prior_task and not prior_task.done():
-            prior_task.cancel()
-        self._pending_text_batch_tasks[key] = asyncio.create_task(
-            self._flush_text_batch(key)
+            if getattr(prior_task, "_telegram_dispatch_started", False):
+                predecessor_task = prior_task
+            else:
+                predecessor_task = getattr(
+                    prior_task, "_telegram_dispatch_predecessor", None
+                )
+                prior_task._telegram_batch_superseded = True  # type: ignore[attr-defined]
+                prior_task.cancel()
+        flush_task = asyncio.create_task(
+            self._flush_text_batch(key, predecessor_task)
         )
+        flush_task._telegram_dispatch_predecessor = predecessor_task  # type: ignore[attr-defined]
+        self._pending_text_batch_tasks[key] = flush_task
 
-    async def _flush_text_batch(self, key: str) -> None:
+    async def _flush_text_batch(
+        self,
+        key: str,
+        predecessor_task: "asyncio.Task[None] | None" = None,
+    ) -> None:
         """Wait for the quiet period then dispatch the aggregated text.
 
         Uses a longer delay when the latest chunk is near Telegram's 4096-char
@@ -8794,17 +8808,39 @@ class TelegramAdapter(BasePlatformAdapter):
             else:
                 delay = self._text_batch_delay_seconds
             await asyncio.sleep(delay)
+            # Preserve Telegram arrival order. If a follow-up batch was created
+            # while the previous event was already being dispatched, wait for
+            # that dispatch before claiming the buffered successor event.
+            if predecessor_task is not None:
+                try:
+                    await asyncio.shield(predecessor_task)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception(
+                        "[Telegram] Prior text dispatch failed; continuing buffered successor"
+                    )
+
             event = self._pending_text_batches.pop(key, None)
             if not event:
                 return
             if self._should_drop_delayed_delivery():
                 logger.debug("[Telegram] Dropping text batch flush after disconnect started")
                 return
+
             logger.info(
                 "[Telegram] Flushing text batch %s (%d chars)",
                 key, len(event.text or ""),
             )
+            current_task._telegram_dispatch_started = True  # type: ignore[attr-defined]
             await self.handle_message(event)
+        except asyncio.CancelledError:
+            if getattr(current_task, "_telegram_batch_superseded", False):
+                return
+            if predecessor_task is not None and not predecessor_task.done():
+                predecessor_task.cancel()
+                await asyncio.gather(predecessor_task, return_exceptions=True)
+            raise
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -139,6 +139,123 @@ class TestTextBatching:
         assert len(adapter._pending_text_batch_tasks) == 0
 
     @pytest.mark.asyncio
+    async def test_follow_up_text_does_not_cancel_dispatch_in_progress(self):
+        """A new batch must not cancel a prior event already being dispatched."""
+        adapter = _make_adapter()
+        adapter._text_batch_delay_seconds = 0.01
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        both_completed = asyncio.Event()
+        completed = []
+
+        async def handle_message(event):
+            if event.text == "first clarify response":
+                first_started.set()
+                await release_first.wait()
+            completed.append(event.text)
+            if len(completed) == 2:
+                both_completed.set()
+
+        adapter.handle_message = handle_message
+        adapter._enqueue_text_event(_make_event("first clarify response"))
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+
+        adapter._enqueue_text_event(_make_event("second text"))
+        await asyncio.sleep(0.05)
+        assert completed == []
+
+        release_first.set()
+        await asyncio.wait_for(both_completed.wait(), timeout=1)
+
+        assert completed == ["first clarify response", "second text"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_follow_ups_remain_buffered_behind_active_dispatch(self):
+        """A third text must not drop a successor waiting behind active dispatch."""
+        adapter = _make_adapter()
+        adapter._text_batch_delay_seconds = 0.01
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        both_completed = asyncio.Event()
+        completed = []
+
+        async def handle_message(event):
+            if event.text == "first clarify response":
+                first_started.set()
+                await release_first.wait()
+            completed.append(event.text)
+            if len(completed) == 2:
+                both_completed.set()
+
+        adapter.handle_message = handle_message
+        adapter._enqueue_text_event(_make_event("first clarify response"))
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+
+        adapter._enqueue_text_event(_make_event("second text"))
+        await asyncio.sleep(0.05)
+        adapter._enqueue_text_event(_make_event("third text"))
+        release_first.set()
+        await asyncio.wait_for(both_completed.wait(), timeout=1)
+
+        assert completed == ["first clarify response", "second text\nthird text"]
+
+    @pytest.mark.asyncio
+    async def test_successor_dispatches_after_predecessor_error(self):
+        """A failed predecessor must not strand an already-buffered successor."""
+        adapter = _make_adapter()
+        adapter._text_batch_delay_seconds = 0.01
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        successor_completed = asyncio.Event()
+        attempted = []
+
+        async def handle_message(event):
+            attempted.append(event.text)
+            if event.text == "first clarify response":
+                first_started.set()
+                await release_first.wait()
+                raise RuntimeError("simulated gateway dispatch failure")
+            successor_completed.set()
+
+        adapter.handle_message = handle_message
+        adapter._enqueue_text_event(_make_event("first clarify response"))
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+
+        adapter._enqueue_text_event(_make_event("second text"))
+        release_first.set()
+        await asyncio.wait_for(successor_completed.wait(), timeout=1)
+
+        assert attempted == ["first clarify response", "second text"]
+        assert len(adapter._pending_text_batches) == 0
+        assert len(adapter._pending_text_batch_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_external_cancellation_still_cancels_dispatch_in_progress(self):
+        """Only batching supersession may preserve an in-progress dispatch."""
+        adapter = _make_adapter()
+        adapter._text_batch_delay_seconds = 0.01
+        dispatch_started = asyncio.Event()
+        dispatch_cancelled = asyncio.Event()
+
+        async def handle_message(event):
+            dispatch_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                dispatch_cancelled.set()
+
+        adapter.handle_message = handle_message
+        adapter._enqueue_text_event(_make_event("cancel me"))
+        await asyncio.wait_for(dispatch_started.wait(), timeout=1)
+        flush_task = next(iter(adapter._pending_text_batch_tasks.values()))
+
+        flush_task.cancel()
+        await asyncio.gather(flush_task, return_exceptions=True)
+
+        assert flush_task.cancelled()
+        await asyncio.wait_for(dispatch_cancelled.wait(), timeout=1)
+
+    @pytest.mark.asyncio
     async def test_dm_topic_batching_recovers_thread_before_keying(self):
         """DM-topic text batches should use the recovered topic lane."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

Fix a Telegram text-batching cancellation race that can drop free-text replies to active `clarify` prompts.

When a follow-up text arrived after the previous batch had begun dispatch, `_enqueue_text_event()` cancelled the prior flush task. Because that task directly awaited `handle_message()`, cancellation could prevent the earlier event from reaching gateway/clarify routing. Repeated replies could therefore disappear until one dispatch completed before the next message arrived.

## Fix

- Distinguish a pending batching timer from a batch whose gateway dispatch has started.
- Preserve an already-started dispatch instead of superseding it.
- Chain successor batches behind the active dispatch to preserve Telegram arrival order.
- Keep multiple follow-ups buffered while waiting behind the active dispatch.
- Continue propagating genuine external/shutdown cancellation.

## Tests

Added regressions covering:

- A follow-up text cannot cancel an in-progress first dispatch.
- The successor cannot overtake the first event.
- A third text remains buffered rather than dropping the waiting second text.
- A predecessor dispatch error does not strand an already-buffered successor.
- External cancellation still cancels an in-progress dispatch.

Verification:

- `tests/gateway/test_telegram_text_batching.py`
- `tests/gateway/test_telegram_text_batch_perf.py`
- `tests/gateway/test_telegram_photo_interrupts.py`
- `tests/gateway/test_telegram_clarify_buttons.py`
- 45 tests passed.
- Four race/error tests passed in 20 repeated runs.

## Live reproduction

Gateway logs showed Telegram flushing multiple text batches during an active `clarify`, while only the final batch reached `Gateway intercepted clarify text response`. Earlier flushed messages had no clarify interception or normal inbound dispatch.
