### PR TITLE
fix(update): ignore processes in foreign PID namespaces

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -114,6 +114,8 @@ def _scan_dashboard_processes(
             # with `hermes_cli.gateway._scan_gateway_pids` and avoids the
             # greedy regex matching unrelated cmdlines that merely contain
             # both words (e.g. a chat session discussing "dashboard").
+            from hermes_cli.gateway import _pid_in_current_namespace
+
             result = subprocess.run(
                 ["ps", "-A", "-o", "pid=,command="],
                 capture_output=True,
@@ -133,7 +135,11 @@ def _scan_dashboard_processes(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if (
+                        any(p in command for p in patterns)
+                        and pid != self_pid
+                        and _pid_in_current_namespace(pid)
+                    ):
                         dashboard_processes.append((pid, command))
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -333,6 +333,31 @@ def _append_unique_pid(
     pids.append(pid)
 
 
+def _pid_in_current_namespace(pid: int) -> bool:
+    """Return whether *pid* shares this process's Linux PID namespace.
+
+    A Linux host can see processes running inside LXC containers in its global
+    ``/proc`` tree. A host-side ``hermes update`` must not classify those guest
+    gateways as local manual gateways and signal them.
+
+    Non-Linux platforms retain the existing process-scan behavior. If the
+    caller's namespace cannot be inspected, also retain legacy behavior; if
+    only the target cannot be inspected, skip it because it either exited or
+    is outside our authority.
+    """
+    if not sys.platform.startswith("linux"):
+        return True
+    try:
+        current_namespace = os.stat("/proc/self/ns/pid").st_ino
+    except OSError:
+        return True
+    try:
+        target_namespace = os.stat(f"/proc/{pid}/ns/pid").st_ino
+    except OSError:
+        return False
+    return target_namespace == current_namespace
+
+
 def _scan_gateway_pids(
     exclude_pids: set[int],
     all_profiles: bool = False,
@@ -486,6 +511,8 @@ def _scan_gateway_pids(
                         pid = int(entry)
                         if pid == my_pid or pid in exclude_pids:
                             continue
+                        if not _pid_in_current_namespace(pid):
+                            continue
                         try:
                             with open(f"/proc/{pid}/cmdline", "rb") as _f:
                                 cmdline = _f.read().decode("utf-8", errors="replace")
@@ -532,6 +559,8 @@ def _scan_gateway_pids(
                             command = " ".join(aux_parts[10:])
 
                     if pid is None:
+                        continue
+                    if not _pid_in_current_namespace(pid):
                         continue
                     if _matches_gateway_runtime(command) and (
                         all_profiles or _matches_current_profile(command)

--- a/tests/hermes_cli/test_gateway_proc_fallback.py
+++ b/tests/hermes_cli/test_gateway_proc_fallback.py
@@ -9,6 +9,8 @@ See: NousResearch/hermes-agent#7622
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import hermes_cli.gateway as gateway_mod
 
 
@@ -51,6 +53,46 @@ def _fake_proc_dir(entries: dict):
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _same_pid_namespace_by_default(monkeypatch, request):
+    """Keep synthetic PIDs in scanner tests in the caller's PID namespace."""
+    if request.cls is TestPidNamespacePredicate:
+        return
+    monkeypatch.setattr(
+        gateway_mod,
+        "_pid_in_current_namespace",
+        lambda _pid: True,
+        raising=False,
+    )
+
+
+class TestPidNamespacePredicate:
+    def test_accepts_same_namespace(self):
+        with patch(
+            "hermes_cli.gateway.os.stat",
+            side_effect=[MagicMock(st_ino=100), MagicMock(st_ino=100)],
+        ):
+            assert gateway_mod._pid_in_current_namespace(12345) is True
+
+    def test_rejects_foreign_namespace(self):
+        with patch(
+            "hermes_cli.gateway.os.stat",
+            side_effect=[MagicMock(st_ino=100), MagicMock(st_ino=200)],
+        ):
+            assert gateway_mod._pid_in_current_namespace(12345) is False
+
+    def test_rejects_uninspectable_target(self):
+        with patch(
+            "hermes_cli.gateway.os.stat",
+            side_effect=[MagicMock(st_ino=100), FileNotFoundError()],
+        ):
+            assert gateway_mod._pid_in_current_namespace(12345) is False
+
+    def test_preserves_legacy_behavior_if_caller_namespace_is_unavailable(self):
+        with patch("hermes_cli.gateway.os.stat", side_effect=OSError()):
+            assert gateway_mod._pid_in_current_namespace(12345) is True
+
+
 class TestProcFallback:
     """_scan_gateway_pids reads /proc when available, skips ps."""
 
@@ -77,7 +119,66 @@ class TestProcFallback:
         assert 99999 not in pids
         mock_ps.assert_not_called()  # ps must NOT be called when /proc worked
 
+    def test_ignores_gateway_pid_from_foreign_pid_namespace(self, monkeypatch):
+        """A host update must not treat an LXC gateway as a local gateway."""
+        entries = {
+            12345: _GATEWAY_CMD,
+            23456: _GATEWAY_CMD,
+        }
+        _isdir, _listdir, _open = _fake_proc_dir(entries)
+        monkeypatch.setattr(
+            gateway_mod,
+            "_pid_in_current_namespace",
+            lambda pid: pid == 12345,
+        )
 
+        with (
+            patch("hermes_cli.gateway.is_windows", return_value=False),
+            patch("os.path.isdir", side_effect=_isdir),
+            patch("os.listdir", side_effect=_listdir),
+            patch("builtins.open", side_effect=_open),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run") as mock_ps,
+        ):
+            pids = gateway_mod._scan_gateway_pids(set(), all_profiles=True)
+
+        assert pids == [12345]
+        mock_ps.assert_not_called()
+
+    def test_ps_fallback_ignores_gateway_pid_from_foreign_namespace(
+        self, monkeypatch
+    ):
+        """The ps fallback enforces the same PID-namespace boundary as /proc."""
+        monkeypatch.setattr(
+            gateway_mod,
+            "_pid_in_current_namespace",
+            lambda pid: pid == 12345,
+        )
+        ps_output = "\n".join(
+            [
+                f"12345 {_GATEWAY_CMD}",
+                f"23456 {_GATEWAY_CMD}",
+            ]
+        ) + "\n"
+
+        with (
+            patch("hermes_cli.gateway.is_windows", return_value=False),
+            patch("os.path.isdir", return_value=False),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run") as mock_ps,
+        ):
+            mock_ps.return_value = MagicMock(returncode=0, stdout=ps_output)
+            pids = gateway_mod._scan_gateway_pids(set(), all_profiles=True)
+
+        assert pids == [12345]
+        mock_ps.assert_called_once_with(
+            ["ps", "-A", "eww", "-o", "pid=,command="],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
 
 
     def test_proc_permission_error_skips_pid(self):

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -62,7 +62,12 @@ def _refresh_bindings_against_live_module():
     _kill_stale_dashboard_processes = live._kill_stale_dashboard_processes
     _restart_managed_dashboard_service = live._restart_managed_dashboard_service
     _warn_stale_dashboard_processes = live._warn_stale_dashboard_processes
-    yield
+    with patch(
+        "hermes_cli.gateway._pid_in_current_namespace",
+        return_value=True,
+        create=True,
+    ):
+        yield
 
 
 def _ps_line(pid: int, cmd: str) -> str:
@@ -90,6 +95,23 @@ class TestFindStaleDashboardPids:
     """Unit tests for the ps/wmic-based detection step."""
 
 
+
+    def test_foreign_pid_namespace_dashboard_is_ignored(self):
+        """A PVE update must not stop a dashboard running inside an LXC."""
+        with patch("subprocess.run") as mock_run, patch(
+            "hermes_cli.gateway._pid_in_current_namespace",
+            side_effect=lambda pid: pid == 12345,
+            create=True,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(12345, "hermes dashboard --port 9119"),
+                    _ps_line(23456, "hermes dashboard --port 9122"),
+                ]) + "\n",
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == [12345]
 
     def test_self_pid_excluded(self):
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
## Summary

- scope Linux gateway process discovery to the caller's PID namespace
- apply the same boundary to stale-dashboard discovery during updates
- add regression tests for same-, foreign-, and uninspectable-namespace processes

## Problem

A Linux host can see processes running inside LXC containers in its global `/proc` tree. During `hermes update`, host-side gateway and dashboard discovery can therefore match a Hermes process that is actually running inside a separately managed container.

Because that guest process is not managed by the host's Hermes systemd service, the updater can misclassify it as a local manual process and send it `SIGTERM`. A host update should not control a gateway owned by another PID namespace.

## Fix

Before classifying a Linux process as a gateway or stale dashboard, compare the PID namespace inode for `/proc/self/ns/pid` with `/proc/<pid>/ns/pid`.

- Same namespace: preserve existing discovery behavior.
- Different namespace: ignore the process.
- Target namespace cannot be inspected: ignore the target because it exited or is outside the caller's authority.
- Caller namespace cannot be inspected, or platform is not Linux: preserve legacy behavior.

The predicate is shared by the `/proc` and `ps` gateway discovery paths and the update-time dashboard scan.

## Validation

- Focused PID-namespace/update tests: `51 passed`
- Isolated gateway/update regression gate: `430 passed`, `0 failed` across 16 files
  - pristine current-main baseline: `424 passed`, `0 failed`
  - the six additional passing tests are the new regression coverage
- Ruff: passed on all four changed files
- Python compilation: passed on all four changed files
- `git diff --check`: passed
- Live Linux host/LXC verification: the host-managed gateway remained discoverable, the guest gateway was excluded, and no manual gateway candidate remained

## Scope and compatibility

- Four files changed; no configuration or user-facing setting added.
- Non-Linux behavior is unchanged.
- The change is fail-safe for disappearing or inaccessible target processes while retaining legacy behavior if the caller's namespace itself cannot be inspected.
