### PR TITLE
fix(context): escalate the output-cap retry margin so it can converge

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -93,6 +93,37 @@ logger = logging.getLogger(__name__)
 # to treat it as cancellation metadata rather than assistant prose.
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
+# Output-cap retry safety margin, in tokens.
+#
+# When a provider rejects a call because input_tokens + max_tokens exceeds the
+# context window, the retry recomputes max_tokens from the budget the provider
+# reported. That number describes the request that ALREADY FAILED: by the time
+# the retry is sent the payload has grown slightly (retry bookkeeping, status
+# lines), so the true budget is smaller than the parsed one. The margin absorbs
+# that drift.
+#
+# It must ESCALATE. A fixed margin smaller than the per-retry growth can never
+# converge -- each retry lands the same distance over the limit:
+#
+#     safe_out   = (ctx - input_n) - margin
+#     next_total = (input_n + growth) + safe_out = ctx + (growth - margin)
+#
+# so with growth > margin every attempt overshoots by the same amount until the
+# attempt budget runs out. Doubling outgrows any bounded growth in
+# O(log growth) attempts; the shift is capped so a high attempt count cannot
+# collapse the output budget to nothing.
+#
+# The BASE is deliberately generous rather than minimal. `compression.
+# max_attempts` defaults to 3, so a base that only just exceeds the growth
+# burns most of that budget before converging -- starting at 64 against an
+# observed growth of 65 converges only on the third and final attempt, with no
+# headroom left for a provider that drifts slightly more. 1024 tokens is 0.4%
+# of a 262k window and converges on the FIRST retry for any realistic growth,
+# which is the right trade: the cost is a little unused output headroom on one
+# call, and the alternative is a dead turn.
+_OUTPUT_CAP_BASE_MARGIN_TOKENS = 1024
+_OUTPUT_CAP_MAX_MARGIN_SHIFT = 4  # 1024 << 4 = 16384 tokens
+
 # Modules that indicate a deterministic local processing error when they
 # appear in an exception traceback WITHOUT any API-call module. Used by the
 # outer-loop error classifier to avoid retrying bugs that will fail
@@ -4347,21 +4378,47 @@ def run_conversation(
                         request_input_estimate = estimate_request_tokens_rough(
                             api_messages, tools=agent.tools or None,
                         )
+                        # The margin DOUBLES per attempt instead of staying at a
+                        # flat 64 (#TBD).  `available_out` describes the request
+                        # that already failed; by the time the retry goes out the
+                        # payload has grown (retry bookkeeping, status lines), so
+                        # the real budget is smaller than the number we just
+                        # parsed.  A fixed margin that is smaller than that growth
+                        # never converges -- every retry lands the same distance
+                        # over the limit:
+                        #
+                        #   safe_out   = (ctx - input_n) - 64
+                        #   next_total = (input_n + growth) + safe_out
+                        #              = ctx + (growth - 64)
+                        #
+                        # With growth=65 that is ctx+1 forever.  Observed live
+                        # against a 262,144-token vLLM model: three attempts at
+                        # totals of exactly 262,145, then "max compression
+                        # attempts (3) reached" -- the retries could not have
+                        # succeeded at any attempt count.
+                        #
+                        # Doubling makes the margin outgrow any bounded per-retry
+                        # growth in O(log growth) attempts, and costs only unused
+                        # output headroom on the retry that succeeds.
+                        safety_margin = _OUTPUT_CAP_BASE_MARGIN_TOKENS * (
+                            2 ** min(compression_attempts, _OUTPUT_CAP_MAX_MARGIN_SHIFT)
+                        )
                         local_available_out = old_ctx - request_input_estimate
                         if local_available_out > 0:
-                            safe_out = max(1, min(available_out, local_available_out) - 64)
+                            safe_out = max(1, min(available_out, local_available_out) - safety_margin)
                         else:
                             # The rough local estimate can overshoot the real
                             # request size.  Fall back to the provider-reported
                             # budget, which is authoritative for the failed
                             # request.
-                            safe_out = max(1, available_out - 64)
+                            safe_out = max(1, available_out - safety_margin)
                         agent._ephemeral_max_output_tokens = safe_out
                         agent._buffer_vprint(
                             f"⚠️  Output cap too large for current prompt — "
                             f"retrying with max_tokens={safe_out:,} "
                             f"(provider_available={available_out:,}, "
-                            f"estimated_request_tokens={request_input_estimate:,}; "
+                            f"estimated_request_tokens={request_input_estimate:,}, "
+                            f"safety_margin={safety_margin:,}; "
                             f"context_length unchanged at {old_ctx:,})"
                         )
                         # Still count against compression_attempts so we don't

--- a/tests/test_output_cap_retry_convergence.py
+++ b/tests/test_output_cap_retry_convergence.py
@@ -1,0 +1,120 @@
+"""The output-cap retry must make forward progress.
+
+When a provider rejects a call because ``input_tokens + max_tokens`` exceeds
+the context window, ``conversation_loop`` recomputes ``max_tokens`` from the
+budget the provider reported and retries. That budget describes the request
+that ALREADY FAILED -- by the time the retry is sent the payload has grown
+slightly (retry bookkeeping, status lines), so the real budget is smaller than
+the parsed one.
+
+A FIXED safety margin smaller than that per-retry growth can never converge.
+The overshoot is identical on every attempt:
+
+    safe_out   = (ctx - input_n) - margin
+    next_total = (input_n + growth) + safe_out
+               = ctx + (growth - margin)
+
+Observed against a 262,144-token vLLM deployment: three attempts at totals of
+exactly 262,145 (one token over, every time), then "max compression attempts
+(3) reached". No attempt count would have helped.
+
+These tests pin the ESCALATION, not the specific constants -- doubling is what
+guarantees the margin eventually outgrows any bounded growth.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.conversation_loop import (
+    _OUTPUT_CAP_BASE_MARGIN_TOKENS,
+    _OUTPUT_CAP_MAX_MARGIN_SHIFT,
+)
+from agent.model_metadata import parse_available_output_tokens_from_error
+
+_CTX = 262_144
+# The live failure, reproduced exactly.
+_INITIAL_INPUT = 196_674
+_INITIAL_OUTPUT = 65_471
+_OBSERVED_GROWTH = 65
+
+
+def _vllm_error(requested_out: int, input_tokens: int, ctx: int = _CTX) -> str:
+    """The exact wording vLLM / OpenAI-compatible servers return."""
+    return (
+        f"This model's maximum context length is {ctx} tokens. However, you "
+        f"requested {requested_out} output tokens and your prompt contains at "
+        f"least {input_tokens} input tokens, for a total of at least "
+        f"{requested_out + input_tokens} tokens."
+    )
+
+
+def _margin_for_attempt(attempt_index: int) -> int:
+    """Mirrors the production expression in conversation_loop."""
+    return _OUTPUT_CAP_BASE_MARGIN_TOKENS * (
+        2 ** min(attempt_index, _OUTPUT_CAP_MAX_MARGIN_SHIFT)
+    )
+
+
+def _simulate(growth: int, margin_fn, max_attempts: int = 6):
+    """Replay the retry loop's arithmetic. Returns the 1-based converging
+    attempt, or None if it never fits."""
+    inp, req = _INITIAL_INPUT, _INITIAL_OUTPUT
+    for attempt in range(max_attempts):
+        if inp + req <= _CTX:
+            return attempt + 1
+        available_out = parse_available_output_tokens_from_error(_vllm_error(req, inp))
+        assert available_out is not None, "error must classify as an output-cap error"
+        req = max(1, min(available_out, _CTX - inp) - margin_fn(attempt))
+        inp += growth
+    return None
+
+
+class TestFixedMarginCannotConverge:
+    """Why the escalation is required, not merely nicer."""
+
+    def test_flat_margin_below_growth_never_converges(self):
+        assert _simulate(_OBSERVED_GROWTH, lambda _a: 64) is None
+
+    def test_flat_margin_overshoots_by_exactly_the_same_amount_every_time(self):
+        """The signature of the live bug: a constant overshoot, not a shrinking
+        one. This is what makes it look like compression 'isn't working'."""
+        inp, req, overshoots = _INITIAL_INPUT, _INITIAL_OUTPUT, []
+        for _ in range(4):
+            overshoots.append(inp + req - _CTX)
+            available_out = parse_available_output_tokens_from_error(_vllm_error(req, inp))
+            req = max(1, min(available_out, _CTX - inp) - 64)
+            inp += _OBSERVED_GROWTH
+        assert overshoots == [1, 1, 1, 1]
+
+
+class TestEscalatingMarginConverges:
+    def test_converges_on_the_observed_live_failure(self):
+        attempt = _simulate(_OBSERVED_GROWTH, _margin_for_attempt)
+        assert attempt is not None
+        # Must land inside the default compression.max_attempts of 3, with room
+        # to spare -- converging exactly ON the last attempt leaves no headroom
+        # for a provider that drifts a little more than measured.
+        assert attempt <= 2
+
+    @pytest.mark.parametrize("growth", [1, 65, 200, 1000])
+    def test_converges_within_the_default_attempt_budget(self, growth):
+        attempt = _simulate(growth, _margin_for_attempt)
+        assert attempt is not None and attempt <= 3, (
+            f"growth={growth} converged on attempt {attempt}; the default "
+            "compression.max_attempts is 3"
+        )
+
+    def test_margin_doubles_then_caps(self):
+        margins = [_margin_for_attempt(i) for i in range(_OUTPUT_CAP_MAX_MARGIN_SHIFT + 3)]
+        for earlier, later in zip(margins, margins[1:]):
+            assert later in (earlier * 2, earlier), "margin must double or hold at the cap"
+        # The cap exists so a high attempt count cannot collapse the output
+        # budget to nothing.
+        assert margins[-1] == _OUTPUT_CAP_BASE_MARGIN_TOKENS * 2**_OUTPUT_CAP_MAX_MARGIN_SHIFT
+
+    def test_margin_never_drives_the_output_cap_below_one(self):
+        """max(1, ...) in production; a huge margin must not yield 0 or negative."""
+        available_out = 100
+        for attempt in range(10):
+            assert max(1, available_out - _margin_for_attempt(attempt)) >= 1


### PR DESCRIPTION
Fixes #61761.

## The bug

The output-cap recovery path shrinks `max_tokens` to `available_out - 64` and retries. `available_out` describes the request that **already failed** — by the time the retry is sent the payload has grown slightly, so the real budget is smaller than the number just parsed.

When that growth is >= the fixed margin, the retry lands the *same distance* over the limit every time:

```
safe_out   = (ctx - input_n) - margin
next_total = (input_n + growth) + safe_out
           = ctx + (growth - margin)
```

`next_total` doesn't depend on `input_n`, so the overshoot is constant. With the observed growth of 65 and a margin of 64 that's `ctx + 1` forever — **raising `max_compression_attempts` cannot help.** All attempts burn on arithmetic that cannot succeed, then the turn dies with:

> Context length exceeded: max compression attempts (3) reached.

which reads as "your conversation is too big to compress" when compression never ran at all.

## Reproduced twice, on different models

The reporter's trace (200k window) and mine (262k) show the identical signature:

| | input | max_tokens | total | over by |
|---|---|---|---|---|
| #61761, 200k | 134,465 → 134,660 | 65,536 → 65,341 | 200,001 | 1 |
| this, 262k | 196,674 → 196,804 | 65,471 → 65,341 | 262,145 | 1 |

Same 65-token per-retry drift, same constant overshoot of 1, different context sizes — so it isn't model-specific.

## The fix

Double the margin per attempt instead of holding it flat, so it outgrows any bounded growth in `O(log growth)` attempts.

**Why base 1024 rather than something minimal.** `compression.max_attempts` defaults to 3, and a base that merely exceeds the growth converges only on the *last* attempt:

| base | converges on attempt (growth=65) | at growth=1000 |
|---|---|---|
| 64 | 3 — no headroom left | never |
| 256 | 2 | 3 |
| 1024 | 2 | 2 |

1024 tokens is 0.4% of a 262k window. The cost is a little unused output headroom on the retry that succeeds; the alternative is a dead turn. Happy to drop to 256 if you'd prefer the smaller change — the escalation is the part that matters.

Both magic numbers are now named constants with the arithmetic written out, because the failure is invisible without it: the symptom looks like a compression problem, and the numbers look like they're shrinking correctly.

The retry's status line now also reports the margin, so the shrinking `max_tokens` has a visible reason.

## Tests

`tests/test_output_cap_retry_convergence.py`, 9 tests, pinning the **escalation** rather than the constants:

- `TestFixedMarginCannotConverge` — proves a flat margin below the growth rate never converges, and that the overshoot is identical on every attempt (the diagnostic signature). These pass against the unfixed code; they document the defect.
- `TestEscalatingMarginConverges` — proves convergence inside the default 3-attempt budget for growth from 1 to 1000 tokens, that the margin doubles then caps, and that a large margin can never drive the output cap below 1.

I also verified end-to-end against a mock OpenAI-compatible server enforcing vLLM's exact constraint (small context window — the failure depends on the ratio of budget to growth, not absolute size):

```
PRE-FIX  (flat 64):    attempt 2 total=8,193 over_by=1
                       attempt 3 total=8,193 over_by=1  -> never converged
POST-FIX (escalating): attempt 2 ACCEPTED               -> converged
```

The harness is a single self-contained file; happy to add it under `tests/` if that's useful, but I left it out to keep the diff tight.

## Checks

- 9 new tests pass; `tests/test_output_cap_parsing.py` and `tests/test_ctx_halving_fix.py` still pass (56 total across the three files).
- 6 failures in `tests/test_trajectory_compressor*.py` are **pre-existing on `main`** — identical before and after this change (verified by stashing it).
- No behaviour change on the first attempt; only the retry margin moves.

## Related

#62605 reports a different root cause (rough estimate underestimating the real prompt) with the same user-visible symptom. A larger margin should mitigate it, but it isn't the same bug and this PR doesn't claim to fix it.