### PR TITLE
Require a real executable for Playwright Chromium detection

### DIFF
--- a/tests/tools/test_browser_chromium_check.py
+++ b/tests/tools/test_browser_chromium_check.py
@@ -13,6 +13,13 @@ import pytest
 from tools import browser_tool as bt
 
 
+def _make_executable(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
 @pytest.fixture(autouse=True)
 def _reset_chromium_cache():
     bt._cached_chromium_installed = None
@@ -45,13 +52,62 @@ class TestChromiumInstalled:
 
         assert bt._chromium_installed() is True
 
+    def test_true_when_chromium_dir_present(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
+        _make_executable(tmp_path / "chromium-1208" / "chrome-linux" / "chrome")
+        assert bt._chromium_installed() is True
+
+    def test_true_when_headless_shell_present(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
+        _make_executable(
+            tmp_path
+            / "chromium_headless_shell-1208"
+            / "chrome-linux"
+            / "headless_shell"
+        )
+        assert bt._chromium_installed() is True
+
+    def test_false_when_playwright_dir_has_no_executable(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
+        (tmp_path / "chromium_headless_shell-1208").mkdir()
+        monkeypatch.setattr(
+            bt.shutil,
+            "which",
+            lambda name: None,
+        )
+
+        assert bt._chromium_installed() is False
+
+    def test_finds_headless_shell_executable(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
+        executable = _make_executable(
+            tmp_path
+            / "chromium_headless_shell-1208"
+            / "chrome-linux"
+            / "headless_shell"
+        )
+
+        assert bt._playwright_chromium_executable() == str(executable)
+
+    def test_finds_new_playwright_headless_shell_layout(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
+        executable = _make_executable(
+            tmp_path
+            / "chromium_headless_shell-1234"
+            / "chrome-headless-shell-linux64"
+            / "chrome-headless-shell"
+        )
+
+        assert bt._playwright_chromium_executable() == str(executable)
 
     def test_result_cached(self, monkeypatch, tmp_path):
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
-        (tmp_path / "chromium-1208").mkdir()
+        executable = _make_executable(
+            tmp_path / "chromium-1208" / "chrome-linux" / "chrome"
+        )
         assert bt._chromium_installed() is True
         # Delete after first call — cached True should still return True.
-        (tmp_path / "chromium-1208").rmdir()
+        executable.unlink()
         assert bt._chromium_installed() is True
 
 
@@ -63,7 +119,7 @@ class TestCheckBrowserRequirementsChromium:
         monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _: False)
         monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
-        (tmp_path / "chromium-1208").mkdir()
+        _make_executable(tmp_path / "chromium-1208" / "chrome-linux" / "chrome")
 
         assert bt.check_browser_requirements() is True
 
@@ -81,5 +137,3 @@ class TestRunBrowserCommandChromiumGuard:
     """Verify _run_browser_command fails fast (no timeout hang) when
     Chromium is missing in local mode.
     """
-
-

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4656,6 +4656,50 @@ def _chromium_search_roots() -> List[str]:
     return roots
 
 
+def _is_executable_file(path: Path) -> bool:
+    """Return True when path points at a usable browser executable."""
+    if not path.is_file():
+        return False
+    if os.name == "nt":
+        return True
+    return os.access(path, os.X_OK)
+
+
+def _playwright_chromium_executable() -> Optional[str]:
+    """Find the concrete Chromium executable inside Playwright's cache."""
+    for root in _chromium_search_roots():
+        root_path = Path(root)
+        if not root or not root_path.is_dir():
+            continue
+        try:
+            entries = sorted(root_path.iterdir(), key=lambda p: p.name, reverse=True)
+        except OSError:
+            continue
+
+        for entry in entries:
+            candidates: tuple[Path, ...] = ()
+            if entry.name.startswith("chromium_headless_shell-"):
+                candidates = (
+                    entry / "chrome-headless-shell-linux64" / "chrome-headless-shell",
+                    entry / "chrome-headless-shell-linux-arm64" / "chrome-headless-shell",
+                    entry / "chrome-linux" / "headless_shell",
+                    entry / "chrome-mac" / "Chromium.app" / "Contents" / "MacOS" / "Chromium",
+                    entry / "chrome-win" / "headless_shell.exe",
+                    entry / "chrome-win" / "chrome.exe",
+                )
+            elif entry.name.startswith("chromium-"):
+                candidates = (
+                    entry / "chrome-linux" / "chrome",
+                    entry / "chrome-mac" / "Chromium.app" / "Contents" / "MacOS" / "Chromium",
+                    entry / "chrome-win" / "chrome.exe",
+                )
+
+            for candidate in candidates:
+                if _is_executable_file(candidate):
+                    return str(candidate)
+    return None
+
+
 def _chromium_installed() -> bool:
     """Return True when a usable Chromium (or headless-shell) build is on disk.
 
@@ -4665,8 +4709,8 @@ def _chromium_installed() -> bool:
        agent-browser at a pre-installed Chrome/Chromium.
     2. System Chrome/Chromium in PATH (``google-chrome``, ``chromium``,
        ``chromium-browser``, ``chrome``).
-    3. Playwright's browser cache (current logic) — directories containing
-       ``chromium-*`` or ``chromium_headless_shell-*``.
+    3. A concrete executable inside a Playwright ``chromium-*`` or
+       ``chromium_headless_shell-*`` cache directory.
 
     agent-browser (0.26+) downloads Playwright's chromium / headless-shell
     builds into ``PLAYWRIGHT_BROWSERS_PATH`` and won't start without at least
@@ -4697,22 +4741,10 @@ def _chromium_installed() -> bool:
         _cached_chromium_installed = True
         return True
 
-    # 3. Playwright browser cache (legacy — chromium-* / chromium_headless_shell-* dirs)
-    for root in _chromium_search_roots():
-        if not root or not os.path.isdir(root):
-            continue
-        try:
-            entries = os.listdir(root)
-        except OSError:
-            continue
-        # Playwright names them ``chromium-<build>`` and
-        # ``chromium_headless_shell-<build>``; agent-browser accepts either.
-        for entry in entries:
-            if entry.startswith("chromium-") or entry.startswith(
-                "chromium_headless_shell-"
-            ):
-                _cached_chromium_installed = True
-                return True
+    # 3. Playwright browser cache.
+    if _playwright_chromium_executable():
+        _cached_chromium_installed = True
+        return True
 
     _cached_chromium_installed = False
     return False


### PR DESCRIPTION
## Summary
- require a concrete Chromium or headless-shell executable before treating a Playwright cache as installed
- recognize the existing Playwright layouts used on Linux, macOS, and Windows
- reject empty or partial `chromium-*` cache directories so browser tools fail fast instead of being advertised incorrectly

## Reconciliation with current main
- rebased onto current `NousResearch/main`
- removed the Docker-specific executable-path injection because `docker/stage2-hook.sh` already owns that behavior via `3e33e14335ef3f5fd07bc3dcfb2c74f045d49988`
- removed the `hermes doctor` npm-audit changes and all dependency/lockfile updates; PR #74671 remains the dedicated audit implementation

## Validation
- `python3 -m ruff check tools/browser_tool.py tests/tools/test_browser_chromium_check.py`
- `scripts/run_tests.sh tests/tools/test_browser_chromium_check.py -q` (11 passed)

No Docker files or Docker-specific runtime behavior remain in this diff, so the existing stage2 Docker coverage is unchanged.