### PR TITLE
Fix partial stream retries after delivery

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2323,8 +2323,8 @@ def _build_partial_stream_stub(
     Used when the SSE stream ends without a ``finish_reason`` after
     delivering content (text-only drops, tool-call-arg drops).  The stub
     is tagged ``PARTIAL_STREAM_STUB_ID`` with ``FINISH_REASON_LENGTH`` so
-    the conversation loop enters its continuation/retry path instead of
-    silently accepting truncated output as a complete turn (#32086).
+    the conversation loop persists and returns the recovered partial once
+    instead of silently accepting it or calling the provider again (#32086).
     """
     mock_message = SimpleNamespace(
         role=role,
@@ -2566,7 +2566,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _reset_stale_streak(agent)
         return result["response"]
 
-    result = {"response": None, "error": None, "partial_tool_names": []}
+    result: dict[str, Any] = {
+        "response": None,
+        "error": None,
+        "partial_tool_names": [],
+    }
+    # Stream iterators raise after yielding. Preserve anything already
+    # observed so the caller can return it once without replaying the request.
+    partial_observed = threading.Event()
+    partial_content_parts: list[str] = []
+    partial_reasoning_parts: list[str] = []
 
     # Cross-turn stale-stream circuit breaker (#58962) — see the canonical
     # comment block above ``_stale_streak()``.  Raises past the give-up
@@ -2675,7 +2684,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             agent._close_request_openai_client(request_client, reason=reason)
 
     first_delta_fired = {"done": False}
-    deltas_were_sent = {"yes": False}  # Track if any deltas were fired (for fallback)
     # Wall-clock timestamp of the last real streaming chunk.  The outer
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
@@ -2981,16 +2989,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
+                partial_observed.set()
+                partial_reasoning_parts.append(reasoning_text)
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:
                 content_parts.append(delta.content)
+                partial_observed.set()
+                partial_content_parts.append(delta.content)
                 if not tool_calls_acc:
                     _fire_first_delta()
                     agent._fire_stream_delta(delta.content)
-                    deltas_were_sent["yes"] = True
                 # Tool calls suppress regular content streaming (avoids
                 # displaying chatty "I'll use the tool..." text alongside
                 # tool calls).  But reasoning tags embedded in suppressed
@@ -3011,6 +3022,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             # Accumulate tool call deltas — notify display on first name
             if delta and delta.tool_calls:
+                partial_observed.set()
                 for tc_delta in delta.tool_calls:
                     raw_idx = tc_delta.index if tc_delta.index is not None else 0
                     delta_id = tc_delta.id or ""
@@ -3325,9 +3337,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 if event_type == "content_block_start":
                     block = getattr(event, "content_block", None)
                     if block and getattr(block, "type", None) == "tool_use":
+                        partial_observed.set()
                         has_tool_use = True
                         tool_name = getattr(block, "name", None)
                         if tool_name:
+                            if tool_name not in result["partial_tool_names"]:
+                                result["partial_tool_names"].append(tool_name)
                             _fire_first_delta()
                             agent._fire_tool_gen_started(tool_name)
 
@@ -3337,15 +3352,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         delta_type = getattr(delta, "type", None)
                         if delta_type == "text_delta":
                             text = getattr(delta, "text", "")
-                            if text and not has_tool_use:
-                                _fire_first_delta()
-                                agent._fire_stream_delta(text)
-                                deltas_were_sent["yes"] = True
+                            if text:
+                                partial_observed.set()
+                                partial_content_parts.append(text)
+                                if not has_tool_use:
+                                    _fire_first_delta()
+                                    agent._fire_stream_delta(text)
                         elif delta_type == "thinking_delta":
                             thinking_text = getattr(delta, "thinking", "")
                             if thinking_text:
+                                partial_observed.set()
+                                partial_reasoning_parts.append(thinking_text)
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
+                        elif delta_type == "input_json_delta":
+                            partial_observed.set()
 
             # Return the native Anthropic Message for downstream processing.
             # If the stream was interrupted (the event loop broke out above on
@@ -3441,116 +3462,27 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
                     )
                     _is_conn_err = isinstance(
-                        e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError)
+                        e,
+                        (
+                            _httpx.ConnectError,
+                            _httpx.ReadError,
+                            _httpx.RemoteProtocolError,
+                            ConnectionError,
+                        ),
                     )
                     _is_stream_parse_err = agent._is_provider_stream_parse_error(e)
                     _is_empty_stream = isinstance(e, EmptyStreamError)
 
-                    # If the stream died AFTER some tokens were delivered:
-                    # normally we don't retry (the user already saw text,
-                    # retrying would duplicate it).  BUT: if a tool call
-                    # was in-flight when the stream died, silently aborting
-                    # discards the tool call entirely.  In that case we
-                    # prefer to retry — the user sees a brief
-                    # "reconnecting" marker + duplicated preamble text,
-                    # which is strictly better than a failed action with
-                    # a "retry manually" message.  Limit this to transient
-                    # connection errors (Clawdbot-style narrow gate): no
-                    # tool has executed yet within this API call, so
-                    # silent retry is safe wrt side-effects.
-                    if deltas_were_sent["yes"]:
-                        _partial_tool_in_flight = bool(
-                            result.get("partial_tool_names")
+                    # Once any output is observable, retrying would replay paid
+                    # output and may duplicate a tool call. Only an eventless
+                    # stream may use the bounded retry path below.
+                    if partial_observed.is_set():
+                        logger.warning(
+                            "Streaming failed after partial delivery, not retrying: %s",
+                            e,
                         )
-                        _is_sse_conn_err_preview = False
-                        if not _is_timeout and not _is_conn_err:
-                            from openai import APIError as _APIError
-                            if isinstance(e, _APIError) and not getattr(e, "status_code", None):
-                                _err_lower_preview = str(e).lower()
-                                _SSE_PREVIEW_PHRASES = (
-                                    "connection lost",
-                                    "connection reset",
-                                    "connection closed",
-                                    "connection terminated",
-                                    "network error",
-                                    "network connection",
-                                    "terminated",
-                                    "peer closed",
-                                    "broken pipe",
-                                    "upstream connect error",
-                                )
-                                _is_sse_conn_err_preview = any(
-                                    phrase in _err_lower_preview
-                                    for phrase in _SSE_PREVIEW_PHRASES
-                                )
-                        _is_transient = (
-                            _is_timeout
-                            or _is_conn_err
-                            or _is_sse_conn_err_preview
-                            or _is_stream_parse_err
-                        )
-                        _can_silent_retry = (
-                            _partial_tool_in_flight
-                            and _is_transient
-                            and _stream_attempt < _max_stream_retries
-                        )
-                        if not _can_silent_retry:
-                            # Either no tool call was in-flight (so the
-                            # turn was a pure text response — current
-                            # stub-with-recovered-text behaviour is
-                            # correct), or retries are exhausted, or the
-                            # error isn't transient.  Fall through to the
-                            # stub path.
-                            logger.warning(
-                                "Streaming failed after partial delivery, not retrying: %s", e
-                            )
-                            result["error"] = e
-                            return
-                        # Tool call was in-flight AND error is transient:
-                        # retry silently.  Clear per-attempt state so the
-                        # next stream starts clean.  Fire a "reconnecting"
-                        # marker so the user sees why the preamble is
-                        # about to be re-streamed.  Structured WARNING is
-                        # emitted by ``_emit_stream_drop`` below; no
-                        # additional INFO line needed.
-                        try:
-                            agent._fire_stream_delta(
-                                "\n\n⚠ Connection dropped mid tool-call; "
-                                "reconnecting…\n\n"
-                            )
-                        except Exception:
-                            pass
-                        # Reset the streamed-text buffer so the retry's
-                        # fresh preamble doesn't get double-recorded in
-                        # _current_streamed_assistant_text (which would
-                        # pollute the interim-visible-text comparison).
-                        try:
-                            agent._reset_stream_delivery_tracking()
-                        except Exception:
-                            pass
-                        # Reset in-memory accumulators so the next
-                        # attempt's chunks don't concat onto the dead
-                        # stream's partial JSON.
-                        result["partial_tool_names"] = []
-                        deltas_were_sent["yes"] = False
-                        first_delta_fired["done"] = False
-                        agent._emit_stream_drop(
-                            error=e,
-                            attempt=_stream_attempt + 2,
-                            max_attempts=_max_stream_retries + 1,
-                            mid_tool_call=True,
-                            diag=request_client_holder.get("diag"),
-                        )
-                        _cancel_current_stream_attempt("stream_mid_tool_retry_cleanup")
-                        _close_request_client_once("stream_mid_tool_retry_cleanup")
-                        # #67142: anthropic streams on a request-local client,
-                        # already worker-owned-closed by _close_request_client_once
-                        # above; the next attempt builds a fresh one. The shared
-                        # _anthropic_client is never closed from inside a request.
-                        # #70773: same FD-recycle corruption vector for OpenAI.
-                        # The shared client will be replaced lazily by
-                        # _ensure_primary_openai_client on the next attempt.
-                        continue
+                        result["error"] = e
+                        return
 
                     # SSE error events from proxies (e.g. OpenRouter sends
                     # {"error":{"message":"Network connection lost."}}) are
@@ -3827,11 +3759,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _stale_elapsed, _stream_stale_timeout,
                 api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
             )
+            _stale_action = (
+                "preserving partial response"
+                if partial_observed.is_set()
+                else "reconnecting"
+            )
             agent._buffer_status(
                 f"⚠️ No response from provider for {int(_stale_elapsed)}s "
                 f"(model: {api_kwargs.get('model', 'unknown')}, "
                 f"context: ~{_est_ctx:,} tokens). "
-                f"Reconnecting..."
+                f"{_stale_action.capitalize()}..."
             )
             try:
                 _cancel_current_stream_attempt("stale_stream_kill")
@@ -3867,10 +3804,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             last_chunk_time["t"] = time.time()
             agent._emit_wait_notice(
                 f"⚠ no output from provider for {int(_stale_elapsed)}s — "
-                f"reconnecting..."
+                f"{_stale_action}..."
             )
             agent._touch_activity(
-                f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
+                f"stale stream detected after {int(_stale_elapsed)}s, "
+                f"{_stale_action}"
             )
 
         if agent._interrupt_requested:
@@ -3900,15 +3838,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted during streaming API call (post-worker)")
     if result["error"] is not None:
-        if deltas_were_sent["yes"]:
-            # Streaming failed AFTER some tokens were already delivered to
-            # the platform.  Re-raising would let the outer retry loop make
-            # Return a partial response stub with finish_reason="length"
-            # so the conversation loop's continuation machinery fires.
-            # tool_calls=None prevents auto-execution of incomplete calls.
+        if partial_observed.is_set():
+            # Return observed output once. tool_calls=None guarantees an
+            # incomplete tool call cannot execute, and the conversation loop
+            # treats this stub as terminal instead of calling the provider.
             _partial_text = (
-                getattr(agent, "_current_streamed_assistant_text", "") or ""
+                "".join(partial_content_parts)
+                or getattr(agent, "_current_streamed_assistant_text", "")
+                or ""
             ).strip() or None
+            _partial_reasoning = (
+                "".join(partial_reasoning_parts)
+                or getattr(agent, "_current_streamed_reasoning_text", "")
+                or None
+            )
 
             # Append a user-visible warning if tool calls were dropped so
             # the user and model both know what was attempted.
@@ -3938,15 +3881,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 logger.warning(
                     "Partial stream delivered before error; returning "
                     "length-truncated stub with %s chars of recovered "
-                    "content so the loop can continue from where the "
-                    "stream died: %s",
+                    "content as a terminal partial response: %s",
                     len(_partial_text or ""),
                     result["error"],
                 )
                 _stub_finish_reason = FINISH_REASON_LENGTH
             _stub_msg = SimpleNamespace(
                 role="assistant", content=_partial_text, tool_calls=None,
-                reasoning_content=None,
+                reasoning_content=_partial_reasoning,
             )
             # Detect provider output-layer content filtering (e.g. MiniMax
             # "output new_sensitive (1027)", Azure/OpenAI content_filter,
@@ -3954,8 +3896,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # swallowed into a finish_reason=length stub, so classify it HERE
             # while we still have it and stamp the stub.  Retrying such a
             # content-deterministic filter on the same primary just re-hits
-            # the filter — the conversation loop reads this tag and activates
-            # the fallback chain instead of burning continuation retries.
+            # the filter. Keep the tag as diagnostic evidence while returning
+            # the partial body without another provider call.
             # error_classifier is the single source of truth for "what counts
             # as a content filter" (#32421).
             _content_filter_terminated = False

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2344,13 +2344,14 @@ def run_conversation(
                                     response_invalid = True
                                     error_details.append("response.output is empty")
                 elif agent.api_mode == "anthropic_messages":
-                    _tv = agent._get_transport()
-                    if not _tv.validate_response(response):
-                        response_invalid = True
-                        if response is None:
-                            error_details.append("response is None")
-                        else:
-                            error_details.append("response.content invalid (not a non-empty list)")
+                    if getattr(response, "id", "") != PARTIAL_STREAM_STUB_ID:
+                        _tv = agent._get_transport()
+                        if not _tv.validate_response(response):
+                            response_invalid = True
+                            if response is None:
+                                error_details.append("response is None")
+                            else:
+                                error_details.append("response.content invalid (not a non-empty list)")
                 elif agent.api_mode == "bedrock_converse":
                     _btv = agent._get_transport()
                     if not _btv.validate_response(response):
@@ -2562,8 +2563,11 @@ def run_conversation(
                     else:
                         finish_reason = "stop"
                 elif agent.api_mode == "anthropic_messages":
-                    _tfr = agent._get_transport()
-                    finish_reason = _tfr.map_finish_reason(response.stop_reason)
+                    if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
+                        finish_reason = response.choices[0].finish_reason
+                    else:
+                        _tfr = agent._get_transport()
+                        finish_reason = _tfr.map_finish_reason(response.stop_reason)
                 elif agent.api_mode == "bedrock_converse":
                     # Bedrock response already normalized at dispatch — use transport
                     _bt_fr = agent._get_transport()
@@ -2710,7 +2714,9 @@ def run_conversation(
                     # would have been appended in the non-truncated path.
                     _trunc_msg = None
                     _trunc_transport = agent._get_transport()
-                    if agent.api_mode == "anthropic_messages":
+                    if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
+                        _trunc_result = response.choices[0].message
+                    elif agent.api_mode == "anthropic_messages":
                         _trunc_result = _trunc_transport.normalize_response(
                             response, strip_tool_prefix=agent._is_anthropic_oauth
                         )
@@ -2720,6 +2726,65 @@ def run_conversation(
 
                     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
                     _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
+
+                    # A partial-stream stub already contains the delivered
+                    # body. Never continue it: re-calling the provider would
+                    # replay paid output (and a dropped tool call). A real
+                    # output-cap response keeps the existing continuation path.
+                    _partial_stream_response = (
+                        getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+                        and not _trunc_has_tool_calls
+                    )
+                    if _partial_stream_response:
+                        _partial_response = agent._strip_think_blocks(
+                            "".join([
+                                *truncated_response_parts,
+                                _trunc_content or "",
+                            ])
+                        ).strip()
+                        _dropped_tools = getattr(response, "_dropped_tool_names", None) or []
+                        if _dropped_tools and "Stream stalled mid tool-call" not in _partial_response:
+                            _tool_list = ", ".join(_dropped_tools[:3])
+                            if len(_dropped_tools) > 3:
+                                _tool_list += f", +{len(_dropped_tools) - 3} more"
+                            _partial_response = (
+                                f"{_partial_response}\n\n"
+                                f"⚠ Stream stalled mid tool-call ({_tool_list}); "
+                                "the action was not executed. Ask me to retry if "
+                                "you want to continue."
+                            ).strip()
+                        if not _partial_response:
+                            _partial_response = (
+                                "⚠ Stream interrupted before a complete response "
+                                "was received."
+                            )
+                        _partial_message = agent._build_assistant_message(
+                            _trunc_msg, finish_reason
+                        )
+                        if not (
+                            (_partial_message.get("content") or "").strip()
+                            or _partial_message.get("tool_calls")
+                            or (_partial_message.get("reasoning") or "").strip()
+                            or (
+                                _partial_message.get("reasoning_content") or ""
+                            ).strip()
+                            or _partial_message.get("reasoning_details")
+                        ):
+                            _partial_message["content"] = _partial_response
+                        messages.append(_partial_message)
+                        agent._cleanup_task_resources(effective_task_id)
+                        agent._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": _partial_response,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "partial": True,
+                            "failed": False,
+                            "error": (
+                                "network_stream_interrupted_after_partial_response"
+                            ),
+                        }
 
                     # ── Detect thinking-budget exhaustion ──────────────
                     # When the model spends ALL output tokens on reasoning

--- a/tests/run_agent/test_70773_shared_client_fd_corruption.py
+++ b/tests/run_agent/test_70773_shared_client_fd_corruption.py
@@ -12,7 +12,7 @@ application-data record over the SQLite header.
 
 Fix (mirrors the #67142 Anthropic ownership discipline):
 
-1. The three in-request cleanup sites (stale watchdog, mid-tool retry,
+1. The three in-request cleanup sites (stale watchdog, terminal partial,
    stream retry) no longer touch the shared client at all — the
    request-local client is closed via ``_close_request_client_once`` and
    the shared client is replaced lazily by ``_ensure_primary_openai_client``
@@ -155,11 +155,11 @@ class TestStaleWatchdogNeverClosesSharedClient:
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
-    def test_mid_tool_retry_cleanup_does_not_replace_primary(
+    def test_mid_tool_partial_cleanup_does_not_replace_primary(
         self, mock_close, mock_create, mock_replace, monkeypatch,
     ):
-        """Connection drop mid tool-call → silent retry closes only the
-        request-local client; the shared primary is left alone."""
+        """Connection drop mid tool-call → terminal partial cleanup closes
+        only the request-local client; the shared primary is left alone."""
         from tests.run_agent.test_streaming import _make_tool_call_delta
 
         monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
@@ -173,18 +173,9 @@ class TestStaleWatchdogNeverClosesSharedClient:
             ])
             raise httpx.RemoteProtocolError("peer closed connection")
 
-        def _second_stream():
-            yield _make_stream_chunk(tool_calls=[
-                _make_tool_call_delta(index=0, tc_id="call_1", name="terminal"),
-            ])
-            yield _make_stream_chunk(tool_calls=[
-                _make_tool_call_delta(index=0, arguments='{"command": "ls"}'),
-            ])
-            yield _make_stream_chunk(finish_reason="tool_calls")
-
         def _pick_stream(*a, **kw):
             attempts["n"] += 1
-            return _first_stream() if attempts["n"] == 1 else _second_stream()
+            return _first_stream()
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.side_effect = _pick_stream
@@ -193,8 +184,9 @@ class TestStaleWatchdogNeverClosesSharedClient:
         agent = _make_agent()
         response = agent._interruptible_streaming_api_call({})
 
-        assert attempts["n"] == 2
-        assert response.choices[0].message.tool_calls
+        assert attempts["n"] == 1
+        assert response.choices[0].message.tool_calls is None
+        assert mock_close.call_count >= 1
         mock_replace.assert_not_called()
 
 

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -2,12 +2,11 @@
 
 Pins the contract:
 
-- text-only partial stream → stub.finish_reason == "length" so the
-  conversation loop's existing length-continuation path can keep the
-  agent moving against an unfinished goal.
-- partial mid-tool-call → stub.finish_reason == "length" so the loop
-  triggers continuation machinery with targeted chunking guidance
-  instead of ending the turn immediately.
+- any partial stream → stub.finish_reason == "length", but the
+  conversation loop recognizes the stub id and returns the delivered body
+  without a continuation request.
+- partial mid-tool-call → tool_calls stays None and the loop reports the
+  dropped action without executing or retrying it.
 - conversation_loop's length-continuation prompt distinguishes a real
   output-length truncation from a partial-stream-stub network error
   via response.id.
@@ -64,8 +63,8 @@ class TestPartialStreamStubFinishReason:
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
     def test_text_only_partial_returns_length(self, _mock_close, mock_create, monkeypatch):
-        """#30963: text-only partials must classify as length so the loop
-        keeps continuing instead of exiting with budget remaining."""
+        """The low-level stub keeps its historical length classification;
+        the loop handles its id as an abnormal partial terminal result."""
 
         def _stalling_stream():
             yield _make_stream_chunk(content="Here's my answer so far")
@@ -83,9 +82,8 @@ class TestPartialStreamStubFinishReason:
 
         assert response.id == PARTIAL_STREAM_STUB_ID
         assert response.choices[0].finish_reason == FINISH_REASON_LENGTH, (
-            "Text-only partial streams must use finish_reason=length so the "
-            "conversation loop continues from where the network died "
-            "(issue #30963)."
+            "Text-only partial streams retain finish_reason=length while the "
+            "conversation loop returns the recovered body once (issue #30963)."
         )
         assert response.choices[0].message.content == "Here's my answer so far"
         assert response.choices[0].message.tool_calls is None
@@ -93,10 +91,8 @@ class TestPartialStreamStubFinishReason:
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
     def test_partial_tool_call_uses_length(self, _mock_close, mock_create, monkeypatch):
-        """Mid-tool-call partials now use finish_reason=length so the
-        conversation loop's continuation machinery fires — bounded 3-retry
-        with guidance to break output into smaller chunks (#31998).
-        tool_calls=None is preserved, so no tool auto-executes."""
+        """Mid-tool-call partials retain finish_reason=length for diagnostics;
+        tool_calls=None prevents auto-execution or a duplicate provider call."""
 
         def _stalling_stream():
             yield _make_stream_chunk(content="Let me write the audit: ")
@@ -121,9 +117,8 @@ class TestPartialStreamStubFinishReason:
 
         assert response.id == PARTIAL_STREAM_STUB_ID
         assert response.choices[0].finish_reason == FINISH_REASON_LENGTH, (
-            "Partial mid-tool-call must use finish_reason=length so the "
-            "continuation machinery fires instead of ending the turn "
-            "immediately (#31998)."
+            "Partial mid-tool-call must retain finish_reason=length for the "
+            "terminal warning path (#31998)."
         )
         assert response.choices[0].message.tool_calls is None, (
             "tool_calls must remain None (no auto-execution of side-effectful "
@@ -339,19 +334,14 @@ def loop_agent():
         return a
 
 
-class TestConversationLoopPartialStreamContinuation:
-    """End-to-end: a partial-stream stub feeds the loop and the loop
-    asks for continuation instead of exiting with finish_reason=stop."""
+class TestConversationLoopPartialStreamRecovery:
+    """End-to-end recovery without duplicate model calls."""
 
-    def test_partial_stream_stub_does_not_exit_loop_immediately(self, loop_agent):
-        """The stub from chat_completion_helpers used to exit the loop with
-        text_response(finish_reason=stop). Now finish_reason=length routes
-        through length_continue_retries — the loop persists the partial
-        content and asks the model to continue."""
+    def test_text_partial_stream_returns_body_without_continuation(self, loop_agent):
+        """A text-only stub returns its delivered body after one API call."""
 
-        from tests.run_agent.test_run_agent import _mock_response, _mock_assistant_msg
+        from tests.run_agent.test_run_agent import _mock_assistant_msg
 
-        # First API call: the partial-stream stub (length on partial-stream-stub id).
         partial_stub = SimpleNamespace(
             id=PARTIAL_STREAM_STUB_ID,
             model="test/model",
@@ -362,48 +352,243 @@ class TestConversationLoopPartialStreamContinuation:
             )],
             usage=None,
         )
-        # Second API call: model continues with the rest, clean stop.
-        continuation = _mock_response(
-            content="the answer is forty-two.", finish_reason="stop",
+        loop_agent.client.chat.completions.create.return_value = partial_stub
+        persisted_messages = []
+
+        with (
+            patch.object(
+                loop_agent,
+                "_persist_session",
+                side_effect=lambda messages, _history: persisted_messages.append(
+                    [dict(message) for message in messages]
+                ),
+            ),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources") as cleanup,
+        ):
+            result = loop_agent.run_conversation("ask me something")
+
+        assert loop_agent.client.chat.completions.create.call_count == 1
+        assert result["final_response"] == "The first half of"
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert result["failed"] is False
+        assert (
+            result["error"]
+            == "network_stream_interrupted_after_partial_response"
+        )
+        assert result["messages"][-1]["role"] == "assistant"
+        assert result["messages"][-1]["finish_reason"] == FINISH_REASON_LENGTH
+        assert [
+            message.get("content")
+            for message in result["messages"]
+            if message.get("role") == "user"
+        ] == ["ask me something"]
+        assert sum(
+            sum(
+                message.get("role") == "assistant"
+                and message.get("content") == "The first half of"
+                for message in snapshot
+            )
+            for snapshot in persisted_messages
+        ) == 1
+        cleanup.assert_called_once()
+
+    def test_incomplete_chunked_read_runs_transport_to_loop_once(
+        self, loop_agent, monkeypatch
+    ):
+        """A real transport read failure preserves its body without call two."""
+        import httpx
+
+        attempts = {"count": 0}
+
+        def _stream():
+            yield _make_stream_chunk(content="Recovered before disconnect")
+            raise httpx.ReadError("incomplete chunked read")
+
+        request_client = MagicMock()
+
+        def _create(*_args, **_kwargs):
+            attempts["count"] += 1
+            return _stream()
+
+        request_client.chat.completions.create.side_effect = _create
+        loop_agent.stream_delta_callback = lambda _text: None
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        with (
+            patch.object(
+                loop_agent,
+                "_create_request_openai_client",
+                return_value=request_client,
+            ),
+            patch.object(loop_agent, "_close_request_openai_client"),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("keep the partial")
+
+        assert attempts["count"] == 1
+        assert result["final_response"] == "Recovered before disconnect"
+        assert result["partial"] is True
+        assert result["messages"][-1]["finish_reason"] == FINISH_REASON_LENGTH
+        assert result["messages"][-1]["content"] == "Recovered before disconnect"
+
+    def test_anthropic_read_error_runs_transport_to_loop_once(self, monkeypatch):
+        """The Anthropic compatibility stub bypasses native-message validation
+        and reaches the terminal partial path without an outer retry."""
+        import httpx
+
+        from run_agent import AIAgent
+
+        attempts = {"count": 0}
+
+        class _BrokenStream:
+            response = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(
+                    type="content_block_delta",
+                    delta=SimpleNamespace(type="text_delta", text="partial body"),
+                )
+                raise httpx.ReadError("incomplete chunked read")
+
+        request_client = MagicMock()
+
+        def _make_stream(**_kwargs):
+            attempts["count"] += 1
+            return _BrokenStream()
+
+        request_client.messages.stream.side_effect = _make_stream
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://api.anthropic.com",
+                provider="anthropic",
+                api_mode="chat_completions",
+                model="claude-test",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+        agent.stream_delta_callback = lambda _text: None
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+
+        with (
+            patch.object(
+                agent,
+                "_create_request_anthropic_client",
+                return_value=request_client,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("keep the partial")
+
+        assert attempts["count"] == 1
+        assert result["partial"] is True
+        assert result["final_response"] == "partial body"
+        assert result["messages"][-1]["finish_reason"] == FINISH_REASON_LENGTH
+        assert "tool_calls" not in result["messages"][-1]
+
+    def test_tool_partial_stub_returns_warning_without_continuation(self, loop_agent):
+        """A dropped tool call is terminal and can never be auto-executed."""
+
+        from tests.run_agent.test_run_agent import _mock_assistant_msg
+
+        partial_stub = SimpleNamespace(
+            id=PARTIAL_STREAM_STUB_ID,
+            model="test/model",
+            choices=[SimpleNamespace(
+                index=0,
+                message=_mock_assistant_msg(content="Let me write the file."),
+                finish_reason=FINISH_REASON_LENGTH,
+            )],
+            usage=None,
+            _dropped_tool_names=["write_file"],
+        )
+        loop_agent.client.chat.completions.create.return_value = partial_stub
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("write it")
+
+        assert loop_agent.client.chat.completions.create.call_count == 1
+        assert "Stream stalled mid tool-call" in result["final_response"]
+        assert result["messages"][-1]["role"] == "assistant"
+        assert result["messages"][-1]["finish_reason"] == FINISH_REASON_LENGTH
+        assert "tool_calls" not in result["messages"][-1]
+
+    def test_partial_stream_after_real_length_preserves_full_body(self, loop_agent):
+        """A dropped continuation retains both parts without call three."""
+
+        from tests.run_agent.test_run_agent import (
+            _mock_assistant_msg,
+            _mock_response,
         )
 
+        partial_stub = SimpleNamespace(
+            id=PARTIAL_STREAM_STUB_ID,
+            model="test/model",
+            choices=[SimpleNamespace(
+                index=0,
+                message=_mock_assistant_msg(content="Second half partial."),
+                finish_reason=FINISH_REASON_LENGTH,
+            )],
+            usage=None,
+            _dropped_tool_names=["write_file"],
+        )
         loop_agent.client.chat.completions.create.side_effect = [
-            partial_stub, continuation,
+            _mock_response(content="The first half. ", finish_reason="length"),
+            partial_stub,
         ]
 
         with (
             patch.object(loop_agent, "_persist_session"),
             patch.object(loop_agent, "_save_trajectory"),
             patch.object(loop_agent, "_cleanup_task_resources"),
+            patch.object(loop_agent, "_execute_tool_calls") as execute_tools,
         ):
             result = loop_agent.run_conversation("ask me something")
 
-        # The loop made TWO API calls (stub + continuation), not one.
-        assert loop_agent.client.chat.completions.create.call_count == 2, (
-            "Partial-stream-stub must trigger a continuation API call, not "
-            "exit the loop after one call."
+        assert loop_agent.client.chat.completions.create.call_count == 2
+        assert result["final_response"].startswith(
+            "The first half. Second half partial."
         )
-        # The continuation prompt the loop appended must be the network-error
-        # variant, not the "output length limit" lie — otherwise the model
-        # no-ops with "I wasn't truncated, I'm done."
-        # We assert it indirectly by inspecting the second-call kwargs.
-        second_call_kwargs = loop_agent.client.chat.completions.create.call_args_list[1]
-        msgs = second_call_kwargs.kwargs.get("messages") or second_call_kwargs.args[0].get("messages")
-        last_user = next(
-            (m for m in reversed(msgs) if m.get("role") == "user"), None,
-        )
-        assert last_user is not None
-        assert "network error mid-stream" in (last_user.get("content") or ""), (
-            "Continuation prompt for partial-stream-stub must mention the "
-            "network error, not the 'output length limit'."
-        )
-
-        # And the final response stitches both halves together.
-        assert "first half of" in result["final_response"]
-        assert "forty-two" in result["final_response"]
+        assert "Stream stalled mid tool-call" in result["final_response"]
+        assert result["partial"] is True
+        assert result["failed"] is False
+        assert result["messages"][-2]["role"] == "user"
+        assert "output length limit" in result["messages"][-2]["content"]
+        assert result["messages"][-1]["role"] == "assistant"
+        assert "tool_calls" not in result["messages"][-1]
+        execute_tools.assert_not_called()
 
 
-class TestContentFilterStallActivatesFallback:
+class TestContentFilterStallReturnsPartial:
     """Regression for #32421: a provider output-layer content safety filter
     (e.g. MiniMax ``output new_sensitive (1027)``) terminates a streaming
     response mid-delivery.  The raw error is swallowed into a
@@ -418,8 +603,8 @@ class TestContentFilterStallActivatesFallback:
          ``content_policy_blocked``.
       2. interruptible_streaming_api_call runs the swallowed error through
          that classifier and stamps the stub ``_content_filter_terminated``.
-      3. the conversation loop reads the tag and activates fallback BEFORE
-         burning any continuation retries.
+      3. the conversation loop returns the tagged partial once without
+         continuation or provider fallback.
     """
 
     @patch("run_agent.AIAgent._create_request_openai_client")
@@ -455,8 +640,8 @@ class TestContentFilterStallActivatesFallback:
 
         assert response.id == PARTIAL_STREAM_STUB_ID
         assert getattr(response, "_content_filter_terminated", False) is True, (
-            "MiniMax new_sensitive stream stall must tag the stub so the loop "
-            "can route to fallback (#32421)."
+            "MiniMax new_sensitive stream stall must retain its diagnostic tag "
+            "without triggering another provider call (#32421)."
         )
 
     @patch("run_agent.AIAgent._create_request_openai_client")
@@ -465,8 +650,7 @@ class TestContentFilterStallActivatesFallback:
         self, _mock_close, mock_create, monkeypatch,
     ):
         """A plain network stall (no content-filter signature) must NOT be
-        tagged — it should still use the normal continuation path, not
-        switch providers."""
+        tagged or switched to another provider."""
 
         def _network_stall():
             yield _make_stream_chunk(content="Writing the file: ")
@@ -491,11 +675,9 @@ class TestContentFilterStallActivatesFallback:
             "filter — that would needlessly switch providers."
         )
 
-    def test_tagged_stub_activates_fallback_first_pass(self, loop_agent):
-        """Layer 3: a tagged stub activates fallback on the FIRST pass, with
-        zero continuation retries burned, and the fallback provider then
-        completes the turn."""
-        from tests.run_agent.test_run_agent import _mock_assistant_msg, _mock_response
+    def test_tagged_stub_does_not_activate_fallback(self, loop_agent):
+        """Layer 3: a tagged partial is terminal even with a fallback."""
+        from tests.run_agent.test_run_agent import _mock_assistant_msg
 
         def _filter_stub():
             return SimpleNamespace(
@@ -511,12 +693,7 @@ class TestContentFilterStallActivatesFallback:
                 _content_filter_terminated=True,
             )
 
-        recovery = _mock_response(
-            content="Done on the fallback provider.", finish_reason="stop",
-        )
-        loop_agent.client.chat.completions.create.side_effect = [
-            _filter_stub(), recovery,
-        ]
+        loop_agent.client.chat.completions.create.return_value = _filter_stub()
         loop_agent._fallback_chain = [
             {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.7"},
         ]
@@ -537,17 +714,17 @@ class TestContentFilterStallActivatesFallback:
         ):
             result = loop_agent.run_conversation("write me a long file")
 
-        assert fb_calls["n"] == 1, (
-            "Content-filter-tagged stub must activate fallback exactly once, "
-            "on the first pass — not after exhausting continuation retries."
-        )
-        assert result["final_response"] == "Done on the fallback provider."
-        assert result["completed"] is True
+        assert loop_agent.client.chat.completions.create.call_count == 1
+        assert fb_calls["n"] == 0
+        assert result["partial"] is True
+        assert result["completed"] is False
+        assert "Stream stalled mid tool-call" in result["final_response"]
+        assert result["messages"][-1]["finish_reason"] == FINISH_REASON_LENGTH
+        assert "tool_calls" not in result["messages"][-1]
 
-    def test_tagged_stub_no_fallback_falls_through(self, loop_agent):
-        """When no fallback chain is configured, a tagged stub falls through
-        to the normal continuation path (best-effort) rather than crashing."""
-        from tests.run_agent.test_run_agent import _mock_assistant_msg, _mock_response
+    def test_tagged_stub_without_fallback_is_terminal(self, loop_agent):
+        """A tagged partial without a fallback is also terminal."""
+        from tests.run_agent.test_run_agent import _mock_assistant_msg
 
         def _filter_stub():
             return SimpleNamespace(
@@ -563,10 +740,7 @@ class TestContentFilterStallActivatesFallback:
                 _content_filter_terminated=True,
             )
 
-        recovery = _mock_response(content="recovered text", finish_reason="stop")
-        loop_agent.client.chat.completions.create.side_effect = [
-            _filter_stub(), recovery,
-        ]
+        loop_agent.client.chat.completions.create.return_value = _filter_stub()
         # No fallback chain configured.
         loop_agent._fallback_chain = []
         loop_agent._fallback_index = 0
@@ -585,37 +759,18 @@ class TestContentFilterStallActivatesFallback:
         ):
             result = loop_agent.run_conversation("write me a long file")
 
-        # Fallback was not attempted (empty chain gates it out); the loop
-        # continued normally and produced a response.
-        assert fb_calls["n"] == 0, (
-            "With an empty fallback chain, the loop must not even call "
-            "_try_activate_fallback — it should fall through to continuation."
-        )
-        assert result["completed"] is True
+        assert loop_agent.client.chat.completions.create.call_count == 1
+        assert fb_calls["n"] == 0
+        assert result["partial"] is True
+        assert result["completed"] is False
 
 
-class TestEmptyPartialStreamStubNotPersisted:
-    """Regression for the session-poisoning bug hit with moonshotai/kimi-k3
-    via OpenRouter (2026-07-20): a stream dropped mid-``write_file`` tool
-    call before ANY text was delivered.  The partial-stream-stub carries
-    ``content=""`` and ``tool_calls=None``, so the loop's truncation path
-    took the "no tool calls" branch and appended
-    ``{"role": "assistant", "content": ""}`` to history before the
-    continuation user-message.  Moonshot rejects empty assistant content
-    ("the message at position N with role 'assistant' must not be empty")
-    with HTTP 400 on the very next replay — and since the message is
-    persisted, EVERY subsequent turn re-fails: session unrecoverable.
+class TestPartialStreamStubPersistence:
+    """Partial stubs persist one safe assistant result without replay."""
 
-    Fix layer 1 (conversation_loop): an empty partial-stream stub must not
-    be appended as an interim assistant message — only the continuation
-    user-message is.
-    """
+    def test_empty_stub_persists_warning_without_continuation(self, loop_agent):
+        from tests.run_agent.test_run_agent import _mock_assistant_msg
 
-    def test_empty_stub_only_appends_continuation_user_message(self, loop_agent):
-        from tests.run_agent.test_run_agent import _mock_response, _mock_assistant_msg
-
-        # First API call: empty partial-stream stub — stream died mid
-        # tool-call args with zero text delivered.
         empty_stub = SimpleNamespace(
             id=PARTIAL_STREAM_STUB_ID,
             model="test/model",
@@ -627,13 +782,7 @@ class TestEmptyPartialStreamStubNotPersisted:
             usage=None,
             _dropped_tool_names=["write_file"],
         )
-        # Second API call: the model answers normally after the nudge.
-        recovery = _mock_response(content="Done — wrote it in chunks.",
-                                  finish_reason="stop")
-
-        loop_agent.client.chat.completions.create.side_effect = [
-            empty_stub, recovery,
-        ]
+        loop_agent.client.chat.completions.create.return_value = empty_stub
 
         with (
             patch.object(loop_agent, "_persist_session"),
@@ -642,39 +791,19 @@ class TestEmptyPartialStreamStubNotPersisted:
         ):
             result = loop_agent.run_conversation("make me a webpage")
 
-        assert loop_agent.client.chat.completions.create.call_count == 2
+        assert loop_agent.client.chat.completions.create.call_count == 1
+        assert result["partial"] is True
+        assert result["completed"] is False
+        assert "Stream stalled mid tool-call (write_file)" in result["final_response"]
+        assert result["messages"][-1]["role"] == "assistant"
+        assert result["messages"][-1]["content"].strip()
+        assert [
+            message for message in result["messages"][1:]
+            if message.get("role") == "user"
+        ] == []
 
-        # Inspect the history replayed on the SECOND call: there must be NO
-        # empty-content assistant message anywhere — that is the exact shape
-        # Moonshot 400s on.
-        second_call_kwargs = loop_agent.client.chat.completions.create.call_args_list[1]
-        msgs = second_call_kwargs.kwargs.get("messages") or second_call_kwargs.args[0].get("messages")
-        empty_assistants = [
-            m for m in msgs
-            if m.get("role") == "assistant" and not m.get("content")
-        ]
-        assert empty_assistants == [], (
-            "Empty partial-stream stub must not be persisted as an "
-            "empty-content assistant message — strict providers (Moonshot/"
-            "Kimi) reject the replay with HTTP 400 and poison the session."
-        )
-
-        # The continuation nudge is still appended as a user message, and
-        # it's the chunking variant (dropped tool call), not the length lie.
-        last_user = next(
-            (m for m in reversed(msgs) if m.get("role") == "user"), None,
-        )
-        assert last_user is not None
-        assert "too large" in (last_user.get("content") or "")
-        assert "output length limit" not in (last_user.get("content") or "")
-
-        assert result["completed"] is True
-
-    def test_non_empty_partial_stub_still_persisted(self, loop_agent):
-        """Guard against over-correction: a stub that DID deliver partial
-        text must still be appended so the continuation stitches correctly
-        (existing behavior from #32086)."""
-        from tests.run_agent.test_run_agent import _mock_response, _mock_assistant_msg
+    def test_non_empty_partial_stub_persists_body_once(self, loop_agent):
+        from tests.run_agent.test_run_agent import _mock_assistant_msg
 
         partial_stub = SimpleNamespace(
             id=PARTIAL_STREAM_STUB_ID,
@@ -686,13 +815,7 @@ class TestEmptyPartialStreamStubNotPersisted:
             )],
             usage=None,
         )
-        continuation = _mock_response(
-            content="the answer is forty-two.", finish_reason="stop",
-        )
-
-        loop_agent.client.chat.completions.create.side_effect = [
-            partial_stub, continuation,
-        ]
+        loop_agent.client.chat.completions.create.return_value = partial_stub
 
         with (
             patch.object(loop_agent, "_persist_session"),
@@ -701,18 +824,14 @@ class TestEmptyPartialStreamStubNotPersisted:
         ):
             result = loop_agent.run_conversation("ask me something")
 
-        second_call_kwargs = loop_agent.client.chat.completions.create.call_args_list[1]
-        msgs = second_call_kwargs.kwargs.get("messages") or second_call_kwargs.args[0].get("messages")
+        assert loop_agent.client.chat.completions.create.call_count == 1
         partial_assistants = [
-            m for m in msgs
+            m for m in result["messages"]
             if m.get("role") == "assistant" and "first half" in (m.get("content") or "")
         ]
-        assert partial_assistants, (
-            "A partial-stream stub WITH text must still be persisted so the "
-            "continuation can stitch the halves."
-        )
-        assert "first half of" in result["final_response"]
-        assert "forty-two" in result["final_response"]
+        assert len(partial_assistants) == 1
+        assert result["final_response"] == "The first half of"
+        assert result["partial"] is True
 
 
 class TestBuildAssistantMessageEmptyContentPad:

--- a/tests/run_agent/test_stream_interrupt_retry.py
+++ b/tests/run_agent/test_stream_interrupt_retry.py
@@ -168,7 +168,7 @@ class TestStreamInterruptBeforeRetry:
     @patch("run_agent.AIAgent._abort_request_openai_client")
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
-    def test_stale_stream_attempt_cannot_emit_late_chunks_after_retry(
+    def test_stale_stream_attempt_returns_partial_tool_warning_without_retry(
         self,
         mock_close,
         mock_create,
@@ -176,11 +176,12 @@ class TestStreamInterruptBeforeRetry:
         mock_replace,
         monkeypatch,
     ):
-        """A stale attempt must not keep writing deltas after it is killed.
+        """A stale attempt must not write late deltas or trigger call two.
 
         This reproduces the race where the outer stale detector aborts an SSE
         connection, but the old iterator still yields one more chunk before
-        surfacing the connection error that triggers the retry.
+        surfacing the connection error. Once a tool delta is observed, the
+        request returns a terminal partial warning instead of retrying.
         """
         import httpx
         import time
@@ -211,21 +212,8 @@ class TestStreamInterruptBeforeRetry:
                 yield _make_stream_chunk(content="old late ")
                 raise httpx.RemoteProtocolError("peer closed connection")
 
-        retry_chunks = [
-            _make_stream_chunk(content="new final"),
-            _make_stream_chunk(finish_reason="stop", model="test/model"),
-        ]
-        class RetryStream:
-            response = SimpleNamespace(headers={})
-
-            def __iter__(self):
-                return iter(retry_chunks)
-
         mock_client = MagicMock()
-        mock_client.chat.completions.create.side_effect = [
-            LateChunkAfterStaleStream(),
-            RetryStream(),
-        ]
+        mock_client.chat.completions.create.return_value = LateChunkAfterStaleStream()
         mock_create.return_value = mock_client
 
         agent = _make_agent()
@@ -236,7 +224,14 @@ class TestStreamInterruptBeforeRetry:
         response = agent._interruptible_streaming_api_call({})
 
         delivered = "".join(deltas)
+        message = response.choices[0].message
+        content = message.content or ""
+
+        assert mock_client.chat.completions.create.call_count == 1
         assert "old late" not in delivered
-        assert "new final" in delivered
-        assert response.choices[0].message.content == "new final"
+        assert "old late" not in content
+        assert "Stream stalled mid tool-call (terminal)" in delivered
+        assert "Stream stalled mid tool-call (terminal)" in content
+        assert message.tool_calls is None
+        assert getattr(response, "_dropped_tool_names", None) == ["terminal"]
         assert mock_abort.called

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1267,6 +1267,78 @@ class TestAnthropicStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == len(events)
 
+    def test_anthropic_partial_read_error_does_not_retry(self, monkeypatch):
+        """Anthropic text/reasoning/tool deltas survive a real ReadError
+        without a second provider request."""
+        import httpx
+
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.anthropic.com",
+            provider="anthropic",
+            api_mode="chat_completions",
+            model="claude-test",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        class _PartialStream:
+            response = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(
+                    type="content_block_delta",
+                    delta=SimpleNamespace(type="text_delta", text="Recovered text"),
+                )
+                yield SimpleNamespace(
+                    type="content_block_delta",
+                    delta=SimpleNamespace(
+                        type="thinking_delta", thinking="Recovered reasoning"
+                    ),
+                )
+                yield SimpleNamespace(
+                    type="content_block_start",
+                    content_block=SimpleNamespace(
+                        type="tool_use", name="terminal"
+                    ),
+                )
+                yield SimpleNamespace(
+                    type="content_block_delta",
+                    delta=SimpleNamespace(
+                        type="input_json_delta", partial_json='{"cmd":'
+                    ),
+                )
+                raise httpx.ReadError("incomplete chunked read")
+
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.return_value = _PartialStream()
+        agent._create_request_anthropic_client = (
+            lambda *a, **k: agent._anthropic_client
+        )
+
+        response = agent._interruptible_streaming_api_call({})
+
+        message = response.choices[0].message
+        assert agent._anthropic_client.messages.stream.call_count == 1
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert "Recovered text" in message.content
+        assert "Stream stalled mid tool-call (terminal)" in message.content
+        assert message.reasoning_content == "Recovered reasoning"
+        assert message.tool_calls is None
+
     @patch("run_agent.AIAgent._rebuild_anthropic_client")
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     def test_anthropic_stream_parser_valueerror_retries_before_delivery(
@@ -1284,6 +1356,7 @@ class TestAnthropicStreamCallbacks:
             api_key="test-key",
             base_url="https://api.minimax.io/anthropic",
             provider="minimax",
+            api_mode="chat_completions",
             model="MiniMax-M2.7",
             quiet_mode=True,
             skip_context_files=True,
@@ -1341,6 +1414,7 @@ class TestAnthropicStreamCallbacks:
             api_key="test-key",
             base_url="https://api.minimax.io/anthropic",
             provider="minimax",
+            api_mode="chat_completions",
             model="MiniMax-M2.7",
             quiet_mode=True,
             skip_context_files=True,
@@ -1378,6 +1452,7 @@ class TestAnthropicStreamCallbacks:
             api_key="test-key",
             base_url="https://api.anthropic.com",
             provider="anthropic",
+            api_mode="chat_completions",
             model="claude-test",
             quiet_mode=True,
             skip_context_files=True,
@@ -1424,6 +1499,7 @@ class TestAnthropicStreamCallbacks:
             api_key="test-key",
             base_url="https://api.anthropic.com",
             provider="anthropic",
+            api_mode="chat_completions",
             model="claude-test",
             quiet_mode=True,
             skip_context_files=True,
@@ -1584,25 +1660,17 @@ class TestPartialToolCallWarning:
         )
 
 
-class TestSilentRetryMidToolCall:
-    """Regression: when the stream dies mid tool-call JSON after text was
-    already delivered, we previously stubbed the turn with a "retry manually"
-    warning.  Now: if the error is a transient connection error AND a tool
-    call was in flight, silently retry the stream (the user sees a brief
-    reconnect marker + duplicated preamble, which is strictly better than
-    a lost action).  If no tool call was in flight, or the error isn't
-    transient, the existing stub-with-warning behaviour is preserved.
-    """
+class TestPartialToolCallNoRetry:
+    """A transport drop after any observable tool-call delta is terminal for
+    this provider request; retrying could duplicate a paid side effect."""
 
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
-    def test_silent_retry_recovers_tool_call(
+    def test_partial_tool_call_transport_error_does_not_retry(
         self, mock_close, mock_create, mock_replace,
     ):
-        """First attempt: text + partial tool-call + connection drop.
-        Second attempt: text + complete tool-call.  Response should contain
-        the recovered tool call; no warning stub should be returned."""
+        """A real RemoteProtocolError returns one warning stub and no call 2."""
         from run_agent import AIAgent
         import httpx as _httpx
 
@@ -1616,23 +1684,11 @@ class TestSilentRetryMidToolCall:
             yield _make_stream_chunk(tool_calls=[
                 _make_tool_call_delta(index=0, arguments='{"path": "/tmp/x", '),
             ])
-            raise _httpx.RemoteProtocolError("peer closed connection")
-
-        def _second_stream():
-            yield _make_stream_chunk(content="Let me write the audit: ")
-            yield _make_stream_chunk(tool_calls=[
-                _make_tool_call_delta(index=0, tc_id="call_1", name="write_file"),
-            ])
-            yield _make_stream_chunk(tool_calls=[
-                _make_tool_call_delta(
-                    index=0, arguments='{"path": "/tmp/x", "content": "hi"}',
-                ),
-            ])
-            yield _make_stream_chunk(finish_reason="tool_calls")
+            raise _httpx.RemoteProtocolError("incomplete chunked read")
 
         def _pick_stream(*a, **kw):
             attempts["n"] += 1
-            return _first_stream() if attempts["n"] == 1 else _second_stream()
+            return _first_stream()
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.side_effect = _pick_stream
@@ -1663,41 +1719,144 @@ class TestSilentRetryMidToolCall:
             else:
                 _os.environ["HERMES_STREAM_RETRIES"] = _prev
 
-        assert attempts["n"] == 2, (
-            f"Expected silent retry (2 attempts), got {attempts['n']}"
+        assert attempts["n"] == 1, (
+            f"Partial tool-call transport error must not retry, got {attempts['n']} calls"
         )
-        # Response should carry the recovered tool call, not a warning stub.
         msg = response.choices[0].message
-        tool_calls = getattr(msg, "tool_calls", None)
-        assert tool_calls, (
-            f"Silent retry should recover the tool call, got tool_calls={tool_calls!r} "
-            f"content={getattr(msg, 'content', None)!r}"
-        )
-        _tc0 = tool_calls[0]
-        _name = (
-            _tc0["function"]["name"] if isinstance(_tc0, dict)
-            else _tc0.function.name
-        )
-        assert _name == "write_file"
-        # User saw a reconnect marker between attempts.
-        assert any("reconnecting" in d.lower() for d in fired_deltas), (
-            f"Expected a reconnect marker delta, fired_deltas={fired_deltas}"
-        )
-        # Stub-path warning must NOT appear (this was the whole point).
+        assert getattr(msg, "tool_calls", None) is None
         joined = "".join(fired_deltas)
-        assert "Stream stalled" not in joined, (
-            f"Stub-path warning leaked into silent-retry path: {joined!r}"
+        assert "Stream stalled mid tool-call" in joined, (
+            f"Partial tool-call warning was not surfaced: {joined!r}"
         )
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_partial_text_read_error_does_not_retry(self, mock_close, mock_create):
+        """httpx.ReadError after a text delta is terminal, like an incomplete
+        chunked read, and the already generated body is retained."""
+        from run_agent import AIAgent
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+        import httpx as _httpx
+
+        attempts = {"n": 0}
+
+        def _stream():
+            yield _make_stream_chunk(content="The first half")
+            raise _httpx.ReadError("incomplete chunked read")
+
+        def _create(*args, **kwargs):
+            attempts["n"] += 1
+            return _stream()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = _create
+        mock_create.return_value = mock_client
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 1
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].message.content == "The first half"
+        assert response.choices[0].message.tool_calls is None
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_partial_reasoning_read_error_does_not_retry(
+        self, mock_close, mock_create, monkeypatch,
+    ):
+        """A reasoning-only delta is observable and survives without call two."""
+        import httpx as _httpx
+
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+        from run_agent import AIAgent
+
+        def _stream():
+            yield _make_stream_chunk(reasoning_content="Recovered reasoning")
+            raise _httpx.ReadError("incomplete chunked read")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _stream()
+        mock_create.return_value = mock_client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert mock_client.chat.completions.create.call_count == 1
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].message.reasoning_content == "Recovered reasoning"
+        assert response.choices[0].message.tool_calls is None
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_read_error_before_first_delta_retries(
+        self, mock_close, mock_create, monkeypatch,
+    ):
+        """An eventless ReadError keeps the existing bounded retry path."""
+        import httpx as _httpx
+
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+        from run_agent import AIAgent
+
+        attempts = {"n": 0}
+
+        def _create(*_args, **_kwargs):
+            attempts["n"] += 1
+
+            def _stream():
+                if attempts["n"] == 1:
+                    raise _httpx.ReadError("incomplete chunked read")
+                yield _make_stream_chunk(content="Recovered", finish_reason="stop")
+
+            return _stream()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = _create
+        mock_create.return_value = mock_client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 2
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].message.content == "Recovered"
 
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
-    def test_silent_retry_exhausted_falls_back_to_stub(
+    def test_partial_tool_call_transport_error_returns_stub(
         self, mock_close, mock_create, mock_replace,
     ):
-        """When all retry attempts fail with connection errors, fall back
-        to the original stub-with-warning behaviour so the user isn't left
-        with zero signal."""
+        """A partial tool-call transport error returns one warning stub."""
         from run_agent import AIAgent
         import httpx as _httpx
 
@@ -1737,7 +1896,8 @@ class TestSilentRetryMidToolCall:
             else:
                 _os.environ["HERMES_STREAM_RETRIES"] = _prev
 
-        # After retries exhaust, the stub-with-warning path must engage.
+        # The first observed partial immediately takes the warning-stub path.
+        assert mock_client.chat.completions.create.call_count == 1
         content = response.choices[0].message.content or ""
         assert "Stream stalled mid tool-call" in content, (
             f"Exhausted-retry fallback dropped the user-visible warning: {content!r}"


### PR DESCRIPTION
## Summary

- preserve text and reasoning already delivered when an SSE stream ends with a transport error
- do not retry after any observable text, reasoning, preamble, or tool-call delta
- discard incomplete tool calls so they cannot execute, while keeping eventless retries bounded
- treat the recovered partial response as terminal in the conversation loop, including after a real `finish_reason="length"` continuation
- close request-local clients without replacing or closing shared clients

## Root cause

The wrapper discarded generated body content when an `incomplete chunked read` or equivalent transport error arrived after delivery, then retried the provider request. That could duplicate output, billing, or tool side effects. The outer conversation loop could also continue a recovered partial stub and trigger another request.

## Scope

Exactly six files. Codex Responses and Bedrock keep their separate transport/retry implementations and are not claimed as parity in this change.

## Verification

- rebuilt as one commit on upstream `main@202140db53536083b85aba7511c555d07f5ada67`
- focused wrapper regression: 103 passed, 0 failed
- full Python run excluding `seedance` and `seedacne`: 47,958 passed; 110 existing environment/platform failures across 35 untouched files; 5 unrelated oversized files hit the per-file timeout
- all four changed test modules passed again inside the full run: 6 + 28 + 4 + 65 = 103 tests
- three adjacent failures with potential conversation/stream proximity reproduced identically on pristine upstream main
- changed-file Ruff and `git diff --check`: passed
- `ty` diagnostics improved from 51 on pristine main to 44 on the patched files, with no new diagnostics
- Node 22 desktop gate on the prior non-overlapping base: 2,552 passed, 1 skipped, 0 failed; later upstream movement was desktop-only and did not overlap these six files
- independent code review and QA: PASS, no blockers
- exact-path whitelist review for `test_70773_shared_client_fd_corruption.py`: PASS

The remaining local failures are concentrated in macOS `/tmp` canonicalization, Linux/systemd assumptions, DNS/SSRF interception, keychain/config state, and unrelated timing/timeout paths. None of the changed test modules failed.
