### PR TITLE
fix(deps): clear high-severity dependency advisories (#72108)

### DIFF
--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -65,8 +65,11 @@ import secrets
 import stat
 import subprocess
 import sys
+from importlib.metadata import version as _distribution_version
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
+
+from packaging.requirements import Requirement
 
 # Pin the legacy logger name so operator-side log filters keep matching
 # after the in-tree → plugin migration. See adapter.py for context.
@@ -159,9 +162,12 @@ SCOPES: List[str] = [
 
 # Pip packages required for the OAuth flow.
 _REQUIRED_PACKAGES = [
-    "google-api-python-client",
-    "google-auth-oauthlib",
-    "google-auth-httplib2",
+    "google-api-python-client==2.194.0",
+    "google-auth==2.55.1",
+    "google-auth-oauthlib==1.3.1",
+    "google-auth-httplib2==0.3.1",
+    "httplib2==0.32.0",
+    "pyasn1==0.6.4",
 ]
 
 # Out-of-band redirect: Google deprecated the ``urn:ietf:wg:oauth:2.0:oob``
@@ -367,31 +373,44 @@ def _write_private_json(path: Path, data: Any) -> None:
 
 
 def _ensure_deps() -> None:
-    """Check deps available; install if not; exit on failure."""
-    try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
-    except ImportError:
-        if not install_deps():
-            sys.exit(1)
+    """Check exact dependency versions; install if stale; exit on failure."""
+    if _missing_required_packages() and not install_deps():
+        sys.exit(1)
+
+
+def _missing_required_packages() -> List[str]:
+    """Return exact requirements absent or stale in this interpreter."""
+    missing = []
+    for spec in _REQUIRED_PACKAGES:
+        requirement = Requirement(spec)
+        try:
+            installed = _distribution_version(requirement.name)
+            satisfied = requirement.specifier.contains(installed, prereleases=True)
+        except Exception:
+            satisfied = False
+        if not satisfied:
+            missing.append(spec)
+    return missing
 
 
 def install_deps() -> bool:
-    try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
+    missing = _missing_required_packages()
+    if not missing:
         print("Dependencies already installed.")
         return True
-    except ImportError:
-        pass
 
     print("Installing Google Chat OAuth dependencies...")
     try:
         from hermes_cli.tools_config import _pip_install
 
-        result = _pip_install(["--quiet"] + _REQUIRED_PACKAGES)
+        result = _pip_install(["--quiet"] + missing)
         if result.returncode != 0:
             raise RuntimeError((result.stderr or "install failed").strip()[:300])
+        remaining = _missing_required_packages()
+        if remaining:
+            raise RuntimeError(
+                "dependencies remain stale after install: " + " ".join(remaining)
+            )
         print("Dependencies installed.")
         return True
     except Exception as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,12 +103,15 @@ dependencies = [
   # .gitignore-aware file matching for desktop build stamp.
   "pathspec==1.1.1",
   "fastapi>=0.104.0,<1",
+  # FastAPI permits older Starlette releases. Pin the patched floor in core
+  # because supported core-only installs can run the dashboard/serve surface.
+  "starlette==1.3.1",  # GHSA-82w8-qh3p-5jfq, GHSA-wqp7-x3pw-xc5r
   "uvicorn[standard]>=0.24.0,<1",
   # Streaming multipart uploads for the dashboard file manager (NS-501).
   # FastAPI's UploadFile/Form depend on python-multipart; it is NOT pulled in
   # by fastapi itself, so the dashboard's multipart upload endpoint would 500
   # without an explicit dependency here (and in the `web` extra below).
-  "python-multipart>=0.0.9,<1",
+  "python-multipart==0.0.32",
   "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",
   "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
   # Desktop SSH's Windows remote runtime (hermes_cli/windows_ssh_runtime.py)
@@ -118,11 +121,12 @@ dependencies = [
   # Image resize recovery for the vision tools. Pillow shrinks oversized images
   # (>5 MB or >8000px) at embed time; without it the byte AND pixel-dimension
   # shrink paths no-op, so an oversized image bakes into immutable history and
-  # bricks the session on Anthropic's non-retryable 400. Pure-wheel, no system
-  # libs required for the codecs we use, so it's safe to ship in the base
+  # bricks the session on Anthropic's non-retryable 400. Current Linux targets
+  # use wheels, while older-glibc hosts build from source after install.sh
+  # verifies the required compiler/JPEG/zlib headers. It stays in the base
   # install rather than gating it behind an extra + a mid-session lazy install
   # (which deadlocked the CLI under prompt_toolkit — see #40490).
-  "Pillow==12.2.0",
+  "Pillow==12.3.0",
   # Windows log rotation. Stdlib ``RotatingFileHandler.doRollover()`` uses
   # ``os.rename()`` which fails with ``PermissionError [WinError 32]`` on
   # Windows whenever any other process holds an append-mode handle on
@@ -156,7 +160,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.28.1", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.29.0", "slack-sdk==3.43.0", "aiohttp==3.14.1"]
@@ -201,7 +205,7 @@ pty = []
 # `request.url` can be bypassed. We pin a patched Starlette directly in every
 # extra that exposes a Starlette-backed server surface so pip/uv can't resolve
 # a vulnerable pre-1.0.1 transitive. Bump in lockstep with uv.lock.
-mcp = ["mcp==1.26.0", "starlette==1.3.1"]  # starlette: CVE-2026-48710
+mcp = ["mcp==1.28.1", "starlette==1.3.1"]  # starlette: CVE-2026-48710
 nemo-relay = ["nemo-relay>=0.5,<1.0"]
 homeassistant = ["aiohttp==3.14.1"]
 sms = ["aiohttp==3.14.1"]
@@ -210,7 +214,7 @@ teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"]  # aiohttp 3.14.1:
 # The cua-driver binary itself is installed via `hermes tools` post-setup
 # (curl install script); this extra just pins the MCP client used to talk
 # to it, which is already provided by the `mcp` extra.
-computer-use = ["mcp==1.26.0", "starlette==1.3.1"]  # starlette: CVE-2026-48710
+computer-use = ["mcp==1.28.1", "starlette==1.3.1"]  # starlette: CVE-2026-48710
 acp = ["agent-client-protocol==0.9.0"]
 # mistral: Voxtral STT + TTS. Pinned to an exact verified-clean version.
 # The `mistralai` PyPI project was quarantined 2026-05-12 after the malicious
@@ -222,7 +226,7 @@ acp = ["agent-client-protocol==0.9.0"]
 # installs (see [all] policy comment below).
 mistral = ["mistralai==2.4.8"]
 bedrock = ["boto3==1.42.89"]
-vertex = ["google-auth==2.55.1"]
+vertex = ["google-auth==2.55.1", "pyasn1==0.6.4"]
 azure-identity = ["azure-identity==1.25.3"]
 termux = [
   # Baseline Android / Termux path for reliable fresh installs.
@@ -253,8 +257,13 @@ google = [
   # and packagers ship them without hitting runtime `pip install` paths that
   # fail in environments without pip (e.g. Nix-managed Python).
   "google-api-python-client==2.194.0",
+  "google-auth==2.55.1",
   "google-auth-oauthlib==1.3.1",
   "google-auth-httplib2==0.3.1",
+  # The Google SDKs permit older vulnerable transitives, so unlocked installs
+  # must carry the same fixed floors as uv.lock and the runtime installers.
+  "httplib2==0.32.0",
+  "pyasn1==0.6.4",
 ]
 youtube = [
   # Required by skills/media/youtube-content and

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1435,32 +1435,14 @@ install_deps() {
         export VIRTUAL_ENV="$INSTALL_DIR/venv"
     fi
 
-    # On Debian/Ubuntu (including WSL), some Python packages need build tools.
-    # Check and offer to install them if missing.
-    if [ "$DISTRO" = "ubuntu" ] || [ "$DISTRO" = "debian" ]; then
-        local need_build_tools=false
-        for pkg in gcc python3-dev libffi-dev; do
-            if ! dpkg -s "$pkg" &>/dev/null; then
-                need_build_tools=true
-                break
-            fi
-        done
-        if [ "$need_build_tools" = true ]; then
-            log_info "Some build tools may be needed for Python packages..."
-            if command -v sudo &> /dev/null; then
-                if sudo -n true 2>/dev/null; then
-                    sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1 || true
-                    log_success "Build tools installed"
-                else
-                    log_info "sudo is needed ONLY to install build tools (build-essential, python3-dev, libffi-dev) via apt."
-                    log_info "Hermes Agent itself does not require or retain root access."
-                    if prompt_yes_no "Install build tools?" "yes"; then
-                        sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1 || true
-                        log_success "Build tools installed"
-                    fi
-                fi
-            fi
-        fi
+    if ! source "$INSTALL_DIR/scripts/lib/pillow_source_build.sh"; then
+        log_error "Cannot load Pillow compatibility checks."
+        return 1
+    fi
+
+    if ! prepare_python_build_environment; then
+        log_error "Aborting dependency installation: Pillow source-build prerequisites are unavailable."
+        return 1
     fi
 
     # Install the main package in editable mode with all extras.

--- a/scripts/lib/pillow_source_build.sh
+++ b/scripts/lib/pillow_source_build.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+
+# Pillow 12.3 publishes Linux wheels for x86_64/aarch64 at glibc >= 2.27
+# (manylinux_2_27) and musl >= 1.2. Older glibc releases such as RHEL 7 must
+# build it from source. Keep this check local and deterministic rather than
+# relying on a resolver/network failure to reveal the missing wheel midway
+# through the main dependency install.
+pillow_linux_wheel_compatible() {
+    local arch="$1"
+    local libc_name="$2"
+    local libc_version="$3"
+    local major="${libc_version%%.*}"
+    local rest="${libc_version#*.}"
+    local minor="${rest%%.*}"
+
+    case "$arch" in
+        x86_64|amd64|aarch64|arm64) ;;
+        *) return 1 ;;
+    esac
+    case "$major" in ''|*[!0-9]*) return 1 ;; esac
+    case "$minor" in ''|*[!0-9]*) return 1 ;; esac
+
+    case "$libc_name" in
+        glibc|GNU)
+            [ "$major" -gt 2 ] || {
+                [ "$major" -eq 2 ] && [ "$minor" -ge 27 ]
+            }
+            ;;
+        musl)
+            [ "$major" -gt 1 ] || {
+                [ "$major" -eq 1 ] && [ "$minor" -ge 2 ]
+            }
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+pillow_source_build_required() {
+    [ "$OS" = "linux" ] || return 1
+
+    local libc_info libc_name="" libc_version="" gnu_libc musl_info
+
+    # Query the host first. platform.libc_ver() may describe the libc baseline
+    # used to build the selected interpreter instead of the libc on this host.
+    gnu_libc="$(getconf GNU_LIBC_VERSION 2>/dev/null || true)"
+    case "$gnu_libc" in
+        "glibc "*) libc_name="glibc"; libc_version="${gnu_libc#glibc }" ;;
+    esac
+
+    # Python before 3.14 does not reliably identify musl via platform.libc_ver,
+    # so probe ldd directly before using the interpreter fallback.
+    if [ -z "$libc_name" ] || [ -z "$libc_version" ]; then
+        musl_info="$(ldd --version 2>&1 || true)"
+        case "$musl_info" in
+            *musl*)
+                libc_name="musl"
+                libc_version="$(
+                    printf '%s\n' "$musl_info" \
+                        | sed -n 's/^Version \([0-9][0-9.]*\).*$/\1/p' \
+                        | head -n 1
+                )"
+                ;;
+        esac
+    fi
+
+    # Fall back to the interpreter probe only when host tools did not identify
+    # either glibc or musl.
+    if [ -z "$libc_name" ] || [ -z "$libc_version" ]; then
+        libc_info="$(
+            "$PYTHON_PATH" - <<'PY' 2>/dev/null
+import platform
+
+name, version = platform.libc_ver()
+print(f"{name}|{version}")
+PY
+        )" || true
+        libc_name="${libc_info%%|*}"
+        libc_version="${libc_info#*|}"
+    fi
+
+    if pillow_linux_wheel_compatible "$(uname -m)" "$libc_name" "$libc_version"; then
+        return 1
+    fi
+    return 0
+}
+
+pillow_python_headers_ready() {
+    "$PYTHON_PATH" - <<'PY' >/dev/null 2>&1
+from pathlib import Path
+import sysconfig
+
+candidates = (
+    sysconfig.get_path("include"),
+    sysconfig.get_path("platinclude"),
+    sysconfig.get_config_var("INCLUDEPY"),
+)
+seen = set()
+for include_dir in candidates:
+    if not include_dir or include_dir in seen:
+        continue
+    seen.add(include_dir)
+    if (Path(include_dir) / "Python.h").is_file():
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+pillow_source_build_ready() {
+    local compiler
+    compiler="$(command -v cc 2>/dev/null || command -v gcc 2>/dev/null || true)"
+    [ -n "$compiler" ] || return 1
+
+    # The selected interpreter must expose Python.h, and the compiler must be
+    # able to compile and link both required Pillow codecs. This detects the
+    # actual capability instead of trusting package-manager state alone.
+    pillow_python_headers_ready || return 1
+    printf '%s\n' \
+        '#include <zlib.h>' \
+        'int main(void) { return zlibVersion() == 0; }' \
+        | "$compiler" -x c - -o /dev/null -lz >/dev/null 2>&1 || return 1
+    printf '%s\n' \
+        '#include <stddef.h>' \
+        '#include <stdio.h>' \
+        '#include <jpeglib.h>' \
+        'int main(void) { struct jpeg_error_mgr e; return jpeg_std_error(&e) == 0; }' \
+        | "$compiler" -x c - -o /dev/null -ljpeg >/dev/null 2>&1 || return 1
+}
+
+prepare_pillow_source_build() {
+    pillow_source_build_required || return 0
+
+    log_info "Pillow 12.3 has no compatible wheel for this Linux/libc; checking source-build prerequisites..."
+    if pillow_source_build_ready; then
+        log_success "Pillow source-build prerequisites found"
+        return 0
+    fi
+
+    local package_manager=""
+    local packages=""
+    local install_hint=""
+    case "$DISTRO" in
+        ubuntu|debian)
+            package_manager="apt-get"
+            packages="build-essential python3-dev libffi-dev libjpeg-dev zlib1g-dev"
+            install_hint="sudo apt-get update && sudo apt-get install -y $packages"
+            ;;
+        fedora|rhel|centos|rocky|almalinux|ol|amzn)
+            if command -v dnf >/dev/null 2>&1; then
+                package_manager="dnf"
+            elif command -v yum >/dev/null 2>&1; then
+                package_manager="yum"
+            fi
+            packages="gcc python3-devel libffi-devel libjpeg-turbo-devel zlib-devel"
+            install_hint="sudo ${package_manager:-dnf} install -y $packages"
+            ;;
+    esac
+
+    log_warn "Pillow 12.3 must be built from source on this host, but its compiler/JPEG/zlib prerequisites are missing."
+    if [ -z "$package_manager" ]; then
+        log_error "Cannot provision Pillow source-build prerequisites for distro '$DISTRO'."
+        log_info "Install a C compiler, Python development headers, libjpeg development headers, and zlib development headers, then re-run this installer."
+        return 1
+    fi
+
+    local install_requested=false
+    if [ "$(id -u)" -eq 0 ]; then
+        install_requested=true
+    elif command -v sudo >/dev/null 2>&1; then
+        log_info "The installer itself does not require or retain root access."
+        if prompt_yes_no "Install required Pillow source-build packages ($packages)? (requires sudo)" "no"; then
+            install_requested=true
+        fi
+    fi
+
+    if [ "$install_requested" = true ]; then
+        log_info "Installing Pillow source-build prerequisites..."
+        local install_succeeded=false
+        case "$package_manager" in
+            apt-get)
+                if [ "$(id -u)" -eq 0 ]; then
+                    if DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq \
+                        && DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq $packages; then
+                        install_succeeded=true
+                    fi
+                else
+                    if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq \
+                        && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq $packages; then
+                        install_succeeded=true
+                    fi
+                fi
+                ;;
+            dnf|yum)
+                if [ "$(id -u)" -eq 0 ]; then
+                    if "$package_manager" install -y $packages; then
+                        install_succeeded=true
+                    fi
+                else
+                    if sudo "$package_manager" install -y $packages; then
+                        install_succeeded=true
+                    fi
+                fi
+                ;;
+        esac
+        if [ "$install_succeeded" = false ]; then
+            log_error "Could not install Pillow source-build prerequisites."
+            log_info "Install them manually, then re-run this installer:"
+            log_info "  $install_hint"
+            return 1
+        fi
+    else
+        log_error "Pillow source-build prerequisites were not installed."
+        log_info "Install them manually, then re-run this installer:"
+        log_info "  $install_hint"
+        return 1
+    fi
+
+    if ! pillow_source_build_ready; then
+        log_error "Pillow source-build prerequisites are still unavailable after package installation."
+        log_info "Verify the compiler and development libraries, then re-run:"
+        log_info "  $install_hint"
+        return 1
+    fi
+    log_success "Pillow source-build prerequisites installed"
+}
+
+prepare_python_build_environment() {
+    local pillow_needs_source=false
+    if pillow_source_build_required; then
+        pillow_needs_source=true
+    fi
+
+    # A source build needs everything in the normal Debian build-tool prompt
+    # plus Pillow's codec headers. Let the Pillow provisioner own that single
+    # transaction so an older host never sees two overlapping prompts.
+    if [ "$pillow_needs_source" = true ]; then
+        prepare_pillow_source_build
+        return $?
+    fi
+
+    # On Debian/Ubuntu (including WSL), some other Python packages may need
+    # build tools even when Pillow itself has a compatible wheel.
+    if [ "$DISTRO" = "ubuntu" ] || [ "$DISTRO" = "debian" ]; then
+        local need_build_tools=false
+        local build_tool_probe_packages="gcc python3-dev libffi-dev"
+        local build_tool_install_packages="build-essential python3-dev libffi-dev"
+        local pkg
+        for pkg in $build_tool_probe_packages; do
+            if ! dpkg -s "$pkg" &>/dev/null; then
+                need_build_tools=true
+                break
+            fi
+        done
+        if [ "$need_build_tools" = true ]; then
+            log_info "Some build tools may be needed for Python packages..."
+            if [ "$(id -u)" -eq 0 ]; then
+                if DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq \
+                    && DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq $build_tool_install_packages >/dev/null 2>&1; then
+                    log_success "Build tools installed"
+                else
+                    log_warn "Could not install build tools automatically; some Python packages may fail to build."
+                fi
+            elif command -v sudo &>/dev/null; then
+                if sudo -n true 2>/dev/null; then
+                    if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq \
+                        && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq $build_tool_install_packages >/dev/null 2>&1; then
+                        log_success "Build tools installed"
+                    else
+                        log_warn "Could not install build tools automatically; some Python packages may fail to build."
+                    fi
+                else
+                    log_info "sudo is needed ONLY to install build tools ($build_tool_install_packages) via apt."
+                    log_info "Hermes Agent itself does not require or retain root access."
+                    if prompt_yes_no "Install build tools?" "yes"; then
+                        if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq \
+                            && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq $build_tool_install_packages >/dev/null 2>&1; then
+                            log_success "Build tools installed"
+                        else
+                            log_warn "Could not install build tools automatically; some Python packages may fail to build."
+                        fi
+                    fi
+                fi
+            fi
+        fi
+    fi
+}

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -29,7 +29,10 @@ import os
 import shutil
 import subprocess
 import sys
+from importlib.metadata import version as _distribution_version
 from pathlib import Path
+
+from packaging.requirements import Requirement
 
 # Ensure sibling modules (_hermes_home) are importable when run standalone.
 _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
@@ -54,7 +57,14 @@ SCOPES = [
     "https://www.googleapis.com/auth/documents",
 ]
 
-REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
+REQUIRED_PACKAGES = [
+    "google-api-python-client==2.194.0",
+    "google-auth==2.55.1",
+    "google-auth-oauthlib==1.3.1",
+    "google-auth-httplib2==0.3.1",
+    "httplib2==0.32.0",
+    "pyasn1==0.6.4",
+]
 
 # OAuth redirect for "out of band" manual code copy flow.
 # Google deprecated OOB, so we use a localhost redirect and tell the user to
@@ -93,24 +103,40 @@ def _format_missing_scopes(missing_scopes: list[str]) -> str:
     )
 
 
+def _missing_required_packages() -> list[str]:
+    """Return exact requirements absent or stale in this interpreter."""
+    missing = []
+    for spec in REQUIRED_PACKAGES:
+        requirement = Requirement(spec)
+        try:
+            installed = _distribution_version(requirement.name)
+            satisfied = requirement.specifier.contains(installed, prereleases=True)
+        except Exception:
+            satisfied = False
+        if not satisfied:
+            missing.append(spec)
+    return missing
+
+
 def install_deps():
-    """Install Google API packages if missing. Returns True on success."""
-    try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
+    """Install missing or stale Google API packages. Returns True on success."""
+    missing = _missing_required_packages()
+    if not missing:
         print("Dependencies already installed.")
         return True
-    except ImportError:
-        pass
 
     print("Installing Google API dependencies...")
 
     # First choice: pip in the current interpreter. Works for most installs.
     try:
         subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "--quiet"] + REQUIRED_PACKAGES,
+            [sys.executable, "-m", "pip", "install", "--quiet"] + missing,
             stdout=subprocess.DEVNULL,
         )
+        remaining = _missing_required_packages()
+        if remaining:
+            print(f"ERROR: Dependencies remain stale after pip install: {' '.join(remaining)}")
+            return False
         print("Dependencies installed.")
         return True
     except subprocess.CalledProcessError as e:
@@ -126,9 +152,13 @@ def install_deps():
         try:
             subprocess.check_call(
                 [uv, "pip", "install", "--python", sys.executable, "--quiet"]
-                + REQUIRED_PACKAGES,
+                + missing,
                 stdout=subprocess.DEVNULL,
             )
+            remaining = _missing_required_packages()
+            if remaining:
+                print(f"ERROR: Dependencies remain stale after uv install: {' '.join(remaining)}")
+                return False
             print("Dependencies installed.")
             return True
         except subprocess.CalledProcessError as e:
@@ -147,13 +177,9 @@ def install_deps():
 
 
 def _ensure_deps():
-    """Check deps are available, install if not, exit on failure."""
-    try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
-    except ImportError:
-        if not install_deps():
-            sys.exit(1)
+    """Check exact dependency versions, install if stale, exit on failure."""
+    if _missing_required_packages() and not install_deps():
+        sys.exit(1)
 
 
 def check_auth_live():

--- a/tests/gateway/test_google_chat_oauth_dependencies.py
+++ b/tests/gateway/test_google_chat_oauth_dependencies.py
@@ -1,0 +1,76 @@
+"""Security-floor tests for the Google Chat OAuth runtime installer."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from types import SimpleNamespace
+
+from plugins.platforms.google_chat import oauth
+
+
+EXPECTED_PACKAGES = {
+    "google-api-python-client==2.194.0",
+    "google-auth==2.55.1",
+    "google-auth-oauthlib==1.3.1",
+    "google-auth-httplib2==0.3.1",
+    "httplib2==0.32.0",
+    "pyasn1==0.6.4",
+}
+
+
+def test_runtime_installer_exact_pins_all_google_security_dependencies():
+    assert set(oauth._REQUIRED_PACKAGES) == EXPECTED_PACKAGES
+
+
+def test_stale_google_transitives_are_reported_missing(monkeypatch):
+    installed = {
+        "google-api-python-client": "2.194.0",
+        "google-auth": "2.55.0",
+        "google-auth-oauthlib": "1.3.1",
+        "google-auth-httplib2": "0.3.1",
+        "httplib2": "0.31.2",
+        "pyasn1": "0.6.3",
+    }
+
+    def fake_version(name):
+        try:
+            return installed[name]
+        except KeyError:
+            raise PackageNotFoundError(name) from None
+
+    monkeypatch.setattr(oauth, "_distribution_version", fake_version)
+
+    assert oauth._missing_required_packages() == [
+        "google-auth==2.55.1",
+        "httplib2==0.32.0",
+        "pyasn1==0.6.4",
+    ]
+
+
+def test_installer_repairs_stale_transitives(monkeypatch):
+    states = iter(
+        [
+            [
+                "google-auth==2.55.1",
+                "httplib2==0.32.0",
+                "pyasn1==0.6.4",
+            ],
+            [],
+        ]
+    )
+    monkeypatch.setattr(oauth, "_missing_required_packages", lambda: next(states))
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._pip_install",
+        lambda argv: calls.append(argv) or SimpleNamespace(returncode=0, stderr=""),
+    )
+
+    assert oauth.install_deps() is True
+    assert calls == [
+        [
+            "--quiet",
+            "google-auth==2.55.1",
+            "httplib2==0.32.0",
+            "pyasn1==0.6.4",
+        ]
+    ]

--- a/tests/skills/test_google_workspace_setup.py
+++ b/tests/skills/test_google_workspace_setup.py
@@ -1,0 +1,103 @@
+"""Security-floor tests for the Google Workspace runtime installer."""
+
+from __future__ import annotations
+
+import importlib.util
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+
+import pytest
+
+
+SETUP_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts/setup.py"
+)
+
+EXPECTED_PACKAGES = {
+    "google-api-python-client==2.194.0",
+    "google-auth==2.55.1",
+    "google-auth-oauthlib==1.3.1",
+    "google-auth-httplib2==0.3.1",
+    "httplib2==0.32.0",
+    "pyasn1==0.6.4",
+}
+
+
+@pytest.fixture()
+def setup_module():
+    spec = importlib.util.spec_from_file_location(
+        "test_google_workspace_setup_module",
+        SETUP_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_runtime_installer_exact_pins_all_google_security_dependencies(setup_module):
+    assert set(setup_module.REQUIRED_PACKAGES) == EXPECTED_PACKAGES
+
+
+def test_stale_google_transitives_are_reported_missing(setup_module, monkeypatch):
+    installed = {
+        "google-api-python-client": "2.194.0",
+        "google-auth": "2.55.0",
+        "google-auth-oauthlib": "1.3.1",
+        "google-auth-httplib2": "0.3.1",
+        "httplib2": "0.31.2",
+        "pyasn1": "0.6.3",
+    }
+
+    def fake_version(name):
+        try:
+            return installed[name]
+        except KeyError:
+            raise PackageNotFoundError(name) from None
+
+    monkeypatch.setattr(setup_module, "_distribution_version", fake_version)
+
+    assert setup_module._missing_required_packages() == [
+        "google-auth==2.55.1",
+        "httplib2==0.32.0",
+        "pyasn1==0.6.4",
+    ]
+
+
+def test_installer_repairs_stale_transitives(setup_module, monkeypatch):
+    states = iter(
+        [
+            [
+                "google-auth==2.55.1",
+                "httplib2==0.32.0",
+                "pyasn1==0.6.4",
+            ],
+            [],
+        ]
+    )
+    monkeypatch.setattr(
+        setup_module,
+        "_missing_required_packages",
+        lambda: next(states),
+    )
+    calls = []
+    monkeypatch.setattr(
+        setup_module.subprocess,
+        "check_call",
+        lambda argv, **kwargs: calls.append(argv),
+    )
+
+    assert setup_module.install_deps() is True
+    assert calls == [
+        [
+            setup_module.sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "google-auth==2.55.1",
+            "httplib2==0.32.0",
+            "pyasn1==0.6.4",
+        ]
+    ]

--- a/tests/test_install_sh_pillow_source_build.py
+++ b/tests/test_install_sh_pillow_source_build.py
@@ -1,0 +1,249 @@
+"""Behavioral tests for Pillow 12.3 source builds on older Linux hosts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PILLOW_HELPERS = REPO_ROOT / "scripts" / "lib" / "pillow_source_build.sh"
+
+
+def _run_bash(body: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", f"source {shlex.quote(str(PILLOW_HELPERS))}\n{body}"],
+        cwd=REPO_ROOT,
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_pillow_12_3_linux_wheel_floor() -> None:
+    """The compatibility predicate matches Pillow 12.3's published wheel tags."""
+    result = _run_bash(
+        """
+set -u
+pillow_linux_wheel_compatible x86_64 glibc 2.17; echo "rhel7=$?"
+pillow_linux_wheel_compatible x86_64 glibc 2.27; echo "glibc227=$?"
+pillow_linux_wheel_compatible aarch64 musl 1.2; echo "musl12=$?"
+pillow_linux_wheel_compatible ppc64le glibc 2.39; echo "ppc64le=$?"
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "rhel7=1",
+        "glibc227=0",
+        "musl12=0",
+        "ppc64le=1",
+    ]
+
+
+def test_host_getconf_glibc_takes_precedence_over_python_build_baseline() -> None:
+    """Wheel selection uses the host glibc even when Python has an older baseline."""
+    result = _run_bash(
+        """
+set -u
+OS=linux
+PYTHON_PATH=python_probe
+getconf() { printf 'glibc 2.39\n'; }
+uname() { printf 'x86_64\n'; }
+python_probe() { echo "PYTHON_FALLBACK_RAN"; return 99; }
+pillow_source_build_required
+printf 'source_required=%s\n' "$?"
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["source_required=1"]
+
+
+def test_musl_falls_back_to_interpreter_probe() -> None:
+    """A non-glibc host uses the bounded interpreter fallback when needed."""
+    result = _run_bash(
+        """
+set -u
+OS=linux
+PYTHON_PATH=python_probe
+getconf() { return 1; }
+ldd() { printf 'not a dynamic executable\n'; return 1; }
+uname() { printf 'aarch64\n'; }
+python_probe() { cat >/dev/null; printf 'musl|1.2\n'; }
+pillow_source_build_required
+printf 'source_required=%s\n' "$?"
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["source_required=1"]
+
+
+def test_musl_host_probe_precedes_pre_3_14_python_fallback() -> None:
+    """Compatible musl hosts do not need Python 3.14 libc detection."""
+    result = _run_bash(
+        """
+set -u
+OS=linux
+PYTHON_PATH=python_probe
+getconf() { return 1; }
+ldd() { printf 'musl libc (x86_64)\nVersion 1.2.5\n'; return 1; }
+uname() { printf 'x86_64\n'; }
+python_probe() { echo "PYTHON_FALLBACK_RAN"; return 99; }
+pillow_source_build_required
+printf 'source_required=%s\n' "$?"
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["source_required=1"]
+
+
+def test_python_header_probe_checks_platinclude_and_includepy(
+    tmp_path: Path,
+) -> None:
+    """Alternate interpreter layouts can expose Python.h outside ``include``."""
+    python_h = tmp_path / "alternate" / "Python.h"
+    python_h.parent.mkdir()
+    python_h.touch()
+
+    for candidate_kind in ("include", "platinclude", "INCLUDEPY"):
+        fake_stdlib = tmp_path / candidate_kind
+        fake_stdlib.mkdir()
+        path_value = (
+            f"CANDIDATE if name == {candidate_kind!r} else None"
+            if candidate_kind != "INCLUDEPY"
+            else "None"
+        )
+        config_value = (
+            "CANDIDATE if name == 'INCLUDEPY' else None"
+            if candidate_kind == "INCLUDEPY"
+            else "None"
+        )
+        (fake_stdlib / "sysconfig.py").write_text(
+            "\n".join([
+                f"CANDIDATE = {str(python_h.parent)!r}",
+                "def get_path(name):",
+                f"    return {path_value}",
+                "def get_config_var(name):",
+                f"    return {config_value}",
+            ]),
+            encoding="utf-8",
+        )
+        result = _run_bash(
+            f"""
+set -u
+PYTHON_PATH={shlex.quote(sys.executable)}
+PYTHONPATH={shlex.quote(str(fake_stdlib))}
+export PYTHONPATH
+pillow_python_headers_ready
+"""
+        )
+        assert result.returncode == 0, (
+            f"{candidate_kind} was not checked: {result.stderr}"
+        )
+
+
+def test_missing_debian_prerequisites_fail_with_actionable_command() -> None:
+    """A non-interactive older Debian host never escalates privileges itself."""
+    result = _run_bash(
+        """
+set -u
+DISTRO=debian
+NON_INTERACTIVE=true
+IS_INTERACTIVE=false
+pillow_source_build_required() { return 0; }
+pillow_source_build_ready() { return 1; }
+log_info() { printf 'INFO:%s\n' "$1"; }
+log_warn() { printf 'WARN:%s\n' "$1"; }
+log_error() { printf 'ERROR:%s\n' "$1"; }
+prompt_yes_no() { return 1; }
+id() { [ "$1" = "-u" ] && echo 1000; }
+sudo() { echo "UNSAFE_SUDO:$*"; return 99; }
+prepare_python_build_environment
+"""
+    )
+    assert result.returncode == 1
+    assert "UNSAFE_SUDO" not in result.stdout
+    assert (
+        "sudo apt-get update && sudo apt-get install -y "
+        "build-essential python3-dev libffi-dev libjpeg-dev zlib1g-dev"
+    ) in result.stdout
+
+
+def test_missing_rhel_prerequisites_fail_with_actionable_command() -> None:
+    """RHEL-family diagnostics name the codec headers required by Pillow."""
+    result = _run_bash(
+        """
+set -u
+DISTRO=rocky
+pillow_source_build_required() { return 0; }
+pillow_source_build_ready() { return 1; }
+log_info() { printf 'INFO:%s\n' "$1"; }
+log_warn() { printf 'WARN:%s\n' "$1"; }
+log_error() { printf 'ERROR:%s\n' "$1"; }
+prompt_yes_no() { return 1; }
+id() { [ "$1" = "-u" ] && echo 1000; }
+dnf() { :; }
+sudo() { echo "UNSAFE_SUDO:$*"; return 99; }
+prepare_python_build_environment
+"""
+    )
+    assert result.returncode == 1
+    assert "UNSAFE_SUDO" not in result.stdout
+    assert (
+        "sudo dnf install -y "
+        "gcc python3-devel libffi-devel libjpeg-turbo-devel zlib-devel"
+    ) in result.stdout
+
+
+def test_compatible_wheel_keeps_normal_debian_build_tool_path() -> None:
+    """Compatible-wheel hosts preserve the installer's existing build-tool setup."""
+    result = _run_bash(
+        """
+set -u
+DISTRO=debian
+TRACE="$(mktemp)"
+pillow_source_build_required() { printf 'WHEEL_CHECK\n'; return 1; }
+dpkg() { printf 'DPKG:%s\n' "$*" >>"$TRACE"; return 1; }
+id() { [ "$1" = "-u" ] && echo 0; }
+apt-get() { printf 'APT:%s\n' "$*" >>"$TRACE"; }
+log_info() { printf 'INFO:%s\n' "$1"; }
+log_success() { printf 'SUCCESS:%s\n' "$1"; }
+log_warn() { printf 'WARN:%s\n' "$1"; }
+prepare_python_build_environment
+cat "$TRACE"
+rm -f "$TRACE"
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "WHEEL_CHECK",
+        "INFO:Some build tools may be needed for Python packages...",
+        "SUCCESS:Build tools installed",
+        "DPKG:-s gcc",
+        "APT:update -qq",
+        "APT:install -y -qq build-essential python3-dev libffi-dev",
+    ]
+
+
+def test_source_build_uses_one_provisioning_path_before_resolver() -> None:
+    """Older Debian hosts use the Pillow transaction and stop on its failure."""
+    result = _run_bash(
+        """
+set -u
+DISTRO=debian
+pillow_source_build_required() { printf 'SOURCE_REQUIRED\n'; return 0; }
+prepare_pillow_source_build() { printf 'PILLOW_PROVISION\n'; return 1; }
+dpkg() { printf 'UNEXPECTED_DPKG\n'; return 1; }
+prepare_python_build_environment
+printf 'result=%s\n' "$?"
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "SOURCE_REQUIRED",
+        "PILLOW_PROVISION",
+        "result=1",
+    ]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -4,6 +4,7 @@ import tomllib
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -62,8 +63,9 @@ def test_faster_whisper_is_not_a_base_dependency():
 # authz in middleware/endpoints that gate on ``request.url``. Starlette is a
 # transitive dep (fastapi in [web]; sse-starlette/mcp in [mcp]/[computer-use]/
 # [dev]) so we pin it directly in every extra that exposes a server surface and
-# enforce the floor in both pyproject and the committed lockfile.
-_STARLETTE_CVE_FLOOR = (1, 0, 1)
+# enforce the current reviewed floor in both pyproject and the committed
+# lockfile.
+_STARLETTE_CVE_FLOOR = (1, 3, 1)
 _UPDATE_DOWNGRADE_GUARD_FLOORS = {
     # `hermes update` reinstalls exact pins from pyproject/lazy_deps. These
     # reviewed CVE pins must not slide back to stale versions that downgrade
@@ -74,33 +76,44 @@ _UPDATE_DOWNGRADE_GUARD_FLOORS = {
 }
 
 
-def _version_tuple(spec: str) -> tuple[int, ...]:
-    # "1.0.1" -> (1, 0, 1); tolerant of pre/post suffixes by truncating.
-    head = spec.split("+", 1)[0]
-    parts = []
-    for chunk in head.split("."):
-        digits = "".join(ch for ch in chunk if ch.isdigit())
-        if not digits:
-            break
-        parts.append(int(digits))
-    return tuple(parts)
+def _version_below_floor(version: str, floor: tuple[int, ...]) -> bool:
+    """Compare dependency versions with PEP 440 prerelease semantics."""
+    return Version(version) < Version(".".join(map(str, floor)))
 
 
-def test_starlette_pinned_above_cve_2026_48710_floor_in_pyproject():
-    """Every extra that declares Starlette must pin a patched (>=1.0.1) version.
+def test_security_floor_comparison_rejects_prereleases() -> None:
+    assert _version_below_floor("1.3.1rc1", (1, 3, 1))
 
-    Regression guard for #35067 / CVE-2026-48710. A future edit that drops the
+
+def test_starlette_pinned_above_current_security_floor_in_pyproject():
+    """Core and every server extra must exact-pin patched Starlette.
+
+    Regression guard for #35067 and #72108. A future edit that drops the
     pin (re-exposing the unbounded transitive ``starlette>=0.27`` from mcp /
-    ``>=0.40.0`` from fastapi) or pins a pre-1.0.1 version fails here instead of
-    shipping a Host-header auth-bypass to dashboard / MCP-HTTP users.
+    ``>=0.40.0`` from fastapi) or pins a pre-1.3.1 version fails here instead of
+    shipping a known-vulnerable server dependency to dashboard / MCP users.
     """
     data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    core = data["project"]["dependencies"]
     extras = data["project"]["optional-dependencies"]
+
+    expected = f"starlette=={'.'.join(map(str, _STARLETTE_CVE_FLOOR))}"
+    assert expected in core, (
+        "core dependencies must exact-pin the Starlette security floor because "
+        "core FastAPI installs otherwise admit a stale vulnerable transitive"
+    )
 
     found = {}
     for extra, specs in extras.items():
         for spec in specs:
-            name = spec.split("==", 1)[0].split(">", 1)[0].split("<", 1)[0].split("[", 1)[0].strip()
+            name = (
+                spec
+                .split("==", 1)[0]
+                .split(">", 1)[0]
+                .split("<", 1)[0]
+                .split("[", 1)[0]
+                .strip()
+            )
             if name.lower() == "starlette":
                 assert "==" in spec, f"[{extra}] must exact-pin starlette, got {spec!r}"
                 ver = spec.split("==", 1)[1].split(";", 1)[0].strip()
@@ -109,44 +122,40 @@ def test_starlette_pinned_above_cve_2026_48710_floor_in_pyproject():
     # The four server-surface extras must each carry the direct pin.
     for extra in ("web", "mcp", "computer-use", "dev"):
         assert extra in found, (
-            f"[{extra}] no longer pins starlette directly — CVE-2026-48710 "
-            f"regression risk (mcp/fastapi pull it transitively with no upper bound)"
+            f"[{extra}] no longer pins starlette directly — security regression "
+            f"risk (mcp/fastapi pull it transitively with no upper bound)"
         )
 
     for extra, ver in found.items():
-        assert _version_tuple(ver) >= _STARLETTE_CVE_FLOOR, (
-            f"[{extra}] pins starlette=={ver}, below the CVE-2026-48710 fix "
-            f"floor {'.'.join(map(str, _STARLETTE_CVE_FLOOR))}"
+        assert not _version_below_floor(ver, _STARLETTE_CVE_FLOOR), (
+            f"[{extra}] pins starlette=={ver}, below the current security floor "
+            f"{'.'.join(map(str, _STARLETTE_CVE_FLOOR))}"
         )
 
 
-def test_locked_starlette_is_not_vulnerable_to_cve_2026_48710():
-    """The committed uv.lock must resolve starlette to a patched version.
+def test_locked_dependencies_clear_issue_72108_high_advisories():
+    """The hash-verified install must retain every #72108 security floor."""
+    minimums = {
+        "cryptography": (48, 0, 1),
+        "httplib2": (0, 32, 0),
+        "mcp": (1, 28, 1),
+        "pillow": (12, 3, 0),
+        "pyasn1": (0, 6, 4),
+        "python-multipart": (0, 0, 32),
+        "starlette": _STARLETTE_CVE_FLOOR,
+    }
+    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    locked: dict[str, list[str]] = {}
+    for package in lock["package"]:
+        locked.setdefault(package["name"].lower(), []).append(package["version"])
 
-    pyproject pins protect the declared extras, but the lockfile is what
-    hash-verified installs (``uv sync --locked``) actually pull. Assert the
-    resolved version is >= the CVE-2026-48710 fix floor so a stale-lock
-    regression can't ship a vulnerable Starlette to users.
-    """
-    lock = (REPO_ROOT / "uv.lock").read_text(encoding="utf-8")
-    versions = []
-    in_starlette = False
-    for line in lock.splitlines():
-        if line.startswith("[[package]]"):
-            in_starlette = False
-        elif line.strip() == 'name = "starlette"':
-            in_starlette = True
-        elif in_starlette and line.startswith("version = "):
-            versions.append(line.split("=", 1)[1].strip().strip('"'))
-            in_starlette = False
-
-    assert versions, "starlette not found in uv.lock"
-    for ver in versions:
-        assert _version_tuple(ver) >= _STARLETTE_CVE_FLOOR, (
-            f"uv.lock resolves starlette=={ver}, below the CVE-2026-48710 fix "
-            f"floor {'.'.join(map(str, _STARLETTE_CVE_FLOOR))} — regenerate the "
-            f"lockfile after bumping the pin"
-        )
+    for package, floor in minimums.items():
+        assert package in locked, f"{package} not found in uv.lock"
+        for version in locked[package]:
+            assert not _version_below_floor(version, floor), (
+                f"uv.lock resolves {package}=={version}, "
+                f"below the #72108 security floor {'.'.join(map(str, floor))}"
+            )
 
 
 def test_update_cve_pins_do_not_downgrade_reviewed_current_versions():
@@ -163,7 +172,7 @@ def test_update_cve_pins_do_not_downgrade_reviewed_current_versions():
         assert versions, f"{package} is no longer exact-pinned; update this guard"
         below_floor = sorted(
             version for version in versions
-            if _version_tuple(version) < floor
+            if _version_below_floor(version, floor)
         )
         assert not below_floor, (
             f"{package} exact pin(s) {below_floor} are below the reviewed "
@@ -174,7 +183,7 @@ def test_update_cve_pins_do_not_downgrade_reviewed_current_versions():
         assert locked_versions, f"{package} is missing from uv.lock"
         locked_below_floor = sorted(
             version for version in locked_versions
-            if _version_tuple(version) < floor
+            if _version_below_floor(version, floor)
         )
         assert not locked_below_floor, (
             f"uv.lock resolves {package} version(s) {locked_below_floor} below "
@@ -313,8 +322,10 @@ def _lazy_deps_by_feature():
     tree = ast.parse(src)
     for node in ast.walk(tree):
         targets = (
-            node.targets if isinstance(node, ast.Assign)
-            else [node.target] if isinstance(node, ast.AnnAssign)
+            node.targets
+            if isinstance(node, ast.Assign)
+            else [node.target]
+            if isinstance(node, ast.AnnAssign)
             else []
         )
         if not any(isinstance(t, ast.Name) and t.id == "LAZY_DEPS" for t in targets):
@@ -330,7 +341,9 @@ def _lazy_deps_by_feature():
                 for sub in ast.walk(value)
                 if isinstance(sub, ast.Constant) and isinstance(sub.value, str)
             ]
-        assert by_feature, "could not extract features from LAZY_DEPS — AST parser drifted"
+        assert by_feature, (
+            "could not extract features from LAZY_DEPS — AST parser drifted"
+        )
         return by_feature
     raise AssertionError("LAZY_DEPS dict literal not found in tools/lazy_deps.py")
 
@@ -358,7 +371,54 @@ _REQUIRED_SECURITY_PINS = {
         "platform.matrix",
         "platform.teams",
     },
+    # google-api-python-client admits old httplib2 releases. Both the unlocked
+    # google extra and the lazy Workspace installer must carry the patched
+    # decompression-bound floor directly.
+    "httplib2": {
+        "skill.google_workspace",
+    },
+    # google-auth's pyasn1-modules dependency admits old pyasn1 releases.
+    # Workspace and Vertex must repair the stale transitive on unlocked and
+    # lazy install paths instead of relying on uv.lock alone.
+    "pyasn1": {
+        "skill.google_workspace",
+        "provider.vertex",
+    },
 }
+
+_REQUIRED_EXTRA_SECURITY_PINS = {
+    "httplib2": {
+        "google",
+    },
+    "pyasn1": {
+        "google",
+        "vertex",
+    },
+}
+
+
+def test_security_pins_present_in_google_extras():
+    """Unlocked Google extras must directly carry their transitive floors."""
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    extras = data["project"]["optional-dependencies"]
+    all_pins = _pins_from_specs(_pyproject_pinned_specs())
+
+    problems = []
+    for pkg, required_extras in _REQUIRED_EXTRA_SECURITY_PINS.items():
+        canon = _canonical(pkg)
+        expected = all_pins.get(canon)
+        assert expected, f"{pkg} has no exact pin in pyproject.toml"
+        for extra in sorted(required_extras):
+            got = _pins_from_specs(extras[extra]).get(canon)
+            if got != expected:
+                problems.append(
+                    f"{extra}: {pkg}="
+                    f"{sorted(got) if got else 'MISSING'}, expected {sorted(expected)}"
+                )
+    assert not problems, (
+        "a Google extra is missing a transitive security floor:\n  "
+        + "\n  ".join(problems)
+    )
 
 
 def test_security_pins_present_in_mirrored_lazy_features():

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1304,7 +1304,7 @@ class TestLazyMcpInstall:
     def test_feature_registered_in_allowlist(self):
         from tools import lazy_deps
         assert lazy_deps.feature_specs("tool.computer_use") == (
-            "mcp==1.26.0",
+            "mcp==1.28.1",
             "starlette==1.3.1",
         )
 
@@ -1324,7 +1324,7 @@ class TestLazyMcpInstall:
         from tools.computer_use import cua_backend
         from tools.lazy_deps import FeatureUnavailable
         unavailable = FeatureUnavailable(
-            "tool.computer_use", ("mcp==1.26.0",), "lazy installs disabled"
+            "tool.computer_use", ("mcp==1.28.1",), "lazy installs disabled"
         )
         with patch.object(cua_backend, "_maybe_nudge_update"), \
              patch("tools.lazy_deps.ensure", side_effect=unavailable), \

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -309,6 +309,59 @@ class TestIsSatisfiedVersionAware:
         assert ld._is_satisfied(spec) is True
         assert ld.feature_missing("tool.trace_upload") == ()
 
+    @pytest.mark.parametrize(
+        ("feature", "installed_versions", "expected_repairs"),
+        [
+            (
+                "skill.google_workspace",
+                {
+                    "google-api-python-client": "2.194.0",
+                    "google-auth": "2.55.0",
+                    "google-auth-oauthlib": "1.3.1",
+                    "google-auth-httplib2": "0.3.1",
+                    "httplib2": "0.31.2",
+                    "pyasn1": "0.6.3",
+                },
+                (
+                    "google-auth==2.55.1",
+                    "httplib2==0.32.0",
+                    "pyasn1==0.6.4",
+                ),
+            ),
+            (
+                "provider.vertex",
+                {
+                    "google-auth": "2.55.1",
+                    "pyasn1": "0.6.3",
+                },
+                ("pyasn1==0.6.4",),
+            ),
+        ],
+    )
+    def test_google_features_repair_stale_transitives(
+        self,
+        monkeypatch,
+        feature,
+        installed_versions,
+        expected_repairs,
+    ):
+        self._fake_version(monkeypatch, installed_versions)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        installed = []
+
+        def fake_install(specs, **kwargs):
+            installed.extend(specs)
+            for spec in specs:
+                package, wanted = spec.split("==", 1)
+                installed_versions[package] = wanted
+            return ld._InstallResult(True, "ok", "")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+
+        ld.ensure(feature, prompt=False)
+
+        assert tuple(installed) == expected_repairs
+
 
 # ---------------------------------------------------------------------------
 # active_features + refresh_active_features (Piece A — hermes update wiring)

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -174,11 +174,12 @@ class TestBuildOAuthAuth:
         auth = build_oauth_auth("test", "https://example.com/mcp")
         assert isinstance(auth, OAuthClientProvider)
 
-    def test_returns_none_without_sdk(self, monkeypatch):
+    def test_returns_none_without_sdk(self, monkeypatch, caplog):
         import tools.mcp_oauth as mod
         monkeypatch.setattr(mod, "_OAUTH_AVAILABLE", False)
         result = build_oauth_auth("test", "https://example.com")
         assert result is None
+        assert "pip install 'mcp==1.28.1'" in caplog.text
 
     def test_pre_registered_client_id_stored(self, tmp_path, monkeypatch):
         try:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -104,7 +104,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # Google Vertex AI provider — OAuth2 token minting for the Gemini
     # OpenAI-compatible endpoint. Only loaded when provider=vertex is selected;
     # google-auth is NOT in [all] so plain installs don't carry it.
-    "provider.vertex": ("google-auth==2.55.1",),
+    "provider.vertex": (
+        "google-auth==2.55.1",
+        "pyasn1==0.6.4",
+    ),
     # Microsoft Foundry — Entra ID auth (managed identity, workload identity,
     # service principal, az login, VS Code, azd, PowerShell). Only loaded
     # when model.auth_mode=entra_id is selected; key-based azure-foundry
@@ -210,8 +213,11 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Skills ────────────────────────────────────────────────────────────
     "skill.google_workspace": (
         "google-api-python-client==2.194.0",
+        "google-auth==2.55.1",
         "google-auth-oauthlib==1.3.1",
         "google-auth-httplib2==0.3.1",
+        "httplib2==0.32.0",
+        "pyasn1==0.6.4",
     ),
     "skill.youtube": ("youtube-transcript-api==1.2.4",),
 
@@ -230,14 +236,14 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # for stripped/source-build installs that somehow dropped it. The vision
     # call site uses prompt=False so it can never raise a blocking input()
     # prompt mid-session (#40490).
-    "tool.vision": ("Pillow==12.2.0",),
+    "tool.vision": ("Pillow==12.3.0",),
     # Computer Use (cua-driver) — the MCP client SDK used to spawn and talk
     # to the cua-driver process over stdio. Matches the `mcp` / `computer-use`
     # extras in pyproject.toml. The one-liner installer pulls this in via
     # `[all]`; lazy-installing here covers lean / partial / broken-extra
     # installs so computer_use never dead-ends on `No module named 'mcp'`.
     "tool.computer_use": (
-        "mcp==1.26.0",
+        "mcp==1.28.1",
         "starlette==1.3.1",  # CVE-2026-48710 — keep in sync with pyproject [computer-use]
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1152,7 +1152,7 @@ def build_oauth_auth(
     if not _OAUTH_AVAILABLE:
         logger.warning(
             "MCP OAuth requested for '%s' but SDK auth types are not available. "
-            "Install with: pip install 'mcp>=1.26.0'",
+            "Install with: pip install 'mcp==1.28.1'",
             server_name,
         )
         return None

--- a/uv.lock
+++ b/uv.lock
@@ -1547,6 +1547,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "ruamel-yaml" },
+    { name = "starlette" },
     { name = "tenacity" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "urllib3" },
@@ -1563,9 +1564,12 @@ all = [
     { name = "aiohttp" },
     { name = "fastapi" },
     { name = "google-api-python-client" },
+    { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "httplib2" },
     { name = "mcp" },
+    { name = "pyasn1" },
     { name = "python-multipart" },
     { name = "simple-term-menu" },
     { name = "starlette" },
@@ -1624,8 +1628,11 @@ firecrawl = [
 ]
 google = [
     { name = "google-api-python-client" },
+    { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "httplib2" },
+    { name = "pyasn1" },
 ]
 hindsight = [
     { name = "hindsight-client" },
@@ -1699,10 +1706,13 @@ termux-all = [
     { name = "aiohttp" },
     { name = "fastapi" },
     { name = "google-api-python-client" },
+    { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
     { name = "honcho-ai" },
+    { name = "httplib2" },
     { name = "mcp" },
+    { name = "pyasn1" },
     { name = "python-multipart" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "simple-term-menu" },
@@ -1714,6 +1724,7 @@ tts-premium = [
 ]
 vertex = [
     { name = "google-auth" },
+    { name = "pyasn1" },
 ]
 voice = [
     { name = "faster-whisper" },
@@ -1769,6 +1780,7 @@ requires-dist = [
     { name = "fire", specifier = "==0.7.1" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl'", specifier = "==4.17.0" },
     { name = "google-api-python-client", marker = "extra == 'google'", specifier = "==2.194.0" },
+    { name = "google-auth", marker = "extra == 'google'", specifier = "==2.55.1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = "==2.55.1" },
     { name = "google-auth-httplib2", marker = "extra == 'google'", specifier = "==0.3.1" },
     { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = "==1.3.1" },
@@ -1795,14 +1807,15 @@ requires-dist = [
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
+    { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
-    { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.26.0" },
-    { name = "mcp", marker = "extra == 'dev'", specifier = "==1.26.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = "==1.26.0" },
+    { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.28.1" },
+    { name = "mcp", marker = "extra == 'dev'", specifier = "==1.28.1" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = "==1.28.1" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = "==2.0.10" },
     { name = "microsoft-teams-apps", marker = "extra == 'teams'", specifier = "==2.0.13.4" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = "==2.4.8" },
@@ -1813,16 +1826,18 @@ requires-dist = [
     { name = "packaging", specifier = "==26.0" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
-    { name = "pillow", specifier = "==12.2.0" },
+    { name = "pillow", specifier = "==12.3.0" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "psutil", specifier = "==7.2.2" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },
+    { name = "pyasn1", marker = "extra == 'google'", specifier = "==0.6.4" },
+    { name = "pyasn1", marker = "extra == 'vertex'", specifier = "==0.6.4" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
-    { name = "python-multipart", specifier = ">=0.0.9,<1" },
+    { name = "python-multipart", specifier = "==0.0.32" },
     { name = "python-multipart", marker = "extra == 'web'", specifier = "==0.0.32" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = "==22.6" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = "==22.6" },
@@ -1843,6 +1858,7 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'messaging'", specifier = "==3.43.0" },
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = "==3.43.0" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = "==0.5.5" },
+    { name = "starlette", specifier = "==1.3.1" },
     { name = "starlette", marker = "extra == 'computer-use'", specifier = "==1.3.1" },
     { name = "starlette", marker = "extra == 'dev'", specifier = "==1.3.1" },
     { name = "starlette", marker = "extra == 'mcp'", specifier = "==1.3.1" },
@@ -1930,14 +1946,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]
@@ -2298,7 +2314,7 @@ encryption = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2316,9 +2332,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -2948,64 +2964,45 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.2.0"
+version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
-    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
-    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
-    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
-    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
-    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
-    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
-    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
-    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
-    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
-    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
-    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
-    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c8/0a78b0e02d7ac54bc03e5321c9220da52f0c2ea83b21f7c40e7f3169c502/pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756", size = 5392415, upload-time = "2026-07-01T11:53:47.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5b/a02d30018abd97ced9f5a6c63d28597694a00d066516b9c1c6de45859fc9/pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6", size = 4785266, upload-time = "2026-07-01T11:53:49.079Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/766667a4be768150a202836acd9fad19c06824ca86c4286d3cf6b274964e/pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd", size = 6263814, upload-time = "2026-07-01T11:53:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/ede717bc1144f63886c21fd349bb95860b0d1a21149ff16f2bb362b612b6/pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd", size = 6934408, upload-time = "2026-07-01T11:53:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/48/9c58b685e69d49c31af6c8eb9012055fab7e665785165c84796e2c73ce72/pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c", size = 6337160, upload-time = "2026-07-01T11:53:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fa/dc2a5c0ba6df93f67c31d34b808b7ce440b40cdbf96f0b81cde1d1e6fa93/pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5", size = 7045172, upload-time = "2026-07-01T11:53:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a5/444817a4d4c4c2417df00513086ca196f388d8f9ef40c2e4ccd1ad1af54b/pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b", size = 6472232, upload-time = "2026-07-01T11:53:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c6/4bad1b18d132a50b27e1365e1ab163616f7a5bb56d330f66f9d1d9d4f9d4/pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a", size = 7233653, upload-time = "2026-07-01T11:54:02.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/16/00f91ab7760dc842f5aad55217e80fc4a7067a0604535249bc8a2d6d9870/pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26", size = 2568195, upload-time = "2026-07-01T11:54:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+    { url = "https://files.pythonhosted.org/packages/75/18/2e8b40223153ccbc60df07f9e8928dc0c76202aa4e55ae9f53962b6510d6/pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468", size = 5302510, upload-time = "2026-07-01T11:56:25.736Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/51fabf59d5ab801ceab709453d3ab6b180083496579549de4c45ced6528a/pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94", size = 4736058, upload-time = "2026-07-01T11:56:28.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
+    { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
 ]
 
 [[package]]
@@ -3185,11 +3182,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- raise the seven affected dependency lines to reviewed patched versions and keep eager, lazy, and runtime-repair paths aligned
- repair stale Google Workspace and Google Chat OAuth environments instead of accepting vulnerable transitives
- detect Pillow 12.3 wheel compatibility and fail early with actionable source-build provisioning on older Linux/libc hosts
- add behavioral regressions for dependency floors, runtime repair, and installer compatibility

## Validation

- focused canonical suite: 421 passed
- security audit: 160 components, zero High findings
- Bash syntax, Ruff, `uv lock --check`, `pip check`, and diff checks passed
- independent final security and compatibility reviews found no actionable issues
- CodeRabbit findings were addressed; its final retry was rate-limited and treated fail-open under project policy

## AI disclosure

Prepared by GPT-5.6-sol with xhigh reasoning in Codex. The account owner loosely reviews my actions and receives usual GitHub notifications.

Fixes #72108
