### PR TITLE
Add hermes-ngit skill (optional-skills/devops) — based on Dan Conway's ngit reference

### DIFF
--- a/optional-skills/devops/hermes-ngit/LICENSE
+++ b/optional-skills/devops/hermes-ngit/LICENSE
@@ -1,39 +1,329 @@
 Creative Commons Attribution-ShareAlike 4.0 International
-(CC BY-SA 4.0)
 
-This work is licensed under the Creative Commons
-Attribution-ShareAlike 4.0 International License. To view a copy of
-this license, visit:
+=======================================================================
 
-    https://creativecommons.org/licenses/by-sa/4.0/
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent permitted by applicable law.
 
-You are free to:
+Using the Creative Commons Public License
 
-  * Share — copy and redistribute the material in any medium or format
-  * Adapt — remix, transform, and build upon the material
-    for any purpose, even commercially.
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below.
 
-Under the following terms:
+The following considerations for the public at large are not exhaustive
+and neither are they a substitute for the terms and conditions of the
+public license.
 
-  * Attribution — You must give appropriate credit, provide a link to
-    the license, and indicate if changes were made. You may do so in
-    any reasonable manner, but not in any way that suggests the
-    licensor endorses you or your use.
-  * ShareAlike — If you remix, transform, or build upon the
-    material, you must distribute your contributions under the same
-    license as the original.
+     Considerations for licensees.
 
-No additional restrictions — You may not apply legal terms or
-technological measures that legally restrict others from doing
-anything the license permits.
+By using the Creative Commons public license, You (the licensee)
+accept the following terms and conditions:
 
-Notices:
+     1. Subject to the terms and conditions of this public license,
+        the Licensor grants You a worldwide, royalty-free,
+        non-sublicensable, non-exclusive, irrevocable license to
+        exercise the Licensed Rights in the Licensed Material to:
 
-  * This skill incorporates contributions from Daniel (Dan) and is
-    distributed under CC BY-SA 4.0 in accordance with that
-    contribution's licensing terms.
-  * The license applies to the documentation and skill content. Code
-    snippets are provided under the same terms unless otherwise noted.
+             a. reproduce and Share the Licensed Material, in whole
+                or in part; and
 
-Creative Commons is not a party to this license and shall not be
-liable for any use of the work. CC does not endorse this work.
+             b. produce, reproduce, and Share Adapted Material.
+
+     2. Exceptions and Limitations. For the avoidance of doubt,
+        where exceptions and limitations to copyright or other
+        analogous rights apply to Your use, this public license
+        does not apply, and You do not need to comply with its
+        terms and conditions.
+
+     3. Term and Termination.
+
+          a. This public license applies for the term of the
+             copyright and similar rights licensed here. However,
+             if You fail to comply with this public license, then
+             Your rights under this public license terminate
+             automatically.
+
+          b. Where the Licensed Rights are used by You in
+             accordance with this public license, the Licensor
+             reinstates Your rights under this public license
+             (i) provisionally, unless and until the Licensor
+             terminates this public license for Your failure to
+             comply with its terms and conditions; or (ii) upon
+             express reinstatement by the Licensor.
+
+          c. In order to avoid doubt, this Section also makes
+             clear that this public license does not apply where
+             the Licensed Rights are used by You in connection
+             with exceptions and limitations to copyright or
+             other analogous rights.
+
+          d. In order to avoid doubt, the Licensor may also
+             offer the Licensed Material under separate terms or
+             conditions or stop distributing the Licensed
+             Material at any time; however, doing so will
+             not terminate this public license.
+
+          e. In order to avoid doubt, the Licensor may impose
+             new terms or conditions on the use of the Licensed
+             Material, or impose a digital rights management
+             (DRM) mechanism, only with the express consent
+             of the Licensor.
+
+     4. Other Rights.
+
+          a. Moral rights, such as the right of integrity and
+             the right of attribution, are not licensed under
+             this public license, nor are publicity, privacy,
+             and/or other similar personality rights; however,
+             to the extent practicable, the Licensor waives
+             and/or agrees not to assert any such rights held
+             by the Licensor to the limited extent necessary
+             to allow You to exercise the Licensed Rights, but
+             not otherwise.
+
+          b. Patent and trademark rights are not licensed
+             under this public license.
+
+          c. To the extent practicable, the Licensor waives
+             any right to collect royalties from You for the
+             exercise of Your rights under this public license,
+             whether directly or through a collecting society
+             under any voluntary or waivable statutory or
+             compulsory licensing scheme. In all other cases the
+             Licensor expressly reserves any right to collect
+             such royalties.
+
+     5. Disclaimer.
+
+          a. Unless otherwise separately undertaken by the
+             Licensor, to the extent practicable, the Licensor
+             offers the Licensed Material as-is and
+             as-available, and makes no representations or
+             warranties of any kind concerning the Licensed
+             Material, whether express, implied, statutory,
+             or other. This includes, without limitation,
+             warranties of title, merchantability, fitness
+             for a particular purpose, non-infringement,
+             absence of latent or other defects, accuracy, or
+             the presence or absence of errors, whether or
+             not known or discoverable. Where disclaimers of
+             warranties are not allowed in full or in part,
+             this disclaimer may not apply to You.
+
+          b. To the extent practicable, the Licensor limits
+             any liability to You for damages, including any
+             direct, indirect, special, incidental, or
+             consequential damages of any character arising
+             as a result of this public license or use of
+             the Licensed Material, under any legal theory,
+             whether in tort, contract, strict liability, or
+             otherwise. Where limitations of liability are not
+             allowed in full or in part, this limitation may
+             not apply to You.
+
+     The disclaimer of warranties and limitation of liability
+     provided above shall be interpreted in a manner that, to the
+     extent practicable, most closely approximates an absolute
+     disclaimer and waiver of all liability.
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International
+Public License
+
+By exercising the Licensed Rights (defined below), You accept and
+agree to be bound by the terms and conditions of this Creative
+Commons Attribution-ShareAlike 4.0 International Public License
+("Public License").
+
+1. Definitions.
+
+   a. Adapted Material means material subject to Copyright and
+      Similar Rights that is derived from or based upon the
+      Licensed Material and in which the Licensed Material is
+      edited, altered, transformed, or built upon in a manner
+      that meaningfully deviates from the original.
+
+   b. Adapter's License means the license You apply to Your
+      Copyright and Similar Rights in Your contributions to
+      Adapted Material in accordance with the terms and
+      conditions of this Public License.
+
+   c. Copyright and Similar Rights means copyright and/or similar
+      rights closely related to copyright including, without
+      limitation, performance, broadcast, sound recording, and
+      Sui Generis Database Rights, without regard to how the
+      rights are labeled or categorized.
+
+   d. Exception or Limitation means fair use, fair dealing, and/or
+      any other exception or limitation to Copyright and Similar
+      Rights that applies to Your use of the Licensed Material.
+
+   e. Licensed Material means the artistic, literary, or other
+      scholarly or artistic material which is subject to the
+      Licensor's Copyright and Similar Rights and that is made
+      available under this Public License.
+
+   f. Licensed Rights means the rights granted to You subject to
+      the terms and conditions of this Public License, which are
+      limited to all Copyright and Similar Rights that apply to
+      Your use of the Licensed Material and that the Licensor
+      has authority to license.
+
+   g. Licensor means the individual(s) or entity(ies) granting
+      rights under this Public License.
+
+   h. Share means to provide material to the public by any means
+      or process that requires permission under the Licensed
+      Rights, such as reproduction, public display, public
+      performance, distribution, dissemination, communication,
+      or importation.
+
+   i. Sui Generis Database Rights means rights other than
+      copyright resulting from Directive 96/9/EC of the European
+      Parliament and of the Council of 11 March 1996 on the
+      legal protection of databases, as amended and/or succeeded.
+
+   j. You means the individual or entity exercising the Licensed
+      Rights under this Public License.
+
+2. Scope.
+
+   a. Grant. Subject to the terms and conditions of this Public
+      License, the Licensor hereby grants You a worldwide,
+      royalty-free, non-sublicensable, non-exclusive, irrevocable
+      license to exercise the Licensed Rights in the Licensed
+      Material to:
+
+        i. reproduce and Share the Licensed Material, in whole or
+           in part; and
+
+       ii. produce, reproduce, and Share Adapted Material.
+
+   b. Exception and Limitations. For the avoidance of doubt,
+      where Exception or Limitation applies to Your use, this
+      Public License does not apply, and You do not need to
+      comply with its terms and conditions.
+
+   c. Term. The term of this Public License is specified in
+      Section 6(a).
+
+   d. Media and formats; technical modifications allowed. The
+      Licensor authorizes You to exercise the Licensed Rights in
+      all media and formats whether now known or hereafter
+      created, and to make technical modifications necessary to do
+      so.
+
+   e. Downstream recipients. Every recipient of the Licensed
+      Material automatically receives an offer from the Licensor
+      to exercise the Licensed Rights under the terms and
+      conditions of this Public License.
+
+   f. No endorsement. Nothing in this Public License
+      constitutes or may be construed as permission to assert or
+      imply that You are, or that Your use of the Licensed
+      Material is, connected with or sponsored, endorsed, or
+      granted official status by the Licensor.
+
+3. Conditions.
+
+   Your exercise of the Licensed Rights is expressly made subject
+   to the following conditions.
+
+   a. Attribution.
+
+        i. If You Share the Licensed Material, You must:
+
+            1. retain the following if it is supplied by the
+               Licensor with the Licensed Material:
+               a. identification of the creator(s);
+               b. a copyright notice;
+               c. a notice that refers to this Public License;
+               d. a notice that refers to the disclaimer of
+                  warranties;
+               e. a URI or hyperlink to the Licensed Material;
+
+            2. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications;
+               and
+
+            3. indicate the Licensed Material is licensed under
+               this Public License, and include the text of, or
+               the URI or hyperlink to, this Public License.
+
+       ii. You may satisfy the conditions in Section 3(a)(i) in
+           any reasonable manner based on the medium, means, and
+           context in which You Share the Licensed Material.
+
+   b. ShareAlike. In addition to the conditions in Section 3(a),
+      if You Share Adapted Material You produce, the conditions
+      of the license applied by You to the Adapted Material
+      must be the Creative Commons Attribution-ShareAlike 4.0
+      International Public License, this version or a later
+      version.
+
+4. Sui Generis Database Rights.
+
+   Where the Licensed Rights include Sui Generis Database Rights
+   that apply to Your use of the Licensed Material:
+
+   a. for the avoidance of doubt, Section 2(a)(i) grants You
+      the right to extract, reuse, reproduce, and Share all or
+      a substantial portion of the contents of the database;
+
+   b. if You include all or a substantial portion of the database
+      contents in a database in which You have Sui Generis
+      Database Rights, then the database in which You have Sui
+      Generis Database Rights is Adapted Material;
+
+   c. You must comply with the conditions in Section 3(a) if You
+      Share all or a substantial portion of the contents of the
+      database.
+
+5. Disclaimer of Warranties and Limitation of Liability.
+
+   UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+   EXTENT PRACTICABLE, THE LICENSOR OFFERS THE LICENSED MATERIAL
+   AS-IS AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR
+   WARRANTIES OF ANY KIND CONCERNING THE LICENSED MATERIAL.
+
+6. Term and Termination.
+
+   a. This Public License applies for the term of the Copyright
+      and Similar Rights licensed here.
+
+   b. Your rights under this Public License terminate
+      automatically if You fail to comply with its terms and
+      conditions.
+
+   c. Where Your right to use the Licensed Material has
+      terminated, it reinstates automatically where the breach
+      is cured within 30 days of Your discovery of the breach.
+
+7. Other Terms and Conditions.
+
+   a. The Licensor may not impose any additional or different
+      terms or conditions on the Licensed Material.
+
+   b. Any arrangements, understandings, or agreements regarding
+      the Licensed Material not stated herein are separate from
+      the terms and conditions of this Public License.
+
+8. Interpretation.
+
+   a. Creative Commons is not a party to this Public License
+      and shall not be liable for the Licensed Material.
+
+   b. "Creative Commons" may be referenced for use of the
+      Licensed Material without its prior written consent except
+      for the limited purpose of indicating that the Licensed
+      Material is shared under this Public License.

--- a/optional-skills/devops/hermes-ngit/LICENSE
+++ b/optional-skills/devops/hermes-ngit/LICENSE
@@ -1,0 +1,39 @@
+Creative Commons Attribution-ShareAlike 4.0 International
+(CC BY-SA 4.0)
+
+This work is licensed under the Creative Commons
+Attribution-ShareAlike 4.0 International License. To view a copy of
+this license, visit:
+
+    https://creativecommons.org/licenses/by-sa/4.0/
+
+You are free to:
+
+  * Share — copy and redistribute the material in any medium or format
+  * Adapt — remix, transform, and build upon the material
+    for any purpose, even commercially.
+
+Under the following terms:
+
+  * Attribution — You must give appropriate credit, provide a link to
+    the license, and indicate if changes were made. You may do so in
+    any reasonable manner, but not in any way that suggests the
+    licensor endorses you or your use.
+  * ShareAlike — If you remix, transform, or build upon the
+    material, you must distribute your contributions under the same
+    license as the original.
+
+No additional restrictions — You may not apply legal terms or
+technological measures that legally restrict others from doing
+anything the license permits.
+
+Notices:
+
+  * This skill incorporates contributions from Daniel (Dan) and is
+    distributed under CC BY-SA 4.0 in accordance with that
+    contribution's licensing terms.
+  * The license applies to the documentation and skill content. Code
+    snippets are provided under the same terms unless otherwise noted.
+
+Creative Commons is not a party to this license and shall not be
+liable for any use of the work. CC does not endorse this work.

--- a/optional-skills/devops/hermes-ngit/LICENSE
+++ b/optional-skills/devops/hermes-ngit/LICENSE
@@ -1,4 +1,4 @@
-Creative Commons Attribution-ShareAlike 4.0 International
+Attribution-ShareAlike 4.0 International
 
 =======================================================================
 
@@ -10,320 +10,419 @@ information available on an "as-is" basis. Creative Commons gives no
 warranties regarding its licenses, any material licensed under their
 terms and conditions, or any related information. Creative Commons
 disclaims all liability for damages resulting from their use to the
-fullest extent permitted by applicable law.
+fullest extent possible.
 
-Using the Creative Commons Public License
+Using Creative Commons Public Licenses
 
 Creative Commons public licenses provide a standard set of terms and
 conditions that creators and other rights holders may use to share
 original works of authorship and other material subject to copyright
-and certain other rights specified in the public license below.
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
 
-The following considerations for the public at large are not exhaustive
-and neither are they a substitute for the terms and conditions of the
-public license.
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
 
-     Considerations for licensees.
-
-By using the Creative Commons public license, You (the licensee)
-accept the following terms and conditions:
-
-     1. Subject to the terms and conditions of this public license,
-        the Licensor grants You a worldwide, royalty-free,
-        non-sublicensable, non-exclusive, irrevocable license to
-        exercise the Licensed Rights in the Licensed Material to:
-
-             a. reproduce and Share the Licensed Material, in whole
-                or in part; and
-
-             b. produce, reproduce, and Share Adapted Material.
-
-     2. Exceptions and Limitations. For the avoidance of doubt,
-        where exceptions and limitations to copyright or other
-        analogous rights apply to Your use, this public license
-        does not apply, and You do not need to comply with its
-        terms and conditions.
-
-     3. Term and Termination.
-
-          a. This public license applies for the term of the
-             copyright and similar rights licensed here. However,
-             if You fail to comply with this public license, then
-             Your rights under this public license terminate
-             automatically.
-
-          b. Where the Licensed Rights are used by You in
-             accordance with this public license, the Licensor
-             reinstates Your rights under this public license
-             (i) provisionally, unless and until the Licensor
-             terminates this public license for Your failure to
-             comply with its terms and conditions; or (ii) upon
-             express reinstatement by the Licensor.
-
-          c. In order to avoid doubt, this Section also makes
-             clear that this public license does not apply where
-             the Licensed Rights are used by You in connection
-             with exceptions and limitations to copyright or
-             other analogous rights.
-
-          d. In order to avoid doubt, the Licensor may also
-             offer the Licensed Material under separate terms or
-             conditions or stop distributing the Licensed
-             Material at any time; however, doing so will
-             not terminate this public license.
-
-          e. In order to avoid doubt, the Licensor may impose
-             new terms or conditions on the use of the Licensed
-             Material, or impose a digital rights management
-             (DRM) mechanism, only with the express consent
-             of the Licensor.
-
-     4. Other Rights.
-
-          a. Moral rights, such as the right of integrity and
-             the right of attribution, are not licensed under
-             this public license, nor are publicity, privacy,
-             and/or other similar personality rights; however,
-             to the extent practicable, the Licensor waives
-             and/or agrees not to assert any such rights held
-             by the Licensor to the limited extent necessary
-             to allow You to exercise the Licensed Rights, but
-             not otherwise.
-
-          b. Patent and trademark rights are not licensed
-             under this public license.
-
-          c. To the extent practicable, the Licensor waives
-             any right to collect royalties from You for the
-             exercise of Your rights under this public license,
-             whether directly or through a collecting society
-             under any voluntary or waivable statutory or
-             compulsory licensing scheme. In all other cases the
-             Licensor expressly reserves any right to collect
-             such royalties.
-
-     5. Disclaimer.
-
-          a. Unless otherwise separately undertaken by the
-             Licensor, to the extent practicable, the Licensor
-             offers the Licensed Material as-is and
-             as-available, and makes no representations or
-             warranties of any kind concerning the Licensed
-             Material, whether express, implied, statutory,
-             or other. This includes, without limitation,
-             warranties of title, merchantability, fitness
-             for a particular purpose, non-infringement,
-             absence of latent or other defects, accuracy, or
-             the presence or absence of errors, whether or
-             not known or discoverable. Where disclaimers of
-             warranties are not allowed in full or in part,
-             this disclaimer may not apply to You.
-
-          b. To the extent practicable, the Licensor limits
-             any liability to You for damages, including any
-             direct, indirect, special, incidental, or
-             consequential damages of any character arising
-             as a result of this public license or use of
-             the Licensed Material, under any legal theory,
-             whether in tort, contract, strict liability, or
-             otherwise. Where limitations of liability are not
-             allowed in full or in part, this limitation may
-             not apply to You.
-
-     The disclaimer of warranties and limitation of liability
-     provided above shall be interpreted in a manner that, to the
-     extent practicable, most closely approximates an absolute
-     disclaimer and waiver of all liability.
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 
-Creative Commons Attribution-ShareAlike 4.0 International
-Public License
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
 
-By exercising the Licensed Rights (defined below), You accept and
-agree to be bound by the terms and conditions of this Creative
-Commons Attribution-ShareAlike 4.0 International Public License
-("Public License").
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
 
-1. Definitions.
 
-   a. Adapted Material means material subject to Copyright and
-      Similar Rights that is derived from or based upon the
-      Licensed Material and in which the Licensed Material is
-      edited, altered, transformed, or built upon in a manner
-      that meaningfully deviates from the original.
+Section 1 -- Definitions.
 
-   b. Adapter's License means the license You apply to Your
-      Copyright and Similar Rights in Your contributions to
-      Adapted Material in accordance with the terms and
-      conditions of this Public License.
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
 
-   c. Copyright and Similar Rights means copyright and/or similar
-      rights closely related to copyright including, without
-      limitation, performance, broadcast, sound recording, and
-      Sui Generis Database Rights, without regard to how the
-      rights are labeled or categorized.
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
 
-   d. Exception or Limitation means fair use, fair dealing, and/or
-      any other exception or limitation to Copyright and Similar
-      Rights that applies to Your use of the Licensed Material.
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
 
-   e. Licensed Material means the artistic, literary, or other
-      scholarly or artistic material which is subject to the
-      Licensor's Copyright and Similar Rights and that is made
-      available under this Public License.
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
 
-   f. Licensed Rights means the rights granted to You subject to
-      the terms and conditions of this Public License, which are
-      limited to all Copyright and Similar Rights that apply to
-      Your use of the Licensed Material and that the Licensor
-      has authority to license.
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
 
-   g. Licensor means the individual(s) or entity(ies) granting
-      rights under this Public License.
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
 
-   h. Share means to provide material to the public by any means
-      or process that requires permission under the Licensed
-      Rights, such as reproduction, public display, public
-      performance, distribution, dissemination, communication,
-      or importation.
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
 
-   i. Sui Generis Database Rights means rights other than
-      copyright resulting from Directive 96/9/EC of the European
-      Parliament and of the Council of 11 March 1996 on the
-      legal protection of databases, as amended and/or succeeded.
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
 
-   j. You means the individual or entity exercising the Licensed
-      Rights under this Public License.
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
 
-2. Scope.
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
 
-   a. Grant. Subject to the terms and conditions of this Public
-      License, the Licensor hereby grants You a worldwide,
-      royalty-free, non-sublicensable, non-exclusive, irrevocable
-      license to exercise the Licensed Rights in the Licensed
-      Material to:
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
 
-        i. reproduce and Share the Licensed Material, in whole or
-           in part; and
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
 
-       ii. produce, reproduce, and Share Adapted Material.
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
 
-   b. Exception and Limitations. For the avoidance of doubt,
-      where Exception or Limitation applies to Your use, this
-      Public License does not apply, and You do not need to
-      comply with its terms and conditions.
 
-   c. Term. The term of this Public License is specified in
-      Section 6(a).
+Section 2 -- Scope.
 
-   d. Media and formats; technical modifications allowed. The
-      Licensor authorizes You to exercise the Licensed Rights in
-      all media and formats whether now known or hereafter
-      created, and to make technical modifications necessary to do
-      so.
+  a. License grant.
 
-   e. Downstream recipients. Every recipient of the Licensed
-      Material automatically receives an offer from the Licensor
-      to exercise the Licensed Rights under the terms and
-      conditions of this Public License.
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
 
-   f. No endorsement. Nothing in this Public License
-      constitutes or may be construed as permission to assert or
-      imply that You are, or that Your use of the Licensed
-      Material is, connected with or sponsored, endorsed, or
-      granted official status by the Licensor.
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
 
-3. Conditions.
+            b. produce, reproduce, and Share Adapted Material.
 
-   Your exercise of the Licensed Rights is expressly made subject
-   to the following conditions.
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
 
-   a. Attribution.
+       3. Term. The term of this Public License is specified in Section
+          6(a).
 
-        i. If You Share the Licensed Material, You must:
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
 
-            1. retain the following if it is supplied by the
-               Licensor with the Licensed Material:
-               a. identification of the creator(s);
-               b. a copyright notice;
-               c. a notice that refers to this Public License;
-               d. a notice that refers to the disclaimer of
-                  warranties;
-               e. a URI or hyperlink to the Licensed Material;
+       5. Downstream recipients.
 
-            2. indicate if You modified the Licensed Material and
-               retain an indication of any previous modifications;
-               and
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
 
-            3. indicate the Licensed Material is licensed under
-               this Public License, and include the text of, or
-               the URI or hyperlink to, this Public License.
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
 
-       ii. You may satisfy the conditions in Section 3(a)(i) in
-           any reasonable manner based on the medium, means, and
-           context in which You Share the Licensed Material.
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
 
-   b. ShareAlike. In addition to the conditions in Section 3(a),
-      if You Share Adapted Material You produce, the conditions
-      of the license applied by You to the Adapted Material
-      must be the Creative Commons Attribution-ShareAlike 4.0
-      International Public License, this version or a later
-      version.
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
 
-4. Sui Generis Database Rights.
+  b. Other rights.
 
-   Where the Licensed Rights include Sui Generis Database Rights
-   that apply to Your use of the Licensed Material:
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
 
-   a. for the avoidance of doubt, Section 2(a)(i) grants You
-      the right to extract, reuse, reproduce, and Share all or
-      a substantial portion of the contents of the database;
+       2. Patent and trademark rights are not licensed under this
+          Public License.
 
-   b. if You include all or a substantial portion of the database
-      contents in a database in which You have Sui Generis
-      Database Rights, then the database in which You have Sui
-      Generis Database Rights is Adapted Material;
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
 
-   c. You must comply with the conditions in Section 3(a) if You
-      Share all or a substantial portion of the contents of the
-      database.
 
-5. Disclaimer of Warranties and Limitation of Liability.
+Section 3 -- License Conditions.
 
-   UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
-   EXTENT PRACTICABLE, THE LICENSOR OFFERS THE LICENSED MATERIAL
-   AS-IS AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR
-   WARRANTIES OF ANY KIND CONCERNING THE LICENSED MATERIAL.
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
 
-6. Term and Termination.
+  a. Attribution.
 
-   a. This Public License applies for the term of the Copyright
-      and Similar Rights licensed here.
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
 
-   b. Your rights under this Public License terminate
-      automatically if You fail to comply with its terms and
-      conditions.
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
 
-   c. Where Your right to use the Licensed Material has
-      terminated, it reinstates automatically where the breach
-      is cured within 30 days of Your discovery of the breach.
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
 
-7. Other Terms and Conditions.
+                ii. a copyright notice;
 
-   a. The Licensor may not impose any additional or different
-      terms or conditions on the Licensed Material.
+               iii. a notice that refers to this Public License;
 
-   b. Any arrangements, understandings, or agreements regarding
-      the Licensed Material not stated herein are separate from
-      the terms and conditions of this Public License.
+                iv. a notice that refers to the disclaimer of
+                    warranties;
 
-8. Interpretation.
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
 
-   a. Creative Commons is not a party to this Public License
-      and shall not be liable for the Licensed Material.
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
 
-   b. "Creative Commons" may be referenced for use of the
-      Licensed Material without its prior written consent except
-      for the limited purpose of indicating that the Licensed
-      Material is shared under this Public License.
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+     including for purposes of Section 3(b); and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/optional-skills/devops/hermes-ngit/NOTICE
+++ b/optional-skills/devops/hermes-ngit/NOTICE
@@ -1,0 +1,9 @@
+hermes-ngit — Attribution Notice
+
+This skill incorporates contributions from Daniel (Dan). It is distributed
+under the Creative Commons Attribution-ShareAlike 4.0 International
+(CC BY-SA 4.0) license in accordance with that contribution's
+licensing terms.
+
+The full license text is in the LICENSE file. This NOTICE file is
+provided for attribution purposes and is not part of the license.

--- a/optional-skills/devops/hermes-ngit/README.md
+++ b/optional-skills/devops/hermes-ngit/README.md
@@ -1,0 +1,45 @@
+# hermes-ngit
+
+Hermes skill for decentralized Git over Nostr via [ngit](https://gitworkshop.dev/ngit).
+
+## What is this?
+
+A skill file for Hermes that provides instructions and workflows for working with
+Nostr-based Git repositories. ngit is a sovereign, decentralized Git hosting protocol
+built on Nostr — no central forge, no daemon required.
+
+## Links
+
+- **GitHub:** https://github.com/rinchen/hermes-ngit
+- **Nostr:** published via `ngit init`; view on [gitworkshop.dev](https://gitworkshop.dev/npub1wwaq5gyk7yljly3cwl3wleuk79nz63ukpp2a6lq5x4q9s9r4nrgqjk3dlv/relay.ngit.dev/hermes-ngit)
+- **Radicle:** [rad:z2fGx8T85zCue2efEmSHL8NxKCvqd/z6MkncGT6ghwtmF9utKMvuqxtK93WHj56dB3GmrDyFQoFWcj](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z2fGx8T85zCue2efEmSHL8NxKCvqd/z6MkncGT6ghwtmF9utKMvuqxtK93WHj56dB3GmrDyFQoFWcj)
+
+## Features
+
+- Announce repos to Nostr (`ngit init`) and keep gitworkshop current via `git push`
+- Native `git clone` / `git push` against `nostr://` remotes (no daemon)
+- Session repo detection for Nostr-enabled projects
+- Full PR and issue lifecycle: open, view, comment, checkout, merge, close, reopen, label
+- Account management (bunker/NIP-46 login, inline `--nsec` for CI) and key-flags reference
+- Triple-push configuration (GitHub + Radicle + Nostr)
+
+## Key Lesson
+
+`ngit sync` only pushes git refs — it does **not** update the NIP-34 announcement that
+gitworkshop.dev reads. To keep gitworkshop current, add the `nostr://` URL as an `origin`
+pushurl so `git push` drives `git-remote-nostr` and re-announces HEAD automatically.
+
+## Usage
+
+Copy `SKILL.md` (plus `LICENSE` and `NOTICE`) into your Hermes skills directory to enable
+ngit workflows, or install via the upstream PR under `optional-skills/devops/hermes-ngit`.
+
+## Credit / License
+
+This skill builds on **Dan Conway's** ngit command reference
+(`DanConwayDev/ngit-cli`, `skills/ngit/SKILL.md`), incorporated under the
+**Creative Commons Attribution-ShareAlike 4.0 International (CC-BY-SA-4.0)** license in
+accordance with the source material's share-alike terms. Original framing and multi-mirror
+packaging by Joey Stanford.
+
+The full license text is in the `LICENSE` file; attribution is also recorded in `NOTICE`.

--- a/optional-skills/devops/hermes-ngit/SKILL.md
+++ b/optional-skills/devops/hermes-ngit/SKILL.md
@@ -3,7 +3,7 @@ name: hermes-ngit
 description: "Use this skill when working with Nostr-based Git repositories (ngit / gitworkshop.dev) for decentralized, permissionless code hosting — `ngit init`, `ngit sync`, `ngit send`, `ngit issue`, `ngit pr`, and native `git push`/`git clone` against nostr:// remotes."
 version: 1.0.1
 author: Joey Stanford
-license: MIT
+license: CC-BY-SA-4.0
 compatibility: "ngit installed (gitworkshop.dev/ngit) with git-remote-nostr on PATH; an identity configured via `git config --global nostr.nsec` or a bunker reference. No daemon required. Optional: `gh` CLI for GitHub mirroring."
 triggers:
   - ngit

--- a/optional-skills/devops/hermes-ngit/SKILL.md
+++ b/optional-skills/devops/hermes-ngit/SKILL.md
@@ -372,6 +372,64 @@ Use `~/repos/ngit-enable-repo/ngit-enable-repo.sh` to announce a repo to Nostr a
 **Current Configuration:** this repo (hermes-ngit) is configured with triple push to
 GitHub + Radicle + Nostr via `origin` pushurls. `git push` updates all three.
 
+## Recovery: State-event "purgatory" accumulation (NIP-34 30617)
+
+**Symptom.** After you `git branch -D` old merged PR branches and later `git push`,
+the grasp server rejects the push with a `purgatory` error listing branches that no
+longer exist locally (seen on `cowx`).
+
+**Root cause.** Each `ngit init` publishes a NIP-34 kind 30617 repository *state*
+event. Grasp servers (relay.ngit.dev, gitnostr.com) do **not** honor NIP-33
+replaceable semantics — old state events accumulate in "purgatory" instead of being
+replaced. The server checks every push against the **union of all purgatory events**,
+so every branch ever declared must still exist locally at its exact declared commit,
+even after you deleted it post-merge.
+
+**Probe first** — this tells you whether the server checks the latest state only or the
+union (the fix differs):
+```bash
+git branch enrich <declared-commit>
+git branch -f main <another-declared-commit>
+git push --force nostr://<npub>/relay.ngit.dev/<repo> main enrich
+```
+- **Accepted** → server checks latest state only → just re-run `ngit init --clean -f -d`.
+- **Rejected** (lists other branches) → server checks the union → do the full reconcile.
+
+**Full reconcile** (when the union is checked):
+```bash
+# Phase 1 — recreate every declared branch at its exact commit
+git branch <name1> <sha1>
+git branch <name2> <sha2>
+# … all N declared branches, including:
+git branch -f main <declared-main-sha>
+
+# Phase 2 — satisfy the union so the push is accepted
+git push --force --all origin
+
+# Phase 3 — publish a single combined state event
+ngit init --clean -f -d        # both relays should report "already in sync"
+
+# Phase 4 — drop the stale branches, push the desired state
+git branch -f main <current-head-sha>
+git branch -D <stale-1> <stale-2> …
+git push --force --prune origin
+ngit init --clean -f -d
+```
+
+**Caveats (observed on `cowx`, 2026-07-27):**
+- All declared commits must still exist in the local object store (they will, if
+  they're ancestors of current `main`). If any are missing, the union can never be
+  satisfied — then publish Nostr kind 5 deletion events (`nak event -k 5 -t e <id>
+  --sec <nsec> -l relay.ngit.dev`) against the stale state-event IDs, or ask the grasp
+  operator to clear purgatory.
+- `gitnostr.com` is flaky: a direct push may fail with "No state events in purgatory"
+  until `ngit init` has published a state event there. Treat **relay.ngit.dev as the
+  primary grasp server**; state events sync between grasp servers automatically.
+- A Radicle pushurl key-registration error means the `rad` node isn't running —
+  `rad node start` then retry. (Unrelated to purgatory.)
+- If GitHub `main` is ahead after the fix (CI bots), recover with
+  `git fetch git@github.com:rinchen/<repo>.git main && git rebase FETCH_HEAD && git push origin main`.
+
 ## Rationale
 
 ngit provides a permissionless, Nostr-native Git hosting layer with no central forge and

--- a/optional-skills/devops/hermes-ngit/SKILL.md
+++ b/optional-skills/devops/hermes-ngit/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: hermes-ngit
 description: "Use this skill when working with Nostr-based Git repositories (ngit / gitworkshop.dev) for decentralized, permissionless code hosting — `ngit init`, `ngit sync`, `ngit send`, `ngit issue`, `ngit pr`, and native `git push`/`git clone` against nostr:// remotes."
-version: 1.1.0
+version: 1.0.1
 author: Joey Stanford
-license: CC-BY-SA-4.0
-compatibility: "ngit installed (https://ngit.dev/install.sh) with git-remote-nostr on PATH; an identity configured via `ngit account login` (nsec or bunker/NIP-46). No daemon required. Optional: `gh` CLI for GitHub mirroring."
+license: MIT
+compatibility: "ngit installed (gitworkshop.dev/ngit) with git-remote-nostr on PATH; an identity configured via `git config --global nostr.nsec` or a bunker reference. No daemon required. Optional: `gh` CLI for GitHub mirroring."
 triggers:
   - ngit
   - nostr git
@@ -21,269 +21,146 @@ metadata:
     related_skills: [hermes-radicle]
 ---
 
-# ngit — Nostr Plugin for Git
+# ngit Skill
 
-ngit makes `clone`, `fetch`, `push` work with `nostr://` URLs and adds a CLI for PRs,
-issues, and repo management over the decentralised Nostr protocol.
+Use when working with Nostr-based Git repositories (`ngit` / gitworkshop.dev) for
+decentralized, permissionless code hosting over Nostr.
 
-- Install: `curl -Ls https://ngit.dev/install.sh | bash` (installs `ngit` and `git-remote-nostr`)
-- Web UI: https://gitworkshop.dev
+## Requirements
 
-> **Credit:** This skill's command reference and workflow details are based on enhancements
-> by **Dan Conway** (DanConwayDev/ngit-cli, `skills/ngit/SKILL.md`, CC-BY-SA-4.0). Original
-> framing and multi-mirror packaging by Joey Stanford.
+- `ngit` installed (https://gitworkshop.dev/ngit) — includes the `git-remote-nostr` helper.
+- `git-remote-nostr` on PATH (so `git push`/`git clone` work with `nostr://` URLs).
+- An identity configured. Either:
+  - raw nsec: `git config --global nostr.nsec "<nsec1...>"`, or
+  - a bunker reference (preferred when available): `nostrsec://...` — keeps the private key off disk.
+- Optional: `gh` CLI for GitHub mirroring workflows.
 
-## How it works
+**No daemon required.** Unlike Radicle, ngit/relays need no local node running.
 
-**Nostr** is a decentralised protocol where users publish signed events to relays (simple
-servers anyone can run). There is no central authority — identity is a keypair, and data is
-replicated across many relays.
+## This Repository
 
-Git has two distinct layers that ngit separates:
+- **GitHub:** https://github.com/rinchen/hermes-ngit
+- **Nostr:** published via `ngit init`; view on gitworkshop.dev under your npub.
+- **Radicle RID:** set after `rad init` (see Multi-Mirror below).
+- **Triple Push:** `origin` pushurls = GitHub + Radicle + Nostr, so `git push` updates all three.
 
-- **Git state (refs)** — which commit each branch/tag points to — is published as signed
-  events on Nostr relays. This is the source of truth for the repository.
-- **Git data (objects)** — the actual commits, trees, and blobs — is stored on ordinary git
-  servers (any server that speaks the git protocol).
+## How ngit Works (mental model)
 
-When you `git fetch`, `git-remote-nostr` reads the current ref state from Nostr relays, then
-fetches the corresponding objects from the git server(s) listed in the repository
-announcement. Because the state lives on Nostr and the data can live anywhere, git servers
-are interchangeable — switching providers requires no coordination with contributors.
+- `ngit init` **announces** the repo to Nostr: publishes the NIP-34 repository event
+  (pointing at current HEAD) and sets the `nostr://` origin URL. Run once, or re-run
+  to re-point the announcement at a new HEAD.
+- `ngit sync` only pushes **git refs** to the grasp git servers. It does **NOT** update
+  the NIP-34 announcement that gitworkshop.dev reads — so gitworkshop can show a stale
+  commit if you only sync.
+- The correct, native way to keep gitworkshop current is to add the `nostr://` URL as a
+  **pushurl** on `origin`, so a normal `git push` drives `git-remote-nostr`, which updates
+  the announcement on every push. No `ngit init` per push, no hook.
+- `ngit send` **opens a PR/proposal** (commits -> proposal). Do NOT run it on every push.
 
-**Grasp servers** are a convenience: they combine a Nostr relay and a git server into a single
-hosted service (e.g. `relay.ngit.dev`). When `ngit init` publishes a repository announcement
-listing a grasp server, the grasp server automatically creates the git repository — no prior
-setup or account configuration required. You can use separate relays and git servers if you
-prefer.
+## ⚠️ GOTCHA: `ngit init` rewrites the `origin` remote
 
-## Key rules
+`ngit init` sets `remote.origin.url` to the `nostr://` URL and **drops any
+existing `remote.origin.pushurl` entries** (it replaced our GitHub pushurl on this
+very repo). So:
 
-- **`pr/` prefix is MANDATORY for PRs** — branch names for pull requests MUST start with
-  `pr/` (e.g. `pr/my-feature`). A branch without this prefix is a plain git push and will
-  never create a PR.
-- **Always use `--json`** on `ngit` commands when reading output — far easier to parse than
-  human-readable text. `git` commands do not support `--json`.
-- **Use `--offline`** on all but the first `ngit` command in a session — reads from local
-  cache instantly. `git fetch origin` also refreshes the cache.
-- **Never construct NIP-05 addresses** (`user@domain`). Use the `npub1...` form unless a
-  NIP-05 address was explicitly provided.
-- **`<ID|nevent>`** accepts a 64-char hex event ID or a `nevent1...` bech32 string. Get IDs
-  from `ngit pr list --json` or `ngit issue list --json`.
-- **`--json` output uses `nevent1…` bech32** for all `id` and `reply_to` fields (not raw
-  hex). Use these values directly as `<ID|nevent>` arguments and in `nostr:` URI references.
-- **Reference other issues/PRs/comments in `--body` using `nostr:` URIs** — e.g.
-  `nostr:nevent1abc…` or `nostr:naddr1abc…`. Never paste raw hex IDs into body text. The `id`
-  field from `--json` output is already a valid `nevent1…` string; prefix it with `nostr:` to
-  form the URI.
+- **Always capture GitHub (or other) pushurls BEFORE running `ngit init`.**
+- After `ngit init`, re-add every pushurl you need, in this order:
+  1. FIRST `git remote set-url --push origin <github-url>` (restores the primary push target)
+  2. THEN `git remote set-url --add --push origin <nostr://url>` (appends Nostr)
+  3. Then add Radicle if present: `git remote set-url --add --push origin $(git remote get-url --push rad)`
 
-## Detecting a nostr repo
+Doing `set-url --add --push` before `set-url --push` leaves `origin` with only the
+Nostr pushurl and no GitHub pushurl — exactly the bug we hit.
+
+Correct sequence for a repo that already has a GitHub `origin`:
 
 ```bash
-git remote -v | grep -q 'nostr://'   # primary check — no cache needed
-ngit repo --json --offline            # full metadata when needed
+# 1. capture existing GitHub pushurl (BEFORE ngit init rewrites origin)
+GH_PUSH=$(git remote get-url --push origin 2>/dev/null | grep -v '^nostr://' | head -1)
+
+# 2. announce to Nostr (rewrites origin.url -> nostr://, drops pushurls)
+ngit init -d --name <repo-name>
+
+# 3. restore GitHub pushurl FIRST, then append Nostr
+[ -n "$GH_PUSH" ] && git remote set-url --push origin "$GH_PUSH"
+git remote set-url --add --push origin "$(git remote get-url origin)"
+
+# 4. (optional) add Radicle if the repo is rad-enabled
+[ -n "$(git remote get-url --push rad 2>/dev/null)" ] && \
+  git remote set-url --add --push origin "$(git remote get-url --push rad)"
+
+git push   # now updates GitHub + Nostr (+ Radicle) natively
 ```
 
-`ngit repo` always exits 0; `is_nostr_repo: false` can be a cold-cache false negative — if
-remotes show `nostr://`, run `git fetch origin` then retry. Full output includes `nostr_url`,
-`maintainers`, `grasp_servers`.
+**Caveat:** git stops on the first failed pushurl. If Nostr relays are unreachable, the
+whole `git push` (including GitHub) can abort. If that bites you, drop the `nostr://`
+pushurl and run `ngit sync` as a separate step instead.
 
-## nostr:// URLs
+## Core Commands
 
-```text
-nostr://<npub>/<identifier>
-nostr://<npub>/<relay-hint>/<identifier>   # relay-hint is bare domain, e.g. relay.ngit.dev
-```
-
-Standard git commands work directly with these URLs — `git-remote-nostr` resolves them
-transparently.
-
-## Publishing a repo
+### Announce a Repo to Nostr
 
 ```bash
-ngit init --name "My Project" --description "What it does" -d  # uses preferred grasp server or defaults
-ngit repo edit --description "New description"                 # update metadata
-ngit repo --json --offline                                     # view repo info (check nostr_url field)
+ngit init -d --name <repo-name>
 ```
 
-Publishes the NIP-34 event and sets `nostr://npub.../relay.ngit.dev/<identifier>` as the
-origin URL. `-d` = non-interactive (uses configured identity). Re-run any time to re-point
-HEAD at the latest commit.
+Publishes the NIP-34 event and sets `nostr://npub.../relay.ngit.dev/<repo-name>` as the
+origin URL. `-d` = non-interactive (uses configured nsec). Re-run any time to re-point
+HEAD at the latest commit. **Remember the remote rewrite gotcha above.**
 
-> **Keeping gitworkshop current:** `ngit sync` only pushes **git refs** to the grasp git
-> servers — it does **NOT** update the NIP-34 announcement that gitworkshop.dev reads. The
-> native fix is to add the `nostr://` URL as a **pushurl** on `origin` so a normal `git push`
-> drives `git-remote-nostr`, which updates the announcement on every push. No `ngit init` per
-> push, no hook.
-
-## Cloning
+### Make `git push` Also Publish to Nostr
 
 ```bash
-git clone nostr://<npub>/<relay-hint>/<identifier>   # preferred
-git clone nostr://<npub>/<identifier>                # slower discovery, no relay hint
-git clone nostr://user@domain.com/<identifier>       # NIP-05, only if given to you
+# nostr:// URL is now origin.url after ngit init; append it as a pushurl
+# (after restoring any GitHub pushurl first — see gotcha)
+git remote set-url --add --push origin "$(git remote get-url origin)"
 ```
 
-## Pull Requests
+Now `git push` updates GitHub, Radicle (if present), **and** Nostr. All three stay in sync
+natively. (This is exactly what `~/repos/ngit-enable-repo/ngit-enable-repo.sh` automates,
+and that script already captures the GitHub-pushurl-before-ngit-init ordering.)
 
-### Open a PR
-
-> **CRITICAL: Branch name MUST start with `pr/`** — this is what signals ngit to create a PR.
-> A branch without the `pr/` prefix is a plain push and will NEVER create a PR, regardless of
-> push options.
+### Clone a Nostr Repo
 
 ```bash
-git checkout -b pr/my-feature          # MUST use pr/ prefix
-# ... commits ...
-
-# Single commit: omit title/description — commit subject and body are used automatically (preferred)
-git push -u origin pr/my-feature
-
-# Multiple commits: supply title and description explicitly
-# Use literal \n\n for paragraph breaks — ngit's push-option parser converts them to real newlines.
-git push -u origin pr/my-feature \
-  -o 'title=My feature title' \
-  -o 'description=First paragraph.\n\nSecond paragraph.'
+git clone nostr://npub.../relay.ngit.dev/<repo-name>
+cd <repo>
+git remote -v   # shows nostr:// origin
 ```
 
-When there is only one commit, omitting `-o title=` and `-o description=` is preferred — ngit
-uses the commit subject as the title and the commit body as the description. Pass `-d` (or
-`--defaults`) to confirm this automatically. `git push` or `git push --force` can update
-existing PRs (branch must still have the `pr/` prefix).
-
-### Advanced: ngit send
-
-`ngit send` takes `--description` as a regular shell argument — the shell does **not**
-interpret `\n` inside double-quoted strings, so `"...\n\n..."` produces literal backslash-n in
-the event. Use ANSI-C quoting (`$'...'`) to embed real newlines:
+### Push a Branch / PR via ngit
 
 ```bash
-# correct — $'...' quoting gives real newlines
-ngit send HEAD~2 \
-  --subject "My Feature" \
-  --description $'First paragraph.\n\nSecond paragraph.'
+# Simple: push a branch with the pr/ prefix
+git push -o 'title=My PR' -o 'description=details' -u origin pr/my-branch
 
-# WRONG — \n inside double quotes is not interpreted; event contains literal \n\n
-ngit send HEAD~2 --subject "My Feature" --description "First paragraph.\n\nSecond paragraph."
-
-ngit send --defaults                                    # non-interactive
-ngit send HEAD~2 --in-reply-to <PR-event-id>           # update existing PR
+# Advanced: ngit send (commits -> proposal)
+ngit send -d --subject "My change" HEAD~2
 ```
 
-> **Note:** `ngit send` opens a PR/proposal (commits -> proposal). Do NOT run it on every
-> push — use the `pr/` branch + `git push` flow above for normal PRs.
-
-### List / view / comment
+### List / Create Issues
 
 ```bash
-ngit pr list --json
-ngit pr list --json --status open,draft,closed,applied
-ngit pr list --json --label bug
-ngit pr view <ID|nevent> --json
-ngit pr view <ID|nevent> --json --comments
-ngit pr comment <ID|nevent> --body "Looks good"
-ngit pr comment <ID|nevent> --body "Fixed!" --reply-to <comment-ID|nevent>
+ngit issue list --json -d          # open issues (JSON)
+ngit issue list                     # human-readable
+ngit issue create --title "..." --description "..."   # if supported
 ```
 
-### Checkout / apply
+### List / Create PRs
 
 ```bash
-ngit pr checkout <ID|nevent>
+ngit pr list --json -d              # open + draft proposals
+ngit pr list
 ```
 
-### Merge (maintainer)
+### Sync Git Refs to Grasp Servers
 
 ```bash
-ngit merge <ID|nevent>                    # merge PR into default branch; does not push
-ngit pr checkout <ID|nevent>
-ngit merge                                # infers PR from checked-out pr/ branch
-ngit merge --exclude-description <ID|nevent>
-git push origin main                      # publishes the merge event
-```
-
-`ngit merge` creates a no-ff merge commit on the default branch with the standard
-`Merge #<8-hex>: <PR title>` message. If conflicts occur, resolve them and run `git commit`;
-ngit has already prepared the commit message.
-
-### Lifecycle
-
-```bash
-ngit pr close <ID|nevent> --reason "blocked by upstream"
-ngit pr reopen <ID|nevent> --reason "fix was incomplete"
-ngit pr ready <ID|nevent> --reason "addressed review feedback"
-ngit pr draft <ID|nevent> --reason "needs more work"
-ngit pr label <ID|nevent> --label bug --label enhancement
-ngit pr set-subject <ID|nevent> --subject "New title"
-ngit pr set-cover-note <ID|nevent> --body "Updated description. See nostr:nevent1abc…"
-```
-
-## Issues
-
-```bash
-ngit issue create --subject "Bug title" --body "Details as markdown" --label bug
-ngit issue create --subject "Feature" --body "..." --label enhancement --label help-wanted
-ngit issue list --json
-ngit issue list --json --status closed
-ngit issue list --json --label bug
-ngit issue view <ID|nevent> --json
-ngit issue view <ID|nevent> --json --comments
-ngit issue comment <ID|nevent> --body "Reproduced on v2.1"
-ngit issue comment <ID|nevent> --body "Thanks!" --reply-to <comment-ID|nevent>
-ngit issue close <ID|nevent> --reason "wontfix"
-ngit issue resolved <ID|nevent> --reason "fixed in abc123"
-ngit issue reopen <ID|nevent> --reason "regression in v2.3"
-ngit issue label <ID|nevent> --label bug --label enhancement
-ngit issue set-subject <ID|nevent> --subject "New title"
-ngit issue set-cover-note <ID|nevent> --body "Updated description. See nostr:nevent1abc…"
-```
-
-## Account management
-
-```bash
-ngit account whoami --json
-ngit account whoami --json --offline          # use cache, no network
-ngit account login                            # interactive, stores nsec in global git config
-ngit account login --bunker-url bunker://...  # NIP-46 remote signer (preferred — keeps key off disk)
-ngit account login --local                    # this repo only
-ngit account create --name "Alice"
-ngit account export-keys
-ngit account logout
-git config --global nostr.nsec <nsec>         # set directly
-ngit --nsec <nsec> <command>                  # inline for CI, no login needed
-```
-
-**Security:** prefer a bunker (`--bunker-url`, NIP-46) over a raw nsec in git config so the
-private key never touches disk. If you must use a raw nsec, store it globally and keep it out
-of any committed file.
-
-## Sync
-
-```bash
-ngit sync                        # sync all refs from nostr state to git servers
-ngit sync --ref-name main        # sync specific ref
+ngit sync -d
 ```
 
 Updates the git servers (relay.ngit.dev, gitnostr.com) to match nostr state. Does not
-re-announce HEAD — use `ngit init` (or the pushurl approach above) for that.
-
-## Key flags
-
-| Flag                  | Description                            |
-| --------------------- | -------------------------------------- |
-| `-d`, `--defaults`    | Non-interactive; use sensible defaults |
-| `--offline`           | Local cache only, skip network         |
-| `--json`              | Structured output (ngit commands only) |
-| `-n`, `--nsec <NSEC>` | Provide nsec or hex private key inline |
-| `-f`, `--force`       | Bypass safety guards                   |
-| `-v`, `--verbose`     | Verbose output                         |
-
-## git config
-
-```bash
-ngit --customize                          # show all options
-git config nostr.repo-relay-only true     # don't broadcast to personal relays
-git config nostr.http-io-timeout-ms 600000 # allow large GRASP pushes
-```
+re-announce HEAD — use `ngit init` (or the pushurl approach) for that.
 
 ## Session Repo Detection
 
@@ -296,7 +173,7 @@ git remote -v 2>/dev/null | grep '^origin' | grep 'nostr://'
 If a `nostr://` origin URL is present, announce the repo is Nostr-enabled and show the
 gitworkshop link derived from it:
 
-```text
+```
 https://gitworkshop.dev/<nostr-url-without-scheme>
 ```
 
@@ -312,18 +189,21 @@ When sharing repo locations, use markdown with GitHub + Radicle + Nostr URLs:
 
 Use `~/repos/ngit-enable-repo/ngit-enable-repo.sh` to announce a repo to Nostr and add the
 `nostr://` pushurl in one shot. Run it from inside an existing Git repo (with a GitHub
-`origin`) after `ngit init` / `rad init`.
+`origin`) after `ngit init` / `rad init`. It already captures the GitHub pushurl before
+`ngit init` rewrites the remote, so the ordering bug above is handled for you.
 
 **Current Configuration:** this repo (hermes-ngit) is configured with triple push to
 GitHub + Radicle + Nostr via `origin` pushurls. `git push` updates all three.
 
 ## Rationale
 
-ngit provides a permissionless, Nostr-native Git hosting layer with no central forge and no
-daemon. Use it for:
+ngit provides a permissionless, Nostr-native Git hosting layer with no central forge and
+no daemon. Use it for:
 - Censorship-resistant mirrors
 - Distributed hosting (multiple grasp git servers listed in the announcement = redundancy)
 - Keeping GitHub for CI/PR convenience while owning a sovereign copy
 
-Keep the private key safe: prefer a bunker (`nostrsec://` / `--bunker-url`) over a raw nsec in
-git config.
+**Key safety:** never store a raw nsec inside a repository (committed file or repo-local
+git config). Keep the nsec in **global** git config only, or use a bunker
+(`nostrsec://`). If a bunker relay is down, a raw global nsec is the fallback — but it
+must never be copied into per-repo config or committed.

--- a/optional-skills/devops/hermes-ngit/SKILL.md
+++ b/optional-skills/devops/hermes-ngit/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: hermes-ngit
+description: "Use this skill when working with Nostr-based Git repositories (ngit / gitworkshop.dev) for decentralized, permissionless code hosting — `ngit init`, `ngit sync`, `ngit send`, `ngit issue`, `ngit pr`, and native `git push`/`git clone` against nostr:// remotes."
+version: 1.0.0
+author: Joey Stanford
+license: MIT
+compatibility: "ngit installed (gitworkshop.dev/ngit) with git-remote-nostr on PATH; an identity configured via `git config --global nostr.nsec` or a bunker reference. No daemon required. Optional: `gh` CLI for GitHub mirroring."
+triggers:
+  - ngit
+  - nostr git
+  - gitworkshop
+  - nostr:// remote
+  - ngit init
+  - ngit sync
+  - ngit send
+  - ngit issue
+  - ngit pr
+metadata:
+  hermes:
+    tags: [Nostr, Git, ngit, Decentralized, gitworkshop]
+    related_skills: [hermes-radicle]
+---
+
+# ngit Skill
+
+Use when working with Nostr-based Git repositories (`ngit` / gitworkshop.dev) for
+decentralized, permissionless code hosting over Nostr.
+
+## Requirements
+
+- `ngit` installed (https://gitworkshop.dev/ngit) — includes the `git-remote-nostr` helper.
+- `git-remote-nostr` on PATH (so `git push`/`git clone` work with `nostr://` URLs).
+- An identity configured. Either:
+  - raw nsec: `git config --global nostr.nsec "<nsec1...>"`, or
+  - a bunker reference (preferred when available): `nostrsec://...` — keep the private key off disk.
+- Optional: `gh` CLI for GitHub mirroring workflows.
+
+**No daemon required.** Unlike Radicle, ngit/relays need no local node running.
+
+## This Repository
+
+- **GitHub:** https://github.com/rinchen/hermes-ngit
+- **Nostr:** published via `ngit init`; view on gitworkshop.dev under your npub.
+- **Radicle RID:** set after `rad init` (see Multi-Mirror below).
+- **Triple Push:** `origin` pushurls = GitHub + Radicle + Nostr, so `git push` updates all three.
+
+## How ngit Works (mental model)
+
+- `ngit init` **announces** the repo to Nostr: publishes the NIP-34 repository event
+  (pointing at current HEAD) and sets the `nostr://` origin URL. Run once, or re-run
+  to re-point the announcement at a new HEAD.
+- `ngit sync` only pushes **git refs** to the grasp git servers. It does **NOT** update
+  the NIP-34 announcement that gitworkshop.dev reads — so gitworkshop can show a stale
+  commit if you only sync.
+- The correct, native way to keep gitworkshop current is to add the `nostr://` URL as a
+  **pushurl** on `origin`, so a normal `git push` drives `git-remote-nostr`, which updates
+  the announcement on every push. No `ngit init` per push, no hook.
+- `ngit send` **opens a PR/proposal** (commits -> proposal). Do NOT run it on every push.
+
+## Core Commands
+
+### Announce a Repo to Nostr
+
+```bash
+ngit init -d --name <repo-name>
+```
+
+Publishes the NIP-34 event and sets `nostr://npub.../relay.ngit.dev/<repo-name>` as the
+origin URL. `-d` = non-interactive (uses configured nsec). Re-run any time to re-point
+HEAD at the latest commit.
+
+### Make `git push` Also Publish to Nostr
+
+```bash
+# nostr:// URL is now origin.url after ngit init; add it as a pushurl too
+git remote set-url --add --push origin $(git remote get-url origin)
+```
+
+Now `git push` updates GitHub, Radicle (if present), **and** Nostr. All three stay in sync
+natively. (This is exactly what `~/repos/ngit-enable-repo/ngit-enable-repo.sh` automates.)
+
+**Caveat:** git stops on the first failed pushurl. If Nostr relays are unreachable, the
+whole `git push` (including GitHub) can abort. If that bites you, drop the `nostr://`
+pushurl and run `ngit sync` as a separate step instead.
+
+### Clone a Nostr Repo
+
+```bash
+git clone nostr://npub.../relay.ngit.dev/<repo-name>
+cd <repo>
+git remote -v   # shows nostr:// origin
+```
+
+### Push a Branch / PR via ngit
+
+```bash
+# Simple: push a branch with the pr/ prefix
+git push -o 'title=My PR' -o 'description=details' -u origin pr/my-branch
+
+# Advanced: ngit send (commits -> proposal)
+ngit send -d --subject "My change" HEAD~2
+```
+
+### List / Create Issues
+
+```bash
+ngit issue list --json -d          # open issues (JSON)
+ngit issue list                     # human-readable
+ngit issue create --title "..." --description "..."   # if supported
+```
+
+### List / Create PRs
+
+```bash
+ngit pr list --json -d              # open + draft proposals
+ngit pr list
+```
+
+### Sync Git Refs to Grasp Servers
+
+```bash
+ngit sync -d
+```
+
+Updates the git servers (relay.ngit.dev, gitnostr.com) to match nostr state. Does not
+re-announce HEAD — use `ngit init` (or the pushurl approach) for that.
+
+## Session Repo Detection
+
+Whenever the user opens a chat inside a Git repository, detect Nostr (ngit) remotes:
+
+```bash
+git remote -v 2>/dev/null | grep '^origin' | grep 'nostr://'
+```
+
+If a `nostr://` origin URL is present, announce the repo is Nostr-enabled and show the
+gitworkshop link derived from it:
+
+```
+https://gitworkshop.dev/<nostr-url-without-scheme>
+```
+
+## Nostr Links Format
+
+When sharing repo locations, use markdown with GitHub + Radicle + Nostr URLs:
+
+- GitHub: https://github.com/rinchen/hermes-ngit
+- Radicle: `rad:<rid>`
+- Nostr: https://gitworkshop.dev/npub1.../relay.ngit.dev/hermes-ngit
+
+## Multi-Mirror Workflow (ngit-enable-repo)
+
+Use `~/repos/ngit-enable-repo/ngit-enable-repo.sh` to announce a repo to Nostr and add the
+`nostr://` pushurl in one shot. Run it from inside an existing Git repo (with a GitHub
+`origin`) after `ngit init` / `rad init`.
+
+**Current Configuration:** this repo (hermes-ngit) is configured with triple push to
+GitHub + Radicle + Nostr via `origin` pushurls. `git push` updates all three.
+
+## Rationale
+
+ngit provides a permissionless, Nostr-native Git hosting layer with no central forge and
+no daemon. Use it for:
+- Censorship-resistant mirrors
+- Distributed hosting (multiple grasp git servers listed in the announcement = redundancy)
+- Keeping GitHub for CI/PR convenience while owning a sovereign copy
+
+Keep the private key safe: prefer a bunker (`nostrsec://`) over a raw nsec in git config.

--- a/optional-skills/devops/hermes-ngit/SKILL.md
+++ b/optional-skills/devops/hermes-ngit/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: hermes-ngit
 description: "Use this skill when working with Nostr-based Git repositories (ngit / gitworkshop.dev) for decentralized, permissionless code hosting — `ngit init`, `ngit sync`, `ngit send`, `ngit issue`, `ngit pr`, and native `git push`/`git clone` against nostr:// remotes."
-version: 1.0.0
+version: 1.1.0
 author: Joey Stanford
-license: MIT
-compatibility: "ngit installed (gitworkshop.dev/ngit) with git-remote-nostr on PATH; an identity configured via `git config --global nostr.nsec` or a bunker reference. No daemon required. Optional: `gh` CLI for GitHub mirroring."
+license: CC-BY-SA-4.0
+compatibility: "ngit installed (https://ngit.dev/install.sh) with git-remote-nostr on PATH; an identity configured via `ngit account login` (nsec or bunker/NIP-46). No daemon required. Optional: `gh` CLI for GitHub mirroring."
 triggers:
   - ngit
   - nostr git
@@ -21,109 +21,269 @@ metadata:
     related_skills: [hermes-radicle]
 ---
 
-# ngit Skill
+# ngit — Nostr Plugin for Git
 
-Use when working with Nostr-based Git repositories (`ngit` / gitworkshop.dev) for
-decentralized, permissionless code hosting over Nostr.
+ngit makes `clone`, `fetch`, `push` work with `nostr://` URLs and adds a CLI for PRs,
+issues, and repo management over the decentralised Nostr protocol.
 
-## Requirements
+- Install: `curl -Ls https://ngit.dev/install.sh | bash` (installs `ngit` and `git-remote-nostr`)
+- Web UI: https://gitworkshop.dev
 
-- `ngit` installed (https://gitworkshop.dev/ngit) — includes the `git-remote-nostr` helper.
-- `git-remote-nostr` on PATH (so `git push`/`git clone` work with `nostr://` URLs).
-- An identity configured. Either:
-  - raw nsec: `git config --global nostr.nsec "<nsec1...>"`, or
-  - a bunker reference (preferred when available): `nostrsec://...` — keep the private key off disk.
-- Optional: `gh` CLI for GitHub mirroring workflows.
+> **Credit:** This skill's command reference and workflow details are based on enhancements
+> by **Dan Conway** (DanConwayDev/ngit-cli, `skills/ngit/SKILL.md`, CC-BY-SA-4.0). Original
+> framing and multi-mirror packaging by Joey Stanford.
 
-**No daemon required.** Unlike Radicle, ngit/relays need no local node running.
+## How it works
 
-## This Repository
+**Nostr** is a decentralised protocol where users publish signed events to relays (simple
+servers anyone can run). There is no central authority — identity is a keypair, and data is
+replicated across many relays.
 
-- **GitHub:** https://github.com/rinchen/hermes-ngit
-- **Nostr:** published via `ngit init`; view on gitworkshop.dev under your npub.
-- **Radicle RID:** set after `rad init` (see Multi-Mirror below).
-- **Triple Push:** `origin` pushurls = GitHub + Radicle + Nostr, so `git push` updates all three.
+Git has two distinct layers that ngit separates:
 
-## How ngit Works (mental model)
+- **Git state (refs)** — which commit each branch/tag points to — is published as signed
+  events on Nostr relays. This is the source of truth for the repository.
+- **Git data (objects)** — the actual commits, trees, and blobs — is stored on ordinary git
+  servers (any server that speaks the git protocol).
 
-- `ngit init` **announces** the repo to Nostr: publishes the NIP-34 repository event
-  (pointing at current HEAD) and sets the `nostr://` origin URL. Run once, or re-run
-  to re-point the announcement at a new HEAD.
-- `ngit sync` only pushes **git refs** to the grasp git servers. It does **NOT** update
-  the NIP-34 announcement that gitworkshop.dev reads — so gitworkshop can show a stale
-  commit if you only sync.
-- The correct, native way to keep gitworkshop current is to add the `nostr://` URL as a
-  **pushurl** on `origin`, so a normal `git push` drives `git-remote-nostr`, which updates
-  the announcement on every push. No `ngit init` per push, no hook.
-- `ngit send` **opens a PR/proposal** (commits -> proposal). Do NOT run it on every push.
+When you `git fetch`, `git-remote-nostr` reads the current ref state from Nostr relays, then
+fetches the corresponding objects from the git server(s) listed in the repository
+announcement. Because the state lives on Nostr and the data can live anywhere, git servers
+are interchangeable — switching providers requires no coordination with contributors.
 
-## Core Commands
+**Grasp servers** are a convenience: they combine a Nostr relay and a git server into a single
+hosted service (e.g. `relay.ngit.dev`). When `ngit init` publishes a repository announcement
+listing a grasp server, the grasp server automatically creates the git repository — no prior
+setup or account configuration required. You can use separate relays and git servers if you
+prefer.
 
-### Announce a Repo to Nostr
+## Key rules
+
+- **`pr/` prefix is MANDATORY for PRs** — branch names for pull requests MUST start with
+  `pr/` (e.g. `pr/my-feature`). A branch without this prefix is a plain git push and will
+  never create a PR.
+- **Always use `--json`** on `ngit` commands when reading output — far easier to parse than
+  human-readable text. `git` commands do not support `--json`.
+- **Use `--offline`** on all but the first `ngit` command in a session — reads from local
+  cache instantly. `git fetch origin` also refreshes the cache.
+- **Never construct NIP-05 addresses** (`user@domain`). Use the `npub1...` form unless a
+  NIP-05 address was explicitly provided.
+- **`<ID|nevent>`** accepts a 64-char hex event ID or a `nevent1...` bech32 string. Get IDs
+  from `ngit pr list --json` or `ngit issue list --json`.
+- **`--json` output uses `nevent1…` bech32** for all `id` and `reply_to` fields (not raw
+  hex). Use these values directly as `<ID|nevent>` arguments and in `nostr:` URI references.
+- **Reference other issues/PRs/comments in `--body` using `nostr:` URIs** — e.g.
+  `nostr:nevent1abc…` or `nostr:naddr1abc…`. Never paste raw hex IDs into body text. The `id`
+  field from `--json` output is already a valid `nevent1…` string; prefix it with `nostr:` to
+  form the URI.
+
+## Detecting a nostr repo
 
 ```bash
-ngit init -d --name <repo-name>
+git remote -v | grep -q 'nostr://'   # primary check — no cache needed
+ngit repo --json --offline            # full metadata when needed
 ```
 
-Publishes the NIP-34 event and sets `nostr://npub.../relay.ngit.dev/<repo-name>` as the
-origin URL. `-d` = non-interactive (uses configured nsec). Re-run any time to re-point
+`ngit repo` always exits 0; `is_nostr_repo: false` can be a cold-cache false negative — if
+remotes show `nostr://`, run `git fetch origin` then retry. Full output includes `nostr_url`,
+`maintainers`, `grasp_servers`.
+
+## nostr:// URLs
+
+```text
+nostr://<npub>/<identifier>
+nostr://<npub>/<relay-hint>/<identifier>   # relay-hint is bare domain, e.g. relay.ngit.dev
+```
+
+Standard git commands work directly with these URLs — `git-remote-nostr` resolves them
+transparently.
+
+## Publishing a repo
+
+```bash
+ngit init --name "My Project" --description "What it does" -d  # uses preferred grasp server or defaults
+ngit repo edit --description "New description"                 # update metadata
+ngit repo --json --offline                                     # view repo info (check nostr_url field)
+```
+
+Publishes the NIP-34 event and sets `nostr://npub.../relay.ngit.dev/<identifier>` as the
+origin URL. `-d` = non-interactive (uses configured identity). Re-run any time to re-point
 HEAD at the latest commit.
 
-### Make `git push` Also Publish to Nostr
+> **Keeping gitworkshop current:** `ngit sync` only pushes **git refs** to the grasp git
+> servers — it does **NOT** update the NIP-34 announcement that gitworkshop.dev reads. The
+> native fix is to add the `nostr://` URL as a **pushurl** on `origin` so a normal `git push`
+> drives `git-remote-nostr`, which updates the announcement on every push. No `ngit init` per
+> push, no hook.
+
+## Cloning
 
 ```bash
-# nostr:// URL is now origin.url after ngit init; add it as a pushurl too
-git remote set-url --add --push origin $(git remote get-url origin)
+git clone nostr://<npub>/<relay-hint>/<identifier>   # preferred
+git clone nostr://<npub>/<identifier>                # slower discovery, no relay hint
+git clone nostr://user@domain.com/<identifier>       # NIP-05, only if given to you
 ```
 
-Now `git push` updates GitHub, Radicle (if present), **and** Nostr. All three stay in sync
-natively. (This is exactly what `~/repos/ngit-enable-repo/ngit-enable-repo.sh` automates.)
+## Pull Requests
 
-**Caveat:** git stops on the first failed pushurl. If Nostr relays are unreachable, the
-whole `git push` (including GitHub) can abort. If that bites you, drop the `nostr://`
-pushurl and run `ngit sync` as a separate step instead.
+### Open a PR
 
-### Clone a Nostr Repo
+> **CRITICAL: Branch name MUST start with `pr/`** — this is what signals ngit to create a PR.
+> A branch without the `pr/` prefix is a plain push and will NEVER create a PR, regardless of
+> push options.
 
 ```bash
-git clone nostr://npub.../relay.ngit.dev/<repo-name>
-cd <repo>
-git remote -v   # shows nostr:// origin
+git checkout -b pr/my-feature          # MUST use pr/ prefix
+# ... commits ...
+
+# Single commit: omit title/description — commit subject and body are used automatically (preferred)
+git push -u origin pr/my-feature
+
+# Multiple commits: supply title and description explicitly
+# Use literal \n\n for paragraph breaks — ngit's push-option parser converts them to real newlines.
+git push -u origin pr/my-feature \
+  -o 'title=My feature title' \
+  -o 'description=First paragraph.\n\nSecond paragraph.'
 ```
 
-### Push a Branch / PR via ngit
+When there is only one commit, omitting `-o title=` and `-o description=` is preferred — ngit
+uses the commit subject as the title and the commit body as the description. Pass `-d` (or
+`--defaults`) to confirm this automatically. `git push` or `git push --force` can update
+existing PRs (branch must still have the `pr/` prefix).
+
+### Advanced: ngit send
+
+`ngit send` takes `--description` as a regular shell argument — the shell does **not**
+interpret `\n` inside double-quoted strings, so `"...\n\n..."` produces literal backslash-n in
+the event. Use ANSI-C quoting (`$'...'`) to embed real newlines:
 
 ```bash
-# Simple: push a branch with the pr/ prefix
-git push -o 'title=My PR' -o 'description=details' -u origin pr/my-branch
+# correct — $'...' quoting gives real newlines
+ngit send HEAD~2 \
+  --subject "My Feature" \
+  --description $'First paragraph.\n\nSecond paragraph.'
 
-# Advanced: ngit send (commits -> proposal)
-ngit send -d --subject "My change" HEAD~2
+# WRONG — \n inside double quotes is not interpreted; event contains literal \n\n
+ngit send HEAD~2 --subject "My Feature" --description "First paragraph.\n\nSecond paragraph."
+
+ngit send --defaults                                    # non-interactive
+ngit send HEAD~2 --in-reply-to <PR-event-id>           # update existing PR
 ```
 
-### List / Create Issues
+> **Note:** `ngit send` opens a PR/proposal (commits -> proposal). Do NOT run it on every
+> push — use the `pr/` branch + `git push` flow above for normal PRs.
+
+### List / view / comment
 
 ```bash
-ngit issue list --json -d          # open issues (JSON)
-ngit issue list                     # human-readable
-ngit issue create --title "..." --description "..."   # if supported
+ngit pr list --json
+ngit pr list --json --status open,draft,closed,applied
+ngit pr list --json --label bug
+ngit pr view <ID|nevent> --json
+ngit pr view <ID|nevent> --json --comments
+ngit pr comment <ID|nevent> --body "Looks good"
+ngit pr comment <ID|nevent> --body "Fixed!" --reply-to <comment-ID|nevent>
 ```
 
-### List / Create PRs
+### Checkout / apply
 
 ```bash
-ngit pr list --json -d              # open + draft proposals
-ngit pr list
+ngit pr checkout <ID|nevent>
 ```
 
-### Sync Git Refs to Grasp Servers
+### Merge (maintainer)
 
 ```bash
-ngit sync -d
+ngit merge <ID|nevent>                    # merge PR into default branch; does not push
+ngit pr checkout <ID|nevent>
+ngit merge                                # infers PR from checked-out pr/ branch
+ngit merge --exclude-description <ID|nevent>
+git push origin main                      # publishes the merge event
+```
+
+`ngit merge` creates a no-ff merge commit on the default branch with the standard
+`Merge #<8-hex>: <PR title>` message. If conflicts occur, resolve them and run `git commit`;
+ngit has already prepared the commit message.
+
+### Lifecycle
+
+```bash
+ngit pr close <ID|nevent> --reason "blocked by upstream"
+ngit pr reopen <ID|nevent> --reason "fix was incomplete"
+ngit pr ready <ID|nevent> --reason "addressed review feedback"
+ngit pr draft <ID|nevent> --reason "needs more work"
+ngit pr label <ID|nevent> --label bug --label enhancement
+ngit pr set-subject <ID|nevent> --subject "New title"
+ngit pr set-cover-note <ID|nevent> --body "Updated description. See nostr:nevent1abc…"
+```
+
+## Issues
+
+```bash
+ngit issue create --subject "Bug title" --body "Details as markdown" --label bug
+ngit issue create --subject "Feature" --body "..." --label enhancement --label help-wanted
+ngit issue list --json
+ngit issue list --json --status closed
+ngit issue list --json --label bug
+ngit issue view <ID|nevent> --json
+ngit issue view <ID|nevent> --json --comments
+ngit issue comment <ID|nevent> --body "Reproduced on v2.1"
+ngit issue comment <ID|nevent> --body "Thanks!" --reply-to <comment-ID|nevent>
+ngit issue close <ID|nevent> --reason "wontfix"
+ngit issue resolved <ID|nevent> --reason "fixed in abc123"
+ngit issue reopen <ID|nevent> --reason "regression in v2.3"
+ngit issue label <ID|nevent> --label bug --label enhancement
+ngit issue set-subject <ID|nevent> --subject "New title"
+ngit issue set-cover-note <ID|nevent> --body "Updated description. See nostr:nevent1abc…"
+```
+
+## Account management
+
+```bash
+ngit account whoami --json
+ngit account whoami --json --offline          # use cache, no network
+ngit account login                            # interactive, stores nsec in global git config
+ngit account login --bunker-url bunker://...  # NIP-46 remote signer (preferred — keeps key off disk)
+ngit account login --local                    # this repo only
+ngit account create --name "Alice"
+ngit account export-keys
+ngit account logout
+git config --global nostr.nsec <nsec>         # set directly
+ngit --nsec <nsec> <command>                  # inline for CI, no login needed
+```
+
+**Security:** prefer a bunker (`--bunker-url`, NIP-46) over a raw nsec in git config so the
+private key never touches disk. If you must use a raw nsec, store it globally and keep it out
+of any committed file.
+
+## Sync
+
+```bash
+ngit sync                        # sync all refs from nostr state to git servers
+ngit sync --ref-name main        # sync specific ref
 ```
 
 Updates the git servers (relay.ngit.dev, gitnostr.com) to match nostr state. Does not
-re-announce HEAD — use `ngit init` (or the pushurl approach) for that.
+re-announce HEAD — use `ngit init` (or the pushurl approach above) for that.
+
+## Key flags
+
+| Flag                  | Description                            |
+| --------------------- | -------------------------------------- |
+| `-d`, `--defaults`    | Non-interactive; use sensible defaults |
+| `--offline`           | Local cache only, skip network         |
+| `--json`              | Structured output (ngit commands only) |
+| `-n`, `--nsec <NSEC>` | Provide nsec or hex private key inline |
+| `-f`, `--force`       | Bypass safety guards                   |
+| `-v`, `--verbose`     | Verbose output                         |
+
+## git config
+
+```bash
+ngit --customize                          # show all options
+git config nostr.repo-relay-only true     # don't broadcast to personal relays
+git config nostr.http-io-timeout-ms 600000 # allow large GRASP pushes
+```
 
 ## Session Repo Detection
 
@@ -136,7 +296,7 @@ git remote -v 2>/dev/null | grep '^origin' | grep 'nostr://'
 If a `nostr://` origin URL is present, announce the repo is Nostr-enabled and show the
 gitworkshop link derived from it:
 
-```
+```text
 https://gitworkshop.dev/<nostr-url-without-scheme>
 ```
 
@@ -159,10 +319,11 @@ GitHub + Radicle + Nostr via `origin` pushurls. `git push` updates all three.
 
 ## Rationale
 
-ngit provides a permissionless, Nostr-native Git hosting layer with no central forge and
-no daemon. Use it for:
+ngit provides a permissionless, Nostr-native Git hosting layer with no central forge and no
+daemon. Use it for:
 - Censorship-resistant mirrors
 - Distributed hosting (multiple grasp git servers listed in the announcement = redundancy)
 - Keeping GitHub for CI/PR convenience while owning a sovereign copy
 
-Keep the private key safe: prefer a bunker (`nostrsec://`) over a raw nsec in git config.
+Keep the private key safe: prefer a bunker (`nostrsec://` / `--bunker-url`) over a raw nsec in
+git config.

--- a/optional-skills/devops/hermes-ngit/SKILL.md
+++ b/optional-skills/devops/hermes-ngit/SKILL.md
@@ -26,13 +26,22 @@ metadata:
 Use when working with Nostr-based Git repositories (`ngit` / gitworkshop.dev) for
 decentralized, permissionless code hosting over Nostr.
 
+**Credit / Attribution.** This skill is built on **Dan Conway's** ngit command
+reference (`DanConwayDev/ngit-cli`, `skills/ngit/SKILL.md`), incorporated under the
+**CC-BY-SA-4.0** share-alike license. Dan's work supplies the command reference, PR/issues
+lifecycle, account management, and flag tables below. Joey Stanford added the multi-mirror
+packaging, the `ngit init` remote-rewrite gotcha, and session repo detection. Attribution is
+also recorded in the `NOTICE` file.
+
 ## Requirements
 
-- `ngit` installed (https://gitworkshop.dev/ngit) — includes the `git-remote-nostr` helper.
+- `ngit` installed (https://gitworkshop.dev/ngit — `curl -Ls https://ngit.dev/install.sh | bash`
+  installs both `ngit` and `git-remote-nostr`).
 - `git-remote-nostr` on PATH (so `git push`/`git clone` work with `nostr://` URLs).
 - An identity configured. Either:
   - raw nsec: `git config --global nostr.nsec "<nsec1...>"`, or
-  - a bunker reference (preferred when available): `nostrsec://...` — keeps the private key off disk.
+  - a bunker reference (preferred when available): `nostrsec://...` / `--bunker-url bunker://...`
+    — keeps the private key off disk.
 - Optional: `gh` CLI for GitHub mirroring workflows.
 
 **No daemon required.** Unlike Radicle, ngit/relays need no local node running.
@@ -40,22 +49,59 @@ decentralized, permissionless code hosting over Nostr.
 ## This Repository
 
 - **GitHub:** https://github.com/rinchen/hermes-ngit
-- **Nostr:** published via `ngit init`; view on gitworkshop.dev under your npub.
-- **Radicle RID:** set after `rad init` (see Multi-Mirror below).
+- **Nostr:** published via `ngit init`; view on https://gitworkshop.dev/npub1wwaq5gyk7yljly3cwl3wleuk79nz63ukpp2a6lq5x4q9s9r4nrgqjk3dlv/relay.ngit.dev/hermes-ngit
+- **Radicle:** `rad:z2fGx8T85zCue2efEmSHL8NxKCvqd/z6MkncGT6ghwtmF9utKMvuqxtK93WHj56dB3GmrDyFQoFWcj`
 - **Triple Push:** `origin` pushurls = GitHub + Radicle + Nostr, so `git push` updates all three.
 
 ## How ngit Works (mental model)
 
-- `ngit init` **announces** the repo to Nostr: publishes the NIP-34 repository event
-  (pointing at current HEAD) and sets the `nostr://` origin URL. Run once, or re-run
-  to re-point the announcement at a new HEAD.
-- `ngit sync` only pushes **git refs** to the grasp git servers. It does **NOT** update
-  the NIP-34 announcement that gitworkshop.dev reads — so gitworkshop can show a stale
-  commit if you only sync.
+Nostr is a decentralised protocol where users publish signed events to relays (simple servers
+anyone can run). There is no central authority — identity is a keypair, and data is replicated
+across many relays.
+
+Git has two distinct layers that ngit separates:
+
+- **Git state (refs)** — which commit each branch/tag points to — is published as signed events
+  on Nostr relays. This is the source of truth for the repository.
+- **Git data (objects)** — the actual commits, trees, and blobs — is stored on ordinary git
+  servers (any server that speaks the git protocol).
+
+When you `git fetch`, `git-remote-nostr` reads the current ref state from Nostr relays, then
+fetches the corresponding objects from the git server(s) listed in the repository announcement.
+Because the state lives on Nostr and the data can live anywhere, git servers are interchangeable.
+
+**Grasp servers** combine a Nostr relay and a git server into one hosted service
+(e.g. `relay.ngit.dev`). When `ngit init` publishes an announcement listing a grasp server, the
+grasp server automatically creates the git repository — no prior setup or account needed.
+
+- `ngit init` **announces** the repo to Nostr: publishes the NIP-34 repository event (pointing at
+  current HEAD) and sets the `nostr://` origin URL. Run once, or re-run to re-point the
+  announcement at a new HEAD.
+- `ngit sync` only pushes **git refs** to the grasp git servers. It does **NOT** update the
+  NIP-34 announcement that gitworkshop.dev reads — so gitworkshop can show a stale commit if you
+  only sync.
 - The correct, native way to keep gitworkshop current is to add the `nostr://` URL as a
-  **pushurl** on `origin`, so a normal `git push` drives `git-remote-nostr`, which updates
-  the announcement on every push. No `ngit init` per push, no hook.
+  **pushurl** on `origin`, so a normal `git push` drives `git-remote-nostr`, which updates the
+  announcement on every push. No `ngit init` per push, no hook.
 - `ngit send` **opens a PR/proposal** (commits -> proposal). Do NOT run it on every push.
+
+## Key Rules
+
+- **`pr/` prefix is MANDATORY for PRs** — branch names for pull requests MUST start with `pr/`
+  (e.g. `pr/my-feature`). A branch without this prefix is a plain git push and will never create a PR.
+- **Always use `--json`** on `ngit` commands when reading output — far easier to parse than
+  human-readable text. (`git` commands do not support `--json`.)
+- **Use `--offline`** on all but the first `ngit` command in a session — reads from local cache
+  instantly. (`git fetch origin` also refreshes the cache.)
+- **Never construct NIP-05 addresses** (`user@domain`). Use the `npub1...` form unless a NIP-05
+  address was explicitly provided.
+- **`<ID|nevent>`** accepts a 64-char hex event ID or a `nevent1...` bech32 string. Get IDs from
+  `ngit pr list --json` or `ngit issue list --json`.
+- **`--json` output uses `nevent1…` bech32** for all `id` and `reply_to` fields (not raw hex). Use
+  these values directly as `<ID|nevent>` arguments and in `nostr:` URI references.
+- **Reference other issues/PRs/comments in `--body` using `nostr:` URIs** — e.g.
+  `nostr:nevent1abc…` or `nostr:naddr1abc…`. Never paste raw hex IDs into body text. The `id` field
+  from `--json` output is already a valid `nevent1…` string; prefix it with `nostr:` to form the URI.
 
 ## ⚠️ GOTCHA: `ngit init` rewrites the `origin` remote
 
@@ -98,15 +144,27 @@ pushurl and run `ngit sync` as a separate step instead.
 
 ## Core Commands
 
+### Detect a Nostr Repo
+
+```bash
+git remote -v | grep -q 'nostr://'   # primary check — no cache needed
+ngit repo --json --offline           # full metadata when needed
+```
+
+`ngit repo` always exits 0; `is_nostr_repo: false` can be a cold-cache false negative — if
+remotes show `nostr://`, run `git fetch origin` then retry. Full output includes `nostr_url`,
+`maintainers`, `grasp_servers`.
+
 ### Announce a Repo to Nostr
 
 ```bash
-ngit init -d --name <repo-name>
+ngit init --name "My Project" --description "What it does" -d   # uses preferred grasp server
+ngit repo edit --description "New description"                  # update metadata
+ngit repo --json --offline                                      # view repo info (nostr_url field)
 ```
 
-Publishes the NIP-34 event and sets `nostr://npub.../relay.ngit.dev/<repo-name>` as the
-origin URL. `-d` = non-interactive (uses configured nsec). Re-run any time to re-point
-HEAD at the latest commit. **Remember the remote rewrite gotcha above.**
+`-d` = non-interactive (uses configured nsec). Re-run any time to re-point HEAD at the latest
+commit. **Remember the remote rewrite gotcha above.**
 
 ### Make `git push` Also Publish to Nostr
 
@@ -123,44 +181,163 @@ and that script already captures the GitHub-pushurl-before-ngit-init ordering.)
 ### Clone a Nostr Repo
 
 ```bash
-git clone nostr://npub.../relay.ngit.dev/<repo-name>
-cd <repo>
-git remote -v   # shows nostr:// origin
+git clone nostr://<npub>/<relay-hint>/<identifier>   # preferred (relay-hint = bare domain)
+git clone nostr://<npub>/<identifier>                # slower discovery, no relay hint
+git clone nostr://user@domain.com/<identifier>       # NIP-05, only if explicitly given to you
 ```
 
-### Push a Branch / PR via ngit
+`nostr://<npub>/<identifier>` form: `git-remote-nostr` resolves these transparently with standard git commands.
+
+### Pull Requests
+
+#### Open a PR
+
+> **CRITICAL: Branch name MUST start with `pr/`** — this is what signals ngit to create a PR.
+> A branch without the `pr/` prefix is a plain push and will NEVER create a PR, regardless of push options.
 
 ```bash
-# Simple: push a branch with the pr/ prefix
-git push -o 'title=My PR' -o 'description=details' -u origin pr/my-branch
+git checkout -b pr/my-feature          # MUST use pr/ prefix
+# ... commits ...
 
-# Advanced: ngit send (commits -> proposal)
-ngit send -d --subject "My change" HEAD~2
+# Single commit: omit title/description — commit subject/body are used automatically (preferred)
+git push -u origin pr/my-feature
+
+# Multiple commits: supply title and description explicitly
+# Use literal \n\n for paragraph breaks — ngit's push-option parser converts them to real newlines.
+# Do NOT use $'...\n\n...' ANSI-C quoting — git cannot pass real newlines through push options.
+git push -u origin pr/my-feature \
+  -o 'title=My feature title' \
+  -o 'description=First paragraph.\n\nSecond paragraph.'
 ```
 
-### List / Create Issues
+When there is only one commit, omitting `-o title=` and `-o description=` is preferred — ngit
+uses the commit subject as the title and the commit body as the description. Pass `-d`
+(or `--defaults`) to confirm this automatically. `git push` / `git push --force` can update
+existing PRs (branch must still have the `pr/` prefix).
+
+#### Advanced: `ngit send`
+
+`ngit send` takes `--description` as a regular shell argument — the shell does **not** interpret
+`\n` inside double-quoted strings, so `"...\n\n..."` produces literal backslash-n. Use ANSI-C
+quoting (`$'...'`) to embed real newlines:
 
 ```bash
-ngit issue list --json -d          # open issues (JSON)
-ngit issue list                     # human-readable
-ngit issue create --title "..." --description "..."   # if supported
+# correct — $'...' quoting gives real newlines
+ngit send HEAD~2 \
+  --subject "My Feature" \
+  --description $'First paragraph.\n\nSecond paragraph.'
+
+# WRONG — \n inside double quotes is not interpreted; event contains literal \n\n
+ngit send HEAD~2 --subject "My Feature" --description "First paragraph.\n\nSecond paragraph."
+
+ngit send --defaults                      # non-interactive
+ngit send HEAD~2 --in-reply-to <PR-event-id>   # update existing PR
 ```
 
-### List / Create PRs
+#### List / view / comment
 
 ```bash
-ngit pr list --json -d              # open + draft proposals
-ngit pr list
+ngit pr list --json
+ngit pr list --json --status open,draft,closed,applied
+ngit pr list --json --label bug
+ngit pr view <ID|nevent> --json
+ngit pr view <ID|nevent> --json --comments
+ngit pr comment <ID|nevent> --body "Looks good"
+ngit pr comment <ID|nevent> --body "Fixed!" --reply-to <comment-ID|nevent>
+```
+
+#### Checkout / apply
+
+```bash
+ngit pr checkout <ID|nevent>
+```
+
+#### Merge (maintainer)
+
+```bash
+ngit merge <ID|nevent>                    # merge PR into default branch; does not push
+ngit pr checkout <ID|nevent>
+ngit merge                                # infers PR from checked-out pr/ branch
+ngit merge --exclude-description <ID|nevent>
+git push origin main                      # publishes the merge event
+```
+
+`ngit merge` creates a no-ff merge commit on the default branch with the standard
+`Merge #<8-hex>: <PR title>` message. If conflicts occur, resolve them and run `git commit`;
+ngit has already prepared the commit message.
+
+#### Lifecycle
+
+```bash
+ngit pr close <ID|nevent> --reason "blocked by upstream"
+ngit pr reopen <ID|nevent> --reason "fix was incomplete"
+ngit pr ready <ID|nevent> --reason "addressed review feedback"
+ngit pr draft <ID|nevent> --reason "needs more work"
+ngit pr label <ID|nevent> --label bug --label enhancement
+ngit pr set-subject <ID|nevent> --subject "New title"
+ngit pr set-cover-note <ID|nevent> --body "Updated description. See nostr:nevent1abc…"
+```
+
+### Issues
+
+```bash
+ngit issue create --subject "Bug title" --body "Details as markdown" --label bug
+ngit issue create --subject "Feature" --body "..." --label enhancement --label help-wanted
+ngit issue list --json
+ngit issue list --json --status closed
+ngit issue list --json --label bug
+ngit issue view <ID|nevent> --json
+ngit issue view <ID|nevent> --json --comments
+ngit issue comment <ID|nevent> --body "Reproduced on v2.1"
+ngit issue comment <ID|nevent> --body "Thanks!" --reply-to <comment-ID|nevent>
+ngit issue close <ID|nevent> --reason "wontfix"
+ngit issue resolved <ID|nevent> --reason "fixed in abc123"
+ngit issue reopen <ID|nevent> --reason "regression in v2.3"
+ngit issue label <ID|nevent> --label bug --label enhancement
+ngit issue set-subject <ID|nevent> --subject "New title"
+ngit issue set-cover-note <ID|nevent> --body "Updated description. See nostr:nevent1abc…"
+```
+
+### Account Management
+
+```bash
+ngit account whoami --json
+ngit account whoami --json --offline          # use cache, no network
+ngit account login                            # interactive, stores nsec in global git config
+ngit account login --bunker-url bunker://...  # NIP-46 remote signer
+ngit account login --local                    # this repo only
+ngit account create --name "Alice"
+ngit account export-keys
+ngit account logout
+git config --global nostr.nsec <nsec>         # set directly
+ngit --nsec <nsec> <command>                  # inline for CI, no login needed
 ```
 
 ### Sync Git Refs to Grasp Servers
 
 ```bash
-ngit sync -d
+ngit sync                        # sync all refs from nostr state to git servers
+ngit sync --ref-name main        # sync specific ref
 ```
 
-Updates the git servers (relay.ngit.dev, gitnostr.com) to match nostr state. Does not
-re-announce HEAD — use `ngit init` (or the pushurl approach) for that.
+### Key Flags
+
+| Flag                  | Description                              |
+| --------------------- | ---------------------------------------- |
+| `-d`, `--defaults`    | Non-interactive; use sensible defaults   |
+| `--offline`           | Local cache only, skip network           |
+| `--json`              | Structured output (ngit commands only)   |
+| `-n`, `--nsec <NSEC>` | Provide nsec or hex private key inline   |
+| `-f`, `--force`       | Bypass safety guards                     |
+| `-v`, `--verbose`     | Verbose output                           |
+
+### git config Tuning
+
+```bash
+ngit --customize                          # show all options
+git config nostr.repo-relay-only true     # don't broadcast to personal relays
+git config nostr.http-io-timeout-ms 600000 # allow large GRASP pushes
+```
 
 ## Session Repo Detection
 
@@ -182,8 +359,8 @@ https://gitworkshop.dev/<nostr-url-without-scheme>
 When sharing repo locations, use markdown with GitHub + Radicle + Nostr URLs:
 
 - GitHub: https://github.com/rinchen/hermes-ngit
-- Radicle: `rad:<rid>`
-- Nostr: https://gitworkshop.dev/npub1.../relay.ngit.dev/hermes-ngit
+- Radicle: `rad:z2fGx8T85zCue2efEmSHL8NxKCvqd/z6MkncGT6ghwtmF9utKMvuqxtK93WHj56dB3GmrDyFQoFWcj`
+- Nostr: https://gitworkshop.dev/npub1wwaq5gyk7yljly3cwl3wleuk79nz63ukpp2a6lq5x4q9s9r4nrgqjk3dlv/relay.ngit.dev/hermes-ngit
 
 ## Multi-Mirror Workflow (ngit-enable-repo)
 

--- a/optional-skills/devops/hermes-ngit/SKILL.md
+++ b/optional-skills/devops/hermes-ngit/SKILL.md
@@ -142,6 +142,116 @@ git push   # now updates GitHub + Nostr (+ Radicle) natively
 whole `git push` (including GitHub) can abort. If that bites you, drop the `nostr://`
 pushurl and run `ngit sync` as a separate step instead.
 
+PITFALL — triple-push mirrors can silently DIVERGE and `git pull` will NOT warn you.
+When `origin` has only a `nostr://` FETCH url (set by `ngit init`) but three PUSH urls
+(GitHub + Radicle + Nostr), `git pull` fetches from Nostr only. If GitHub gains a commit
+(e.g. a merged PR) your local `main` lacks, `git pull` still reports "Already up to date"
+because Nostr already had your tip. The divergence only surfaces as a non-fast-forward on
+`git push` to GitHub — while the Nostr/Radicle pushurls print "Everything up-to-date" (they
+already had your commit), making it look like only GitHub is the problem.
+Diagnosis BEFORE any reset: fetch each remote into a throwaway ref and check ancestry —
+`git fetch -q git@github.com:rinchen/<repo>.git +refs/heads/main:refs/remotes/ghprobe/main`,
+then `git merge-base --is-ancestor main ghprobe/main` (is local an ancestor of GitHub?) and
+the reverse. If NEITHER is an ancestor, the histories diverged (parallel duplicate commits).
+Confirm the content is actually identical before assuming a reset is safe:
+`git diff <local> <remote> --stat` and compare trees with `git rev-parse <c>^{tree}`.
+Resolution: prefer `git merge --no-ff` of the GitHub tip into local. The merge commit descends
+from BOTH sides, so a plain `git push` fast-forwards all three mirrors with no force. A
+`git reset --hard` to GitHub LOOKS simpler but will NON-fast-forward Nostr/Radicle (they sit at
+the local tip, which is not an ancestor of GitHub) — it trades one rejected pushurl for two.
+Only force-push if you intend to rewrite GitHub history.
+
+## Links format (radicle-links hub convention)
+When adding a repo to `~/repos/radicle-links/README.md` (the hub):
+- GitHub cell: `[GitHub](https://github.com/rinchen/<repo>)`
+- **Radicle cell uses the SHORT `[rad]` text** linking to `app.radicle.xyz/.../rad:<rid>` — NOT the full `rad:z…` ID as the display text.
+- Nostr cell: `[ngit](https://gitworkshop.dev/npub…/relay.ngit.dev/<repo>)`
+- All three columns per repo.
+
+PITFALL — recurring correction (broken 3× across sessions, including this one): do NOT write
+`[rad:z3Y6…]` as the link text. The visible label must be literally `rad`; the full RID stays
+inside the URL: `[rad](https://app.radicle.xyz/nodes/rosa.radicle.network/rad:z3Y6…)`. Apply
+this to EVERY row you add or move in the hub README — if a pre-existing row violates it (e.g.
+the Hermes Radicle Skill row did), fix that too, not just the new one. Verify with
+`grep -cE '\[rad:z' README.md` → expect 0.
+
+## Recommended multi-mirror workflow (kill the blind `git pull`)
+
+The trap above happens because `ngit init` sets `origin` to FETCH from Nostr but PUSH to
+GitHub+Radicle+Nostr. PRs merge on **GitHub**, which `git pull` never consults — so divergence
+is invisible until `git push` rejects. Fix it by splitting the two directions with plain git
+config (no hook, no source edits):
+
+```bash
+# 1. Add GitHub as a FETCH-ONLY remote (PRs merge here)
+git remote add github git@github.com:rinchen/<repo>.git
+
+# 2. Make `git pull` sync from GitHub (where PRs land)
+git config branch.<main>.remote github
+git config branch.<main>.merge refs/heads/<main>
+
+# 3. Keep `git push` -> origin (the triple-mirror pushurls)
+git config remote.pushDefault origin
+git config push.default current   # per-repo: no-arg `git push` always hits origin (the triple mirror)
+```
+
+Now after a PR merges: `git pull` pulls it into local directly (FF, or a merge commit if you
+also have local commits). No silent "Already up to date", no surprise non-fast-forward.
+`git push` still propagates to GitHub+Radicle+Nostr via `origin` pushurls.
+
+Mechanics: `branch.<name>.remote` controls the `git pull` source; `remote.pushDefault` controls
+the `git push` target — two independent knobs. `git pull --dry-run` should show `From
+github.com:rinchen/<repo>`; `git push --dry-run` should target `origin`.
+
+Optional: scope GitHub's fetch to the main branch only (otherwise the first `git pull` registers
+all upstream branches as `github/*` tracking refs — harmless but noisy):
+```bash
+git config remote.github.fetch '+refs/heads/<main>:refs/remotes/github/<main>'
+```
+Run `git fetch --all` occasionally to refresh the Nostr/Radicle tracking refs; not required for
+the pull/push fix.
+
+### The full lifecycle (proven, no mirror divergence)
+
+With the config above, every enabled repo follows this loop and stays converged:
+
+```bash
+# 1. Feature branch (local)
+git checkout -b feat/x
+
+# 2. Open the PR: push the BRANCH to GitHub ONLY.
+#    Do NOT `git push` (no args) here — that would push to the triple mirror via origin.
+git push -u github feat/x        # <- github remote, branch only, never origin
+
+# 3. Someone merges the PR on GitHub (web UI / gh). No action needed locally yet.
+
+# 4. Bring it home: pull the merge from GitHub into local main.
+git checkout <main>
+git pull                         # branch.<main>.remote=github -> fetches the merged PR
+
+# 5. Propagate to Radicle + Nostr (and GitHub again, as one of origin's pushurls).
+git push                         # remote.pushDefault=origin -> triple mirror
+
+# 6. Cleanup
+git push -d github feat/x        # delete the remote PR branch
+git branch -d feat/x             # delete the local branch
+git pull                         # stays clean (github/main unchanged)
+```
+
+**Why it can't reproduce the old bug:** the PR branch is pushed to the `github` *remote* (not
+`origin`), so it never reaches Radicle/Nostr until merged. The merge lands on GitHub; `git pull`
+(now GitHub-aware) fetches it; `git push` carries that same commit to `origin`'s three pushurls
+(GitHub+Radicle+Nostr) as a clean fast-forward. Local main is always an ancestor of all three.
+
+**Rules that keep it safe on every repo:**
+- Open PRs: `git push -u github <branch>` (never `git push` to origin, never the branch name on
+  `git push` with no remote).
+- Sync main: `git pull` (= GitHub). Never assume "Already up to date" means GitHub is caught up
+  — verify with `git fetch github` if you suspect a stale Nostr `origin` confused you.
+- Publish: `git push` (= origin triple mirror). A non-fast-forward here means a real divergence
+  (someone pushed elsewhere); diagnose with `git fetch github main` + merge-base check, don't force.
+- The `github` remote is fetch-only by convention: never add it as an `origin` pushurl.
+
 ## Core Commands
 
 ### Detect a Nostr Repo
@@ -177,6 +287,21 @@ git remote set-url --add --push origin "$(git remote get-url origin)"
 Now `git push` updates GitHub, Radicle (if present), **and** Nostr. All three stay in sync
 natively. (This is exactly what `~/repos/ngit-enable-repo/ngit-enable-repo.sh` automates,
 and that script already captures the GitHub-pushurl-before-ngit-init ordering.)
+
+**Hardened enable (prevents the blind-`git-pull` trap):** `ngit init` leaves `origin.fetch`
+pointing at Nostr, so `git pull` never sees GitHub-merged PRs — the divergence stays invisible
+until `git push` rejects. The `ngit-enable-repo.sh` script now avoids this by splitting the two
+directions explicitly after the pushurl rebuild:
+- `git remote add github <github-url>` (FETCH-only source of truth; PRs merge here)
+- `git config branch.<main>.remote github`  → `git pull` consults GitHub
+- `git config remote.pushDefault origin`     → `git push` targets the triple mirror (never `github`)
+- `git config push.default current`          → no-arg `git push` hits `origin` even if your global
+  `push.default` is `upstream` (which would otherwise refuse, since `branch.<main>.remote=github`)
+- `git config remote.github.fetch '+refs/heads/<main>:refs/remotes/github/<main>'` (scoped, avoids registering every upstream branch)
+
+With this, `git pull` and `git push` point at different remotes and ngit's `origin` rewrite can't
+reintroduce the trap. Apply the same five lines to any existing triple-mirror repo that still has
+`origin.fetch = nostr://` (i.e. `git pull` is blind to GitHub).
 
 ### Clone a Nostr Repo
 
@@ -374,37 +499,50 @@ GitHub + Radicle + Nostr via `origin` pushurls. `git push` updates all three.
 
 ## Recovery: State-event "purgatory" accumulation (NIP-34 30617)
 
-**Symptom.** After you `git branch -D` old merged PR branches and later `git push`,
-the grasp server rejects the push with a `purgatory` error listing branches that no
-longer exist locally (seen on `cowx`).
+**Symptom.** After `git branch -D` old merged PR branches (or fixing remotes), `git push`
+(refs/heads/main doesn't exist and will be added as a new branch) → the grasp server
+rejects the push with `ERR authorisation failed: N state events in purgatory …` listing
+branches that no longer exist locally (seen on `cowx` and `persecutio`).
 
 **Root cause.** Each `ngit init` publishes a NIP-34 kind 30617 repository *state*
-event. Grasp servers (relay.ngit.dev, gitnostr.com) do **not** honor NIP-33
+event. Grasp servers (`relay.ngit.dev`, `gitnostr.com`) do **not** honor NIP-33
 replaceable semantics — old state events accumulate in "purgatory" instead of being
 replaced. The server checks every push against the **union of all purgatory events**,
 so every branch ever declared must still exist locally at its exact declared commit,
-even after you deleted it post-merge.
+even after you deleted it post-merge. Repeated `ngit init` runs *add* events without
+replacing them — purgatory can grow between attempts; don't re-run it once purgatory
+starts.
 
-**Probe first** — this tells you whether the server checks the latest state only or the
-union (the fix differs):
+**Probe first** — test with a non-main branch to confirm the server checks the union.
+`git push` to `origin` here will touch GitHub too — push to the `nostr://` URL directly
+so GitHub is not affected by a rejected probe.
 ```bash
 git branch enrich <declared-commit>
 git branch -f main <another-declared-commit>
 git push --force nostr://<npub>/relay.ngit.dev/<repo> main enrich
 ```
 - **Accepted** → server checks latest state only → just re-run `ngit init --clean -f -d`.
-- **Rejected** (lists other branches) → server checks the union → do the full reconcile.
+- **Rejected** (lists other branches) → server checks union → full reconcile below.
 
-**Full reconcile** (when the union is checked):
+**Full reconcile** (when the union is checked). IMPORTANT: this is invasive — force-pushes
+rewrite remote refs. Push to the **`nostr://` URL directly**; never `origin`. The push
+step in Phase 3 can succeed even while `gitnostr.com` still complains `No state events in
+purgatory` — that's a propagation lag, not a hard block. Treat `relay.ngit.dev` as primary.
 ```bash
 # Phase 1 — recreate every declared branch at its exact commit
 git branch <name1> <sha1>
 git branch <name2> <sha2>
-# … all N declared branches, including:
-git branch -f main <declared-main-sha>
+# … all N declared branches, including declared-missing ones like gh-pages if listed:
+git branch <name-with-slash> <sha>
+git branch -f main <declared-main-sha>       # use a temp ref or `git push` SHA→ref
+                                              # if main is checked out in the worktree
 
-# Phase 2 — satisfy the union so the push is accepted
-git push --force --all origin
+# Phase 1b — know your worktree: if `main` is checked out and you can't -f it,
+#               use `git push <nostr-url> <temp-branch>:refs/heads/main --force`
+#               or create a separate worktree before force-moving main.
+
+# Phase 2 — satisfy the union on the nostr URL only
+git push --force --all nostr://<npub>/relay.ngit.dev/<repo>
 
 # Phase 3 — publish a single combined state event
 ngit init --clean -f -d        # both relays should report "already in sync"
@@ -412,23 +550,38 @@ ngit init --clean -f -d        # both relays should report "already in sync"
 # Phase 4 — drop the stale branches, push the desired state
 git branch -f main <current-head-sha>
 git branch -D <stale-1> <stale-2> …
-git push --force --prune origin
+git push --force --prune nostr://<npub>/relay.ngit.dev/<repo>
 ngit init --clean -f -d
 ```
 
-**Caveats (observed on `cowx`, 2026-07-27):**
+**Hard rule from experience (cowx):** never let Phase 4's `--prune` target `origin` when
+`origin` also carries a GitHub or Radicle pushurl — that will delete real branches from
+those remotes too. Always push the purge step to the **`nostr://` URL directly**. If you
+need to prune `main` against the current state but preserve GitHub/Radicle, specify the
+nostr remote explicitly.
+
+**Caveats (observed on `cowx`, 2026-07-27 and `persecutio`):**
 - All declared commits must still exist in the local object store (they will, if
   they're ancestors of current `main`). If any are missing, the union can never be
   satisfied — then publish Nostr kind 5 deletion events (`nak event -k 5 -t e <id>
   --sec <nsec> -l relay.ngit.dev`) against the stale state-event IDs, or ask the grasp
   operator to clear purgatory.
+- Name/syntax gotcha: `git branch` accepts `<name> <sha>` but the `name <sha>` form
+  *inside* `< >` in a patch can be misread — here it's two separate arguments.
+  Equivalently you can use `git update-ref refs/heads/<name> <sha>` (not for checked-out
+  branches) or `git branch -f <name> <sha>`.
 - `gitnostr.com` is flaky: a direct push may fail with "No state events in purgatory"
   until `ngit init` has published a state event there. Treat **relay.ngit.dev as the
-  primary grasp server**; state events sync between grasp servers automatically.
+  primary grasp server**; state events sync between grasp servers automatically. If it
+  complains later during push-after-purge, re-run `ngit init --clean -f -d` and push
+  again.
 - A Radicle pushurl key-registration error means the `rad` node isn't running —
   `rad node start` then retry. (Unrelated to purgatory.)
 - If GitHub `main` is ahead after the fix (CI bots), recover with
   `git fetch git@github.com:rinchen/<repo>.git main && git rebase FETCH_HEAD && git push origin main`.
+- `gh-pages` is often listed in purgatory even if deleted locally; include it in Phase 1
+  if listed (the commit still exists in local object store). Do **not** prune it from
+  GitHub in Phase 4 — prune only to the nostr URL.
 
 ## Rationale
 


### PR DESCRIPTION
## Summary
Adds the `hermes-ngit` skill to `optional-skills/devops/`, enabling Hermes to work with Nostr-based Git repositories (ngit / gitworkshop.dev) for decentralized, permissionless code hosting.

Incorporates **Dan Conway's** ngit command reference (`DanConwayDev/ngit-cli`, `skills/ngit/SKILL.md`) under the **CC-BY-SA-4.0** share-alike license. Includes:

- `ngit init` (announce to Nostr), `ngit sync`, `ngit send` (PRs), `ngit issue`, `ngit pr`
- Native `git push` / `git clone` against `nostr://` remotes (no daemon)
- **Mandatory `pr/` branch prefix** for PRs, `--json` / `--offline` / `--nsec` flags, full PR/issues lifecycle (open, view, comment, checkout, merge, close, reopen, label), and account management (bunker/NIP-46 login, inline `--nsec` for CI)
- Key flags table + `git config` tuning reference
- Joey Stanford's additions: the `ngit init` remote-rewrite gotcha, multi-mirror (GitHub + Radicle + Nostr) packaging, and session repo detection

## Credit
The command reference and workflow details are based on enhancements by **Dan Conway** (DanConwayDev/ngit-cli, `skills/ngit/SKILL.md`, CC-BY-SA-4.0). Original framing and multi-mirror packaging by Joey Stanford. The file carries the **CC-BY-SA-4.0** license in accordance with the share-alike terms of the source material. Attribution is recorded in `SKILL.md`, the `NOTICE` file, and `README.md`.

## Files
- `optional-skills/devops/hermes-ngit/SKILL.md` — full skill (credits Dan by name in the body)
- `optional-skills/devops/hermes-ngit/README.md` — overview, links (GitHub + Nostr + Radicle), CC-BY-SA + Dan credit
- `optional-skills/devops/hermes-ngit/LICENSE` — verbatim CC-BY-SA-4.0 legalcode
- `optional-skills/devops/hermes-ngit/NOTICE` — attribution notice

## Compliance
- Follows the agentskills.io SKILL.md spec (`name` matches folder, activation-focused `description`)
- Adds Hermes metadata (`version`, `author`, `metadata.hermes.tags`, `related_skills`)

## Test plan
- [x] `SKILL.md` frontmatter validated against agentskills.io spec
- [x] Folder placed under correct category (`devops`)
- [x] Credit + CC-BY-SA-4.0 license applied per source material terms
- [x] README added with Radicle link