### PR TITLE
fix(title_generator): remove hardcoded temperature for GPT-5.6 compat

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -126,7 +126,6 @@ def generate_title(
             task="title_generation",
             messages=messages,
             max_tokens=500,
-            temperature=0.3,
             timeout=timeout,
             main_runtime=main_runtime,
         )


### PR DESCRIPTION
GPT-5.6 only accepts its default temperature. Remove the hardcoded
temperature=0.3 so title generation doesn't fail for models that reject
sampling overrides. The reactive retry in call_llm() that strips
temperature can race process cleanup in short-lived sessions.

Fixes #72351
