### PR TITLE
fix(gemini_native_adapter): prefer tool_name_by_call_id for functionResponse

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -282,8 +282,8 @@ def _translate_tool_result_to_gemini(
     tool_name_by_call_id = tool_name_by_call_id or {}
     tool_call_id = str(message.get("tool_call_id") or "")
     name = str(
-        message.get("name")
-        or tool_name_by_call_id.get(tool_call_id)
+        tool_name_by_call_id.get(tool_call_id)
+        or message.get("name")
         or tool_call_id
         or "tool"
     )


### PR DESCRIPTION
When Tool Search bridges a tool_call, the functionResponse.name must match
the original functionCall.name ('tool_call'), not the unwrapped internal
tool name. The executor stores the internal name on the result message,
which overrode the call-ID mapping. Prefer the call-ID mapping first.

Fixes #72089
