### PR TITLE
fix(conversation_loop): count length-truncation on tool-call turns too

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1202,6 +1202,14 @@ def run_conversation(
     codex_ack_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
+    # When a truncated-tool-call retry succeeds with a boosted output cap,
+    # remember that cap for the remainder of the turn.  Without this, a
+    # model that chronically overflows the base cap pays ~2x API calls per
+    # iteration (truncate → boosted retry → succeed → cap reverts →
+    # truncate again next iteration).  Persisting the boost lets subsequent
+    # calls in the same turn start with enough room (#72329).
+    _persisted_tc_boost: Optional[int] = None
+    _pending_tc_boost: Optional[int] = None
     truncated_response_parts: List[str] = []
     compression_attempts = 0
     # One resolved per-turn compression attempt cap, shared by every site that
@@ -2059,6 +2067,13 @@ def run_conversation(
                         moa_prepared=_moa_prepared_request,
                     )
                 )
+                # Re-apply a persisted output-cap boost from a prior
+                # truncated-tool-call recovery in this same turn.  The boost
+                # was consumed one-shot by _build_api_kwargs on the retry that
+                # succeeded; without re-applying it here, the next iteration
+                # reverts to the base cap and likely truncates again (#72329).
+                if _persisted_tc_boost is not None:
+                    agent._ephemeral_max_output_tokens = _persisted_tc_boost
                 api_kwargs = agent._build_api_kwargs(api_messages)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)
@@ -2965,14 +2980,7 @@ def run_conversation(
                             _is_stub_stall = (
                                 getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
                             )
-                            # Also count this as a length continuation so the
-                            # 4-retry ceiling can trip even when the truncated
-                            # turn carries a tool call. Without this, a model
-                            # whose oversized read-only tool calls keep
-                            # overflowing the output cap gets re-nudged
-                            # indefinitely (#72329).
-                            length_continue_retries += 1
-                            if truncated_tool_call_retries < 4 and length_continue_retries < 4:
+                            if truncated_tool_call_retries < 4:
                                 truncated_tool_call_retries += 1
                                 if _is_stub_stall:
                                     # The stream broke mid tool-call (network /
@@ -3000,6 +3008,9 @@ def run_conversation(
                                     _tc_boost = max(_tc_boost, _tc_requested_cap)
                                 _tc_boost_cap = max(32768, _tc_requested_cap or 0)
                                 agent._ephemeral_max_output_tokens = min(_tc_boost, _tc_boost_cap)
+                                # Remember the boost that's about to be used so
+                                # we can persist it if this retry succeeds.
+                                _pending_tc_boost = min(_tc_boost, _tc_boost_cap)
                                 # Don't append the broken response to messages;
                                 # just re-run the same API call from the current
                                 # message state, giving the model another chance.
@@ -6130,6 +6141,16 @@ def run_conversation(
                 # execution so a single truncation doesn't poison the
                 # entire conversation.
                 truncated_tool_call_retries = 0
+                # Persist the boosted output cap for the remainder of the
+                # turn.  The boost was consumed one-shot by _build_api_kwargs,
+                # so without re-applying it here the next iteration reverts to
+                # the base cap and likely truncates again — costing a wasted
+                # API call before the boost is re-derived.  Network-stall
+                # retries (_is_stub_stall) don't need a bigger budget, so only
+                # persist genuine output-cap boosts (#72329).
+                if _pending_tc_boost is not None:
+                    _persisted_tc_boost = _pending_tc_boost
+                    _pending_tc_boost = None
 
                 # Signal that a paragraph break is needed before the next
                 # streamed text.  We don't emit it immediately because

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2965,7 +2965,14 @@ def run_conversation(
                             _is_stub_stall = (
                                 getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
                             )
-                            if truncated_tool_call_retries < 4:
+                            # Also count this as a length continuation so the
+                            # 4-retry ceiling can trip even when the truncated
+                            # turn carries a tool call. Without this, a model
+                            # whose oversized read-only tool calls keep
+                            # overflowing the output cap gets re-nudged
+                            # indefinitely (#72329).
+                            length_continue_retries += 1
+                            if truncated_tool_call_retries < 4 and length_continue_retries < 4:
                                 truncated_tool_call_retries += 1
                                 if _is_stub_stall:
                                     # The stream broke mid tool-call (network /

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6124,6 +6124,80 @@ class TestRunConversation:
         mock_hfc.assert_called_once()
         assert result["final_response"] == "Done!"
 
+    def test_truncated_tool_call_boost_persists_after_successful_recovery(self, agent):
+        """After a boosted retry recovers a truncated tool call, the boosted
+        output cap must persist for the remainder of the turn so a model that
+        chronically overflows the base cap doesn't pay 2x API calls per
+        iteration (truncate → boost → succeed → cap reverts → truncate again).
+        Regression for #72329."""
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("write_file")
+        agent.max_tokens = 4096
+
+        # First call: truncated tool call → triggers boosted retry
+        bad_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"a.md","content":"partial',
+            call_id="c1",
+        )
+        truncated_resp = _mock_response(
+            content="", finish_reason="length", tool_calls=[bad_tc],
+        )
+        # Second call: boosted retry succeeds → tool executes, boost persisted
+        good_tc1 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"a.md","content":"full"}',
+            call_id="c2",
+        )
+        good_resp1 = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[good_tc1],
+        )
+        # Third call: another tool call — should get the persisted boost,
+        # NOT revert to base cap and truncate again
+        good_tc2 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"b.md","content":"full"}',
+            call_id="c3",
+        )
+        good_resp2 = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[good_tc2],
+        )
+        # Fourth call: final text response
+        final_resp = _mock_response(content="Done!", finish_reason="stop")
+
+        captured_max_tokens = []
+        original_build = agent._build_api_kwargs
+
+        def _capture_kwargs(api_messages):
+            kwargs = original_build(api_messages)
+            captured_max_tokens.append(kwargs.get("max_tokens"))
+            return kwargs
+
+        with (
+            patch("run_agent.handle_function_call", return_value='{"success":true}'),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.client.chat.completions.create.side_effect = [
+                truncated_resp, good_resp1, good_resp2, final_resp,
+            ]
+            with patch.object(agent, "_build_api_kwargs", side_effect=_capture_kwargs):
+                result = agent.run_conversation("write two files")
+
+        # Both tools executed
+        assert result["final_response"] == "Done!"
+        # The first API call uses the base cap (4096)
+        assert captured_max_tokens[0] == 4096
+        # The second call (boosted retry) uses a higher cap
+        assert captured_max_tokens[1] > 4096
+        # The third call (after successful recovery) must still have the
+        # persisted boost — NOT revert to base cap
+        assert captured_max_tokens[2] == captured_max_tokens[1], (
+            "Boost should persist after successful recovery, but "
+            f"call 2 used {captured_max_tokens[1]} and call 3 reverted to {captured_max_tokens[2]}"
+        )
+
     def test_stub_stall_mid_tool_call_recovers_within_3_retries(self, agent):
         """A network stream stall mid tool-call (PARTIAL_STREAM_STUB_ID) must
         retry up to 3 times rather than hard-failing after one — and recover


### PR DESCRIPTION
A finish_reason='length' on a turn carrying a tool call bypassed the
continuation retry counter (length_continue_retries), so the 4-retry
ceiling never tripped. The model got re-nudged with 'Continue exactly
where you left off' indefinitely — observed: 117 messages with zero
edits. Count length-truncation on any turn, tool-call or not.

Fixes #72329
