### PR TITLE
fix(system_prompt,prompt_builder): gate project context behind coding_context

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2005,6 +2005,7 @@ def build_context_files_prompt(
     skip_soul: bool = False,
     context_length: Optional[int] = None,
     allow_install_tree_fallback: bool = False,
+    skip_project_context: bool = False,
 ) -> str:
     """Discover and load context files for the system prompt.
 
@@ -2015,6 +2016,11 @@ def build_context_files_prompt(
       4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
 
     SOUL.md from HERMES_HOME is independent and always included when present.
+
+    When *skip_project_context* is True, project-context files (HERMES.md,
+    AGENTS.md, CLAUDE.md, .cursorrules) are not loaded — only SOUL.md is
+    included. This is used to gate project context behind the coding_context
+    setting (#72268).
 
     Each context source is capped before injection. The cap defaults to the
     model's context window (scaled — see ``_dynamic_context_file_max_chars``)
@@ -2043,7 +2049,9 @@ def build_context_files_prompt(
     # their launch dir IS the user's shell cwd (developing Hermes in-tree).
     from agent.runtime_cwd import _is_install_tree
 
-    if (
+    if skip_project_context:
+        project_context = ""
+    elif (
         cwd_is_fallback
         and not allow_install_tree_fallback
         and _is_install_tree(cwd_path)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -470,10 +470,24 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # (developing Hermes). Every other surface (desktop chat panel,
         # gateway daemons) self-spawns into the install tree, where the
         # fallback would inject this repo's contributor AGENTS.md (#64590).
+        #
+        # skip_project_context: gate project-context files (AGENTS.md,
+        # CLAUDE.md, .cursorrules) behind the coding_context setting, matching
+        # the same check coding_system_blocks already uses (#72268).
+        _is_coding = False
+        try:
+            from agent.coding_context import is_coding_context
+            _is_coding = is_coding_context(
+                platform=agent.platform,
+                cwd=resolve_context_cwd(),
+            )
+        except Exception:
+            pass
         context_files_prompt = _r.build_context_files_prompt(
             cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
             context_length=_ctx_len,
-            allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+            allow_install_tree_fallback=agent.platform in ("cli", "tui"),
+            skip_project_context=not _is_coding)
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 


### PR DESCRIPTION
Project-context files (AGENTS.md, CLAUDE.md, .cursorrules) were injected
into chat-platform sessions regardless of the coding_context setting.
build_context_files_prompt() is called unconditionally when
skip_context_files is False, with no awareness of coding_context or
platform. Gate project-context discovery behind the same
is_coding_context() check that coding_system_blocks already uses.

Fixes #72268
