### PR TITLE
fix(tests): stabilize cross-platform full-suite baseline

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -896,7 +896,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
             )
             # Wait briefly for the worker to notice the closed connection.
             t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
+            if result["response"] is None:
+                # The abort can make the worker publish its transport error
+                # before this thread synthesizes the watchdog timeout. The
+                # watchdog owns the outcome once its deadline has fired.
                 if _silent_hint:
                     result["error"] = TimeoutError(
                         f"Codex stream produced no bytes within {int(_elapsed)}s "
@@ -941,7 +944,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 f"codex stream killed after {int(_event_stale_elapsed)}s with no SSE events"
             )
             t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
+            if result["response"] is None:
                 result["error"] = TimeoutError(
                     f"Codex stream produced no SSE events for {int(_event_stale_elapsed)}s "
                     f"after first byte (threshold: {int(_codex_idle_timeout)}s)"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6588,14 +6588,7 @@ def cmd_gui(args: argparse.Namespace):
 
     packaged_executable = _desktop_packaged_executable(desktop_dir)
 
-    if source_mode or not skip_build:
-        npm = _resolve_node_runtime_npm()
-        if not npm:
-            print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
-            print("Install Node.js, then run:  hermes gui")
-            sys.exit(1)
-    else:
-        npm = None
+    npm = None
 
     if skip_build:
         if source_mode:
@@ -6629,6 +6622,11 @@ def cmd_gui(args: argparse.Namespace):
             build_label = "source build" if source_mode else "packaged app"
             print(f"✓ Desktop {build_label} is up to date (content stamp matches)")
         else:
+            npm = _resolve_node_runtime_npm()
+            if not npm:
+                print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
+                print("Install Node.js, then run:  hermes gui")
+                sys.exit(1)
             print("→ Installing desktop workspace dependencies...")
             # Put the Hermes-managed Node on PATH so npm's child scripts (which
             # shell out to bare `node`, e.g. electron-winstaller's
@@ -6768,6 +6766,12 @@ def cmd_gui(args: argparse.Namespace):
         return
 
     if source_mode:
+        if npm is None:
+            npm = _resolve_node_runtime_npm()
+            if not npm:
+                print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
+                print("Install Node.js, then run:  hermes gui")
+                sys.exit(1)
         print("→ Launching Hermes Desktop from source build...")
         launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
         sys.exit(launch_result.returncode)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -720,7 +720,7 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
             token = run_oauth_setup_token()
 
         assert token == "from-cred-file"
@@ -738,7 +738,7 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
             token = run_oauth_setup_token()
 
         assert token == "from-env-var"
@@ -751,7 +751,7 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
             token = run_oauth_setup_token()
 
         assert token is None

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -282,20 +282,24 @@ def test_event_idle_kills_after_first_event_then_silence(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "1")
 
     closes: list = []
+    stop = {"flag": False}
     dummy_client = SimpleNamespace()
     monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+
+    def _abort_request(_client, reason=None):
+        closes.append(reason)
+        stop["flag"] = True
+
     monkeypatch.setattr(
         agent,
         "_abort_request_openai_client",
-        lambda c, reason=None: closes.append(reason),
+        _abort_request,
     )
     monkeypatch.setattr(
         agent,
         "_close_request_openai_client",
         lambda c, reason=None: closes.append(reason),
     )
-
-    stop = {"flag": False}
 
     def fake_stream(api_kwargs, client=None, on_first_delta=None):
         agent._codex_stream_last_event_ts = time.time()

--- a/tests/agent/test_credential_pool_oat_authtype.py
+++ b/tests/agent/test_credential_pool_oat_authtype.py
@@ -128,6 +128,12 @@ def test_profile_global_fallback_normalizes_in_memory_without_writing(tmp_path, 
             }],
         },
     }))
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_hermes_oauth_credentials", lambda: None
+    )
 
     from agent.credential_pool import load_pool
 

--- a/tests/cli/test_chat_q_exit_clear.py
+++ b/tests/cli/test_chat_q_exit_clear.py
@@ -94,6 +94,7 @@ def test_single_query_main_skips_clear_on_exit_summary(monkeypatch):
                 clear_calls.append("CLEARED")  # should NOT happen
 
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "worktree", False)
     monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
     monkeypatch.setattr(
         cli_mod,

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -181,6 +181,7 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
             calls.append("summary")
 
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "worktree", False)
     monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         cli_mod,
@@ -254,6 +255,7 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "worktree", False)
     monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         cli_mod,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -670,6 +670,40 @@ def _live_system_guard(request, monkeypatch):
         _psutil = None
         _initial_children = set()
 
+    # ``parents()`` is insufficient once a child daemonizes or the direct
+    # parent exits: the process is reparented and no longer appears below the
+    # pytest worker. Record exact process identities at spawn time so tests can
+    # still terminate children they created without weakening the foreign-PID
+    # guard. ``create_time`` prevents a reused PID from inheriting trust.
+    _spawned_children = {}
+
+    def _record_spawned_child(proc):
+        try:
+            pid = int(proc.pid)
+        except Exception:
+            return proc
+        if _psutil is None:
+            return proc
+        try:
+            created = _psutil.Process(pid).create_time()
+        except Exception:
+            return proc
+        _spawned_children[pid] = created
+        return proc
+
+    def _is_recorded_child(pid: int) -> bool:
+        if _psutil is None:
+            return False
+        expected_created = _spawned_children.get(pid)
+        if expected_created is None:
+            return False
+        try:
+            return _psutil.Process(pid).create_time() == expected_created
+        except _psutil.NoSuchProcess:
+            return True
+        except Exception:
+            return False
+
     def _is_own_subtree(pid: int) -> bool:
         # PID 0 means "our own process group"; -1 means "every process we
         # can signal". Both are dangerous when paired with SIGTERM/SIGKILL,
@@ -679,15 +713,16 @@ def _live_system_guard(request, monkeypatch):
             return True
         if pid < 0:
             return False
-        if pid == test_pid or pid in _initial_children:
+        if pid == test_pid or pid in _initial_children or _is_recorded_child(pid):
             return True
         if _psutil is None:
             return False
         try:
             walker = _psutil.Process(pid)
-        except Exception:
-            # Stale PID — kill would be a no-op anyway, allow it.
+        except _psutil.NoSuchProcess:
             return True
+        except Exception:
+            return False
         try:
             for parent in walker.parents():
                 if parent.pid == test_pid:
@@ -730,11 +765,35 @@ def _live_system_guard(request, monkeypatch):
         real_killpg = _os.killpg
         own_pgid = _os.getpgrp()
 
+        def _is_own_session_group(pgid: int) -> bool:
+            """Return True for an exact, recorded child leading its own session."""
+            if pgid <= 0 or _psutil is None:
+                return False
+            expected_created = _spawned_children.get(pgid)
+            if expected_created is None:
+                return False
+            try:
+                proc = _psutil.Process(pgid)
+                return (
+                    proc.create_time() == expected_created
+                    and _os.getpgid(pgid) == pgid
+                    and _os.getsid(pgid) == pgid
+                )
+            except Exception:
+                return False
+
         def _guarded_killpg(pgid, sig, *args, **kwargs):
             # Signal 0 is a pure liveness probe — never destructive.
             if int(sig) == 0:
                 return real_killpg(pgid, sig, *args, **kwargs)
-            if int(pgid) == own_pgid or _is_own_subtree(int(pgid)):
+            # A PGID is not a process identity: it can equal the PID of a
+            # recorded child while containing unrelated processes. Besides the
+            # pytest worker's group, only trust a recorded child whose exact
+            # identity is still present and which leads a new session. POSIX
+            # prevents unrelated processes outside that session from joining
+            # the group, so product cleanup paths can safely kill their own
+            # start_new_session=True subprocess trees.
+            if int(pgid) == own_pgid or _is_own_session_group(int(pgid)):
                 return real_killpg(pgid, sig, *args, **kwargs)
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
@@ -891,6 +950,7 @@ def _live_system_guard(request, monkeypatch):
             def __init__(self, cmd, *args, **kwargs):
                 _check_subprocess_cmd("Popen", cmd)
                 super().__init__(cmd, *args, **kwargs)
+                _record_spawned_child(self)
 
         _GuardedPopen.__name__ = "Popen"
         _GuardedPopen.__qualname__ = "Popen"
@@ -963,11 +1023,13 @@ def _live_system_guard(request, monkeypatch):
             _check_subprocess_cmd(
                 "asyncio.create_subprocess_exec", [program, *args]
             )
-            return await real_async_exec(program, *args, **kwargs)
+            proc = await real_async_exec(program, *args, **kwargs)
+            return _record_spawned_child(proc)
 
         async def _guarded_async_shell(cmd, *args, **kwargs):
             _check_subprocess_cmd("asyncio.create_subprocess_shell", cmd)
-            return await real_async_shell(cmd, *args, **kwargs)
+            proc = await real_async_shell(cmd, *args, **kwargs)
+            return _record_spawned_child(proc)
 
         monkeypatch.setattr(_asyncio, "create_subprocess_exec", _guarded_async_exec)
         monkeypatch.setattr(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1069,7 +1069,9 @@ class TestHealthDetailedEndpoint:
             "active_agents": 2,
             "exit_reason": None,
             "updated_at": "2026-04-14T00:00:00Z",
-        }), patch("gateway.run._resolve_gateway_model", return_value="test/model"):
+        }), patch("gateway.run._resolve_gateway_model", return_value="test/model"), patch(
+            "gateway.readiness._probe_disk", return_value={"status": "ok"}
+        ):
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.get("/health/detailed")
                 assert resp.status == 200

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -352,13 +352,13 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            assert _os.path.realpath(mock_adapter.send_voice.call_args.kwargs["audio_path"]) == _os.path.realpath(_ogg)
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            assert _os.path.realpath(mock_adapter.send_video.call_args.kwargs["video_path"]) == _os.path.realpath(_mp4)
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            assert _os.path.realpath(mock_adapter.send_image_file.call_args.kwargs["image_path"]) == _os.path.realpath(_png)
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            assert _os.path.realpath(mock_adapter.send_document.call_args.kwargs["file_path"]) == _os.path.realpath(_pdf)
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -18,6 +18,9 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
     with sqlite3.connect(home / "state.db") as conn:
         conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        "gateway.readiness._probe_disk", lambda _home: {"status": "ok"}
+    )
 
     result = collect_runtime_readiness(
         configured_model="test/model",

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -167,7 +167,7 @@ async def test_startup_aborts_when_restart_begins_during_platform_connect(tmp_pa
     telegram.disconnect = disconnect_and_release
     runner._create_adapter = MagicMock(side_effect=[telegram, slack])
 
-    result = await asyncio.wait_for(runner.start(), timeout=2)
+    result = await asyncio.wait_for(runner.start(), timeout=5)
 
     assert result is True
     assert telegram.disconnected is True

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import sys
 
 import pytest
 
@@ -31,7 +32,8 @@ def test_notify_sends_real_unix_datagram(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
+    not sys.platform.startswith("linux") or not hasattr(socket, "AF_UNIX"),
+    reason="abstract Unix sockets are Linux-only",
 )
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1299,6 +1299,9 @@ class TestProfileRestoration:
         hermes_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.check_alias_collision", lambda _name: None
+        )
 
         # Mock the wrapper dir to be inside tmp_path
         wrapper_dir = tmp_path / ".local" / "bin"

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -178,10 +178,18 @@ class TestGenerateZsh:
                 [
                     "zsh",
                     "-fc",
-                    f"autoload -Uz compinit && compinit -D; source {path}; [[ ${{_comps[hermes]}} == _hermes ]]",
+                    "for dir in $fpath; do "
+                    "[[ -r $dir/compinit ]] && { fpath=($dir); break; }; "
+                    "done; autoload -Uz compinit && compinit -D; "
+                    f"source {path}; [[ ${{_comps[hermes]}} == _hermes ]]",
                 ],
                 capture_output=True,
                 text=True,
+                env={
+                    **os.environ,
+                    "HOME": os.path.dirname(path),
+                    "ZDOTDIR": os.path.dirname(path),
+                },
             )
             assert result.returncode == 0, result.stderr
             assert result.stderr == ""

--- a/tests/hermes_cli/test_desktop_exe_integrity.py
+++ b/tests/hermes_cli/test_desktop_exe_integrity.py
@@ -536,7 +536,7 @@ def test_build_only_fails_when_pack_produces_corrupt_exe(tmp_path, monkeypatch, 
     install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
     pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \
@@ -570,7 +570,7 @@ def test_build_only_succeeds_with_valid_exe(tmp_path, monkeypatch, capsys):
     install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
     pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -122,6 +122,10 @@ class TestWslSystemdOperational:
 class TestSupportsSystemdServicesWSL:
     """Test that supports_systemd_services() handles WSL correctly."""
 
+    @pytest.fixture(autouse=True)
+    def _systemctl_available(self, monkeypatch):
+        monkeypatch.setattr(gateway.shutil, "which", lambda _name: "/usr/bin/systemctl")
+
     def test_wsl_with_systemd(self, monkeypatch):
         """WSL + working systemd → True."""
         monkeypatch.setattr(gateway, "is_linux", lambda: True)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -312,7 +312,7 @@ def test_gui_source_mode_uses_renderer_build_and_electron(tmp_path, monkeypatch)
     build_ok = subprocess.CompletedProcess(["npm", "run", "build"], 0)
     launch_ok = subprocess.CompletedProcess(["npm", "exec", "--", "electron", "."], 0)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
@@ -325,6 +325,37 @@ def test_gui_source_mode_uses_renderer_build_and_electron(tmp_path, monkeypatch)
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
     assert mock_run.call_args_list[1].args[0] == ["/usr/bin/npm", "exec", "--", "electron", "."]
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
+
+
+@pytest.mark.parametrize("skip_build", [False, True])
+def test_gui_source_mode_resolves_npm_when_build_is_skipped(
+    tmp_path, monkeypatch, skip_build
+):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    (desktop_dir / "dist").mkdir()
+    (desktop_dir / "dist" / "index.html").write_text("", encoding="utf-8")
+    electron_dir = root / "node_modules" / "electron"
+    electron_dir.mkdir(parents=True)
+    (electron_dir / "package.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+
+    launch_ok = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm") as mock_npm, \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(source=True, skip_build=skip_build))
+
+    assert exc.value.code == 0
+    mock_npm.assert_called_once_with()
+    mock_install.assert_not_called()
+    assert mock_run.call_args.args[0] == [
+        "/usr/bin/npm", "exec", "--", "electron", "."
+    ]
+    assert mock_run.call_args.kwargs["cwd"] == desktop_dir
 
 
 @pytest.mark.parametrize(
@@ -352,6 +383,7 @@ def test_desktop_build_stamp_skips_build_when_up_to_date(tmp_path, monkeypatch):
     launch_ok = subprocess.CompletedProcess([], 0)
 
     with patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._resolve_node_runtime_npm") as mock_npm, \
          patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
          patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
@@ -359,6 +391,7 @@ def test_desktop_build_stamp_skips_build_when_up_to_date(tmp_path, monkeypatch):
         cli_main.cmd_gui(_ns())
 
     assert exc.value.code == 0
+    mock_npm.assert_not_called()
     mock_install.assert_not_called()
     mock_run.assert_called_once()  # only the launch call, no build
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -566,7 +566,8 @@ class TestDeleteProfile:
         profile_dir = create_profile("coder", no_alias=True)
         assert profile_dir.is_dir()
         # Mock gateway import to avoid real systemd/launchd interaction
-        with patch("hermes_cli.profiles._cleanup_gateway_service"):
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles._profile_bound_backend_pids", return_value=[]):
             delete_profile("coder", yes=True)
         assert not profile_dir.is_dir()
 
@@ -583,6 +584,7 @@ class TestDeleteProfile:
         set_active_profile("coder")
 
         with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles._profile_bound_backend_pids", return_value=[]), \
              patch("hermes_cli.profiles.time.sleep"), \
              patch("hermes_cli.profiles.shutil.rmtree", side_effect=PermissionError("locked")):
             with pytest.raises(RuntimeError, match="Could not remove profile directory"):
@@ -1847,7 +1849,8 @@ class TestEdgeCases:
         set_active_profile("coder")
         assert get_active_profile() == "coder"
 
-        with patch("hermes_cli.profiles._cleanup_gateway_service"):
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles._profile_bound_backend_pids", return_value=[]):
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -7,6 +7,8 @@ implementation in this same file once that phase ships.
 """
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from hermes_cli.service_manager import (
@@ -450,8 +452,9 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
-        f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
+    expected_event_mode = 0o1730 if sys.platform == "darwin" else 0o3730
+    assert stat.S_IMODE(event.stat().st_mode) == expected_event_mode, (
+        f"event/ mode = {oct(event.stat().st_mode)}, want {oct(expected_event_mode)}"
     )
 
     # supervise/ dir.
@@ -462,7 +465,7 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
+    assert stat.S_IMODE(supervise_event.stat().st_mode) == expected_event_mode
 
     # supervise/control FIFO.
     control = supervise / "control"
@@ -497,7 +500,8 @@ def test_seed_supervise_skeleton_handles_log_subservice(tmp_path) -> None:
     log_control = log_supervise / "control"
 
     assert log_event.is_dir()
-    assert stat.S_IMODE(log_event.stat().st_mode) == 0o3730
+    expected_event_mode = 0o1730 if sys.platform == "darwin" else 0o3730
+    assert stat.S_IMODE(log_event.stat().st_mode) == expected_event_mode
     assert log_supervise.is_dir()
     assert log_supervise_event.is_dir()
     assert log_control.exists() and stat.S_ISFIFO(log_control.stat().st_mode)

--- a/tests/hermes_cli/test_signal_handler_kanban_worker.py
+++ b/tests/hermes_cli/test_signal_handler_kanban_worker.py
@@ -103,6 +103,20 @@ def _is_alive_like_dispatcher(pid: int) -> bool:
                         break
         except (FileNotFoundError, PermissionError, OSError):
             pass
+    elif sys.platform == "darwin":
+        try:
+            status = subprocess.run(
+                ["ps", "-o", "stat=", "-p", str(pid)],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=False,
+            )
+            if status.returncode != 0 or "Z" in status.stdout:
+                return False
+        except (OSError, subprocess.SubprocessError):
+            pass
     return True
 
 

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -18,6 +18,7 @@ the guard? Add a test here too.
 from __future__ import annotations
 
 import os
+import shutil
 import signal
 import subprocess
 import types
@@ -277,7 +278,12 @@ def test_subprocess_killall_hermes_blocked():
 
 # ──────────────────── pass-through cases (must NOT raise) ──────
 
+requires_systemctl = pytest.mark.skipif(
+    shutil.which("systemctl") is None,
+    reason="systemctl is unavailable",
+)
 
+@requires_systemctl
 def test_systemctl_status_passes_through():
     """Read-only systemctl probes (status/show/list-units) are fine."""
     # Run with check=False so we don't fail on the gateway's exit code.
@@ -290,6 +296,7 @@ def test_systemctl_status_passes_through():
     assert r is not None  # Did not raise — the guard let it through.
 
 
+@requires_systemctl
 def test_systemctl_show_passes_through():
     r = subprocess.run(
         ["systemctl", "--user", "show", "hermes-gateway", "--no-pager"],
@@ -300,6 +307,7 @@ def test_systemctl_show_passes_through():
     assert r is not None
 
 
+@requires_systemctl
 def test_systemctl_list_units_passes_through():
     r = subprocess.run(
         ["systemctl", "--user", "list-units", "fake-not-real-unit*", "--no-pager"],
@@ -310,6 +318,7 @@ def test_systemctl_list_units_passes_through():
     assert r is not None
 
 
+@requires_systemctl
 def test_systemctl_unrelated_unit_passes_through():
     """systemctl restart of a non-hermes unit is allowed (we only protect hermes)."""
     # Use --dry-run so we don't actually try to restart anything; just
@@ -334,6 +343,26 @@ def test_kill_own_subtree_passes_through():
         p.wait(timeout=2)
     # SIGTERM = 15; subprocess returncode is -15 on POSIX.
     assert p.returncode in {-signal.SIGTERM, 128 + int(signal.SIGTERM)}
+
+
+def test_kill_child_without_proven_identity_is_blocked(monkeypatch):
+    """A failed create-time lookup must not turn a recorded PID into trust."""
+    psutil = pytest.importorskip("psutil")
+    real_process = psutil.Process
+
+    def _deny_process_lookup(pid):
+        raise psutil.AccessDenied(pid)
+
+    monkeypatch.setattr(psutil, "Process", _deny_process_lookup)
+    p = subprocess.Popen(["sleep", "30"])
+    try:
+        with pytest.raises(RuntimeError, match="outside the test process subtree"):
+            os.kill(p.pid, signal.SIGTERM)
+    finally:
+        monkeypatch.setattr(psutil, "Process", real_process)
+        if p.poll() is None:
+            os.kill(p.pid, signal.SIGTERM)
+        p.wait(timeout=2)
 
 
 def test_subprocess_pkill_with_unrelated_pattern_passes_through():

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3123,6 +3123,9 @@ def test_init_session_fires_reset_hook(monkeypatch):
 
     monkeypatch.setattr(_approval, "register_gateway_notify", lambda key, cb: None)
     monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_args: threading.Event()
+    )
 
     sid = "sid"
     try:
@@ -4019,14 +4022,8 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
         assert nested_started.wait(timeout=5)
         threads[0].join(timeout=5)
         assert not threads[0].is_alive()
-        # Membership, not order: the completion_queue is process-global, and
-        # notification pollers leaked by earlier session.init tests in this
-        # file legitimately steal-and-requeue foreign-session events (see
-        # _notification_poller_loop's belongs-elsewhere branch), rotating the
-        # queue. The requeue contract is that batch_2 and batch_3 both remain
-        # queued (never consumed) while batch_1's turn is in flight — so drain
-        # with a deadline (an event may be transiently held by a poller
-        # mid-cycle) and assert exactly {batch_2, batch_3} come back.
+        # Queue order is an implementation detail. The contract is that batch_2
+        # and batch_3 both remain queued while batch_1's turn is in flight.
         queued: dict = {}
         deadline = time.time() + 5.0
         while time.time() < deadline and set(queued) != {

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -156,8 +156,11 @@ class TestDetectDangerousRm:
 
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
         with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+            temp_dir = os.path.realpath("/tmp")
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                assert detect_dangerous_command(
+                    f"rm -f {temp_dir}/{prefix}example.py"
+                ) == (
                     False,
                     None,
                     None,

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -151,34 +151,24 @@ class TestAtomicSnapshotWrite:
         assert f"> '{snap}'" not in wrapped
         assert f"> {snap}\n" not in wrapped
 
-    def test_temp_path_uses_bashpid_not_dollardollar(self):
-        """The temp name MUST use ``$BASHPID`` (the real subshell PID), not
-        ``$$``.  In ``&``-launched concurrent subshells ``$$`` stays the parent
-        shell's PID, so two writers would pick the same temp name, clobber each
-        other mid-write, and mv would publish a torn file — the corruption is
-        only narrowed, not closed.  This is the bug shared by every prior PR in
-        the #38249 cluster."""
+    def test_temp_path_uses_mktemp_not_shell_pid(self):
+        """macOS bash 3.2 has no ``BASHPID`` and ``$$`` is shared by
+        background subshells, so only mktemp is portable and unique."""
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
-        assert "$BASHPID" in wrapped
-        # The bare $$ temp form must be gone.
+        assert "mktemp " in wrapped
+        assert ".tmp.XXXXXX" in wrapped
+        assert "$BASHPID" not in wrapped
         assert ".tmp.$$" not in wrapped
 
-    def test_temp_path_static_part_is_quoted_bashpid_outside(self):
-        """The static path portion must be shlex-quoted (Windows/Git-Bash
-        ``C:/Users/...`` or spaces) while ``$BASHPID`` stays OUTSIDE the quotes
-        so it still expands."""
+    def test_temp_path_template_with_spaces_is_quoted(self):
         env = _TestableEnv()
         env._snapshot_ready = True
         env._snapshot_path = "/tmp/has space/hermes-snap-x.sh"
         wrapped = env._wrap_command("echo hi", "/tmp")
-        # The static path (with its space) is shlex-quoted as a single word, with
-        # $BASHPID appended OUTSIDE the quotes so it still expands at runtime.
-        assert "'/tmp/has space/hermes-snap-x.sh.tmp.'$BASHPID" in wrapped
-        # The space must never appear bare/unquoted in the temp token (that would
-        # word-split into two args and break the redirect/mv).
-        assert " space/hermes-snap-x.sh.tmp.$BASHPID" not in wrapped
+        assert "mktemp '/tmp/has space/hermes-snap-x.sh.tmp.XXXXXX'" in wrapped
+        assert '> "$__hermes_snap_tmp"' in wrapped
 
     def test_wrap_command_mv_chained_on_export_success(self):
         """A failed/partial ``export -p`` must NOT mv a torn temp over a good
@@ -190,10 +180,9 @@ class TestAtomicSnapshotWrite:
         assert "export -p" in wrapped and "> " in wrapped and "&& mv -f " in wrapped
         assert "rm -f " in wrapped  # temp cleanup on failure
 
-    def test_init_session_bootstrap_also_atomic_and_bashpid(self):
+    def test_init_session_bootstrap_also_atomic_and_unique(self):
         """The init_session bootstrap (first snapshot write) is the same shared
-        file a concurrent command could source — it must be atomic and use
-        ``$BASHPID`` too."""
+        file a concurrent command could source, so it uses mktemp too."""
         env = _TestableEnv()
         captured = {}
 
@@ -208,8 +197,8 @@ class TestAtomicSnapshotWrite:
             pass
         boot = captured.get("cmd", "")
         assert ".tmp." in boot and "mv -f " in boot, boot
-        assert "$BASHPID" in boot
-        assert ".tmp.$$" not in boot
+        assert "mktemp " in boot and ".tmp.XXXXXX" in boot
+        assert "$BASHPID" not in boot and ".tmp.$$" not in boot
 
     def test_snapshot_writes_use_private_umask_after_user_command(self):
         env = _TestableEnv()
@@ -246,8 +235,9 @@ class TestAtomicSnapshotConcurrencyBehavioral:
     the emitted script's guarantee holds under real concurrency: N concurrent
     writers + readers, and the snapshot is ALWAYS a complete, parseable env
     dump — never truncated mid-line with a ``declare -x`` / ``export`` fragment
-    that would corrupt PATH.  Crucially it uses ``$BASHPID`` (per-subshell
-    unique), which is what closes the race; ``$$`` would still tear here.
+    that would corrupt PATH. Each writer uses ``mktemp`` because macOS bash 3.2
+    leaves ``BASHPID`` unset and would otherwise collapse every writer onto the
+    same temp path.
     """
 
     def _run(self, script):
@@ -262,13 +252,15 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         import shlex
         snap = str(tmp_path / "hermes-snap-x.sh")
         _q = shlex.quote
-        _snap_tmp = _q(snap + ".tmp.") + "$BASHPID"
+        snap_template = _q(snap + ".tmp.XXXXXX")
+        snap_tmp = '"$__hermes_snap_tmp"'
         # One writer iteration = the exact atomic sequence _wrap_command emits.
         writer = (
             "for i in $(seq 1 80); do "
             "export BIG_$i=$(head -c 600 /dev/zero | tr '\\0' x); "
-            f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_q(snap)}; }} "
-            f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true; "
+            f"if __hermes_snap_tmp=$(mktemp {snap_template}); then "
+            f"{{ export -p > {snap_tmp} && mv -f {snap_tmp} {_q(snap)}; }} "
+            f"2>/dev/null || rm -f {snap_tmp} 2>/dev/null || true; fi; "
             "done"
         )
         # Reader: repeatedly source the snapshot and check PATH never absorbs
@@ -301,9 +293,10 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         snap = str(tmp_path / "snap.sh")
         _q = shlex.quote
         self._run(f"echo 'export GOOD=1' > {_q(snap)}")  # seed good snapshot
-        # Redirect export into an unwritable dir so the export side fails; mv
-        # must then NOT run (&&) and not clobber snap.
-        bad_tmp = _q("/nonexistent-dir/snap.tmp.") + "$BASHPID"
+        # Redirect export to a directory so the export side fails; mv must then
+        # NOT run (&&) and not clobber snap.
+        bad_tmp = _q(str(tmp_path / "bad.tmp"))
+        self._run(f"mkdir {bad_tmp}")
         script = (
             f"{{ export -p > {bad_tmp} && mv -f {bad_tmp} {_q(snap)}; }} "
             f"2>/dev/null || rm -f {bad_tmp} 2>/dev/null || true"

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1902,7 +1902,8 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_window_id == 2
         assert backend._last_app == "Chrome"
 
-    def test_linux_default_capture_skips_gnome_shell_helper(self):
+    def test_linux_default_capture_skips_gnome_shell_helper(self, monkeypatch):
+        monkeypatch.setattr("tools.computer_use.cua_backend.sys.platform", "linux")
         windows = [
             {"app_name": "", "pid": 100, "window_id": 1,
              "is_on_screen": None, "title": "@!1921,0;BDHF", "z_index": 0},

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 
 import pytest
@@ -47,6 +48,8 @@ def test_real_binaries_execute_leading_dash_program_payload(
     tmp_path, tool, args, stdin, needs_tty
 ):
     """A PATH marker proves these binaries do not reparse '-program' as an option."""
+    if sys.platform == "darwin" and (tool == "sort" or needs_tty):
+        pytest.skip("test command uses GNU/Linux-only options")
     if shutil.which(tool) is None or (needs_tty and shutil.which("script") is None):
         pytest.skip(f"{tool} or script is not installed")
 

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            os.path.realpath("/tmp/out.txt"), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -182,7 +185,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "foo", "bar", False
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -195,7 +200,9 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "x", "y", True
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -54,7 +54,7 @@ def test_regex_preserves_user_env():
 
 
 def test_export_snippet_shape():
-    snippet = _export_dump_excluding_session_vars("/tmp/snap.tmp.$BASHPID")
+    snippet = _export_dump_excluding_session_vars('"$__hermes_snap_tmp"')
     assert "export -p" in snippet
     # Unset-by-name (not line-grep): multi-line declare values must not leave
     # continuation lines in the snapshot (issue #71296).
@@ -63,15 +63,11 @@ def test_export_snippet_shape():
     assert "${!HERMES_CRON_AUTO_DELIVER_*}" in snippet
     assert "HERMES_UI_SESSION_ID" in snippet
     assert "grep -vE" not in snippet
-    assert "/tmp/snap.tmp.$BASHPID" in snippet
-    # The redirection must be attached to a brace group wrapping the dump,
-    # NOT to a pipeline segment: a redirect on a pipeline segment expands
-    # $BASHPID inside that segment's subshell (a different PID than the parent
-    # that expands the follow-up ``mv`` operand), silently orphaning the dump
-    # and breaking snapshot env persistence entirely.
+    assert '"$__hermes_snap_tmp"' in snippet
+    # The redirection applies to the whole filtered export compound.
     assert snippet.lstrip().startswith("{ ")
     assert "|| true; }" in snippet
-    assert snippet.rstrip().endswith("> /tmp/snap.tmp.$BASHPID")
+    assert snippet.rstrip().endswith('> "$__hermes_snap_tmp"')
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -418,13 +418,9 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
     means ``export -p`` never emits those vars — including any continuation
     lines. ``|| true`` keeps the success contract for callers that chain on it.
 
-    The dump MUST be wrapped in a brace group with the redirection applied to
-    the group. *tmp_path* typically embeds ``$BASHPID`` for concurrency-safe
-    temp names; a redirection attached to a pipeline segment would expand
-    ``$BASHPID`` inside that segment's subshell (a different PID than the
-    parent that expands the follow-up ``mv``), silently orphaning the dump.
-    The brace-group redirect is expanded in the current shell, keeping both
-    expansions consistent.
+    The dump is wrapped in a brace group with the redirection applied to the
+    group, so the caller's quoted temp-path expression is expanded by the same
+    shell that later performs the atomic ``mv``.
     """
     # ${!PREFIX*} is bash 3.2+ name-prefix expansion; empty matches are fine
     # because ``unset`` with only missing names is ignored under 2>/dev/null.
@@ -542,18 +538,14 @@ class BaseEnvironment(ABC):
         # source() either sees the old complete snapshot or the new complete
         # one — never a partial/truncated file.
         #
-        # The temp name MUST be unique per concurrent writer.  ``$$`` is the
-        # bash PID, but in ``&``-launched subshells (how concurrent terminal
-        # calls run) ``$$`` stays the *parent* shell's PID — so two concurrent
-        # writers would pick the SAME temp name, clobber each other's temp
-        # mid-write, and mv would then publish a torn file (the corruption is
-        # only narrowed, not closed).  ``$BASHPID`` is the actual subshell PID
-        # and is genuinely unique per writer, which closes the race.  The
-        # static path is shell-quoted (Windows/Git-Bash drive letters, spaces)
-        # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # ``BASHPID`` is absent from macOS' system bash 3.2, while ``$$`` is
+        # shared by ``&``-launched subshells.  Use mktemp so every concurrent
+        # writer gets a real unique path on every supported bash version.
+        _snap_template = self._quote_shell_path(self._snapshot_path + ".tmp.XXXXXX")
+        _snap_tmp = '"$__hermes_snap_tmp"'
         bootstrap = (
             f"umask 077\n"
+            f"__hermes_snap_tmp=$(mktemp {_snap_template}) || exit 1\n"
             f"{_export_dump_excluding_session_vars(_snap_tmp)}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
@@ -662,11 +654,10 @@ class BaseEnvironment(ABC):
         # Use atomic file replacement for env snapshot updates (issue #38249).
         # Assemble into a per-writer-unique temp file, then mv to atomically
         # replace the snapshot so concurrent source() calls never read a
-        # truncated/half-written file.  ``$BASHPID`` (not ``$$``) is the actual
-        # subshell PID — unique per concurrent ``&``-launched writer — so two
-        # writers never share a temp name and clobber each other before the mv.
-        # Static path shell-quoted (Windows/spaces); ``$BASHPID`` left to expand.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # truncated/half-written file. ``mktemp`` is portable to macOS' system
+        # bash 3.2, where ``BASHPID`` is unset, and to Git Bash.
+        _snap_template = self._quote_shell_path(self._snapshot_path + ".tmp.XXXXXX")
+        _snap_tmp = '"$__hermes_snap_tmp"'
 
         parts = []
 
@@ -698,16 +689,12 @@ class BaseEnvironment(ABC):
         # Chain mv on the export succeeding so a failed/partial dump never
         # replaces a good snapshot; drop the temp on failure so it isn't
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
-        # NOTE: the redirection must be attached to a brace group — ``_snap_tmp``
-        # embeds ``$BASHPID``, and a redirect on a pipeline segment expands
-        # inside that segment's subshell (a different PID than the parent that
-        # expands the ``mv`` operand), silently orphaning the dump. See
-        # _export_dump_excluding_session_vars.
         if self._snapshot_ready:
             parts.append(
+                f"if __hermes_snap_tmp=$(mktemp {_snap_template}); then "
                 f"{{ {_export_dump_excluding_session_vars(_snap_tmp)} "
-                f"&& mv -f {_snap_tmp} {_quoted_snap}; }} "
-                f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
+                f"&& mv -f {_snap_tmp} {_quoted_snap}; }} 2>/dev/null "
+                f"|| rm -f {_snap_tmp} 2>/dev/null || true; fi"
             )
 
         # Emit the CWD stdout marker; all backends (including local, since


### PR DESCRIPTION
## What does this PR do?

Restores a green macOS full-suite baseline by fixing three real cross-platform/runtime edge cases and isolating tests from host-specific state.

- use `mktemp` for atomic environment snapshots so concurrent writers stay unique on macOS Bash 3.2, where `BASHPID` is unavailable
- make Codex watchdog deadlines own the timeout result even when aborting the transport races with the worker thread
- resolve npm only on desktop GUI paths that actually need it
- make the live-system test guard recognize exact spawned-process identities without allowing PID reuse or unsafe process-group signaling
- isolate tests from host paths, configuration, services, disk pressure, process state, and platform-specific command behavior

## Related Issue

No single issue. This was found while validating current `main`; it is independent of #72147.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/base.py`: replace shell-PID temp names with quoted `mktemp` templates for bootstrap and incremental snapshot writes.
- `agent/chat_completion_helpers.py`: preserve Codex TTFB/event-idle watchdog timeout semantics across abort races.
- `hermes_cli/main.py`: defer npm discovery until a build/install/source-launch path needs it.
- `tests/conftest.py`: record spawned PID creation times and restrict destructive process-group signals to verified session leaders.
- `tests/**`: isolate host-dependent fixtures and normalize macOS/Linux path, mode, socket, shell, service, and process behavior.

## How to Test

1. Run `scripts/run_tests.sh`.
2. Run Ruff on the changed Python files and `python scripts/check-windows-footguns.py --all`.
3. Run `git diff --check` and compare advisory `ty check` diagnostics with the unchanged base.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the canonical complete suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and comments are self-contained
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- Canonical suite: **2,347 files, 48,712 tests passed, 0 failed** in 492.9s.
- Focused current-base/overlap coverage: **439 passed, 0 failed**.
- Ruff: passed.
- Windows footgun scan: **830 files scanned, 0 findings**.
- `git diff --check`: passed.
- Advisory `ty` comparison: no new semantic source diagnostics; two existing `hermes_cli/main.py` diagnostics resolved. Both base and candidate hit the same known panic class in unchanged `tools/checkpoint_manager.py`.
