### PR TITLE
fix: preserve reasoning_effort on switch_model (#72856)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2374,7 +2374,12 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         from hermes_cli.config import load_config as _sm_load_config
 
         _reasoning_cfg = _sm_load_config() or {}
-        agent.reasoning_config = resolve_reasoning_config(_reasoning_cfg, agent.model)
+        _resolved = resolve_reasoning_config(_reasoning_cfg, agent.model)
+        # Only overwrite when config returns a real value (#72856).
+        # This preserves session-level reasoning_effort set via /reasoning
+        # while still applying per-model reasoning_overrides (non-None).
+        if _resolved is not None:
+            agent.reasoning_config = _resolved
         logger.info(
             "switch_model: reasoning_config resolved for %s: %s",
             agent.model, agent.reasoning_config,


### PR DESCRIPTION
Fixes #72856

When a user sets a session-level reasoning effort via `/reasoning high` and then switches models with `/model`, the reasoning setting was silently reset to the config file value (or `None` if unconfigured). Subsequent API calls would omit `reasoning_effort`.

## Root Cause

`agent/agent_runtime_helpers.py:2382` — `switch_model()` unconditionally overwrote `agent.reasoning_config` with the result of `resolve_reasoning_config()`. When config has no `reasoning_effort` set, this resets to `None`, dropping any session-level override.

## Fix

Guard the assignment: only overwrite `agent.reasoning_config` when `resolve_reasoning_config()` returns a non-None value. This preserves per-model `reasoning_overrides` (they return non-None) while not silently dropping session-level choices when config is unset.

## Testing

- `/reasoning high` → `/model` → `/reasoning` — still shows `high`
- `/model` without prior `/reasoning` — unchanged behavior
- Models with `reasoning_overrides` in config — override still applied on switch