### PR TITLE
fix(streaming): fall back to non-stream on custom provider SSE order error (#72833)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2970,6 +2970,8 @@ def _is_stream_unavailable_error(exc: Exception) -> bool:
         from agent.bedrock_adapter import is_streaming_access_denied_error
 
         return is_streaming_access_denied_error(exc)
+    if "unexpected event order" in err_lower:
+        return True
     return False
 
 


### PR DESCRIPTION
## Summary

Fixes #72833

When using a custom provider (`api_mode: anthropic_messages`) whose proxy sends SSE events out of order — specifically `content_block_*` events arriving before `message_start` — the Anthropic SDK (v0.87.0) raises a `RuntimeError` with the message "Unexpected event order, got {event.type} before message_start".

Before this fix, this exception was not recognized by `_is_stream_unavailable_error()`, so it propagated up as a crash instead of triggering the non-stream fallback to `messages.create()`.

## Changes

**`agent/anthropic_adapter.py`** — Added a check for "unexpected event order" in `_is_stream_unavailable_error()`. When the SDK raises this error (e.g., due to a custom proxy that emits SSE events in non-canonical order), the function now returns `True`, causing `create_anthropic_message()` to fall back to `messages.create()` instead of crashing.

## Related

See also #28156 for the analogous fix for Bedrock's AnthropicBedrock SDK path, which already handled this symptom in `conversation_loop.py`.

## Testing

- Existing `_is_stream_unavailable_error` catches: "stream not supported" text, "invokemodelwithresponsestream" (Bedrock), and now "unexpected event order".