### PR TITLE
fix(mcp): prevent duplicate stdio server processes on concurrent registration (#72818)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4404,6 +4404,29 @@ class TestRegisterMcpServers:
 
         _servers.pop("srv", None)
 
+    def test_skips_already_connecting_servers(self):
+        """A server name already in _server_connecting is not re-spawned.
+
+        Regression for #72818: concurrent register_mcp_servers() calls can
+        both see the name absent from _servers but neither checks
+        _server_connecting, resulting in duplicate stdio processes.
+        """
+        from tools.mcp_tool import register_mcp_servers, _server_connecting, _lock
+
+        with _lock:
+            _server_connecting.add("connecting")
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=[]), \
+                 patch("tools.mcp_tool._run_on_mcp_loop") as mock_run:
+                result = register_mcp_servers({"connecting": {"command": "test"}})
+            assert result == []
+            mock_run.assert_not_called()
+        finally:
+            with _lock:
+                _server_connecting.discard("connecting")
+
+
 
 # ---------------------------------------------------------------------------
 # Tests for parallel tool call support (port from openai/codex#17667)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5658,6 +5658,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             k: v
             for k, v in servers.items()
             if k not in _servers
+            and k not in _server_connecting
             and _parse_boolish(v.get("enabled", True), default=True)
             # Skip a server still serving its post-failure backoff. Without
             # this, a server that fails to connect (and is therefore never
@@ -5789,7 +5790,9 @@ def discover_mcp_tools() -> List[str]:
         new_server_names = [
             name
             for name, cfg in servers.items()
-            if name not in _servers and _parse_boolish(cfg.get("enabled", True), default=True)
+            if name not in _servers
+            and name not in _server_connecting
+            and _parse_boolish(cfg.get("enabled", True), default=True)
         ]
 
     tool_names = register_mcp_servers(servers)


### PR DESCRIPTION
## Problem

`register_mcp_servers()` has a check-then-connect race that can spawn multiple long-lived stdio MCP processes for the same configured server.

Inside the module lock it builds `new_servers` by excluding names already present in `_servers`, then adds those names to `_server_connecting`. A concurrent caller sees the name absent from `_servers` but does **not** consult `_server_connecting`, so it starts a second `MCPServerTask` for the same server. Each successful completion overwrites `_servers[name]`; the earlier task remains alive but is no longer reachable for shutdown/reconnect bookkeeping.

On a cron-heavy gateway with parallel agent initialization, this produced four direct children with the identical command, whose ages were staggered (roughly 37m, 33m, 11m, 7m). Each orphaned stdio session keeps its stdin/stdout/stderr pipe descriptors open, eventually producing `OSError: [Errno 24] Too many open files` under launchd's default `maxfiles=256`.

## Root Cause

In both `register_mcp_servers()` and `discover_mcp_tools()`, the new-name filter only checked `name not in _servers` but not `name not in _server_connecting`. Since `_server_connecting` is the in-flight ownership claim, it must participate in the same locked filter as `_servers`.

## Fix

Add `and name not in _server_connecting` to the new-name filter in both:
1. `register_mcp_servers()` — the dict comprehension that builds `new_servers`
2. `discover_mcp_tools()` — the list comprehension that builds `new_server_names`

Both checks already execute under `_lock`, so this turns `_server_connecting` into the intended atomic dedup guard.

## Testing

- New regression test `test_skips_already_connecting_servers` fails before the fix and passes after
- All 7 `TestRegisterMcpServers` tests pass
- All 8 `test_mcp_bridge_single_failure` tests pass
- All 31 `test_mcp_stability` tests pass

Fixes #72818