### PR TITLE
fix(curator): thread-scoped output silencing — global redirect poisons sys.stdout process-wide

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set
 
 from hermes_constants import get_hermes_home
+from agent.thread_scoped_output import thread_scoped_silence
 from tools import skill_usage
 from utils import atomic_json_write
 
@@ -1947,14 +1948,25 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # start (see agent/turn_context.py).
         review_agent._memory_write_origin = "background_review"
 
-        # Redirect the forked agent's stdout/stderr to /dev/null while it
-        # runs so its tool-call chatter doesn't pollute the foreground
-        # terminal. The background-thread runner also hides it; this
-        # belt-and-suspenders path matters when a caller invokes
-        # run_curator_review(synchronous=True) from the CLI.
-        with open(os.devnull, "w", encoding="utf-8") as _devnull, \
-             contextlib.redirect_stdout(_devnull), \
-             contextlib.redirect_stderr(_devnull):
+        # Silence the forked agent's stdout/stderr for THIS thread only so its
+        # tool-call chatter doesn't pollute the foreground terminal.
+        #
+        # A process-global ``contextlib.redirect_stdout(open(devnull))`` here is
+        # unsafe: the default path runs _llm_pass() on a daemon thread
+        # ("curator-review"), so the redirect rebinds sys.stdout/sys.stderr for
+        # EVERY thread in the process. Two overlapping redirects (a second
+        # curator pass, a background review, any other capture) then restore in
+        # the wrong order and leave sys.stdout pointing at the ALREADY-CLOSED
+        # devnull handle. Every subsequent bare ``print`` in the process — cron
+        # scheduler job runs, gateway turns, conversation_loop's tool-name
+        # repair print — dies with "ValueError: I/O operation on closed file."
+        # until the process is restarted. Observed 2026-07-27: 9 cron jobs
+        # failed in the same tick from a single poisoned sys.stdout.
+        #
+        # ``thread_scoped_silence`` routes only this thread's writes to a sink
+        # and leaves every other thread on the real streams (same fix already
+        # applied in agent/background_review.py for #55769 / #55925).
+        with thread_scoped_silence():
             conv_result = review_agent.run_conversation(user_message=prompt)
 
         final = ""

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import threading
 from datetime import datetime, timedelta, timezone
@@ -1839,7 +1838,6 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
 
     Never raises; callers get a structured failure instead.
     """
-    import contextlib
     result_meta: Dict[str, Any] = {
         "final": "",
         "summary": "",

--- a/tests/agent/test_curator_stdout_isolation.py
+++ b/tests/agent/test_curator_stdout_isolation.py
@@ -1,0 +1,125 @@
+"""Regression: the curator's LLM fork must not poison process-global stdout.
+
+``run_curator_review()`` runs its LLM pass on a daemon thread by default.  The
+old implementation wrapped ``review_agent.run_conversation()`` in a
+process-global ``contextlib.redirect_stdout(open(os.devnull))``.  Because
+``redirect_stdout`` rebinds ``sys.stdout`` for the WHOLE process, two overlapping
+curator/background-review passes restore in the wrong order and leave
+``sys.stdout`` pointing at an already-closed devnull handle.  Every subsequent
+bare ``print`` anywhere in the process then raises::
+
+    ValueError: I/O operation on closed file.
+
+Observed 2026-07-27 on a live gateway: nine cron jobs failed inside a single
+scheduler tick, all with that error, because one curator pass had poisoned
+``sys.stdout`` for the entire process.
+
+The contract asserted here is behavioural, not implementation-shaped: after any
+number of concurrent curator review passes, a print from an unrelated thread
+must still reach the real stream.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+
+def _drain(fn):
+    """Bind a StringIO as the real stdout, run fn, return what reached it."""
+    real_out = io.StringIO()
+    orig = sys.stdout
+    sys.stdout = real_out
+    try:
+        fn()
+    finally:
+        sys.stdout = orig
+    return real_out.getvalue()
+
+
+def test_global_redirect_on_overlapping_threads_poisons_stdout():
+    """Characterize the bug we are protecting against.
+
+    This documents WHY the curator may not use ``contextlib.redirect_stdout``
+    from a worker thread. If CPython ever makes redirect_stdout thread-local
+    this test will fail loudly and the guard below can be revisited.
+    """
+
+    def body():
+        def worker(hold: float):
+            with open(os.devnull, "w", encoding="utf-8") as devnull, \
+                    contextlib.redirect_stdout(devnull):
+                time.sleep(hold)
+
+        # Overlapping enter/exit: A exits first and restores sys.stdout to the
+        # devnull handle B installed; B then exits and closes that handle.
+        a = threading.Thread(target=worker, args=(0.05,))
+        b = threading.Thread(target=worker, args=(0.30,))
+        a.start()
+        time.sleep(0.02)
+        b.start()
+        a.join()
+        b.join()
+
+        with pytest.raises(ValueError, match="closed file"):
+            sys.stdout.write("this must fail")
+
+    _drain(body)
+
+
+def test_thread_scoped_silence_leaves_stdout_usable():
+    """The replacement primitive survives the same overlapping pattern."""
+    from agent.thread_scoped_output import thread_scoped_silence
+
+    def body():
+        def worker(hold: float):
+            with thread_scoped_silence():
+                print("silenced chatter")
+                time.sleep(hold)
+
+        a = threading.Thread(target=worker, args=(0.05,))
+        b = threading.Thread(target=worker, args=(0.30,))
+        a.start()
+        time.sleep(0.02)
+        b.start()
+        a.join()
+        b.join()
+
+        # No poisoning: the main thread can still print.
+        print("survivor")
+
+    captured = _drain(body)
+    assert "survivor" in captured
+    assert "silenced chatter" not in captured
+
+
+def test_curator_llm_pass_does_not_use_global_redirect():
+    """Source-level guard on the exact call site that caused the outage.
+
+    A behavioural test would need a real forked AIAgent + credentials; instead
+    we assert the invariant that matters: the curator's review call is wrapped
+    in ``thread_scoped_silence()``, not a process-global redirect.
+    """
+    import inspect
+
+    import agent.curator as curator
+
+    src = inspect.getsource(curator)
+
+    # Find the block that runs the forked agent's conversation.
+    assert "run_conversation(user_message=prompt)" in src
+    idx = src.index("run_conversation(user_message=prompt)")
+    window = src[max(0, idx - 600):idx]
+    assert "thread_scoped_silence()" in window, (
+        "curator LLM pass must silence output per-thread; a process-global "
+        "redirect_stdout here poisons sys.stdout for every other thread"
+    )
+    assert "redirect_stdout" not in window, (
+        "process-global redirect_stdout found at the curator LLM call site"
+    )

--- a/tests/agent/test_curator_stdout_isolation.py
+++ b/tests/agent/test_curator_stdout_isolation.py
@@ -99,27 +99,62 @@ def test_thread_scoped_silence_leaves_stdout_usable():
     assert "silenced chatter" not in captured
 
 
-def test_curator_llm_pass_does_not_use_global_redirect():
-    """Source-level guard on the exact call site that caused the outage.
+def test_run_llm_review_does_not_poison_other_threads_stdout():
+    """Behavioral guard on the exact call site that caused the outage.
 
-    A behavioural test would need a real forked AIAgent + credentials; instead
-    we assert the invariant that matters: the curator's review call is wrapped
-    in ``thread_scoped_silence()``, not a process-global redirect.
+    Runs ``_run_llm_review()`` on a worker thread with a stubbed review agent
+    that blocks mid-conversation, and asserts an unrelated thread's print
+    still reaches the real stream while the review is executing — and that
+    stdout is still usable afterwards.  Fails on the pre-fix implementation,
+    which wrapped the conversation in a process-global ``redirect_stdout``.
     """
-    import inspect
+    from unittest.mock import patch
 
     import agent.curator as curator
 
-    src = inspect.getsource(curator)
+    in_review = threading.Event()
+    unrelated_done = threading.Event()
 
-    # Find the block that runs the forked agent's conversation.
-    assert "run_conversation(user_message=prompt)" in src
-    idx = src.index("run_conversation(user_message=prompt)")
-    window = src[max(0, idx - 600):idx]
-    assert "thread_scoped_silence()" in window, (
-        "curator LLM pass must silence output per-thread; a process-global "
-        "redirect_stdout here poisons sys.stdout for every other thread"
-    )
-    assert "redirect_stdout" not in window, (
-        "process-global redirect_stdout found at the curator LLM call site"
-    )
+    class _StubReviewAgent:
+        """Stands in for the forked AIAgent; blocks inside the review pass."""
+
+        def __init__(self, *args, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, user_message=""):
+            # Chatter the real agent would emit — must be silenced.
+            print("review agent chatter")
+            in_review.set()
+            assert unrelated_done.wait(timeout=5)
+            return {"final_response": "review done"}
+
+    def body():
+        results = {}
+
+        def run_review():
+            results["meta"] = curator._run_llm_review("review prompt")
+
+        def unrelated_writer():
+            assert in_review.wait(timeout=5)
+            print("unrelated write during review")
+            unrelated_done.set()
+
+        reviewer = threading.Thread(target=run_review)
+        writer = threading.Thread(target=unrelated_writer)
+        with patch("run_agent.AIAgent", _StubReviewAgent):
+            reviewer.start()
+            writer.start()
+            reviewer.join(timeout=10)
+            writer.join(timeout=10)
+
+        meta = results.get("meta") or {}
+        assert meta.get("error") is None, meta
+        assert meta.get("final") == "review done"
+
+        # stdout must not be poisoned once the review pass finishes.
+        print("survivor")
+
+    captured = _drain(body)
+    assert "unrelated write during review" in captured
+    assert "survivor" in captured
+    assert "review agent chatter" not in captured


### PR DESCRIPTION
## Symptom

On a live gateway, nine cron jobs failed inside a **single scheduler tick**, all with the same error:

```
ValueError: I/O operation on closed file.
```

Plus repeated `conversation_loop` failures at the tool-name auto-repair `print()` (`conversation_loop.py:4801`). Different jobs, different models, different providers — one shared cause.

## Root cause

`agent/curator.py` runs its LLM review pass on a daemon thread (`"curator-review"`, spawned in `run_curator_review`), but wrapped `review_agent.run_conversation()` in a **process-global** redirect:

```python
with open(os.devnull, "w", encoding="utf-8") as _devnull, \
     contextlib.redirect_stdout(_devnull), \
     contextlib.redirect_stderr(_devnull):
    conv_result = review_agent.run_conversation(user_message=prompt)
```

`contextlib.redirect_stdout` rebinds `sys.stdout` for the **whole process**, not the calling thread. When two passes overlap (a second curator pass, a background review, any other capture), they restore in the wrong order and leave `sys.stdout` pointing at an **already-closed** devnull handle. From that moment every bare `print` anywhere in the process raises `ValueError: I/O operation on closed file.` until restart.

Minimal reproduction (no Hermes needed):

```python
def worker(hold):
    with open(os.devnull, "w") as f, contextlib.redirect_stdout(f):
        time.sleep(hold)

a = threading.Thread(target=worker, args=(0.05,)); a.start()
time.sleep(0.02)
b = threading.Thread(target=worker, args=(0.30,)); b.start()
a.join(); b.join()
sys.stdout.write("x")   # ValueError: I/O operation on closed file.
```

## Fix

Use `thread_scoped_silence()` from `agent/thread_scoped_output.py`, which routes only the calling thread's writes to a sink and leaves every other thread on the real streams. This is the **same primitive already applied in `agent/background_review.py`** for the identical bug class (#55769 / #55925) — the curator call site was simply missed in that pass.

## Tests

New `tests/agent/test_curator_stdout_isolation.py`:

1. `test_global_redirect_on_overlapping_threads_poisons_stdout` — characterizes the CPython behaviour we are guarding against (fails loudly if `redirect_stdout` ever becomes thread-local).
2. `test_thread_scoped_silence_leaves_stdout_usable` — same overlapping pattern, no poisoning, chatter still suppressed.
3. `test_curator_llm_pass_does_not_use_global_redirect` — guards the call site. **Fails on the pre-fix source**, passes after.

`79 passed` across `test_curator*.py` + `test_thread_scoped_output.py`; `192 passed` across the full curator suite (`tests/agent/test_curator*`, `tests/hermes_cli/test_curator*`).
