### PR TITLE
fix(agent): redecorate prompt-cache breakpoints after provider failover (salvage #72682)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2247,14 +2247,13 @@ def compress_context(
             # (same startswith gate as the restore path); otherwise the
             # request layer falls back to the legacy single-breakpoint
             # layout with the prompt bytes untouched.
-            try:
-                from agent.system_prompt import build_system_prompt_parts as _build_parts
+            from agent.system_prompt import reconstruct_static_prefix
 
-                _static = _build_parts(agent, system_message=system_message)["stable"]
-                if _static and cached_system_prompt.startswith(_static):
-                    agent._cached_system_prompt_static = _static
-            except Exception:
-                pass
+            reconstruct_static_prefix(
+                agent,
+                system_message=system_message,
+                log_label="compression keep-prompt",
+            )
         else:
             new_system_prompt = agent._build_system_prompt(system_message)
             agent._cached_system_prompt = new_system_prompt

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -447,30 +447,13 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         # first turn — flip-flopping the wire shape mid-conversation and
         # silently degrading to the legacy single-breakpoint layout.
         #
-        # Safety: the rebuilt stable tier is used ONLY when the restored
-        # prompt literally starts with it (checked here AND re-checked by
-        # ``_apply_system_cache_markers``'s ``startswith`` gate). If any
-        # stable-tier input changed since the prompt was persisted (skills
-        # edited, identity changed), the prefix mismatches, ``_static``
-        # stays None, and the request falls back to the legacy layout with
-        # the restored prompt bytes untouched — never a rewritten prompt.
-        #
-        # Gated on ``_use_prompt_caching`` so non-Anthropic routes skip the
-        # rebuild entirely (the static prefix is only consumed by
-        # ``apply_anthropic_cache_control``).
-        if getattr(agent, "_use_prompt_caching", False):
-            try:
-                from agent.system_prompt import build_system_prompt_parts as _build_parts
+        # ``reconstruct_static_prefix`` gates on ``_use_prompt_caching`` (so
+        # non-Anthropic routes skip the rebuild), applies the startswith
+        # safety gate (stored prompt bytes are never rewritten), and
+        # fails open to the legacy cache layout.
+        from agent.system_prompt import reconstruct_static_prefix
 
-                _static = _build_parts(agent, system_message=system_message)["stable"]
-                if _static and stored_prompt.startswith(_static):
-                    agent._cached_system_prompt_static = _static
-            except Exception:
-                # Fail-open: restore continues with the legacy cache layout.
-                logger.debug(
-                    "static system-prefix reconstruction failed on restore",
-                    exc_info=True,
-                )
+        reconstruct_static_prefix(agent, system_message=system_message)
         return
     if stored_prompt:
         stored_state = "stale_runtime"
@@ -846,29 +829,16 @@ def _ensure_cached_system_prompt_static(agent, system_message=None) -> None:
     (gated on ``_use_prompt_caching`` at restore time). A later failover to a
     cache-on provider would otherwise redecorate with ``static_system_prefix=
     None`` and silently fall back to the legacy system-plus-3 layout (#72626).
-    """
-    if not getattr(agent, "_use_prompt_caching", False):
-        return
-    stored = getattr(agent, "_cached_system_prompt", None)
-    if not isinstance(stored, str) or not stored:
-        return
-    existing = getattr(agent, "_cached_system_prompt_static", None)
-    if isinstance(existing, str) and existing and stored.startswith(existing):
-        return
-    try:
-        from agent.system_prompt import build_system_prompt_parts as _build_parts
 
-        static = _build_parts(agent, system_message=system_message)["stable"]
-        if static and stored.startswith(static):
-            agent._cached_system_prompt_static = static
-        else:
-            agent._cached_system_prompt_static = None
-    except Exception:
-        logger.debug(
-            "static system-prefix reconstruction failed on failover redecoration",
-            exc_info=True,
-        )
-        agent._cached_system_prompt_static = None
+    Thin wrapper over :func:`agent.system_prompt.reconstruct_static_prefix`,
+    which memoizes failed rebuilds so this stays cheap on the retry-loop hot
+    path (it runs at the top of every attempt).
+    """
+    from agent.system_prompt import reconstruct_static_prefix
+
+    reconstruct_static_prefix(
+        agent, system_message=system_message, log_label="failover redecoration"
+    )
 
 
 def _peel_moa_guidance(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -72,7 +72,10 @@ from agent.model_metadata import (
     save_context_length,
 )
 from agent.process_bootstrap import _install_safe_stdio
-from agent.prompt_caching import apply_anthropic_cache_control
+from agent.prompt_caching import (
+    apply_anthropic_cache_control,
+    strip_anthropic_cache_control,
+)
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
@@ -834,6 +837,134 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
         if not _rewrite_system_content_blocks(api_messages[0], effective):
             api_messages[0]["content"] = effective
     return sp
+
+
+def _ensure_cached_system_prompt_static(agent, system_message=None) -> None:
+    """Rebuild ``_cached_system_prompt_static`` when caching becomes active.
+
+    Sessions restored under a cache-off primary skip the static-prefix rebuild
+    (gated on ``_use_prompt_caching`` at restore time). A later failover to a
+    cache-on provider would otherwise redecorate with ``static_system_prefix=
+    None`` and silently fall back to the legacy system-plus-3 layout (#72626).
+    """
+    if not getattr(agent, "_use_prompt_caching", False):
+        return
+    stored = getattr(agent, "_cached_system_prompt", None)
+    if not isinstance(stored, str) or not stored:
+        return
+    existing = getattr(agent, "_cached_system_prompt_static", None)
+    if isinstance(existing, str) and existing and stored.startswith(existing):
+        return
+    try:
+        from agent.system_prompt import build_system_prompt_parts as _build_parts
+
+        static = _build_parts(agent, system_message=system_message)["stable"]
+        if static and stored.startswith(static):
+            agent._cached_system_prompt_static = static
+        else:
+            agent._cached_system_prompt_static = None
+    except Exception:
+        logger.debug(
+            "static system-prefix reconstruction failed on failover redecoration",
+            exc_info=True,
+        )
+        agent._cached_system_prompt_static = None
+
+
+def _peel_moa_guidance(
+    messages: List[Dict[str, Any]],
+    guidance: Any,
+) -> List[Dict[str, Any]]:
+    """Remove MoA reference guidance previously attached by ``_attach_reference_guidance``.
+
+    Redecoration must run on the base transcript so the last cache breakpoint
+    does not land on the turn-varying guidance block; callers then rebase via
+    ``rebase_prepared_request`` (#72626).
+    """
+    if not guidance or not messages:
+        return messages
+    guidance_text = str(guidance)
+    last = messages[-1]
+    if not isinstance(last, dict) or last.get("role") != "user":
+        return messages
+    content = last.get("content")
+    if content == guidance_text:
+        return list(messages[:-1])
+    suffix = "\n\n" + guidance_text
+    if isinstance(content, str) and content.endswith(suffix):
+        peeled = dict(last)
+        peeled["content"] = content[: -len(suffix)]
+        return [*messages[:-1], peeled]
+    if isinstance(content, list) and content:
+        last_part = content[-1]
+        if isinstance(last_part, dict) and last_part.get("type", "text") == "text":
+            text = last_part.get("text") or ""
+            if text == suffix or text == guidance_text:
+                peeled = dict(last)
+                peeled["content"] = list(content[:-1])
+                return [*messages[:-1], peeled]
+            if text.endswith(suffix):
+                new_part = dict(last_part)
+                new_part["text"] = text[: -len(suffix)]
+                peeled = dict(last)
+                peeled["content"] = [*content[:-1], new_part]
+                return [*messages[:-1], peeled]
+    return messages
+
+
+def _redecorate_prompt_cache_for_provider(
+    agent,
+    api_messages: List[Dict[str, Any]],
+    *,
+    system_message=None,
+    moa_prepared: Optional[Dict[str, Any]] = None,
+) -> tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Strip and re-apply cache_control for the *current* provider policy.
+
+    Decoration runs once per call block before the retry loop for the primary
+    provider. ``try_activate_fallback`` refreshes ``_use_prompt_caching`` /
+    ``_use_native_cache_layout`` but the nine failover ``continue`` paths reused
+    the old ``api_messages`` (#72626). Mirror ``_reapply_reasoning_echo_for_provider``
+    by reshaping at the top of each retry attempt.
+
+    The source list is the mutated in-flight request (image shrink / ASCII /
+    reasoning_details recoveries already applied) — never a pristine
+    pre-decoration snapshot. MoA guidance is peeled, the base is redecorated,
+    then ``rebase_prepared_request`` re-attaches guidance outside the cached
+    span.
+    """
+    messages: List[Dict[str, Any]] = [
+        dict(m) if isinstance(m, dict) else m for m in (api_messages or [])
+    ]
+    prepared = moa_prepared
+    guidance = prepared.get("guidance") if isinstance(prepared, dict) else None
+    if guidance:
+        messages = _peel_moa_guidance(messages, guidance)
+
+    strip_anthropic_cache_control(messages)
+
+    if getattr(agent, "_use_prompt_caching", False):
+        _ensure_cached_system_prompt_static(agent, system_message=system_message)
+        static = getattr(agent, "_cached_system_prompt_static", None)
+        messages = apply_anthropic_cache_control(
+            messages,
+            cache_ttl=getattr(agent, "_cache_ttl", None) or "5m",
+            native_anthropic=bool(getattr(agent, "_use_native_cache_layout", False)),
+            static_system_prefix=static if isinstance(static, str) else None,
+        )
+
+    if (
+        prepared is not None
+        and getattr(agent, "provider", None) == "moa"
+        and guidance
+    ):
+        completions = getattr(getattr(agent.client, "chat", None), "completions", None)
+        rebase = getattr(completions, "rebase_prepared_request", None)
+        if callable(rebase):
+            prepared = rebase(prepared, messages)
+            messages = prepared["messages"]
+
+    return messages, prepared
 
 
 def _apply_context_engine_selection(
@@ -1909,6 +2040,18 @@ def run_conversation(
                 # unless the active provider needs it) so the fallback request
                 # isn't sent with stale, primary-shaped reasoning fields.
                 agent._reapply_reasoning_echo_for_provider(api_messages)
+                # Same story for prompt-cache decoration (#72626): try_activate_
+                # fallback refreshes the policy flags, but the decorated list
+                # still carries the primary's breakpoints (or none). Strip and
+                # re-render for the current provider before building kwargs.
+                api_messages, _moa_prepared_request = (
+                    _redecorate_prompt_cache_for_provider(
+                        agent,
+                        api_messages,
+                        system_message=system_message,
+                        moa_prepared=_moa_prepared_request,
+                    )
+                )
                 api_kwargs = agent._build_api_kwargs(api_messages)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -887,13 +887,16 @@ def _redecorate_prompt_cache_for_provider(
 
     strip_anthropic_cache_control(messages)
 
-    if getattr(agent, "_use_prompt_caching", False):
+    # Direct attribute access matches the call-block decoration site — the
+    # flags are unconditionally initialized on AIAgent, and a getattr
+    # default here would mask a real init bug as silent cache-off.
+    if agent._use_prompt_caching:
         _ensure_cached_system_prompt_static(agent, system_message=system_message)
         static = getattr(agent, "_cached_system_prompt_static", None)
         messages = apply_anthropic_cache_control(
             messages,
-            cache_ttl=getattr(agent, "_cache_ttl", None) or "5m",
-            native_anthropic=bool(getattr(agent, "_use_native_cache_layout", False)),
+            cache_ttl=agent._cache_ttl,
+            native_anthropic=agent._use_native_cache_layout,
             static_system_prefix=static if isinstance(static, str) else None,
         )
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -847,39 +847,13 @@ def _peel_moa_guidance(
 ) -> List[Dict[str, Any]]:
     """Remove MoA reference guidance previously attached by ``_attach_reference_guidance``.
 
-    Redecoration must run on the base transcript so the last cache breakpoint
-    does not land on the turn-varying guidance block; callers then rebase via
-    ``rebase_prepared_request`` (#72626).
+    Thin wrapper over :func:`agent.moa_loop.peel_reference_guidance` (kept
+    adjacent to the attach so the forward/inverse shapes evolve together).
+    Lazy import mirrors the module's other moa_loop touchpoints.
     """
-    if not guidance or not messages:
-        return messages
-    guidance_text = str(guidance)
-    last = messages[-1]
-    if not isinstance(last, dict) or last.get("role") != "user":
-        return messages
-    content = last.get("content")
-    if content == guidance_text:
-        return list(messages[:-1])
-    suffix = "\n\n" + guidance_text
-    if isinstance(content, str) and content.endswith(suffix):
-        peeled = dict(last)
-        peeled["content"] = content[: -len(suffix)]
-        return [*messages[:-1], peeled]
-    if isinstance(content, list) and content:
-        last_part = content[-1]
-        if isinstance(last_part, dict) and last_part.get("type", "text") == "text":
-            text = last_part.get("text") or ""
-            if text == suffix or text == guidance_text:
-                peeled = dict(last)
-                peeled["content"] = list(content[:-1])
-                return [*messages[:-1], peeled]
-            if text.endswith(suffix):
-                new_part = dict(last_part)
-                new_part["text"] = text[: -len(suffix)]
-                peeled = dict(last)
-                peeled["content"] = [*content[:-1], new_part]
-                return [*messages[:-1], peeled]
-    return messages
+    from agent.moa_loop import peel_reference_guidance
+
+    return peel_reference_guidance(messages, guidance)
 
 
 def _redecorate_prompt_cache_for_provider(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -926,8 +926,14 @@ def _redecorate_prompt_cache_for_provider(
     if (
         prepared is not None
         and getattr(agent, "provider", None) == "moa"
-        and guidance
     ):
+        # No `and guidance` here: guidance=None is a real prepared shape
+        # (all-references-failed / silent degraded policy builds the
+        # prepared request without attaching guidance), and the MoA facade
+        # sends prepared["messages"] — not api_kwargs["messages"] — so the
+        # rebase must refresh the prepared object even when there is no
+        # guidance to re-attach. rebase_prepared_request handles falsy
+        # guidance by copying the messages and skipping the attach.
         completions = getattr(getattr(agent.client, "chat", None), "completions", None)
         rebase = getattr(completions, "rebase_prepared_request", None)
         if callable(rebase):

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1337,6 +1337,63 @@ def _attach_reference_guidance(agg_messages: list[dict[str, Any]], guidance: str
     agg_messages.append({"role": "user", "content": guidance})
 
 
+def peel_reference_guidance(
+    messages: list[dict[str, Any]],
+    guidance: Any,
+) -> list[dict[str, Any]]:
+    """Remove reference guidance previously attached by ``_attach_reference_guidance``.
+
+    Exact inverse of the three attach shapes above (string merge, trailing
+    text part, appended user message) — kept adjacent so the two evolve
+    together; a drifting separator or shape would make the peel silently
+    no-op and let a cache breakpoint land on the turn-varying guidance
+    block (the bug class #72626 fixes).
+
+    Used by the failover redecoration chokepoint: redecoration must run on
+    the base transcript so the last cache breakpoint does not land on the
+    guidance; callers then rebase via ``rebase_prepared_request``.
+
+    Returns a new list (input list and its messages are not mutated).
+    """
+    if not guidance or not messages:
+        return messages
+    guidance_text = str(guidance)
+    last = messages[-1]
+    if not isinstance(last, dict) or last.get("role") != "user":
+        return messages
+    content = last.get("content")
+    if content == guidance_text:
+        # Attach shape (c): guidance was appended as its own user message.
+        return list(messages[:-1])
+    suffix = "\n\n" + guidance_text
+    if isinstance(content, str) and content.endswith(suffix):
+        # Attach shape (a): merged into a trailing string user turn.
+        peeled = dict(last)
+        peeled["content"] = content[: -len(suffix)]
+        return [*messages[:-1], peeled]
+    if isinstance(content, list) and content:
+        last_part = content[-1]
+        if isinstance(last_part, dict) and last_part.get("type", "text") == "text":
+            text = last_part.get("text") or ""
+            if text == suffix or text == guidance_text:
+                # Attach shape (b): guidance rode as its own trailing part.
+                peeled = dict(last)
+                peeled["content"] = list(content[:-1])
+                if not peeled["content"]:
+                    # The guidance part was the only content — mirror the
+                    # string shape (c) and drop the whole message rather
+                    # than leaving an empty-content user turn behind.
+                    return list(messages[:-1])
+                return [*messages[:-1], peeled]
+            if text.endswith(suffix):
+                new_part = dict(last_part)
+                new_part["text"] = text[: -len(suffix)]
+                peeled = dict(last)
+                peeled["content"] = [*content[:-1], new_part]
+                return [*messages[:-1], peeled]
+    return messages
+
+
 class MoAChatCompletions:
     """OpenAI-chat-compatible facade where the aggregator is the acting model."""
 

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -122,19 +122,25 @@ def _apply_system_cache_markers(
 def strip_anthropic_cache_control(
     api_messages: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
-    """Remove ``cache_control`` markers and flatten pure-text content lists.
+    """Remove ``cache_control`` markers and undo decoration-produced list shapes.
 
     Used before re-applying decoration after a mid-turn provider failover so
     the mutated, undecorated shape (image shrink / ASCII cleanup / etc.) is
     preserved while markers match the *new* provider's cache policy (#72626).
 
-    Pure-text content lists (including the ``[static, volatile]`` system
-    layout) are flattened back to a single string so
-    :func:`apply_anthropic_cache_control` can re-split them. Multimodal
-    content lists keep their part structure; only per-part markers are
-    removed.
+    Flattening back to a plain string is restricted to the exact shapes
+    :func:`apply_anthropic_cache_control` produces from string content —
+    a single ``{"type": "text"}`` part, or the two-part ``[static, volatile]``
+    system split — so the ``""``-join is provably byte-exact. Organic
+    multi-part text (merged user turns, imported transcripts) and parts
+    carrying extra keys (``citations`` etc.) keep their structure; only
+    per-part markers are removed. Marker removal is copy-on-write on the
+    part dicts: content parts may alias the persistent conversation history
+    (the per-call copy is shallow), and stripping must never rewrite the
+    stored transcript.
 
-    Mutates ``api_messages`` in place and returns the same list.
+    Mutates the top-level message dicts of ``api_messages`` in place and
+    returns the same list.
     """
     for msg in api_messages:
         if not isinstance(msg, dict):
@@ -143,15 +149,25 @@ def strip_anthropic_cache_control(
         content = msg.get("content")
         if not isinstance(content, list):
             continue
-        for part in content:
-            if isinstance(part, dict):
-                part.pop("cache_control", None)
-        if content and all(
+        if any(isinstance(part, dict) and "cache_control" in part for part in content):
+            content = [
+                {k: v for k, v in part.items() if k != "cache_control"}
+                if isinstance(part, dict) and "cache_control" in part
+                else part
+                for part in content
+            ]
+            msg["content"] = content
+        decoration_shape = content and all(
             isinstance(part, dict)
             and part.get("type", "text") == "text"
             and isinstance(part.get("text"), str)
+            and set(part.keys()) <= {"type", "text"}
             for part in content
-        ):
+        ) and (
+            len(content) == 1
+            or (msg.get("role") == "system" and len(content) == 2)
+        )
+        if decoration_shape:
             msg["content"] = "".join(part["text"] for part in content)
     return api_messages
 

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -119,6 +119,43 @@ def _apply_system_cache_markers(
     return 1
 
 
+def strip_anthropic_cache_control(
+    api_messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Remove ``cache_control`` markers and flatten pure-text content lists.
+
+    Used before re-applying decoration after a mid-turn provider failover so
+    the mutated, undecorated shape (image shrink / ASCII cleanup / etc.) is
+    preserved while markers match the *new* provider's cache policy (#72626).
+
+    Pure-text content lists (including the ``[static, volatile]`` system
+    layout) are flattened back to a single string so
+    :func:`apply_anthropic_cache_control` can re-split them. Multimodal
+    content lists keep their part structure; only per-part markers are
+    removed.
+
+    Mutates ``api_messages`` in place and returns the same list.
+    """
+    for msg in api_messages:
+        if not isinstance(msg, dict):
+            continue
+        msg.pop("cache_control", None)
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if isinstance(part, dict):
+                part.pop("cache_control", None)
+        if content and all(
+            isinstance(part, dict)
+            and part.get("type", "text") == "text"
+            and isinstance(part.get("text"), str)
+            for part in content
+        ):
+            msg["content"] = "".join(part["text"] for part in content)
+    return api_messages
+
+
 def apply_anthropic_cache_control(
     api_messages: List[Dict[str, Any]],
     cache_ttl: str = "5m",

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -26,6 +26,7 @@ Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import Any, Dict, List, Optional
 
@@ -50,6 +51,8 @@ from agent.prompt_builder import (
 from agent.runtime_cwd import resolve_context_cwd
 from hermes_constants import get_hermes_home
 from utils import is_truthy_value
+
+logger = logging.getLogger(__name__)
 
 
 def _ra():
@@ -580,6 +583,60 @@ def invalidate_system_prompt(agent: Any) -> None:
     agent._cached_system_prompt_static = None
     if agent._memory_store:
         agent._memory_store.load_from_disk()
+
+
+def reconstruct_static_prefix(
+    agent: Any,
+    system_message: Optional[str] = None,
+    *,
+    log_label: str = "restore",
+) -> None:
+    """Reconstruct ``_cached_system_prompt_static`` for a stored prompt.
+
+    The static prefix is not persisted (only the full prompt is), so any
+    path that adopts a stored/kept ``_cached_system_prompt`` — session
+    restore, the compression keep-prompt path, or a failover to a cache-on
+    provider mid-turn (#72626) — must rebuild the stable tier to regain the
+    two-block ``[static, volatile]`` system layout.
+
+    Safety: the rebuilt stable tier is used ONLY when the stored prompt
+    literally starts with it (checked here AND re-checked by
+    ``_apply_system_cache_markers``'s ``startswith`` gate). If any
+    stable-tier input changed since the prompt was persisted (skills
+    edited, identity changed), the prefix mismatches, the static stays
+    None, and requests fall back to the legacy layout with the stored
+    prompt bytes untouched — never a rewritten prompt.
+
+    A failed reconstruction is memoized per stored prompt
+    (``_static_rebuild_failed_for``): ``build_system_prompt_parts`` does
+    real file I/O (SOUL.md, context files, memory), and callers on the
+    retry-loop hot path must not re-run it every attempt when the inputs
+    haven't changed. A legitimately changed stored prompt retries once.
+    """
+    if not getattr(agent, "_use_prompt_caching", False):
+        return
+    stored = getattr(agent, "_cached_system_prompt", None)
+    if not isinstance(stored, str) or not stored:
+        return
+    existing = getattr(agent, "_cached_system_prompt_static", None)
+    if isinstance(existing, str) and existing and stored.startswith(existing):
+        return
+    if getattr(agent, "_static_rebuild_failed_for", None) == stored:
+        return
+    try:
+        static = build_system_prompt_parts(agent, system_message=system_message)["stable"]
+        if static and stored.startswith(static):
+            agent._cached_system_prompt_static = static
+            agent._static_rebuild_failed_for = None
+            return
+    except Exception:
+        logger.debug(
+            "static system-prefix reconstruction failed on %s",
+            log_label,
+            exc_info=True,
+        )
+    agent._cached_system_prompt_static = None
+    agent._static_rebuild_failed_for = stored
 
 
 def format_tools_for_system_message(agent: Any) -> str:

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -376,3 +376,37 @@ class TestRedecoratePromptCacheOnPolicyChange:
         else:
             assert guidance in content
 
+
+    def test_moa_no_guidance_prepared_messages_still_refreshed(self):
+        # guidance=None is a real prepared shape (all references failed /
+        # silent degraded policy). The MoA facade sends prepared["messages"],
+        # so the rebase must refresh the prepared object even without
+        # guidance — otherwise the aggregator ships the STALE decoration
+        # and #72626 persists for the no-guidance MoA sub-path.
+        prompt = "sys"
+        decorated = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": "task"},
+            ],
+            native_anthropic=True,
+        )
+
+        class _Completions:
+            def rebase_prepared_request(self, prepared, messages):
+                # Mirrors MoAChatCompletions.rebase_prepared_request with
+                # falsy guidance: copy messages, skip the attach.
+                return {**prepared, "messages": [dict(m) for m in messages]}
+
+        # Policy change while staying on moa: cache-on -> cache-off.
+        agent = _cache_agent(use_caching=False, prompt=prompt, provider="moa")
+        agent.client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+        prepared = {"guidance": None, "messages": decorated}
+        out, new_prepared = _redecorate_prompt_cache_for_provider(
+            agent, decorated, moa_prepared=prepared
+        )
+        assert new_prepared is not None
+        # The prepared object the facade will send must carry the
+        # redecorated (stripped) messages, not the stale decorated list.
+        assert _count_cache_markers(new_prepared["messages"]) == 0
+        assert new_prepared["messages"] == out

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -410,3 +410,62 @@ class TestRedecoratePromptCacheOnPolicyChange:
         # redecorated (stripped) messages, not the stale decorated list.
         assert _count_cache_markers(new_prepared["messages"]) == 0
         assert new_prepared["messages"] == out
+
+
+class TestPeelReferenceGuidanceRoundTrip:
+    """peel must invert every attach shape — the two live adjacent in
+    moa_loop.py precisely so this contract can't drift silently."""
+
+    _GUIDANCE = "[Mixture of Agents reference context]\nAdvice body."
+
+    def _round_trip(self, base):
+        import copy
+
+        from agent.moa_loop import _attach_reference_guidance, peel_reference_guidance
+
+        attached = copy.deepcopy(base)
+        _attach_reference_guidance(attached, self._GUIDANCE)
+        assert attached != base, "attach must change the transcript"
+        return peel_reference_guidance(attached, self._GUIDANCE)
+
+    def test_string_merge_shape(self):
+        base = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "task"},
+        ]
+        assert self._round_trip(base) == base
+
+    def test_list_part_shape(self):
+        base = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "task", "cache_control": {"type": "ephemeral"}}],
+            },
+        ]
+        assert self._round_trip(base) == base
+
+    def test_appended_user_message_shape(self):
+        # No trailing user turn — attach appends a separate user message.
+        base = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "done"},
+        ]
+        assert self._round_trip(base) == base
+
+    def test_guidance_only_part_drops_message_not_empty_residue(self):
+        # If the guidance part is the only content left after peeling, the
+        # whole message goes — an empty-content user turn must never remain.
+        from agent.moa_loop import peel_reference_guidance
+
+        messages = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "ok"},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": self._GUIDANCE}],
+            },
+        ]
+        peeled = peel_reference_guidance(messages, self._GUIDANCE)
+        assert peeled == messages[:-1]

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -11,7 +11,10 @@ gpt-5.4-mini after a Codex usage-limit 429.
 from types import SimpleNamespace
 
 from agent.chat_completion_helpers import rewrite_prompt_model_identity
-from agent.conversation_loop import _sync_failover_system_message
+from agent.conversation_loop import (
+    _redecorate_prompt_cache_for_provider,
+    _sync_failover_system_message,
+)
 from agent.prompt_caching import apply_anthropic_cache_control
 
 
@@ -31,6 +34,40 @@ def _agent(prompt=_PROMPT, ephemeral=None):
     return SimpleNamespace(
         _cached_system_prompt=prompt,
         ephemeral_system_prompt=ephemeral,
+    )
+
+
+def _count_cache_markers(messages):
+    count = 0
+    for msg in messages:
+        if "cache_control" in msg:
+            count += 1
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and "cache_control" in part:
+                    count += 1
+    return count
+
+
+def _cache_agent(
+    *,
+    use_caching,
+    native=False,
+    prompt=_PROMPT,
+    static=None,
+    cache_ttl="5m",
+    provider="openai",
+):
+    return SimpleNamespace(
+        _cached_system_prompt=prompt,
+        _cached_system_prompt_static=static,
+        ephemeral_system_prompt=None,
+        _use_prompt_caching=use_caching,
+        _use_native_cache_layout=native,
+        _cache_ttl=cache_ttl,
+        provider=provider,
+        client=None,
     )
 
 
@@ -189,3 +226,153 @@ class TestSyncFailoverPreservesCacheDecoration:
         ]
         _sync_failover_system_message(agent, api_messages, _PROMPT)
         assert api_messages[0]["content"] == agent._cached_system_prompt
+
+
+class TestRedecoratePromptCacheOnPolicyChange:
+    """#72626: failover must re-render breakpoints for the *new* cache policy.
+
+    ``TestSyncFailoverPreservesCacheDecoration`` only covers same-policy
+    identity sync (native→native). These cases cover the policy-change class.
+    """
+
+    _STATIC = "You are a helpful assistant.\n\nStable brief.\n"
+
+    def test_cache_off_to_cache_on_adds_breakpoints(self):
+        prompt = self._STATIC + "Model: gpt-5.4-mini\nProvider: openai"
+        # Primary never decorated (cache-off).
+        undecorated = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "again"},
+        ]
+        assert _count_cache_markers(undecorated) == 0
+
+        agent = _cache_agent(
+            use_caching=True,
+            native=True,
+            prompt=prompt,
+            static=self._STATIC,
+            provider="anthropic",
+        )
+        decorated, _ = _redecorate_prompt_cache_for_provider(agent, undecorated)
+        assert _count_cache_markers(decorated) >= 2
+        assert isinstance(decorated[0]["content"], list)
+        assert decorated[0]["content"][0]["text"] == self._STATIC
+
+    def test_cache_on_to_cache_off_strips_breakpoints(self):
+        prompt = self._STATIC + "Model: claude\nProvider: anthropic"
+        decorated = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": "hello"},
+            ],
+            native_anthropic=True,
+            static_system_prefix=self._STATIC,
+        )
+        assert _count_cache_markers(decorated) >= 2
+
+        agent = _cache_agent(
+            use_caching=False,
+            native=False,
+            prompt=prompt,
+            static=self._STATIC,
+            provider="custom",
+        )
+        stripped, _ = _redecorate_prompt_cache_for_provider(agent, decorated)
+        assert _count_cache_markers(stripped) == 0
+        assert stripped[0]["content"] == prompt
+
+    def test_native_to_envelope_relocates_breakpoints_to_carriers(self):
+        prompt = "Model: claude\nProvider: anthropic"
+        # Native layout can mark empty assistant turns; envelope cannot.
+        native = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": "do it"},
+                {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+                {"role": "tool", "content": "ok", "tool_call_id": "1"},
+                {"role": "user", "content": "thanks"},
+            ],
+            native_anthropic=True,
+        )
+        agent = _cache_agent(
+            use_caching=True,
+            native=False,
+            prompt=prompt,
+            provider="openrouter",
+        )
+        envelope, _ = _redecorate_prompt_cache_for_provider(agent, native)
+        # Empty assistant must not carry a wasted top-level marker on envelope.
+        empty_assistant = next(
+            m for m in envelope if m.get("role") == "assistant" and not m.get("content")
+        )
+        assert "cache_control" not in empty_assistant
+        assert _count_cache_markers(envelope) >= 1
+
+    def test_preserves_mutated_tool_result_bytes(self):
+        # Redecoration must use the in-flight mutated list, not a pristine
+        # pre-decoration snapshot — image-shrink / ASCII recoveries live here.
+        prompt = "sys"
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "run"},
+            {"role": "tool", "content": "SHRUNK_IMAGE_PAYLOAD", "tool_call_id": "t1"},
+        ]
+        agent = _cache_agent(use_caching=True, native=True, prompt=prompt)
+        out, _ = _redecorate_prompt_cache_for_provider(agent, messages)
+        tool = next(m for m in out if m.get("role") == "tool")
+        text = (
+            tool["content"]
+            if isinstance(tool["content"], str)
+            else tool["content"][0]["text"]
+        )
+        assert text == "SHRUNK_IMAGE_PAYLOAD"
+
+    def test_moa_guidance_stays_outside_last_breakpoint(self):
+        prompt = "sys"
+        guidance = (
+            "[Mixture of Agents context — use this as private guidance for the "
+            "normal Hermes agent loop.]\nAggregator: agg\n\nadvice"
+        )
+        base = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "task\n\n" + guidance},
+        ]
+        decorated = apply_anthropic_cache_control(base, native_anthropic=True)
+
+        class _Completions:
+            def rebase_prepared_request(self, prepared, messages):
+                from agent.moa_loop import _attach_reference_guidance
+
+                out = [dict(m) for m in messages]
+                _attach_reference_guidance(out, prepared["guidance"])
+                return {**prepared, "messages": out}
+
+        agent = _cache_agent(use_caching=True, native=True, prompt=prompt, provider="moa")
+        agent.client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+        prepared = {"guidance": guidance, "messages": decorated}
+        out, new_prepared = _redecorate_prompt_cache_for_provider(
+            agent, decorated, moa_prepared=prepared
+        )
+        assert new_prepared is not None
+        # Guidance must be present, but the cache marker on the last user
+        # turn's content parts must terminate *before* the guidance text.
+        last = out[-1]
+        assert last.get("role") == "user"
+        content = last["content"]
+        if isinstance(content, list):
+            marked = [p for p in content if isinstance(p, dict) and "cache_control" in p]
+            guidance_parts = [
+                p for p in content
+                if isinstance(p, dict) and guidance in (p.get("text") or "")
+            ]
+            assert marked, "base transcript should still carry breakpoints"
+            assert guidance_parts, "guidance must be re-attached"
+            # Marked part should not contain the guidance body.
+            assert all(guidance not in (p.get("text") or "") for p in marked)
+        else:
+            assert guidance in content
+

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -393,3 +393,57 @@ class TestStripAnthropicCacheControl:
         assert content[0] == {"type": "text", "text": "see"}
         assert content[1]["type"] == "image_url"
 
+    def test_preserves_organic_multipart_text_lists(self):
+        # Multi-part pure-text lists NOT produced by decoration (merged user
+        # turns, imported transcripts) must keep their structure — a ""-join
+        # would fuse "Hello"+"world" into "Helloworld" and change wire bytes
+        # on the common no-failover path (redecoration runs every attempt).
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello"},
+                    {"type": "text", "text": "world"},
+                ],
+            }
+        ]
+        strip_anthropic_cache_control(messages)
+        content = messages[0]["content"]
+        assert isinstance(content, list) and len(content) == 2
+        assert [p["text"] for p in content] == ["Hello", "world"]
+
+    def test_preserves_extra_part_keys_like_citations(self):
+        # anthropic_adapter deliberately whitelists citations on text blocks;
+        # strip must not destroy them by flattening the part away.
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "answer",
+                        "citations": [{"src": "doc"}],
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+        strip_anthropic_cache_control(messages)
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        assert content[0]["citations"] == [{"src": "doc"}]
+        assert "cache_control" not in content[0]
+
+    def test_marker_removal_is_copy_on_write_for_part_dicts(self):
+        # The per-call api_messages copy is SHALLOW (msg.copy()) — content
+        # part dicts alias the persistent history. Stripping a marker must
+        # never rewrite the stored transcript's part dicts in place.
+        shared_part = {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}
+        history = [{"role": "user", "content": [shared_part]}]
+        api_messages = [m.copy() for m in history]
+        strip_anthropic_cache_control(api_messages)
+        assert "cache_control" in shared_part  # history untouched
+        api_content = api_messages[0]["content"]
+        if isinstance(api_content, list):
+            assert all("cache_control" not in p for p in api_content)
+

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -5,6 +5,7 @@ from agent.prompt_caching import (
     _apply_cache_marker,
     _can_carry_marker,
     apply_anthropic_cache_control,
+    strip_anthropic_cache_control,
 )
 
 
@@ -317,7 +318,10 @@ class TestNormalizationOrdering:
         from agent import conversation_loop
 
         src = inspect.getsource(conversation_loop)
-        mark = src.index("apply_anthropic_cache_control(\n")
+        # Anchor on the call-block decoration (before the retry loop), not the
+        # mid-failover redecoration helper which also calls apply_*.
+        anchor = src.index("Runs LAST, after every message mutation above")
+        mark = src.index("apply_anthropic_cache_control(\n", anchor)
         for earlier in (
             'am["content"].strip()',              # whitespace normalization
             "_sanitize_api_messages(api_messages)",       # orphan sweep
@@ -327,3 +331,65 @@ class TestNormalizationOrdering:
             assert src.index(earlier) < mark, (
                 f"{earlier!r} must run before cache breakpoints are injected"
             )
+
+
+class TestStripAnthropicCacheControl:
+    """strip must undo decoration so failover can re-render for a new policy."""
+
+    def test_removes_top_level_and_part_markers(self):
+        messages = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "yo"},
+            ],
+            native_anthropic=True,
+        )
+        assert any(
+            "cache_control" in (m if isinstance(m.get("content"), str) else {})
+            or (
+                isinstance(m.get("content"), list)
+                and any(
+                    isinstance(p, dict) and "cache_control" in p for p in m["content"]
+                )
+            )
+            or "cache_control" in m
+            for m in messages
+        )
+        strip_anthropic_cache_control(messages)
+        for msg in messages:
+            assert "cache_control" not in msg
+            content = msg.get("content")
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict):
+                        assert "cache_control" not in part
+
+    def test_flattens_system_static_volatile_back_to_string(self):
+        static = "You are helpful.\n"
+        full = static + "Model: claude\nProvider: anthropic"
+        messages = apply_anthropic_cache_control(
+            [{"role": "system", "content": full}, {"role": "user", "content": "hi"}],
+            native_anthropic=True,
+            static_system_prefix=static,
+        )
+        assert isinstance(messages[0]["content"], list)
+        strip_anthropic_cache_control(messages)
+        assert messages[0]["content"] == full
+
+    def test_preserves_multimodal_part_structure(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "see", "cache_control": {"type": "ephemeral"}},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,xx"}},
+                ],
+            }
+        ]
+        strip_anthropic_cache_control(messages)
+        content = messages[0]["content"]
+        assert isinstance(content, list) and len(content) == 2
+        assert content[0] == {"type": "text", "text": "see"}
+        assert content[1]["type"] == "image_url"
+

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -350,5 +350,77 @@ class TestStaticPrefixReconstructionOnRestore:
         assert agent._cached_system_prompt_static is None
 
 
+class TestReconstructStaticPrefixMemoization:
+    """A failed static rebuild must not re-run the parts builder every call.
+
+    ``reconstruct_static_prefix`` sits on the retry-loop hot path via the
+    failover redecoration chokepoint (#72626); ``build_system_prompt_parts``
+    does real file I/O (SOUL.md, context files, memory), so a persistent
+    stable-tier mismatch must be checked once per stored prompt, not on
+    every attempt of every API call.
+    """
+
+    def _agent(self, stored):
+        agent = _make_agent()
+        agent._use_prompt_caching = True
+        agent._cached_system_prompt = stored
+        agent._cached_system_prompt_static = None
+        return agent
+
+    def test_failed_rebuild_is_memoized_per_stored_prompt(self):
+        from unittest.mock import patch as _patch
+
+        from agent.system_prompt import reconstruct_static_prefix
+
+        stored = "STORED PROMPT\n\ntail"
+        agent = self._agent(stored)
+        with _patch(
+            "agent.system_prompt.build_system_prompt_parts",
+            return_value={"stable": "MISMATCH", "context": "", "volatile": ""},
+        ) as build:
+            reconstruct_static_prefix(agent)
+            reconstruct_static_prefix(agent)
+            reconstruct_static_prefix(agent)
+        assert build.call_count == 1
+        assert agent._cached_system_prompt_static is None
+
+    def test_changed_stored_prompt_retries_once(self):
+        from unittest.mock import patch as _patch
+
+        from agent.system_prompt import reconstruct_static_prefix
+
+        agent = self._agent("OLD STORED")
+        with _patch(
+            "agent.system_prompt.build_system_prompt_parts",
+            return_value={"stable": "MISMATCH", "context": "", "volatile": ""},
+        ) as build:
+            reconstruct_static_prefix(agent)
+            # A new stored prompt (e.g. after compression) invalidates the
+            # failure memo and gets exactly one fresh attempt.
+            agent._cached_system_prompt = "NEW STORED"
+            reconstruct_static_prefix(agent)
+            reconstruct_static_prefix(agent)
+        assert build.call_count == 2
+
+    def test_success_clears_failure_memo_and_early_returns(self):
+        from unittest.mock import patch as _patch
+
+        from agent.system_prompt import reconstruct_static_prefix
+
+        stable = "STATIC HEAD"
+        stored = stable + "\n\nvolatile"
+        agent = self._agent(stored)
+        with _patch(
+            "agent.system_prompt.build_system_prompt_parts",
+            return_value={"stable": stable, "context": "", "volatile": ""},
+        ) as build:
+            reconstruct_static_prefix(agent)
+            reconstruct_static_prefix(agent)
+        # Second call early-returns on the already-valid static prefix.
+        assert build.call_count == 1
+        assert agent._cached_system_prompt_static == stable
+        assert getattr(agent, "_static_rebuild_failed_for", None) is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Provider failover now re-renders prompt-cache breakpoints for the new provider's policy — cache-off → cache-on fallbacks get breakpoints (instead of full input price for the rest of the conversation), cache-on → cache-off stops shipping stale `cache_control`, and native ↔ envelope transitions relocate markers to carriers the new layout honors.

Salvage of #72682 by @HexLab98 (both commits cherry-picked, authorship preserved), plus five follow-up commits addressing review findings.

Fixes #72626

## Changes

Contributor commits (cherry-picked from #72682):
- `agent/prompt_caching.py`: new `strip_anthropic_cache_control`
- `agent/conversation_loop.py`: `_redecorate_prompt_cache_for_provider` chokepoint at the top of the retry loop (next to `_reapply_reasoning_echo_for_provider`), covering all failover `continue` paths by construction; MoA guidance peel + `rebase_prepared_request` rebase; static-prefix rebuild for sessions restored under a cache-off primary
- tests: policy-change coverage (`TestRedecoratePromptCacheOnPolicyChange`, `TestStripAnthropicCacheControl`)

Follow-up commits (review findings):
- **Restrict strip flatten to decoration-produced shapes** — the original flattened ANY pure-text multi-part list with a separator-less join, word-jamming organic multi-part text and dropping part keys like `citations` on the common no-failover path (redecoration runs every attempt). Also made marker removal copy-on-write on part dicts (the per-call message copy is shallow; parts alias persistent history).
- **Share static-prefix reconstruction + memoize failed rebuilds** — the `build_system_prompt_parts` → `startswith` pattern existed in 3 copies (restore path, compression keep-prompt path, new helper); hoisted into `agent/system_prompt.reconstruct_static_prefix`. Failed rebuilds are memoized per stored prompt so a persistent stable-tier mismatch no longer re-runs full prompt-build file I/O on every attempt of every API call.
- **Rebase MoA prepared request even when guidance is empty** — `guidance=None` is a real prepared shape (all-refs-failed / silent policy); the facade sends `prepared["messages"]`, so gating on `and guidance` left the stale decoration on that sub-path.
- **Co-locate guidance peel with attach** — moved the inverse transform into `moa_loop.peel_reference_guidance` next to `_attach_reference_guidance` with a round-trip contract test over all three attach shapes; fixed the empty-list residue (guidance-only part now drops the whole message).
- **Direct flag access** matching the call-block decoration site (getattr defaults with a divergent `_cache_ttl` fallback would mask init bugs as silent cache-off).

## Validation

| Check | Result |
|---|---|
| `test_prompt_caching` + `test_failover_identity` + `test_system_prompt_restore` | 74 passed |
| moa / caching / failover / system_prompt / compression sweep (`tests/agent/`) | 401 passed |
| E2E (real imports): `apply(strip(apply(x)))` idempotency, off→on / on→off transitions, organic multi-part preservation, MoA byte-equal round-trip, no-guidance prepared refresh, peel round-trip all shapes | all pass |
| Mutation checks: reverting the MoA gate fails its guard test; reverting all 5 agent files fails collection/suite | confirmed |
| ruff | clean |

## Credit

Based on #72682 by @HexLab98 — commits cherry-picked with authorship preserved. Issue analysis by @Sora-bluesky (#72626).
