### PR TITLE
fix(dashboard): surface and retry failed initial config/env loads

### DIFF
--- a/web/src/lib/initial-load.test.ts
+++ b/web/src/lib/initial-load.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  INITIAL_LOAD_START,
+  initialLoadErrorMessage,
+  initialLoadFailed,
+  initialLoadRetrying,
+  initialLoadSucceeded,
+  initialLoadView,
+} from "./initial-load";
+
+describe("initialLoadErrorMessage", () => {
+  it("surfaces the message of a rejected Error", () => {
+    expect(initialLoadErrorMessage(new Error("500: config unreadable"))).toBe(
+      "500: config unreadable",
+    );
+  });
+
+  it("passes a plain string rejection through", () => {
+    expect(initialLoadErrorMessage("NetworkError")).toBe("NetworkError");
+  });
+
+  it("falls back to a readable message for a shapeless rejection", () => {
+    for (const reason of [undefined, null, {}, new Error(""), ""]) {
+      const message = initialLoadErrorMessage(reason);
+      expect(message).toBe(
+        "Failed to load. The Hermes server may be unreachable.",
+      );
+      expect(message).not.toContain("undefined");
+      expect(message).not.toContain("[object Object]");
+    }
+  });
+});
+
+describe("required reads gate the page", () => {
+  it("moves to failed and surfaces the error instead of swallowing it", () => {
+    const state = initialLoadFailed(new Error("503: gateway down"));
+    expect(state.status).toBe("failed");
+    expect(state.error).toBe("503: gateway down");
+    // The regression this PR exists to prevent: a rejected required read
+    // must NOT leave the page on the spinner forever.
+    expect(initialLoadView(state, false)).toBe("error");
+  });
+
+  it("shows content once every required read resolves", () => {
+    const state = initialLoadSucceeded(INITIAL_LOAD_START);
+    expect(state.status).toBe("ready");
+    expect(state.error).toBeNull();
+    expect(initialLoadView(state, true)).toBe("content");
+  });
+
+  it("keeps the spinner while the required reads are still in flight", () => {
+    expect(initialLoadView(INITIAL_LOAD_START, false)).toBe("spinner");
+  });
+});
+
+describe("optional enrichment failures stay silent", () => {
+  it("stays ready when an optional read rejects and the required reads resolved", () => {
+    // ConfigPage's getDefaults / getConfigRaw / getStatus never call
+    // initialLoadFailed — they keep their own `.catch(() => {})`. This asserts
+    // the state machine a page in that situation is left in: still ready, no
+    // error, content rendered. Guards the profile-path reads and the header
+    // lifecycle against being dragged into the error state.
+    const state = initialLoadSucceeded(INITIAL_LOAD_START);
+    expect(state.status).toBe("ready");
+    expect(state.error).toBeNull();
+    expect(initialLoadView(state, true)).toBe("content");
+  });
+
+  it("does not let a required failure be papered over by a later success", () => {
+    // getConfig rejects, getSchema then resolves: the page is still broken.
+    const failed = initialLoadFailed(new Error("config read failed"));
+    const afterSibling = initialLoadSucceeded(failed);
+    expect(afterSibling.status).toBe("failed");
+    expect(afterSibling.error).toBe("config read failed");
+    expect(initialLoadView(afterSibling, false)).toBe("error");
+  });
+
+  it("shows the error even if partial data arrived", () => {
+    const failed = initialLoadFailed(new Error("schema read failed"));
+    expect(initialLoadView(failed, true)).toBe("error");
+  });
+});
+
+describe("retry", () => {
+  it("returns to loading and clears the error", () => {
+    const failed = initialLoadFailed(new Error("boom"));
+    const retrying = initialLoadRetrying();
+    expect(failed.status).toBe("failed");
+    expect(retrying.status).toBe("loading");
+    expect(retrying.error).toBeNull();
+    expect(initialLoadView(retrying, false)).toBe("spinner");
+  });
+
+  it("surfaces the new message when the retry fails again", () => {
+    initialLoadFailed(new Error("first failure"));
+    const retrying = initialLoadRetrying();
+    expect(retrying.error).toBeNull();
+    const second = initialLoadFailed(new Error("second failure"));
+    expect(second.status).toBe("failed");
+    // The stale message must not stick — a second failure reports itself.
+    expect(second.error).toBe("second failure");
+  });
+
+  it("reaches ready when the retry succeeds", () => {
+    initialLoadFailed(new Error("transient"));
+    const state = initialLoadSucceeded(initialLoadRetrying());
+    expect(state.status).toBe("ready");
+    expect(state.error).toBeNull();
+    expect(initialLoadView(state, true)).toBe("content");
+  });
+});

--- a/web/src/lib/initial-load.ts
+++ b/web/src/lib/initial-load.ts
@@ -1,0 +1,96 @@
+/**
+ * Initial-load state for dashboard pages whose first render is gated on a
+ * required read.
+ *
+ * ConfigPage and EnvPage both block their entire render behind a nullable
+ * data object (`!config || !schema`, `!vars`) that is only ever populated
+ * from a mount-effect fetch whose rejection was swallowed by
+ * `.catch(() => {})`. When that fetch fails the object stays null forever,
+ * so the page shows a spinner with no error text and no way to retry — the
+ * user cannot tell a down backend from a hung request, and a full browser
+ * reload is the only escape.
+ *
+ * Pages that gate on a `loading` boolean cleared in `.finally()` do not have
+ * this problem: they fall through to a rendered (if empty) page. Only the
+ * two null-gated pages need this state.
+ *
+ * Kept pure and React-free so it is unit-testable without a DOM — the same
+ * shape as `session-refresh.ts`. The page owns the state; this module owns
+ * the transitions and the render decision.
+ */
+
+export type InitialLoadStatus = "loading" | "ready" | "failed";
+
+export interface InitialLoadState {
+  status: InitialLoadStatus;
+  /** Message from the rejected required read; null unless `status` is "failed". */
+  error: string | null;
+}
+
+export const INITIAL_LOAD_START: InitialLoadState = {
+  status: "loading",
+  error: null,
+};
+
+/**
+ * Turn an unknown rejection value into a message safe to render.
+ *
+ * `api.*` helpers reject with an `Error` whose message carries the server's
+ * detail string, but a network-layer failure can reject with anything, so
+ * this never assumes a shape. Falls back to a generic message rather than
+ * rendering "undefined" or "[object Object]" at the user.
+ */
+export function initialLoadErrorMessage(reason: unknown): string {
+  if (reason instanceof Error && reason.message) return reason.message;
+  if (typeof reason === "string" && reason) return reason;
+  return "Failed to load. The Hermes server may be unreachable.";
+}
+
+/**
+ * Record a rejected **required** read.
+ *
+ * Only reads the page's render gate actually depends on may call this.
+ * Optional enrichment reads (ConfigPage's `getDefaults`, `getConfigRaw` and
+ * `getStatus`) must keep failing silently — the page is fully usable without
+ * them, and raising the error state for a merely-slow `/api/status` would
+ * regress a page that renders fine today.
+ */
+export function initialLoadFailed(reason: unknown): InitialLoadState {
+  return { status: "failed", error: initialLoadErrorMessage(reason) };
+}
+
+/**
+ * Record that every required read resolved.
+ *
+ * A late-arriving success does not clear a failure: if one required read
+ * rejected the page is broken regardless of what its sibling returned, and
+ * flipping back to "ready" would strand the page with partial data and no
+ * error. Retry is the only way out of "failed".
+ */
+export function initialLoadSucceeded(prev: InitialLoadState): InitialLoadState {
+  return prev.status === "failed" ? prev : { status: "ready", error: null };
+}
+
+/**
+ * Reset for a retry: back to "loading" with the error cleared, so a second
+ * failure surfaces its own message instead of the stale one sticking.
+ */
+export function initialLoadRetrying(): InitialLoadState {
+  return INITIAL_LOAD_START;
+}
+
+/**
+ * What the page should render right now.
+ *
+ * `hasRequiredData` is the page's existing null gate (`!!config && !!schema`,
+ * `!!vars`), passed in rather than duplicated here so the two stay in sync.
+ * The error branch wins over the data branch: a required read that failed
+ * means what data did arrive is incomplete.
+ */
+export function initialLoadView(
+  state: InitialLoadState,
+  hasRequiredData: boolean,
+): "error" | "spinner" | "content" {
+  if (state.status === "failed") return "error";
+  return hasRequiredData ? "content" : "spinner";
+}

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -1,5 +1,13 @@
-import { useEffect, useLayoutEffect, useRef, useState, useMemo } from "react";
 import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useMemo,
+} from "react";
+import {
+  AlertCircle,
   Code,
   Download,
   FormInput,
@@ -38,6 +46,14 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { getNestedValue, setNestedValue } from "@/lib/nested";
+import {
+  INITIAL_LOAD_START,
+  initialLoadFailed,
+  initialLoadRetrying,
+  initialLoadSucceeded,
+  initialLoadView,
+  type InitialLoadState,
+} from "@/lib/initial-load";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { AutoField } from "@/components/AutoField";
@@ -108,6 +124,8 @@ export default function ConfigPage() {
     Record<string, unknown>
   > | null>(null);
   const [categoryOrder, setCategoryOrder] = useState<string[]>([]);
+  const [initialLoad, setInitialLoad] =
+    useState<InitialLoadState>(INITIAL_LOAD_START);
   const [defaults, setDefaults] = useState<Record<string, unknown> | null>(
     null,
   );
@@ -161,14 +179,14 @@ export default function ConfigPage() {
     return cat.charAt(0).toUpperCase() + cat.slice(1);
   }
 
-  useEffect(() => {
-    api
-      .getConfig()
-      .then(setConfig)
-      .catch(() => {});
-    api
-      .getSchema()
-      .then((resp) => {
+  // getConfig and getSchema are the two reads the render gate below depends
+  // on, so they are the only ones allowed to raise the initial-load error
+  // state. Extracted into a callback so the Retry button can re-run exactly
+  // this set without re-firing the enrichment reads.
+  const loadRequired = useCallback(() => {
+    Promise.all([
+      api.getConfig().then(setConfig),
+      api.getSchema().then((resp) => {
         // memory.provider has a dedicated management UI on the Plugins page
         // (provider cards + guided setup/switch flow). Hide it from the
         // generic config form so the two surfaces don't fight; the schema
@@ -180,8 +198,26 @@ export default function ConfigPage() {
         delete fields["memory.provider"];
         setSchema(fields);
         setCategoryOrder(resp.category_order ?? []);
-      })
-      .catch(() => {});
+      }),
+    ])
+      .then(() => setInitialLoad(initialLoadSucceeded))
+      .catch((err: unknown) => setInitialLoad(initialLoadFailed(err)));
+  }, []);
+
+  // Retry clears the previous error and puts the spinner back, so a second
+  // failure reports its own message rather than the stale one sticking.
+  const retryInitialLoad = useCallback(() => {
+    setInitialLoad(initialLoadRetrying());
+    loadRequired();
+  }, [loadRequired]);
+
+  useEffect(() => {
+    loadRequired();
+    // The three reads below are enrichments, not render gates, so they keep
+    // failing silently: `defaults` only powers reset-to-default (guarded by
+    // `if (!defaults || !config) return`), and `configPath` is a header
+    // string. A slow or failing /api/status must not black out a page that
+    // otherwise renders fine.
     api
       .getDefaults()
       .then(setDefaults)
@@ -200,7 +236,7 @@ export default function ConfigPage() {
       .getStatus()
       .then((resp) => setConfigPath((prev) => prev ?? resp.config_path))
       .catch(() => {});
-  }, []);
+  }, [loadRequired]);
 
   // Set active category when categories load
   useEffect(() => {
@@ -366,8 +402,29 @@ export default function ConfigPage() {
     reader.readAsText(file);
   };
 
-  /* ---- Loading ---- */
-  if (!config || !schema) {
+  /* ---- Loading / initial-load failure ---- */
+  const initialView = initialLoadView(initialLoad, Boolean(config && schema));
+  if (initialView === "error") {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-24 text-sm">
+        <div className="flex items-start gap-2 text-destructive">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span className="wrap-break-word">{initialLoad.error}</span>
+        </div>
+        <Button
+          size="sm"
+          outlined
+          onClick={retryInitialLoad}
+          prefix={<RefreshCw />}
+        >
+          {t.common.retry}
+        </Button>
+      </div>
+    );
+  }
+  // The null re-check is implied by `initialView === "spinner"`; it is spelled
+  // out so TypeScript keeps narrowing config/schema to non-null below.
+  if (initialView === "spinner" || !config || !schema) {
     return (
       <div className="flex items-center justify-center py-24">
         <Spinner className="text-2xl text-primary" />

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import {
+  AlertCircle,
   Eye,
   EyeOff,
   ExternalLink,
@@ -14,9 +15,18 @@ import {
   Zap,
   ChevronDown,
   ChevronRight,
+  RefreshCw,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import type { EnvVarInfo } from "@/lib/api";
+import {
+  INITIAL_LOAD_START,
+  initialLoadFailed,
+  initialLoadRetrying,
+  initialLoadSucceeded,
+  initialLoadView,
+  type InitialLoadState,
+} from "@/lib/initial-load";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
@@ -608,6 +618,8 @@ function CustomKeysCard({
 
 export default function EnvPage() {
   const [vars, setVars] = useState<Record<string, EnvVarInfo> | null>(null);
+  const [initialLoad, setInitialLoad] =
+    useState<InitialLoadState>(INITIAL_LOAD_START);
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [revealed, setRevealed] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState<string | null>(null);
@@ -616,12 +628,29 @@ export default function EnvPage() {
   const { t } = useI18n();
   const { setAfterTitle } = usePageHeader();
 
-  useEffect(() => {
+  // getEnvVars is the only read gating this page's render, so its rejection
+  // must surface instead of leaving the spinner up forever. Extracted so the
+  // Retry button can re-run it.
+  const loadVars = useCallback(() => {
     api
       .getEnvVars()
-      .then(setVars)
-      .catch(() => {});
+      .then((resp) => {
+        setVars(resp);
+        setInitialLoad(initialLoadSucceeded);
+      })
+      .catch((err: unknown) => setInitialLoad(initialLoadFailed(err)));
   }, []);
+
+  // Retry clears the previous error and puts the spinner back, so a second
+  // failure reports its own message rather than the stale one sticking.
+  const retryInitialLoad = useCallback(() => {
+    setInitialLoad(initialLoadRetrying());
+    loadVars();
+  }, [loadVars]);
+
+  useEffect(() => {
+    loadVars();
+  }, [loadVars]);
 
   // Scroll-to sub-nav in the page header
   const sections = useMemo(() => {
@@ -883,7 +912,28 @@ export default function EnvPage() {
     };
   }, [vars, showAdvanced, t]);
 
-  if (!vars) {
+  const initialView = initialLoadView(initialLoad, Boolean(vars));
+  if (initialView === "error") {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-24 text-sm">
+        <div className="flex items-start gap-2 text-destructive">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span className="wrap-break-word">{initialLoad.error}</span>
+        </div>
+        <Button
+          size="sm"
+          outlined
+          onClick={retryInitialLoad}
+          prefix={<RefreshCw />}
+        >
+          {t.common.retry}
+        </Button>
+      </div>
+    );
+  }
+  // The null re-check is implied by `initialView === "spinner"`; it is spelled
+  // out so TypeScript keeps narrowing `vars` to non-null below.
+  if (initialView === "spinner" || !vars) {
     return (
       <div className="flex items-center justify-center py-24">
         <Spinner className="text-2xl text-primary" />


### PR DESCRIPTION
## What does this PR do?

`supersedes #14165`

**Symptom:** the dashboard's Config and Keys pages spin forever with no error text and no way to retry whenever their initial read fails. The user cannot tell a down backend from a hung request, and a full browser reload is the only escape.

Both pages gate their entire render on a nullable data object (`!config || !schema`, `!vars`) that is only ever populated by a mount-effect fetch whose rejection is discarded by `.catch(() => {})`. On failure the object stays `null` forever, so the spinner never resolves.

#14165 proposed the right fix in April but has been stale since `2026-04-22` and never picked up the review. This is a fresh implementation against current `main` supplying exactly the three things the review asked for.

### Addressing the review on #14165, in order

1. **"This April patch needs a targeted salvage rather than a clean apply: current main changed ConfigPage by 440 lines and EnvPage by 891 lines since base `b49a1b71a…`."**
   Nothing is applied from the original patch. This is written against current `main`, reusing the mount effect and render gate as they exist today.

2. **"Adapt the retry buttons to the current design-system API: current callers use `outlined` (for example `web/src/components/ChatSessionList.tsx:167`), whereas the patch uses `variant="outline"`."**
   Both buttons use `outlined`. The error block copies the shape of `ChatSessionList.tsx:160-172` — `AlertCircle`, `text-destructive`, `wrap-break-word`, `<Button size="sm" outlined prefix={<RefreshCw />}>{t.common.retry}</Button>` — centred rather than left-aligned because this is a full-page state, not a sidebar one. **No new i18n key**: `t.common.retry` already exists, and the caught error's message is rendered directly the same way `ChatSessionList` renders `{error}`.

3. **"The patch adds no automated rejected-load coverage for either page."**
   12 tests in `web/src/lib/initial-load.test.ts` covering rejected required reads, the optional-read carve-out, and retry.

### Preserved deliberately

The review also asked to *"preserve current ConfigPage's profile-path reads and header lifecycle while introducing a retryable initial-load state."*

Only the reads the render gate actually depends on may raise the error state — `getConfig` and `getSchema` on ConfigPage, `getEnvVars` on EnvPage. ConfigPage's other three reads stay exactly as they are, `.catch(() => {})` included:

- `getDefaults` → `defaults`, which only powers reset-to-default and is already guarded by `if (!defaults || !config) return`.
- `getConfigRaw` / `getStatus` → `configPath`, a header string. The profile-scoped-`getConfigRaw`-beats-global-`getStatus` fallback ordering documented in the comment at `ConfigPage.tsx:189-192` is untouched.

Widening the error state to all five reads would black out a page whose `/api/status` is merely slow. There is a test asserting the carve-out.

### Why the state machine lives in `web/src/lib/`

`web/` has `vitest` and no `jsdom` / `happy-dom` / `@testing-library/react`; all 19 existing `web/src` tests are pure-lib tests. Adding a DOM test environment would be a build-infra change riding along on a bug fix, so instead the state machine is extracted into a pure, React-free module and unit-tested directly. This mirrors the existing `web/src/lib/session-refresh.ts` idiom — a pure exported decision function consumed by a page and covered by its own test file. **No new dependency, no `package.json` change.**

### Sibling-site sweep

Every other page under `web/src/pages` that shows the same full-page spinner (`AnalyticsPage`, `ChannelsPage`, `CronPage`, `McpPage`, `ModelsPage`, `PairingPage`, `SessionsPage`, `SkillsPage`, `SystemPage`, `WebhooksPage`) gates on a `loading` boolean cleared in `.finally()`, so a failed initial read falls through to a rendered page rather than spinning forever. **ConfigPage and EnvPage are the only two sites with this root cause**, so this PR is the complete set, not a subset.

## Related Issue

No issue exists for this. `supersedes #14165`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`web/src/lib/initial-load.ts`** (new) — pure, React-free initial-load state machine: `InitialLoadState` (`loading` / `ready` / `failed` + message), `initialLoadErrorMessage` (never renders `undefined` or `[object Object]`), `initialLoadFailed`, `initialLoadSucceeded` (a late sibling success does not clear a recorded failure), `initialLoadRetrying`, and `initialLoadView` (error beats partial data).
- **`web/src/lib/initial-load.test.ts`** (new) — 12 tests.
- **`web/src/pages/ConfigPage.tsx`** — `getConfig` + `getSchema` extracted into a `loadRequired` callback whose rejection sets the error state; the three enrichment reads keep their silent catches; error branch with Retry added ahead of the spinner branch.
- **`web/src/pages/EnvPage.tsx`** — same for the single `getEnvVars` read.

## How to Test

1. `cd web && npm run typecheck && npx vitest run` — 20 files, 118 tests pass.
2. `npx eslint src/pages/ConfigPage.tsx src/pages/EnvPage.tsx src/lib/initial-load.ts src/lib/initial-load.test.ts` — 0 errors, and warning counts are identical to `main` (ConfigPage 4, EnvPage 0): this adds none.
3. Manually: stop the Hermes server, load `/config` and `/env` in the dashboard. Before this change both spin indefinitely; after it both show the failure message and a Retry button. Restart the server and click Retry — the page loads.

### Red-before / green-after

The regression guard was verified in both directions. Reverting the production hunk in `initial-load.ts` so a rejected required read is swallowed (returning the initial `loading` state, i.e. today's `.catch(() => {})` behaviour):

```
 × moves to failed and surfaces the error instead of swallowing it
   AssertionError: expected 'loading' to be 'failed'
 × does not let a required failure be papered over by a later success
   AssertionError: expected 'ready' to be 'failed'
 × shows the error even if partial data arrived
   AssertionError: expected 'content' to be 'error'
 × returns to loading and clears the error
   AssertionError: expected 'loading' to be 'failed'
 × surfaces the new message when the retry fails again
   AssertionError: expected 'loading' to be 'failed'

 Test Files  1 failed (1)
      Tests  5 failed | 7 passed (12)
```

With the fix restored:

```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a `web/` change with no Python surface; the `web` suite is run above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (browser-only change)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
