### PR TITLE
fix(agent): preserve session-level reasoning_config in switch_model when config has no override

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2374,7 +2374,9 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         from hermes_cli.config import load_config as _sm_load_config
 
         _reasoning_cfg = _sm_load_config() or {}
-        agent.reasoning_config = resolve_reasoning_config(_reasoning_cfg, agent.model)
+        _resolved = resolve_reasoning_config(_reasoning_cfg, agent.model)
+        if _resolved is not None:
+            agent.reasoning_config = _resolved
         logger.info(
             "switch_model: reasoning_config resolved for %s: %s",
             agent.model, agent.reasoning_config,


### PR DESCRIPTION
## Description
This PR resolves issue #72856 by ensuring `switch_model()` in `agent/agent_runtime_helpers.py` does not overwrite an active session-level `reasoning_config` with `None` when no config-level or per-model override is returned.