### PR TITLE
fix(tui): fail closed when prompt.submit cannot persist history truncation

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7972,6 +7972,58 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
+    """If replace_messages fails during edit/regenerate truncate, do not run the turn.
+
+    Memory-first + fail-open left session['history'] short while state.db kept
+    the old tail. The agent flush then appends the new exchange on top of the
+    'undone' turns — durable zombie history. Write first; on failure leave
+    memory and DB unchanged and return 5008.
+    """
+    original_history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "second reply"},
+    ]
+    sess = _session(history=list(original_history))
+    server._sessions["trunc-fail-sid"] = sess
+
+    class _FailDb:
+        def replace_messages(self, session_id, messages):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FailDb())
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "trunc-fail-sid",
+                    "text": "edited second",
+                    "truncate_before_user_ordinal": 1,
+                },
+            }
+        )
+        assert "error" in resp
+        assert resp["error"]["code"] == 5008
+        assert "truncat" in resp["error"]["message"].lower() or "persist" in resp["error"]["message"].lower()
+        # Memory left intact — same list contents as before the refused cut.
+        assert sess["history"] == original_history
+        assert sess["history_version"] == 0
+        assert sess.get("running") is not True
+    finally:
+        server._sessions.pop("trunc-fail-sid", None)
+
+
 # ---------------------------------------------------------------------------
 # session.interrupt must only cancel pending prompts owned by the calling
 # session — it must not blast-resolve clarify/sudo/secret prompts on

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10902,13 +10902,33 @@ def _(rid, params: dict) -> dict:
                 len(truncated),
                 ordinal,
             )
-            session["history"] = truncated
-            session["history_version"] = int(session.get("history_version", 0)) + 1
+            # Write-before-memory (mirrors gateway hygiene / manual /compress):
+            # persist the truncated transcript first. If replace_messages fails
+            # after we already rewrote session["history"], the turn still runs
+            # against the short list while state.db keeps the old tail. The
+            # agent flush is append-only for history-dict identities, so the
+            # new exchange is appended on top of the "undone" turns — durable
+            # zombie history on resume, and the edit/regenerate never sticks.
+            # Fail closed: refuse the turn and leave memory/DB unchanged.
             if (db := _get_db()) is not None:
                 try:
                     db.replace_messages(session["session_key"], truncated)
                 except Exception as exc:
-                    print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
+                    logger.error(
+                        "prompt.submit: replace_messages failed for session %s "
+                        "(ordinal=%d); refusing turn so memory and DB stay "
+                        "aligned: %s",
+                        sid,
+                        ordinal,
+                        exc,
+                    )
+                    return _err(
+                        rid,
+                        5008,
+                        f"failed to persist history truncation: {exc}",
+                    )
+            session["history"] = truncated
+            session["history_version"] = int(session.get("history_version", 0)) + 1
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()


### PR DESCRIPTION
## Summary

Desktop edit / regenerate / restore-checkpoint send `truncate_before_user_ordinal` on `prompt.submit`. The handler rewrote `session["history"]` **first**, then called `replace_messages`, and on failure only printed to stderr and **still started the turn**.

When the durable write fails (SQLite lock, ENOSPC, FTS write error):

1. In-memory history is already truncated and `history_version` is bumped
2. `state.db` still holds the pre-edit tail
3. The agent runs with the short list as `conversation_history`
4. End-of-turn flush is **append-only** for history-dict identities (`run_agent._flush_messages_to_session_db`): the pre-cut rows are marked already-persisted and skipped; only the new exchange is inserted

Result: the "undone" turns remain in the DB forever, the new exchange is appended on top, and on resume the user sees zombie history. The edit never sticks as a true truncate.

Same class as the hygiene write-before-repoint fix (#72859) and manual `/compress` write-first fail-closed: **do not commit a destructive in-memory state change until the canonical write lands**.

## Problem

**Before:**

```python
session["history"] = truncated
session["history_version"] += 1
if db is not None:
    try:
        db.replace_messages(session["session_key"], truncated)
    except Exception as exc:
        print(...)  # fail open
# turn starts anyway
```

**Why neither existing guard helps:**

- Out-of-range ordinal → 4018 (does not fire on a successful cut)
- Empty-truncation → 4028 (does not fire when the cut is non-empty)

**Default path.** Edit-a-message, Regenerate, and restore-checkpoint always-visible controls all funnel through this ordinal + `replace_messages`.

**Unrecoverable for the intended cut.** The soft-deleted (intended) rows are never removed; the new exchange is durable. Soft-archive is not used here — `replace_messages` is the only wipe, and it never ran.

## Fix

Persist first; only then mutate memory:

```python
if db is not None:
    try:
        db.replace_messages(session["session_key"], truncated)
    except Exception as exc:
        return _err(rid, 5008, f"failed to persist history truncation: {exc}")
session["history"] = truncated
session["history_version"] += 1
```

On failure the in-memory history and version are left unchanged and the turn is not started.

## Scope

- `tui_gateway/server.py` — `prompt.submit` truncate branch only
- Regression test in `tests/test_tui_gateway_server.py`

Related but distinct:

- #72695 — ordinal miscount (wrong cut index); this PR is write fail-closed after a correct cut
- #72859 — hygiene rotation write-before-repoint (gateway)
- #41234 — wrong *profile* DB for remote multi-profile; not failure handling
- #69109 — refresh history before ordinal; not fail-closed persist

## Testing

New `test_prompt_submit_refuses_turn_when_truncate_persist_fails`: `replace_messages` raises; assert 5008, history/version untouched, turn not started.

Existing truncate suite still green:

```text
python -m pytest \
  tests/test_tui_gateway_server.py::test_prompt_submit_refuses_turn_when_truncate_persist_fails \
  tests/test_tui_gateway_server.py::test_prompt_submit_can_truncate_before_user_ordinal \
  tests/test_tui_gateway_server.py::test_prompt_submit_rejects_negative_truncate_ordinal \
  tests/test_tui_gateway_server.py::test_prompt_submit_refuses_empty_truncation_without_confirm \
  -o addopts= -q
4 passed
```
