### PR TITLE
fix(gateway): expand ${VAR} references in gateway config and warn on unresolved refs

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -16,7 +16,7 @@ from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
-from hermes_cli.config import get_hermes_home
+from hermes_cli.config import get_hermes_home, _expand_env_vars
 from agent.secret_scope import current_secret_scope, get_secret as _get_secret
 from utils import is_truthy_value
 
@@ -1280,6 +1280,13 @@ def load_gateway_config() -> GatewayConfig:
         if config_yaml_path.exists():
             with open(config_yaml_path, encoding="utf-8") as f:
                 yaml_cfg = yaml.safe_load(f) or {}
+
+            # Expand ${VAR} references in config values, matching the behavior
+            # of hermes_cli.config.load_config(). Without this, values under
+            # platforms.<name>.extra (admin lists, webhook URLs, chat IDs)
+            # keep the literal ${VAR} text, which silently breaks gating
+            # (#72096).
+            yaml_cfg = _expand_env_vars(yaml_cfg)
 
             # Managed scope: overlay administrator-pinned values so the gateway
             # honors them too. This loader builds its own dict instead of going

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -34,8 +34,15 @@ included here — only the slash-command access split.
 
 from __future__ import annotations
 
+import logging
+import re
 from dataclasses import dataclass
 from typing import Any, FrozenSet, Iterable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Pattern matching unresolved ${VAR} references that survived env-var expansion.
+_UNRESOLVED_VAR_RE = re.compile(r"^\$\{[^}]+\}$")
 
 
 # Slash commands that MUST stay reachable for any allowed user, even when
@@ -96,6 +103,10 @@ def _coerce_id_list(raw: Any) -> FrozenSet[str]:
 
     Accepts ``None``, list, tuple, or comma-separated string. Stringifies
     each entry and strips whitespace; empty entries are dropped.
+
+    Logs a warning for entries that look like unresolved ``${VAR}`` references
+    (defense-in-depth for #72096 — the primary fix is env-var expansion in
+    ``load_gateway_config()``).
     """
     if raw is None:
         return frozenset()
@@ -110,6 +121,14 @@ def _coerce_id_list(raw: Any) -> FrozenSet[str]:
     for it in items:
         s = str(it).strip()
         if s:
+            if _UNRESOLVED_VAR_RE.match(s):
+                logger.warning(
+                    "Unresolved env-var reference %r in admin/user id list — "
+                    "the referenced variable is not set. This entry will never "
+                    "match a real user. Fix: set %s in your .env or config.",
+                    s,
+                    s,
+                )
             out.append(s)
     return frozenset(out)
 


### PR DESCRIPTION
## What does this PR do?

The gateway config loader (`load_gateway_config`) reads `config.yaml` with its own `yaml.safe_load()` call, bypassing `hermes_cli.config.load_config()` where `_expand_env_vars()` is normally applied. Values under `platforms.<name>.extra` (admin lists, webhook URLs, chat IDs) therefore keep literal `${VAR}` text.

For slash-command admin lists, an unresolved `${TELEGRAM_ADMIN_ID}` becomes the one-element set `{'\${TELEGRAM_ADMIN_ID}'}`. Since the set is non-empty, gating is switched ON with an admin list that can never match any real user id — a silent lockout of every tiered slash command.

## Related Issue

Fixes #72096

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py`: Call `_expand_env_vars()` on the YAML dict right after `yaml.safe_load()` in `load_gateway_config()`, matching the CLI config path.
- `gateway/slash_access.py`: Add defense-in-depth in `_coerce_id_list()` to log a warning when an entry still looks like an unresolved `${VAR}` reference.

## How to Test

1. Set `TELEGRAM_ADMIN_ID=12345` in your environment
2. Configure `config.yaml` with `group_allow_admin_from: \"\${TELEGRAM_ADMIN_ID}\"`
3. Before fix: `is_admin()` checks `str(user_id) in {'\${TELEGRAM_ADMIN_ID}'}` — always False
4. After fix: `is_admin()` checks `str(user_id) in {'12345'}` — matches correctly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A