### PR TITLE
refactor(gateway): name MAX_ATTEMPTS in the redelivery-claim comment (#67663)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7628,7 +7628,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return 0
             # Only claim rows we can actually send this boot: self.adapters
             # holds a platform only after its connect() succeeded, and each
-            # claim spends one of the row's three redelivery attempts.
+            # claim spends one of the row's MAX_ATTEMPTS redelivery attempts.
             _deliverable = {
                 getattr(p, "value", str(p)) for p in self.adapters
             }


### PR DESCRIPTION
## What does this PR do?

The comment above the `sweep_recoverable` claim in `_redeliver_pending_obligations` spelled the redelivery budget out as **"three attempts"**, duplicating the value of `delivery_ledger.MAX_ATTEMPTS` in prose:

```python
# Only claim rows we can actually send this boot: self.adapters
# holds a platform only after its connect() succeeded, and each
# claim spends one of the row's three redelivery attempts.
```

`MAX_ATTEMPTS` is the single source of truth for that bound and is already read that way at [`gateway/delivery_ledger.py:272`](https://github.com/NousResearch/hermes-agent/blob/main/gateway/delivery_ledger.py#L272). Changing the constant to `2` or `5` would leave this comment quietly asserting a value the code no longer uses, so the next reader has to go verify whether "three" is still true.

This names the constant instead of restating its current value. No behavior change.

I took option **(a)** from the issue, which the reporter also recommended: keep the inline comment short and let it reference the constant, rather than moving the prose into the `sweep_recoverable` docstring.

## Related Issue

Fixes #67663

## Type of Change

- [x] ♻️ Refactor (no behavior change)

## Changes Made

- `gateway/run.py:7631` — replace the literal `three` with `MAX_ATTEMPTS` in the redelivery-claim comment. One line, comment only.

### Deliberately not changed

`website/docs/user-guide/messaging/index.md:231` also states `3 attempts, 24-hour freshness`. I left it alone on purpose: user-facing documentation should give the reader the concrete bound, not the name of an internal Python constant they cannot see. The drift risk the issue describes is specific to a code comment sitting next to the code that reads the constant.

## How to Test

There is no behavior to exercise, so this is a no-regression check.

1. `scripts/run_tests.sh tests/gateway/test_delivery_ledger.py tests/gateway/test_restart_redelivery_dedup.py tests/gateway/test_delivery_ledger_producer.py -q`
   → `3 files, 50 tests passed, 0 failed`
2. `python -m ruff check gateway/run.py` → `All checks passed!`
3. `git diff` confirms the change is a single comment line inside `_redeliver_pending_obligations`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`refactor(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open or merged PR touches this comment or #67663
- [x] My PR contains **only** changes related to this fix (single commit, one line)
- [x] Tests pass — I ran the three delivery-ledger suites via `scripts/run_tests.sh` (per `AGENTS.md`, which requires the wrapper rather than calling `pytest` directly) instead of the full suite, since the change is comment-only
- [ ] I've added tests for my changes — **N/A and intentional.** This is a comment-only refactor with no observable behavior. The only test that could assert on it would have to read `gateway/run.py` as text, which `AGENTS.md` bans outright under "Never read source code in tests."
- [x] I've tested on my platform: Ubuntu (aarch64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, see "Deliberately not changed" above
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture or workflow change
- [x] I've considered cross-platform impact — N/A, comment only
- [x] I've updated tool descriptions/schemas — N/A, no tool behavior change
