### PR TITLE
fix(gateway): verify macOS restarts and recover Discord gaps

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2192,6 +2192,7 @@ from gateway.shutdown_watchdog import (
     loop_heartbeat_forever,
     resolve_shutdown_watchdog_delay,
     start_loop_liveness_watchdog,
+    write_loop_heartbeat,
 )
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
@@ -3733,6 +3734,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # the loop is dispatching. External supervisors use the file mtime /
         # updated_at to distinguish "process alive" from "loop frozen".
         self._gateway_started_at: float = time.time()
+        self._gateway_startup_phase: str = "created"
         self._loop_heartbeat_task: Optional[asyncio.Task] = None
         self._loop_floor_timer_handle = None
         self._loop_liveness_watchdog = None
@@ -3747,6 +3749,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Set after a wake (re-arm cooldown, 0.F) so we don't immediately re-go
         # dormant before the drained backlog has a chance to update the clock.
         self._scale_to_zero_cooldown_until: float = 0.0
+
+    def _ensure_loop_heartbeat(self) -> None:
+        """Start the process-generation heartbeat before slow platform startup.
+
+        Supervisors must be able to distinguish a live gateway progressing
+        through Discord/plugin connection from a dead replacement. The phase
+        remains non-ready until startup completes, so activation verifiers
+        cannot mistake an early process heartbeat for a usable chat runtime.
+        """
+        try:
+            existing = getattr(self, "_loop_heartbeat_task", None)
+            if existing is not None and not existing.done():
+                return
+            self._loop_heartbeat_task = asyncio.create_task(
+                loop_heartbeat_forever(
+                    interval_s=DEFAULT_HEARTBEAT_INTERVAL_S,
+                    start_time=getattr(self, "_gateway_started_at", 0.0),
+                    extra_fn=lambda: {
+                        "phase": getattr(
+                            self,
+                            "_gateway_startup_phase",
+                            "unknown",
+                        ),
+                    },
+                )
+            )
+            background = getattr(self, "_background_tasks", None)
+            if background is not None:
+                background.add(self._loop_heartbeat_task)
+                self._loop_heartbeat_task.add_done_callback(background.discard)
+        except Exception:
+            logger.debug("Failed to start gateway loop heartbeat", exc_info=True)
 
 
     def _wire_teams_pipeline_runtime(self) -> None:
@@ -7967,6 +8001,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("Could not set up faulthandler file logging", exc_info=True)
 
+        self._gateway_startup_phase = "booting"
+        self._ensure_loop_heartbeat()
         try:
             self._gateway_loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -8286,6 +8322,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_platform_count = 0
         startup_nonretryable_errors: list[str] = []
         startup_retryable_errors: list[str] = []
+        self._gateway_startup_phase = "platforms_connecting"
         
         # Initialize and connect each configured platform
         _multiplex_on = bool(getattr(self.config, "multiplex_profiles", False))
@@ -8566,27 +8603,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._wire_teams_pipeline_runtime()
 
         self._running = True
+        self._gateway_startup_phase = (
+            "degraded"
+            if enabled_platform_count > 0 and connected_count == 0
+            else "running"
+        )
+        write_loop_heartbeat(
+            start_time=getattr(self, "_gateway_started_at", 0.0),
+            extra={"phase": self._gateway_startup_phase},
+        )
         self._update_runtime_status("running")
 
         # Loop-liveness heartbeat (#66892): an asyncio task so a frozen loop
         # stops refreshing ``state/gateway.heartbeat``. Cancelled with the
         # other background tasks during stop(). Best-effort — a liveness probe
         # must never be able to abort startup.
-        try:
-            _existing_hb = getattr(self, "_loop_heartbeat_task", None)
-            if _existing_hb is None or _existing_hb.done():
-                self._loop_heartbeat_task = asyncio.create_task(
-                    loop_heartbeat_forever(
-                        interval_s=DEFAULT_HEARTBEAT_INTERVAL_S,
-                        start_time=getattr(self, "_gateway_started_at", 0.0),
-                    )
-                )
-                _bg = getattr(self, "_background_tasks", None)
-                if _bg is not None:
-                    _bg.add(self._loop_heartbeat_task)
-                    self._loop_heartbeat_task.add_done_callback(_bg.discard)
-        except Exception:
-            logger.debug("Failed to start gateway loop heartbeat", exc_info=True)
+        self._ensure_loop_heartbeat()
 
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -406,6 +406,7 @@ async def loop_heartbeat_forever(
     start_time: Optional[float] = None,
     home: Optional[Path] = None,
     should_continue: Optional[Callable[[], bool]] = None,
+    extra_fn: Optional[Callable[[], Dict[str, Any]]] = None,
 ) -> None:
     """Rewrite the loop heartbeat file on a cadence until cancelled / gated off.
 
@@ -419,11 +420,29 @@ async def loop_heartbeat_forever(
 
     # Immediate first write so monitors see a fresh file as soon as the
     # gateway is running, not after the first interval.
-    write_loop_heartbeat(start_time=start_time, home=home)
+    def current_extra() -> Optional[Dict[str, Any]]:
+        if extra_fn is None:
+            return None
+        try:
+            value = extra_fn()
+        except Exception:
+            logger.debug("Failed to collect gateway heartbeat metadata", exc_info=True)
+            return None
+        return value if isinstance(value, dict) else None
+
+    write_loop_heartbeat(
+        start_time=start_time,
+        home=home,
+        extra=current_extra(),
+    )
     while True:
         if should_continue is not None and not should_continue():
             return
         await asyncio.sleep(interval)
         if should_continue is not None and not should_continue():
             return
-        write_loop_heartbeat(start_time=start_time, home=home)
+        write_loop_heartbeat(
+            start_time=start_time,
+            home=home,
+            extra=current_extra(),
+        )

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4290,6 +4290,106 @@ def launchd_uninstall():
     print("✓ Service uninstalled")
 
 
+def _launchd_gateway_ready_snapshot(
+    label: str,
+    *,
+    previous_pid: int | None = None,
+) -> int | None:
+    """Return the ready launchd PID, never just a registered job.
+
+    ``launchctl kickstart`` returning zero proves only that launchd accepted
+    the request. A replacement is usable only after launchd exposes its PID,
+    Hermes runtime status belongs to that PID, and the event-loop heartbeat
+    reports a ready phase. Legacy heartbeats without ``phase`` remain
+    compatible once runtime status says ``running``.
+    """
+    try:
+        listed = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if listed.returncode != 0:
+        return None
+    pid = _parse_launchd_pid_from_list_output(listed.stdout)
+    if pid is None or (previous_pid is not None and pid == previous_pid):
+        return None
+
+    try:
+        from gateway.shutdown_watchdog import get_loop_heartbeat_path
+        from gateway.status import read_runtime_status
+
+        runtime = read_runtime_status()
+        heartbeat_path = get_loop_heartbeat_path()
+        heartbeat = json.loads(heartbeat_path.read_text(encoding="utf-8"))
+        runtime_pid = runtime.get("pid") if isinstance(runtime, dict) else None
+        heartbeat_pid = heartbeat.get("pid")
+        gateway_state = runtime.get("gateway_state") if isinstance(runtime, dict) else None
+        phase = heartbeat.get("phase")
+        heartbeat_age = time.time() - heartbeat_path.stat().st_mtime
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+    if runtime_pid != pid or heartbeat_pid != pid:
+        return None
+    if gateway_state not in {"running", "degraded"}:
+        return None
+    if isinstance(phase, str) and phase.strip().lower() not in {
+        "running",
+        "degraded",
+    }:
+        return None
+    if heartbeat_age < -5.0 or heartbeat_age > 90.0:
+        return None
+    return pid
+
+
+def _wait_for_launchd_gateway_ready(
+    *,
+    previous_pid: int | None = None,
+    timeout: float = 120.0,
+) -> bool:
+    """Wait for two stable ready observations of a launchd replacement."""
+    deadline = time.monotonic() + max(0.0, timeout)
+    stable_pid: int | None = None
+    stable = 0
+    while True:
+        pid = _launchd_gateway_ready_snapshot(
+            get_launchd_label(),
+            previous_pid=previous_pid,
+        )
+        if pid is None:
+            stable_pid = None
+            stable = 0
+        elif pid == stable_pid:
+            stable += 1
+        else:
+            stable_pid = pid
+            stable = 1
+        if stable >= 2:
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(1.0, remaining))
+
+
+def _require_launchd_gateway_ready(
+    *,
+    action: str,
+    previous_pid: int | None = None,
+) -> None:
+    if _wait_for_launchd_gateway_ready(previous_pid=previous_pid):
+        return
+    raise RuntimeError(
+        f"launchd accepted gateway {action}, but no stable ready runtime "
+        "appeared within 120 seconds; leaving automatic recovery to launchd"
+    )
+
+
 def launchd_start():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
@@ -4314,6 +4414,7 @@ def launchd_start():
                 raise
             _launchd_fallback_to_detached(f"launchctl exit {e.returncode}")
             return
+        _require_launchd_gateway_ready(action="start")
         print("✓ Service started")
         _clear_launchd_unsupported_marker()
         return
@@ -4344,6 +4445,7 @@ def launchd_start():
                 raise
             _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
             return
+    _require_launchd_gateway_ready(action="start")
     print("✓ Service started")
     _clear_launchd_unsupported_marker()
 
@@ -4465,6 +4567,10 @@ def launchd_restart():
                         f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
                     )
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+        _require_launchd_gateway_ready(
+            action="restart",
+            previous_pid=pid,
+        )
         print("✓ Service restarted")
         _clear_launchd_unsupported_marker()
     except subprocess.CalledProcessError as e:
@@ -4501,6 +4607,10 @@ def launchd_restart():
                 raise
             _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
             return
+        _require_launchd_gateway_ready(
+            action="restart",
+            previous_pid=pid,
+        )
         print("✓ Service restarted")
         _clear_launchd_unsupported_marker()
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -55,6 +55,7 @@ _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.
 
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_MISSED_MESSAGE_RETRY_DUPLICATE_WINDOW_SECONDS = 600.0
 # Discord enforces a hard cap of 100 global application (slash) commands per
 # app. Registering more makes the ENTIRE sync fail with error 30032
 # ("Maximum number of application commands reached"), which silently breaks
@@ -2085,6 +2086,7 @@ class DiscordAdapter(BasePlatformAdapter):
         dispatched = 0
         scanned = 0
         missed = 0
+        recovered_retries: dict[tuple[str, str, str], float] = {}
         try:
             async for message in self._iter_missed_message_backfill_candidates(channels):
                 scanned += 1
@@ -2098,6 +2100,31 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not await self._should_backfill_discord_message(message):
                     continue
                 missed += 1
+                retry_fingerprint = self._missed_message_retry_fingerprint(message)
+                retry_created_at = self._missed_message_created_timestamp(message)
+                prior_retry_at = (
+                    recovered_retries.get(retry_fingerprint)
+                    if retry_fingerprint is not None
+                    else None
+                )
+                if (
+                    prior_retry_at is not None
+                    and retry_created_at is not None
+                    and abs(retry_created_at - prior_retry_at)
+                    <= _MISSED_MESSAGE_RETRY_DUPLICATE_WINDOW_SECONDS
+                ):
+                    self._record_recovery_attempt(
+                        message,
+                        status="superseded_duplicate",
+                    )
+                    logger.info(
+                        "[%s] Suppressed repeated missed Discord retry %s; "
+                        "an equivalent request from the same sender/channel "
+                        "was already recovered",
+                        self.name,
+                        message_id,
+                    )
+                    continue
                 logger.info(
                     "[%s] Backfilling missed Discord message %s in channel %s",
                     self.name,
@@ -2109,6 +2136,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     admitted = await self._dispatch_recovered_message(message)
                     if admitted:
                         dispatched += 1
+                        if (
+                            retry_fingerprint is not None
+                            and retry_created_at is not None
+                        ):
+                            recovered_retries[retry_fingerprint] = retry_created_at
                 except asyncio.CancelledError:
                     self._dedup.discard(message_id)
                     self._record_recovery_attempt(message, status="cancelled")
@@ -2155,6 +2187,34 @@ class DiscordAdapter(BasePlatformAdapter):
                 error=str(exc),
             )
             logger.warning("[%s] Missed-message backfill failed: %s", self.name, exc, exc_info=True)
+
+    @staticmethod
+    def _missed_message_created_timestamp(message: Any) -> Optional[float]:
+        created_at = getattr(message, "created_at", None)
+        if created_at is None or not hasattr(created_at, "timestamp"):
+            return None
+        try:
+            return float(created_at.timestamp())
+        except (OSError, TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _missed_message_retry_fingerprint(
+        message: Any,
+    ) -> Optional[tuple[str, str, str]]:
+        """Identify outage retries without conflating normal live messages."""
+        content = " ".join(str(getattr(message, "content", "") or "").split())
+        if not content:
+            return None
+        channel_id = str(
+            getattr(getattr(message, "channel", None), "id", "") or ""
+        )
+        author_id = str(
+            getattr(getattr(message, "author", None), "id", "") or ""
+        )
+        if not channel_id or not author_id:
+            return None
+        return channel_id, author_id, content.casefold()
 
     async def _dispatch_recovered_message(self, message: Any) -> bool:
         """Run one recovered message through the live Discord ingress gates."""
@@ -2557,7 +2617,10 @@ class DiscordAdapter(BasePlatformAdapter):
             if not row:
                 return False
             status, replied, outage = row
-            return status == "responded" and bool(replied) and not bool(outage)
+            return (
+                status == "superseded_duplicate"
+                or (status == "responded" and bool(replied) and not bool(outage))
+            )
 
         return bool(self._with_discord_recovery_db(_op, default=False))
 

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -274,6 +274,35 @@ async def test_run_backfill_counts_only_messages_that_reach_dispatch(adapter, mo
 
 
 @pytest.mark.asyncio
+async def test_backfill_collapses_repeated_outage_retries(adapter, monkeypatch):
+    created = datetime.now(timezone.utc)
+    messages = [
+        make_message(message_id=1, content="Tvirtinu"),
+        make_message(message_id=2, content="  TVIRTINU  "),
+        make_message(message_id=3, content="Tvirtinu"),
+    ]
+    for offset, message in enumerate(messages):
+        message.created_at = created + dt.timedelta(seconds=offset * 30)
+
+    async def candidates(_channels):
+        for message in messages:
+            yield message
+
+    dispatch = AsyncMock(return_value=True)
+    monkeypatch.setattr(adapter, "_iter_missed_message_backfill_candidates", candidates)
+    monkeypatch.setattr(adapter, "_should_backfill_discord_message", AsyncMock(return_value=True))
+    monkeypatch.setattr(adapter, "_dispatch_recovered_message", dispatch)
+    monkeypatch.setattr(adapter, "_missed_message_backfill_channels", lambda: {"123"})
+    monkeypatch.setattr(adapter, "_missed_message_backfill_max_dispatches", lambda: 10)
+
+    await adapter._run_missed_message_backfill()
+
+    dispatch.assert_awaited_once_with(messages[0])
+    assert adapter._discord_message_is_persistently_complete("2") is True
+    assert adapter._discord_message_is_persistently_complete("3") is True
+
+
+@pytest.mark.asyncio
 async def test_recovery_aborts_when_durable_ledger_is_unavailable(adapter, monkeypatch):
     dispatch = AsyncMock()
     monkeypatch.setattr(adapter, "_dispatch_recovered_message", dispatch)

--- a/tests/gateway/test_shutdown_watchdog.py
+++ b/tests/gateway/test_shutdown_watchdog.py
@@ -136,6 +136,37 @@ async def test_loop_heartbeat_rewrites_until_cancelled(tmp_path):
             await task
 
 
+@pytest.mark.asyncio
+async def test_loop_heartbeat_tracks_live_startup_phase(tmp_path):
+    phase = {"value": "booting"}
+    path = get_loop_heartbeat_path(tmp_path)
+    task = asyncio.create_task(
+        loop_heartbeat_forever(
+            interval_s=0.01,
+            start_time=12.0,
+            home=tmp_path,
+            extra_fn=lambda: {"phase": phase["value"]},
+        )
+    )
+    try:
+        for _ in range(50):
+            if path.is_file():
+                break
+            await asyncio.sleep(0.02)
+        assert json.loads(path.read_text(encoding="utf-8"))["phase"] == "booting"
+
+        phase["value"] = "running"
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if json.loads(path.read_text(encoding="utf-8"))["phase"] == "running":
+                break
+        assert json.loads(path.read_text(encoding="utf-8"))["phase"] == "running"
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
 def test_gateway_runner_exposes_shutdown_watchdog_state():
     """Attrs used by stop()/start() exist after normal construction hooks."""
     from gateway.run import GatewayRunner

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,5 +1,6 @@
 """Tests for gateway service management helpers."""
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -624,6 +625,15 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    @pytest.fixture(autouse=True)
+    def _stable_launchd_runtime(self, monkeypatch):
+        """Most command-routing tests do not build runtime heartbeat files."""
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_gateway_ready",
+            lambda **_kwargs: True,
+        )
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
@@ -892,6 +902,88 @@ class TestLaunchdServiceRecovery:
         out = capsys.readouterr().out
         assert "draining in-flight runs" in out
         assert "up to 12s" in out
+
+    def test_launchd_restart_fails_when_kickstart_never_becomes_ready(
+        self,
+        monkeypatch,
+    ):
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda: 321,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda _pid: False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda **_kwargs: True,
+        )
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_gateway_ready",
+            lambda **_kwargs: False,
+        )
+        calls = []
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(cmd)
+            or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        with pytest.raises(RuntimeError, match="no stable ready runtime"):
+            gateway_cli.launchd_restart()
+
+        # No second kickstart/restart is attempted by Hermes.
+        assert calls.count(["launchctl", "kickstart", "-k", target]) == 1
+
+    def test_launchd_ready_snapshot_requires_ready_phase_and_matching_pid(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        heartbeat = tmp_path / "gateway.heartbeat"
+        heartbeat.write_text(
+            json.dumps({"pid": 456, "phase": "platforms_connecting"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=0,
+                stdout='{\n"PID" = 456;\n}',
+                stderr="",
+            ),
+        )
+        monkeypatch.setattr(
+            "gateway.status.read_runtime_status",
+            lambda: {"pid": 456, "gateway_state": "running"},
+        )
+        monkeypatch.setattr(
+            "gateway.shutdown_watchdog.get_loop_heartbeat_path",
+            lambda: heartbeat,
+        )
+
+        assert gateway_cli._launchd_gateway_ready_snapshot("test") is None
+
+        heartbeat.write_text(
+            json.dumps({"pid": 456, "phase": "running"}),
+            encoding="utf-8",
+        )
+        assert gateway_cli._launchd_gateway_ready_snapshot("test") == 456
+        assert (
+            gateway_cli._launchd_gateway_ready_snapshot(
+                "test",
+                previous_pid=456,
+            )
+            is None
+        )
 
     def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
         calls = []


### PR DESCRIPTION
## Summary
- start a phase-aware gateway heartbeat before plugin/platform startup, so service managers can distinguish booting from ready
- make launchd start/restart wait for a new, stable, PID-matched running runtime instead of treating `kickstart` exit 0 as readiness
- keep routine macOS restarts transactional by leaving recovery to launchd rather than bootout/bootstrap churn
- recover Discord messages missed during outages and collapse repeated same-text retries (for example repeated `Tvirtinu`) into one admitted turn with durable duplicate receipts

## Why
A macOS gateway could accept `launchctl kickstart` and be reported as restarted before Discord had connected. If startup was slow or restart verification timed out, orchestration could trigger another restart. Messages sent during that window had no acknowledgement and were not replayed by default.

## Verification
- all required checks passed on the fork PR: https://github.com/justascesnauskas/hermes-agent/pull/3
- upstream rebase: ruff passed on all touched files
- focused upstream gateway/launchd/Discord recovery tests passed
- fork branch broader suite: 431 passed
