### PR TITLE
feat(kanban): add atomic reconciliation primitives

### DIFF
--- a/docs/kanban/atomic-reconciliation.md
+++ b/docs/kanban/atomic-reconciliation.md
@@ -1,0 +1,42 @@
+# Atomic Kanban reconciliation protocol
+
+`hermes kanban --board <slug> reconcile --input -` is the automation-only boundary for synchronizing an authoritative external source into Hermes Kanban without dispatcher races.
+
+## Transport
+
+- Input is one UTF-8, canonical JSON object terminated by `\n` (sorted keys, no insignificant whitespace), maximum 1 MiB.
+- `--input -` reads stdin; a file path is also accepted.
+- Output is exactly one canonical JSON object.
+- Invalid input exits `2`; internal failure exits `1`. Error output is bounded and never reflects paths, bodies, credentials, or exception strings.
+
+## Schema version 1
+
+Every request contains:
+
+- `schema_version`: `1`
+- `operation`: `create-if-absent`, `replace-unclaimed`, or `cancel-unclaimed`
+- `canonical_ref`: lowercase `owner/repo#number`
+- `idempotency_key`: `sha256:<64 lowercase hex>` for this source event
+- `idempotency_lineage`: stable `sha256:<64 lowercase hex>` for the source item
+- `source_revision`: lexicographically monotonic UTC timestamp (`YYYY-MM-DDTHH:MM:SSZ`)
+
+Create and replace include `task`; replace and cancel include `expected`. The strict field schema is enforced in `kanban_db.reconcile_task` rather than only at the CLI.
+
+`expected` carries the projected task id, its unclaimed status (`triage`, `todo`, or `ready`), previous source revision and lineage, plus null `claim_lock` and `run_id` expectations.
+
+## Atomic behavior
+
+Each operation runs under the board database's `BEGIN IMMEDIATE` writer transaction:
+
+- **create-if-absent** creates at most one active task for a lineage.
+- **replace-unclaimed** archives the expected unclaimed task and creates its replacement in the same transaction.
+- **cancel-unclaimed** archives the expected unclaimed task and marks the lineage inactive in the same transaction.
+- A dispatcher claim that wins first produces `claimed`; reconciliation never overwrites its work.
+- If reconciliation wins first, a later claim of the superseded task cannot succeed.
+- A failed replacement creation rolls back the archive, lineage update, audit event, and replay ledger together.
+
+The current lineage state and an append-only request replay ledger are durable. Replaying an identical request key returns the exact prior bounded result. Reusing a key with different input returns `conflict`. Older source revisions return `stale-source-revision` without mutation.
+
+## Redaction boundary
+
+Task title/body live only in the ordinary task row. Reconciliation state stores lineage, task id, source revision, and active state. The replay ledger stores only a SHA-256 request digest and bounded result. Reconciliation audit events contain only operation, hashes, revision, and task ids.

--- a/docs/kanban/atomic-reconciliation.md
+++ b/docs/kanban/atomic-reconciliation.md
@@ -6,7 +6,8 @@
 
 - Input is one UTF-8, canonical JSON object terminated by `\n` (sorted keys, no insignificant whitespace), maximum 1 MiB.
 - `--input -` reads stdin; a file path is also accepted.
-- Output is exactly one canonical JSON object.
+- Output is exactly one canonical JSON object, including delegated-child denial
+  (`permission-denied`).
 - Invalid input exits `2`; internal failure exits `1`. Error output is bounded and never reflects paths, bodies, credentials, or exception strings.
 
 ## Schema version 1
@@ -22,7 +23,9 @@ Every request contains:
 
 Create and replace include `task`; replace and cancel include `expected`. The strict field schema is enforced in `kanban_db.reconcile_task` rather than only at the CLI.
 
-`expected` carries the projected task id, its unclaimed status (`triage`, `todo`, or `ready`), previous source revision and lineage, plus null `claim_lock` and `run_id` expectations.
+`expected` carries the projected task id, its unclaimed status (`triage`, `todo`,
+or `ready`), previous source revision, lineage, and idempotency key, plus null
+`claim_lock` and `run_id` expectations.
 
 ## Atomic behavior
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -993,6 +993,9 @@ def kanban_command(args: argparse.Namespace) -> int:
     # Fast-fail for clearer CLI UX only. The durable trust boundary is lower in
     # hermes_cli.kanban_db, because children can import DB mutators directly.
     if _is_delegated_child_cli_mutation(args):
+        if action == "reconcile":
+            print('{"outcome":"permission-denied","schema_version":1}')
+            return 1
         print(
             "kanban: delegate_task child contexts cannot mutate Kanban tasks via the CLI",
             file=sys.stderr,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -251,6 +251,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     # --- init ---
     sub.add_parser("init", help="Create kanban.db if missing (idempotent)")
 
+    # --- reconcile (atomic external projection mutations) ---
+    p_reconcile = sub.add_parser(
+        "reconcile",
+        help="Apply one schema-versioned atomic task reconciliation request",
+    )
+    p_reconcile.add_argument(
+        "--input",
+        default="-",
+        metavar="PATH|-",
+        help="Canonical JSON request file, or '-' for stdin (default)",
+    )
+
     # --- boards (new in v2: multi-project support) ---
     p_boards = sub.add_parser(
         "boards",
@@ -1044,6 +1056,7 @@ def kanban_command(args: argparse.Namespace) -> int:
 
         handlers = {
             "init":     _cmd_init,
+            "reconcile": _cmd_reconcile,
             "create":   _cmd_create,
             "swarm":    _cmd_swarm,
             "list":     _cmd_list,
@@ -1116,6 +1129,7 @@ def _profile_author() -> str:
 
 _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "init",
+    "reconcile",
     "create",
     "swarm",
     "assign",
@@ -1436,6 +1450,40 @@ def _cmd_init(args: argparse.Namespace) -> int:
         "by default (config: kanban.dispatch_interval_seconds). Without a\n"
         "running gateway, tasks stay in 'ready' forever."
     )
+    return 0
+
+
+def _cmd_reconcile(args: argparse.Namespace) -> int:
+    """Apply one canonical JSON request and emit one canonical JSON result."""
+    limit = 1024 * 1024
+    try:
+        source = getattr(args, "input", "-")
+        if source == "-":
+            raw = sys.stdin.read(limit + 1)
+        else:
+            with Path(source).open("r", encoding="utf-8") as handle:
+                raw = handle.read(limit + 1)
+        if len(raw.encode("utf-8")) > limit:
+            raise ValueError("request too large")
+        request = json.loads(raw)
+        if not isinstance(request, dict):
+            raise ValueError("request must be an object")
+        canonical = json.dumps(
+            request, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ) + "\n"
+        if raw != canonical:
+            raise ValueError("request must be canonical JSON")
+        with kb.connect_closing() as conn:
+            result = kb.reconcile_task(conn, request)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError):
+        print('{"outcome":"invalid-input","schema_version":1}')
+        return 2
+    except Exception:
+        # The contract intentionally does not reflect DB paths, task bodies,
+        # exception strings, or subprocess details to stdout/stderr.
+        print('{"outcome":"internal-error","schema_version":1}')
+        return 1
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1246,6 +1246,31 @@ CREATE TABLE IF NOT EXISTS task_events (
     created_at INTEGER NOT NULL
 );
 
+-- Current authoritative projection for an external reconciliation lineage.
+-- Raw task bodies and source payloads deliberately never enter this table.
+CREATE TABLE IF NOT EXISTS kanban_reconcile_state (
+    lineage          TEXT PRIMARY KEY,
+    task_id           TEXT,
+    source_revision   TEXT NOT NULL,
+    active            INTEGER NOT NULL CHECK (active IN (0, 1)),
+    updated_at        INTEGER NOT NULL
+);
+
+-- Durable replay ledger. A request key always returns the exact same bounded
+-- JSON result; a reused key with different input fails closed.
+CREATE TABLE IF NOT EXISTS kanban_reconcile_requests (
+    request_key      TEXT PRIMARY KEY,
+    lineage          TEXT NOT NULL,
+    request_digest   TEXT NOT NULL,
+    result_json      TEXT NOT NULL,
+    created_at       INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_reconcile_state_task
+    ON kanban_reconcile_state(task_id);
+CREATE INDEX IF NOT EXISTS idx_reconcile_requests_lineage
+    ON kanban_reconcile_requests(lineage);
+
 -- Historical attempt record. Each time the dispatcher claims a task, a
 -- new row is created here; claim state, PID, heartbeat, runtime cap,
 -- and structured summary all live on the run, not the task. Multiple
@@ -2838,6 +2863,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    _within_transaction: bool = False,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3030,21 +3056,6 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
-    if idempotency_key:
-        row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
-
     now = int(time.time())
 
     # Resolve workspace_path from board-level default_workdir when the
@@ -3071,7 +3082,24 @@ def create_task(
     for attempt in range(2):
         task_id = _new_task_id()
         try:
-            with write_txn(conn):
+            transaction = (
+                contextlib.nullcontext()
+                if _within_transaction
+                else write_txn(conn)
+            )
+            with transaction:
+                # Serialize lookup and insert under the same writer lock. This
+                # closes the historical duplicate-create race without a
+                # legacy-breaking unique-index migration.
+                if idempotency_key:
+                    row = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if row:
+                        return row["id"]
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -3190,6 +3218,365 @@ def create_task(
             # Retry with a fresh id.
             continue
     raise RuntimeError("unreachable")
+
+
+_RECONCILE_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_RECONCILE_REVISION_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+_RECONCILE_UNCLAIMED = {"triage", "todo", "ready"}
+
+
+def _reconcile_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _reconcile_result(
+    *,
+    operation: str,
+    outcome: str,
+    lineage: str,
+    source_revision: str,
+    task_id: Optional[str] = None,
+    replaced_task_id: Optional[str] = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "schema_version": 1,
+        "operation": operation,
+        "outcome": outcome,
+        "idempotency_lineage": lineage,
+        "source_revision": source_revision,
+    }
+    if task_id is not None:
+        result["task_id"] = task_id
+    if replaced_task_id is not None:
+        result["replaced_task_id"] = replaced_task_id
+    return result
+
+
+def _validate_reconcile_request(request: Mapping[str, Any]) -> tuple[str, str, str, str]:
+    operation = request.get("operation")
+    lineage = request.get("idempotency_lineage")
+    request_key = request.get("idempotency_key")
+    source_revision = request.get("source_revision")
+    if request.get("schema_version") != 1:
+        raise ValueError("unsupported reconcile schema_version")
+    if operation not in {"create-if-absent", "replace-unclaimed", "cancel-unclaimed"}:
+        raise ValueError("unsupported reconcile operation")
+    if not isinstance(lineage, str) or not _RECONCILE_HASH_RE.fullmatch(lineage):
+        raise ValueError("idempotency_lineage must be a sha256 digest")
+    if not isinstance(request_key, str) or not _RECONCILE_HASH_RE.fullmatch(request_key):
+        raise ValueError("idempotency_key must be a sha256 digest")
+    if not isinstance(source_revision, str) or not _RECONCILE_REVISION_RE.fullmatch(source_revision):
+        raise ValueError("source_revision must be an RFC3339 UTC timestamp")
+    try:
+        time.strptime(source_revision, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as exc:
+        raise ValueError("source_revision must be a valid RFC3339 UTC timestamp") from exc
+
+    base_fields = {
+        "schema_version", "operation", "canonical_ref", "idempotency_key",
+        "idempotency_lineage", "source_revision",
+    }
+    required_fields = base_fields | ({"task"} if operation == "create-if-absent" else {"expected"})
+    if operation == "replace-unclaimed":
+        required_fields.add("task")
+    if set(request) != required_fields:
+        raise ValueError("reconcile request fields do not match schema_version 1")
+    canonical_ref = request.get("canonical_ref")
+    if not isinstance(canonical_ref, str) or not re.fullmatch(
+        r"[a-z0-9_.-]+/[a-z0-9_.-]+#[1-9][0-9]*", canonical_ref
+    ):
+        raise ValueError("canonical_ref must use owner/repo#number")
+    if operation in {"create-if-absent", "replace-unclaimed"}:
+        task = request.get("task")
+        task_fields = {
+            "title", "body", "assignee", "project", "parents", "canonical_ref",
+            "source_status", "source_revision", "idempotency_lineage", "idempotency_key",
+        }
+        if not isinstance(task, Mapping) or set(task) != task_fields:
+            raise ValueError("task fields do not match schema_version 1")
+        title = task.get("title")
+        body = task.get("body")
+        assignee = task.get("assignee")
+        project = task.get("project")
+        parents = task.get("parents")
+        if (
+            not isinstance(title, str) or not title.strip()
+            or not isinstance(body, str)
+            or not isinstance(assignee, str) or not assignee
+            or not isinstance(project, str) or not project
+            or not isinstance(parents, list)
+            or any(not isinstance(parent, str) or not parent for parent in (parents or []))
+            or task.get("canonical_ref") != canonical_ref
+            or task.get("source_status") != "Ready"
+            or task.get("source_revision") != source_revision
+            or task.get("idempotency_lineage") != lineage
+            or task.get("idempotency_key") != request_key
+        ):
+            raise ValueError("task values do not match reconcile request")
+    if operation in {"replace-unclaimed", "cancel-unclaimed"}:
+        expected = request.get("expected")
+        expected_fields = {
+            "task_id", "status", "source_revision", "idempotency_lineage",
+            "idempotency_key", "claim_lock", "run_id",
+        }
+        if not isinstance(expected, Mapping) or set(expected) != expected_fields:
+            raise ValueError("expected fields do not match schema_version 1")
+    return operation, lineage, request_key, source_revision
+
+
+def reconcile_task(conn: sqlite3.Connection, request: Mapping[str, Any]) -> dict[str, Any]:
+    """Apply one external task projection mutation in a single transaction.
+
+    The durable replay ledger stores only a request digest and bounded result;
+    raw task bodies never enter reconciliation metadata or audit payloads.
+    Dispatcher claims and this operation serialize on ``BEGIN IMMEDIATE``.
+    """
+    _assert_not_delegated_child_mutation()
+    operation, lineage, request_key, source_revision = _validate_reconcile_request(request)
+    request_json = _reconcile_json(request)
+    request_digest = "sha256:" + hashlib.sha256(request_json.encode("utf-8")).hexdigest()
+    now = int(time.time())
+
+    def persist(result: dict[str, Any]) -> dict[str, Any]:
+        conn.execute(
+            "INSERT INTO kanban_reconcile_requests "
+            "(request_key, lineage, request_digest, result_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (request_key, lineage, request_digest, _reconcile_json(result), now),
+        )
+        return result
+
+    with write_txn(conn):
+        replay = conn.execute(
+            "SELECT request_digest, result_json FROM kanban_reconcile_requests "
+            "WHERE request_key = ?",
+            (request_key,),
+        ).fetchone()
+        if replay is not None:
+            if replay["request_digest"] != request_digest:
+                return _reconcile_result(
+                    operation=operation,
+                    outcome="conflict",
+                    lineage=lineage,
+                    source_revision=source_revision,
+                )
+            result = json.loads(replay["result_json"])
+            if not isinstance(result, dict):  # pragma: no cover - DB corruption guard
+                raise RuntimeError("invalid reconcile replay row")
+            return result
+
+        state = conn.execute(
+            "SELECT task_id, source_revision, active "
+            "FROM kanban_reconcile_state WHERE lineage = ?",
+            (lineage,),
+        ).fetchone()
+        if state is not None:
+            current_revision = str(state["source_revision"])
+            if source_revision < current_revision:
+                return persist(_reconcile_result(
+                    operation=operation,
+                    outcome="stale-source-revision",
+                    lineage=lineage,
+                    source_revision=source_revision,
+                    task_id=state["task_id"],
+                ))
+            if source_revision == current_revision:
+                return persist(_reconcile_result(
+                    operation=operation,
+                    outcome="conflict",
+                    lineage=lineage,
+                    source_revision=source_revision,
+                    task_id=state["task_id"],
+                ))
+
+        if operation == "create-if-absent":
+            if state is not None and int(state["active"]):
+                return persist(_reconcile_result(
+                    operation=operation,
+                    outcome="precondition-failed",
+                    lineage=lineage,
+                    source_revision=source_revision,
+                    task_id=state["task_id"],
+                ))
+            task = request.get("task")
+            if not isinstance(task, Mapping):
+                raise ValueError("create-if-absent requires task")
+            task_id = create_task(
+                conn,
+                title=str(task.get("title") or ""),
+                body=task.get("body") if isinstance(task.get("body"), str) else None,
+                assignee=task.get("assignee") if isinstance(task.get("assignee"), str) else None,
+                created_by="reconciler",
+                parents=tuple(
+                    parent for parent in task.get("parents", ())
+                    if isinstance(parent, str) and parent
+                ),
+                idempotency_key=request_key,
+                project_id=task.get("project") if isinstance(task.get("project"), str) else None,
+                _within_transaction=True,
+            )
+            conn.execute(
+                "INSERT INTO kanban_reconcile_state "
+                "(lineage, task_id, source_revision, active, updated_at) "
+                "VALUES (?, ?, ?, 1, ?) "
+                "ON CONFLICT(lineage) DO UPDATE SET task_id=excluded.task_id, "
+                "source_revision=excluded.source_revision, active=1, updated_at=excluded.updated_at",
+                (lineage, task_id, source_revision, now),
+            )
+            result = _reconcile_result(
+                operation=operation,
+                outcome="created",
+                lineage=lineage,
+                source_revision=source_revision,
+                task_id=task_id,
+            )
+            _append_event(conn, task_id, "reconcile_created", {
+                "operation": operation,
+                "idempotency_lineage": lineage,
+                "idempotency_key": request_key,
+                "source_revision": source_revision,
+            })
+            return persist(result)
+
+        expected = request.get("expected")
+        if not isinstance(expected, Mapping):
+            raise ValueError(f"{operation} requires expected state")
+        expected_task_id = expected.get("task_id")
+        expected_status = expected.get("status")
+        if (
+            not isinstance(expected_task_id, str)
+            or expected_status not in _RECONCILE_UNCLAIMED
+            or expected.get("source_revision") != (state["source_revision"] if state is not None else None)
+            or expected.get("idempotency_lineage") != lineage
+            or expected.get("claim_lock") is not None
+            or expected.get("run_id") is not None
+            or state is None
+            or not int(state["active"])
+            or state["task_id"] != expected_task_id
+        ):
+            return persist(_reconcile_result(
+                operation=operation,
+                outcome="precondition-failed",
+                lineage=lineage,
+                source_revision=source_revision,
+                task_id=state["task_id"] if state is not None else None,
+            ))
+
+        row = conn.execute(
+            "SELECT status, idempotency_key, claim_lock, current_run_id, worker_pid "
+            "FROM tasks WHERE id = ?",
+            (expected_task_id,),
+        ).fetchone()
+        if row is None:
+            return persist(_reconcile_result(
+                operation=operation,
+                outcome="precondition-failed",
+                lineage=lineage,
+                source_revision=source_revision,
+            ))
+        if (
+            row["status"] != expected_status
+            or row["idempotency_key"] != expected.get("idempotency_key")
+            or row["claim_lock"] is not None
+            or row["current_run_id"] is not None
+            or row["worker_pid"] is not None
+        ):
+            outcome = "claimed" if (
+                row["status"] in {"running", "blocked"}
+                or row["claim_lock"] is not None
+                or row["current_run_id"] is not None
+                or row["worker_pid"] is not None
+            ) else "precondition-failed"
+            return persist(_reconcile_result(
+                operation=operation,
+                outcome=outcome,
+                lineage=lineage,
+                source_revision=source_revision,
+                task_id=expected_task_id,
+            ))
+
+        changed = conn.execute(
+            "UPDATE tasks SET status='archived', completed_at=?, "
+            "claim_lock=NULL, claim_expires=NULL, current_run_id=NULL, worker_pid=NULL "
+            "WHERE id=? AND status=? AND claim_lock IS NULL "
+            "AND current_run_id IS NULL AND worker_pid IS NULL",
+            (now, expected_task_id, expected_status),
+        ).rowcount
+        if changed != 1:  # pragma: no cover - same transaction, defensive CAS
+            return persist(_reconcile_result(
+                operation=operation,
+                outcome="precondition-failed",
+                lineage=lineage,
+                source_revision=source_revision,
+                task_id=expected_task_id,
+            ))
+
+        if operation == "cancel-unclaimed":
+            conn.execute(
+                "UPDATE kanban_reconcile_state SET source_revision=?, active=0, updated_at=? "
+                "WHERE lineage=?",
+                (source_revision, now, lineage),
+            )
+            result = _reconcile_result(
+                operation=operation,
+                outcome="cancelled",
+                lineage=lineage,
+                source_revision=source_revision,
+                task_id=expected_task_id,
+            )
+            _append_event(conn, expected_task_id, "reconcile_cancelled", {
+                "operation": operation,
+                "idempotency_lineage": lineage,
+                "idempotency_key": request_key,
+                "source_revision": source_revision,
+            })
+            return persist(result)
+
+        task = request.get("task")
+        if not isinstance(task, Mapping):
+            raise ValueError("replace-unclaimed requires task")
+        new_task_id = create_task(
+            conn,
+            title=str(task.get("title") or ""),
+            body=task.get("body") if isinstance(task.get("body"), str) else None,
+            assignee=task.get("assignee") if isinstance(task.get("assignee"), str) else None,
+            created_by="reconciler",
+            parents=tuple(
+                    parent for parent in task.get("parents", ())
+                    if isinstance(parent, str) and parent
+                ),
+            idempotency_key=request_key,
+            project_id=task.get("project") if isinstance(task.get("project"), str) else None,
+            _within_transaction=True,
+        )
+        conn.execute(
+            "UPDATE kanban_reconcile_state SET task_id=?, source_revision=?, active=1, updated_at=? "
+            "WHERE lineage=?",
+            (new_task_id, source_revision, now, lineage),
+        )
+        result = _reconcile_result(
+            operation=operation,
+            outcome="replaced",
+            lineage=lineage,
+            source_revision=source_revision,
+            task_id=new_task_id,
+            replaced_task_id=expected_task_id,
+        )
+        _append_event(conn, expected_task_id, "reconcile_superseded", {
+            "operation": operation,
+            "idempotency_lineage": lineage,
+            "idempotency_key": request_key,
+            "source_revision": source_revision,
+            "replacement_task_id": new_task_id,
+        })
+        _append_event(conn, new_task_id, "reconcile_replaced", {
+            "operation": operation,
+            "idempotency_lineage": lineage,
+            "idempotency_key": request_key,
+            "source_revision": source_revision,
+            "replaced_task_id": expected_task_id,
+        })
+        return persist(result)
 
 
 def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> list[str]:

--- a/tests/hermes_cli/test_kanban_reconcile.py
+++ b/tests/hermes_cli/test_kanban_reconcile.py
@@ -1,0 +1,262 @@
+"""Atomic external-projection reconciliation tests for Hermes Kanban."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import copy
+import hashlib
+import io
+import json
+import threading
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+LINEAGE = "sha256:" + "1" * 64
+
+
+def key(char: str) -> str:
+    return "sha256:" + char * 64
+
+
+def request(
+    operation: str = "create-if-absent",
+    *,
+    revision: str = "2026-07-27T18:00:00Z",
+    request_key: str = key("2"),
+    expected: dict | None = None,
+    title: str = "Redacted task",
+    parents: list[str] | None = None,
+) -> dict:
+    value = {
+        "schema_version": 1,
+        "operation": operation,
+        "canonical_ref": "nuri-com/nuri-infra#37",
+        "idempotency_key": request_key,
+        "idempotency_lineage": LINEAGE,
+        "source_revision": revision,
+    }
+    if operation in {"create-if-absent", "replace-unclaimed"}:
+        value["task"] = {
+            "title": title,
+            "body": "Redacted bounded scope",
+            "assignee": "nuriforge",
+            "project": "nuri-infra",
+            "parents": parents or [],
+            "canonical_ref": value["canonical_ref"],
+            "source_status": "Ready",
+            "source_revision": revision,
+            "idempotency_lineage": LINEAGE,
+            "idempotency_key": request_key,
+        }
+    if expected is not None:
+        value["expected"] = expected
+    return value
+
+
+def expected(
+    task_id: str,
+    revision: str = "2026-07-27T18:00:00Z",
+    request_key: str = key("2"),
+) -> dict:
+    return {
+        "task_id": task_id,
+        "status": "ready",
+        "source_revision": revision,
+        "idempotency_lineage": LINEAGE,
+        "idempotency_key": request_key,
+        "claim_lock": None,
+        "run_id": None,
+    }
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    kb.init_db()
+    return tmp_path
+
+
+def test_create_is_atomic_across_independent_connections_and_replays_exactly(kanban_home):
+    payload = request()
+    barrier = threading.Barrier(2)
+
+    def create() -> dict:
+        with kb.connect_closing() as conn:
+            barrier.wait(timeout=5)
+            return kb.reconcile_task(conn, payload)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first, second = list(pool.map(lambda _: create(), range(2)))
+
+    assert first == second
+    assert first["outcome"] == "created"
+    with kb.connect_closing() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks WHERE status != 'archived'").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM kanban_reconcile_requests").fetchone()[0] == 1
+        stored = " ".join(
+            str(row[0] or "")
+            for table, column in (
+                ("kanban_reconcile_requests", "result_json"),
+                ("task_events", "payload"),
+            )
+            for row in conn.execute(f"SELECT {column} FROM {table}").fetchall()
+        )
+        assert "Redacted bounded scope" not in stored
+
+
+def test_reused_request_key_with_changed_body_conflicts_without_mutation(kanban_home):
+    original = request()
+    changed = copy.deepcopy(original)
+    changed["task"]["body"] = "different body"
+    with kb.connect_closing() as conn:
+        created = kb.reconcile_task(conn, original)
+        conflict = kb.reconcile_task(conn, changed)
+        assert conflict["outcome"] == "conflict"
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+        assert kb.get_task(conn, created["task_id"]).body == "Redacted bounded scope"
+
+
+def test_replace_is_atomic_and_replay_is_stable(kanban_home):
+    with kb.connect_closing() as conn:
+        created = kb.reconcile_task(conn, request())
+        replacement = request(
+            "replace-unclaimed",
+            revision="2026-07-27T18:01:00Z",
+            request_key=key("3"),
+            expected=expected(created["task_id"]),
+            title="Revised task",
+        )
+        result = kb.reconcile_task(conn, replacement)
+        assert result["outcome"] == "replaced"
+        assert result["replaced_task_id"] == created["task_id"]
+        assert kb.get_task(conn, created["task_id"]).status == "archived"
+        assert kb.get_task(conn, result["task_id"]).status == "ready"
+        assert kb.reconcile_task(conn, replacement) == result
+
+
+def test_replace_rolls_back_archival_state_and_ledger_on_create_failure(kanban_home):
+    with kb.connect_closing() as conn:
+        created = kb.reconcile_task(conn, request())
+        broken = request(
+            "replace-unclaimed",
+            revision="2026-07-27T18:01:00Z",
+            request_key=key("4"),
+            expected=expected(created["task_id"]),
+            parents=["missing-parent"],
+        )
+        with pytest.raises(ValueError, match="unknown parent"):
+            kb.reconcile_task(conn, broken)
+        assert kb.get_task(conn, created["task_id"]).status == "ready"
+        state = conn.execute(
+            "SELECT task_id, source_revision, active FROM kanban_reconcile_state WHERE lineage=?",
+            (LINEAGE,),
+        ).fetchone()
+        assert tuple(state) == (created["task_id"], "2026-07-27T18:00:00Z", 1)
+        assert conn.execute(
+            "SELECT COUNT(*) FROM kanban_reconcile_requests WHERE request_key=?",
+            (key("4"),),
+        ).fetchone()[0] == 0
+
+
+def test_cancel_unclaimed_and_stale_revision(kanban_home):
+    with kb.connect_closing() as conn:
+        created = kb.reconcile_task(conn, request())
+        cancelled = kb.reconcile_task(
+            conn,
+            request(
+                "cancel-unclaimed",
+                revision="2026-07-27T18:02:00Z",
+                request_key=key("5"),
+                expected=expected(created["task_id"]),
+            ),
+        )
+        assert cancelled["outcome"] == "cancelled"
+        assert kb.get_task(conn, created["task_id"]).status == "archived"
+        stale = kb.reconcile_task(
+            conn,
+            request(
+                revision="2026-07-27T18:01:00Z",
+                request_key=key("6"),
+            ),
+        )
+        assert stale["outcome"] == "stale-source-revision"
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+
+
+def test_dispatch_claim_and_replace_race_never_overwrites_claimed_work(kanban_home):
+    for index in range(8):
+        lineage = "sha256:" + f"{index + 10:064x}"
+        create_payload = request(request_key="sha256:" + f"{index + 100:064x}")
+        create_payload["idempotency_lineage"] = lineage
+        create_payload["task"]["idempotency_lineage"] = lineage
+        with kb.connect_closing() as conn:
+            created = kb.reconcile_task(conn, create_payload)
+        replace_payload = request(
+            "replace-unclaimed",
+            revision="2026-07-27T18:01:00Z",
+            request_key="sha256:" + f"{index + 200:064x}",
+            expected={
+                **expected(
+                    created["task_id"],
+                    request_key=create_payload["idempotency_key"],
+                ),
+                "idempotency_lineage": lineage,
+            },
+        )
+        replace_payload["idempotency_lineage"] = lineage
+        replace_payload["task"]["idempotency_lineage"] = lineage
+        barrier = threading.Barrier(2)
+
+        def claim():
+            with kb.connect_closing() as conn:
+                barrier.wait(timeout=5)
+                return kb.claim_task(conn, created["task_id"], claimer="race-test")
+
+        def replace():
+            with kb.connect_closing() as conn:
+                barrier.wait(timeout=5)
+                return kb.reconcile_task(conn, replace_payload)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            claimed_future = pool.submit(claim)
+            replaced_future = pool.submit(replace)
+            claimed = claimed_future.result(timeout=10)
+            replaced = replaced_future.result(timeout=10)
+
+        with kb.connect_closing() as conn:
+            old = kb.get_task(conn, created["task_id"])
+            if claimed is not None:
+                assert replaced["outcome"] == "claimed"
+                assert old.status == "running"
+                assert replaced["task_id"] == old.id
+            else:
+                assert replaced["outcome"] == "replaced"
+                assert old.status == "archived"
+                assert kb.get_task(conn, replaced["task_id"]).status == "ready"
+
+
+def test_cli_requires_canonical_json_and_emits_canonical_result(kanban_home, monkeypatch, capsys):
+    payload = request()
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    monkeypatch.setattr("sys.stdin", io.StringIO(canonical))
+    assert kc._cmd_reconcile(type("Args", (), {"input": "-"})()) == 0
+    output = capsys.readouterr().out
+    decoded = json.loads(output)
+    assert decoded["outcome"] == "created"
+    assert output == json.dumps(decoded, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload, indent=2)))
+    assert kc._cmd_reconcile(type("Args", (), {"input": "-"})()) == 2
+    assert capsys.readouterr().out == '{"outcome":"invalid-input","schema_version":1}\n'
+
+
+def test_delegated_child_guard_includes_reconcile():
+    assert "reconcile" in kc._DELEGATED_CHILD_DENIED_ACTIONS

--- a/tests/hermes_cli/test_kanban_reconcile.py
+++ b/tests/hermes_cli/test_kanban_reconcile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import concurrent.futures
 import copy
 import hashlib
@@ -258,5 +259,15 @@ def test_cli_requires_canonical_json_and_emits_canonical_result(kanban_home, mon
     assert capsys.readouterr().out == '{"outcome":"invalid-input","schema_version":1}\n'
 
 
-def test_delegated_child_guard_includes_reconcile():
+def test_delegated_child_guard_emits_canonical_reconcile_result(monkeypatch, capsys):
     assert "reconcile" in kc._DELEGATED_CHILD_DENIED_ACTIONS
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(dest="command")
+    kc.build_parser(subparsers)
+    args = root.parse_args(["kanban", "reconcile", "--input", "-"])
+
+    assert kc.kanban_command(args) == 1
+    captured = capsys.readouterr()
+    assert captured.out == '{"outcome":"permission-denied","schema_version":1}\n'
+    assert captured.err == ""

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -656,6 +656,7 @@ This is the surface **you** (or scripts, cron, the dashboard) use to drive the b
 
 ```
 hermes kanban init                                     # create kanban.db + print daemon hint
+hermes kanban --board <slug> reconcile --input -       # atomic external projection mutation
 hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--parent <id>]... [--tenant <name>]
                                 [--workspace scratch|worktree|worktree:<path>|dir:<path>]
@@ -716,6 +717,16 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
+
+### Atomic external reconciliation
+
+Automation that projects an authoritative source into Kanban should use `reconcile`, not a read-then-create/archive sequence. The command accepts one strict canonical JSON request on stdin and implements `create-if-absent`, `replace-unclaimed`, and `cancel-unclaimed` under the same SQLite writer transaction used by dispatcher claims.
+
+```bash
+canonical_request_generator | hermes kanban --board delivery reconcile --input -
+```
+
+Requests carry a stable SHA-256 lineage, event-specific SHA-256 idempotency key, monotonic UTC source revision, and (for replacement/cancellation) the expected task/status plus null claim/run ownership. Identical retries return the stored prior result. Stale revisions, changed expectations, and claimed work produce bounded non-mutating outcomes. Raw task bodies are excluded from reconciliation metadata and audit events. See [the protocol contract](https://github.com/NousResearch/hermes-agent/blob/main/docs/kanban/atomic-reconciliation.md) for the complete schema and outcome semantics.
 
 ### Concurrency, scheduling, and child promotion config
 


### PR DESCRIPTION
## What does this PR do?

Adds one automation-only atomic reconciliation boundary for projecting authoritative external work into Hermes Kanban without duplicate tasks, stale-event overwrites, or dispatcher races.

The command is:

```sh
hermes kanban --board <slug> reconcile --input -
```

It accepts strict canonical protocol-v1 JSON and executes the expected-state check, task mutation, lineage projection, replay record, and redacted audit event in one SQLite writer transaction.

## Related Issue

Tracks nuri-com/nuri-infra#37.

Related partial approaches inspected before implementation: #31361 and #66171. Neither provides the complete expected-state/replay/race contract implemented here.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `create-if-absent`, `replace-unclaimed`, and `cancel-unclaimed` in `hermes_cli/kanban_db.py`.
- Persist lineage state and exact-request replay results.
- Compare expected task id/status/source revision/idempotency lineage+key/claim/run ownership before replace or cancel.
- Preserve claimed work and serialize dispatcher/reconciler races through the existing SQLite writer boundary.
- Add strict bounded canonical-JSON CLI handling and machine-readable delegated-child denial.
- Keep bodies and secrets out of reconciliation results, projection state, replay storage, and audit events.
- Document the protocol and add independent-connection concurrency, rollback, replay, stale-revision, claim-race, CLI, and delegated-child tests.

## How to Test

1. `env -u HERMES_DELEGATED_CHILD_CONTEXT PYTHONPATH=. python3 -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_reconcile.py -q`
   - Result at exact head `9bc40a34bc07d872f06d2938a6850338e3924706`: **238 passed**.
2. `python3 -m ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_reconcile.py`
   - Result: passed.
3. Delegated-child probe:
   - exit `1`
   - stdout exactly `{"outcome":"permission-denied","schema_version":1}`
   - stderr empty.
4. Cross-repository create → exact retry → replace → cancel proof completed against the Nuri adapter: no duplicate active task, old/replaced tasks archived atomically, newest lineage inactive, task bodies absent from replay/audit storage.

## Review evidence

- Exact-head implementation review: initial Medium finding on delegated-child output contract.
- Remediation exact head `9bc40a34bc07d872f06d2938a6850338e3924706`: independently **APPROVED**; focused remediation suite `8 passed`.
- Live upstream `main` moved to `551e1c6d6470a0911dabd9e0d1a756ca2f86e8b1` after review. The intervening base delta touches only `agent/` and `tests/agent/`; there is no changed-file overlap and the merge tree is conflict-free.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

The full repository suite was not run locally; the focused database/reconciliation suite and exact-head review evidence are recorded above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example`: N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no contributor workflow changed
- [x] I've considered cross-platform impact; implementation uses existing Python/SQLite and argparse boundaries
- [x] I've updated tool descriptions/schemas where behavior changed

## Screenshots / Logs

```text
238 passed in 5.05s
All checks passed!
```
