### PR TITLE
fix(desktop): paint the titlebar with the sidebar's surface color

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -665,7 +665,7 @@ export function ContribController() {
                   tree-published --workspace-left/right vars (pure CSS, no rect
                   threading), clamped to clear the REAL TitlebarControls
                   clusters (fixed, z-70); center is truly window-centered. */}
-          <div className="relative flex h-[34px] shrink-0 items-center border-b border-(--ui-stroke-tertiary) text-xs">
+          <div className="relative flex h-[34px] shrink-0 items-center border-b border-(--ui-stroke-tertiary) bg-(--ui-sidebar-surface-background) text-xs">
             {/* Drag strips, AppShell-style: cut to AVOID the fixed control
                 clusters instead of overlapping them — Electron's no-drag
                 carve-out of fixed/transformed elements is unreliable, so a


### PR DESCRIPTION
## Summary

The shell titlebar declared no background of its own, so it showed through to the wrapper's `--ui-bg-chrome` and read as a lighter band sitting above the session list. It now paints `--ui-sidebar-surface-background` — the same token the sidebar uses — so the two chrome surfaces meet on the `--ui-stroke-tertiary` hairline instead of a color change.

No new token, no new class; the strip just declares the surface it was already meant to sit on.

## Test plan

- [ ] Titlebar and sidebar read as one continuous surface, separated only by the hairline
- [ ] Holds in light and dark (the seeds diverge: `--theme-mix-chrome: 92%` vs `--theme-mix-sidebar: 100%`)
- [ ] Window dragging still works across the strip, and the traffic-light / tool clusters stay clickable
