### PR TITLE
fix(agent): clarify file mutation verifier uncertainty

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3306,9 +3306,9 @@ class AIAgent:
             return ""
         lines = [
             "⚠️ File-mutation verifier: "
-            f"{len(failed)} file(s) were NOT modified this turn despite any "
-            "wording above that may suggest otherwise. Run `git status` or "
-            "`read_file` to confirm."
+            f"{len(failed)} unresolved file-mutation failure(s) remain for this turn; "
+            "verify the intended final state despite any wording above that may "
+            "suggest otherwise. Run `git status` or `read_file` to confirm."
         ]
         shown = 0
         for path, info in failed.items():

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -193,6 +193,36 @@ class TestRecordFileMutationResult:
 
         assert paths == ["/tmp/project/src/app.py"]
 
+    def test_success_then_failure_keeps_unresolved_failure_without_negating_prior_success(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "write_file",
+            {"path": "/tmp/a.md", "content": "landed content"},
+            json.dumps({"success": True, "bytes_written": 14}),
+            is_error=False,
+        )
+        agent._record_file_mutation_result(
+            "patch",
+            {
+                "mode": "replace",
+                "path": "/tmp/a.md",
+                "old_string": "updated: 2026-06-17",
+                "new_string": "updated: 2026-06-17",
+            },
+            json.dumps({"success": False, "error": "old_string and new_string are identical"}),
+            is_error=True,
+        )
+
+        state = getattr(agent, "_turn_failed_file_mutations")
+        assert "/tmp/a.md" in state
+        assert state["/tmp/a.md"]["tool"] == "patch"
+        assert "old_string and new_string are identical" in state["/tmp/a.md"]["error_preview"]
+
+        footer = AIAgent._format_file_mutation_failure_footer(state)
+        assert "unresolved file-mutation failure(s) remain for this turn" in footer
+        assert "verify the intended final state" in footer
+        assert "were NOT modified this turn" not in footer
+
     def test_write_file_with_lint_error_counts_as_landed(self):
         agent = _bare_agent()
         agent._record_file_mutation_result(
@@ -309,10 +339,11 @@ class TestFormatFooter:
         out = AIAgent._format_file_mutation_failure_footer(
             {"/tmp/a.md": {"tool": "patch", "error_preview": "Could not find old_string"}},
         )
-        assert "1 file(s) were NOT modified" in out
+        assert "1 unresolved file-mutation failure(s) remain" in out
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
+        assert "were NOT modified this turn" not in out
 
     def test_terminal_recovery_does_not_claim_target_was_unchanged(self):
         """An untracked terminal write makes absolute unchanged wording unsafe."""
@@ -349,7 +380,7 @@ class TestFormatFooter:
             for i in range(15)
         }
         out = AIAgent._format_file_mutation_failure_footer(failed)
-        assert "15 file(s) were NOT modified" in out
+        assert "15 unresolved file-mutation failure(s) remain" in out
         assert "… and 5 more" in out
         # Ten file bullets + header + "and X more" line
         lines = out.split("\n")

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -12,9 +12,9 @@ Covers the three moving pieces:
 
 Regression target: the "Ben Eng llm-wiki" session where grok-4.1-fast
 batched parallel patches, half failed, and the model summarised the
-turn claiming every file was edited.  This verifier makes over-claiming
-structurally impossible past the model: the user always sees the real
-list of files that did NOT change.
+turn claiming every file was edited. The verifier makes those unresolved
+tracked failures visible after the model response; callers must still verify
+the current file state when another tool may have changed the target.
 """
 
 from __future__ import annotations
@@ -313,6 +313,35 @@ class TestFormatFooter:
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
+
+    def test_terminal_recovery_does_not_claim_target_was_unchanged(self):
+        """An untracked terminal write makes absolute unchanged wording unsafe."""
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {
+                "mode": "replace",
+                "path": "/tmp/a.md",
+                "old_string": "old",
+                "new_string": "new",
+            },
+            json.dumps({"error": "write denied"}),
+            is_error=True,
+        )
+        agent._record_file_mutation_result(
+            "terminal",
+            {"command": "python -c 'write /tmp/a.md'"},
+            json.dumps({"exit_code": 0}),
+            is_error=False,
+        )
+
+        out = agent._format_file_mutation_failure_footer(
+            agent._turn_failed_file_mutations,
+        )
+
+        assert "unresolved file-mutation failure" in out
+        assert "verify the intended final state" in out
+        assert "were NOT modified" not in out
 
     def test_truncation_at_10_entries(self):
         failed = {

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1575,12 +1575,12 @@ Both keys are display-only and CLI-only: they are suppressed in quiet mode, when
 
 ### File-mutation verifier
 
-When `display.file_mutation_verifier` is `true` (default), Hermes appends a one-line advisory to the assistant's final response whenever a `write_file` or `patch` call failed during the turn and was never superseded by a successful write to the same path. This catches the "batch of parallel patches, half silently fail, model summarises success" class of over-claim without requiring you to manually run `git status` after every edit.
+When `display.file_mutation_verifier` is `true` (default), Hermes appends a one-line advisory to the assistant's final response whenever a `write_file` or `patch` call failed during the turn and was never superseded by a successful tracked write to the same path. This catches the "batch of parallel patches, half silently fail, model summarises success" class of over-claim. Because the verifier tracks `write_file` and `patch` rather than every possible filesystem effect, treat the footer as an unresolved-attempt warning and inspect the current state when another tool may have changed the target.
 
 Example footer:
 
 ```
-⚠️ File-mutation verifier: 3 file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.
+⚠️ File-mutation verifier: 3 unresolved file-mutation failure(s) remain for this turn; verify the intended final state despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.
   • concepts/automatic-organization.md — [patch] Could not find match for old_string
   • concepts/lora.md — [patch] Could not find match for old_string
   • concepts/rag-pipeline.md — [patch] Could not find match for old_string
@@ -1588,7 +1588,7 @@ Example footer:
 
 Set `file_mutation_verifier: false` (or `HERMES_FILE_MUTATION_VERIFIER=0`) to suppress the footer. The verifier only fires when real failures are outstanding at turn end — a model that retries a failed patch and succeeds within the same turn will not trigger it for that file.
 
-**Trust the verifier over the model's summary.** The footer means the listed files were **not** modified on disk, even if the assistant's closing message says the task is done. Common causes:
+**Treat the verifier as evidence of unresolved direct file-tool failures, not proof that a target was unchanged.** A listed path may have been modified earlier in the turn or through another approved tool such as `terminal`. Use `git status`, `read_file`, or another appropriate state check to determine the final result. Common causes of the tracked failure include:
 
 - **Write denied** — path is on the credential denylist or outside `HERMES_WRITE_SAFE_ROOT` (see [File write safety](./security.md#file-write-safety))
 - **Patch mismatch** — `old_string` did not match the file on disk
@@ -1597,7 +1597,7 @@ Set `file_mutation_verifier: false` (or `HERMES_FILE_MUTATION_VERIFIER=0`) to su
 Example footer when writes are blocked:
 
 ```
-⚠️ File-mutation verifier: 2 file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.
+⚠️ File-mutation verifier: 2 unresolved file-mutation failure(s) remain for this turn; verify the intended final state despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.
   • ~/.hermes/cron/jobs.json — [patch] Write denied: '…' is outside HERMES_WRITE_SAFE_ROOT (/path/to/project)
   • ~/.hermes/scripts/monitor.py — [write_file] Write denied: '…' is outside HERMES_WRITE_SAFE_ROOT (/path/to/project)
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1167,12 +1167,12 @@ display:
 
 ### 文件变更验证器
 
-当 `display.file_mutation_verifier` 为 `true`（默认）时，每当本轮中 `write_file` 或 `patch` 调用失败且从未被对同一路径的成功写入取代时，Hermes 会在 assistant 的最终响应中附加一行建议。这捕获了"批量并行补丁，一半静默失败，模型总结成功"这类过度声明，而无需您在每次编辑后手动运行 `git status`。
+当 `display.file_mutation_verifier` 为 `true`（默认）时，每当本轮中 `write_file` 或 `patch` 调用失败且从未被对同一路径的成功跟踪写入取代时，Hermes 会在 assistant 的最终响应中附加一行建议。这捕获了"批量并行补丁，一半静默失败，模型总结成功"这类过度声明。由于验证器只跟踪 `write_file` 和 `patch`，而不是所有可能的文件系统变更，因此应将该页脚视为未解决尝试的警告；如果其他工具可能更改了目标，请检查当前状态。
 
 示例页脚：
 
 ```
-⚠️ File-mutation verifier: 3 file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.
+⚠️ File-mutation verifier: 3 unresolved file-mutation failure(s) remain for this turn; verify the intended final state despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.
   • concepts/automatic-organization.md — [patch] Could not find match for old_string
   • concepts/lora.md — [patch] Could not find match for old_string
   • concepts/rag-pipeline.md — [patch] Could not find match for old_string


### PR DESCRIPTION
## Summary

Narrow the file-mutation verifier footer so it reports what Hermes actually knows: one or more tracked `write_file`/`patch` failures remain unresolved. It no longer claims that the listed targets were not modified during the turn, because other approved tools such as `terminal` can change the same path without participating in the verifier's state.

Fixes #72884.

## Reproduction

1. A `patch` attempt for a protected path fails.
2. An explicitly authorized `terminal` command changes and verifies that same path.
3. The turn ends while the original failed `patch` remains in `_turn_failed_file_mutations`.
4. Current `main` emits `were NOT modified this turn`, contradicting the observed final state.

The new regression models this sequence and failed against current `upstream/main` before the implementation was applied.

## Changes

- Replace the absolute unchanged assertion with `unresolved file-mutation failure(s)` wording.
- Tell users to verify the intended final state.
- Add a terminal-recovery regression test.
- Preserve the existing success-then-failure regression from #49412.
- Update English and Simplified Chinese configuration documentation.
- Clarify in the docs that this verifier observes `write_file` and `patch`; it is not proof that no other tool changed a path.

## Contributor credit

The core wording change and its original success-then-failure regression were salvaged from #49412 and remain authored by @timbeaulac in commit history. This branch adds the terminal-specific reproduction and missing documentation requested by automated review. The unrelated fuzzy-match changes from that PR were intentionally excluded to keep this fix focused.

## Validation

- RED on `upstream/main`:
  - `test_terminal_recovery_does_not_claim_target_was_unchanged` failed on `were NOT modified this turn`.
- GREEN after the fix:
  - `scripts/run_tests.sh tests/run_agent/test_file_mutation_verifier.py -q`
  - **39 passed, 0 failed**
- `ruff 0.15.10 check run_agent.py tests/run_agent/test_file_mutation_verifier.py`
  - passed (one pre-existing invalid `# noqa` warning in `run_agent.py`)
- `git diff --check`
  - passed
- Added-lines security scan
  - no hardcoded secrets, shell injection, `eval`/`exec`, unsafe pickle, or SQL-formatting findings
- `scripts/check-windows-footguns.py` reports one pre-existing `open(..., "w")` without `encoding=` in the verifier test file; the same finding reproduces on untouched `upstream/main` and is outside this diff.

## Scope

This changes reporting semantics only. It does **not** claim to prevent filesystem writes made through `terminal`, `execute_code`, subprocesses, or other mechanisms.
