### PR TITLE
fix(desktop): preserve live model after settings save

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -51,9 +51,6 @@ import {
   sessionPinId,
   setAwaitingResponse,
   setBusy,
-  setCurrentModel,
-  setCurrentModelSource,
-  setCurrentProvider,
   setMessages
 } from '@/store/session'
 import { focusedSessionNeedsRoute, focusOpenSession } from '@/store/session-states'
@@ -269,7 +266,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   const { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds } = useHermesConfig({ activeSessionIdRef })
 
-  const { refreshCurrentModel, selectModel, updateModelOptionsCache } = useModelControls({
+  const { applySavedMainModel, refreshCurrentModel, selectModel } = useModelControls({
     queryClient,
     requestGateway
   })
@@ -1000,10 +997,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
               void queryClient.invalidateQueries({ queryKey: ['model-options'] })
             }}
             onMainModelChanged={(provider, model) => {
-              setCurrentProvider(provider)
-              setCurrentModel(model)
-              setCurrentModelSource('default')
-              updateModelOptionsCache($activeSessionId.get(), provider, model, true)
+              applySavedMainModel(provider, model)
               void refreshCurrentModel()
               void queryClient.invalidateQueries({ queryKey: ['model-options'] })
             }}

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -140,6 +140,85 @@ describe('useModelControls', () => {
     expect($currentProvider.get()).toBe('deepseek')
   })
 
+  it('keeps a live session authoritative when Settings saves a new profile default', async () => {
+    const queryClient = new QueryClient()
+    $activeSessionId.set('runtime-1')
+    setCurrentModel('tencent/hy3:free')
+    setCurrentProvider('nous')
+    setCurrentModelSource('manual')
+    queryClient.setQueryData(modelOptionsQueryKey('default'), {
+      model: 'tencent/hy3:free',
+      provider: 'nous',
+      providers: []
+    })
+    queryClient.setQueryData(modelOptionsQueryKey('default', 'runtime-1'), {
+      model: 'tencent/hy3:free',
+      provider: 'nous',
+      providers: []
+    })
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'poolside/laguna-xs-2.1:free',
+      provider: 'nous'
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient,
+        requestGateway: vi.fn()
+      })
+    )
+
+    result.current.applySavedMainModel('nous', 'poolside/laguna-xs-2.1:free')
+    await result.current.refreshCurrentModel()
+
+    // Settings changes the profile default, not the active session. The footer
+    // and its session-scoped picker cache must keep showing the live runtime.
+    expect($currentModel.get()).toBe('tencent/hy3:free')
+    expect($currentProvider.get()).toBe('nous')
+    expect(queryClient.getQueryData(modelOptionsQueryKey('default', 'runtime-1'))).toMatchObject({
+      model: 'tencent/hy3:free',
+      provider: 'nous'
+    })
+
+    // The global cache reflects the save, and the next fresh draft may reseed
+    // from that default instead of preserving the old session's model.
+    expect(getCurrentModelSource()).toBe('default')
+    expect(queryClient.getQueryData(modelOptionsQueryKey('default'))).toMatchObject({
+      model: 'poolside/laguna-xs-2.1:free',
+      provider: 'nous'
+    })
+
+    $activeSessionId.set(null)
+    await result.current.refreshCurrentModel()
+
+    expect($currentModel.get()).toBe('poolside/laguna-xs-2.1:free')
+    expect($currentProvider.get()).toBe('nous')
+  })
+
+  it('paints a saved profile default immediately when no session is active', () => {
+    const queryClient = new QueryClient()
+    setCurrentModel('tencent/hy3:free')
+    setCurrentProvider('nous')
+    setCurrentModelSource('manual')
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient,
+        requestGateway: vi.fn()
+      })
+    )
+
+    result.current.applySavedMainModel('nous', 'poolside/laguna-xs-2.1:free')
+
+    expect($currentModel.get()).toBe('poolside/laguna-xs-2.1:free')
+    expect($currentProvider.get()).toBe('nous')
+    expect(getCurrentModelSource()).toBe('default')
+    expect(queryClient.getQueryData(modelOptionsQueryKey('default'))).toMatchObject({
+      model: 'poolside/laguna-xs-2.1:free',
+      provider: 'nous'
+    })
+  })
+
   it('routes active-session picker changes through config.set with an explicit session-scoped provider', async () => {
     $activeSessionId.set('session-1')
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -55,6 +55,29 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
     [queryClient]
   )
 
+  // Settings → Model writes the profile default, which the backend applies to
+  // new sessions only. Keep a live session's renderer state and session-scoped
+  // model-options cache authoritative instead of briefly painting the saved
+  // default as if the active agent had switched. Marking the composer as
+  // default-derived still lets the next fresh draft reseed from profile config.
+  const applySavedMainModel = useCallback(
+    (provider: string, model: string) => {
+      const liveSessionId = $activeSessionId.get()
+
+      setCurrentModelSource('default')
+
+      if (!liveSessionId) {
+        setCurrentProvider(provider)
+        setCurrentModel(model)
+      }
+
+      // A null session id is the profile-global model-options key. Never patch
+      // the live session key here: only config.set --session may change it.
+      updateModelOptionsCache(null, provider, model, false)
+    },
+    [updateModelOptionsCache]
+  )
+
   // Seed the composer's model state from the profile default. `force` reseeds
   // for a profile swap (the new profile has its own default); otherwise this
   // only fills an EMPTY selection so a user's pick (plain UI state in
@@ -220,5 +243,5 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
     [copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
   )
 
-  return { refreshCurrentModel, selectModel, updateModelOptionsCache }
+  return { applySavedMainModel, refreshCurrentModel, selectModel }
 }


### PR DESCRIPTION
## What does this PR do?

Keeps an active Desktop chat aligned with its session-scoped model when Settings saves a different profile default.

The Settings model endpoint updates the default for new sessions. The renderer was also overwriting the active session's provider/model atoms and session-scoped model-options cache, which made the footer show the saved default even though the live backend session had not switched. The next send then appeared to revert to the session's actual model.

This change moves that reconciliation policy into `useModelControls`: a Settings save updates the profile-global cache and marks future drafts as default-derived, but it does not mutate an active session. With no active session, the saved default still paints immediately.

Reported in Discord: https://discord.com/channels/1053877538025386074/1530345717422489742

## Related Issue

Related: #62055

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `applySavedMainModel` to keep profile-default saves separate from active-session model state.
- Updated Desktop Settings wiring to use that model-control path instead of mutating session atoms and caches directly.
- Added regression coverage for both an active session and a fresh draft with no active session.

## How to Test

1. Run `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-model-controls.test.tsx` and confirm all 15 tests pass.
2. Run `npm --workspace apps/desktop run typecheck`.
3. Run ESLint and Prettier against the three changed Desktop files.

Focused validation completed on Windows:

- Model-controls UI tests: 15/15 passed.
- Desktop TypeScript checks passed.
- ESLint passed.
- Prettier check passed.
- Full-suite coverage is left to GitHub CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run: Desktop-only change; full-suite coverage is left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing workflow or API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only state reconciliation is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. The regression is covered by the focused model-controls behavior tests above.
