### PR TITLE
fix(kanban): honor the CLI create auto-subscribe contract for subprocess creates

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -401,6 +401,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "that require immediate human ops (R3 gate) "
                                "to skip the brief running-to-blocked transition.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
+    p_create.add_argument("--notify-chat", default=None, dest="notify_chat",
+                          help="Subscribe this chat to the new card's "
+                               "terminal events (completed/blocked/etc). The "
+                               "in-gateway `kanban` tool auto-subscribes the "
+                               "calling session; a bare CLI/subprocess create "
+                               "has no session channel, so pass the target "
+                               "explicitly here. Requires --notify-platform.")
+    p_create.add_argument("--notify-platform", default=None, dest="notify_platform",
+                          help="Platform for --notify-chat (e.g. discord, "
+                               "telegram, slack). Requires --notify-chat.")
+    p_create.add_argument("--notify-thread", default=None, dest="notify_thread",
+                          help="Optional thread id for --notify-chat.")
 
     # --- swarm ---
     p_swarm = sub.add_parser(
@@ -1496,6 +1508,18 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    # --notify-chat and --notify-platform are a pair: half a target can't
+    # deliver, and silently ignoring it would recreate the exact
+    # hand-back-goes-unseen failure the flag exists to prevent.
+    _nchat = getattr(args, "notify_chat", None)
+    _nplat = getattr(args, "notify_platform", None)
+    if bool(_nchat) != bool(_nplat):
+        print(
+            "kanban: --notify-chat and --notify-platform must be given "
+            "together (a partial notify target can't deliver).",
+            file=sys.stderr,
+        )
+        return 2
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
@@ -1522,6 +1546,21 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
+        # Explicit notify subscription for CLI/subprocess creates. The
+        # in-gateway `kanban` tool auto-subscribes the calling session off
+        # its ContextVars (HERMES_SESSION_PLATFORM/CHAT_ID); a bare CLI or
+        # subprocess create has no session channel, so the auto path no-ops
+        # and the card would hand back silently. --notify-chat closes that
+        # gap by writing the same notify-sub row explicitly.
+        notify_chat = getattr(args, "notify_chat", None)
+        notify_platform = getattr(args, "notify_platform", None)
+        if notify_chat and notify_platform:
+            kb.add_notify_sub(
+                conn, task_id=task_id,
+                platform=notify_platform, chat_id=notify_chat,
+                thread_id=getattr(args, "notify_thread", None),
+                notifier_profile=_profile_author(),
+            )
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:

--- a/tests/hermes_cli/test_kanban_cli_notify_create.py
+++ b/tests/hermes_cli/test_kanban_cli_notify_create.py
@@ -1,0 +1,74 @@
+"""CLI `create --notify-chat`: explicit notify subscription for CLI/subprocess
+creates.
+
+The in-gateway `kanban` tool auto-subscribes the calling session off its
+ContextVars (HERMES_SESSION_PLATFORM/CHAT_ID). A bare CLI or subprocess create
+has no session channel, so the auto path no-ops and a review-required `blocked`
+hand-back would arrive with no subscriber to notify. `--notify-chat` /
+`--notify-platform` close that gap explicitly.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _created_id(out: str) -> str:
+    m = re.search(r"(t_[a-f0-9]+)", out)
+    assert m, f"no task id in output: {out!r}"
+    return m.group(1)
+
+
+def test_create_notify_chat_writes_subscription(kanban_home):
+    out = kc.run_slash(
+        "create 'watched' --notify-chat 12345 --notify-platform discord "
+        "--notify-thread 67890"
+    )
+    tid = _created_id(out)
+    with kb.connect_closing() as conn:
+        subs = kb.list_notify_subs(conn, tid)
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "12345"
+    assert subs[0]["thread_id"] == "67890"
+
+
+def test_create_without_notify_flags_writes_no_subscription(kanban_home):
+    # A bare CLI create has no session channel; auto-subscribe no-ops and we
+    # must not invent a target. Zero rows is the correct, documented behaviour.
+    out = kc.run_slash("create 'unwatched'")
+    tid = _created_id(out)
+    with kb.connect_closing() as conn:
+        subs = kb.list_notify_subs(conn, tid)
+    assert subs == []
+
+
+def test_create_half_notify_target_is_rejected(kanban_home):
+    # Only one of the pair given -> hard error, not a silent no-op (silently
+    # dropping it recreates the exact hand-back-goes-unseen failure the flag
+    # exists to prevent).
+    out_chat_only = kc.run_slash("create 'x' --notify-chat 12345")
+    assert (
+        "must be given" in out_chat_only.lower()
+        or "together" in out_chat_only.lower()
+    )
+    out_plat_only = kc.run_slash("create 'y' --notify-platform discord")
+    assert (
+        "must be given" in out_plat_only.lower()
+        or "together" in out_plat_only.lower()
+    )


### PR DESCRIPTION
## Problem

`hermes kanban create` documents itself as auto-subscribing:

```
create <title>…     Create a task (auto-subscribes you to events)
```

and the in-gateway `kanban` tool does — `_maybe_auto_subscribe` (tools/kanban_tools.py) runs on create, reading the session ContextVars `HERMES_SESSION_PLATFORM` / `HERMES_SESSION_CHAT_ID` and writing a `kanban_notify_subs` row so a worker's terminal events (completed/blocked) get delivered.

But the **CLI** `create` handler (hermes_cli/kanban.py, the `kb.create_task(...)` path) never subscribes anything. A bare CLI invocation — or a subprocess `hermes kanban create` — has no gateway session, so `_maybe_auto_subscribe` correctly hits its `CLI / cron / test — no persistent channel` no-op branch and writes nothing. The result: a card created from the CLI whose worker later blocks for review hands back **silently**, with no subscriber to notify. The help text advertises a behavior this code path does not implement.

## Fix

Add `--notify-chat` / `--notify-platform` (+ optional `--notify-thread`) to the `create` subcommand. When both are supplied, the handler writes the same `kanban_notify_subs` row `notify-subscribe` would. A half-specified pair (one flag without the other) is a hard error (exit 2), not a silent no-op — silently dropping it recreates exactly the missed-handback failure the flag exists to prevent.

No behavior change when the flags are absent: a bare create still writes no subscription (that stays correct — there is no channel to invent).

## Tests

3 new in `tests/hermes_cli/test_kanban_cli_notify_create.py`:
- both flags -> exactly one sub row with the right platform/chat/thread
- no flags -> zero sub rows (documented no-op preserved)
- half a target -> rejected

RED-proven: reverting the handler change fails the two positive tests with `unrecognized arguments: --notify-chat`; restoring makes them green. The no-flags test passes both ways (it guards pre-existing behavior).