### PR TITLE
Drop the leftover session counts inside an entered project

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -133,8 +133,6 @@ function RepoFlatSection({
       group.isMain || !dismissedWorktrees.includes(group.id) || (group.path && discoveredWorktreePaths.has(group.path))
   )
 
-  const repoCount = ordered.reduce((sum, group) => sum + group.sessions.length, 0)
-
   // Removal asks how: actually `git worktree remove` it, or just hide the lane
   // and leave the worktree on disk. A dirty worktree escalates to a force prompt
   // instead of erroring (those changes are usually throwaway).
@@ -268,7 +266,6 @@ function RepoFlatSection({
             />
           )
         }
-        count={repoCount}
         emphasis
         icon={<Codicon className="shrink-0 text-(--ui-text-tertiary)" name="repo" size="0.75rem" />}
         label={repo.label}

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -121,7 +121,6 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
             </div>
           )
         }
-        count={visibleSessions.length}
         icon={leadingIcon}
         label={group.label}
         onToggle={toggleOpen}

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -15,7 +15,7 @@ import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import { copyPath, revealPath } from '@/store/projects'
 
-import { SidebarCount, SidebarRowLead } from '../chrome'
+import { SidebarRowLead } from '../chrome'
 
 import { WorktreeDialog } from './worktree-dialog'
 
@@ -151,7 +151,6 @@ export function StartWorkButton({ repoPath, onStarted }: { repoPath: string; onS
 // button with a leading glyph, plus an optional trailing action (the +).
 export function WorkspaceHeader({
   action,
-  count,
   emphasis = false,
   icon,
   label,
@@ -160,7 +159,6 @@ export function WorkspaceHeader({
   title
 }: {
   action?: React.ReactNode
-  count: React.ReactNode
   emphasis?: boolean
   icon: React.ReactNode
   label: string
@@ -186,9 +184,6 @@ export function WorkspaceHeader({
       >
         <SidebarRowLead>{icon}</SidebarRowLead>
         <LaneLabel label={label} title={title ? `${label}\n${title}` : label} />
-        <span className="shrink-0">
-          <SidebarCount>{count}</SidebarCount>
-        </span>
         <DisclosureCaret
           className="shrink-0 text-(--ui-text-tertiary) opacity-0 transition group-hover/workspace:opacity-100"
           open={open}


### PR DESCRIPTION
The flat sidebar session list lost its count chip in [#72336](https://github.com/NousResearch/hermes-agent/pull/72336), but the project drill-in never did. Entering a project still put a number beside every repo header and every branch/worktree lane, because `WorkspaceHeader` kept its own `SidebarCount` slot.

This removes that slot, the two call sites that fed it, and the repo total that existed only to fill it.