### PR TITLE
fix(cli): defer zsh completion registration

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -240,7 +240,23 @@ _hermes() {{
     esac
 }}
 
-compdef _hermes hermes
+_hermes_register_completion() {{
+    if (( ! $+functions[compdef] )); then
+        return 0
+    fi
+
+    compdef _hermes hermes
+    precmd_functions=(${{precmd_functions:#_hermes_register_completion}})
+    unfunction _hermes_register_completion 2>/dev/null
+}}
+
+_hermes_register_completion
+if (( ! $+functions[compdef] )); then
+    typeset -ga precmd_functions
+    if [[ -z "${{precmd_functions[(r)_hermes_register_completion]}}" ]]; then
+        precmd_functions+=(_hermes_register_completion)
+    fi
+fi
 """
 
 

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -188,6 +188,37 @@ class TestGenerateZsh:
         finally:
             os.unlink(path)
 
+    def test_zsh_eval_style_source_defers_registration_until_compinit(self):
+        if not shutil.which("zsh"):
+            pytest.skip("zsh not installed")
+        out = generate_zsh(_make_parser())
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".zsh", delete=False) as f:
+            f.write(out)
+            path = f.name
+        try:
+            result = subprocess.run(
+                [
+                    "zsh",
+                    "-dfc",
+                    (
+                        f"source {path}; "
+                        '[[ -z "${_comps[hermes]-}" ]]; '
+                        '[[ "${precmd_functions[(r)_hermes_register_completion]-}" '
+                        "== _hermes_register_completion ]]; "
+                        "autoload -Uz compinit && compinit -D; "
+                        "_hermes_register_completion; "
+                        '[[ "${_comps[hermes]-}" == _hermes ]]; '
+                        '[[ -z "${precmd_functions[(r)_hermes_register_completion]-}" ]]'
+                    ),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, result.stderr
+            assert "command not found: compdef" not in result.stderr
+        finally:
+            os.unlink(path)
+
 
 # ---------------------------------------------------------------------------
 # 4. Fish output

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -125,6 +126,36 @@ class TestGenerateZsh:
         finally:
             os.unlink(path)
 
+    def test_zsh_eval_style_source_defers_registration_until_compinit(self):
+        if not shutil.which("zsh"):
+            pytest.skip("zsh not installed")
+        out = generate_zsh(_make_parser())
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".zsh", delete=False) as f:
+            f.write(out)
+            path = f.name
+        try:
+            result = subprocess.run(
+                [
+                    "zsh",
+                    "-dfc",
+                    (
+                        f"source {shlex.quote(path)}; "
+                        '[[ -z "${_comps[hermes]-}" ]]; '
+                        '[[ "${precmd_functions[(r)_hermes_register_completion]-}" '
+                        "== _hermes_register_completion ]]; "
+                        "autoload -Uz compinit && compinit -D; "
+                        "_hermes_register_completion; "
+                        '[[ "${_comps[hermes]-}" == _hermes ]]; '
+                        '[[ -z "${precmd_functions[(r)_hermes_register_completion]-}" ]]'
+                    ),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, result.stderr
+            assert "command not found: compdef" not in result.stderr
+        finally:
+            os.unlink(path)
 
 # ---------------------------------------------------------------------------
 # 4. Fish output


### PR DESCRIPTION
## What does this PR do?

Makes generated zsh completion safe to source before `compinit`.

The output now attempts registration immediately, but if `compdef` is unavailable it installs one deduplicated `precmd_functions` hook. Once `compinit` makes `compdef` available, the helper registers `_hermes`, removes its hook, and removes itself.

This preserves all supported load orders:

- `eval "$(hermes completion zsh)"` before `compinit`
- eval/source after `compinit`
- a file loaded through `fpath` and `compinit`
- repeated sourcing before registration

## Related Issue

Fixes #72909

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `hermes_cli/completion.py`: defer `compdef` registration until the function exists.
- `tests/hermes_cli/test_completion.py`: add a real zsh integration test for source-before-compinit ordering.

## How to Test

1. Generate completion and source it in a clean zsh without `compinit`; no `command not found: compdef` error should appear.
2. Run `compinit`, invoke the deferred registration helper, and verify `_comps[hermes] == _hermes`.
3. Run:

```text
python -m pytest -q -o addopts='' tests/hermes_cli/test_completion.py
python -m ruff check hermes_cli/completion.py tests/hermes_cli/test_completion.py
```

Validation:

- Focused suite on Windows: `28 passed, 4 skipped`.
- Real macOS zsh 5.9 proof: source-before-compinit, deferred registration, registration after `compinit -C`, and hook cleanup all passed.
- Ruff: passed.
- `git diff --check`: passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed issues/PRs for duplicates.
- [x] This PR contains only the completion ordering fix and its regression test.
- [ ] I've run the full `pytest tests/ -q` suite; focused tests are listed above.
- [x] I've added a regression test.
- [x] Tested on Windows 11 and macOS with zsh 5.9.

### Documentation & Housekeeping

- [x] Documentation update: N/A; the existing recommended eval command becomes valid.
- [x] Config example update: N/A.
- [x] Architecture/workflow docs: N/A.
- [x] Cross-platform impact considered.
- [x] Tool schema update: N/A.

## Screenshots / Logs

Before:

```text
zsh: command not found: compdef
```

After:

```text
source-before-compinit: PASS
deferred registration after compinit: PASS
hook cleanup: PASS
```
