### PR TITLE
fix(agent): classify Codex account token failures

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -438,6 +438,7 @@ _AUTH_PATTERNS = [
     "invalid token",
     "token expired",
     "token revoked",
+    "failed to extract accountid from token",
     "access denied",
 ]
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -489,6 +489,7 @@ _AUTH_PATTERNS = [
     "invalid token",
     "token expired",
     "token revoked",
+    "failed to extract accountid from token",
     "access denied",
 ]
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1113,6 +1113,14 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.auth
 
+    def test_message_account_id_token_extraction_failure_is_auth(self):
+        e = Exception("Failed to extract accountId from token")
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason == FailoverReason.auth
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
     def test_message_model_not_found_pattern(self):
         e = Exception("gpt-99 is not a valid model")
         result = classify_api_error(e)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -542,6 +542,13 @@ class TestClassifyApiError:
 
 
 
+    def test_message_account_id_token_extraction_failure_is_auth(self):
+        e = Exception("Failed to extract accountId from token")
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason == FailoverReason.auth
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
 
 
     # ── Message-only usage limit disambiguation (no status code) ──


### PR DESCRIPTION
## What does this PR do?

Classifies OpenAI Codex account-ID token extraction failures as authentication
errors instead of retryable unknown failures.

The change reuses Hermes' existing authentication decision path, so an
unusable token does not consume retries on the same credential and credential
rotation/provider fallback remain available.

## Related Issue

Fixes #72911

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `agent/error_classifier.py`: recognize the normalized account-ID token
  extraction failure in the existing authentication pattern set.
- `tests/agent/test_error_classifier.py`: verify the auth, retry, credential
  rotation, and fallback decisions.

## How to Test

```text
python -m pytest -q -o addopts='' tests/agent/test_error_classifier.py
python -m ruff check agent/error_classifier.py tests/agent/test_error_classifier.py
git diff --check
```

Validation:

- `206 passed`
- Ruff passed
- `git diff --check` passed

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed issues/PRs for duplicates.
- [x] This PR contains only the error-classification fix and its regression
  test.
- [ ] I've run the full `pytest tests/ -q` suite; focused tests are listed
  above.
- [x] I've added regression coverage.
- [x] Tested on Windows 11 with Python 3.11.

### Documentation & Housekeeping

- [x] Documentation update: N/A.
- [x] Config example update: N/A.
- [x] Architecture/workflow docs: N/A.
- [x] Cross-platform impact considered.
- [x] Tool schema update: N/A.

## Screenshots / Logs

Before:

```text
reason=unknown retryable=True rotate=False fallback=False
```

After:

```text
reason=auth retryable=False rotate=True fallback=True
```
