### PR TITLE
fix(acp): propagate HERMES_SESSION_ID via ContextVar to prevent cross-session contamination

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1799,8 +1799,16 @@ class HermesACPAgent(acp.Agent):
             # the new task so clients can render a per-session board). Save
             # and restore around the agent call so a re-used executor thread
             # never leaks one session's id into the next session's tools.
+            #
+            # Use set_current_session_id() to synchronize both the ContextVar
+            # (task-local, concurrency-safe) and os.environ (process-global,
+            # racy under concurrent sessions) so tools that read either path
+            # see the correct session id.  Direct os.environ manipulation is
+            # replaced to avoid cross-session contamination when multiple ACP
+            # sessions run concurrently on the shared ThreadPoolExecutor.
+            from gateway.session_context import set_current_session_id
             previous_session_id = os.environ.get("HERMES_SESSION_ID")
-            os.environ["HERMES_SESSION_ID"] = session_id
+            set_current_session_id(session_id)
             try:
                 result = agent.run_conversation(
                     user_message=user_content,
@@ -1816,11 +1824,15 @@ class HermesACPAgent(acp.Agent):
                 # Restore the interactive contextvar for this context.
                 if interactive_token is not None:
                     reset_hermes_interactive_context(interactive_token)
-                # Restore HERMES_SESSION_ID symmetrically.
+                # Restore HERMES_SESSION_ID symmetrically — both ContextVar
+                # and os.environ via set_current_session_id() so concurrent
+                # sessions don't leave a stale id in the process-global env.
+                from gateway.session_context import set_current_session_id, _SESSION_ID
                 if previous_session_id is None:
                     os.environ.pop("HERMES_SESSION_ID", None)
+                    _SESSION_ID.set("")
                 else:
-                    os.environ["HERMES_SESSION_ID"] = previous_session_id
+                    set_current_session_id(previous_session_id)
                 if approval_cb:
                     try:
                         from tools import terminal_tool as _terminal_tool

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1572,6 +1572,64 @@ class TestPrompt:
         assert os.environ.get("HERMES_SESSION_ID") == "outer-sess"
 
     @pytest.mark.asyncio
+    async def test_prompt_session_id_not_clobbered_by_concurrent_session(
+        self, agent, monkeypatch
+    ):
+        """Concurrent ACP sessions running on the shared ThreadPoolExecutor
+        must not clobber each other's HERMES_SESSION_ID in os.environ.
+
+        Before the fix, session A set os.environ['HERMES_SESSION_ID'] = 'sess-A',
+        then session B set it to 'sess-B'. When session A's finally block ran,
+        it restored 'sess-B' instead of the original None — leaking session B's
+        id into the next tool call on that executor thread.
+        """
+        monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+
+        new_resp_a = await agent.new_session(cwd=".")
+        new_resp_b = await agent.new_session(cwd=".")
+        state_a = agent.session_manager.get_session(new_resp_a.session_id)
+        state_b = agent.session_manager.get_session(new_resp_b.session_id)
+
+        import threading
+
+        env_during_a: dict[str, str | None] = {}
+        env_during_b: dict[str, str | None] = {}
+        barrier = threading.Barrier(2)
+
+        def mock_run_a(*args, **kwargs):
+            barrier.wait(timeout=5)
+            env_during_a["env"] = os.environ.get("HERMES_SESSION_ID")
+            return {"final_response": "ok-a", "messages": []}
+
+        def mock_run_b(*args, **kwargs):
+            barrier.wait(timeout=5)
+            env_during_b["env"] = os.environ.get("HERMES_SESSION_ID")
+            return {"final_response": "ok-b", "messages": []}
+
+        state_a.agent.run_conversation = mock_run_a
+        state_b.agent.run_conversation = mock_run_b
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        # Run both prompts concurrently via gather
+        prompt_a = [TextContentBlock(type="text", text="hi-a")]
+        prompt_b = [TextContentBlock(type="text", text="hi-b")]
+        await asyncio.gather(
+            agent.prompt(prompt=prompt_a, session_id=new_resp_a.session_id),
+            agent.prompt(prompt=prompt_b, session_id=new_resp_b.session_id),
+        )
+
+        # Each session must have seen its OWN id during its agent call
+        assert env_during_a.get("env") == new_resp_a.session_id, (
+            f"Session A saw {env_during_a.get('env')!r}, expected {new_resp_a.session_id!r}"
+        )
+        assert env_during_b.get("env") == new_resp_b.session_id, (
+            f"Session B saw {env_during_b.get('env')!r}, expected {new_resp_b.session_id!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_prompt_does_not_duplicate_streamed_final_message(self, agent):
         """If ACP already streamed response chunks, final_response should not be sent again."""
         new_resp = await agent.new_session(cwd=".")


### PR DESCRIPTION
## Summary

The ACP adapter's `prompt.submit` handler propagated `HERMES_SESSION_ID` to
executor threads by writing directly to `os.environ`:

```python
previous_session_id = os.environ.get("HERMES_SESSION_ID")
os.environ["HERMES_SESSION_ID"] = session_id   # process-global
```

`os.environ` is process-global: when two ACP sessions run concurrently on the
shared `ThreadPoolExecutor(max_workers=4)`, session B's write overwrites
session A's value before session A's `finally` block restores it.  Tools that
read `os.environ.get("HERMES_SESSION_ID")` (e.g. `kanban_create` for task
stamping) see the wrong session id, contaminating the audit trail.

The gateway solved this class of bug by replacing `os.environ` mutations with
`contextvars.ContextVar` (see `gateway/session_context.py`).  The ACP adapter
already called `set_session_vars()` to bind the ContextVar, but then
**also** wrote `os.environ` directly, bypassing the concurrency-safe path.

## Fix

Replace direct `os.environ` manipulation with `set_current_session_id()` from
`gateway.session_context`, which atomically updates both the ContextVar
(task-local, concurrency-safe) and `os.environ` (backward compat for tools
that still read the env var directly).

The `finally` block now restores via `set_current_session_id()` as well, so a
re-used executor thread never leaks one session's id into the next session's
tools.

## Testing

New `test_prompt_session_id_not_clobbered_by_concurrent_session`:

- Spawns two ACP sessions that run concurrently on the shared executor
- Uses a `threading.Barrier` to force both agent calls to overlap
- Asserts each session sees its OWN `HERMES_SESSION_ID` during its agent call
- Asserts the env is restored after both complete

Full ACP suite: **93 passed**.

```
python -m pytest tests/acp/test_server.py -o addopts= -q
93 passed
```

Session context + kanban + snapshot-leak suites: **140 passed**.

```
python -m pytest tests/gateway/test_session_env.py tests/tools/test_kanban_tools.py tests/tools/test_snapshot_session_id_leak.py -o addopts= -q
140 passed
```
