### PR TITLE
feat: add Impossibl AI API provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@
 #   accounts/fireworks/models/kimi-k2p6, accounts/fireworks/models/glm-5p2
 # FIREWORKS_API_KEY=
 # =============================================================================
+# LLM PROVIDER (Impossibl AI API)
+# =============================================================================
+# One API for models across providers.
+# Get your key at: https://impossibl.com/
+# IMPOSSIBL_API_KEY=
+
+# =============================================================================
 # LLM PROVIDER (OpenRouter)
 # =============================================================================
 # OpenRouter provides access to many models through one API

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -18,6 +18,7 @@ model:
   #   "anthropic"    - Direct Anthropic API (requires: ANTHROPIC_API_KEY)
   #   "openai-codex" - OpenAI Codex (requires: hermes auth)
   #   "copilot"      - GitHub Copilot / GitHub Models (requires: GITHUB_TOKEN)
+  #   "impossibl"    - Impossibl AI API (requires: IMPOSSIBL_API_KEY)
   #   "gemini"      - Use Google AI Studio direct (requires: GOOGLE_API_KEY or GEMINI_API_KEY)
   #   "zai"         - Use z.ai / ZhipuAI GLM models (requires: GLM_API_KEY)
   #   "kimi-coding"  - Kimi / Moonshot AI (requires: KIMI_API_KEY)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1065,6 +1065,7 @@ def run_doctor(args):
                 "lmstudio",
                 "nous",
                 "nvidia",
+                "impossibl",
                 # Fireworks' native model IDs are slash-form
                 # (accounts/fireworks/models/... and .../routers/...), so a "/"
                 # is expected, not an aggregator vendor prefix.

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -70,6 +70,7 @@ _AGGREGATOR_PROVIDERS: frozenset[str] = frozenset({
     "openrouter",
     "nous",
     "kilocode",
+    "impossibl",
 })
 
 # Providers that want bare names with dots replaced by hyphens.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1273,6 +1273,7 @@ _PROVIDER_ALIASES = {
     "gmicloud": "gmi",
     "fireworks-ai": "fireworks",
     "fw": "fireworks",
+    "imp": "impossibl",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
     "minimax-portal": "minimax-oauth",
@@ -2106,7 +2107,7 @@ def _model_in_provider_catalog(name_lower: str, providers: set[str]) -> bool:
 
 
 _AGGREGATOR_PROVIDERS = frozenset(
-    {"nous", "openrouter", "copilot", "kilocode"}
+    {"nous", "openrouter", "copilot", "kilocode", "impossibl"}
 )
 
 # Subscription/OAuth providers whose catalogs RE-EXPOSE other vendors' models
@@ -2287,6 +2288,16 @@ def detect_provider_for_model(
     """
     name = (model_name or "").strip()
     if not name:
+        return None
+
+    # A vendor/model ID is already native to the current aggregator's
+    # namespace. Do not reinterpret its vendor prefix as a reason to hop to
+    # OpenRouter or a direct provider; downstream live validation remains
+    # responsible for rejecting models the current aggregator does not serve.
+    if (
+        normalize_provider(current_provider) in _AGGREGATOR_PROVIDERS
+        and "/" in name
+    ):
         return None
 
     static_match = detect_static_provider_for_model(name, current_provider)

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -54,6 +54,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="OPENROUTER_BASE_URL",
     ),
+    "impossibl": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("IMPOSSIBL_API_KEY",),
+        base_url_override="https://api.impossibl.com/v1",
+    ),
     "nous": HermesOverlay(
         transport="openai_chat",
         auth_type="oauth_device_code",
@@ -265,6 +271,9 @@ ALIASES: Dict[str, str] = {
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
 
+    # impossibl
+    "imp": "impossibl",
+
     # zai
     "glm": "zai",
     "z-ai": "zai",
@@ -393,6 +402,7 @@ ALIASES: Dict[str, str] = {
 _LABEL_OVERRIDES: Dict[str, str] = {
     "moa": "Mixture of Agents",
     "nous": "Nous Portal",
+    "impossibl": "Impossibl AI API",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
     "stepfun": "StepFun Step Plan",
@@ -823,12 +833,12 @@ def resolve_provider_full(
             from hermes_cli.auth import PROVIDER_REGISTRY as _AUTH_PROVIDER_REGISTRY
             _pcfg = _AUTH_PROVIDER_REGISTRY.get(raw)
             if _pcfg is not None:
-                _collapsed_siblings = [
-                    _rid
-                    for _rid in _AUTH_PROVIDER_REGISTRY
+                _collapsed_provider_ids = {
+                    _rcfg.id
+                    for _rid, _rcfg in _AUTH_PROVIDER_REGISTRY.items()
                     if normalize_provider(_rid) == canonical
-                ]
-                if len(_collapsed_siblings) > 1:
+                }
+                if len(_collapsed_provider_ids) > 1:
                     return ProviderDef(
                         id=_pcfg.id,
                         name=_pcfg.name,

--- a/plugins/model-providers/impossibl/__init__.py
+++ b/plugins/model-providers/impossibl/__init__.py
@@ -1,0 +1,29 @@
+"""Impossibl AI API provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+impossibl = ProviderProfile(
+    name="impossibl",
+    aliases=("imp",),
+    display_name="Impossibl AI API",
+    description="Impossibl AI API — one API for models across providers",
+    signup_url="https://impossibl.com/",
+    env_vars=("IMPOSSIBL_API_KEY",),
+    base_url="https://api.impossibl.com/v1",
+    models_url="https://api.impossibl.com/v1/models",
+    auth_type="api_key",
+    # Cheap, long-context model for compression and other side tasks.
+    default_aux_model="moonshotai/kimi-k3",
+    # Small/current agentic models verified against the public live catalog.
+    fallback_models=(
+        "moonshotai/kimi-k3",
+        "deepseek/deepseek-v4-flash",
+        "xiaomi/mimo-v2.5",
+        "google/gemini-3.5-flash-lite",
+        "openai/gpt-5.4-mini",
+    ),
+)
+
+register_provider(impossibl)

--- a/plugins/model-providers/impossibl/plugin.yaml
+++ b/plugins/model-providers/impossibl/plugin.yaml
@@ -1,0 +1,5 @@
+name: impossibl-provider
+kind: model-provider
+version: 1.0.0
+description: Impossibl AI API — one API for models across providers
+author: Impossibl Inc.

--- a/tests/hermes_cli/test_impossibl_provider.py
+++ b/tests/hermes_cli/test_impossibl_provider.py
@@ -1,0 +1,240 @@
+"""Focused tests for the Impossibl AI API model-provider plugin."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import types
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_api_key_provider_credentials,
+    resolve_provider,
+)
+from hermes_cli.models import CANONICAL_PROVIDERS, provider_model_ids
+from hermes_cli.model_normalize import normalize_model_for_provider
+from hermes_cli.model_switch import switch_model
+from hermes_cli.provider_catalog import provider_catalog_by_slug
+from hermes_cli.providers import resolve_provider_full
+from hermes_cli.runtime_provider import resolve_runtime_provider
+from providers import get_provider_profile
+
+
+@pytest.fixture(autouse=True)
+def _clear_impossibl_env(monkeypatch):
+    monkeypatch.delenv("IMPOSSIBL_API_KEY", raising=False)
+
+
+def test_profile_registers_with_expected_identity_and_catalog():
+    profile = get_provider_profile("impossibl")
+
+    assert profile is not None
+    assert get_provider_profile("imp") is profile
+    assert profile.display_name == "Impossibl AI API"
+    assert profile.description == "Impossibl AI API — one API for models across providers"
+    assert profile.signup_url == "https://impossibl.com/"
+    assert profile.env_vars == ("IMPOSSIBL_API_KEY",)
+    assert profile.base_url == "https://api.impossibl.com/v1"
+    assert profile.models_url == "https://api.impossibl.com/v1/models"
+    assert profile.auth_type == "api_key"
+    assert profile.default_aux_model in profile.fallback_models
+
+
+def test_alias_and_credentials_resolve_through_generated_registry(monkeypatch):
+    monkeypatch.setenv("IMPOSSIBL_API_KEY", "imp-test-key")
+
+    assert resolve_provider("imp") == "impossibl"
+
+    registry_entry = PROVIDER_REGISTRY["impossibl"]
+    assert registry_entry.name == "Impossibl AI API"
+    assert registry_entry.api_key_env_vars == ("IMPOSSIBL_API_KEY",)
+    assert registry_entry.inference_base_url == "https://api.impossibl.com/v1"
+
+    credentials = resolve_api_key_provider_credentials("impossibl")
+    assert credentials == {
+        "provider": "impossibl",
+        "api_key": "imp-test-key",
+        "base_url": "https://api.impossibl.com/v1",
+        "source": "IMPOSSIBL_API_KEY",
+    }
+
+
+def test_runtime_uses_openai_compatible_chat_transport(monkeypatch):
+    monkeypatch.setenv("IMPOSSIBL_API_KEY", "imp-runtime-key")
+
+    with patch("hermes_cli.runtime_provider._get_model_config", return_value={}):
+        runtime = resolve_runtime_provider(requested="imp")
+
+    assert runtime["provider"] == "impossibl"
+    assert runtime["requested_provider"] == "imp"
+    assert runtime["api_mode"] == "chat_completions"
+    assert runtime["base_url"] == "https://api.impossibl.com/v1"
+    assert runtime["api_key"] == "imp-runtime-key"
+
+
+def test_auxiliary_client_uses_the_profile_default(monkeypatch):
+    from agent.auxiliary_client import resolve_provider_client
+
+    monkeypatch.setenv("IMPOSSIBL_API_KEY", "imp-aux-key")
+    with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+        mock_openai.return_value = object()
+        client, model = resolve_provider_client("impossibl")
+
+    assert client is not None
+    assert model == "moonshotai/kimi-k3"
+    assert mock_openai.call_args.kwargs["api_key"] == "imp-aux-key"
+    assert mock_openai.call_args.kwargs["base_url"] == "https://api.impossibl.com/v1"
+
+
+def test_model_catalog_merges_static_agentic_fallbacks_with_live_models(monkeypatch):
+    profile = get_provider_profile("impossibl")
+    assert profile is not None
+    live = [
+        "openai/gpt-5.4-mini",
+        "anthropic/claude-sonnet-5",
+    ]
+
+    monkeypatch.setenv("IMPOSSIBL_API_KEY", "imp-catalog-key")
+    monkeypatch.setattr(profile, "fetch_models", lambda **_kwargs: live)
+
+    models = provider_model_ids("impossibl")
+
+    assert models[: len(profile.fallback_models)] == list(profile.fallback_models)
+    assert set(profile.fallback_models) | set(live) <= set(models)
+    assert models.count("openai/gpt-5.4-mini") == 1
+
+
+def test_model_catalog_falls_back_without_credentials():
+    profile = get_provider_profile("impossibl")
+    assert profile is not None
+
+    assert provider_model_ids("impossibl") == list(profile.fallback_models)
+
+
+def test_provider_is_automatically_wired_to_model_and_provider_menus():
+    model_entry = next(entry for entry in CANONICAL_PROVIDERS if entry.slug == "impossibl")
+    descriptor = provider_catalog_by_slug()["impossibl"]
+
+    assert model_entry.label == "Impossibl AI API"
+    assert model_entry.tui_desc == "Impossibl AI API — one API for models across providers"
+    assert descriptor.label == model_entry.label
+    assert descriptor.description == model_entry.tui_desc
+    assert descriptor.tab == "keys"
+    assert descriptor.api_key_env_vars == ("IMPOSSIBL_API_KEY",)
+    assert descriptor.signup_url == "https://impossibl.com/"
+
+
+@pytest.mark.parametrize("provider_name", ["impossibl", "imp"])
+def test_shared_provider_def_resolver_supports_canonical_and_alias(provider_name):
+    resolved = resolve_provider_full(provider_name)
+
+    assert resolved is not None
+    assert resolved.id == "impossibl"
+    assert resolved.name == "Impossibl AI API"
+    assert resolved.api_key_env_vars == ("IMPOSSIBL_API_KEY",)
+    assert resolved.base_url == "https://api.impossibl.com/v1"
+    assert resolved.is_aggregator is True
+
+
+def test_model_normalization_uses_impossibl_vendor_slugs():
+    assert (
+        normalize_model_for_provider("claude-sonnet-4.6", "impossibl")
+        == "anthropic/claude-sonnet-4.6"
+    )
+    assert (
+        normalize_model_for_provider(
+            "deepseek/deepseek-v4-flash", "impossibl"
+        )
+        == "deepseek/deepseek-v4-flash"
+    )
+
+
+def test_switch_model_preserves_current_impossibl_for_vendor_slug(monkeypatch):
+    model_id = "openai/gpt-5.4-mini"
+    monkeypatch.setenv("IMPOSSIBL_API_KEY", "imp-switch-key")
+
+    with (
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch("hermes_cli.models.fetch_api_models", return_value=[model_id]),
+    ):
+        result = switch_model(
+            raw_input=model_id,
+            current_provider="impossibl",
+            current_model="deepseek/deepseek-v4-flash",
+            current_base_url="https://api.impossibl.com/v1",
+            current_api_key="imp-switch-key",
+        )
+
+    assert result.success is True
+    assert result.target_provider == "impossibl"
+    assert result.new_model == model_id
+    assert result.base_url == "https://api.impossibl.com/v1"
+    assert result.api_key == "imp-switch-key"
+
+
+def test_switch_model_accepts_explicit_impossibl_for_vendor_slug(monkeypatch):
+    model_id = "openai/gpt-5.4-mini"
+    monkeypatch.setenv("IMPOSSIBL_API_KEY", "imp-switch-key")
+
+    with (
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch("hermes_cli.models.fetch_api_models", return_value=[model_id]),
+    ):
+        result = switch_model(
+            raw_input=model_id,
+            current_provider="openrouter",
+            current_model="anthropic/claude-sonnet-4.6",
+            explicit_provider="impossibl",
+        )
+
+    assert result.success is True
+    assert result.target_provider == "impossibl"
+    assert result.new_model == model_id
+    assert result.base_url == "https://api.impossibl.com/v1"
+    assert result.api_key == "imp-switch-key"
+
+
+def test_doctor_accepts_impossibl_vendor_slug(monkeypatch, tmp_path):
+    from hermes_cli import doctor as doctor_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: impossibl\n"
+        "  default: deepseek/deepseek-v4-flash\n",
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setitem(
+        sys.modules,
+        "model_tools",
+        types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        ),
+    )
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False, ack=None))
+    output = buf.getvalue()
+
+    assert "model.provider 'impossibl' is not a recognised provider" not in output
+    assert "model.provider 'impossibl' is unknown" not in output
+    assert (
+        "model.default 'deepseek/deepseek-v4-flash' uses a vendor/model slug "
+        "but provider is 'impossibl'"
+        not in output
+    )
+    assert "Either set model.provider to 'openrouter', or drop the vendor prefix." not in output

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -113,6 +113,7 @@ Good defaults:
 | **OpenAI Codex** | ChatGPT OAuth, uses Codex models | Device code auth via `hermes model` |
 | **Anthropic** | Claude models directly — Max plan + extra usage credits (OAuth), or API key for pay-per-token | `hermes model` → OAuth login (requires Max + extra credits), or an Anthropic API key |
 | **OpenRouter** | Multi-provider routing across many models | Enter your API key |
+| **Impossibl AI API** | One API for models across providers | Set `IMPOSSIBL_API_KEY` |
 | **Fireworks AI** | Direct OpenAI-compatible model API | Set `FIREWORKS_API_KEY` |
 | **Z.AI** | GLM / Zhipu-hosted models | Set `GLM_API_KEY` / `ZAI_API_KEY` (also accepts `Z_AI_API_KEY`) |
 | **Kimi / Moonshot** | Moonshot-hosted coding and chat models | Set `KIMI_API_KEY` (or the Kimi-Coding-specific `KIMI_CODING_API_KEY`) |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -20,6 +20,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
+| **Impossibl AI API** | `IMPOSSIBL_API_KEY` in `~/.hermes/.env` (provider: `impossibl`; alias: `imp`) |
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
@@ -215,6 +216,10 @@ model:
 These providers have built-in support with dedicated provider IDs. Set the API key and use `--provider` to select:
 
 ```bash
+# Impossibl AI API
+hermes chat --provider impossibl --model deepseek/deepseek-v4-flash
+# Requires: IMPOSSIBL_API_KEY in ~/.hermes/.env
+
 # Fireworks AI
 hermes chat --provider fireworks --model accounts/fireworks/models/kimi-k2p6
 # Requires: FIREWORKS_API_KEY in ~/.hermes/.env

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -14,6 +14,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 |----------|-------------|
 | `OPENROUTER_API_KEY` | OpenRouter API key (recommended for flexibility) |
 | `OPENROUTER_BASE_URL` | Override the OpenRouter-compatible base URL |
+| `IMPOSSIBL_API_KEY` | Impossibl AI API key ([impossibl.com](https://impossibl.com/)) |
 | `FIREWORKS_API_KEY` | Fireworks AI API key ([app.fireworks.ai](https://app.fireworks.ai/settings/users/api-keys)). Configure endpoint overrides with `model.base_url` in `config.yaml`. |
 | `HERMES_OPENROUTER_CACHE` | Enable OpenRouter response caching (`1`/`true`/`yes`/`on`). Overrides `openrouter.response_cache` in config.yaml. See [Response Caching](https://openrouter.ai/docs/guides/features/response-caching). |
 | `HERMES_OPENROUTER_CACHE_TTL` | Cache TTL in seconds (1-86400). Overrides `openrouter.response_cache_ttl` in config.yaml. |


### PR DESCRIPTION
## Summary
- add Impossibl AI API as a first-class OpenAI-compatible model provider
- wire API-key auth, live model discovery, aliases, vendor-slug routing, model switching, and doctor checks
- document setup with `IMPOSSIBL_API_KEY`

## Validation
- `scripts/run_tests.sh tests/hermes_cli/` — 9,832 passed
- post-rebase provider/model/doctor suite — 306 passed
- Docusaurus production build — passed for `en` and `zh-Hans`
- Windows footgun scan — passed
- live public catalog — 94 models; auxiliary and fallback models verified

No custom transport or account-creation flow is added; this uses Hermes' existing provider architecture.