### PR TITLE
fix(skills): restore curly quotes in humanizer pattern 19 example

### DIFF
--- a/skills/creative/humanizer/SKILL.md
+++ b/skills/creative/humanizer/SKILL.md
@@ -339,10 +339,10 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 ### 19. Curly Quotation Marks
 
-**Problem:** ChatGPT uses curly quotes ("...") instead of straight quotes ("...").
+**Problem:** ChatGPT uses curly quotes (“...”) instead of straight quotes ("...").
 
 **Before:**
-> He said "the project is on track" but others disagreed.
+> He said “the project is on track” but others disagreed.
 
 **After:**
 > He said "the project is on track" but others disagreed.


### PR DESCRIPTION
## What does this PR do?

Pattern 19 of the `humanizer` skill ("Curly Quotation Marks") tells the agent to replace curly quotes with straight ones. Its Before and After examples were byte-identical, so the example demonstrated nothing:

```
Before: > He said "the project is on track" but others disagreed.
After:  > He said "the project is on track" but others disagreed.
```

The Problem line had the same defect, describing curly quotes using straight quotes on both sides of "instead of".

Upstream [`blader/humanizer`](https://github.com/blader/humanizer), the MIT-licensed source this skill was ported from, has U+201C/U+201D in both places. The characters were lost in the initial port (12d745bd), so this pattern has never been demonstrable in Hermes. I checked every commit that has touched the file: 12d745bd, 98db898c, ef010f87, and current main (731aa0cc) all have zero smart-quote codepoints.

This restores the four characters. The After line stays straight, since that is the corrected output the pattern teaches.

Worth noting for review: there is no repo-wide prohibition on these characters. `skills/creative/claude-design/SKILL.md`, `optional-skills/productivity/telephony/SKILL.md`, `optional-skills/migration/openclaw-migration/SKILL.md`, and `optional-skills/mlops/pytorch-fsdp/SKILL.md` all contain U+201C/U+201D today and pass CI. The `ascii-guard` dependency in `docs-site-checks.yml` guards ASCII diagrams inside fenced blocks, not prose punctuation.

## Related Issue

No existing issue. Opening directly as a PR since the fix is unambiguous and two lines.

I searched open and closed issues and PRs for `humanizer`, `curly quotes`, `curly quotation`, and `smart quotes`. The existing curly-quote reports (#40915, #40925, #41018) are all about the kanban slash-command parser and unrelated to this skill. No open PR touches `skills/creative/humanizer/`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/creative/humanizer/SKILL.md`: restored U+201C/U+201D in the pattern 19 Problem line and in the Before example. Two lines, +2/-2. Nothing else in the file changed.

## How to Test

1. Show the section on current main and confirm Before and After are identical:

   ```bash
   git show origin/main:skills/creative/humanizer/SKILL.md | sed -n '/^### 19\./,/^## COMMUNICATION/p'
   ```

2. Run the same command on this branch. Before now has curly quotes; After stays straight.

3. Count the smart-quote codepoints in the section (0 on main, 4 here):

   ```bash
   python3 -c "
   t = open('skills/creative/humanizer/SKILL.md', encoding='utf-8').read()
   s = t.split('### 19. Curly Quotation Marks')[1].split('## COMMUNICATION')[0]
   print([hex(ord(c)) for c in s if ord(c) > 127])
   "
   ```

4. Confirm the section now matches upstream:

   ```bash
   curl -sL https://raw.githubusercontent.com/blader/humanizer/main/SKILL.md -o /tmp/up.md
   diff <(sed -n '/^### 19\./,/^## COMMUNICATION/p' /tmp/up.md | grep -E 'Problem|He said') \
        <(sed -n '/^### 19\./,/^## COMMUNICATION/p' skills/creative/humanizer/SKILL.md | grep -E 'Problem|He said')
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run. The change is punctuation inside skill markdown with no executable code path. I verified `python3 website/scripts/generate-skill-docs.py` regenerates the page cleanly with the characters intact.
- [ ] I've added tests for my changes — N/A. No existing test asserts skill prose content; adding one for two characters seemed disproportionate, but happy to add a check if you want one.
- [x] I've tested on my platform: macOS 15 (Sequoia)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A. `website/docs/user-guide/skills/bundled/creative/creative-humanizer.md` is generated from this file by `website/scripts/generate-skill-docs.py`, so it picks the fix up on the next run.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A. The file is already UTF-8 and contains other non-ASCII characters, including em dashes in pattern 14.
