### PR TITLE
fix(files): preserve native Windows paths for ripgrep

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -468,7 +468,7 @@ class TestShellFileOpsHelpers:
         assert result.count("'") >= 4  # wrapping + escaping
 
     def test_escape_shell_arg_rewrites_windows_drive_paths_to_msys(self, monkeypatch, file_ops):
-        # bash eats backslashes and MSYS mangles ``C:\...``; the Git Bash
+        # bash eats backslashes and MSYS mangles ``C:\\...``; the Git Bash
         # ``/c/...`` form is the reliable one (reuses _windows_to_msys_path).
         import tools.environments.local as local_mod
 
@@ -476,6 +476,13 @@ class TestShellFileOpsHelpers:
         assert file_ops._escape_shell_arg(r"C:\Users\alice\notes.txt") == "'/c/Users/alice/notes.txt'"
         # Non-drive paths are untouched.
         assert file_ops._escape_shell_arg("/tmp/foo") == "'/tmp/foo'"
+
+    def test_native_windows_cli_keeps_drive_paths_for_rg(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_native_cli_path(r"C:\Users\alice\notes.txt") == "'C:/Users/alice/notes.txt'"
+        assert file_ops._escape_native_cli_path("/c/Users/alice/notes.txt") == "'C:/Users/alice/notes.txt'"
 
     def test_escape_shell_arg_normalizes_mixed_msys_paths(self, monkeypatch, file_ops):
         import tools.environments.local as local_mod

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -975,6 +975,24 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_native_cli_path(self, path: str) -> str:
+        """Quote a path for native Windows executables invoked from Git Bash.
+
+        Shell builtins understand Git-Bash ``/c/...`` paths, but native
+        ``rg.exe`` does not when MSYS argument conversion is disabled. Keep a
+        drive path in ``C:/...`` form for those binaries.
+        """
+        from tools.environments.local import _IS_WINDOWS
+
+        if not _IS_WINDOWS:
+            return self._escape_shell_arg(path)
+
+        native = path.replace("\\", "/")
+        msys = re.match(r"^/([A-Za-z])(?:/(.*))?$", native)
+        if msys:
+            native = f"{msys.group(1).upper()}:/{msys.group(2) or ''}"
+        return "'" + native.replace("'", "'\"'\"'") + "'"
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -2218,7 +2236,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._escape_native_cli_path(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2229,7 +2247,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._escape_native_cli_path(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2283,9 +2301,10 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
+        # Add pattern and path. rg.exe is a native Windows binary and must
+        # receive a drive path rather than Git Bash's /c/... spelling.
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._escape_native_cli_path(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,


### PR DESCRIPTION
## What does this PR do?

Fixes `search_files` with absolute Windows paths when Hermes runs under Git Bash but invokes native `rg.exe`.

Hermes intentionally disables MSYS argv conversion. The existing generic shell escaping then rewrites `C:/Users/...` to `/c/Users/...`, which reaches native ripgrep verbatim and fails with IO error 3. This PR preserves drive-letter paths only at the native-ripgrep boundary while leaving MSYS paths intact for shell builtins and fallback tools.

## Related Issue

Fixes #63177
Fixes #67629

Related: #72047

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_operations.py`: add native-CLI path escaping and use it for all three ripgrep path arguments.
- `tests/tools/test_file_operations.py`: cover native `C:\\...` and MSYS `/c/...` inputs while preserving existing shell escaping.

## How to Test

1. On native Windows with Git Bash and native `rg.exe`, call `search_files` with an absolute `C:/Users/...` path.
2. Confirm ripgrep receives `C:/...`, not `/c/...`, and returns matching files/content.
3. Run:
   `env -u VIRTUAL_ENV uv run --no-project --python 3.12 --with pytest --with pytest-xdist python -m pytest tests/tools/test_file_operations.py -q -n 0 -k 'native_windows_cli_keeps_drive_paths_for_rg or escape_shell_arg_rewrites_windows_drive_paths_to_msys'`

Result: `2 passed`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open and closed PRs and issues for duplicates.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted affected tests were run; full upstream CI remains authoritative).
- [x] I've added tests for my changes.
- [x] I've tested on Windows 10 with native ripgrep and Git Bash.

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior is internal and regression-covered.
- [x] `cli-config.yaml.example` update — N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: non-Windows behavior delegates to the existing escaping path unchanged.
- [x] Tool descriptions/schemas update — N/A; public tool contract is unchanged.

## Screenshots / Logs

Before:

```text
rg: /c/Users/...: IO error for operation on /c/Users/...:
The system cannot find the path specified. (os error 3)
```

After: the same absolute-path `search_files` request returns matches in the running Windows Hermes environment.
