### PR TITLE
fix(desktop): settle orphaned tool calls on completion

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -29,7 +29,13 @@ import { setSessionTodos } from '@/store/todos'
 import type { ClientSessionState } from '../../../types'
 
 import { useGatewayEventHandler } from './gateway-event'
-import { completionErrorText, delegateTaskPayloads, MAX_STREAM_FLUSH_GAP_MS, STREAM_DELTA_FLUSH_MS } from './utils'
+import {
+  completionErrorText,
+  delegateTaskPayloads,
+  MAX_STREAM_FLUSH_GAP_MS,
+  settleOrphanedToolMessages,
+  STREAM_DELTA_FLUSH_MS
+} from './utils'
 
 interface MessageStreamOptions {
   activeGatewayProfile?: string
@@ -504,12 +510,12 @@ export function useMessageStream({
           const settled = { ...message, pending: false, interim: false }
 
           if (completionError && !keepFailedPartialText) {
-            return { ...settled, error: completionError, parts: message.parts.filter(part => part.type !== 'text') }
+            return { ...settled, error: completionError, parts: settled.parts.filter(part => part.type !== 'text') }
           }
 
           return {
             ...settled,
-            parts: replaceTextPart(message.parts),
+            parts: replaceTextPart(settled.parts),
             ...(completionError ? { error: completionError } : {})
           }
         }
@@ -522,7 +528,7 @@ export function useMessageStream({
           ...(completionError && { error: completionError })
         })
 
-        const prev = state.messages
+        const prev = settleOrphanedToolMessages(state.messages)
         let nextMessages = prev
 
         if (streamId && prev.some(m => m.id === streamId)) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
@@ -1,16 +1,68 @@
 import { describe, expect, it } from 'vitest'
 
-import type { GatewayEventPayload } from '@/lib/chat-messages'
+import type { ChatMessage, GatewayEventPayload } from '@/lib/chat-messages'
 
 import {
   completionErrorText,
   delegateTaskPayloads,
   hasSessionInfoStatePatch,
   sessionInfoStatePatch,
+  settleOrphanedToolMessages,
+  settleOrphanedToolParts,
   toTodoPayload
 } from './utils'
 
 const payload = (over: Record<string, unknown>): GatewayEventPayload => over as GatewayEventPayload
+
+describe('settleOrphanedToolParts', () => {
+  it('settles only tool calls that never received a completion event', () => {
+    const pending = { type: 'tool-call', toolCallId: 'pending', toolName: 'patch', args: {} } as const
+    const completed = {
+      type: 'tool-call',
+      toolCallId: 'completed',
+      toolName: 'patch',
+      args: {},
+      result: { success: true }
+    } as const
+
+    const [settledPending, settledCompleted] = settleOrphanedToolParts([pending, completed])
+
+    expect(settledPending).toMatchObject({ isError: true, result: { error: expect.stringContaining('completion') } })
+    expect(settledCompleted).toBe(completed)
+  })
+
+  it('preserves the parts array when every tool already has a terminal result', () => {
+    const parts = [
+      { type: 'tool-call', toolCallId: 'null-result', toolName: 'patch', args: {}, result: null }
+    ] as ChatMessage['parts']
+
+    expect(settleOrphanedToolParts(parts)).toBe(parts)
+  })
+})
+
+describe('settleOrphanedToolMessages', () => {
+  it('settles a tool in a sealed interim bubble even when the final answer uses another bubble', () => {
+    const interim = {
+      id: 'interim',
+      role: 'assistant',
+      interim: true,
+      parts: [{ type: 'tool-call', toolCallId: 'pending', toolName: 'patch', args: {} }]
+    } as ChatMessage
+    const final = { id: 'final', role: 'assistant', parts: [{ type: 'text', text: 'Done' }] } as ChatMessage
+
+    const settled = settleOrphanedToolMessages([interim, final])
+
+    expect(settled[0]).not.toBe(interim)
+    expect(settled[0].parts[0]).toMatchObject({ isError: true })
+    expect(settled[1]).toBe(final)
+  })
+
+  it('preserves transcript identity when there are no orphaned tools', () => {
+    const messages = [{ id: 'final', role: 'assistant', parts: [{ type: 'text', text: 'Done' }] }] as ChatMessage[]
+
+    expect(settleOrphanedToolMessages(messages)).toBe(messages)
+  })
+})
 
 describe('completionErrorText', () => {
   it('flags provider/HTTP/retry failures, ignores normal text', () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -1,4 +1,4 @@
-import type { GatewayEventPayload } from '@/lib/chat-messages'
+import type { ChatMessage, ChatMessagePart, GatewayEventPayload } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 
 import type { ClientSessionState } from '../../../types'
@@ -85,6 +85,49 @@ export function completionErrorText(finalText: string): string | null {
   const text = finalText.trim()
 
   return text && COMPLETION_ERROR_PATTERNS.some(re => re.test(text)) ? text : null
+}
+
+// A terminal message event is authoritative: no tool may remain running after
+// it. If a tool.complete event was dropped during reconnect or shutdown, settle
+// that orphan explicitly instead of leaving the Desktop card spinning forever.
+export function settleOrphanedToolParts(parts: ChatMessagePart[]): ChatMessagePart[] {
+  let changed = false
+  const settled = parts.map(part => {
+    if (part.type !== 'tool-call' || part.result !== undefined) {
+      return part
+    }
+
+    changed = true
+
+    return {
+      ...part,
+      result: { error: 'Tool execution ended before a completion event was received' },
+      isError: true
+    }
+  })
+
+  return changed ? settled : parts
+}
+
+// Tool calls can live in a sealed interim bubble while the final answer lands
+// in a new bubble. Reconcile the whole session transcript at the terminal turn
+// boundary so an orphan cannot survive merely because it is not in the bubble
+// selected to receive the final text. Preserve references on the no-op path.
+export function settleOrphanedToolMessages(messages: ChatMessage[]): ChatMessage[] {
+  let changed = false
+  const settled = messages.map(message => {
+    const parts = settleOrphanedToolParts(message.parts)
+
+    if (parts === message.parts) {
+      return message
+    }
+
+    changed = true
+
+    return { ...message, parts }
+  })
+
+  return changed ? settled : messages
 }
 
 export const SUBAGENT_EVENT_TYPES = new Set([


### PR DESCRIPTION
## What does this PR do?

Prevents Desktop tool cards from remaining in a running state forever after the assistant turn has already received `message.complete`.

If an intermediate `tool.complete` event is dropped during reconnect or shutdown, the renderer currently preserves the result-less tool part indefinitely. This PR reconciles orphaned tool calls across the session transcript at the authoritative terminal boundary: `message.complete`. That includes tools in sealed interim bubbles when the final answer lands in a separate bubble. Completed tool results remain unchanged; only result-less tool calls are settled as explicit interrupted errors.

## Related Issue

Related: #50723, #57237, #70871, #54756

These issues describe adjacent missing-completion and stuck-busy states. This PR addresses the narrower Desktop case where `message.complete` is present but a child `tool.complete` is missing, so it does not claim to close the broader reports.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/utils.ts`: add identity-preserving reconciliation for result-less tool-call parts and transcript messages.
- `apps/desktop/src/app/session/hooks/use-message-stream/index.ts`: reconcile the session transcript at terminal message completion.
- `apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts`: verify orphan settlement across separate interim/final bubbles, completed/null results, and no-op identity preservation.

## How to Test

1. Create an assistant message with one result-less tool-call part and one completed tool-call part.
2. Apply terminal message completion.
3. Verify the orphan becomes an explicit interrupted error and the completed part remains unchanged.
4. Run from `apps/desktop`:
   - `npm test -- --project ui src/app/session/hooks/use-message-stream/utils.test.ts`
   - `npm run typecheck`
   - `git diff --check`

Results: `10 tests passed`; typecheck and diff check passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open and closed PRs and issues for duplicates.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass (this is a Desktop-only TypeScript change; affected Vitest and full Desktop typecheck passed).
- [x] I've added tests for my changes.
- [x] I've tested the packaged fix on Windows 10.

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior is internal and regression-covered.
- [x] `cli-config.yaml.example` update — N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: renderer logic is platform-neutral and only runs at terminal message completion.
- [x] Tool descriptions/schemas update — N/A; no tool contract changed.

## Screenshots / Logs

Before: a completed assistant turn could retain a tool card labelled **Editing** indefinitely.

After: the orphaned card is terminal and displays an explicit completion-event error instead of a spinner.
