### PR TITLE
feat(hindsight): default retain_source to "hermes" for memory attribution

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -20,7 +20,7 @@ Config via environment variables:
   HINDSIGHT_EMBED_PORT_HEALTH_GRACE_TIMEOUT — seconds to wait for a slow embedded daemon /health before treating it as stale (default: 30; set via config.json port_health_grace_timeout)
   HINDSIGHT_RETAIN_TAGS            — comma-separated tags attached to retained memories
   HINDSIGHT_RETAIN_OBSERVATION_SCOPES — observation scoping for retained memories: per_tag/combined/all_combinations, or a JSON list of tag-lists for custom scopes
-  HINDSIGHT_RETAIN_SOURCE          — metadata source value attached to retained memories
+  HINDSIGHT_RETAIN_SOURCE          — metadata source value attached to retained memories (default: hermes)
   HINDSIGHT_RETAIN_USER_PREFIX     — label used before user turns in retained transcripts
   HINDSIGHT_RETAIN_ASSISTANT_PREFIX — label used before assistant turns in retained transcripts
 
@@ -56,6 +56,10 @@ _DEFAULT_LOCAL_URL = "http://localhost:8888"
 _MIN_CLIENT_VERSION = "0.6.1"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
+# Stamped as ``metadata.source`` on every retained memory so Hindsight can
+# attribute memories to Hermes (analytics, provenance). User-overridable via
+# the ``retain_source`` config key or HINDSIGHT_RETAIN_SOURCE.
+_DEFAULT_RETAIN_SOURCE = "hermes"
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
 # `update_mode='append'` semantics on retain (vectorize-io/hindsight#932).
 # Without it, reusing a stable session-scoped document_id silently
@@ -388,7 +392,7 @@ def _load_config() -> dict:
         "idle_timeout": _parse_int_setting(os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT),
         "retain_tags": os.environ.get("HINDSIGHT_RETAIN_TAGS", ""),
         "observation_scopes": os.environ.get("HINDSIGHT_RETAIN_OBSERVATION_SCOPES", ""),
-        "retain_source": os.environ.get("HINDSIGHT_RETAIN_SOURCE", ""),
+        "retain_source": os.environ.get("HINDSIGHT_RETAIN_SOURCE", _DEFAULT_RETAIN_SOURCE),
         "retain_user_prefix": os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User"),
         "retain_assistant_prefix": os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"),
         "banks": {
@@ -653,7 +657,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._memory_mode = "hybrid"  # "context", "tools", or "hybrid"
         self._prefetch_method = "recall"  # "recall" or "reflect"
         self._retain_tags: List[str] = []
-        self._retain_source = ""
+        self._retain_source = _DEFAULT_RETAIN_SOURCE
         self._retain_user_prefix = "User"
         self._retain_assistant_prefix = "Assistant"
         self._platform = ""
@@ -1005,7 +1009,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
             {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
             {"key": "observation_scopes", "description": "How observations are scoped during consolidation: 'combined' (default — one pass over all tags), 'per_tag' (one isolated observation per tag), 'all_combinations' (every tag subset — expensive), or a JSON list of tag-lists for explicit custom scopes. Empty uses Hindsight's 'combined' default.", "default": ""},
-            {"key": "retain_source", "description": "Metadata source value attached to retained memories", "default": ""},
+            {"key": "retain_source", "description": "Metadata source value attached to retained memories (identifies the client that stored them)", "default": _DEFAULT_RETAIN_SOURCE},
             {"key": "retain_user_prefix", "description": "Label used before user turns in retained transcripts", "default": "User"},
             {"key": "retain_assistant_prefix", "description": "Label used before assistant turns in retained transcripts", "default": "Assistant"},
             {"key": "recall_tags", "description": "Tags to filter when searching memories (comma-separated)", "default": ""},
@@ -1336,7 +1340,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_tags = self._config.get("recall_tags") or None
         self._recall_tags_match = self._config.get("recall_tags_match", "any")
         self._retain_source = str(
-            self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
+            self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", _DEFAULT_RETAIN_SOURCE)
         ).strip()
         self._retain_user_prefix = str(
             self._config.get("retain_user_prefix") or os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -383,6 +383,20 @@ class TestConfig:
         assert p._recall_max_input_chars == 500
         assert p._bank_mission == "Test agent mission"
 
+    def test_retain_source_defaults_to_hermes(self, provider):
+        # No retain_source configured -> defaults to "hermes" so Hindsight can
+        # attribute the memory to Hermes via metadata.source.
+        assert provider._retain_source == "hermes"
+
+    def test_retain_source_default_lands_in_metadata(self, provider):
+        meta = provider._build_metadata(message_count=2, turn_index=1)
+        assert meta["source"] == "hermes"
+
+    def test_retain_source_user_override_wins(self, provider_with_config):
+        p = provider_with_config(retain_source="cogoport")
+        assert p._retain_source == "cogoport"
+        assert p._build_metadata(message_count=2, turn_index=1)["source"] == "cogoport"
+
     def test_config_from_env_fallback(self, tmp_path, monkeypatch):
         """When no config file exists, falls back to env vars."""
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

The Hindsight provider already stamps `metadata.source` on every retained memory (from the `retain_source` setting), but it defaulted to `""` — so Hermes-originated memories carried **no source**, and Hindsight had no clean, in-band signal that a memory came from Hermes.

This defaults `retain_source` to **`"hermes"`**, so every memory Hermes stores self-identifies via `metadata.source`. Hindsight persists metadata and returns it on every recall, so this enables **provenance and per-client attribution/analytics** with zero server-side changes.

## Change

- New `_DEFAULT_RETAIN_SOURCE = "hermes"` constant, used across the four default sites (config load, `__init__`, `get_config_schema`, `initialize`).
- Doc + schema description updated.

**Fully user-overridable** — precedence is unchanged: a `retain_source` in `~/.hermes/hindsight/config.json` or `HINDSIGHT_RETAIN_SOURCE` still wins (e.g. a deployment can set its own source label). Only the empty/unset case now resolves to `hermes` instead of no source.

`metadata.source` is a documented Hindsight convention (their retain API/SDK docs use `metadata: {"source": "slack"}`), so this just populates it correctly for the Hermes client.

## Tests

`tests/plugins/memory/test_hindsight_provider.py`:
- default (no config) → `_retain_source == "hermes"` and lands in `metadata.source`
- user override (`retain_source="cogoport"`) still wins, in both `_retain_source` and `metadata.source`

```
scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py   # 121 passed
```
(The 2 pre-existing `TestConfig::test_config_from_env_fallback` / `TestAvailability::test_available_with_api_key` failures reproduce on a clean `main` — an env-isolation quirk in the harness — and are unrelated to this change.)