### PR TITLE
fix(codex): use default SDK HTTP transport

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2031,7 +2031,12 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # constructs a fresh one — no stale closed transport can be reused.
     # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
     # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
-    if "http_client" not in client_kwargs:
+    # The ChatGPT Codex edge rejects Hermes' injected httpx transport on some
+    # networks. Let the OpenAI SDK build its default client for this endpoint.
+    is_codex_backend = base_url_host_matches(
+        client_kwargs.get("base_url", ""), "chatgpt.com"
+    )
+    if "http_client" not in client_kwargs and not is_codex_backend:
         keepalive_http = agent._build_keepalive_http_client(
             client_kwargs.get("base_url", ""), verify=httpx_verify,
         )

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -83,7 +83,7 @@ def test_create_openai_client_routes_via_proxy_when_env_set(mock_openai, monkeyp
     agent = _make_agent()
     kwargs = {
         "api_key": "test-key",
-        "base_url": "https://chatgpt.com/backend-api/codex",
+        "base_url": "https://api.openai.com/v1",
     }
     agent._create_openai_client(kwargs, reason="test", shared=False)
 
@@ -118,7 +118,7 @@ def test_create_openai_client_no_proxy_when_env_unset(mock_openai, monkeypatch):
     agent = _make_agent()
     kwargs = {
         "api_key": "test-key",
-        "base_url": "https://chatgpt.com/backend-api/codex",
+        "base_url": "https://api.openai.com/v1",
     }
     agent._create_openai_client(kwargs, reason="test", shared=False)
 
@@ -135,6 +135,26 @@ def test_create_openai_client_no_proxy_when_env_unset(mock_openai, monkeypatch):
         "pools were %r" % (pool_types,)
     )
     http_client.close()
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_uses_sdk_transport_for_codex(mock_openai, monkeypatch):
+    """The ChatGPT Codex edge rejects Hermes' injected httpx transport."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+
+    agent = _make_agent()
+    agent._create_openai_client(
+        {
+            "api_key": "test-key",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+        reason="test",
+        shared=False,
+    )
+
+    assert "http_client" not in mock_openai.call_args.kwargs
 
 
 @patch("run_agent.OpenAI")


### PR DESCRIPTION
## Summary

Use the OpenAI SDK's default HTTP transport for the ChatGPT Codex backend instead of injecting Hermes' custom `httpx.Client`.

## Problem

On Windows, Hermes v0.19.0 with valid ChatGPT OAuth credentials consistently received an immediate Cloudflare challenge:

```text
HTTP 403 — HTML error page (title not found)
```

The same account and network worked in the official Codex client. Authentication, model selection, IPv4/IPv6, and HTTP/2 were ruled out.

PR #58766 removed the old socket-options transport, but the remaining explicitly constructed `httpx.Client` / `HTTPTransport` still triggered the Codex edge challenge on this setup.

## Fix

For `chatgpt.com`, do not inject Hermes' keepalive client. The OpenAI SDK creates its default transport instead. Other providers retain the existing pool-level keepalive behavior.

This restores the narrow Codex bypass proposed in #12953, which was closed after #58766 was expected to remove the full failure class.

## Validation

Live A/B test on Windows:

- Before: every native `openai-codex` request returned Cloudflare HTML 403.
- After: the same OAuth credentials, model, network, and prompt returned a normal response.
- Switching back to the injected transport reproduced the 403.

Targeted tests:

```text
15 passed in 11.83s
```

Tests cover proxy routing, `NO_PROXY`, client lifecycle/reuse, kwargs isolation, and the new Codex default-transport regression.

Related: #12952, #12953, #58766
