### PR TITLE
feat(plugins): coordinate managed product updates

### DIFF
--- a/hermes_cli/managed_plugin_update.py
+++ b/hermes_cli/managed_plugin_update.py
@@ -8,10 +8,13 @@ import json
 import os
 import re
 import secrets
+import shutil
 import socket
 import struct
 import subprocess
 import sys
+import tarfile
+import tempfile
 import threading
 import time
 from contextlib import contextmanager
@@ -30,6 +33,14 @@ class ManagedPluginUpdateError(RuntimeError):
 class ManagedUpdateSpec:
     contract: str
     entrypoint: str
+
+
+@dataclass(frozen=True)
+class ManagedUpdateCandidate:
+    source_commit: str
+    prior_commit: str
+    staged_root: Path
+    spec: ManagedUpdateSpec
 
 
 def get_managed_update_spec(
@@ -117,9 +128,24 @@ def run_managed_update(
     plugin_name: str,
     plugin_root: Path,
     spec: ManagedUpdateSpec,
+    *,
+    implementation_root: Path | None = None,
+    bootstrap: ManagedUpdateCandidate | None = None,
 ) -> dict[str, Any]:
     """Run the plugin-owned product transaction in its declared isolated worker."""
-    entrypoint = (plugin_root / spec.entrypoint).resolve()
+    worker_root = implementation_root or plugin_root
+    entrypoint = (worker_root / spec.entrypoint).resolve()
+    environment = os.environ.copy()
+    if bootstrap is not None:
+        environment[_BOOTSTRAP_ENV] = json.dumps(
+            {
+                "plugin_name": plugin_name,
+                "prior_commit": bootstrap.prior_commit,
+                "candidate_commit": bootstrap.source_commit,
+                "contract": spec.contract,
+            },
+            sort_keys=True,
+        )
     try:
         result = subprocess.run(
             [
@@ -127,9 +153,10 @@ def run_managed_update(
                 "-I",
                 str(entrypoint),
                 str(plugin_root.resolve()),
-                "update",
+                "migrate" if bootstrap is not None else "update",
             ],
             cwd=str(plugin_root),
+            env=environment,
             capture_output=True,
             text=True,
             encoding="utf-8",
@@ -160,6 +187,208 @@ def run_managed_update(
     return payload
 
 
+def _git(
+    plugin_root: Path,
+    args: list[str],
+    *,
+    check: bool = True,
+    timeout: float = 60,
+) -> subprocess.CompletedProcess[str]:
+    git = shutil.which("git")
+    if not git:
+        raise ManagedPluginUpdateError("git is not installed or not in PATH.")
+    try:
+        result = subprocess.run(
+            [git, *args],
+            cwd=str(plugin_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ManagedPluginUpdateError(f"Could not run git: {_redact_error(exc)}") from exc
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise ManagedPluginUpdateError(
+            _redact_error(detail) or f"git exited with status {result.returncode}."
+        )
+    return result
+
+
+def _candidate_spec_from_git(
+    plugin_name: str,
+    plugin_root: Path,
+    source_commit: str,
+) -> ManagedUpdateSpec | None:
+    manifest = _git(
+        plugin_root,
+        ["show", f"{source_commit}:plugin.yaml"],
+        check=False,
+    )
+    if manifest.returncode != 0:
+        return None
+    try:
+        import yaml
+
+        data = yaml.safe_load(manifest.stdout) or {}
+    except Exception as exc:
+        raise ManagedPluginUpdateError(
+            f"Could not read fetched plugin manifest: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ManagedPluginUpdateError("Fetched plugin manifest must be a mapping.")
+    update = data.get("update")
+    if not isinstance(update, dict) or update.get("mode") != "managed":
+        return None
+    if data.get("name") != plugin_name:
+        raise ManagedPluginUpdateError(
+            "Fetched managed plugin identity does not match the installed plugin."
+        )
+    contract = update.get("contract")
+    entrypoint = update.get("entrypoint")
+    if (
+        not isinstance(contract, str)
+        or contract not in _SUPPORTED_CONTRACTS
+        or not isinstance(entrypoint, str)
+        or not entrypoint.strip()
+    ):
+        raise ManagedPluginUpdateError(
+            "Fetched plugin does not declare a supported managed update contract."
+        )
+    candidate = Path(entrypoint)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise ManagedPluginUpdateError(
+            "Fetched managed update entrypoint is not a safe relative path."
+        )
+    tree = _git(
+        plugin_root,
+        ["ls-tree", source_commit, "--", candidate.as_posix()],
+        check=False,
+    )
+    fields = tree.stdout.rstrip("\n").split(maxsplit=3)
+    if (
+        tree.returncode != 0
+        or len(fields) != 4
+        or fields[0] not in {"100644", "100755"}
+        or fields[1] != "blob"
+        or fields[3] != candidate.as_posix()
+    ):
+        raise ManagedPluginUpdateError(
+            "Fetched managed update entrypoint is not a regular Git file."
+        )
+    return ManagedUpdateSpec(contract=contract, entrypoint=entrypoint)
+
+
+def _extract_git_archive(plugin_root: Path, source_commit: str, destination: Path) -> None:
+    archive_path = destination.parent / "candidate.tar"
+    git = shutil.which("git")
+    if not git:
+        raise ManagedPluginUpdateError("git is not installed or not in PATH.")
+    try:
+        with archive_path.open("wb") as archive:
+            result = subprocess.run(
+                [git, "archive", "--format=tar", source_commit],
+                cwd=str(plugin_root),
+                stdout=archive,
+                stderr=subprocess.PIPE,
+                timeout=60,
+                check=False,
+            )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ManagedPluginUpdateError(
+            f"Could not stage fetched plugin source: {_redact_error(exc)}"
+        ) from exc
+    if result.returncode != 0:
+        raise ManagedPluginUpdateError(
+            _redact_error(result.stderr.decode("utf-8", errors="replace"))
+            or "Could not archive fetched plugin source."
+        )
+    destination.mkdir(mode=0o700)
+    with tarfile.open(archive_path, "r:") as bundle:
+        for member in bundle:
+            target = (destination / member.name).resolve()
+            try:
+                target.relative_to(destination.resolve())
+            except ValueError as exc:
+                raise ManagedPluginUpdateError(
+                    "Fetched plugin archive contains an unsafe path."
+                ) from exc
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if member.issym() or member.islnk():
+                # Links are not needed to execute a regular declared entrypoint
+                # and omitting them avoids platform-specific escape semantics.
+                continue
+            if not member.isfile():
+                raise ManagedPluginUpdateError(
+                    "Fetched plugin archive contains a non-regular file."
+                )
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = bundle.extractfile(member)
+            if source is None:
+                raise ManagedPluginUpdateError(
+                    "Fetched plugin archive contains an unreadable file."
+                )
+            with source, target.open("xb") as output:
+                shutil.copyfileobj(source, output)
+
+
+@contextmanager
+def stage_managed_update_candidate(
+    plugin_name: str, plugin_root: Path
+):
+    """Fetch and privately stage an exact FF target when it becomes managed."""
+    prior_commit = _git(plugin_root, ["rev-parse", "HEAD"]).stdout.strip()
+    if re.fullmatch(r"[0-9a-f]{40}", prior_commit) is None:
+        raise ManagedPluginUpdateError("Could not identify installed plugin source.")
+    # Honor the checkout's configured submodule recursion, as legacy
+    # ``git pull --ff-only`` did, while separating inspection from cutover.
+    _git(plugin_root, ["fetch"])
+    candidate_commit = _git(
+        plugin_root, ["rev-parse", "@{upstream}^{commit}"]
+    ).stdout.strip()
+    spec = _candidate_spec_from_git(plugin_name, plugin_root, candidate_commit)
+    if spec is None:
+        yield None, candidate_commit
+        return
+    if _git(
+        plugin_root,
+        ["merge-base", "--is-ancestor", prior_commit, candidate_commit],
+        check=False,
+    ).returncode != 0:
+        raise ManagedPluginUpdateError(
+            "Fetched managed update is not a fast-forward of the installed plugin."
+        )
+    if _git(
+        plugin_root,
+        ["status", "--porcelain", "--untracked-files=all"],
+    ).stdout.strip():
+        raise ManagedPluginUpdateError(
+            "Plugin checkout has local changes; managed Update made no source cutover."
+        )
+    with tempfile.TemporaryDirectory(prefix="hermes-managed-update-") as temporary:
+        staged_root = Path(temporary) / "plugin"
+        _extract_git_archive(plugin_root, candidate_commit, staged_root)
+        staged_spec = get_managed_update_spec(staged_root, strict=True)
+        if staged_spec != spec:
+            raise ManagedPluginUpdateError(
+                "Staged managed plugin declaration changed during validation."
+            )
+        yield (
+            ManagedUpdateCandidate(
+                source_commit=candidate_commit,
+                prior_commit=prior_commit,
+                staged_root=staged_root,
+                spec=spec,
+            ),
+            candidate_commit,
+        )
+
+
 _RUNTIME_DIR = "runtime"
 _DESCRIPTOR_DIR = "managed-plugin-update-hosts"
 _SUPPORTED_CONTRACTS = {"t3code-hermes-v1"}
@@ -167,6 +396,7 @@ _CONNECT_TIMEOUT_SECONDS = 2.0
 _HANDSHAKE_TIMEOUT_SECONDS = 2.0
 _OPERATION_TIMEOUT_SECONDS = 60.0
 _MAX_MESSAGE_BYTES = 1024 * 1024
+_BOOTSTRAP_ENV = "HERMES_INTERNAL_MANAGED_UPDATE_BOOTSTRAP"
 
 
 def _runtime_dir(*, create: bool = False) -> Path:
@@ -358,15 +588,47 @@ def _ipc_call(payload: dict[str, Any]) -> dict[str, Any]:
     return first
 
 
+def _bootstrap_context(name: str) -> dict[str, str] | None:
+    raw = os.environ.get(_BOOTSTRAP_ENV)
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if (
+        not isinstance(value, dict)
+        or value.get("plugin_name") != name
+        or value.get("contract") not in _SUPPORTED_CONTRACTS
+        or re.fullmatch(r"[0-9a-f]{40}", str(value.get("prior_commit", ""))) is None
+        or re.fullmatch(r"[0-9a-f]{40}", str(value.get("candidate_commit", "")))
+        is None
+    ):
+        return None
+    return {
+        "bootstrap_prior_commit": str(value["prior_commit"]),
+        "bootstrap_candidate_commit": str(value["candidate_commit"]),
+        "bootstrap_contract": str(value["contract"]),
+    }
+
+
 class _ManagedUpdateContractV1:
     version = 1
 
-    def __init__(self, plugin_name: str):
+    def __init__(
+        self, plugin_name: str, bootstrap: dict[str, str] | None = None
+    ):
         self._plugin_name = plugin_name
+        self._bootstrap = bootstrap or {}
 
     def _call(self, operation: str, **payload: Any) -> dict[str, Any]:
         return _ipc_call(
-            {"operation": operation, "plugin_name": self._plugin_name, **payload}
+            {
+                "operation": operation,
+                "plugin_name": self._plugin_name,
+                **self._bootstrap,
+                **payload,
+            }
         )
 
     def preflight(self, *, plugin_name: str, plugin_root: Path) -> None:
@@ -413,6 +675,9 @@ def get_managed_update_contract(name: str) -> _ManagedUpdateContractV1 | None:
     """Return the synchronous host contract requested by managed workers."""
     if not isinstance(name, str) or not name or "/" in name or "\\" in name:
         return None
+    bootstrap = _bootstrap_context(name)
+    if bootstrap is not None:
+        return _ManagedUpdateContractV1(name, bootstrap)
     plugin_root = get_process_hermes_home() / "plugins" / name
     try:
         spec = get_managed_update_spec(plugin_root, strict=True)
@@ -421,6 +686,59 @@ def get_managed_update_contract(name: str) -> _ManagedUpdateContractV1 | None:
     if spec is None or spec.contract not in _SUPPORTED_CONTRACTS:
         return None
     return _ManagedUpdateContractV1(name)
+
+
+def begin_managed_update_bootstrap(
+    plugin_name: str,
+    plugin_root: Path,
+    candidate: ManagedUpdateCandidate,
+) -> None:
+    _ipc_call(
+        {
+            "operation": "bootstrap_begin",
+            "plugin_name": plugin_name,
+            "requested_plugin_name": plugin_name,
+            "plugin_root": str(plugin_root.resolve()),
+            "bootstrap_prior_commit": candidate.prior_commit,
+            "bootstrap_candidate_commit": candidate.source_commit,
+            "bootstrap_contract": candidate.spec.contract,
+        }
+    )
+
+
+def abort_managed_update_bootstrap(
+    plugin_name: str,
+    plugin_root: Path,
+    candidate: ManagedUpdateCandidate,
+) -> None:
+    _ipc_call(
+        {
+            "operation": "bootstrap_abort",
+            "plugin_name": plugin_name,
+            "requested_plugin_name": plugin_name,
+            "plugin_root": str(plugin_root.resolve()),
+            "bootstrap_prior_commit": candidate.prior_commit,
+            "bootstrap_candidate_commit": candidate.source_commit,
+            "bootstrap_contract": candidate.spec.contract,
+        }
+    )
+
+
+def finalize_managed_update_bootstrap(
+    plugin_name: str,
+    plugin_root: Path,
+    candidate: ManagedUpdateCandidate,
+) -> None:
+    payload = {
+        "plugin_name": plugin_name,
+        "requested_plugin_name": plugin_name,
+        "plugin_root": str(plugin_root.resolve()),
+        "bootstrap_prior_commit": candidate.prior_commit,
+        "bootstrap_candidate_commit": candidate.source_commit,
+        "bootstrap_contract": candidate.spec.contract,
+    }
+    _ipc_call({**payload, "operation": "bootstrap_prepare_finalize"})
+    _ipc_call({**payload, "operation": "bootstrap_finalize"})
 
 
 def _acquire_owner_lock(path: Path, *, contention_message: str) -> int:
@@ -474,6 +792,14 @@ def plugin_update_lock(plugin_root: Path):
         _release_owner_lock(fd)
 
 
+@dataclass
+class _BootstrapAuthorization:
+    prior_commit: str
+    candidate_commit: str
+    contract: str
+    phase: str = "begun"
+
+
 class ManagedUpdateCoordinator:
     """Authenticated local coordinator owned by the running dashboard host."""
 
@@ -482,9 +808,14 @@ class ManagedUpdateCoordinator:
         *,
         preflight: Callable[[str, Path], None],
         reload_backend: Callable[[str, Path, str, str | None], dict[str, Any]],
+        begin_bootstrap: Callable[[str, Path], None] | None = None,
+        release_bootstrap: Callable[[str, Path], None] | None = None,
     ):
         self._preflight = preflight
         self._reload_backend = reload_backend
+        self._begin_bootstrap = begin_bootstrap or (lambda _name, _root: None)
+        self._release_bootstrap = release_bootstrap or (lambda _name, _root: None)
+        self._bootstraps: dict[str, _BootstrapAuthorization] = {}
         self._operation_lock = threading.Lock()
         self._client_threads: set[threading.Thread] = set()
         self._client_threads_lock = threading.Lock()
@@ -610,23 +941,173 @@ class ManagedUpdateCoordinator:
             raise ManagedPluginUpdateError(
                 "Managed update request does not match the installed plugin root."
             )
-        spec = get_managed_update_spec(expected_root, strict=True)
-        if spec is None or spec.contract not in _SUPPORTED_CONTRACTS:
-            raise ManagedPluginUpdateError(
-                "The installed plugin does not declare a supported managed update."
-            )
         return name, expected_root
+
+    @staticmethod
+    def _requested_bootstrap(
+        request: dict[str, Any],
+    ) -> _BootstrapAuthorization | None:
+        prior = request.get("bootstrap_prior_commit")
+        candidate = request.get("bootstrap_candidate_commit")
+        contract = request.get("bootstrap_contract")
+        if prior is None and candidate is None and contract is None:
+            return None
+        if (
+            not isinstance(prior, str)
+            or re.fullmatch(r"[0-9a-f]{40}", prior) is None
+            or not isinstance(candidate, str)
+            or re.fullmatch(r"[0-9a-f]{40}", candidate) is None
+            or contract not in _SUPPORTED_CONTRACTS
+        ):
+            raise ManagedPluginUpdateError(
+                "Invalid managed update bootstrap identity."
+            )
+        return _BootstrapAuthorization(prior, candidate, str(contract))
+
+    def _validate_bootstrap_candidate(
+        self,
+        name: str,
+        root: Path,
+        authorization: _BootstrapAuthorization,
+    ) -> None:
+        head = _git(root, ["rev-parse", "HEAD"]).stdout.strip()
+        upstream = _git(root, ["rev-parse", "@{upstream}^{commit}"]).stdout.strip()
+        if (
+            head != authorization.prior_commit
+            or upstream != authorization.candidate_commit
+            or _git(
+                root,
+                [
+                    "merge-base",
+                    "--is-ancestor",
+                    authorization.prior_commit,
+                    authorization.candidate_commit,
+                ],
+                check=False,
+            ).returncode
+            != 0
+            or _git(
+                root,
+                ["status", "--porcelain", "--untracked-files=all"],
+            ).stdout.strip()
+        ):
+            raise ManagedPluginUpdateError(
+                "Managed update bootstrap no longer matches a clean fast-forward target."
+            )
+        spec = _candidate_spec_from_git(
+            name, root, authorization.candidate_commit
+        )
+        if spec is None or spec.contract != authorization.contract:
+            raise ManagedPluginUpdateError(
+                "Managed update bootstrap target is not authorized by its manifest."
+            )
+
+    def _matching_bootstrap(
+        self,
+        name: str,
+        request: dict[str, Any],
+    ) -> _BootstrapAuthorization | None:
+        requested = self._requested_bootstrap(request)
+        active = self._bootstraps.get(name)
+        if requested is None or active is None:
+            return None
+        if (
+            requested.prior_commit != active.prior_commit
+            or requested.candidate_commit != active.candidate_commit
+            or requested.contract != active.contract
+        ):
+            raise ManagedPluginUpdateError(
+                "Managed update bootstrap authorization does not match."
+            )
+        return active
 
     def _handle(self, request: dict[str, Any]) -> dict[str, Any]:
         if not self._operation_lock.acquire(timeout=5):
             raise ManagedPluginUpdateError(
                 "Another managed plugin handoff is already in progress."
-            )
+        )
         try:
             name, root = self._validate_request(request)
             operation = request.get("operation")
+            requested_bootstrap = self._requested_bootstrap(request)
+            if operation == "bootstrap_begin":
+                if requested_bootstrap is None:
+                    raise ManagedPluginUpdateError(
+                        "Managed update bootstrap identity is required."
+                    )
+                existing = self._bootstraps.get(name)
+                if existing is not None:
+                    if existing != requested_bootstrap:
+                        raise ManagedPluginUpdateError(
+                            "Another managed update bootstrap is already active."
+                        )
+                    return {"ok": True, "result": {}}
+                if get_managed_update_spec(root, strict=True) is not None:
+                    raise ManagedPluginUpdateError(
+                        "Managed update bootstrap is only valid for a legacy plugin."
+                    )
+                self._validate_bootstrap_candidate(
+                    name, root, requested_bootstrap
+                )
+                self._preflight(name, root)
+                self._begin_bootstrap(name, root)
+                self._bootstraps[name] = requested_bootstrap
+                return {"ok": True, "result": {}}
+
+            active_bootstrap = self._matching_bootstrap(name, request)
+            if operation == "bootstrap_prepare_finalize":
+                if active_bootstrap is None:
+                    return {"ok": True, "result": {}}
+                if active_bootstrap.phase != "completed":
+                    raise ManagedPluginUpdateError(
+                        "Managed update bootstrap has not completed on this host."
+                    )
+                return {"ok": True, "result": {}}
+            if operation == "bootstrap_finalize":
+                if active_bootstrap is None:
+                    return {"ok": True, "result": {}}
+                if active_bootstrap.phase != "completed":
+                    raise ManagedPluginUpdateError(
+                        "Managed update bootstrap has not completed on this host."
+                    )
+                self._release_bootstrap(name, root)
+                self._bootstraps.pop(name, None)
+                return {"ok": True, "result": {}}
+            if operation == "bootstrap_abort":
+                if active_bootstrap is None:
+                    return {"ok": True, "result": {}}
+                if active_bootstrap.phase not in {
+                    "begun",
+                    "preflighted",
+                    "rolled_back",
+                }:
+                    raise ManagedPluginUpdateError(
+                        "Managed update recovery is incomplete; plugin routes remain gated."
+                    )
+                head = _git(root, ["rev-parse", "HEAD"]).stdout.strip()
+                dirty = _git(
+                    root, ["status", "--porcelain", "--untracked-files=all"]
+                ).stdout.strip()
+                if head != active_bootstrap.prior_commit or dirty:
+                    raise ManagedPluginUpdateError(
+                        "Managed update bootstrap could not safely restore the prior source."
+                    )
+                self._release_bootstrap(name, root)
+                self._bootstraps.pop(name, None)
+                return {"ok": True, "result": {}}
+
+            spec = get_managed_update_spec(root, strict=True)
+            supported_installed = (
+                spec is not None and spec.contract in _SUPPORTED_CONTRACTS
+            )
+            if not supported_installed and active_bootstrap is None:
+                raise ManagedPluginUpdateError(
+                    "The installed plugin does not declare a supported managed update."
+                )
             if operation == "preflight":
                 self._preflight(name, root)
+                if active_bootstrap is not None:
+                    active_bootstrap.phase = "preflighted"
                 return {"ok": True, "result": {}}
             if operation not in {"complete", "rollback"}:
                 raise ManagedPluginUpdateError("Invalid managed update operation.")
@@ -647,6 +1128,53 @@ class ManagedUpdateCoordinator:
                 raise ManagedPluginUpdateError(
                     "Invalid managed update target identity."
                 )
+            if active_bootstrap is not None:
+                if (
+                    operation == "rollback"
+                    and source_commit != active_bootstrap.prior_commit
+                ):
+                    raise ManagedPluginUpdateError(
+                        "Managed update bootstrap requested an unauthorized "
+                        "rollback source commit."
+                    )
+                if operation == "complete":
+                    within_validated_history = (
+                        _git(
+                            root,
+                            [
+                                "merge-base",
+                                "--is-ancestor",
+                                active_bootstrap.prior_commit,
+                                source_commit,
+                            ],
+                            check=False,
+                        ).returncode
+                        == 0
+                        and _git(
+                            root,
+                            [
+                                "merge-base",
+                                "--is-ancestor",
+                                source_commit,
+                                active_bootstrap.candidate_commit,
+                            ],
+                            check=False,
+                        ).returncode
+                        == 0
+                    )
+                    target_spec = _candidate_spec_from_git(
+                        name, root, source_commit
+                    )
+                    if (
+                        not within_validated_history
+                        or target_spec is None
+                        or target_spec.contract != active_bootstrap.contract
+                    ):
+                        raise ManagedPluginUpdateError(
+                            "Managed update bootstrap target is outside the "
+                            "validated managed fast-forward history."
+                        )
+                active_bootstrap.phase = "reloading"
             result = self._reload_backend(
                 name, root, source_commit, product_version
             )
@@ -657,6 +1185,10 @@ class ManagedUpdateCoordinator:
             ):
                 raise ManagedPluginUpdateError(
                     "The dashboard host could not attest the requested loaded product."
+                )
+            if active_bootstrap is not None:
+                active_bootstrap.phase = (
+                    "completed" if operation == "complete" else "rolled_back"
                 )
             return {"ok": True, "result": result}
         finally:
@@ -673,6 +1205,14 @@ class ManagedUpdateCoordinator:
             client_threads = list(self._client_threads)
         for thread in client_threads:
             thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        for name in tuple(self._bootstraps):
+            try:
+                self._release_bootstrap(
+                    name, (get_process_hermes_home() / "plugins" / name).resolve()
+                )
+            except Exception:
+                pass
+        self._bootstraps.clear()
         try:
             self._descriptor_path.unlink()
         except OSError:

--- a/hermes_cli/managed_plugin_update.py
+++ b/hermes_cli/managed_plugin_update.py
@@ -1,0 +1,685 @@
+"""Managed plugin update handoff between isolated workers and the dashboard host."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import socket
+import struct
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from hermes_constants import get_process_hermes_home
+
+
+class ManagedPluginUpdateError(RuntimeError):
+    """A managed update cannot be coordinated safely."""
+
+
+@dataclass(frozen=True)
+class ManagedUpdateSpec:
+    contract: str
+    entrypoint: str
+
+
+def get_managed_update_spec(
+    plugin_root: Path, *, strict: bool = False
+) -> ManagedUpdateSpec | None:
+    """Return a validated managed-update declaration, or ``None`` if unmanaged."""
+    manifest_path = plugin_root / "plugin.yaml"
+    if not manifest_path.is_file():
+        return None
+    try:
+        import yaml
+
+        raw_manifest = manifest_path.read_text(encoding="utf-8")
+        if not isinstance(raw_manifest, str):
+            return None
+        manifest = yaml.safe_load(raw_manifest) or {}
+    except Exception as exc:
+        if not strict:
+            return None
+        raise ManagedPluginUpdateError(
+            f"Could not read managed plugin manifest: {exc}"
+        ) from exc
+    if not isinstance(manifest, dict):
+        if strict:
+            raise ManagedPluginUpdateError("Managed plugin manifest must be a mapping.")
+        return None
+
+    update = manifest.get("update")
+    if not isinstance(update, dict) or update.get("mode") != "managed":
+        return None
+    contract = update.get("contract")
+    entrypoint = update.get("entrypoint")
+    if not isinstance(contract, str) or not contract.strip():
+        raise ManagedPluginUpdateError(
+            "Managed plugin manifest requires update.contract."
+        )
+    if not isinstance(entrypoint, str) or not entrypoint.strip():
+        raise ManagedPluginUpdateError(
+            "Managed plugin manifest requires update.entrypoint."
+        )
+
+    candidate = Path(entrypoint)
+    if candidate.is_absolute():
+        raise ManagedPluginUpdateError(
+            "Managed plugin update.entrypoint must be relative to the plugin root."
+        )
+    try:
+        resolved = (plugin_root / candidate).resolve()
+        resolved.relative_to(plugin_root.resolve())
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ManagedPluginUpdateError(
+            "Managed plugin update.entrypoint escapes the plugin root."
+        ) from exc
+    if not resolved.is_file():
+        raise ManagedPluginUpdateError(
+            f"Managed plugin update entrypoint was not found: {entrypoint}"
+        )
+    return ManagedUpdateSpec(contract=contract.strip(), entrypoint=entrypoint)
+
+
+def _redact_error(value: object) -> str:
+    message = str(value)
+    message = re.sub(r"(https?://)[^/\s@]+@", r"\1[REDACTED]@", message)
+    message = re.sub(
+        r"(https?://[^\s?]+)\?[^\s]+", r"\1?[REDACTED]", message
+    )
+    message = re.sub(
+        r"\b(?:gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+)\b",
+        "[REDACTED]",
+        message,
+    )
+    message = re.sub(
+        r"(?i)\b(Bearer\s+)[^\s,;]+", r"\1[REDACTED]", message
+    )
+    message = re.sub(
+        r"(?i)\b(access[_-]?token|pairing[_-]?token|token|password|secret)"
+        r"\s*[=:]\s*([^\s,;]+)",
+        r"\1=[REDACTED]",
+        message,
+    )
+    return message
+
+
+def run_managed_update(
+    plugin_name: str,
+    plugin_root: Path,
+    spec: ManagedUpdateSpec,
+) -> dict[str, Any]:
+    """Run the plugin-owned product transaction in its declared isolated worker."""
+    entrypoint = (plugin_root / spec.entrypoint).resolve()
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                str(entrypoint),
+                str(plugin_root.resolve()),
+                "update",
+            ],
+            cwd=str(plugin_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=360,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ManagedPluginUpdateError(
+            f"Could not start managed Update for '{plugin_name}': {_redact_error(exc)}"
+        ) from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise ManagedPluginUpdateError(
+            _redact_error(detail)
+            or f"Managed Update for '{plugin_name}' exited with status {result.returncode}."
+        )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ManagedPluginUpdateError(
+            f"Managed Update for '{plugin_name}' returned invalid JSON."
+        ) from exc
+    if not isinstance(payload, dict) or payload.get("ok") is not True:
+        raise ManagedPluginUpdateError(
+            f"Managed Update for '{plugin_name}' did not report coherent success."
+        )
+    return payload
+
+
+_RUNTIME_DIR = "runtime"
+_DESCRIPTOR_DIR = "managed-plugin-update-hosts"
+_SUPPORTED_CONTRACTS = {"t3code-hermes-v1"}
+_CONNECT_TIMEOUT_SECONDS = 2.0
+_HANDSHAKE_TIMEOUT_SECONDS = 2.0
+_OPERATION_TIMEOUT_SECONDS = 60.0
+_MAX_MESSAGE_BYTES = 1024 * 1024
+
+
+def _runtime_dir(*, create: bool = False) -> Path:
+    path = get_process_hermes_home() / _RUNTIME_DIR
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _descriptor_dir(*, create: bool = False) -> Path:
+    path = _runtime_dir(create=create) / _DESCRIPTOR_DIR
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_private_json(path: Path, value: dict[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(4)}")
+    fd = os.open(temporary, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, path)
+        if os.name != "nt":
+            os.chmod(path, 0o600)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _read_descriptor(path: Path) -> dict[str, Any]:
+    try:
+        if path.stat().st_size > 4096:
+            raise ValueError("descriptor is too large")
+        if os.name != "nt":
+            stat_result = path.stat()
+            if stat_result.st_uid != os.geteuid() or stat_result.st_mode & 0o077:
+                raise PermissionError("descriptor permissions are not private")
+        value = json.loads(path.read_text(encoding="utf-8"))
+        address = value["address"]
+        authkey = bytes.fromhex(value["authkey"])
+        if (
+            not isinstance(address, list)
+            or len(address) != 2
+            or address[0] != "127.0.0.1"
+            or type(address[1]) is not int
+            or not (1 <= address[1] <= 65535)
+            or len(authkey) != 32
+            or type(value.get("pid")) is not int
+        ):
+            raise ValueError("invalid descriptor")
+        return {
+            "address": (address[0], address[1]),
+            "authkey": authkey,
+            "pid": value["pid"],
+        }
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise ManagedPluginUpdateError(
+            "A Hermes managed-update host descriptor is invalid or unreadable."
+        ) from exc
+
+
+def _process_is_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _recv_exact(connection: socket.socket, size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = connection.recv(remaining)
+        if not chunk:
+            raise EOFError("managed update connection closed early")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _send_frame(connection: socket.socket, payload: bytes) -> None:
+    if len(payload) > _MAX_MESSAGE_BYTES:
+        raise ValueError("managed update message is too large")
+    connection.sendall(struct.pack("!I", len(payload)) + payload)
+
+
+def _recv_frame(connection: socket.socket) -> bytes:
+    size = struct.unpack("!I", _recv_exact(connection, 4))[0]
+    if size > _MAX_MESSAGE_BYTES:
+        raise ValueError("managed update message is too large")
+    return _recv_exact(connection, size)
+
+
+def _ipc_call_one(
+    descriptor: dict[str, Any], payload: dict[str, Any]
+) -> dict[str, Any]:
+    authkey = descriptor["authkey"]
+    nonce = secrets.token_bytes(32)
+    request = json.dumps(
+        payload, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    signature = hmac.digest(authkey, b"request" + nonce + request, "sha256")
+    try:
+        with socket.create_connection(
+            descriptor["address"], timeout=_CONNECT_TIMEOUT_SECONDS
+        ) as connection:
+            connection.settimeout(_OPERATION_TIMEOUT_SECONDS)
+            _send_frame(connection, nonce + signature + request)
+            response_frame = _recv_frame(connection)
+    except (OSError, EOFError, ValueError) as exc:
+        raise ManagedPluginUpdateError(
+            "A live Hermes managed-update host did not respond before the deadline."
+        ) from exc
+    if len(response_frame) < 32:
+        raise ManagedPluginUpdateError(
+            "The Hermes managed-update host returned an invalid response."
+        )
+    response_signature, response_bytes = response_frame[:32], response_frame[32:]
+    expected = hmac.digest(
+        authkey, b"response" + nonce + response_bytes, "sha256"
+    )
+    if not hmac.compare_digest(response_signature, expected):
+        raise ManagedPluginUpdateError(
+            "The Hermes managed-update host response was not authenticated."
+        )
+    try:
+        response = json.loads(response_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManagedPluginUpdateError(
+            "The Hermes managed-update host returned invalid JSON."
+        ) from exc
+    if not isinstance(response, dict) or response.get("ok") is not True:
+        detail = response.get("error") if isinstance(response, dict) else None
+        raise ManagedPluginUpdateError(
+            str(detail or "The Hermes host rejected the managed update handoff.")
+        )
+    result = response.get("result")
+    return result if isinstance(result, dict) else {}
+
+
+def _ipc_call(payload: dict[str, Any]) -> dict[str, Any]:
+    directory = _descriptor_dir()
+    try:
+        paths = sorted(directory.glob("*.json"))
+    except OSError:
+        paths = []
+    live_descriptors: list[dict[str, Any]] = []
+    for path in paths:
+        try:
+            descriptor = _read_descriptor(path)
+        except ManagedPluginUpdateError:
+            continue
+        if _process_is_running(descriptor["pid"]):
+            live_descriptors.append(descriptor)
+    if not live_descriptors:
+        raise ManagedPluginUpdateError(
+            "The Hermes managed-update coordinator is unavailable. Start the "
+            "dashboard or desktop backend with this Hermes profile and retry; "
+            "no plugin or product files were changed."
+        )
+
+    results: list[dict[str, Any]] = []
+    for descriptor in live_descriptors:
+        try:
+            results.append(_ipc_call_one(descriptor, payload))
+        except ManagedPluginUpdateError:
+            if _process_is_running(descriptor["pid"]):
+                raise
+    if not results:
+        raise ManagedPluginUpdateError(
+            "The Hermes managed-update coordinator is unavailable. Start or "
+            "restart the dashboard or desktop backend with this Hermes profile "
+            "and retry; no source-only update was attempted."
+        )
+    first = results[0]
+    if any(result != first for result in results[1:]):
+        raise ManagedPluginUpdateError(
+            "Hermes dashboard hosts returned inconsistent managed-update attestations."
+        )
+    return first
+
+
+class _ManagedUpdateContractV1:
+    version = 1
+
+    def __init__(self, plugin_name: str):
+        self._plugin_name = plugin_name
+
+    def _call(self, operation: str, **payload: Any) -> dict[str, Any]:
+        return _ipc_call(
+            {"operation": operation, "plugin_name": self._plugin_name, **payload}
+        )
+
+    def preflight(self, *, plugin_name: str, plugin_root: Path) -> None:
+        self._call(
+            "preflight",
+            requested_plugin_name=plugin_name,
+            plugin_root=str(plugin_root.resolve()),
+        )
+
+    def complete(
+        self,
+        *,
+        plugin_name: str,
+        plugin_root: Path,
+        source_commit: str,
+        product_version: str,
+    ) -> dict[str, Any]:
+        return self._call(
+            "complete",
+            requested_plugin_name=plugin_name,
+            plugin_root=str(plugin_root.resolve()),
+            source_commit=source_commit,
+            product_version=product_version,
+        )
+
+    def rollback(
+        self,
+        *,
+        plugin_name: str,
+        plugin_root: Path,
+        source_commit: str,
+        product_version: str | None,
+    ) -> dict[str, Any]:
+        return self._call(
+            "rollback",
+            requested_plugin_name=plugin_name,
+            plugin_root=str(plugin_root.resolve()),
+            source_commit=source_commit,
+            product_version=product_version,
+        )
+
+
+def get_managed_update_contract(name: str) -> _ManagedUpdateContractV1 | None:
+    """Return the synchronous host contract requested by managed workers."""
+    if not isinstance(name, str) or not name or "/" in name or "\\" in name:
+        return None
+    plugin_root = get_process_hermes_home() / "plugins" / name
+    try:
+        spec = get_managed_update_spec(plugin_root, strict=True)
+    except ManagedPluginUpdateError:
+        return None
+    if spec is None or spec.contract not in _SUPPORTED_CONTRACTS:
+        return None
+    return _ManagedUpdateContractV1(name)
+
+
+def _acquire_owner_lock(path: Path, *, contention_message: str) -> int:
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (ImportError, OSError) as exc:
+        os.close(fd)
+        raise ManagedPluginUpdateError(contention_message) from exc
+    return fd
+
+
+def _release_owner_lock(fd: int) -> None:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    except (ImportError, OSError):
+        pass
+    finally:
+        os.close(fd)
+
+
+@contextmanager
+def plugin_update_lock(plugin_root: Path):
+    """Serialize CLI and dashboard update requests for one installed plugin."""
+    key = hashlib.sha256(str(plugin_root.resolve()).encode("utf-8")).hexdigest()[:16]
+    fd = _acquire_owner_lock(
+        _runtime_dir(create=True) / f"plugin-update-{key}.lock",
+        contention_message="Another update for this plugin is already in progress.",
+    )
+    try:
+        yield
+    finally:
+        _release_owner_lock(fd)
+
+
+class ManagedUpdateCoordinator:
+    """Authenticated local coordinator owned by the running dashboard host."""
+
+    def __init__(
+        self,
+        *,
+        preflight: Callable[[str, Path], None],
+        reload_backend: Callable[[str, Path, str, str | None], dict[str, Any]],
+    ):
+        self._preflight = preflight
+        self._reload_backend = reload_backend
+        self._operation_lock = threading.Lock()
+        self._client_threads: set[threading.Thread] = set()
+        self._client_threads_lock = threading.Lock()
+        self._stopped = threading.Event()
+        self._authkey = secrets.token_bytes(32)
+        self._instance = secrets.token_hex(16)
+        self._descriptor_path = (
+            _descriptor_dir(create=True) / f"{self._instance}.json"
+        )
+        try:
+            self._listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self._listener.bind(("127.0.0.1", 0))
+            self._listener.listen()
+            self._listener.settimeout(0.5)
+            host, port = self._listener.getsockname()
+            self._address = (host, port)
+            _write_private_json(
+                self._descriptor_path,
+                {
+                    "address": [host, port],
+                    "authkey": self._authkey.hex(),
+                    "instance": self._instance,
+                    "pid": os.getpid(),
+                    "version": 1,
+                },
+            )
+        except Exception:
+            try:
+                self._listener.close()
+            except (AttributeError, OSError):
+                pass
+            raise
+        self._thread = threading.Thread(
+            target=self._serve,
+            name="managed-plugin-update-coordinator",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _serve(self) -> None:
+        while not self._stopped.is_set():
+            try:
+                connection, _address = self._listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            thread = threading.Thread(
+                target=self._serve_connection,
+                args=(connection,),
+                name="managed-plugin-update-client",
+                daemon=True,
+            )
+            with self._client_threads_lock:
+                self._client_threads.add(thread)
+            thread.start()
+
+    def _serve_connection(self, connection: socket.socket) -> None:
+        try:
+            with connection:
+                connection.settimeout(_HANDSHAKE_TIMEOUT_SECONDS)
+                try:
+                    frame = _recv_frame(connection)
+                    if len(frame) < 64:
+                        raise ValueError("managed update request is too short")
+                    nonce = frame[:32]
+                    signature = frame[32:64]
+                    request_bytes = frame[64:]
+                    expected = hmac.digest(
+                        self._authkey,
+                        b"request" + nonce + request_bytes,
+                        "sha256",
+                    )
+                    if not hmac.compare_digest(signature, expected):
+                        raise PermissionError(
+                            "managed update request was not authenticated"
+                        )
+                except (OSError, EOFError, ValueError, PermissionError):
+                    return
+                try:
+                    request = json.loads(request_bytes.decode("utf-8"))
+                    response = self._handle(request)
+                except Exception as exc:
+                    response = {"ok": False, "error": _redact_error(exc)}
+                try:
+                    response_bytes = json.dumps(
+                        response, sort_keys=True, separators=(",", ":")
+                    ).encode("utf-8")
+                    response_signature = hmac.digest(
+                        self._authkey,
+                        b"response" + nonce + response_bytes,
+                        "sha256",
+                    )
+                    _send_frame(
+                        connection, response_signature + response_bytes
+                    )
+                except (OSError, ValueError):
+                    pass
+        finally:
+            with self._client_threads_lock:
+                self._client_threads.discard(threading.current_thread())
+
+    def _validate_request(self, request: dict[str, Any]) -> tuple[str, Path]:
+        if not isinstance(request, dict):
+            raise ManagedPluginUpdateError("Invalid managed update request.")
+        name = request.get("plugin_name")
+        requested_name = request.get("requested_plugin_name")
+        if (
+            not isinstance(name, str)
+            or name != requested_name
+            or not name
+            or "/" in name
+            or "\\" in name
+        ):
+            raise ManagedPluginUpdateError("Invalid managed plugin identity.")
+        expected_root = (get_process_hermes_home() / "plugins" / name).resolve()
+        try:
+            requested_root = Path(str(request["plugin_root"])).resolve()
+        except (KeyError, OSError, RuntimeError) as exc:
+            raise ManagedPluginUpdateError("Invalid managed plugin root.") from exc
+        if requested_root != expected_root:
+            raise ManagedPluginUpdateError(
+                "Managed update request does not match the installed plugin root."
+            )
+        spec = get_managed_update_spec(expected_root, strict=True)
+        if spec is None or spec.contract not in _SUPPORTED_CONTRACTS:
+            raise ManagedPluginUpdateError(
+                "The installed plugin does not declare a supported managed update."
+            )
+        return name, expected_root
+
+    def _handle(self, request: dict[str, Any]) -> dict[str, Any]:
+        if not self._operation_lock.acquire(timeout=5):
+            raise ManagedPluginUpdateError(
+                "Another managed plugin handoff is already in progress."
+            )
+        try:
+            name, root = self._validate_request(request)
+            operation = request.get("operation")
+            if operation == "preflight":
+                self._preflight(name, root)
+                return {"ok": True, "result": {}}
+            if operation not in {"complete", "rollback"}:
+                raise ManagedPluginUpdateError("Invalid managed update operation.")
+            source_commit = request.get("source_commit")
+            product_version = request.get("product_version")
+            if (
+                not isinstance(source_commit, str)
+                or re.fullmatch(r"[0-9a-f]{40}", source_commit) is None
+                or (
+                    product_version is not None
+                    and (
+                        not isinstance(product_version, str)
+                        or not product_version.strip()
+                    )
+                )
+                or (operation == "complete" and product_version is None)
+            ):
+                raise ManagedPluginUpdateError(
+                    "Invalid managed update target identity."
+                )
+            result = self._reload_backend(
+                name, root, source_commit, product_version
+            )
+            if (
+                result.get("reloaded") is not True
+                or result.get("loaded_source_commit") != source_commit
+                or result.get("loaded_product_version") != product_version
+            ):
+                raise ManagedPluginUpdateError(
+                    "The dashboard host could not attest the requested loaded product."
+                )
+            return {"ok": True, "result": result}
+        finally:
+            self._operation_lock.release()
+
+    def close(self) -> None:
+        if self._stopped.is_set():
+            return
+        self._stopped.set()
+        self._listener.close()
+        self._thread.join(timeout=_HANDSHAKE_TIMEOUT_SECONDS + 1)
+        deadline = time.monotonic() + _HANDSHAKE_TIMEOUT_SECONDS + 1
+        with self._client_threads_lock:
+            client_threads = list(self._client_threads)
+        for thread in client_threads:
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        try:
+            self._descriptor_path.unlink()
+        except OSError:
+            pass
+
+    def __enter__(self) -> "ManagedUpdateCoordinator":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -288,6 +288,9 @@ class PluginManifest:
     requires_env: List[Union[str, Dict[str, Any]]] = field(default_factory=list)
     provides_tools: List[str] = field(default_factory=list)
     provides_hooks: List[str] = field(default_factory=list)
+    update_mode: str = ""
+    update_contract: str = ""
+    update_entrypoint: str = ""
     source: str = ""        # "user", "project", or "entrypoint"
     path: Optional[str] = None
     # Plugin kind — see plugins.py module docstring for semantics.
@@ -1651,6 +1654,9 @@ class PluginManager:
                 "Parsed manifest: key=%s name=%s kind=%s source=%s path=%s",
                 key, name, kind, source, plugin_dir,
             )
+            update = data.get("update")
+            if not isinstance(update, dict):
+                update = {}
             return PluginManifest(
                 name=name,
                 version=str(data.get("version", "")),
@@ -1659,6 +1665,9 @@ class PluginManager:
                 requires_env=data.get("requires_env", []),
                 provides_tools=data.get("provides_tools", []),
                 provides_hooks=data.get("provides_hooks", []),
+                update_mode=str(update.get("mode", "")),
+                update_contract=str(update.get("contract", "")),
+                update_entrypoint=str(update.get("entrypoint", "")),
                 source=source,
                 path=str(plugin_dir),
                 kind=kind,
@@ -2008,6 +2017,8 @@ class PluginManager:
                     "version": loaded.manifest.version,
                     "description": loaded.manifest.description,
                     "source": loaded.manifest.source,
+                    "update_mode": loaded.manifest.update_mode,
+                    "update_contract": loaded.manifest.update_contract,
                     "enabled": loaded.enabled,
                     "tools": len(loaded.tools_registered),
                     "hooks": len(loaded.hooks_registered),

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -66,6 +66,10 @@ class PluginOperationError(Exception):
     """Recoverable plugin install/update failure (CLI exits; HTTP maps to 4xx)."""
 
 
+class NoManagedUpdateCandidate(Exception):
+    """The fetched target remains an ordinary unmanaged plugin."""
+
+
 # Minimum manifest version this installer understands.
 # Plugins may declare ``manifest_version: 1`` in plugin.yaml;
 # future breaking changes to the manifest schema bump this.
@@ -1939,13 +1943,22 @@ def _user_installed_plugin_dir(name: str) -> Optional[Path]:
     return target if target.is_dir() else None
 
 
-def _update_user_plugin(name: str, target: Path) -> dict[str, Any]:
+def _update_user_plugin(
+    name: str,
+    target: Path,
+    *,
+    managed_candidate_only: bool = False,
+) -> dict[str, Any]:
     """Shared CLI/dashboard update dispatch with no managed-to-Git fallback."""
     from hermes_cli.managed_plugin_update import (
         ManagedPluginUpdateError,
+        abort_managed_update_bootstrap,
+        begin_managed_update_bootstrap,
+        finalize_managed_update_bootstrap,
         get_managed_update_spec,
         plugin_update_lock,
         run_managed_update,
+        stage_managed_update_candidate,
     )
 
     try:
@@ -1960,7 +1973,44 @@ def _update_user_plugin(name: str, target: Path) -> dict[str, Any]:
                     "update_mode": "managed",
                 }
 
-            ok, output = _git_pull_plugin_dir(target)
+            with stage_managed_update_candidate(name, target) as staged:
+                candidate, fetched_commit = staged
+                if candidate is not None:
+                    try:
+                        begin_managed_update_bootstrap(name, target, candidate)
+                        result = run_managed_update(
+                            name,
+                            target,
+                            candidate.spec,
+                            implementation_root=candidate.staged_root,
+                            bootstrap=candidate,
+                        )
+                    except ManagedPluginUpdateError as exc:
+                        try:
+                            abort_managed_update_bootstrap(
+                                name, target, candidate
+                            )
+                        except ManagedPluginUpdateError as abort_exc:
+                            raise ManagedPluginUpdateError(
+                                f"{exc}; bootstrap recovery: {abort_exc}"
+                            ) from exc
+                        raise
+                    # The product transaction is coherent now. Finalization
+                    # only releases host route gates; it must not trigger a
+                    # product rollback if one host needs a retry.
+                    finalize_managed_update_bootstrap(name, target, candidate)
+                    return {
+                        **result,
+                        "ok": True,
+                        "name": name,
+                        "update_mode": "managed",
+                    }
+
+            if managed_candidate_only:
+                raise NoManagedUpdateCandidate
+            # Advance only to the source we classified as unmanaged.  The
+            # remote may move to a managed commit after inspection.
+            ok, output = _git_pull_plugin_dir(target, fetched_commit)
             if not ok:
                 raise PluginOperationError(output)
             _clear_plugin_bytecode(target)
@@ -2024,13 +2074,18 @@ def _clear_plugin_bytecode(target: Path) -> int:
     return removed
 
 
-def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
+def _git_pull_plugin_dir(
+    target: Path, commit: str | None = None
+) -> tuple[bool, str]:
     git_exe = _resolve_git_executable()
     if not git_exe:
         return False, "git is not installed or not in PATH."
+    command = [git_exe, "pull", "--ff-only"]
+    if commit is not None:
+        command.extend([".", commit])
     try:
         result = subprocess.run(
-            [git_exe, "pull", "--ff-only"],
+            command,
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
             timeout=60,

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -634,7 +634,7 @@ def cmd_install(
 
 
 def cmd_update(name: str) -> None:
-    """Update an installed plugin by pulling latest from its git remote."""
+    """Run the plugin's managed Update or pull an unmanaged Git plugin."""
     from rich.console import Console
 
     console = Console()
@@ -654,28 +654,27 @@ def cmd_update(name: str) -> None:
         sys.exit(1)
 
     console.print(f"[dim]Updating {name}...[/dim]")
-
-    ok, output = _git_pull_plugin_dir(target)
-    if not ok:
-        console.print(f"[red]Error:[/red] {output}")
+    try:
+        result = _update_user_plugin(name, target)
+    except PluginOperationError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
         sys.exit(1)
 
-    # Same stale-bytecode class as the main checkout (#6207/#60242): the
-    # pull just changed .py files under this plugin dir, so drop any
-    # __pycache__ compiled from the previous revision.
-    _clear_plugin_bytecode(target)
-
-    # Copy any new .example files
-    _copy_example_files(target, console)
-
-    out = output.strip()
-    if "Already up to date" in out:
+    if result.get("update_mode") == "managed":
+        version = result.get("version")
+        suffix = f" to product version [bold]{version}[/bold]" if version else ""
+        console.print(
+            f"[green]✓[/green] Plugin [bold]{name}[/bold] and its native "
+            f"runtime updated together{suffix}."
+        )
+    elif result.get("unchanged"):
         console.print(
             f"[green]✓[/green] Plugin [bold]{name}[/bold] is already up to date."
         )
     else:
         console.print(f"[green]✓[/green] Plugin [bold]{name}[/bold] updated.")
-        console.print(f"[dim]{out}[/dim]")
+        if result.get("output"):
+            console.print(f"[dim]{str(result['output']).strip()}[/dim]")
 
 
 def cmd_remove(name: str) -> None:
@@ -1940,8 +1939,48 @@ def _user_installed_plugin_dir(name: str) -> Optional[Path]:
     return target if target.is_dir() else None
 
 
+def _update_user_plugin(name: str, target: Path) -> dict[str, Any]:
+    """Shared CLI/dashboard update dispatch with no managed-to-Git fallback."""
+    from hermes_cli.managed_plugin_update import (
+        ManagedPluginUpdateError,
+        get_managed_update_spec,
+        plugin_update_lock,
+        run_managed_update,
+    )
+
+    try:
+        with plugin_update_lock(target):
+            spec = get_managed_update_spec(target, strict=True)
+            if spec is not None:
+                result = run_managed_update(name, target, spec)
+                return {
+                    **result,
+                    "ok": True,
+                    "name": name,
+                    "update_mode": "managed",
+                }
+
+            ok, output = _git_pull_plugin_dir(target)
+            if not ok:
+                raise PluginOperationError(output)
+            _clear_plugin_bytecode(target)
+
+            from rich.console import Console
+
+            _copy_example_files(target, Console())
+            return {
+                "ok": True,
+                "name": name,
+                "output": output,
+                "unchanged": "Already up to date" in output,
+                "update_mode": "git",
+            }
+    except ManagedPluginUpdateError as exc:
+        raise PluginOperationError(str(exc)) from exc
+
+
 def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
-    """``git pull`` inside ``~/.hermes/plugins/<name>``."""
+    """Run the same managed-or-Git update dispatch as the CLI."""
     target = _user_installed_plugin_dir(name)
     if target is None:
         return {
@@ -1955,19 +1994,10 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
             "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
         }
 
-    ok, msg = _git_pull_plugin_dir(target)
-    if not ok:
-        return {"ok": False, "error": msg}
-
-    # Sibling of the CLI ``hermes plugins update`` path: drop bytecode
-    # compiled from the pre-pull plugin revision.
-    _clear_plugin_bytecode(target)
-
-    from rich.console import Console
-
-    _copy_example_files(target, Console())
-    unchanged = "Already up to date" in msg
-    return {"ok": True, "name": name, "output": msg, "unchanged": unchanged}
+    try:
+        return _update_user_plugin(name, target)
+    except PluginOperationError as exc:
+        return {"ok": False, "error": str(exc)}
 
 
 def _clear_plugin_bytecode(target: Path) -> int:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -282,6 +282,107 @@ def _get_pty_active_session_files(app: "FastAPI") -> dict[str, Path]:
 
 app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
 
+_plugin_api_gate_condition = threading.Condition()
+_plugin_api_gated: set[str] = set()
+_plugin_api_active: Dict[str, int] = {}
+
+
+def _legacy_update_route_has_no_dependencies(
+    request: Request, plugin_name: str
+) -> bool:
+    """Only bridge a legacy update route whose mounted route adds no auth.
+
+    Dashboard authentication still runs outside this middleware.  A plugin
+    route with its own FastAPI dependencies must execute normally; bypassing
+    those dependencies to bootstrap an update would weaken plugin auth.
+    """
+    path = f"/api/plugins/{plugin_name}/update"
+    mounted = _plugin_api_routes.get(plugin_name, ())
+    for included in mounted:
+        original_router = getattr(included, "original_router", None)
+        if original_router is not None:
+            include_context = getattr(included, "include_context", None)
+            prefix = getattr(include_context, "prefix", "")
+            include_dependencies = getattr(
+                include_context, "dependencies", ()
+            )
+            routes = getattr(original_router, "routes", ())
+        else:
+            prefix = ""
+            include_dependencies = ()
+            routes = (included,)
+        for route in routes:
+            route_path = f"{prefix}{getattr(route, 'path', '')}"
+            dependant = getattr(route, "dependant", None)
+            if (
+                route_path == path
+                and "POST" in (getattr(route, "methods", None) or ())
+            ):
+                return not bool(
+                    include_dependencies
+                    or getattr(dependant, "dependencies", ())
+                )
+    return False
+
+
+@app.middleware("http")
+async def _managed_plugin_bootstrap_gate(request: Request, call_next):
+    """Drain and block a legacy plugin prefix during managed bootstrap."""
+    parts = request.url.path.split("/")
+    plugin_name = (
+        parts[3]
+        if len(parts) > 3 and parts[1:3] == ["api", "plugins"]
+        else None
+    )
+    if plugin_name is None:
+        return await call_next(request)
+    if (
+        request.method == "POST"
+        and len(parts) == 5
+        and parts[4] == "update"
+        and _legacy_update_route_has_no_dependencies(request, plugin_name)
+    ):
+        from hermes_cli.plugins_cmd import (
+            NoManagedUpdateCandidate,
+            PluginOperationError,
+            _update_user_plugin,
+            _user_installed_plugin_dir,
+        )
+
+        plugin_root = _user_installed_plugin_dir(plugin_name)
+        if plugin_root is not None and (plugin_root / ".git").is_dir():
+            try:
+                result = await run_in_threadpool(
+                    _update_user_plugin,
+                    plugin_name,
+                    plugin_root,
+                    managed_candidate_only=True,
+                )
+            except NoManagedUpdateCandidate:
+                pass
+            except PluginOperationError as exc:
+                return JSONResponse({"detail": str(exc)}, status_code=400)
+            else:
+                _get_dashboard_plugins(force_rescan=True)
+                return JSONResponse(result)
+    with _plugin_api_gate_condition:
+        if plugin_name in _plugin_api_gated:
+            return JSONResponse(
+                {"detail": "Plugin Update is in progress."}, status_code=503
+            )
+        _plugin_api_active[plugin_name] = _plugin_api_active.get(plugin_name, 0) + 1
+    try:
+        return await call_next(request)
+    finally:
+        with _plugin_api_gate_condition:
+            remaining = _plugin_api_active.get(plugin_name, 1) - 1
+            if remaining:
+                _plugin_api_active[plugin_name] = remaining
+            else:
+                _plugin_api_active.pop(plugin_name, None)
+            _plugin_api_gate_condition.notify_all()
+
+
 # Memory-provider OAuth connect routes live in the memory layer, not here.
 from hermes_cli.memory_oauth import router as _memory_oauth_router  # noqa: E402
 
@@ -19968,17 +20069,29 @@ def _preflight_managed_plugin_reload(name: str, plugin_root: Path) -> None:
         )
 
 
-def _has_mounted_managed_plugin() -> bool:
-    from hermes_cli.managed_plugin_update import get_managed_update_spec
+def _begin_managed_plugin_bootstrap(name: str, _plugin_root: Path) -> None:
+    deadline = time.monotonic() + 55
+    with _plugin_api_gate_condition:
+        _plugin_api_gated.add(name)
+        while _plugin_api_active.get(name, 0):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _plugin_api_gated.discard(name)
+                _plugin_api_gate_condition.notify_all()
+                raise RuntimeError(
+                    f"Timed out draining legacy plugin '{name}' before Update."
+                )
+            _plugin_api_gate_condition.wait(timeout=remaining)
 
-    plugins_root = get_process_hermes_home() / "plugins"
-    for name in _plugin_api_routes:
-        try:
-            if get_managed_update_spec(plugins_root / name) is not None:
-                return True
-        except Exception:
-            continue
-    return False
+
+def _release_managed_plugin_bootstrap(name: str, _plugin_root: Path) -> None:
+    with _plugin_api_gate_condition:
+        _plugin_api_gated.discard(name)
+        _plugin_api_gate_condition.notify_all()
+
+
+def _has_mounted_plugin_backend() -> bool:
+    return bool(_plugin_api_routes)
 
 
 def _managed_product_identity(name: str, plugin_root: Path) -> tuple[str, str | None]:
@@ -20432,13 +20545,15 @@ def start_server(
                 return
 
             managed_update_coordinator = None
-            if _has_mounted_managed_plugin():
+            if _has_mounted_plugin_backend():
                 from hermes_cli.managed_plugin_update import ManagedUpdateCoordinator
 
                 try:
                     managed_update_coordinator = ManagedUpdateCoordinator(
                         preflight=_preflight_managed_plugin_reload,
                         reload_backend=_reload_managed_plugin_backend,
+                        begin_bootstrap=_begin_managed_plugin_bootstrap,
+                        release_bootstrap=_release_managed_plugin_bootstrap,
                     )
                 except Exception:
                     if server.started:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -102,7 +102,7 @@ from utils import env_var_enabled
 
 try:
     from fastapi import (
-        FastAPI, File, Form, HTTPException, Request, UploadFile,
+        APIRouter, FastAPI, File, Form, HTTPException, Request, UploadFile,
         WebSocket, WebSocketDisconnect,
     )
     from fastapi.middleware.cors import CORSMiddleware
@@ -118,7 +118,7 @@ except ImportError:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("tool.dashboard", prompt=False)
         from fastapi import (
-            FastAPI, File, Form, HTTPException, Request, UploadFile,
+            APIRouter, FastAPI, File, Form, HTTPException, Request, UploadFile,
             WebSocket, WebSocketDisconnect,
         )
         from fastapi.middleware.cors import CORSMiddleware
@@ -19524,11 +19524,19 @@ def _merged_plugins_hub() -> Dict[str, Any]:
         can_remove_update = (
             source in {"user", "git"} and under_user_tree and Path(dir_str).is_dir()
         )
+        manifest_data = _read_plugin_manifest_at(dir_path)
+        update_data = manifest_data.get("update")
+        update_mode = (
+            str(update_data.get("mode", ""))
+            if isinstance(update_data, dict)
+            else ""
+        )
+        is_managed_update = update_mode == "managed"
+        is_git_checkout = (Path(dir_str) / ".git").exists()
 
         # Check if this plugin provides tools that require auth
         auth_required = False
         auth_command = ""
-        manifest_data = _read_plugin_manifest_at(dir_path)
         provides_tools = manifest_data.get("provides_tools") or []
         if provides_tools:
             try:
@@ -19552,7 +19560,13 @@ def _merged_plugins_hub() -> Dict[str, Any]:
             "dashboard_manifest": _strip_dashboard_manifest(dm) if dm else None,
             "path": dir_str,
             "can_remove": can_remove_update,
-            "can_update_git": can_remove_update and (Path(dir_str) / ".git").exists(),
+            "can_update": can_remove_update and (
+                is_managed_update or is_git_checkout
+            ),
+            "can_update_git": (
+                can_remove_update and is_git_checkout and not is_managed_update
+            ),
+            "update_mode": update_mode or ("git" if is_git_checkout else ""),
             "auth_required": auth_required,
             "auth_command": auth_command,
             "user_hidden": name in hidden_plugins,
@@ -19656,7 +19670,7 @@ async def post_agent_plugin_update(request: Request, name: str):
     name = _validate_plugin_name(name)
     from hermes_cli.plugins_cmd import dashboard_update_user_plugin
 
-    result = dashboard_update_user_plugin(name)
+    result = await run_in_threadpool(dashboard_update_user_plugin, name)
     if not result.get("ok"):
         raise HTTPException(status_code=400, detail=result.get("error") or "Update failed.")
     _get_dashboard_plugins(force_rescan=True)
@@ -19814,30 +19828,78 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
     )
 
 
-def _mount_plugin_api_routes():
-    """Import and mount backend API routes from plugins that declare them.
+_plugin_api_routes: Dict[str, tuple] = {}
+_plugin_api_modules: Dict[str, Any] = {}
+_plugin_api_mount_lock = threading.RLock()
 
-    Each plugin's ``api`` field points to a Python file that must expose
-    a ``router`` (FastAPI APIRouter).  Routes are mounted under
-    ``/api/plugins/<name>/``.
 
-    Backend import is restricted to ``bundled`` and ``user`` sources.
-    Project plugins (``./.hermes/plugins/``) ship with the CWD and are
-    therefore attacker-controlled in any threat model where the user
-    opens a malicious repo; they can extend the dashboard UI via
-    static JS/CSS but their Python ``api`` file is never auto-imported
-    by the web server.  See GHSA-5qr3-c538-wm9j (#29156).
+def _plugin_api_allowed(
+    plugin: Dict[str, Any],
+    enabled_set: set,
+    disabled_set: set,
+) -> bool:
+    name = str(plugin.get("name", ""))
+    source = plugin.get("source")
+    if source == "project":
+        _log.warning(
+            "Plugin %s: ignoring backend api=%s (project plugins may not "
+            "auto-import Python code; move the plugin to ~/.hermes/plugins/ "
+            "if you trust it)",
+            name,
+            plugin.get("_api_file"),
+        )
+        return False
+    if name in disabled_set:
+        _log.debug("Plugin %s: skipping API mount (explicitly disabled)", name)
+        return False
+    if source == "user" and name not in enabled_set:
+        _log.debug("Plugin %s: skipping API mount (not in plugins.enabled)", name)
+        return False
+    return source in {"user", "bundled"}
 
-    Additionally, user plugins must be explicitly enabled via the
-    ``plugins.enabled`` allow-list in config.yaml before their backend
-    code is imported. Without this gate, an installed-but-not-enabled
-    plugin's Python code would execute at dashboard startup — a code
-    execution vector that bypasses the user's intent. (#46435,
-    GHSA-mcfc-hp25-cjv7)
-    """
-    # Load the enabled/disabled sets once for the loop.
+
+def _load_plugin_api(plugin: Dict[str, Any]) -> tuple[Any, Any, tuple]:
+    """Import one plugin backend and build its prefixed routes off-app."""
+    name = str(plugin["name"])
+    dashboard_dir = Path(plugin["_dir"])
+    api_path = dashboard_dir / str(plugin["_api_file"])
     try:
-        from hermes_cli.plugins_cmd import _get_enabled_set, _get_disabled_set
+        api_path.resolve().relative_to(dashboard_dir.resolve())
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError(
+            f"Plugin {name} API file is outside its dashboard directory."
+        ) from exc
+    if not api_path.is_file():
+        raise RuntimeError(
+            f"Plugin {name} declares api={plugin['_api_file']} but it was not found."
+        )
+
+    module_name = f"hermes_dashboard_plugin_{name}"
+    spec = importlib.util.spec_from_file_location(module_name, api_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load plugin {name} API module.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    router = getattr(module, "router", None)
+    if router is None:
+        sys.modules.pop(module_name, None)
+        raise RuntimeError(f"Plugin {name} API file has no 'router' attribute.")
+
+    staged = APIRouter()
+    staged.include_router(router, prefix=f"/api/plugins/{name}")
+    return module, router, tuple(staged.routes)
+
+
+def _mount_plugin_api_routes():
+    """Import enabled trusted/user plugin backends under isolated prefixes."""
+    try:
+        from hermes_cli.plugins_cmd import _get_disabled_set, _get_enabled_set
+
         enabled_set = _get_enabled_set()
         disabled_set = _get_disabled_set()
     except Exception:
@@ -19845,87 +19907,216 @@ def _mount_plugin_api_routes():
         disabled_set = set()
 
     for plugin in _get_dashboard_plugins():
-        api_file_name = plugin.get("_api_file")
-        if not api_file_name:
-            continue
-        plugin_name = plugin.get("name", "")
-        # Gate: user plugins must be in plugins.enabled and not in
-        # plugins.disabled before we import their Python code.
-        # Bundled plugins are trusted (they ship with the release) but
-        # still respect an explicit disable.
-        if plugin.get("source") == "user":
-            if plugin_name in disabled_set:
-                _log.debug(
-                    "Plugin %s: skipping API mount (explicitly disabled)",
-                    plugin_name,
-                )
-                continue
-            if plugin_name not in enabled_set:
-                _log.debug(
-                    "Plugin %s: skipping API mount (not in plugins.enabled)",
-                    plugin_name,
-                )
-                continue
-        elif plugin.get("source") == "bundled":
-            if plugin_name in disabled_set:
-                _log.debug(
-                    "Plugin %s: skipping API mount (explicitly disabled)",
-                    plugin_name,
-                )
-                continue
-        if plugin.get("source") == "project":
-            _log.warning(
-                "Plugin %s: ignoring backend api=%s (project plugins may "
-                "not auto-import Python code; move the plugin to "
-                "~/.hermes/plugins/ if you trust it)",
-                plugin["name"], api_file_name,
-            )
-            continue
-        dashboard_dir = Path(plugin["_dir"])
-        api_path = dashboard_dir / api_file_name
-        try:
-            resolved_api = api_path.resolve()
-            resolved_base = dashboard_dir.resolve()
-            resolved_api.relative_to(resolved_base)
-        except (OSError, RuntimeError, ValueError):
-            # Discovery already filters this, but re-check here in case
-            # ``_dir`` was tampered with after caching or a future caller
-            # bypasses the validator.  Defence in depth keeps the import
-            # primitive contained even if the upstream check regresses.
-            _log.warning(
-                "Plugin %s: refusing to import api file outside its "
-                "dashboard directory (%s)", plugin["name"], api_path,
-            )
-            continue
-        if not api_path.exists():
-            _log.warning("Plugin %s declares api=%s but file not found", plugin["name"], api_file_name)
+        name = str(plugin.get("name", ""))
+        if not plugin.get("_api_file") or not _plugin_api_allowed(
+            plugin, enabled_set, disabled_set
+        ):
             continue
         try:
-            module_name = f"hermes_dashboard_plugin_{plugin['name']}"
-            spec = importlib.util.spec_from_file_location(module_name, api_path)
-            if spec is None or spec.loader is None:
-                continue
-            mod = importlib.util.module_from_spec(spec)
-            # Register in sys.modules BEFORE exec_module so pydantic/FastAPI
-            # can resolve forward references (e.g. models defined in a file
-            # that uses `from __future__ import annotations`). Without this,
-            # TypeAdapter lazy-build fails at first request with
-            # "is not fully defined" because the module namespace isn't
-            # reachable by name for string-annotation resolution.
-            sys.modules[module_name] = mod
-            try:
-                spec.loader.exec_module(mod)
-            except Exception:
-                sys.modules.pop(module_name, None)
-                raise
-            router = getattr(mod, "router", None)
-            if router is None:
-                _log.warning("Plugin %s api file has no 'router' attribute", plugin["name"])
-                continue
-            app.include_router(router, prefix=f"/api/plugins/{plugin['name']}")
-            _log.info("Mounted plugin API routes: /api/plugins/%s/", plugin["name"])
+            module, router, _staged_routes = _load_plugin_api(plugin)
+            first_route = len(app.router.routes)
+            app.include_router(router, prefix=f"/api/plugins/{name}")
+            routes = tuple(app.router.routes[first_route:])
+            _plugin_api_routes[name] = routes
+            _plugin_api_modules[name] = module
+            _log.info("Mounted plugin API routes: /api/plugins/%s/", name)
         except Exception as exc:
-            _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)
+            _log.warning("Failed to load plugin %s API routes: %s", name, exc)
+
+
+def _module_is_under(module: Any, root: Path) -> bool:
+    candidates: List[Path] = []
+    module_file = getattr(module, "__file__", None)
+    if module_file:
+        candidates.append(Path(module_file))
+    module_path = getattr(module, "__path__", None)
+    if module_path:
+        candidates.extend(Path(value) for value in module_path)
+    for candidate in candidates:
+        try:
+            candidate.resolve().relative_to(root)
+            return True
+        except (OSError, RuntimeError, ValueError):
+            continue
+    return False
+
+
+def _managed_plugin_entry(name: str, plugin_root: Path) -> Dict[str, Any]:
+    from hermes_cli.plugins_cmd import _get_disabled_set, _get_enabled_set
+
+    enabled_set = _get_enabled_set()
+    disabled_set = _get_disabled_set()
+    for plugin in _get_dashboard_plugins(force_rescan=True):
+        if (
+            plugin.get("name") == name
+            and Path(plugin["_dir"]).resolve().parent == plugin_root
+            and plugin.get("_api_file")
+            and _plugin_api_allowed(plugin, enabled_set, disabled_set)
+        ):
+            return plugin
+    raise RuntimeError(
+        f"Managed plugin '{name}' is not enabled with a mounted dashboard backend."
+    )
+
+
+def _preflight_managed_plugin_reload(name: str, plugin_root: Path) -> None:
+    _managed_plugin_entry(name, plugin_root)
+    if name not in _plugin_api_routes:
+        raise RuntimeError(
+            f"Managed plugin '{name}' backend is not mounted. Enable it and "
+            "restart the dashboard before Update."
+        )
+
+
+def _has_mounted_managed_plugin() -> bool:
+    from hermes_cli.managed_plugin_update import get_managed_update_spec
+
+    plugins_root = get_process_hermes_home() / "plugins"
+    for name in _plugin_api_routes:
+        try:
+            if get_managed_update_spec(plugins_root / name) is not None:
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _managed_product_identity(name: str, plugin_root: Path) -> tuple[str, str | None]:
+    git = shutil.which("git")
+    if not git:
+        raise RuntimeError("git is required to attest managed plugin source.")
+    head = subprocess.run(
+        [git, "rev-parse", "HEAD"],
+        cwd=str(plugin_root),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+        check=False,
+    )
+    dirty = subprocess.run(
+        [git, "status", "--porcelain", "--untracked-files=all"],
+        cwd=str(plugin_root),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+        check=False,
+    )
+    source_commit = head.stdout.strip()
+    if (
+        head.returncode != 0
+        or re.fullmatch(r"[0-9a-f]{40}", source_commit) is None
+        or dirty.returncode != 0
+        or dirty.stdout.strip()
+    ):
+        raise RuntimeError(
+            "Managed plugin checkout is not a clean, attestable Git commit."
+        )
+
+    state_path = get_process_hermes_home() / name / "service-state.json"
+    if not state_path.is_file():
+        return source_commit, None
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Managed product state is not valid JSON.") from exc
+    if not isinstance(state, dict):
+        raise RuntimeError("Managed product state is invalid.")
+    desired_state = state.get("desired_state")
+    if desired_state == "uninstalled":
+        if (
+            state.get("product_source_commit") is not None
+            or state.get("product_version") is not None
+        ):
+            raise RuntimeError(
+                "Uninstalled managed product state contains a stale product identity."
+            )
+        return source_commit, None
+    if desired_state != "installed":
+        raise RuntimeError("Managed product desired state is invalid.")
+    state_commit = state.get("product_source_commit")
+    product_version = state.get("product_version")
+    if state_commit != source_commit or not isinstance(product_version, str):
+        raise RuntimeError(
+            "Managed product state does not match the checked-out source."
+        )
+    return source_commit, product_version
+
+
+def _reload_managed_plugin_backend(
+    name: str,
+    plugin_root: Path,
+    source_commit: str,
+    product_version: str | None,
+) -> Dict[str, Any]:
+    """Load fresh code, atomically replace routes, and attest host-derived state."""
+    plugin = _managed_plugin_entry(name, plugin_root)
+    importlib.invalidate_caches()
+    for cache_dir in plugin_root.rglob("__pycache__"):
+        if cache_dir.is_dir():
+            shutil.rmtree(cache_dir, ignore_errors=True)
+
+    before = _managed_product_identity(name, plugin_root)
+    if before != (source_commit, product_version):
+        raise RuntimeError(
+            "Managed product state does not match the requested reload target."
+        )
+
+    previous_modules = {
+        module_name: module
+        for module_name, module in tuple(sys.modules.items())
+        if module is not None and _module_is_under(module, plugin_root)
+    }
+    for module_name in previous_modules:
+        sys.modules.pop(module_name, None)
+
+    try:
+        module, _router, new_routes = _load_plugin_api(plugin)
+        for cache_dir in plugin_root.rglob("__pycache__"):
+            if cache_dir.is_dir():
+                shutil.rmtree(cache_dir, ignore_errors=True)
+        after = _managed_product_identity(name, plugin_root)
+        if after != (source_commit, product_version):
+            raise RuntimeError(
+                "Managed product changed while its backend was being loaded."
+            )
+    except Exception:
+        for module_name, candidate in tuple(sys.modules.items()):
+            if candidate is not None and _module_is_under(candidate, plugin_root):
+                sys.modules.pop(module_name, None)
+        sys.modules.update(previous_modules)
+        raise
+
+    with _plugin_api_mount_lock:
+        old_route_ids = {id(route) for route in _plugin_api_routes.get(name, ())}
+        current_routes = app.router.routes
+        insertion_index = next(
+            (
+                index
+                for index, route in enumerate(current_routes)
+                if id(route) in old_route_ids
+            ),
+            len(current_routes),
+        )
+        retained_routes = [
+            route for route in current_routes if id(route) not in old_route_ids
+        ]
+        app.router.routes = (
+            retained_routes[:insertion_index]
+            + list(new_routes)
+            + retained_routes[insertion_index:]
+        )
+        _plugin_api_routes[name] = new_routes
+        _plugin_api_modules[name] = module
+
+    return {
+        "reloaded": True,
+        "loaded_source_commit": after[0],
+        "loaded_product_version": after[1],
+    }
 
 
 # Mount plugin API routes before the SPA catch-all.
@@ -20240,6 +20431,19 @@ def start_server(
             if server.should_exit:
                 return
 
+            managed_update_coordinator = None
+            if _has_mounted_managed_plugin():
+                from hermes_cli.managed_plugin_update import ManagedUpdateCoordinator
+
+                try:
+                    managed_update_coordinator = ManagedUpdateCoordinator(
+                        preflight=_preflight_managed_plugin_reload,
+                        reload_backend=_reload_managed_plugin_backend,
+                    )
+                except Exception:
+                    if server.started:
+                        await server.shutdown()
+                    raise
             actual_port = _read_bound_port(server, fallback=port)
             app.state.bound_port = actual_port
 
@@ -20299,9 +20503,13 @@ def start_server(
                 _hb_interval, _loop_heartbeat, _hb_loop.time() + _hb_interval
             )
 
-            await server.main_loop()
-            if server.started:
-                await server.shutdown()
+            try:
+                await server.main_loop()
+            finally:
+                if server.started:
+                    await server.shutdown()
+                if managed_update_coordinator is not None:
+                    managed_update_coordinator.close()
 
     # On POSIX, keep the long-standing ``asyncio.run(_serve())`` behavior
     # unchanged — Python's default loop there is already a SelectorEventLoop

--- a/tests/hermes_cli/test_managed_plugin_update.py
+++ b/tests/hermes_cli/test_managed_plugin_update.py
@@ -5,6 +5,7 @@ import socket
 import subprocess
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -121,6 +122,12 @@ def test_unmanaged_dispatch_keeps_ff_only_git_behavior(tmp_path, monkeypatch):
     root.mkdir()
     (root / "plugin.yaml").write_text("name: legacy\n", encoding="utf-8")
     pull = Mock(return_value=(True, "Already up to date."))
+
+    @contextmanager
+    def stage(_name, _root):
+        yield None, "a" * 40
+
+    monkeypatch.setattr(managed, "stage_managed_update_candidate", stage)
     monkeypatch.setattr(plugins_cmd, "_git_pull_plugin_dir", pull)
     monkeypatch.setattr(plugins_cmd, "_copy_example_files", Mock())
 
@@ -133,7 +140,7 @@ def test_unmanaged_dispatch_keeps_ff_only_git_behavior(tmp_path, monkeypatch):
         "unchanged": True,
         "update_mode": "git",
     }
-    pull.assert_called_once_with(root)
+    pull.assert_called_once_with(root, "a" * 40)
 
 
 def test_dashboard_and_cli_share_managed_dispatch(tmp_path, monkeypatch, capsys):
@@ -394,22 +401,175 @@ def _git(root: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
-def _write_backend(root: Path, implementation: str, delay: float = 0) -> None:
+def _write_bootstrap_worker(root: Path, *, fail_after_cutover: bool = False) -> None:
+    (root / "update_process.py").write_text(
+        """
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=root, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+actual = Path(sys.argv[1]).resolve()
+if sys.argv[2] != "migrate":
+    raise SystemExit("legacy bootstrap did not use migrate")
+home = Path(os.environ["HERMES_HOME"])
+state_path = home / "t3code" / "service-state.json"
+prior = git(actual, "rev-parse", "HEAD")
+candidate = git(actual, "rev-parse", "@{upstream}^{commit}")
+# Model a real pre-managed install: the native runtime is present, but the
+# old integration never wrote service-state.json.  A migration must discover
+# and snapshot that runtime identity without mutating anything before
+# preflight, then establish canonical state as part of cutover/rollback.
+old_version = "1.0"
+if os.environ.get("TEST_HERMES_SOURCE_ROOT"):
+    sys.path.insert(0, os.environ["TEST_HERMES_SOURCE_ROOT"])
+from hermes_cli.managed_plugin_update import get_managed_update_contract
+
+contract = get_managed_update_contract("t3code")
+if contract is None:
+    raise SystemExit("missing bootstrap contract")
+contract.preflight(plugin_name="t3code", plugin_root=actual)
+try:
+    git(actual, "checkout", "--detach", candidate)
+    if FAIL_AFTER_CUTOVER:
+        raise RuntimeError("simulated activation failure")
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "desired_state": "installed",
+                "product_source_commit": candidate,
+                "product_version": "2.0",
+            }
+        )
+    )
+    attestation = contract.complete(
+        plugin_name="t3code",
+        plugin_root=actual,
+        source_commit=candidate,
+        product_version="2.0",
+    )
+except Exception as error:
+    git(actual, "checkout", "--detach", prior)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "desired_state": "installed",
+                "product_source_commit": prior,
+                "product_version": old_version,
+            }
+        )
+    )
+    contract.rollback(
+        plugin_name="t3code",
+        plugin_root=actual,
+        source_commit=prior,
+        product_version=old_version,
+    )
+    print(str(error), file=sys.stderr)
+    raise SystemExit(1)
+print(
+    json.dumps(
+        {
+            "ok": True,
+            "version": "2.0",
+            "source_commit": candidate,
+            "attestation": attestation,
+        }
+    )
+)
+""".replace("FAIL_AFTER_CUTOVER", repr(fail_after_cutover)),
+        encoding="utf-8",
+    )
+
+
+def _legacy_remote(
+    tmp_path: Path,
+    *,
+    fail_after_cutover: bool = False,
+    update_dependency: bool = False,
+) -> tuple[Path, Path, str, str]:
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _write_backend(
+        seed, "old", delay=0.2, update_dependency=update_dependency
+    )
+    (seed / ".gitignore").write_text("__pycache__/\n*.pyc\n", encoding="utf-8")
+    (seed / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "t3code", "version": "1.0"}),
+        encoding="utf-8",
+    )
+    _git(seed, "init", "-q", "-b", "main")
+    _git(seed, "add", "-A")
+    _git(seed, "commit", "-q", "-m", "legacy")
+    prior = _git(seed, "rev-parse", "HEAD")
+
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(seed), str(remote)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    home = tmp_path / "home"
+    root = home / "plugins" / "t3code"
+    root.parent.mkdir(parents=True)
+    subprocess.run(
+        ["git", "clone", str(remote), str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    _write_backend(seed, "new", update_dependency=update_dependency)
+    _write_managed_manifest(seed)
+    _write_bootstrap_worker(seed, fail_after_cutover=fail_after_cutover)
+    _git(seed, "add", "-A")
+    _git(seed, "commit", "-q", "-m", "managed")
+    candidate = _git(seed, "rev-parse", "HEAD")
+    _git(seed, "push", "-q", str(remote), "main")
+    return home, root, prior, candidate
+
+
+def _write_backend(
+    root: Path,
+    implementation: str,
+    delay: float = 0,
+    *,
+    name: str = "t3code",
+    update_dependency: bool = False,
+) -> None:
     dashboard = root / "dashboard"
     dashboard.mkdir(parents=True, exist_ok=True)
     (dashboard / "manifest.json").write_text(
         json.dumps(
             {
-                "name": "t3code",
+                "name": name,
                 "entry": "dist/index.js",
                 "api": "plugin_api.py",
             }
         ),
         encoding="utf-8",
     )
+    update_decorator = (
+        "@router.post('/update', dependencies=[Depends(require_update_auth)])\n"
+        if update_dependency
+        else "@router.post('/update')\n"
+    )
     (dashboard / "plugin_api.py").write_text(
         "import time\n"
-        "from fastapi import APIRouter\n"
+        "from fastapi import APIRouter, Depends, Header, HTTPException\n"
         "router = APIRouter()\n"
         f"IMPLEMENTATION = {implementation!r}\n"
         f"DELAY = {delay!r}\n"
@@ -417,7 +577,14 @@ def _write_backend(root: Path, implementation: str, delay: float = 0) -> None:
         "def identity():\n"
         "    value = IMPLEMENTATION\n"
         "    time.sleep(DELAY)\n"
-        "    return {'implementation': value}\n",
+        "    return {'implementation': value}\n"
+        "def require_update_auth(x_plugin_auth: str = Header(...)):\n"
+        "    if x_plugin_auth != 'allowed':\n"
+        "        raise HTTPException(status_code=403)\n"
+        + update_decorator
+        +
+        "def runtime_only_update():\n"
+        "    return {'runtime_only': IMPLEMENTATION}\n",
         encoding="utf-8",
     )
 
@@ -435,6 +602,411 @@ def _write_state(home: Path, source_commit: str, version: str) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def test_fetched_unmanaged_target_keeps_exact_ff_only_update(
+    tmp_path, monkeypatch
+):
+    fastapi = pytest.importorskip("fastapi")
+    testclient = pytest.importorskip("fastapi.testclient")
+    from hermes_cli import web_server
+
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _write_backend(seed, "old", name="legacy")
+    (seed / ".gitignore").write_text("__pycache__/\n*.pyc\n")
+    (seed / "plugin.yaml").write_text("name: legacy\nversion: '1'\n")
+    _git(seed, "init", "-q", "-b", "main")
+    _git(seed, "add", "-A")
+    _git(seed, "commit", "-q", "-m", "one")
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(seed), str(remote)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    home = tmp_path / "home"
+    root = home / "plugins" / "legacy"
+    root.parent.mkdir(parents=True)
+    subprocess.run(
+        ["git", "clone", str(remote), str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _write_backend(seed, "new", name="legacy")
+    (seed / "plugin.yaml").write_text("name: legacy\nversion: '2'\n")
+    _git(seed, "add", "-A")
+    _git(seed, "commit", "-q", "-m", "two")
+    candidate = _git(seed, "rev-parse", "HEAD")
+    _git(seed, "push", "-q", str(remote), "main")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["legacy"], "disabled": []}})
+    )
+    web_server._dashboard_plugins_cache = None
+    web_server._plugin_api_routes.clear()
+    web_server._plugin_api_modules.clear()
+    test_app = fastapi.FastAPI()
+    test_app.middleware("http")(web_server._managed_plugin_bootstrap_gate)
+    monkeypatch.setattr(web_server, "app", test_app)
+    web_server._mount_plugin_api_routes()
+    client = testclient.TestClient(test_app)
+
+    plugin_update = client.post("/api/plugins/legacy/update")
+    assert plugin_update.status_code == 200
+    assert plugin_update.json() == {"runtime_only": "old"}
+    assert _git(root, "rev-parse", "HEAD") != candidate
+
+    result = plugins_cmd._update_user_plugin("legacy", root)
+
+    assert result["update_mode"] == "git"
+    assert _git(root, "rev-parse", "HEAD") == candidate
+    assert managed.get_managed_update_spec(root, strict=True) is None
+
+
+def test_legacy_update_route_with_plugin_auth_is_not_intercepted(
+    tmp_path, monkeypatch
+):
+    fastapi = pytest.importorskip("fastapi")
+    testclient = pytest.importorskip("fastapi.testclient")
+    from hermes_cli import web_server
+
+    home, root, prior_commit, _candidate_commit = _legacy_remote(
+        tmp_path, update_dependency=True
+    )
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["t3code"], "disabled": []}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    web_server._dashboard_plugins_cache = None
+    web_server._plugin_api_routes.clear()
+    web_server._plugin_api_modules.clear()
+    test_app = fastapi.FastAPI()
+    test_app.middleware("http")(web_server._managed_plugin_bootstrap_gate)
+    monkeypatch.setattr(web_server, "app", test_app)
+    web_server._mount_plugin_api_routes()
+    client = testclient.TestClient(test_app)
+
+    assert client.post("/api/plugins/t3code/update").status_code == 422
+    response = client.post(
+        "/api/plugins/t3code/update",
+        headers={"x-plugin-auth": "allowed"},
+    )
+    assert response.json() == {"runtime_only": "old"}
+    assert _git(root, "rev-parse", "HEAD") == prior_commit
+
+
+def test_legacy_managed_candidate_needs_host_before_source_cutover(
+    tmp_path, monkeypatch
+):
+    home, root, prior_commit, candidate_commit = _legacy_remote(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with pytest.raises(
+        plugins_cmd.PluginOperationError,
+        match="coordinator is unavailable",
+    ):
+        plugins_cmd._update_user_plugin("t3code", root)
+
+    assert _git(root, "rev-parse", "HEAD") == prior_commit
+    assert _git(root, "rev-parse", "origin/main") == candidate_commit
+    assert managed.get_managed_update_spec(root, strict=True) is None
+
+
+def test_partial_multi_host_bootstrap_is_ungated_on_preflight_failure(
+    tmp_path, monkeypatch
+):
+    home, root, prior_commit, _candidate_commit = _legacy_remote(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    begun = Mock()
+    released = Mock()
+
+    with (
+        managed.ManagedUpdateCoordinator(
+            preflight=lambda _name, _root: None,
+            reload_backend=Mock(),
+            begin_bootstrap=begun,
+            release_bootstrap=released,
+        ),
+        managed.ManagedUpdateCoordinator(
+            preflight=Mock(side_effect=RuntimeError("host cannot remount")),
+            reload_backend=Mock(),
+        ),
+    ):
+        with pytest.raises(
+            plugins_cmd.PluginOperationError,
+            match="host cannot remount",
+        ):
+            plugins_cmd._update_user_plugin("t3code", root)
+
+    assert begun.call_count == released.call_count
+    assert _git(root, "rev-parse", "HEAD") == prior_commit
+
+
+@pytest.mark.live_system_guard_bypass
+def test_partial_multi_host_complete_rolls_every_host_back(
+    tmp_path, monkeypatch
+):
+    home, root, prior_commit, candidate_commit = _legacy_remote(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv(
+        "TEST_HERMES_SOURCE_ROOT",
+        str(Path(__file__).resolve().parents[2]),
+    )
+    instances = iter(("a" * 32, "b" * 32))
+    monkeypatch.setattr(
+        managed.secrets,
+        "token_hex",
+        lambda size: next(instances) if size == 16 else "c" * (size * 2),
+    )
+    calls_a: list[str] = []
+    calls_b: list[str] = []
+    released_a = Mock()
+    released_b = Mock()
+
+    def reload_a(_name, _root, source_commit, product_version):
+        calls_a.append(source_commit)
+        return {
+            "reloaded": True,
+            "loaded_source_commit": source_commit,
+            "loaded_product_version": product_version,
+        }
+
+    def reload_b(_name, _root, source_commit, product_version):
+        calls_b.append(source_commit)
+        if source_commit == candidate_commit:
+            raise RuntimeError("second host could not activate")
+        return {
+            "reloaded": True,
+            "loaded_source_commit": source_commit,
+            "loaded_product_version": product_version,
+        }
+
+    with (
+        managed.ManagedUpdateCoordinator(
+            preflight=lambda _name, _root: None,
+            reload_backend=reload_a,
+            release_bootstrap=released_a,
+        ),
+        managed.ManagedUpdateCoordinator(
+            preflight=lambda _name, _root: None,
+            reload_backend=reload_b,
+            release_bootstrap=released_b,
+        ),
+    ):
+        with pytest.raises(
+            plugins_cmd.PluginOperationError,
+            match="second host could not activate",
+        ):
+            plugins_cmd._update_user_plugin("t3code", root)
+
+    assert calls_a == [candidate_commit, prior_commit]
+    assert calls_b == [candidate_commit, prior_commit]
+    assert released_a.call_count == 1
+    assert released_b.call_count == 1
+    assert _git(root, "rev-parse", "HEAD") == prior_commit
+
+
+@pytest.mark.live_system_guard_bypass
+def test_partial_multi_host_finalize_is_retriable_without_product_rollback(
+    tmp_path, monkeypatch
+):
+    home, root, prior_commit, candidate_commit = _legacy_remote(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv(
+        "TEST_HERMES_SOURCE_ROOT",
+        str(Path(__file__).resolve().parents[2]),
+    )
+    instances = iter(("a" * 32, "b" * 32))
+    monkeypatch.setattr(
+        managed.secrets,
+        "token_hex",
+        lambda size: next(instances) if size == 16 else "c" * (size * 2),
+    )
+    released_a = Mock()
+    release_attempts = 0
+
+    def release_b(_name, _root):
+        nonlocal release_attempts
+        release_attempts += 1
+        if release_attempts == 1:
+            raise RuntimeError("second host release failed")
+
+    def reload(_name, _root, source_commit, product_version):
+        return {
+            "reloaded": True,
+            "loaded_source_commit": source_commit,
+            "loaded_product_version": product_version,
+        }
+
+    with (
+        managed.ManagedUpdateCoordinator(
+            preflight=lambda _name, _root: None,
+            reload_backend=reload,
+            release_bootstrap=released_a,
+        ),
+        managed.ManagedUpdateCoordinator(
+            preflight=lambda _name, _root: None,
+            reload_backend=reload,
+            release_bootstrap=release_b,
+        ),
+    ):
+        with pytest.raises(
+            plugins_cmd.PluginOperationError,
+            match="second host release failed",
+        ):
+            plugins_cmd._update_user_plugin("t3code", root)
+
+        assert _git(root, "rev-parse", "HEAD") == candidate_commit
+        spec = managed.get_managed_update_spec(root, strict=True)
+        assert spec is not None
+        managed.finalize_managed_update_bootstrap(
+            "t3code",
+            root,
+            managed.ManagedUpdateCandidate(
+                source_commit=candidate_commit,
+                prior_commit=prior_commit,
+                staged_root=root,
+                spec=spec,
+            ),
+        )
+
+    assert released_a.call_count == 1
+    assert release_attempts == 2
+    assert _git(root, "rev-parse", "HEAD") == candidate_commit
+
+
+def test_bootstrap_allows_managed_release_behind_staged_tip(
+    tmp_path, monkeypatch
+):
+    home, root, prior_commit, release_commit = _legacy_remote(tmp_path)
+    seed = tmp_path / "seed"
+    (seed / "tip.txt").write_text("after release\n", encoding="utf-8")
+    _git(seed, "add", "-A")
+    _git(seed, "commit", "-q", "-m", "post-release tip")
+    tip_commit = _git(seed, "rev-parse", "HEAD")
+    _git(seed, "push", "-q", str(tmp_path / "remote.git"), "main")
+    _git(root, "fetch", "-q")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    def reload(_name, _root, source_commit, product_version):
+        return {
+            "reloaded": True,
+            "loaded_source_commit": source_commit,
+            "loaded_product_version": product_version,
+        }
+
+    payload = {
+        "plugin_name": "t3code",
+        "requested_plugin_name": "t3code",
+        "plugin_root": str(root),
+        "bootstrap_prior_commit": prior_commit,
+        "bootstrap_candidate_commit": tip_commit,
+        "bootstrap_contract": "t3code-hermes-v1",
+    }
+    with managed.ManagedUpdateCoordinator(
+        preflight=lambda _name, _root: None,
+        reload_backend=reload,
+    ) as coordinator:
+        coordinator._handle({**payload, "operation": "bootstrap_begin"})
+        _git(root, "checkout", "--detach", release_commit)
+        result = coordinator._handle(
+            {
+                **payload,
+                "operation": "complete",
+                "source_commit": release_commit,
+                "product_version": "2.0",
+            }
+        )
+
+    assert result["result"]["loaded_source_commit"] == release_commit
+
+
+@pytest.mark.parametrize("fail_after_cutover", [False, True])
+@pytest.mark.live_system_guard_bypass
+def test_legacy_checkout_bootstraps_or_rolls_back_as_one_product(
+    tmp_path, monkeypatch, request, fail_after_cutover
+):
+    fastapi = pytest.importorskip("fastapi")
+    testclient = pytest.importorskip("fastapi.testclient")
+    from hermes_cli import web_server
+
+    home, root, prior_commit, candidate_commit = _legacy_remote(
+        tmp_path, fail_after_cutover=fail_after_cutover
+    )
+    state_path = home / "t3code" / "service-state.json"
+    assert not state_path.exists()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["t3code"], "disabled": []}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv(
+        "TEST_HERMES_SOURCE_ROOT",
+        str(Path(__file__).resolve().parents[2]),
+    )
+    web_server._dashboard_plugins_cache = None
+    web_server._plugin_api_routes.clear()
+    web_server._plugin_api_modules.clear()
+    web_server._plugin_api_gated.clear()
+    web_server._plugin_api_active.clear()
+
+    test_app = fastapi.FastAPI()
+    test_app.middleware("http")(web_server._managed_plugin_bootstrap_gate)
+    monkeypatch.setattr(web_server, "app", test_app)
+    web_server._mount_plugin_api_routes()
+    assert web_server._has_mounted_plugin_backend() is True
+    client = testclient.TestClient(test_app)
+    assert client.get("/api/plugins/t3code/identity").json() == {
+        "implementation": "old"
+    }
+
+    coordinator = managed.ManagedUpdateCoordinator(
+        preflight=web_server._preflight_managed_plugin_reload,
+        reload_backend=web_server._reload_managed_plugin_backend,
+        begin_bootstrap=web_server._begin_managed_plugin_bootstrap,
+        release_bootstrap=web_server._release_managed_plugin_bootstrap,
+    )
+    request.addfinalizer(coordinator.close)
+
+    stale_response: dict[str, object] = {}
+    stale = threading.Thread(
+        target=lambda: stale_response.update(
+            client.get("/api/plugins/t3code/identity").json()
+        )
+    )
+    stale.start()
+    time.sleep(0.05)
+
+    if fail_after_cutover:
+        with pytest.raises(
+            plugins_cmd.PluginOperationError,
+            match="simulated activation failure",
+        ):
+            plugins_cmd._update_user_plugin("t3code", root)
+    else:
+        response = client.post("/api/plugins/t3code/update")
+        assert response.status_code == 200
+        result = response.json()
+        assert result["update_mode"] == "managed"
+        assert result["source_commit"] == candidate_commit
+
+    stale.join(timeout=2)
+    assert stale_response == {"implementation": "old"}
+    expected_commit = prior_commit if fail_after_cutover else candidate_commit
+    expected_version = "1.0" if fail_after_cutover else "2.0"
+    expected_implementation = "old" if fail_after_cutover else "new"
+    assert _git(root, "rev-parse", "HEAD") == expected_commit
+    assert web_server._managed_product_identity("t3code", root) == (
+        expected_commit,
+        expected_version,
+    )
+    assert client.get("/api/plugins/t3code/identity").json() == {
+        "implementation": expected_implementation
+    }
+    assert "t3code" not in web_server._plugin_api_gated
 
 
 def test_complete_and_rollback_swap_live_routes_with_exact_attestation(

--- a/tests/hermes_cli/test_managed_plugin_update.py
+++ b/tests/hermes_cli/test_managed_plugin_update.py
@@ -1,0 +1,563 @@
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import threading
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import yaml
+
+from hermes_cli import managed_plugin_update as managed
+from hermes_cli import plugins_cmd
+
+
+def _write_managed_manifest(root: Path, *, name: str = "t3code") -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ".gitignore").write_text("__pycache__/\n*.pyc\n", encoding="utf-8")
+    (root / "update_process.py").write_text("# worker\n", encoding="utf-8")
+    (root / "plugin.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": name,
+                "version": "1.0",
+                "update": {
+                    "mode": "managed",
+                    "contract": "t3code-hermes-v1",
+                    "entrypoint": "update_process.py",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_plugin_manifest_parses_managed_update_metadata(tmp_path, monkeypatch):
+    from hermes_cli.plugins import PluginManager
+
+    home = tmp_path / "home"
+    root = home / "plugins" / "t3code"
+    _write_managed_manifest(root)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    manager = PluginManager()
+    manifests = manager._scan_directory(root.parent, "user")
+    manifest = next(item for item in manifests if item.name == "t3code")
+
+    assert manifest.update_mode == "managed"
+    assert manifest.update_contract == "t3code-hermes-v1"
+    assert manifest.update_entrypoint == "update_process.py"
+
+
+def test_managed_dispatch_never_falls_back_to_git_pull(tmp_path, monkeypatch):
+    root = tmp_path / "t3code"
+    _write_managed_manifest(root)
+    expected = {"ok": True, "version": "2.0", "source_commit": "a" * 40}
+    managed_run = Mock(return_value=expected)
+    monkeypatch.setattr(managed, "run_managed_update", managed_run)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_git_pull_plugin_dir",
+        Mock(side_effect=AssertionError("source-only fallback reached")),
+    )
+
+    result = plugins_cmd._update_user_plugin("t3code", root)
+
+    assert result["update_mode"] == "managed"
+    assert result["version"] == "2.0"
+    managed_run.assert_called_once()
+
+
+def test_invalid_managed_declaration_fails_without_git_fallback(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "t3code"
+    root.mkdir()
+    (root / "plugin.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "t3code",
+                "update": {
+                    "mode": "managed",
+                    "contract": "t3code-hermes-v1",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    pull = Mock(side_effect=AssertionError("source-only fallback reached"))
+    monkeypatch.setattr(plugins_cmd, "_git_pull_plugin_dir", pull)
+
+    with pytest.raises(
+        plugins_cmd.PluginOperationError,
+        match="update.entrypoint",
+    ):
+        plugins_cmd._update_user_plugin("t3code", root)
+    pull.assert_not_called()
+
+
+def test_unreadable_manifest_fails_closed_without_git_fallback(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "plugin"
+    root.mkdir()
+    (root / "plugin.yaml").write_text("update: [\n", encoding="utf-8")
+    pull = Mock(side_effect=AssertionError("source-only fallback reached"))
+    monkeypatch.setattr(plugins_cmd, "_git_pull_plugin_dir", pull)
+
+    with pytest.raises(
+        plugins_cmd.PluginOperationError,
+        match="Could not read managed plugin manifest",
+    ):
+        plugins_cmd._update_user_plugin("plugin", root)
+    pull.assert_not_called()
+
+
+def test_unmanaged_dispatch_keeps_ff_only_git_behavior(tmp_path, monkeypatch):
+    root = tmp_path / "legacy"
+    root.mkdir()
+    (root / "plugin.yaml").write_text("name: legacy\n", encoding="utf-8")
+    pull = Mock(return_value=(True, "Already up to date."))
+    monkeypatch.setattr(plugins_cmd, "_git_pull_plugin_dir", pull)
+    monkeypatch.setattr(plugins_cmd, "_copy_example_files", Mock())
+
+    result = plugins_cmd._update_user_plugin("legacy", root)
+
+    assert result == {
+        "ok": True,
+        "name": "legacy",
+        "output": "Already up to date.",
+        "unchanged": True,
+        "update_mode": "git",
+    }
+    pull.assert_called_once_with(root)
+
+
+def test_dashboard_and_cli_share_managed_dispatch(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    root = home / "plugins" / "t3code"
+    _write_managed_manifest(root)
+    (root / ".git").mkdir()
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: home / "plugins")
+    shared = Mock(
+        return_value={
+            "ok": True,
+            "name": "t3code",
+            "update_mode": "managed",
+            "version": "2.0",
+        }
+    )
+    monkeypatch.setattr(plugins_cmd, "_update_user_plugin", shared)
+
+    plugins_cmd.cmd_update("t3code")
+    dashboard = plugins_cmd.dashboard_update_user_plugin("t3code")
+
+    assert dashboard["update_mode"] == "managed"
+    assert shared.call_args_list[0].args == ("t3code", root.resolve())
+    assert shared.call_args_list[1].args == ("t3code", root.resolve())
+    assert "native runtime updated together" in capsys.readouterr().out
+
+
+def test_host_unavailable_preflight_fails_closed(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    root = home / "plugins" / "t3code"
+    _write_managed_manifest(root)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    contract = managed.get_managed_update_contract("t3code")
+
+    assert contract is not None
+    with pytest.raises(
+        managed.ManagedPluginUpdateError,
+        match="coordinator is unavailable",
+    ):
+        contract.preflight(plugin_name="t3code", plugin_root=root)
+    assert not (home / "runtime").exists()
+
+
+def test_authenticated_worker_handoff_and_host_attestation(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    root = home / "plugins" / "t3code"
+    _write_managed_manifest(root)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    preflight = Mock()
+    def attest(
+        _name: str, _root: Path, source_commit: str, product_version: str | None
+    ) -> dict[str, object]:
+        return {
+            "reloaded": True,
+            "loaded_source_commit": source_commit,
+            "loaded_product_version": product_version,
+        }
+
+    reload_backend = Mock(side_effect=attest)
+
+    with managed.ManagedUpdateCoordinator(
+        preflight=preflight,
+        reload_backend=reload_backend,
+    ):
+        contract = managed.get_managed_update_contract("t3code")
+        assert contract is not None
+        contract.preflight(plugin_name="t3code", plugin_root=root)
+        attestation = contract.complete(
+            plugin_name="t3code",
+            plugin_root=root,
+            source_commit="a" * 40,
+            product_version="2.0",
+        )
+        rollback = contract.rollback(
+            plugin_name="t3code",
+            plugin_root=root,
+            source_commit="b" * 40,
+            product_version="1.0",
+        )
+
+    assert attestation == {
+        "reloaded": True,
+        "loaded_source_commit": "a" * 40,
+        "loaded_product_version": "2.0",
+    }
+    assert rollback == {
+        "reloaded": True,
+        "loaded_source_commit": "b" * 40,
+        "loaded_product_version": "1.0",
+    }
+    preflight.assert_called_once_with("t3code", root.resolve())
+    assert reload_backend.call_args_list[0].args == (
+        "t3code",
+        root.resolve(),
+        "a" * 40,
+        "2.0",
+    )
+    assert reload_backend.call_args_list[1].args == (
+        "t3code",
+        root.resolve(),
+        "b" * 40,
+        "1.0",
+    )
+
+
+def test_handoff_remounts_every_live_host(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    root = home / "plugins" / "t3code"
+    _write_managed_manifest(root)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    reloads = [Mock(), Mock()]
+
+    def attester(index: int):
+        def attest(
+            _name: str,
+            _root: Path,
+            source_commit: str,
+            product_version: str | None,
+        ) -> dict[str, object]:
+            reloads[index](source_commit, product_version)
+            return {
+                "reloaded": True,
+                "loaded_source_commit": source_commit,
+                "loaded_product_version": product_version,
+            }
+
+        return attest
+
+    with (
+        managed.ManagedUpdateCoordinator(
+            preflight=lambda _name, _root: None,
+            reload_backend=attester(0),
+        ),
+        managed.ManagedUpdateCoordinator(
+            preflight=lambda _name, _root: None,
+            reload_backend=attester(1),
+        ),
+    ):
+        contract = managed.get_managed_update_contract("t3code")
+        assert contract is not None
+        result = contract.complete(
+            plugin_name="t3code",
+            plugin_root=root,
+            source_commit="a" * 40,
+            product_version="2.0",
+        )
+
+    assert result["loaded_source_commit"] == "a" * 40
+    for reload_backend in reloads:
+        reload_backend.assert_called_once_with("a" * 40, "2.0")
+
+
+def test_coordinator_rejects_unauthenticated_and_caller_spoofed_attestation(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    root = home / "plugins" / "t3code"
+    _write_managed_manifest(root)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with managed.ManagedUpdateCoordinator(
+        preflight=lambda _name, _root: None,
+        reload_backend=lambda *_args: {
+            "reloaded": True,
+            "loaded_source_commit": "b" * 40,
+            "loaded_product_version": "old",
+        },
+    ):
+        descriptor_path = next(
+            (home / "runtime" / "managed-plugin-update-hosts").glob("*.json")
+        )
+        descriptor = managed._read_descriptor(descriptor_path)
+        with pytest.raises(
+            managed.ManagedPluginUpdateError,
+            match="did not respond",
+        ):
+            managed._ipc_call_one(
+                {**descriptor, "authkey": b"x" * 32},
+                {
+                    "operation": "preflight",
+                    "plugin_name": "t3code",
+                    "requested_plugin_name": "t3code",
+                    "plugin_root": str(root),
+                },
+            )
+
+        contract = managed.get_managed_update_contract("t3code")
+        assert contract is not None
+        with pytest.raises(
+            managed.ManagedPluginUpdateError,
+            match="could not attest",
+        ):
+            contract.complete(
+                plugin_name="t3code",
+                plugin_root=root,
+                source_commit="a" * 40,
+                product_version="2.0",
+            )
+
+
+def test_stalled_local_client_cannot_block_authenticated_preflight(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    root = home / "plugins" / "t3code"
+    _write_managed_manifest(root)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(managed, "_HANDSHAKE_TIMEOUT_SECONDS", 0.2)
+
+    with managed.ManagedUpdateCoordinator(
+        preflight=lambda _name, _root: None,
+        reload_backend=Mock(),
+    ):
+        descriptor_path = next(
+            (home / "runtime" / "managed-plugin-update-hosts").glob("*.json")
+        )
+        descriptor = managed._read_descriptor(descriptor_path)
+        stalled = socket.create_connection(descriptor["address"], timeout=1)
+        try:
+            contract = managed.get_managed_update_contract("t3code")
+            assert contract is not None
+            started = time.monotonic()
+            contract.preflight(plugin_name="t3code", plugin_root=root)
+            assert time.monotonic() - started < 1
+        finally:
+            stalled.close()
+
+
+def test_plugin_update_lock_rejects_contention(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    root = tmp_path / "plugin"
+    root.mkdir()
+
+    with managed.plugin_update_lock(root):
+        with pytest.raises(
+            managed.ManagedPluginUpdateError,
+            match="already in progress",
+        ):
+            with managed.plugin_update_lock(root):
+                pass
+
+
+def _git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **__import__("os").environ,
+            "GIT_AUTHOR_NAME": "Hermes Test",
+            "GIT_AUTHOR_EMAIL": "hermes-test@example.invalid",
+            "GIT_COMMITTER_NAME": "Hermes Test",
+            "GIT_COMMITTER_EMAIL": "hermes-test@example.invalid",
+        },
+    )
+    return result.stdout.strip()
+
+
+def _write_backend(root: Path, implementation: str, delay: float = 0) -> None:
+    dashboard = root / "dashboard"
+    dashboard.mkdir(parents=True, exist_ok=True)
+    (dashboard / "manifest.json").write_text(
+        json.dumps(
+            {
+                "name": "t3code",
+                "entry": "dist/index.js",
+                "api": "plugin_api.py",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (dashboard / "plugin_api.py").write_text(
+        "import time\n"
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n"
+        f"IMPLEMENTATION = {implementation!r}\n"
+        f"DELAY = {delay!r}\n"
+        "@router.get('/identity')\n"
+        "def identity():\n"
+        "    value = IMPLEMENTATION\n"
+        "    time.sleep(DELAY)\n"
+        "    return {'implementation': value}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_state(home: Path, source_commit: str, version: str) -> None:
+    state = home / "t3code" / "service-state.json"
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text(
+        json.dumps(
+            {
+                "desired_state": "installed",
+                "product_source_commit": source_commit,
+                "product_version": version,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_complete_and_rollback_swap_live_routes_with_exact_attestation(
+    tmp_path, monkeypatch, request
+):
+    fastapi = pytest.importorskip("fastapi")
+    testclient = pytest.importorskip("fastapi.testclient")
+    from hermes_cli import web_server
+
+    home = tmp_path / "home"
+    root = home / "plugins" / "t3code"
+    _write_managed_manifest(root)
+    _write_backend(root, "old", delay=0.2)
+    _git(root, "init", "-q")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "old")
+    old_commit = _git(root, "rev-parse", "HEAD")
+    _write_state(home, old_commit, "1.0")
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["t3code"], "disabled": []}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    web_server._dashboard_plugins_cache = None
+    managed_row = next(
+        row
+        for row in web_server._merged_plugins_hub()["plugins"]
+        if row["name"] == "t3code"
+    )
+    assert managed_row["can_update"] is True
+    assert managed_row["can_update_git"] is False
+    assert managed_row["update_mode"] == "managed"
+
+    test_app = fastapi.FastAPI()
+    monkeypatch.setattr(web_server, "app", test_app)
+    web_server._dashboard_plugins_cache = None
+    web_server._plugin_api_routes.clear()
+    web_server._plugin_api_modules.clear()
+    web_server._mount_plugin_api_routes()
+
+    @test_app.get("/{path:path}")
+    def fallback(path: str):
+        return {"fallback": path}
+
+    client = testclient.TestClient(test_app)
+    assert client.get("/api/plugins/t3code/identity").json() == {
+        "implementation": "old"
+    }
+    coordinator = managed.ManagedUpdateCoordinator(
+        preflight=web_server._preflight_managed_plugin_reload,
+        reload_backend=web_server._reload_managed_plugin_backend,
+    )
+    request.addfinalizer(coordinator.close)
+    contract = managed.get_managed_update_contract("t3code")
+    assert contract is not None
+    contract.preflight(plugin_name="t3code", plugin_root=root)
+
+    state_path = home / "t3code" / "service-state.json"
+    state_path.write_text(
+        json.dumps({"version": 1, "desired_state": "uninstalled"}),
+        encoding="utf-8",
+    )
+    uninstalled = contract.rollback(
+        plugin_name="t3code",
+        plugin_root=root,
+        source_commit=old_commit,
+        product_version=None,
+    )
+    assert uninstalled == {
+        "reloaded": True,
+        "loaded_source_commit": old_commit,
+        "loaded_product_version": None,
+    }
+    assert client.get("/api/plugins/t3code/identity").json() == {
+        "implementation": "old"
+    }
+
+    stale_response: dict[str, object] = {}
+
+    def call_old_route() -> None:
+        stale_response.update(client.get("/api/plugins/t3code/identity").json())
+
+    stale_request = threading.Thread(target=call_old_route)
+    stale_request.start()
+    time.sleep(0.05)
+    _write_backend(root, "new")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "new")
+    new_commit = _git(root, "rev-parse", "HEAD")
+    _write_state(home, new_commit, "2.0")
+
+    complete = contract.complete(
+        plugin_name="t3code",
+        plugin_root=root,
+        source_commit=new_commit,
+        product_version="2.0",
+    )
+    stale_request.join(timeout=2)
+
+    assert stale_response == {"implementation": "old"}
+    assert complete == {
+        "reloaded": True,
+        "loaded_source_commit": new_commit,
+        "loaded_product_version": "2.0",
+    }
+    assert client.get("/api/plugins/t3code/identity").json() == {
+        "implementation": "new"
+    }
+
+    _git(root, "checkout", "-q", old_commit)
+    _write_state(home, old_commit, "1.0")
+    rollback = contract.rollback(
+        plugin_name="t3code",
+        plugin_root=root,
+        source_commit=old_commit,
+        product_version="1.0",
+    )
+
+    assert rollback == {
+        "reloaded": True,
+        "loaded_source_commit": old_commit,
+        "loaded_product_version": "1.0",
+    }
+    assert client.get("/api/plugins/t3code/identity").json() == {
+        "implementation": "old"
+    }

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -454,8 +454,10 @@ class TestCmdUpdate:
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    @patch("hermes_cli.plugins_cmd.subprocess.run")
-    def test_update_git_pull_success(self, mock_run, mock_plugins_dir, mock_sanitize):
+    @patch("hermes_cli.plugins_cmd._update_user_plugin")
+    def test_update_git_pull_success(
+        self, mock_update, mock_plugins_dir, mock_sanitize
+    ):
         from hermes_cli.plugins_cmd import cmd_update
 
         mock_plugins_dir_val = MagicMock()
@@ -467,11 +469,17 @@ class TestCmdUpdate:
         )
         mock_sanitize.return_value = mock_target
 
-        mock_run.return_value = MagicMock(returncode=0, stdout="Updated", stderr="")
+        mock_update.return_value = {
+            "ok": True,
+            "name": "test-plugin",
+            "output": "Updated",
+            "unchanged": False,
+            "update_mode": "git",
+        }
 
         cmd_update("test-plugin")
 
-        mock_run.assert_called_once()
+        mock_update.assert_called_once_with("test-plugin", mock_target)
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -399,6 +399,8 @@ export const en: Translations = {
     authRequired: "Auth required",
     authRequiredHint: "Run this command to authenticate:",
     updateGit: "Git pull",
+    updateManaged: "Update",
+    managedUpdated: "Product updated",
     versionBadge: "Version",
     showInSidebar: "Show in sidebar",
     hideFromSidebar: "Hide from sidebar",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -401,6 +401,7 @@ export const en: Translations = {
     updateGit: "Git pull",
     updateManaged: "Update",
     managedUpdated: "Product updated",
+    pluginUpdated: "Plugin updated",
     versionBadge: "Version",
     showInSidebar: "Show in sidebar",
     hideFromSidebar: "Hide from sidebar",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -351,6 +351,7 @@ export interface Translations {
     updateGit: string;
     updateManaged?: string;
     managedUpdated?: string;
+    pluginUpdated?: string;
     versionBadge: string;
     showInSidebar: string;
     hideFromSidebar: string;

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -349,6 +349,8 @@ export interface Translations {
     authRequired: string;
     authRequiredHint: string;
     updateGit: string;
+    updateManaged?: string;
+    managedUpdated?: string;
     versionBadge: string;
     showInSidebar: string;
     hideFromSidebar: string;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2507,7 +2507,9 @@ export interface HubAgentPluginRow {
   dashboard_manifest: PluginManifestResponse | null;
   path: string;
   can_remove: boolean;
+  can_update: boolean;
   can_update_git: boolean;
+  update_mode: "managed" | "git" | "";
   auth_required: boolean;
   auth_command: string;
   user_hidden: boolean;
@@ -2547,6 +2549,9 @@ export interface AgentPluginUpdateResponse {
   name?: string;
   output?: string;
   unchanged?: boolean;
+  update_mode?: "managed" | "git";
+  version?: string;
+  source_commit?: string;
   error?: string;
 }
 

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -1015,20 +1015,18 @@ function PluginRowCard(props: PluginRowCardProps) {
                 size="sm"
                 onClick={() => {
                   void setRuntimeLoading(row.name, async () => {
-                    await api.updateAgentPlugin(row.name);
+                    const result = await api.updateAgentPlugin(row.name);
                     showToast(
-                      row.update_mode === "managed"
+                      result.update_mode === "managed"
                         ? (t.pluginsPage.managedUpdated ?? "Product updated")
-                        : t.pluginsPage.updateGit,
+                        : (t.pluginsPage.pluginUpdated ?? "Plugin updated"),
                       "success",
                     );
                   });
                 }}
               >
                 {busy ? <Spinner /> : null}
-                {row.update_mode === "managed"
-                  ? (t.pluginsPage.updateManaged ?? "Update")
-                  : t.pluginsPage.updateGit}
+                {t.pluginsPage.updateManaged ?? "Update"}
               </Button>
             ) : null}
 

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -1008,8 +1008,7 @@ function PluginRowCard(props: PluginRowCardProps) {
               </Link>
             ) : null}
 
-            {row.can_update_git ? (
-
+            {row.can_update ? (
               <Button
                 disabled={busy}
                 ghost
@@ -1017,12 +1016,19 @@ function PluginRowCard(props: PluginRowCardProps) {
                 onClick={() => {
                   void setRuntimeLoading(row.name, async () => {
                     await api.updateAgentPlugin(row.name);
-                    showToast(t.pluginsPage.updateGit, "success");
+                    showToast(
+                      row.update_mode === "managed"
+                        ? (t.pluginsPage.managedUpdated ?? "Product updated")
+                        : t.pluginsPage.updateGit,
+                      "success",
+                    );
                   });
                 }}
               >
                 {busy ? <Spinner /> : null}
-                {t.pluginsPage.updateGit}
+                {row.update_mode === "managed"
+                  ? (t.pluginsPage.updateManaged ?? "Update")
+                  : t.pluginsPage.updateGit}
               </Button>
             ) : null}
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -85,6 +85,73 @@ requires_env:          # gate loading on env vars; prompted during install
     secret: true
 ```
 
+### Managed product updates
+
+Most Git-installed plugins are updated with `git pull --ff-only`. A plugin
+whose source and native runtime form one versioned product can instead declare
+the host-coordinated managed update contract:
+
+```yaml
+update:
+  mode: managed
+  contract: t3code-hermes-v1
+  entrypoint: integrations/hermes_plugin/update_process.py
+```
+
+For such a plugin, Hermes exposes one **Update** operation. Both
+`hermes plugins update <name>` and the dashboard update endpoint run the
+declared entrypoint as an isolated Python worker:
+
+```text
+python -I <entrypoint> <absolute-plugin-root> update
+```
+
+Hermes never falls back to `git pull` when `update.mode` is `managed`; a
+malformed or unreadable manifest also fails closed instead of guessing that
+the plugin is unmanaged. The entrypoint owns the complete
+source/runtime/service transaction and must print one JSON object with
+`{"ok": true, ...}` only after coherent success.
+
+The `t3code-hermes-v1` worker imports
+`hermes_cli.managed_plugin_update.get_managed_update_contract("t3code")`.
+The returned synchronous object has `version == 1` and these methods:
+
+```python
+contract.preflight(plugin_name=..., plugin_root=...)
+contract.complete(
+    plugin_name=...,
+    plugin_root=...,
+    source_commit=...,
+    product_version=...,
+)
+contract.rollback(
+    plugin_name=...,
+    plugin_root=...,
+    source_commit=...,
+    product_version=...,  # may be None when restoring an uninstalled product
+)
+```
+
+`preflight` is mutation-free and fails unless a matching profile's dashboard
+or desktop backend host is running, the plugin is enabled, and its backend is mounted. Call it
+before fetch, checkout, runtime replacement, or service changes. `complete`
+and `rollback` return only after Hermes has imported fresh backend code,
+atomically replaced the plugin's prefixed routes, and independently attested
+the requested Git commit and product version. The product identity is read
+from `<HERMES_HOME>/t3code/service-state.json` (`product_source_commit` and
+`product_version` for installed state); caller-provided values are comparison
+targets, not attestation.
+
+The host handoff uses an authenticated, profile-local loopback coordinator.
+When multiple same-profile dashboard/backend hosts have the managed plugin
+mounted, the contract preflights and remounts every live host and rejects
+inconsistent attestations.
+Plugins must not read dashboard session tokens, implement remote reload
+endpoints, or attempt to restart the dashboard from an in-flight handler.
+The product transaction must serialize its own lifecycle work and must call
+`rollback` after restoring prior source/runtime/state whenever activation
+fails after source cutover.
+
 ## Step 3: Write the tool schemas
 
 Create `schemas.py` — this is what the LLM reads to decide when to call your tools:

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -112,6 +112,19 @@ the plugin is unmanaged. The entrypoint owns the complete
 source/runtime/service transaction and must print one JSON object with
 `{"ok": true, ...}` only after coherent success.
 
+Hermes also handles the first migration from a legacy manifest. It fetches the
+configured upstream without changing the live worktree, requires the exact
+upstream commit to be a clean fast-forward with the same plugin identity,
+validates a supported managed declaration and regular-file entrypoint directly
+from that Git commit, and extracts regular files into a private staging
+directory. Only then does it gate and drain the old plugin API prefix and run
+the staged entrypoint against the actual installed root. A legacy plugin-owned
+`POST /api/plugins/<name>/update` with no plugin-specific FastAPI dependencies
+is routed through this same check, so an old runtime-only Update handler cannot
+bypass a newly available managed transaction. Routes with their own
+dependencies retain them and are not intercepted. If the fetched target is
+still unmanaged, its normal exact `git pull --ff-only` update remains unchanged.
+
 The `t3code-hermes-v1` worker imports
 `hermes_cli.managed_plugin_update.get_managed_update_contract("t3code")`.
 The returned synchronous object has `version == 1` and these methods:
@@ -132,9 +145,23 @@ contract.rollback(
 )
 ```
 
+During an authorized legacy migration, the factory returns the same v1 object
+even though the installed manifest is still unmanaged. The host authorization
+binds it to the prior commit, fetched candidate history, installed root, and
+contract. Rollback is restricted to the recorded prior commit; completion must
+select a managed commit within the validated fast-forward history, and the host
+derives and attests the loaded source and product version. A staged entrypoint must load
+its implementation from its own staged source while treating the supplied
+`plugin_root` argument as the installed checkout to mutate; Hermes invokes this
+case with the `migrate` operation instead of `update`. It must snapshot legacy
+installed runtime intent (including installations without coherent product
+metadata) so rollback restores and attests the prior running version, not an
+uninstalled state.
+
 `preflight` is mutation-free and fails unless a matching profile's dashboard
-or desktop backend host is running, the plugin is enabled, and its backend is mounted. Call it
-before fetch, checkout, runtime replacement, or service changes. `complete`
+or desktop backend host is running, the plugin is enabled, and its backend is
+mounted. Call it before the worker fetches releases, checks out source, replaces
+the runtime, or changes the service. `complete`
 and `rollback` return only after Hermes has imported fresh backend code,
 atomically replaced the plugin's prefixed routes, and independently attested
 the requested Git commit and product version. The product identity is read

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -268,11 +268,24 @@ hermes plugins list                          # table: enabled / disabled / not e
 hermes plugins install user/repo             # install from Git, then prompt Enable? [y/N]
 hermes plugins install user/repo --enable    # install AND enable (no prompt)
 hermes plugins install user/repo --no-enable # install but leave disabled (no prompt)
-hermes plugins update my-plugin              # pull latest
+hermes plugins update my-plugin              # update (Git pull unless managed)
 hermes plugins remove my-plugin              # uninstall
 hermes plugins enable my-plugin              # add to allow-list
 hermes plugins disable my-plugin             # remove from allow-list + add to disabled
 ```
+
+For ordinary Git plugins, **Update** remains `git pull --ff-only`. A plugin
+that declares a managed product update has one Update operation instead: its
+plugin source, native runtime, service activation, health proof, and mounted
+dashboard backend advance or roll back together. Hermes does not offer a
+separate source-only Git update for that plugin.
+
+Managed Update requires a matching profile's dashboard or desktop backend host
+to be running with the plugin enabled and mounted. If it is unavailable, the
+CLI and dashboard fail before fetching or changing files and tell you to start
+or restart a backend host. A successful response means requests after the
+update are reaching the newly loaded backend implementation, not merely
+rescanned metadata.
 
 ### Interactive UI
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -282,10 +282,19 @@ separate source-only Git update for that plugin.
 
 Managed Update requires a matching profile's dashboard or desktop backend host
 to be running with the plugin enabled and mounted. If it is unavailable, the
-CLI and dashboard fail before fetching or changing files and tell you to start
-or restart a backend host. A successful response means requests after the
-update are reaching the newly loaded backend implementation, not merely
+CLI and dashboard fail before source, runtime, or service cutover and tell you
+to start or restart a backend host. A successful response means requests after
+the update are reaching the newly loaded backend implementation, not merely
 rescanned metadata.
+
+This also applies to plugins installed before they adopted managed Update.
+Their next Update safely inspects and stages the fetched target first; if that
+target declares managed Update, Hermes migrates source, runtime, service, and
+mounted backend together without an intermediate source-only checkout. The
+legacy plugin tab's Update endpoint is redirected into the same transaction
+when that route does not declare additional plugin-specific dependencies.
+Local checkout changes or an unavailable backend host stop the migration before
+source cutover.
 
 ### Interactive UI
 


### PR DESCRIPTION
## Summary

Implements the Hermes-core half of T3 Code's coherent managed Update contract, including the legacy unmanaged-to-managed bootstrap identified in follow-up review.

- parses `update.mode: managed`, `contract`, and `entrypoint`
- gives CLI, Plugins-page, dashboard API, and eligible plugin-owned Update routes one managed operation
- stages and validates an exact fast-forward candidate without advancing the live checkout
- executes the candidate's trusted entrypoint in a fresh isolated process against the actual installed root
- never falls back to source-only Git after a supported managed candidate is found
- reloads mounted Python routes and attests source/product identity through authenticated host IPC
- preserves coherent rollback for pre-managed installs, including installs with no service-state file
- keeps ordinary unmanaged Git plugins on exact classified `git pull --ff-only` behavior

## Legacy bootstrap

The original draft dispatched only from the installed `plugin.yaml`. An older T3 checkout therefore took the generic Git path on its first update, producing a source-only state while its mounted backend remained old.

Hermes now fetches without changing the live worktree, requires clean fast-forward ancestry and matching plugin identity, validates the managed manifest and regular-file entrypoint from the exact fetched commit, and extracts staged code privately. The host then gates and drains the old route prefix before the staged worker receives the actual installed root. A legacy plugin-owned `POST /api/plugins/<name>/update` with no plugin-specific FastAPI dependencies enters the same transaction; dependency-bearing routes retain and execute their original dependencies.

The bootstrap authorization binds the prior commit, validated candidate history, installed root, and contract. Rollback is restricted to the prior commit. Complete accepts only a supported managed release commit within that validated fast-forward history, then derives attestation from the code and state actually mounted by every live host.

Multi-host completion failure rolls every host back before gates are released. Successful completion uses a verify-all, idempotent finalize phase so a partial gate-release failure can be retried without rolling back a coherent product.

## Required T3 follow-up

T3 PR #42 was merged at `76830f00b2c30f48787702cc6971d9050a1cd0c0`. Its v1 method shapes remain sufficient, but safe legacy bootstrap requires an explicit worker-operation correction now tracked in draft T3 PR #43:

1. accept a `migrate` operation for a staged candidate;
2. import the implementation from the entrypoint's own checkout while treating argv `plugin_root` as the installed mutation target;
3. make preflight support a legacy installed runtime with no canonical service-state, without mutation;
4. snapshot/derive that prior installed version and make rollback write canonical `product_source_commit` / `product_version`, restore the running service, and request host rollback attestation for that prior version.

Until that T3 follow-up lands, Hermes fails the legacy bootstrap transaction without a source-only cutover.

## Validation

- managed-update, route-auth, and plugin runtime security suites: 67 passed
- managed bootstrap suite: 22 passed, including real Git/fresh-worker/HTTP remount integration
- web Vitest: 106 passed across 19 files
- web TypeScript typecheck: passed
- changed Python Ruff checks: passed
- `git diff --check`: passed
- paired T3 Hermes plugin suite on the follow-up branch: 78 passed (the missing migration cases above still need to be added)

Independent review rechecked multi-host recovery/finalize, release-vs-tip ancestry, exact unmanaged SHA cutover, plugin dependencies, no-state legacy rollback, and rollback binding, and found no remaining Hermes blocker.
