### PR TITLE
fix(telegram): keep arg-required plugin commands out of menu

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -832,7 +832,11 @@ def _collect_gateway_skill_entries(
             name = sanitize_name(cmd_name) if sanitize_name else cmd_name
             if not name:
                 continue
-            desc = plugin_cmds[cmd_name].get("description", "Plugin command")
+            meta = plugin_cmds[cmd_name]
+            args_hint = str(meta.get("args_hint") or "") if isinstance(meta, dict) else ""
+            if platform == "telegram" and _requires_argument(args_hint):
+                continue
+            desc = meta.get("description", "Plugin command") if isinstance(meta, dict) else "Plugin command"
             if len(desc) > desc_limit:
                 desc = desc[:desc_limit - 3] + "..."
             plugin_pairs.append((name, desc))

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1604,6 +1604,56 @@ class TestTelegramMenuCommands:
         assert "" not in menu_names
 
 
+class TestTelegramMenuPluginCommands:
+    """Test filtering of plugin commands in Telegram BotCommand menu."""
+
+    def test_plugin_command_argument_filtering(self):
+        """Plugin commands with mandatory args (<query>) are excluded from Telegram
+        bot commands and menu, while no-arg and optional-arg ([query]) plugins stay visible.
+        Discord collection behavior remains unchanged."""
+        from unittest.mock import patch
+        from hermes_cli.commands import (
+            telegram_bot_commands,
+            telegram_menu_commands,
+            discord_skill_commands,
+        )
+
+        fake_plugin_commands = {
+            "req_arg_cmd": {
+                "description": "Requires mandatory argument",
+                "args_hint": "<query>",
+            },
+            "opt_arg_cmd": {
+                "description": "Optional argument",
+                "args_hint": "[query]",
+            },
+            "no_arg_cmd": {
+                "description": "No arguments",
+                "args_hint": "",
+            },
+        }
+
+        with patch("hermes_cli.plugins.get_plugin_commands", return_value=fake_plugin_commands):
+            bot_names = {name for name, _ in telegram_bot_commands()}
+            assert "req_arg_cmd" not in bot_names
+            assert "opt_arg_cmd" in bot_names
+            assert "no_arg_cmd" in bot_names
+
+            menu_cmds, _ = telegram_menu_commands(max_commands=100)
+            menu_names = {name for name, _ in menu_cmds}
+            assert "req_arg_cmd" not in menu_names, (
+                "Plugin command with mandatory args (<query>) should be excluded from Telegram menu"
+            )
+            assert "opt_arg_cmd" in menu_names
+            assert "no_arg_cmd" in menu_names
+
+            discord_cmds, _ = discord_skill_commands(max_slots=100, reserved_names=set())
+            discord_names = {name for name, _, _ in discord_cmds}
+            assert "req_arg_cmd" in discord_names, (
+                "Discord skill commands should keep mandatory-argument plugin commands"
+            )
+
+
 # ---------------------------------------------------------------------------
 # Backward-compat aliases
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Telegram's BotCommand menu builder (`telegram_menu_commands`) re-collected plugin slash commands via `_collect_gateway_skill_entries` after `telegram_bot_commands()` had intentionally filtered out mandatory-argument plugin commands, causing those commands to re-appear in Telegram's native command menu.

## Reproduction

Demonstrated inconsistency between the two menu builders:
- `telegram_bot_commands()`: excludes plugin commands requiring arguments (`args_hint="<query>"`) as documented in PR #24312
- `telegram_menu_commands()`: re-included the excluded argument-requiring plugin commands via Tier 1 of `_collect_gateway_skill_entries()`

## Root cause

In `_collect_gateway_skill_entries()`, Tier 1 plugin command collection iterated `get_plugin_commands()` without evaluating `_requires_argument(args_hint)` for Telegram platforms. Because the commands were filtered out of `telegram_bot_commands()`, their names were not in `reserved_names`, allowing `_collect_gateway_skill_entries()` to re-add them to the returned Telegram menu list.

## Fix

Added a check in `_collect_gateway_skill_entries()` so plugin commands requiring mandatory arguments are skipped when `platform == "telegram"`, preserving exact parity with `telegram_bot_commands()` while leaving Discord collection untouched.

## Tests

- Added `TestTelegramMenuPluginCommands` in `tests/hermes_cli/test_commands.py` covering mandatory-argument, optional-argument, and no-argument plugin commands across Telegram and Discord collectors.
- `pytest tests/hermes_cli/test_commands.py`: 175 passed
- `ruff check hermes_cli/commands.py tests/hermes_cli/test_commands.py`: All checks passed
- `git diff --check`: Passed cleanly
