### PR TITLE
fix: make macOS runtime and tests portable

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -492,10 +492,28 @@ class LSPClient:
                     pass
         finally:
             self._state = "stopped"
-            await self._cleanup_process()
+            await self._cleanup_process(wait_for_graceful_exit=True)
 
-    async def _cleanup_process(self) -> None:
+    async def _cleanup_process(
+        self, *, wait_for_graceful_exit: bool = False
+    ) -> None:
         async with self._cleanup_lock:
+            proc = self._proc
+            if (
+                wait_for_graceful_exit
+                and proc is not None
+                and proc.returncode is None
+            ):
+                # The LSP ``exit`` notification asks the server to terminate.
+                # Give it the advertised grace period before sending an OS signal.
+                # Besides avoiding needless SIGTERM, this closes a Darwin race where
+                # the child exits and its PID is reused before asyncio updates the
+                # Process.returncode field.
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+                except asyncio.TimeoutError:
+                    pass
+
             current_task = asyncio.current_task()
             reader_task = self._reader_task
             self._reader_task = None
@@ -517,7 +535,6 @@ class LSPClient:
                     await stderr_task
                 except (asyncio.CancelledError, Exception):  # noqa: BLE001
                     pass
-            proc = self._proc
             self._proc = None
             if proc is None:
                 return

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -80,7 +80,7 @@ DIAGNOSTICS_DOCUMENT_WAIT = 5.0
 DIAGNOSTICS_FULL_WAIT = 10.0
 DIAGNOSTICS_REQUEST_TIMEOUT = 3.0
 PUSH_DEBOUNCE = 0.15
-SHUTDOWN_GRACE = 1.0  # seconds between SIGTERM and SIGKILL
+SHUTDOWN_GRACE = 1.0  # protocol-exit and SIGTERM grace before stronger signals
 
 # Retry policy for transient ContentModified errors.
 MAX_CONTENT_MODIFIED_RETRIES = 3
@@ -471,9 +471,27 @@ class LSPClient:
                     pass
         finally:
             self._state = "stopped"
-            await self._cleanup_process()
+            await self._cleanup_process(wait_for_graceful_exit=True)
 
-    async def _cleanup_process(self) -> None:
+    async def _cleanup_process(
+        self, *, wait_for_graceful_exit: bool = False
+    ) -> None:
+        proc = self._proc
+        if (
+            wait_for_graceful_exit
+            and proc is not None
+            and proc.returncode is None
+        ):
+            # The LSP ``exit`` notification asks the server to terminate.
+            # Give it the advertised grace period before sending an OS signal.
+            # Besides avoiding needless SIGTERM, this closes a Darwin race where
+            # the child exits and its PID is reused before asyncio updates the
+            # Process.returncode field.
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+            except asyncio.TimeoutError:
+                pass
+
         if self._reader_task is not None and not self._reader_task.done():
             self._reader_task.cancel()
             try:
@@ -486,7 +504,6 @@ class LSPClient:
                 await self._stderr_task
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
-        proc = self._proc
         self._proc = None
         if proc is None:
             return

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import shutil
 import subprocess
 import sys
 import time
@@ -208,9 +209,9 @@ def spawn_async_diagnostic(
     """Fire-and-forget ``ps``-style snapshot written to ``log_path``.
 
     Runs as a detached subprocess so it can't block the asyncio event loop
-    or compete with platform teardown.  The subprocess uses its own
-    ``timeout`` so a wedged ``ps`` still self-cleans within
-    ``timeout_seconds``.
+    or compete with platform teardown. GNU ``timeout`` (or Homebrew
+    ``gtimeout``) bounds the subprocess when available; otherwise the detached
+    diagnostic still cannot block gateway teardown.
 
     Returns the subprocess PID on success, ``None`` on failure.  Never
     raises.
@@ -231,19 +232,31 @@ def spawn_async_diagnostic(
     if sys.platform == "win32":
         return None
 
-    script = (
-        f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
-        "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
-        "echo '--- ps auxf (top 60 by cpu) ---'; "
-        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
-        "echo '--- pstree of self ---'; "
-        f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
-        "echo '--- /proc/loadavg ---'; "
-        "cat /proc/loadavg 2>/dev/null || true; "
-        "echo '--- recent dmesg (oom/killed) ---'; "
-        "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
-        "echo '=== end ==='"
-    )
+    if sys.platform == "darwin":
+        script = (
+            f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
+            "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
+            "echo '--- ps aux (top 60 by cpu) ---'; "
+            "ps aux 2>/dev/null | sort -nrk 3 | head -60; "
+            "echo '--- process ancestry ---'; "
+            f"ps -p {os.getpid()} -o pid=,ppid=,state=,etime=,command= 2>/dev/null || true; "
+            "echo '--- load average ---'; sysctl -n vm.loadavg 2>/dev/null || true; "
+            "echo '=== end ==='"
+        )
+    else:
+        script = (
+            f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
+            "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
+            "echo '--- ps auxf (top 60 by cpu) ---'; "
+            "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
+            "echo '--- pstree of self ---'; "
+            f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
+            "echo '--- /proc/loadavg ---'; "
+            "cat /proc/loadavg 2>/dev/null || true; "
+            "echo '--- recent dmesg (oom/killed) ---'; "
+            "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
+            "echo '=== end ==='"
+        )
 
     try:
         # Open the log file in append mode and let the subprocess inherit.
@@ -259,8 +272,12 @@ def spawn_async_diagnostic(
         # would also reap us anyway, but defense in depth).  Without
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
+        timeout_executable = shutil.which("timeout") or shutil.which("gtimeout")
+        argv = ["bash", "-c", script]
+        if timeout_executable:
+            argv = [timeout_executable, f"{timeout_seconds:.0f}", *argv]
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            argv,
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import shutil
 import subprocess
 import sys
 import time
@@ -203,9 +204,9 @@ def spawn_async_diagnostic(
     """Fire-and-forget ``ps``-style snapshot written to ``log_path``.
 
     Runs as a detached subprocess so it can't block the asyncio event loop
-    or compete with platform teardown.  The subprocess uses its own
-    ``timeout`` so a wedged ``ps`` still self-cleans within
-    ``timeout_seconds``.
+    or compete with platform teardown. GNU ``timeout`` (or Homebrew
+    ``gtimeout``) bounds the subprocess when available; otherwise the detached
+    diagnostic still cannot block gateway teardown.
 
     Returns the subprocess PID on success, ``None`` on failure.  Never
     raises.
@@ -226,19 +227,31 @@ def spawn_async_diagnostic(
     if sys.platform == "win32":
         return None
 
-    script = (
-        f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
-        "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
-        "echo '--- ps auxf (top 60 by cpu) ---'; "
-        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
-        "echo '--- pstree of self ---'; "
-        f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
-        "echo '--- /proc/loadavg ---'; "
-        "cat /proc/loadavg 2>/dev/null || true; "
-        "echo '--- recent dmesg (oom/killed) ---'; "
-        "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
-        "echo '=== end ==='"
-    )
+    if sys.platform == "darwin":
+        script = (
+            f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
+            "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
+            "echo '--- ps aux (top 60 by cpu) ---'; "
+            "ps aux 2>/dev/null | sort -nrk 3 | head -60; "
+            "echo '--- process ancestry ---'; "
+            f"ps -p {os.getpid()} -o pid=,ppid=,state=,etime=,command= 2>/dev/null || true; "
+            "echo '--- load average ---'; sysctl -n vm.loadavg 2>/dev/null || true; "
+            "echo '=== end ==='"
+        )
+    else:
+        script = (
+            f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
+            "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
+            "echo '--- ps auxf (top 60 by cpu) ---'; "
+            "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
+            "echo '--- pstree of self ---'; "
+            f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
+            "echo '--- /proc/loadavg ---'; "
+            "cat /proc/loadavg 2>/dev/null || true; "
+            "echo '--- recent dmesg (oom/killed) ---'; "
+            "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
+            "echo '=== end ==='"
+        )
 
     try:
         # Open the log file in append mode and let the subprocess inherit.
@@ -254,8 +267,12 @@ def spawn_async_diagnostic(
         # would also reap us anyway, but defense in depth).  Without
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
+        timeout_executable = shutil.which("timeout") or shutil.which("gtimeout")
+        argv = ["bash", "-c", script]
+        if timeout_executable:
+            argv = [timeout_executable, f"{timeout_seconds:.0f}", *argv]
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            argv,
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -487,7 +487,6 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
         if path.exists():
             return
         path.mkdir(parents=False, exist_ok=False)
-        path.chmod(mode)
         try:
             os.chown(path, _HERMES_UID, _HERMES_GID)
         except PermissionError:
@@ -496,6 +495,9 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
             # swallowing this keeps both root and unprivileged callers
             # on one code path.
             pass
+        # Apply the final mode after chown: POSIX permits chown() to clear
+        # set-ID bits, which would silently drop event/'s setgid contract.
+        path.chmod(mode)
 
     # Top-level event/ dir (this is the s6-svlisten1 event-subscription
     # dir at the service root, distinct from supervise/event/).
@@ -517,11 +519,11 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
     control = supervise / "control"
     if not control.exists():
         os.mkfifo(control, 0o660)
-        control.chmod(0o660)
         try:
             os.chown(control, _HERMES_UID, _HERMES_GID)
         except PermissionError:
             pass
+        control.chmod(0o660)
 
     # If a log/ subdir is present (the canonical s6 logger pattern —
     # see servicedir(7)), it gets its own s6-supervise instance and
@@ -537,11 +539,11 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
         log_control = log_supervise / "control"
         if not log_control.exists():
             os.mkfifo(log_control, 0o660)
-            log_control.chmod(0o660)
             try:
                 os.chown(log_control, _HERMES_UID, _HERMES_GID)
             except PermissionError:
                 pass
+            log_control.chmod(0o660)
 
 
 class S6Error(RuntimeError):

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -59,9 +59,14 @@ async def test_shutdown_does_not_terminate_server_that_exits_during_grace(
 ) -> None:
     """Protocol-cooperative exit must complete before any OS signal is sent."""
 
+    class _Stdin:
+        def is_closing(self) -> bool:
+            return False
+
     class GracefulProcess:
         def __init__(self) -> None:
             self.returncode = None
+            self.stdin = _Stdin()
             self.wait_calls = 0
             self.terminate = MagicMock()
             self.kill = MagicMock()
@@ -73,7 +78,9 @@ async def test_shutdown_does_not_terminate_server_that_exits_during_grace(
 
     client = _client(tmp_path)
     process = GracefulProcess()
+    reader_task = asyncio.create_task(asyncio.sleep(60))
     client._proc = process
+    client._reader_task = reader_task
     client._state = "running"
     send_request = AsyncMock(return_value=None)
     send_notification = AsyncMock(return_value=None)

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -11,6 +11,7 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -50,6 +51,43 @@ async def test_client_lifecycle_clean(tmp_path: Path):
     finally:
         await client.shutdown()
     assert not client.is_running
+
+
+@pytest.mark.asyncio
+async def test_shutdown_does_not_terminate_server_that_exits_during_grace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Protocol-cooperative exit must complete before any OS signal is sent."""
+
+    class GracefulProcess:
+        def __init__(self) -> None:
+            self.returncode = None
+            self.wait_calls = 0
+            self.terminate = MagicMock()
+            self.kill = MagicMock()
+
+        async def wait(self) -> int:
+            self.wait_calls += 1
+            self.returncode = 0
+            return 0
+
+    client = _client(tmp_path)
+    process = GracefulProcess()
+    client._proc = process
+    client._state = "running"
+    send_request = AsyncMock(return_value=None)
+    send_notification = AsyncMock(return_value=None)
+    monkeypatch.setattr(client, "_send_request", send_request)
+    monkeypatch.setattr(client, "_send_notification", send_notification)
+
+    await client.shutdown()
+
+    assert process.wait_calls == 1
+    send_request.assert_awaited_once_with("shutdown", None)
+    send_notification.assert_awaited_once_with("exit", None)
+    process.terminate.assert_not_called()
+    process.kill.assert_not_called()
+    assert client._proc is None
 
 
 @pytest.mark.asyncio

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -11,6 +11,7 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -52,6 +53,43 @@ async def test_client_lifecycle_clean(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_shutdown_does_not_terminate_server_that_exits_during_grace(
+    tmp_path: Path, monkeypatch
+):
+    """Protocol-cooperative exit must complete before any OS signal is sent."""
+
+    class GracefulProcess:
+        def __init__(self):
+            self.returncode = None
+            self.wait_calls = 0
+            self.terminate = MagicMock()
+            self.kill = MagicMock()
+
+        async def wait(self):
+            self.wait_calls += 1
+            self.returncode = 0
+            return 0
+
+    client = _client(tmp_path)
+    process = GracefulProcess()
+    client._proc = process
+    client._state = "running"
+    send_request = AsyncMock(return_value=None)
+    send_notification = AsyncMock(return_value=None)
+    monkeypatch.setattr(client, "_send_request", send_request)
+    monkeypatch.setattr(client, "_send_notification", send_notification)
+
+    await client.shutdown()
+
+    assert process.wait_calls == 1
+    send_request.assert_awaited_once_with("shutdown", None)
+    send_notification.assert_awaited_once_with("exit", None)
+    process.terminate.assert_not_called()
+    process.kill.assert_not_called()
+    assert client._proc is None
+
+
+@pytest.mark.asyncio
 async def test_client_receives_published_errors(tmp_path: Path):
     f = tmp_path / "x.py"
     f.write_text("print('hi')\n")
@@ -70,8 +108,6 @@ async def test_client_receives_published_errors(tmp_path: Path):
         assert "synthetic error" in d["message"]
     finally:
         await client.shutdown()
-
-
 
 
 

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import sys
 
 import pytest
 
 
 @pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
+    sys.platform != "linux" or not hasattr(socket, "AF_UNIX"),
+    reason="systemd abstract Unix sockets are a Linux-only address format",
 )
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"
@@ -77,5 +79,4 @@ async def test_watchdog_sends_ready_heartbeat_and_stopping(monkeypatch):
     assert "WATCHDOG=1" in calls
     assert calls[-1] == "STOPPING=1"
     assert watchdog.unhealthy is False
-
 

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -250,6 +250,35 @@ def test_seed_supervise_skeleton_sets_setgid_on_event_dirs(tmp_path) -> None:
         assert mode == 0o3730, f"{rel}/ mode = {oct(mode)}, want 0o3730"
 
 
+def test_seed_supervise_skeleton_applies_modes_after_chown(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ownership changes must not silently clear event set-ID bits."""
+    import os
+    from pathlib import Path
+
+    import hermes_cli.service_manager as service_manager
+
+    operations: list[tuple[str, str]] = []
+    real_chmod = Path.chmod
+
+    def record_chown(path, uid, gid) -> None:
+        operations.append(("chown", Path(path).name))
+
+    def record_chmod(path, mode, *, follow_symlinks=True) -> None:
+        operations.append(("chmod", path.name))
+        real_chmod(path, mode, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(os, "chown", record_chown)
+    monkeypatch.setattr(Path, "chmod", record_chmod)
+
+    svc_dir = tmp_path / "gateway-foo"
+    svc_dir.mkdir()
+    service_manager._seed_supervise_skeleton(svc_dir)
+
+    assert operations[:2] == [("chown", "event"), ("chmod", "event")]
+
+
 
 
 

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -192,23 +192,31 @@ def fake_subprocess_run(monkeypatch: pytest.MonkeyPatch):
 # tests/docker/test_s6_profile_gateway_integration.py.
 
 
-def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
+def test_seed_supervise_skeleton_creates_expected_layout(
+    tmp_path, monkeypatch
+) -> None:
     """Verifies the dirs + FIFO + modes the helper lays down."""
+    import os
     import stat
+    import sys
 
-    from hermes_cli.service_manager import _seed_supervise_skeleton
+    import hermes_cli.service_manager as service_manager
+
+    monkeypatch.setattr(service_manager, "_HERMES_UID", os.getuid())
+    monkeypatch.setattr(service_manager, "_HERMES_GID", os.getgid())
 
     svc_dir = tmp_path / "gateway-foo"
     svc_dir.mkdir()
 
-    _seed_supervise_skeleton(svc_dir)
+    service_manager._seed_supervise_skeleton(svc_dir)
 
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
-        f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
-    )
+    event_mode = stat.S_IMODE(event.stat().st_mode)
+    assert event_mode & ~stat.S_ISGID == 0o1730
+    if sys.platform != "darwin":
+        assert event_mode & stat.S_ISGID
 
     # supervise/ dir.
     supervise = svc_dir / "supervise"
@@ -218,7 +226,10 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
+    supervise_event_mode = stat.S_IMODE(supervise_event.stat().st_mode)
+    assert supervise_event_mode & ~stat.S_ISGID == 0o1730
+    if sys.platform != "darwin":
+        assert supervise_event_mode & stat.S_ISGID
 
     # supervise/control FIFO.
     control = supervise / "control"
@@ -227,6 +238,35 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
         "supervise/control must be a FIFO"
     )
     assert stat.S_IMODE(control.stat().st_mode) == 0o660
+
+
+def test_seed_supervise_skeleton_applies_modes_after_chown(
+    tmp_path, monkeypatch
+) -> None:
+    """Ownership changes must not silently clear event set-ID bits."""
+    import os
+    from pathlib import Path
+
+    import hermes_cli.service_manager as service_manager
+
+    operations: list[tuple[str, str]] = []
+    real_chmod = Path.chmod
+
+    def record_chown(path, uid, gid) -> None:
+        operations.append(("chown", Path(path).name))
+
+    def record_chmod(path, mode, *, follow_symlinks=True) -> None:
+        operations.append(("chmod", path.name))
+        real_chmod(path, mode, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(os, "chown", record_chown)
+    monkeypatch.setattr(Path, "chmod", record_chmod)
+
+    svc_dir = tmp_path / "gateway-foo"
+    svc_dir.mkdir()
+    service_manager._seed_supervise_skeleton(svc_dir)
+
+    assert operations[:2] == [("chown", "event"), ("chmod", "event")]
 
 
 
@@ -487,5 +527,4 @@ def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None
     assert after.st_gid == before.st_gid
     assert (victim / "marker").read_text(encoding="utf-8") == "keep"
     assert (victim / "lock").read_text(encoding="utf-8") == "keep-lock"
-
 

--- a/tests/hermes_cli/test_signal_handler_kanban_worker.py
+++ b/tests/hermes_cli/test_signal_handler_kanban_worker.py
@@ -79,47 +79,10 @@ def _synthetic_worker_script() -> str:
 
 
 def _is_alive_like_dispatcher(pid: int) -> bool:
-    """Mirrors hermes_cli/kanban_db.py:_pid_alive on Linux.
+    """Exercise the dispatcher's real cross-platform liveness contract."""
+    from hermes_cli.kanban_db import _pid_alive
 
-    A zombie is treated as dead — the dispatcher's _pid_alive checks
-    /proc/<pid>/status for State: Z. We replicate that here so a clean
-    os._exit followed by zombie-state is correctly counted as dead.
-    """
-    if pid <= 0:
-        return False
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    if sys.platform == "linux":
-        try:
-            with open(f"/proc/{pid}/status") as f:
-                for line in f:
-                    if line.startswith("State:"):
-                        if "Z" in line.split(":", 1)[1]:
-                            return False
-                        break
-        except (FileNotFoundError, PermissionError, OSError):
-            pass
-    elif sys.platform == "darwin":
-        try:
-            proc = subprocess.run(
-                ["ps", "-o", "stat=", "-p", str(pid)],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                text=True,
-                timeout=1,
-                check=False,
-            )
-            if proc.returncode != 0:
-                return False
-            if "Z" in (proc.stdout or "").strip():
-                return False
-        except (OSError, subprocess.SubprocessError, TimeoutError):
-            pass
-    return True
+    return _pid_alive(pid)
 
 
 def _spawn_synthetic(env_overrides: dict) -> subprocess.Popen:
@@ -214,5 +177,4 @@ def test_sigterm_without_kanban_task_env_uses_keyboard_interrupt_path():
             pass
     finally:
         _cleanup(proc)
-
 

--- a/tests/hermes_cli/test_signal_handler_kanban_worker.py
+++ b/tests/hermes_cli/test_signal_handler_kanban_worker.py
@@ -121,6 +121,7 @@ def _cleanup(proc: subprocess.Popen) -> None:
     sys.platform == "win32",
     reason="SIGTERM semantics differ on Windows; kanban dispatcher is POSIX-only",
 )
+@pytest.mark.live_system_guard_bypass
 def test_sigterm_with_kanban_task_env_terminates_quickly():
     """With HERMES_KANBAN_TASK set, SIGTERM should kill the process in <2s
     even when a non-daemon thread is still alive."""
@@ -150,6 +151,7 @@ def test_sigterm_with_kanban_task_env_terminates_quickly():
     sys.platform == "win32",
     reason="SIGTERM semantics differ on Windows; kanban dispatcher is POSIX-only",
 )
+@pytest.mark.live_system_guard_bypass
 def test_sigterm_without_kanban_task_env_uses_keyboard_interrupt_path():
     """Without HERMES_KANBAN_TASK, the original KeyboardInterrupt path runs.
 
@@ -177,4 +179,3 @@ def test_sigterm_without_kanban_task_env_uses_keyboard_interrupt_path():
             pass
     finally:
         _cleanup(proc)
-

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -102,7 +102,8 @@ class TestDetectDangerousRm:
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
         with mock_patch("tempfile.gettempdir", return_value="/tmp"):
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                temp_dir = os.path.realpath("/tmp")
+                assert detect_dangerous_command(f"rm -f {temp_dir}/{prefix}example.py") == (
                     False,
                     None,
                     None,

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -132,6 +132,15 @@ class TestAtomicSnapshotWrite:
         assert ".tmp.$$" not in wrapped
 
 
+    def test_wrap_command_mv_chained_on_export_success(self):
+        """A failed export must not replace a valid snapshot."""
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("echo hi", "/tmp")
+        assert "export -p" in wrapped and "> " in wrapped and "&& mv -f " in wrapped
+        assert "rm -f " in wrapped
+
+
     def test_init_session_bootstrap_also_atomic_and_mktemp(self):
         """The init_session bootstrap (first snapshot write) is the same shared
         file a concurrent command could source — it must be atomic and use

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -115,25 +115,35 @@ class TestAtomicSnapshotWrite:
         assert f"> '{snap}'" not in wrapped
         assert f"> {snap}\n" not in wrapped
 
-    def test_temp_path_uses_bashpid_not_dollardollar(self):
-        """The temp name MUST use ``$BASHPID`` (the real subshell PID), not
-        ``$$``.  In ``&``-launched concurrent subshells ``$$`` stays the parent
-        shell's PID, so two writers would pick the same temp name, clobber each
-        other mid-write, and mv would publish a torn file — the corruption is
-        only narrowed, not closed.  This is the bug shared by every prior PR in
-        the #38249 cluster."""
+    def test_temp_path_uses_mktemp_not_shell_pid(self):
+        """Portable unique names must work on macOS Bash 3.2 too."""
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
-        assert "$BASHPID" in wrapped
-        # The bare $$ temp form must be gone.
+        assert "mktemp " in wrapped
+        assert ".tmp.XXXXXX" in wrapped
+        assert "$BASHPID" not in wrapped
         assert ".tmp.$$" not in wrapped
 
+    def test_temp_path_template_with_spaces_is_quoted(self):
+        """The mktemp template remains one token when its directory has spaces."""
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        env._snapshot_path = "/tmp/has space/hermes-snap-x.sh"
+        wrapped = env._wrap_command("echo hi", "/tmp")
+        assert "mktemp '/tmp/has space/hermes-snap-x.sh.tmp.XXXXXX'" in wrapped
 
-    def test_init_session_bootstrap_also_atomic_and_bashpid(self):
+    def test_wrap_command_mv_chained_on_export_success(self):
+        """A failed export must not replace a valid snapshot."""
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("echo hi", "/tmp")
+        assert "export -p" in wrapped and "> " in wrapped and "&& mv -f " in wrapped
+        assert "rm -f " in wrapped
+
+    def test_init_session_bootstrap_also_atomic_and_uses_mktemp(self):
         """The init_session bootstrap (first snapshot write) is the same shared
-        file a concurrent command could source — it must be atomic and use
-        ``$BASHPID`` too."""
+        file a concurrent command could source and must use portable mktemp."""
         env = _TestableEnv()
         captured = {}
 
@@ -148,7 +158,8 @@ class TestAtomicSnapshotWrite:
             pass
         boot = captured.get("cmd", "")
         assert ".tmp." in boot and "mv -f " in boot, boot
-        assert "$BASHPID" in boot
+        assert "mktemp " in boot and ".tmp.XXXXXX" in boot
+        assert "$BASHPID" not in boot
         assert ".tmp.$$" not in boot
 
 
@@ -178,8 +189,8 @@ class TestAtomicSnapshotConcurrencyBehavioral:
     the emitted script's guarantee holds under real concurrency: N concurrent
     writers + readers, and the snapshot is ALWAYS a complete, parseable env
     dump — never truncated mid-line with a ``declare -x`` / ``export`` fragment
-    that would corrupt PATH.  Crucially it uses ``$BASHPID`` (per-subshell
-    unique), which is what closes the race; ``$$`` would still tear here.
+    that would corrupt PATH. It uses the same portable ``mktemp`` strategy as
+    production, including on macOS Bash 3.2 where ``BASHPID`` is unavailable.
     """
 
     def _run(self, script):
@@ -194,13 +205,13 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         import shlex
         snap = str(tmp_path / "hermes-snap-x.sh")
         _q = shlex.quote
-        _snap_tmp = _q(snap + ".tmp.") + "$BASHPID"
         # One writer iteration = the exact atomic sequence _wrap_command emits.
         writer = (
             "for i in $(seq 1 80); do "
             "export BIG_$i=$(head -c 600 /dev/zero | tr '\\0' x); "
-            f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_q(snap)}; }} "
-            f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true; "
+            f"tmp=$(mktemp {_q(snap + '.tmp.XXXXXX')}) || exit 1; "
+            f"{{ export -p > \"$tmp\" && mv -f \"$tmp\" {_q(snap)}; }} "
+            "2>/dev/null || rm -f \"$tmp\" 2>/dev/null || true; "
             "done"
         )
         # Reader: repeatedly source the snapshot and check PATH never absorbs

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1516,7 +1516,10 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_pid is None
         assert backend._active_window_id is None
 
-    def test_linux_default_capture_skips_gnome_shell_helper(self):
+    def test_linux_default_capture_skips_gnome_shell_helper(self, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        monkeypatch.setattr(cua_backend.sys, "platform", "linux")
         windows = [
             {"app_name": "", "pid": 100, "window_id": 1,
              "is_on_screen": None, "title": "@!1921,0;BDHF", "z_index": 0},

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1221,7 +1221,10 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_pid is None
         assert backend._active_window_id is None
 
-    def test_linux_default_capture_skips_gnome_shell_helper(self):
+    def test_linux_default_capture_skips_gnome_shell_helper(self, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        monkeypatch.setattr(cua_backend.sys, "platform", "linux")
         windows = [
             {"app_name": "", "pid": 100, "window_id": 1,
              "is_on_screen": None, "title": "@!1921,0;BDHF", "z_index": 0},

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 
 import pytest
@@ -49,6 +50,18 @@ def test_real_binaries_execute_leading_dash_program_payload(
     """A PATH marker proves these binaries do not reparse '-program' as an option."""
     if shutil.which(tool) is None or (needs_tty and shutil.which("script") is None):
         pytest.skip(f"{tool} or script is not installed")
+    if tool == "sort":
+        version = subprocess.run(
+            [tool, "--version"], capture_output=True, text=True, check=False
+        )
+        if "GNU coreutils" not in (version.stdout + version.stderr):
+            pytest.skip("execution-bearing sort flags are GNU-sort specific")
+    if tool == "man":
+        version = subprocess.run(
+            [tool, "--version"], capture_output=True, text=True, check=False
+        )
+        if version.returncode != 0 or "man-db" not in (version.stdout + version.stderr):
+            pytest.skip("long pager-option integration is specific to man-db")
 
     marker = tmp_path / "executed"
     payload = tmp_path / "-payload-marker"
@@ -70,7 +83,10 @@ def test_real_binaries_execute_leading_dash_program_payload(
     }
     argv = [tool, *resolved_args]
     if needs_tty:
-        argv = ["script", "-qec", shlex.join(argv), "/dev/null"]
+        if sys.platform == "darwin":
+            argv = ["script", "-q", "/dev/null", *argv]
+        else:
+            argv = ["script", "-qec", shlex.join(argv), "/dev/null"]
 
     subprocess.run(argv, input=input_text, text=True, capture_output=True, env=env, timeout=20)
 

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -54,7 +55,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            os.path.realpath("/tmp/out.txt"), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -145,7 +148,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "foo", "bar", False
+        )
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -52,7 +53,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            os.path.realpath("/tmp/out.txt"), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -143,7 +146,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "foo", "bar", False
+        )
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -256,6 +256,48 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
+    def test_canonical_user_temp_child_allowed(self, tmp_path, monkeypatch):
+        """A canonical temp child remains writable inside a sensitive parent."""
+        from tools import file_tools
+
+        temp_root = tmp_path / "user-temp"
+        temp_root.mkdir()
+        sensitive_parent = str(tmp_path.resolve()) + os.sep
+        monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: str(temp_root))
+        monkeypatch.setattr(
+            file_tools,
+            "_SENSITIVE_PATH_PREFIXES",
+            (sensitive_parent,),
+        )
+
+        target = temp_root / "workspace" / "artifact.txt"
+        assert file_tools._check_sensitive_path(str(target)) is None
+
+    def test_temp_symlink_escape_to_protected_sibling_blocked(
+        self, tmp_path, monkeypatch
+    ):
+        """Canonicalization must prevent a temp-root symlink escape."""
+        from tools import file_tools
+
+        temp_root = tmp_path / "user-temp"
+        protected = tmp_path / "db"
+        temp_root.mkdir()
+        protected.mkdir()
+        escape = temp_root / "escape"
+        escape.symlink_to(protected, target_is_directory=True)
+
+        sensitive_parent = str(tmp_path.resolve()) + os.sep
+        monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: str(temp_root))
+        monkeypatch.setattr(
+            file_tools,
+            "_SENSITIVE_PATH_PREFIXES",
+            (sensitive_parent,),
+        )
+
+        result = file_tools._check_sensitive_path(str(escape / "secret"))
+        assert result is not None
+        assert "sensitive system path" in result
+
 
 class TestAtomicWrite:
     """write_file / patch land via a temp-file + atomic rename.

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -212,6 +212,48 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
+    def test_canonical_user_temp_child_allowed(self, tmp_path, monkeypatch):
+        """A canonical temp child remains writable inside a sensitive parent."""
+        from tools import file_tools
+
+        temp_root = tmp_path / "user-temp"
+        temp_root.mkdir()
+        sensitive_parent = str(tmp_path.resolve()) + os.sep
+        monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: str(temp_root))
+        monkeypatch.setattr(
+            file_tools,
+            "_SENSITIVE_PATH_PREFIXES",
+            (sensitive_parent,),
+        )
+
+        target = temp_root / "workspace" / "artifact.txt"
+        assert file_tools._check_sensitive_path(str(target)) is None
+
+    def test_temp_symlink_escape_to_protected_sibling_blocked(
+        self, tmp_path, monkeypatch
+    ):
+        """Canonicalization must prevent a temp-root symlink escape."""
+        from tools import file_tools
+
+        temp_root = tmp_path / "user-temp"
+        protected = tmp_path / "db"
+        temp_root.mkdir()
+        protected.mkdir()
+        escape = temp_root / "escape"
+        escape.symlink_to(protected, target_is_directory=True)
+
+        sensitive_parent = str(tmp_path.resolve()) + os.sep
+        monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: str(temp_root))
+        monkeypatch.setattr(
+            file_tools,
+            "_SENSITIVE_PATH_PREFIXES",
+            (sensitive_parent,),
+        )
+
+        result = file_tools._check_sensitive_path(str(escape / "secret"))
+        assert result is not None
+        assert "sensitive system path" in result
+
 
 class TestAtomicWrite:
     """write_file / patch land via a temp-file + atomic rename.

--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -124,11 +124,14 @@ def test_run_stdio_malware_check_does_not_block_event_loop():
 def test_run_stdio_malware_check_times_out_fail_open():
     """A check that hangs past the timeout must NOT freeze startup: it times
     out, logs, and proceeds (fail-open) so the server still starts."""
-    import time
+    import threading
     mock_stdio_cm, mock_session_cm = _stdio_mocks()
+    check_started = threading.Event()
+    release_check = threading.Event()
 
     def hung_check(_command, _args):
-        time.sleep(0.5)  # outlasts the 0.2s timeout 2.5x; short enough not to stall teardown
+        check_started.set()
+        release_check.wait(timeout=10)
         return "MALWARE"  # would block startup if awaited to completion
 
     async def _test():
@@ -138,11 +141,17 @@ def test_run_stdio_malware_check_times_out_fail_open():
              patch("tools.mcp_tool.stdio_client", return_value=mock_stdio_cm), \
              patch("tools.mcp_tool.ClientSession", return_value=mock_session_cm):
             server = MCPServerTask("srv")
-            start = time.monotonic()
-            await server.start({"command": "npx", "args": ["-y", "pkg"]})
-            elapsed = time.monotonic() - start
-            await server.shutdown()
-        # Returned shortly after the 0.2s timeout (fail-open), not the 0.5s hang.
-        assert elapsed < 1.0, f"startup did not fail-open promptly ({elapsed:.1f}s)"
+            try:
+                await asyncio.wait_for(
+                    server.start({"command": "npx", "args": ["-y", "pkg"]}),
+                    timeout=5.0,
+                )
+                assert check_started.is_set()
+                # The worker cannot finish until released. Reaching this line
+                # proves the internal timeout proceeded without awaiting it.
+                assert not release_check.is_set()
+            finally:
+                release_check.set()
+                await server.shutdown()
 
     asyncio.run(_test())

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -419,12 +419,9 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
     lines. ``|| true`` keeps the success contract for callers that chain on it.
 
     The dump MUST be wrapped in a brace group with the redirection applied to
-    the group. *tmp_path* typically embeds ``$BASHPID`` for concurrency-safe
-    temp names; a redirection attached to a pipeline segment would expand
-    ``$BASHPID`` inside that segment's subshell (a different PID than the
-    parent that expands the follow-up ``mv``), silently orphaning the dump.
-    The brace-group redirect is expanded in the current shell, keeping both
-    expansions consistent.
+    the group. Callers pass one shell token (normally the quoted value of a
+    temp-path variable created by ``mktemp``), so the dump and follow-up
+    ``mv`` always address the same file.
     """
     # ${!PREFIX*} is bash 3.2+ name-prefix expansion; empty matches are fine
     # because ``unset`` with only missing names is ignored under 2>/dev/null.
@@ -542,18 +539,15 @@ class BaseEnvironment(ABC):
         # source() either sees the old complete snapshot or the new complete
         # one — never a partial/truncated file.
         #
-        # The temp name MUST be unique per concurrent writer.  ``$$`` is the
-        # bash PID, but in ``&``-launched subshells (how concurrent terminal
-        # calls run) ``$$`` stays the *parent* shell's PID — so two concurrent
-        # writers would pick the SAME temp name, clobber each other's temp
-        # mid-write, and mv would then publish a torn file (the corruption is
-        # only narrowed, not closed).  ``$BASHPID`` is the actual subshell PID
-        # and is genuinely unique per writer, which closes the race.  The
-        # static path is shell-quoted (Windows/Git-Bash drive letters, spaces)
-        # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # The temp name MUST be unique per concurrent writer. macOS ships
+        # Bash 3.2, where ``BASHPID`` is unset, so PID-derived names collapse
+        # to one shared ``.tmp.`` path. ``mktemp`` provides the required
+        # uniqueness across Bash 3.2, modern Bash, and Git Bash.
+        _snap_template = self._quote_shell_path(self._snapshot_path + ".tmp.XXXXXX")
+        _snap_tmp = '"$__hermes_snap_tmp"'
         bootstrap = (
             f"umask 077\n"
+            f"__hermes_snap_tmp=$(mktemp {_snap_template}) || exit 1\n"
             f"{_export_dump_excluding_session_vars(_snap_tmp)}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
@@ -662,11 +656,10 @@ class BaseEnvironment(ABC):
         # Use atomic file replacement for env snapshot updates (issue #38249).
         # Assemble into a per-writer-unique temp file, then mv to atomically
         # replace the snapshot so concurrent source() calls never read a
-        # truncated/half-written file.  ``$BASHPID`` (not ``$$``) is the actual
-        # subshell PID — unique per concurrent ``&``-launched writer — so two
-        # writers never share a temp name and clobber each other before the mv.
-        # Static path shell-quoted (Windows/spaces); ``$BASHPID`` left to expand.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # truncated/half-written file. Use ``mktemp`` rather than ``BASHPID``:
+        # the latter is unset by macOS's Bash 3.2 and caused writer collisions.
+        _snap_template = self._quote_shell_path(self._snapshot_path + ".tmp.XXXXXX")
+        _snap_tmp = '"$__hermes_snap_tmp"'
 
         parts = []
 
@@ -698,16 +691,19 @@ class BaseEnvironment(ABC):
         # Chain mv on the export succeeding so a failed/partial dump never
         # replaces a good snapshot; drop the temp on failure so it isn't
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
-        # NOTE: the redirection must be attached to a brace group — ``_snap_tmp``
-        # embeds ``$BASHPID``, and a redirect on a pipeline segment expands
-        # inside that segment's subshell (a different PID than the parent that
-        # expands the ``mv`` operand), silently orphaning the dump. See
-        # _export_dump_excluding_session_vars.
+        # NOTE: the redirection must be attached to a brace group so the dump
+        # has one success status and is only published after complete assembly.
         if self._snapshot_ready:
             parts.append(
-                f"{{ {_export_dump_excluding_session_vars(_snap_tmp)} "
+                f"__hermes_snap_tmp=$(mktemp {_snap_template} 2>/dev/null) "
+                "|| __hermes_snap_tmp="
+            )
+            parts.append(
+                f"[ -n \"$__hermes_snap_tmp\" ] && {{ "
+                f"{_export_dump_excluding_session_vars(_snap_tmp)} "
                 f"&& mv -f {_snap_tmp} {_quoted_snap}; }} "
-                f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
+                f"2>/dev/null || {{ [ -z \"$__hermes_snap_tmp\" ] "
+                f"|| rm -f {_snap_tmp} 2>/dev/null; true; }}"
             )
 
         # Emit the CWD stdout marker; all backends (including local, since

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -8,6 +8,7 @@ import logging
 import os
 import posixpath
 import sys
+import tempfile
 import threading
 from pathlib import Path, PurePosixPath
 
@@ -696,11 +697,6 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
-        return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to
@@ -712,6 +708,24 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+
+    # macOS places each user's writable temporary directory under
+    # /private/var/folders. That subtree is a legitimate workspace even though
+    # /private/var is otherwise sensitive. Compare canonical paths so a symlink
+    # inside the temp directory that escapes to /etc or /private/var/db does not
+    # bypass the guard.
+    try:
+        canonical_temp = os.path.realpath(tempfile.gettempdir())
+        if os.path.commonpath((resolved, canonical_temp)) == canonical_temp:
+            return None
+    except (OSError, ValueError):
+        pass
+
+    for prefix in _SENSITIVE_PATH_PREFIXES:
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return _err
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+        return _err
     return None
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import logging
 import os
 import posixpath
 import sys
+import tempfile
 import threading
 from pathlib import Path, PurePosixPath
 
@@ -604,11 +605,6 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
-        return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to
@@ -620,6 +616,24 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+
+    # macOS places each user's writable temporary directory under
+    # /private/var/folders. That subtree is a legitimate workspace even though
+    # /private/var is otherwise sensitive. Compare canonical paths so a symlink
+    # inside the temp directory that escapes to /etc or /private/var/db does not
+    # bypass the guard.
+    try:
+        canonical_temp = os.path.realpath(tempfile.gettempdir())
+        if os.path.commonpath((resolved, canonical_temp)) == canonical_temp:
+            return None
+    except (OSError, ValueError):
+        pass
+
+    for prefix in _SENSITIVE_PATH_PREFIXES:
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return _err
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+        return _err
     return None
 
 


### PR DESCRIPTION
## Summary

- let LSP servers exit through the protocol grace period before sending OS signals
- make shutdown diagnostics portable across GNU/Linux and macOS
- preserve final s6 directory and FIFO modes by applying chmod after chown
- replace Bash 4-only `$BASHPID` snapshot names with portable `mktemp` files
- allow only the canonical macOS user temp subtree through the sensitive-path guard while retaining symlink-escape protection
- remove Linux-only assumptions from the affected tests

## Root cause

Several runtime and test paths assumed GNU userland, Linux Unix-socket behavior, Linux service availability, or a newer Bash than macOS ships. The LSP cleanup path also signaled immediately after the protocol exit notification, leaving a Darwin PID-reuse race. Separately, applying ownership after permissions could clear required set-ID bits.

## Review follow-up

- added a controlled-process regression proving an LSP server that exits during `SHUTDOWN_GRACE` is never terminated or killed
- added explicit coverage for an allowed canonical macOS temp child and a blocked symlink escape into a protected sibling

## Validation

- post-rebase changed-surface gate: **360 passed, 0 failed** across 12 files
- canonical full suite: **22,912 passed, 17 failed** across 2,471 files; the one interrupt-timing failure passed on serial rerun, and the remaining **16 failures reproduce identically on untouched current upstream main** across the same 8 files
- Ruff on all changed files: passed
- Windows footgun scan on changed production files: passed
- `git diff --check`: passed

## Tracking

Fixes #72944
