### PR TITLE
fix(relay): return None on non-object media upload response

### DIFF
--- a/gateway/relay/media.py
+++ b/gateway/relay/media.py
@@ -141,6 +141,13 @@ class RelayMediaClient:
                     import json
 
                     body = json.loads(resp.read().decode("utf-8"))
+                    # A well-behaved connector returns a JSON object, but a
+                    # valid-JSON non-object (null, [], a string) would make
+                    # `.get` raise AttributeError — which escapes the except
+                    # below and breaks the best-effort contract. Treat any
+                    # non-object body as a failure.
+                    if not isinstance(body, dict):
+                        return None
                     media_id = body.get("id")
                     if not media_id:
                         return None

--- a/tests/gateway/relay/test_relay_media.py
+++ b/tests/gateway/relay/test_relay_media.py
@@ -281,3 +281,27 @@ async def test_client_upload_rejects_oversize_and_missing(tmp_path: Path):
     empty = tmp_path / "empty.bin"
     empty.write_bytes(b"")
     assert await c.upload(str(empty)) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [b"null", b"[]", b'"ok"', b"42"])
+async def test_client_upload_non_object_response_returns_none(tmp_path: Path, payload: bytes):
+    """A valid-JSON non-object response is a failure, not a crash.
+
+    `upload()` promises None on any failure; a body like `null`/`[]` used to
+    reach `.get` and raise AttributeError (outside the caught tuple), escaping
+    into the send path instead of degrading to the caller's fallback.
+    """
+    from unittest.mock import MagicMock, patch
+
+    src = tmp_path / "a.png"
+    src.write_bytes(b"x")
+    c = RelayMediaClient("https://c.example", "gw1", "sec")
+
+    resp = MagicMock()
+    resp.read.return_value = payload
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+
+    with patch("urllib.request.urlopen", return_value=resp):
+        assert await c.upload(str(src)) is None


### PR DESCRIPTION
## What does this PR do?

`RelayMediaClient.upload()` (`gateway/relay/media.py`) documents that it "returns None on any failure (callers fall back to their pre-media behaviour, media delivery is best-effort by design)." Its `except` clause catches `(urllib.error.URLError, ValueError, OSError)`.

But after a successful HTTP response it does `body = json.loads(...)` and then `body.get("id")`. If the connector returns a valid JSON value that is not an object (`null`, `[]`, a string, a number), `json.loads` succeeds and `body.get("id")` raises `AttributeError`, which is not in the caught tuple. So it escapes `upload()`, propagates through `_send_media()` and the `send_image_file` / `send_voice` / `send_video` / `send_document` senders, and bypasses the best-effort fallback those lanes rely on ("never a regression when the connector predates the op").

This guards the parsed body with `isinstance(body, dict)` before `.get`, so a non-object response degrades to `None` like every other failure.

## Related Issue

No open issue. Found by reading the Phase 2 media code (PR #71363, commit 689b51bef).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/relay/media.py`: in `upload()`'s `_post()`, return `None` when the parsed JSON body is not a dict, before calling `.get("id")`.
- `tests/gateway/relay/test_relay_media.py`: add a parametrized test (`null`, `[]`, `"ok"`, `42`) asserting `upload()` returns `None` instead of raising.

## How to Test

```
scripts/run_tests.sh tests/gateway/relay/test_relay_media.py -q
```

- With the fix: 19 passing.
- Reverting just the `isinstance` guard makes the 4 new cases fail with `AttributeError: '...' object has no attribute 'get'`, confirming the test catches the bug.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added a test that fails without the fix and passes with it
- [x] Cross-platform impact considered: pure stdlib logic, platform-independent
