### PR TITLE
fix(gateway): suppress JSON silence envelopes

### DIFF
--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -7,6 +7,7 @@ conversation history.
 
 from __future__ import annotations
 
+import json
 import unicodedata
 from typing import Any
 
@@ -22,6 +23,10 @@ LIVE_GATEWAY_SILENT_MARKERS = frozenset({
     "NO_REPLY",
     "NO REPLY",
 })
+
+_MAX_SILENCE_MARKER_LENGTH = 64
+_MAX_JSON_SILENCE_ENVELOPE_LENGTH = 256
+_JSON_WHITESPACE = frozenset(" \t\r\n")
 
 
 def _canonical_silence_candidate(text: str) -> str:
@@ -53,6 +58,126 @@ def _canonical_silence_candidates(text: str) -> tuple[str, ...]:
     return (exact, fallback)
 
 
+def _is_json_silence_envelope(text: str) -> bool:
+    stripped = text.strip(" \t\r\n")
+    if (
+        not stripped.startswith("{")
+        or not stripped.endswith("}")
+        or len(text) > _MAX_JSON_SILENCE_ENVELOPE_LENGTH
+    ):
+        return False
+    try:
+        pairs = json.loads(stripped, object_pairs_hook=lambda items: items)
+    except (TypeError, ValueError):
+        return False
+    return pairs == [("action", SILENT_REPLY_TOKEN)]
+
+
+def _skip_json_whitespace(text: str, index: int) -> int:
+    while index < len(text) and text[index] in _JSON_WHITESPACE:
+        index += 1
+    return index
+
+
+def _match_json_string_prefix(
+    text: str,
+    index: int,
+    expected: str,
+) -> tuple[str, int]:
+    """Match a JSON string that must decode to ``expected``."""
+    if index >= len(text):
+        return "partial", index
+    if text[index] != '"':
+        return "invalid", index
+    index += 1
+    expected_index = 0
+    simple_escapes = {
+        '"': '"',
+        "\\": "\\",
+        "/": "/",
+        "b": "\b",
+        "f": "\f",
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+    }
+    while index < len(text):
+        char = text[index]
+        if char == '"':
+            if expected_index != len(expected):
+                return "invalid", index
+            return "complete", index + 1
+        if expected_index >= len(expected) or ord(char) < 0x20:
+            return "invalid", index
+        if char != "\\":
+            if char != expected[expected_index]:
+                return "invalid", index
+            expected_index += 1
+            index += 1
+            continue
+
+        if index + 1 >= len(text):
+            return "partial", index
+        escape = text[index + 1]
+        if escape != "u":
+            decoded = simple_escapes.get(escape)
+            if decoded != expected[expected_index]:
+                return "invalid", index
+            expected_index += 1
+            index += 2
+            continue
+
+        expected_hex = f"{ord(expected[expected_index]):04x}"
+        available = text[index + 2 : index + 6]
+        if any(char not in "0123456789abcdefABCDEF" for char in available):
+            return "invalid", index
+        if not expected_hex.startswith(available.lower()):
+            return "invalid", index
+        if len(available) < 4:
+            return "partial", index
+        expected_index += 1
+        index += 6
+    return "partial", index
+
+
+def _could_be_json_silence_envelope(text: str) -> bool:
+    """Return whether a bounded prefix can still become the exact envelope."""
+    if len(text) > _MAX_JSON_SILENCE_ENVELOPE_LENGTH:
+        return False
+    index = _skip_json_whitespace(text, 0)
+    if index >= len(text) or text[index] != "{":
+        return False
+    index = _skip_json_whitespace(text, index + 1)
+    if index >= len(text):
+        return True
+
+    state, index = _match_json_string_prefix(text, index, "action")
+    if state == "partial":
+        return True
+    if state == "invalid":
+        return False
+    index = _skip_json_whitespace(text, index)
+    if index >= len(text):
+        return True
+    if text[index] != ":":
+        return False
+    index = _skip_json_whitespace(text, index + 1)
+    if index >= len(text):
+        return True
+
+    state, index = _match_json_string_prefix(text, index, SILENT_REPLY_TOKEN)
+    if state == "partial":
+        return True
+    if state == "invalid":
+        return False
+    index = _skip_json_whitespace(text, index)
+    if index >= len(text):
+        return True
+    if text[index] != "}":
+        return False
+    return _skip_json_whitespace(text, index + 1) == len(text)
+
+
 def is_intentional_silence_response(response: Any) -> bool:
     """Return True only when ``response`` is exactly a silence marker.
 
@@ -65,9 +190,14 @@ def is_intentional_silence_response(response: Any) -> bool:
     stripped = response.strip()
     if not stripped:
         return False
-    if len(stripped) > 64:
+    if _is_json_silence_envelope(response):
+        return True
+    if len(stripped) > _MAX_SILENCE_MARKER_LENGTH:
         return False
-    return any(candidate in LIVE_GATEWAY_SILENT_MARKERS for candidate in _canonical_silence_candidates(stripped))
+    return any(
+        candidate in LIVE_GATEWAY_SILENT_MARKERS
+        for candidate in _canonical_silence_candidates(stripped)
+    )
 
 
 def is_autonomous_silence_response(response: Any) -> bool:
@@ -91,6 +221,9 @@ def is_autonomous_silence_response(response: Any) -> bool:
     stripped = response.strip()
     if not stripped:
         return False
+
+    if _is_json_silence_envelope(response):
+        return True
 
     def _is_token(line: str) -> bool:
         return _canonical_silence_candidate(line) in LIVE_GATEWAY_SILENT_MARKERS
@@ -139,7 +272,11 @@ def is_partial_silence_marker(text: Any) -> bool:
     if not isinstance(text, str):
         return False
     stripped = text.strip()
-    if not stripped or len(stripped) > 64:
+    if not stripped:
+        return False
+    if _could_be_json_silence_envelope(text):
+        return True
+    if len(stripped) > _MAX_SILENCE_MARKER_LENGTH:
         return False
     for candidate in _canonical_silence_candidates(stripped):
         if candidate and any(marker.startswith(candidate) for marker in LIVE_GATEWAY_SILENT_MARKERS):

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -15,6 +15,31 @@ def test_edge_punctuation_silence_tokens_are_intentional_silence():
         assert is_intentional_silence_response(token)
 
 
+def test_single_action_json_silence_envelopes_are_intentional_silence():
+    for payload in (
+        '{"action":"NO_REPLY"}',
+        '{\n  "action": "NO_REPLY"\n}',
+    ):
+        assert is_intentional_silence_response(payload)
+        assert is_autonomous_silence_response(payload)
+
+
+def test_json_silence_envelope_requires_one_exact_action_key():
+    for payload in (
+        '{"action":"NO_REPLY","reason":"duplicate"}',
+        '{"Action":"NO_REPLY"}',
+        '{"action":"SILENT"}',
+        '{"action":" NO_REPLY "}',
+        '{"action":"NO_REPLY","action":"NO_REPLY"}',
+        '["NO_REPLY"]',
+        '{"action":',
+        '\u00a0{"action":"NO_REPLY"}',
+        '{"action":"NO_REPLY"}\u2028',
+    ):
+        assert not is_intentional_silence_response(payload)
+        assert not is_autonomous_silence_response(payload)
+
+
 def test_blank_and_prose_mentions_are_not_silence():
     assert not is_intentional_silence_response("")
     assert not is_intentional_silence_response("Use NO_REPLY when no answer is needed.")

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -10,6 +10,31 @@ def test_exact_silence_tokens_are_intentional_silence():
         assert is_intentional_silence_response(token)
 
 
+def test_single_action_json_silence_envelopes_are_intentional_silence():
+    for payload in (
+        '{"action":"NO_REPLY"}',
+        '{\n  "action": "NO_REPLY"\n}',
+    ):
+        assert is_intentional_silence_response(payload)
+        assert is_autonomous_silence_response(payload)
+
+
+def test_json_silence_envelope_requires_one_exact_action_key():
+    for payload in (
+        '{"action":"NO_REPLY","reason":"duplicate"}',
+        '{"Action":"NO_REPLY"}',
+        '{"action":"SILENT"}',
+        '{"action":" NO_REPLY "}',
+        '{"action":"NO_REPLY","action":"NO_REPLY"}',
+        '["NO_REPLY"]',
+        '{"action":',
+        '\u00a0{"action":"NO_REPLY"}',
+        '{"action":"NO_REPLY"}\u2028',
+    ):
+        assert not is_intentional_silence_response(payload)
+        assert not is_autonomous_silence_response(payload)
+
+
 def test_autonomous_silence_accepts_marker_with_own_line_note():
     """The loose rule for cron/webhook lanes: marker + explanation suppresses."""
     assert is_autonomous_silence_response("[SILENT]")

--- a/tests/gateway/test_stream_consumer_silence.py
+++ b/tests/gateway/test_stream_consumer_silence.py
@@ -50,6 +50,11 @@ PARTIAL_POSITIVE = [
     "[SILENT]",
     "SILENT",
     "sil",
+    "{",
+    '{"action"',
+    '{"action": "NO_',
+    '{"action":"\\u004e\\u004f_',
+    '{\n  "action": "NO_REPLY"\n}',
 ]
 
 # Buffers that have already diverged from every marker → stream normally.
@@ -63,6 +68,14 @@ PARTIAL_NEGATIVE = [
     "The NO_REPLY token means silence",      # marker mentioned mid-prose
     "x" * 65,                                # over the 64-char cap
     "silence is golden",                     # 'SILENCE...' is not a marker prefix
+    '{"action":"NO_REPLY","reason"',
+    '{"message"',
+    '{"action":"NOPE',
+    '{"action":null',
+    '\u00a0{"action":"NO_REPLY"}',
+    '{"action":"NO_REPLY"}\u2028',
+    '{"message":"NO_REPLY"}',
+    (" " * 257) + '{"action":"NO_REPLY"}',
 ]
 
 
@@ -122,6 +135,39 @@ def _sent_and_edited(adapter):
 
 
 class TestStreamedSilenceSuppression:
+    @pytest.mark.asyncio
+    async def test_json_no_reply_envelope_is_fully_suppressed(self):
+        """A one-key JSON silence envelope never reaches the platform."""
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1),
+        )
+        consumer.on_delta('{\n  "action": "NO_REPLY"\n}')
+        consumer.finish()
+        await consumer.run()
+
+        assert _sent_and_edited(adapter) == []
+        assert consumer.final_response_sent is False
+        assert consumer.final_content_delivered is False
+
+    @pytest.mark.asyncio
+    async def test_json_no_reply_unicode_escape_stream_is_fully_suppressed(self):
+        """An escaped action value stays hidden while its JSON is incomplete."""
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1),
+        )
+        consumer.on_delta('{"action":"\\u004e\\u004f_')
+        consumer.on_delta('REPLY"}')
+        consumer.finish()
+        await consumer.run()
+
+        assert _sent_and_edited(adapter) == []
+        assert consumer.final_response_sent is False
+        assert consumer.final_content_delivered is False
+
     @pytest.mark.asyncio
     async def test_no_reply_only_stream_is_fully_suppressed(self):
         """A stream whose entire content is NO_REPLY sends nothing visible."""

--- a/tests/gateway/test_stream_consumer_silence.py
+++ b/tests/gateway/test_stream_consumer_silence.py
@@ -19,6 +19,7 @@ These tests pin the two halves of the fix:
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -50,6 +51,11 @@ PARTIAL_POSITIVE = [
     "[SILENT]",
     "SILENT",
     "sil",
+    "{",
+    '{"action"',
+    '{"action": "NO_',
+    '{"action":"\\u004e\\u004f_',
+    '{\n  "action": "NO_REPLY"\n}',
 ]
 
 # Buffers that have already diverged from every marker → stream normally.
@@ -63,7 +69,29 @@ PARTIAL_NEGATIVE = [
     "The NO_REPLY token means silence",      # marker mentioned mid-prose
     "x" * 65,                                # over the 64-char cap
     "silence is golden",                     # 'SILENCE...' is not a marker prefix
+    '{"action":"NO_REPLY","reason"',
+    '{"message"',
+    '{"action":"NOPE',
+    '{"action":null',
+    '\u00a0{"action":"NO_REPLY"}',
+    '{"action":"NO_REPLY"}\u2028',
+    '{"message":"NO_REPLY"}',
+    (" " * 257) + '{"action":"NO_REPLY"}',
 ]
+
+
+@pytest.mark.parametrize("text", PARTIAL_POSITIVE)
+def test_partial_silence_marker_positive(text):
+    assert is_partial_silence_marker(text) is True
+
+
+@pytest.mark.parametrize("text", PARTIAL_NEGATIVE)
+def test_partial_silence_marker_negative(text):
+    assert is_partial_silence_marker(text) is False
+
+
+def test_partial_silence_marker_none_safe():
+    assert is_partial_silence_marker(None) is False
 
 
 def test_partial_predicate_agrees_with_exact_on_full_markers():
@@ -109,6 +137,39 @@ def _sent_and_edited(adapter):
 
 class TestStreamedSilenceSuppression:
     @pytest.mark.asyncio
+    async def test_json_no_reply_envelope_is_fully_suppressed(self):
+        """A one-key JSON silence envelope never reaches the platform."""
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1),
+        )
+        consumer.on_delta('{\n  "action": "NO_REPLY"\n}')
+        consumer.finish()
+        await consumer.run()
+
+        assert _sent_and_edited(adapter) == []
+        assert consumer.final_response_sent is False
+        assert consumer.final_content_delivered is False
+
+    @pytest.mark.asyncio
+    async def test_json_no_reply_unicode_escape_stream_is_fully_suppressed(self):
+        """An escaped action value stays hidden while its JSON is incomplete."""
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1),
+        )
+        consumer.on_delta('{"action":"\\u004e\\u004f_')
+        consumer.on_delta('REPLY"}')
+        consumer.finish()
+        await consumer.run()
+
+        assert _sent_and_edited(adapter) == []
+        assert consumer.final_response_sent is False
+        assert consumer.final_content_delivered is False
+
+    @pytest.mark.asyncio
     async def test_no_reply_only_stream_is_fully_suppressed(self):
         """A stream whose entire content is NO_REPLY sends nothing visible."""
         adapter = _make_adapter()
@@ -152,5 +213,27 @@ class TestStreamedSilenceSuppression:
         adapter.delete_message.assert_awaited_once_with("chat_1", "preview_1")
         assert consumer.final_content_delivered is False
         assert consumer.already_sent is False
+
+    @pytest.mark.asyncio
+    async def test_json_prefix_is_held_until_it_diverges(self):
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1),
+        )
+        consumer.on_delta('{"action":"NO_')
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.03)
+
+        assert _sent_and_edited(adapter) == []
+
+        consumer.on_delta('REPLY","reason":"visible"}')
+        consumer.finish()
+        await task
+
+        assert '{"action":"NO_REPLY","reason":"visible"}' in "".join(
+            _sent_and_edited(adapter)
+        )
 
 


### PR DESCRIPTION
## What does this PR do?

Suppresses exact JSON `NO_REPLY` control envelopes in interactive,
autonomous, and streamed gateway responses.

The completed-response parser accepts only one decoded key/value pair:
`{"action":"NO_REPLY"}`. Duplicate keys, extra fields, padded or different
actions, malformed JSON, and unrelated objects remain visible.

Streaming uses a bounded incremental parser for that exact grammar. It holds a
prefix only while the prefix can still become the silence envelope, so normal
JSON such as `{"message":"hello"}` keeps progressive delivery.

## Related Issue

Fixes #72935

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `gateway/response_filters.py`: add strict completed and incremental JSON
  silence-envelope recognition with separate text/JSON bounds.
- `tests/gateway/test_response_filters.py`: cover exact envelopes, malformed
  payloads, duplicate/extra keys, and outer-whitespace boundaries.
- `tests/gateway/test_stream_consumer_silence.py`: cover full suppression,
  escaped values, divergence, overlong input, and unrelated JSON streaming.

## How to Test

1. Run:

```text
python -m pytest -q tests/gateway/test_response_filters.py tests/gateway/test_stream_consumer_silence.py
python -m ruff check gateway/response_filters.py tests/gateway/test_response_filters.py tests/gateway/test_stream_consumer_silence.py
git diff --check origin/main...HEAD
```

2. Verify the exact envelope and its valid streaming prefixes send no visible
   response.
3. Verify malformed, multi-key, duplicate-key, overlong, and unrelated JSON
   remain visible without unnecessary stream buffering.

Validation on rebased `dbc18c6d`:

- Focused tests: `53 passed`.
- Ruff: passed.
- `git diff --check`: passed.
- Structured Codex autoreview: clean, no actionable findings.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed issues/PRs for duplicates.
- [x] This PR contains only the response-filtering fix and its tests.
- [ ] I've run the full `pytest tests/ -q` suite; focused tests are listed
  above.
- [x] I've added regression tests.
- [x] Tested on Windows 11 with Python 3.11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no public configuration or command changed.
- [x] Config example update: N/A.
- [x] Architecture/workflow docs: N/A.
- [x] Cross-platform impact considered; implementation uses Python stdlib only.
- [x] Tool schema update: N/A.

## Screenshots / Logs

Before:

```text
is_intentional_silence_response('{"action":"NO_REPLY"}') == False
is_partial_silence_marker('{"action":"NO_') == False
```

After:

```text
is_intentional_silence_response('{"action":"NO_REPLY"}') == True
is_partial_silence_marker('{"action":"NO_') == True
53 passed
```
