### PR TITLE
fix(telegram): validate reply message IDs

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -54,6 +54,7 @@ def _consume_abandoned_task(task: asyncio.Task) -> None:
 # timeout (including this helper's own expiry hand-off) goes silent, so the
 # gateway hangs at "attempt 1/8" with no further output (#63309).
 _LOOP_BLOCKED_DUMP_GRACE = 5.0
+_TELEGRAM_MESSAGE_ID_MAX = 2_147_483_647
 
 
 def _dump_loop_blocked_diagnostics(timeout: float, grace: float) -> None:
@@ -1108,12 +1109,31 @@ class TelegramAdapter(BasePlatformAdapter):
         topic_id = metadata.get("direct_messages_topic_id") or metadata.get("telegram_direct_messages_topic_id")
         return str(topic_id) if topic_id is not None else None
 
+    @staticmethod
+    def _normalize_reply_to_message_id(value: Any) -> Optional[int]:
+        """Return a positive Telegram message ID or ``None`` for invalid input."""
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value if 0 < value <= _TELEGRAM_MESSAGE_ID_MAX else None
+        if not isinstance(value, str):
+            return None
+        stripped = value.strip()
+        if (
+            not stripped.isascii()
+            or not stripped.isdigit()
+            or len(stripped) > len(str(_TELEGRAM_MESSAGE_ID_MAX))
+        ):
+            return None
+        parsed = int(stripped)
+        return parsed if 0 < parsed <= _TELEGRAM_MESSAGE_ID_MAX else None
+
     @classmethod
     def _metadata_reply_to_message_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[int]:
         if not metadata:
             return None
         reply_to = metadata.get("telegram_reply_to_message_id")
-        return int(reply_to) if reply_to is not None else None
+        return cls._normalize_reply_to_message_id(reply_to)
 
     @classmethod
     def _is_private_dm_topic_send(
@@ -1147,8 +1167,10 @@ class TelegramAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         reply_to_mode: Optional[str] = None,
     ) -> Optional[int]:
-        if reply_to:
-            return int(reply_to)
+        if reply_to is not None:
+            normalized_reply_to = cls._normalize_reply_to_message_id(reply_to)
+            if normalized_reply_to is not None:
+                return normalized_reply_to
         if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
             if reply_to_mode == "off":
                 return None
@@ -1190,7 +1212,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "message_thread_id": None,
                         "direct_messages_topic_id": int(direct_topic_id),
                     }
-                return {}
+                raise ValueError(cls._dm_topic_missing_anchor_error())
             return {"message_thread_id": cls._message_thread_id_for_send(thread_id)}
         direct_topic_id = cls._metadata_direct_messages_topic_id(metadata)
         if direct_topic_id is not None:
@@ -1734,23 +1756,32 @@ class TelegramAdapter(BasePlatformAdapter):
         rich, let the legacy path handle it" — used for the DM-topic fail-loud
         case so the legacy path stays the single source of the refuse result.
         """
-        metadata_reply_to = self._metadata_reply_to_message_id(metadata)
         private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
         dm_topic_reply_to_off = (
             private_dm_topic_send
             and self._reply_to_mode == "off"
             and bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
         )
-        reply_to_source = reply_to or (
-            str(metadata_reply_to)
-            if private_dm_topic_send and metadata_reply_to is not None
-            else None
-        )
         if private_dm_topic_send:
-            should_thread = reply_to_source is not None and self._reply_to_mode != "off"
+            reply_to_id = (
+                None
+                if dm_topic_reply_to_off
+                else self._reply_to_message_id_for_send(
+                    reply_to,
+                    metadata,
+                    reply_to_mode=self._reply_to_mode,
+                )
+            )
         else:
-            should_thread = self._should_thread_reply(reply_to_source, 0)
-        reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
+            should_thread = self._should_thread_reply(reply_to, 0)
+            reply_to_id = (
+                self._normalize_reply_to_message_id(reply_to)
+                if should_thread
+                else None
+            )
+        if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
+            if self._metadata_direct_messages_topic_id(metadata) is None:
+                return None
         thread_kwargs = self._thread_kwargs_for_send(
             chat_id,
             thread_id,
@@ -4382,7 +4413,6 @@ class TelegramAdapter(BasePlatformAdapter):
 
             for i, chunk in enumerate(chunks):
                 retried_thread_not_found = False
-                metadata_reply_to = self._metadata_reply_to_message_id(metadata)
                 private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
                 # reply_to_mode="off" on the existing telegram_dm_topic_reply_fallback path
                 # is an explicit user opt-in to "message_thread_id alone is enough" (PR #23994
@@ -4394,17 +4424,23 @@ class TelegramAdapter(BasePlatformAdapter):
                     and self._reply_to_mode == "off"
                     and bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
                 )
-                reply_to_source = reply_to or (
-                    str(metadata_reply_to) if private_dm_topic_send and metadata_reply_to is not None else None
-                )
                 if private_dm_topic_send:
-                    should_thread = (
-                        reply_to_source is not None
-                        and self._reply_to_mode != "off"
+                    reply_to_id = (
+                        None
+                        if dm_topic_reply_to_off
+                        else self._reply_to_message_id_for_send(
+                            reply_to,
+                            metadata,
+                            reply_to_mode=self._reply_to_mode,
+                        )
                     )
                 else:
-                    should_thread = self._should_thread_reply(reply_to_source, i)
-                reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
+                    should_thread = self._should_thread_reply(reply_to, i)
+                    reply_to_id = (
+                        self._normalize_reply_to_message_id(reply_to)
+                        if should_thread
+                        else None
+                    )
                 if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
                     return SendResult(
                         success=False,

--- a/tests/gateway/test_telegram_reply_mode.py
+++ b/tests/gateway/test_telegram_reply_mode.py
@@ -358,6 +358,62 @@ class TestDMTopicFallbackReplyToMode:
         )
         assert result == 999
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "not-a-message",
+            "123abc",
+            "",
+            " ",
+            "0",
+            "-1",
+            "2147483648",
+            0,
+            -1,
+            2_147_483_648,
+            True,
+            False,
+            1.5,
+            None,
+        ],
+    )
+    def test_invalid_reply_ids_are_ignored(self, value):
+        metadata = {
+            **self.DM_TOPIC_METADATA,
+            "telegram_reply_to_message_id": value,
+        }
+        assert TelegramAdapter._metadata_reply_to_message_id(metadata) is None
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("12345", 12345),
+            (" 12345 ", 12345),
+            (12345, 12345),
+            ("2147483647", 2_147_483_647),
+            (2_147_483_647, 2_147_483_647),
+        ],
+    )
+    def test_valid_reply_ids_are_normalized(self, value, expected):
+        metadata = {
+            **self.DM_TOPIC_METADATA,
+            "telegram_reply_to_message_id": value,
+        }
+        assert TelegramAdapter._metadata_reply_to_message_id(metadata) == expected
+
+    def test_invalid_explicit_reply_id_uses_metadata_anchor(self):
+        result = TelegramAdapter._reply_to_message_id_for_send(
+            "session-meta-id", self.DM_TOPIC_METADATA, reply_to_mode="first",
+        )
+        assert result == 12345
+
+    def test_oversized_numeric_reply_id_is_ignored(self):
+        metadata = {
+            **self.DM_TOPIC_METADATA,
+            "telegram_reply_to_message_id": "9" * 5000,
+        }
+        assert TelegramAdapter._metadata_reply_to_message_id(metadata) is None
+
     # -- _thread_kwargs_for_send classmethod --
 
     def test_thread_kwargs_suppressed_reply_anchor_when_off(self):
@@ -384,6 +440,64 @@ class TestDMTopicFallbackReplyToMode:
         )
         assert result == {"message_thread_id": 42}
 
+    def test_invalid_dm_topic_anchor_refuses_unrouted_send(self):
+        metadata = {
+            **self.DM_TOPIC_METADATA,
+            "telegram_reply_to_message_id": "session-meta-id",
+        }
+        with pytest.raises(ValueError, match="requires a reply anchor"):
+            TelegramAdapter._thread_kwargs_for_send(
+                "100",
+                "42",
+                metadata,
+                reply_to_message_id=None,
+                reply_to_mode="first",
+            )
+
+    @pytest.mark.asyncio
+    async def test_control_send_with_invalid_dm_topic_anchor_fails_loudly(
+        self, adapter_factory,
+    ):
+        adapter = adapter_factory(reply_to_mode="first")
+        adapter._bot = MagicMock()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+        metadata = {
+            **self.DM_TOPIC_METADATA,
+            "telegram_reply_to_message_id": "session-meta-id",
+        }
+
+        result = await adapter.send_update_prompt(
+            "12345", "Continue?", metadata=metadata,
+        )
+
+        assert result.success is False
+        assert "requires a reply anchor" in (result.error or "")
+        adapter._bot.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_document_with_invalid_explicit_reply_uses_metadata_anchor(
+        self, adapter_factory, tmp_path,
+    ):
+        adapter = adapter_factory(reply_to_mode="first")
+        adapter._bot = MagicMock()
+        adapter._bot.send_document = AsyncMock(
+            return_value=MagicMock(message_id=1),
+        )
+        document = tmp_path / "proof.txt"
+        document.write_text("proof", encoding="utf-8")
+
+        result = await adapter.send_document(
+            "12345",
+            str(document),
+            reply_to="session-meta-id",
+            metadata=self.DM_TOPIC_METADATA,
+        )
+
+        assert result.success is True
+        call = adapter._bot.send_document.await_args
+        assert call.kwargs["reply_to_message_id"] == 12345
+        assert call.kwargs["message_thread_id"] == 42
+
     # -- send() integration test --
 
     @pytest.mark.asyncio
@@ -394,7 +508,12 @@ class TestDMTopicFallbackReplyToMode:
         adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
         adapter.truncate_message = lambda content, max_len, **kw: ["chunk1"]
 
-        await adapter.send("12345", "test content", metadata=self.DM_TOPIC_METADATA)
+        await adapter.send(
+            "12345",
+            "test content",
+            reply_to="999",
+            metadata=self.DM_TOPIC_METADATA,
+        )
 
         call = adapter._bot.send_message.call_args_list[0]
         assert call.kwargs.get("reply_to_message_id") is None
@@ -409,5 +528,25 @@ class TestDMTopicFallbackReplyToMode:
 
         await adapter.send("12345", "test content", metadata=self.DM_TOPIC_METADATA)
 
+        call = adapter._bot.send_message.call_args_list[0]
+        assert call.kwargs.get("reply_to_message_id") == 12345
+
+    @pytest.mark.asyncio
+    async def test_send_dm_topic_invalid_explicit_reply_uses_metadata_anchor(
+        self, adapter_factory,
+    ):
+        adapter = adapter_factory(reply_to_mode="first")
+        adapter._bot = MagicMock()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1"]
+
+        result = await adapter.send(
+            "12345",
+            "test content",
+            reply_to="session-meta-id",
+            metadata=self.DM_TOPIC_METADATA,
+        )
+
+        assert result.success is True
         call = adapter._bot.send_message.call_args_list[0]
         assert call.kwargs.get("reply_to_message_id") == 12345

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -562,6 +562,69 @@ async def test_reply_to_propagates_as_reply_parameters():
 
 
 @pytest.mark.asyncio
+async def test_invalid_explicit_reply_uses_dm_topic_metadata_anchor():
+    adapter = _make_adapter()
+    metadata = {
+        "thread_id": "42",
+        "telegram_dm_topic_reply_fallback": True,
+        "telegram_reply_to_message_id": "12345",
+    }
+
+    result = await adapter.send(
+        "12345",
+        RICH_CONTENT,
+        reply_to="session-meta-id",
+        metadata=metadata,
+    )
+
+    assert result.success is True
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert api_kwargs["reply_parameters"] == {"message_id": 12345}
+    assert api_kwargs["message_thread_id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_invalid_dm_topic_anchor_fails_non_retryable_before_rich_send():
+    adapter = _make_adapter()
+    metadata = {
+        "thread_id": "42",
+        "telegram_dm_topic_reply_fallback": True,
+        "telegram_reply_to_message_id": "session-meta-id",
+    }
+
+    result = await adapter.send("12345", RICH_CONTENT, metadata=metadata)
+
+    assert result.success is False
+    assert result.retryable is False
+    assert "requires a reply anchor" in (result.error or "")
+    adapter._bot.do_api_request.assert_not_awaited()
+    adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dm_topic_reply_mode_off_suppresses_explicit_rich_anchor():
+    adapter = _make_adapter()
+    adapter._reply_to_mode = "off"
+    metadata = {
+        "thread_id": "42",
+        "telegram_dm_topic_reply_fallback": True,
+        "telegram_reply_to_message_id": "12345",
+    }
+
+    result = await adapter.send(
+        "12345",
+        RICH_CONTENT,
+        reply_to="999",
+        metadata=metadata,
+    )
+
+    assert result.success is True
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert "reply_parameters" not in api_kwargs
+    assert api_kwargs["message_thread_id"] == 42
+
+
+@pytest.mark.asyncio
 async def test_notification_silent_by_default():
     adapter = _make_adapter()
 


### PR DESCRIPTION
## What does this PR do?

Validates Telegram reply-message IDs before any outbound routing path uses
them.

The adapter now accepts only positive 32-bit message IDs, falls back to a
valid DM-topic metadata anchor when an explicit value is malformed, and
refuses an unroutable private-topic send instead of raising or sending outside
the requested lane.

The behavior is aligned across legacy text, rich text, control prompts, voice,
images, documents, and other attachment paths. Existing
`reply_to_mode: off` text/rich behavior remains intact.

## Related Issue

Fixes #72934

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `plugins/platforms/telegram/adapter.py`:
  - centralize reply-ID normalization;
  - enforce Telegram's `1..2147483647` message-ID range;
  - use a valid metadata anchor when an explicit value is invalid;
  - fail closed and non-retryably when a DM-topic send has no valid route;
  - keep rich, legacy, control, and media routing consistent.
- `tests/gateway/test_telegram_reply_mode.py`: cover malformed, oversized,
  boundary-value, metadata-fallback, control, document, and legacy sends.
- `tests/gateway/test_telegram_rich_messages.py`: cover metadata fallback,
  non-retryable missing anchors, and `reply_to_mode: off` on the rich path.

## How to Test

Run each routing group in an isolated pytest process:

```text
python -m pytest -q tests/gateway/test_telegram_reply_mode.py
python -m pytest -q tests/gateway/test_telegram_thread_fallback.py
python -m pytest -q tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_documents.py
python -m ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_reply_mode.py tests/gateway/test_telegram_rich_messages.py
git diff --check origin/main...HEAD
```

Validation on rebased `dbc18c6d`:

- Reply-mode tests: `65 passed`.
- Thread-routing tests: `51 passed`.
- Rich/document tests: `119 passed`.
- Total focused tests: `235 passed`.
- Ruff: passed.
- `git diff --check`: passed.
- Structured Codex autoreview: clean, no actionable findings.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed issues/PRs for duplicates.
- [x] This PR contains only Telegram reply-ID routing changes and tests.
- [ ] I've run the full `pytest tests/ -q` suite; focused tests are listed
  above.
- [x] I've added regression tests.
- [x] Tested on Windows 11 with Python 3.11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no public configuration changed.
- [x] Config example update: N/A.
- [x] Architecture/workflow docs: N/A.
- [x] Cross-platform impact considered; parsing is platform-independent.
- [x] Tool schema update: N/A.

## Screenshots / Logs

Before:

```text
ValueError: invalid literal for int() with base 10: 'session-meta-id'
```

After:

```text
invalid explicit ID + valid metadata anchor -> metadata anchor used
invalid DM-topic anchor without a direct topic -> non-retryable refusal
235 focused tests passed
```
