### PR TITLE
fix(tirith): suppress .dev lookalike_tld false positives alongside .app

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -623,15 +623,15 @@ class TestSpawnWarningDedup:
 
 
 # ---------------------------------------------------------------------------
-# .app TLD suppression (issue #24461)
+# Benign TLD suppression (.app, .dev — issue #24461)
 # ---------------------------------------------------------------------------
 
 _CFG = {"tirith_enabled": True, "tirith_path": "tirith",
         "tirith_timeout": 5, "tirith_fail_open": True}
 
 
-class TestAppTldSuppression:
-    """warn verdicts whose only finding is lookalike_tld/.app are downgraded to allow."""
+class TestBenignTldSuppression:
+    """warn verdicts whose only finding is lookalike_tld/.app or .dev are downgraded to allow."""
 
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
@@ -647,41 +647,70 @@ class TestAppTldSuppression:
 
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
-    def test_mixed_findings_preserve_warn(self, mock_cfg, mock_run):
-        """If .app finding is accompanied by another finding, warn is preserved."""
+    def test_dev_only_warn_downgraded_to_allow(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        findings = [{"rule_id": "lookalike_tld", "value": ".dev",
+                     "message": "Domain uses '.dev' TLD which can be confused with file extensions"}]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, ".dev TLD warning"))
+        result = check_command_security("curl https://example.dev")
+        assert result["action"] == "allow"
+        assert result["findings"] == []
+        assert result["summary"] == ""
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_mixed_app_and_dev_all_suppressed(self, mock_cfg, mock_run):
+        """If every finding is a benign lookalike_tld, warn is downgraded to allow."""
         mock_cfg.return_value = _CFG
         findings = [
             {"rule_id": "lookalike_tld", "value": ".app"},
+            {"rule_id": "lookalike_tld", "value": ".dev"},
+        ]
+        mock_run.return_value = _mock_run(2, _json_stdout(findings))
+        result = check_command_security("curl https://a.app https://b.dev")
+        assert result["action"] == "allow"
+        assert result["findings"] == []
+        assert result["summary"] == ""
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_mixed_findings_preserve_warn(self, mock_cfg, mock_run):
+        """If benign finding is accompanied by another finding, warn is preserved."""
+        mock_cfg.return_value = _CFG
+        findings = [
+            {"rule_id": "lookalike_tld", "value": ".dev"},
             {"rule_id": "shortened_url", "severity": "medium"},
         ]
         mock_run.return_value = _mock_run(2, _json_stdout(findings, "mixed"))
-        result = check_command_security("curl https://bit.ly/test.app")
+        result = check_command_security("curl https://bit.ly/test.dev")
         assert result["action"] == "warn"
         assert len(result["findings"]) == 2
 
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
     def test_block_verdict_never_suppressed(self, mock_cfg, mock_run):
-        """block exit code is never downgraded, even if finding looks like .app."""
+        """block exit code is never downgraded, even if findings look benign."""
         mock_cfg.return_value = _CFG
-        findings = [{"rule_id": "lookalike_tld", "value": ".app"}]
+        findings = [{"rule_id": "lookalike_tld", "value": ".dev"}]
         mock_run.return_value = _mock_run(1, _json_stdout(findings, "block"))
-        result = check_command_security("curl https://example.app")
+        result = check_command_security("curl https://example.dev")
         assert result["action"] == "block"
 
 
-class TestIsAppTldFinding:
-    """Unit tests for the _is_app_tld_finding helper."""
+class TestIsBenignTldFinding:
+    """Unit tests for the _is_benign_tld_finding helper."""
 
     @pytest.mark.parametrize("finding, expected", [
-        ({"rule_id": "lookalike_tld", "value": ".APP"}, True),   # case-insensitive
+        ({"rule_id": "lookalike_tld", "value": ".APP"}, True),   # case-insensitive .app
+        ({"rule_id": "lookalike_tld", "value": ".DEV"}, True),   # case-insensitive .dev
         ({"rule_id": "lookalike_tld", "message": "Domain uses '.app' TLD"}, True),
+        ({"rule_id": "lookalike_tld", "description": "TLD .dev looks like a file extension"}, True),
         ({"rule_id": "shortened_url", "value": ".app"}, False),  # wrong rule_id
-        ({"rule_id": "lookalike_tld", "value": ".zip"}, False),  # other TLD
+        ({"rule_id": "lookalike_tld", "value": ".zip"}, False),  # non-benign TLD
     ])
-    def test_app_tld_detection(self, finding, expected):
-        from tools.tirith_security import _is_app_tld_finding
-        assert _is_app_tld_finding(finding) is expected
+    def test_benign_tld_detection(self, finding, expected):
+        from tools.tirith_security import _is_benign_tld_finding
+        assert _is_benign_tld_finding(finding) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -840,12 +840,12 @@ def check_command_security(command: str) -> dict:
             summary = "security warning detected (details unavailable)"
 
     # Suppress warn verdicts that consist solely of a lookalike_tld finding for
-    # the .app TLD.  .app is a legitimate gTLD used by many production services
-    # and the "can be confused with file extensions" heuristic generates false
-    # positives for normal API calls.  Any other finding (including other
-    # lookalike_tld entries for non-.app TLDs) preserves the warn action.
+    # benign gTLDs (.app, .dev). These are legitimate TLDs; the "can be confused
+    # with file extensions" heuristic generates false positives for normal API
+    # calls. Any other finding (including lookalike_tld entries for non-benign
+    # TLDs) preserves the warn action.
     if action == "warn" and findings:
-        non_suppressible = [f for f in findings if not _is_app_tld_finding(f)]
+        non_suppressible = [f for f in findings if not _is_benign_tld_finding(f)]
         if not non_suppressible:
             action = "allow"
             findings = []
@@ -854,8 +854,11 @@ def check_command_security(command: str) -> dict:
     return {"action": action, "findings": findings, "summary": summary}
 
 
-def _is_app_tld_finding(finding: dict) -> bool:
-    """Return True if this finding is a lookalike_tld warning for the .app TLD only.
+_BENIGN_TLDS = frozenset((".app", ".dev"))
+
+
+def _is_benign_tld_finding(finding: dict) -> bool:
+    """Return True if this finding is a lookalike_tld warning for a benign gTLD.
 
     Checks the rule_id and inspects common value/detail field names that
     Tirith may use to carry the TLD string.
@@ -866,6 +869,8 @@ def _is_app_tld_finding(finding: dict) -> bool:
         return False
     for field in ("value", "tld", "detail", "description", "message"):
         val = finding.get(field)
-        if val is not None and ".app" in str(val).lower():
-            return True
+        if val is not None:
+            v = str(val).lower()
+            if any(tld in v for tld in _BENIGN_TLDS):
+                return True
     return False


### PR DESCRIPTION
## Problem
Hermes Treasuree security scanner currently flags legitimate `.dev` domains with a `lookalike_tld` finding:

> Domain uses .dev TLD which can be confused with file extensions

This creates noisy warnings for normal commands against real `.dev` services — the same issue that was fixed for `.app` in #24461 / PR #28106.

## Reproduction
```bash
curl https://example.dev
```
Tirith returns a warn verdict with a `lookalike_tld` finding for `.dev`.

## Changes
- Rename `_is_app_tld_finding` → `_is_benign_tld_finding`
- Add `.dev` to the `_BENIGN_TLDS` frozenset alongside `.app`
- Update and extend test coverage for `.dev` cases

## Acceptance criteria met
- `.dev`-only `lookalike_tld` findings are downgraded to `allow`
- `.app` behavior is fully preserved (no regression)
- Mixed findings (`lookalike_tld/.dev` + another finding) preserve the `warn`
- `block` verdicts are never downgraded

Closes #24461 (extends the `.app` fix to `.dev`)