### PR TITLE
fix(telegram): sendRichMessage on standalone cron/hermes-send path

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1824,3 +1824,174 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
+
+
+# ---------------------------------------------------------------------------
+# Standalone sendRichMessage path (cron / hermes-send fallback parity)
+# ---------------------------------------------------------------------------
+
+_TABLE_BODY = (
+    "## Report\n"
+    "| Day | High |\n"
+    "| --- | --- |\n"
+    "| Mon | 80 |\n"
+)
+
+
+class TestStandaloneTelegramRich:
+    """Bot API 10.1 rich path for standalone ``_send_telegram``.
+
+    Cron prefers the live gateway adapter for rich delivery; when that path
+    is unavailable it falls through to ``_send_telegram``. Without a rich
+    attempt here, GFM tables degrade to MarkdownV2 bullet lists while the
+    job still reports ok — the intermittent Morning Report failure mode.
+    """
+
+    def _make_bot(self):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        bot.do_api_request = AsyncMock(
+            return_value={"message_id": 4242, "chat": {"id": 123}}
+        )
+        return bot
+
+    def test_table_body_uses_send_rich_when_opted_in(self, monkeypatch):
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+        monkeypatch.setattr(
+            "tools.send_message_tool._telegram_rich_messages_opt_in",
+            lambda: True,
+        )
+        recorded = []
+
+        def _record(chat_id, message_id, content):
+            recorded.append((str(chat_id), str(message_id), content))
+
+        monkeypatch.setattr(
+            "gateway.rich_sent_store.record", _record, raising=False
+        )
+        # Also patch the import site used inside _try_send_telegram_rich
+        import gateway.rich_sent_store as rss
+
+        monkeypatch.setattr(rss, "record", _record)
+
+        result = asyncio.run(_send_telegram("tok", "123", _TABLE_BODY))
+
+        assert result["success"] is True
+        assert result["message_id"] == "4242"
+        bot.do_api_request.assert_awaited_once()
+        call = bot.do_api_request.await_args
+        assert call.args[0] == "sendRichMessage"
+        api_kwargs = call.kwargs["api_kwargs"]
+        assert api_kwargs["chat_id"] == 123 or api_kwargs["chat_id"] == "123"
+        assert "markdown" in api_kwargs["rich_message"]
+        assert "| Day |" in api_kwargs["rich_message"]["markdown"]
+        bot.send_message.assert_not_awaited()
+        assert recorded and recorded[0][1] == "4242"
+
+    def test_plain_text_stays_on_markdown_v2_even_when_opted_in(self, monkeypatch):
+        """Ordinary replies must not force rich — font/spacing parity."""
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+        monkeypatch.setattr(
+            "tools.send_message_tool._telegram_rich_messages_opt_in",
+            lambda: True,
+        )
+
+        asyncio.run(_send_telegram("tok", "123", "Just a plain status update"))
+
+        bot.do_api_request.assert_not_awaited()
+        bot.send_message.assert_awaited_once()
+        assert bot.send_message.await_args.kwargs["parse_mode"] == "MarkdownV2"
+
+    def test_opt_out_keeps_legacy_path_for_tables(self, monkeypatch):
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+        monkeypatch.setattr(
+            "tools.send_message_tool._telegram_rich_messages_opt_in",
+            lambda: False,
+        )
+
+        asyncio.run(_send_telegram("tok", "123", _TABLE_BODY))
+
+        bot.do_api_request.assert_not_awaited()
+        bot.send_message.assert_awaited_once()
+
+    def test_permanent_rich_error_falls_back_to_markdown_v2(self, monkeypatch):
+        bot = self._make_bot()
+        bot.do_api_request = AsyncMock(
+            side_effect=Exception("Bad Request: can't parse entities")
+        )
+        _install_telegram_mock(monkeypatch, bot)
+        monkeypatch.setattr(
+            "tools.send_message_tool._telegram_rich_messages_opt_in",
+            lambda: True,
+        )
+
+        result = asyncio.run(_send_telegram("tok", "123", _TABLE_BODY))
+
+        assert result["success"] is True
+        bot.do_api_request.assert_awaited_once()
+        bot.send_message.assert_awaited_once()
+
+    def test_transient_rich_error_does_not_legacy_resend(self, monkeypatch):
+        bot = self._make_bot()
+        bot.do_api_request = AsyncMock(side_effect=TimeoutError("Timed out"))
+        _install_telegram_mock(monkeypatch, bot)
+        monkeypatch.setattr(
+            "tools.send_message_tool._telegram_rich_messages_opt_in",
+            lambda: True,
+        )
+        # Force classifier to treat TimeoutError as non-fallback (transient)
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        monkeypatch.setattr(
+            TelegramAdapter,
+            "_is_rich_fallback_error",
+            lambda self, exc: False,
+        )
+
+        result = asyncio.run(_send_telegram("tok", "123", _TABLE_BODY))
+
+        # Outer _send_telegram catches and returns error dict (no double send)
+        assert "error" in result or result.get("success") is not True
+        bot.send_message.assert_not_awaited()
+
+    def test_thread_id_forwarded_on_rich_send(self, monkeypatch):
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+        monkeypatch.setattr(
+            "tools.send_message_tool._telegram_rich_messages_opt_in",
+            lambda: True,
+        )
+
+        asyncio.run(
+            _send_telegram("tok", "-1001234567890", _TABLE_BODY, thread_id="111")
+        )
+
+        api_kwargs = bot.do_api_request.await_args.kwargs["api_kwargs"]
+        assert api_kwargs.get("message_thread_id") == 111
+
+    def test_cjk_table_skips_rich(self, monkeypatch):
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+        monkeypatch.setattr(
+            "tools.send_message_tool._telegram_rich_messages_opt_in",
+            lambda: True,
+        )
+        body = (
+            "## 報告\n"
+            "| 日 | 高 |\n"
+            "| --- | --- |\n"
+            "| 月 | 80 |\n"
+        )
+
+        asyncio.run(_send_telegram("tok", "123", body))
+
+        bot.do_api_request.assert_not_awaited()
+        bot.send_message.assert_awaited_once()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1164,22 +1164,194 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     return last_result
 
 
-def _is_telegram_thread_not_found(error: Exception) -> bool:
-    """Check if a Telegram error is a thread-not-found failure.
+def _is_telegram_thread_not_found(error) -> bool:
+    """True when Telegram rejected the send because message_thread_id is unknown.
 
-    Matches the gateway adapter's ``_is_thread_not_found_error`` for
-    the standalone ``_send_telegram`` path (issue #27012).
+    Matches the gateway adapter's thread-not-found fallback so cron / hermes send
+    and the standalone ``_send_telegram`` path (issue #27012).
     """
     return "thread not found" in str(error).lower()
+
+
+def _telegram_rich_messages_opt_in() -> bool:
+    """Return True when ``platforms.telegram.extra.rich_messages`` is enabled.
+
+    Mirrors the live adapter's opt-in gate so cron standalone fallback and
+    ``hermes send`` honor the same config knob.
+    """
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+        pconfig = cfg.platforms.get(Platform.TELEGRAM) if cfg else None
+        extra = getattr(pconfig, "extra", None) or {}
+        raw = extra.get("rich_messages", False)
+    except Exception:
+        return False
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return raw != 0
+    if isinstance(raw, str):
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(raw)
+
+
+def _standalone_telegram_rich_eligible(content: str) -> bool:
+    """Content gates for standalone ``sendRichMessage`` (adapter parity).
+
+    Reuses the live :class:`TelegramAdapter` helpers so eligibility stays in
+    lockstep with the gateway path (tables / task lists / details / math,
+    CJK skip, details+math crash shape, 32k cap).
+    """
+    if not content or not content.strip():
+        return False
+    if not _telegram_rich_messages_opt_in():
+        return False
+    try:
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        probe = TelegramAdapter.__new__(TelegramAdapter)
+        # Unbound instance: only class-level helpers + content methods needed.
+        probe._rich_messages_enabled = True
+        probe._rich_send_disabled = False
+        if not probe._needs_rich_rendering(content):
+            return False
+        if probe._has_telegram_desktop_details_math_crash_shape(content):
+            return False
+        if probe._has_telegram_desktop_cjk_rich_garble_shape(content):
+            return False
+        if not probe._content_fits_rich_limits(content):
+            return False
+        return True
+    except Exception:
+        return False
+
+
+def _is_standalone_rich_fallback_error(exc: Exception) -> bool:
+    """True ⇒ permanent/capability error ⇒ safe to fall back to MarkdownV2.
+
+    Prefers the live adapter classifier, then adds string heuristics for plain
+    ``Exception`` mocks and non-PTB wrappers that carry ``Bad Request`` /
+    ``method not found`` text without the real exception class.
+    """
+    try:
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        probe = TelegramAdapter.__new__(TelegramAdapter)
+        if probe._is_rich_fallback_error(exc):
+            return True
+    except Exception:
+        pass
+    s = str(exc).lower()
+    name = exc.__class__.__name__.lower()
+    if name in {"badrequest", "endpointnotfound", "invalidtoken"}:
+        return True
+    if name.endswith("badrequest"):
+        return True
+    if "bad request" in s or "can't parse" in s or "cannot parse" in s:
+        return True
+    if ("method" in s or "endpoint" in s) and (
+        "not found" in s or "does not exist" in s or "unsupported" in s
+    ):
+        return True
+    if "unsupported" in s or "not implemented" in s or "no such method" in s:
+        return True
+    return False
+
+
+async def _try_send_telegram_rich(
+    bot,
+    chat_id,
+    content: str,
+    *,
+    thread_kwargs: dict | None = None,
+    disable_link_previews: bool = False,
+):
+    """Attempt one ``sendRichMessage`` via the standalone Bot.
+
+    Returns the raw API result on success, ``None`` to fall back to the legacy
+    MarkdownV2 path (permanent / capability errors), or **raises** on transient
+    failures so callers do not double-send (same contract as the live adapter).
+    """
+    import inspect
+
+    if not inspect.iscoroutinefunction(getattr(bot, "do_api_request", None)):
+        return None
+    if not _standalone_telegram_rich_eligible(content):
+        return None
+
+    try:
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        probe = TelegramAdapter.__new__(TelegramAdapter)
+        payload = {
+            "chat_id": chat_id,
+            "rich_message": probe._rich_message_payload(content),
+        }
+    except Exception as exc:
+        logger.debug(
+            "send_message: standalone rich payload build failed (%s) — MarkdownV2",
+            _sanitize_error_text(exc),
+        )
+        return None
+
+    for key, value in (thread_kwargs or {}).items():
+        if value is not None:
+            payload[key] = value
+    if disable_link_previews:
+        payload["link_preview_options"] = {"is_disabled": True}
+
+    try:
+        msg = await bot.do_api_request("sendRichMessage", api_kwargs=payload)
+    except Exception as exc:
+        is_fallback = _is_standalone_rich_fallback_error(exc)
+        if is_fallback:
+            logger.debug(
+                "send_message: standalone sendRichMessage rejected (%s) — MarkdownV2",
+                _sanitize_error_text(exc),
+            )
+            return None
+        # Transient / network / flood: request may have landed. Do NOT legacy
+        # resend (duplicate risk) — surface the failure to the caller.
+        logger.warning(
+            "send_message: standalone sendRichMessage transient failure "
+            "(no legacy resend): %s",
+            _sanitize_error_text(exc),
+        )
+        raise
+
+    message_id = None
+    if isinstance(msg, dict):
+        message_id = msg.get("message_id")
+        if message_id is None:
+            message_id = (msg.get("result") or {}).get("message_id")
+    else:
+        message_id = getattr(msg, "message_id", None)
+    if message_id is not None:
+        try:
+            from gateway import rich_sent_store
+
+            rich_sent_store.record(str(chat_id), str(message_id), content)
+        except Exception:
+            pass
+    return msg
 
 
 async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
-    Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
-    so that bold, links, and headers render correctly.  If the message
-    already contains HTML tags, it is sent with ``parse_mode='HTML'``
-    instead, bypassing MarkdownV2 conversion.
+    Prefer Bot API 10.1 ``sendRichMessage`` when the gateway's
+    ``platforms.telegram.extra.rich_messages`` opt-in is on and the body needs
+    constructs MarkdownV2 degrades (GFM tables, task lists, details, math).
+    This keeps cron's standalone fallback (and ``hermes send``) on parity with
+    the live gateway adapter — without it, any live-adapter miss delivered
+    tables as bullet lists while the job still reported ``ok``.
+
+    Otherwise applies markdown→MarkdownV2 formatting (same as the gateway
+    adapter) so that bold, links, and headers render correctly.  If the
+    message already contains HTML tags, it is sent with ``parse_mode='HTML'``
+    instead, bypassing both rich and MarkdownV2 conversion.
     """
     try:
         from telegram import Bot
@@ -1284,6 +1456,48 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         if _cap is not None and _utf16_len(formatted) <= _TELEGRAM_CAPTION_LIMIT:
             _tg_caption = formatted
             formatted = ""  # suppress the separate text send below
+
+        # Bot API 10.1 rich fast-path for table/task-list bodies when the
+        # live-adapter path is unavailable (cron standalone fallthrough,
+        # hermes send). Skip when HTML was requested, when the body is riding
+        # as a media caption, or when there is no text body left to send.
+        if (
+            not _has_html
+            and _tg_caption is None
+            and formatted.strip()
+            and message
+            and message.strip()
+        ):
+            try:
+                rich_result = await _try_send_telegram_rich(
+                    bot,
+                    int_chat_id,
+                    message,
+                    thread_kwargs=thread_kwargs,
+                    disable_link_previews=disable_link_previews,
+                )
+            except Exception:
+                # Transient rich failure: do not legacy-resend. Propagate so
+                # cron marks delivery_error rather than risking a duplicate.
+                raise
+            if rich_result is not None:
+                # Normalize to a .message_id attribute so the shared
+                # success return below works for both PTB Message objects
+                # and raw Bot API dicts from do_api_request.
+                if isinstance(rich_result, dict):
+                    from types import SimpleNamespace as _SNS
+
+                    _rid = rich_result.get("message_id")
+                    if _rid is None:
+                        _rid = (rich_result.get("result") or {}).get(
+                            "message_id"
+                        )
+                    last_msg = _SNS(message_id=_rid)
+                else:
+                    last_msg = rich_result
+                # Rich handled the text body. Still attach any media files via
+                # the legacy media path below (media has no rich endpoint).
+                formatted = ""
 
         if formatted.strip():
             # Chunk *after* formatting: MarkdownV2/HTML escaping inflates the


### PR DESCRIPTION
## Summary

- Cron delivery prefers the **live gateway adapter** for Bot API 10.1 `sendRichMessage`. On any miss (no running loop, timeout before dispatch, unconfirmed send) it falls through to `tools/send_message_tool._send_telegram`.
- That standalone path previously only did **MarkdownV2 / HTML**. GFM tables (Morning Report 3-day forecast, Horizon status table, QC tables, …) were rewritten into bullet lists while the job still reported `ok`.
- This is the root of the intermittent “why isn’t Morning Report rich?” reports: content was rich-eligible and `platforms.telegram.extra.rich_messages: true`, but path selection landed on standalone.

## Fix

Mirror the live adapter’s rich contract on the standalone path:

1. Honor `platforms.telegram.extra.rich_messages` (same opt-in as the adapter).
2. When content `_needs_rich_rendering` (pipe tables, task lists, details, math), attempt `bot.do_api_request("sendRichMessage", …)` with raw markdown.
3. Reuse adapter helpers for CJK skip, details+math desktop crash shape, and 32k cap.
4. Permanent/capability errors → fall through to MarkdownV2.
5. Transient errors → **raise, no legacy resend** (duplicate-risk parity with the adapter).
6. Record `rich_sent_store` on success so reply context still resolves.

`hermes send` uses this path, so it is the correct smoke test for cron fallback.

## Test plan

- [x] `pytest tests/tools/test_send_message_tool.py::TestStandaloneTelegramRich tests/tools/test_send_message_tool.py::TestSendTelegramHtmlDetection` (15 passed)
- [ ] With `platforms.telegram.extra.rich_messages: true`:
  ```bash
  hermes send --to 'telegram:<chat>:<topic>'     --file ~/.hermes/cron/output/morning_report/$(date +%Y-%m-%d).md
  ```
  Confirm `~/.hermes/state/rich_sent_index.json` gains a new message_id for that body and Telegram renders the forecast table natively.
- [ ] Force a live-adapter miss (optional): stop gateway briefly and run a no_agent cron with a table body — delivery should still be rich via standalone.

## Notes

- `rich_messages_always` and per-job `telegram_send_rich` remain unused / dead knobs; only `platforms.telegram.extra.rich_messages` is live.
- Live-adapter path is unchanged. Gateway restart is not required for `hermes send` / next standalone import; live adapter already had rich.