### PR TITLE
fix(api-server): resolve CORS headers on session chat stream SSE response (#72892)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3818,6 +3818,12 @@ class APIServerAdapter(BasePlatformAdapter):
             "X-Accel-Buffering": "no",
             "X-Hermes-Session-Id": session_id,
         }
+        # CORS middleware can't inject headers into StreamResponse after
+        # prepare() flushes them, so resolve CORS headers up front (#72892).
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            headers.update(cors)
         if gateway_session_key:
             headers["X-Hermes-Session-Key"] = gateway_session_key
         response = web.StreamResponse(status=200, headers=headers)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2227,6 +2227,61 @@ class TestCORS:
             assert "Authorization" in resp.headers.get("Access-Control-Allow-Headers", "")
 
 
+    @pytest.mark.asyncio
+    async def test_cors_headers_present_on_session_chat_stream(self):
+        """SSE streaming endpoint must include CORS headers on the response.
+
+        The CORS middleware cannot inject headers into a ``StreamResponse``
+        after ``prepare()`` flushes them, so the handler must resolve CORS
+        headers up front — same pattern as ``/v1/chat/completions`` and
+        ``/v1/responses`` streaming paths (#72892).
+        """
+        adapter = _make_adapter(cors_origins=["http://localhost:3000"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": "s1"}, None)),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run,
+            ):
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/api/sessions/s1/chat/stream",
+                    json={"message": "hi"},
+                    headers={"Origin": "http://localhost:3000"},
+                )
+                assert resp.status == 200
+                await resp.text()  # consume SSE stream fully
+        assert resp.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
+        assert "POST" in resp.headers.get("Access-Control-Allow-Methods", "")
+
+    @pytest.mark.asyncio
+    async def test_cors_headers_absent_on_session_chat_stream_no_origin(self):
+        """No CORS headers on the streaming endpoint when no Origin is sent."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": "s1"}, None)),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run,
+            ):
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/api/sessions/s1/chat/stream",
+                    json={"message": "hi"},
+                )
+                assert resp.status == 200
+                await resp.text()
+        assert resp.headers.get("Access-Control-Allow-Origin") is None
+
+
 # ---------------------------------------------------------------------------
 # Conversation parameter
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`POST /api/sessions/{id}/chat/stream` never included CORS headers in its SSE response, even when `API_SERVER_CORS_ORIGINS` was configured and the origin was allowed. The `OPTIONS` preflight returned correct CORS headers, and the non-streaming sibling (`POST /api/sessions/{id}/chat`) worked — only the streaming endpoint was broken.

## Root cause

The CORS middleware (`cors_middleware`) updates `response.headers` *after* the handler returns. For `web.StreamResponse`, `prepare()` is called inside the handler, flushing headers to the wire before the middleware can inject CORS headers. The two other streaming endpoints (`/v1/chat/completions` and `/v1/responses`) already work around this by resolving CORS headers *before* `response.prepare()`. `_handle_session_chat_stream` did not.

## Fix

Resolve CORS headers up front and include them in the `StreamResponse` headers dict before `prepare()`, mirroring the exact pattern already used by `_handle_chat_completions` and `_handle_responses`:

```python
origin = request.headers.get("Origin", "")
cors = self._cors_headers_for_origin(origin) if origin else None
if cors:
    headers.update(cors)
```

## Verification

- **RED**: `test_cors_headers_present_on_session_chat_stream` fails on `upstream/main` — `assert None == 'http://localhost:3000'` (no `Access-Control-Allow-Origin` on the streamed response).
- **GREEN**: 16/16 `TestCORS` tests pass with the fix, including 2 new regression tests:
  - `test_cors_headers_present_on_session_chat_stream` — CORS headers present when `Origin` is allowed
  - `test_cors_headers_absent_on_session_chat_stream_no_origin` — no CORS headers when no `Origin` sent
- Rebased onto current `upstream/main`; branch is a single focused commit (`0 1`).
- Same root-cause class as #6358 (`/v1/runs/{run_id}/events`), tracked separately — that call site is not modified here.

Closes #72892.

---

Auto-published by Moonsong via Path B automated pipeline.