### PR TITLE
fix(desktop): revert a staged new file instead of silently no-oping

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -4,13 +4,18 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { afterEach, test } from 'vitest'
+import simpleGit from 'simple-git'
+import { afterEach, test, vi } from 'vitest'
 
 import { gitFor, repoStatus, resolveRenamePath, reviewRevert } from './git-review-ops'
+
+vi.mock('simple-git', { spy: true })
 
 const tempDirs: string[] = []
 
 afterEach(() => {
+  vi.clearAllMocks()
+
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { force: true, recursive: true })
   }
@@ -180,6 +185,50 @@ test('reviewRevert removes new files before the first commit', async () => {
   assert.deepEqual(await reviewRevert(dir, null, 'git'), { ok: true })
   assert.equal(fs.existsSync(path.join(dir, 'staged.txt')), false)
   assert.equal(fs.existsSync(path.join(dir, 'loose.txt')), false)
+})
+
+test('reviewRevert all does not require HEAD during reset', async () => {
+  const dir = makeTempDir()
+
+  const raw = vi.fn(async args => {
+    if (args[0] === 'reset' && args.includes('HEAD')) {
+      throw new Error("fatal: ambiguous argument 'HEAD'")
+    }
+
+    return ''
+  })
+
+  vi.mocked(simpleGit).mockReturnValueOnce({ raw } as any)
+
+  assert.deepEqual(await reviewRevert(dir, null, 'git'), { ok: true })
+  assert.deepEqual(
+    raw.mock.calls.map(([args]) => args),
+    [
+      ['reset', '-q'],
+      ['rev-parse', '--verify', '--quiet', 'HEAD'],
+      ['clean', '-fd', '--', '.']
+    ]
+  )
+})
+
+test('reviewRevert surfaces ls-tree failures when HEAD exists', async () => {
+  const dir = makeTempDir()
+
+  const raw = vi.fn(async args => {
+    if (args[0] === 'rev-parse') {
+      return 'deadbeef\n'
+    }
+
+    if (args[0] === 'ls-tree') {
+      throw new Error('injected ls-tree failure')
+    }
+
+    return ''
+  })
+
+  vi.mocked(simpleGit).mockReturnValueOnce({ raw } as any)
+
+  await assert.rejects(() => reviewRevert(dir, 'tracked.txt', 'git'), /injected ls-tree failure/)
 })
 
 test('reviewRevert rejects on a git failure instead of reporting success', async () => {

--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 
 import { afterEach, test } from 'vitest'
 
-import { gitFor, repoStatus, resolveRenamePath } from './git-review-ops'
+import { gitFor, repoStatus, resolveRenamePath, reviewRevert } from './git-review-ops'
 
 const tempDirs: string[] = []
 
@@ -28,6 +28,29 @@ function makeRepo() {
   execFileSync('git', ['commit', '-qm', 'initial'], { cwd: dir })
 
   return dir
+}
+
+// A repo with the two shapes the review pane always has to handle at once: a
+// tracked edit and a brand-new file.
+function makeDirtyRepo() {
+  const dir = makeRepo()
+
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'tracked\nedited\n')
+  fs.writeFileSync(path.join(dir, 'new.txt'), 'brand new\n')
+
+  return dir
+}
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-git-plain-'))
+
+  tempDirs.push(dir)
+
+  return dir
+}
+
+async function changedPaths(dir: string) {
+  return (await repoStatus(dir, 'git'))?.files.map(file => file.path)
 }
 
 test('resolveRenamePath: plain path is unchanged', () => {
@@ -86,4 +109,84 @@ test('repoStatus reports an untracked directory without recursively listing its 
     status.files.map(file => file.path),
     ['generated/']
   )
+})
+
+test('reviewRevert removes a staged new file', async () => {
+  // Staging is one click away from reverting in the review pane, and a staged
+  // new file is what `checkout HEAD` (not in HEAD) and `clean` (tracked in the
+  // index) both refuse to touch.
+  const dir = makeDirtyRepo()
+
+  execFileSync('git', ['add', 'new.txt'], { cwd: dir })
+
+  assert.deepEqual(await reviewRevert(dir, 'new.txt', 'git'), { ok: true })
+  assert.equal(fs.existsSync(path.join(dir, 'new.txt')), false)
+  // Scoped: the unrelated tracked edit is left alone.
+  assert.deepEqual(await changedPaths(dir), ['tracked.txt'])
+})
+
+test('reviewRevert removes a plain untracked file', async () => {
+  // `checkout HEAD` legitimately fails here (the path is not in HEAD); `clean`
+  // is the whole job, so that failure must not abort the revert.
+  const dir = makeDirtyRepo()
+
+  assert.deepEqual(await reviewRevert(dir, 'new.txt', 'git'), { ok: true })
+  assert.equal(fs.existsSync(path.join(dir, 'new.txt')), false)
+  assert.deepEqual(await changedPaths(dir), ['tracked.txt'])
+})
+
+test('reviewRevert restores a staged modification', async () => {
+  const dir = makeDirtyRepo()
+
+  execFileSync('git', ['add', 'tracked.txt'], { cwd: dir })
+
+  assert.deepEqual(await reviewRevert(dir, 'tracked.txt', 'git'), { ok: true })
+  assert.equal(fs.readFileSync(path.join(dir, 'tracked.txt'), 'utf8'), 'tracked\n')
+  assert.deepEqual(await changedPaths(dir), ['new.txt'])
+})
+
+test('reviewRevert restores a staged deletion', async () => {
+  const dir = makeDirtyRepo()
+
+  execFileSync('git', ['rm', '-q', '-f', 'tracked.txt'], { cwd: dir })
+
+  assert.deepEqual(await reviewRevert(dir, 'tracked.txt', 'git'), { ok: true })
+  assert.equal(fs.readFileSync(path.join(dir, 'tracked.txt'), 'utf8'), 'tracked\n')
+  assert.deepEqual(await changedPaths(dir), ['new.txt'])
+})
+
+test('reviewRevert with no path clears staged, unstaged and untracked changes', async () => {
+  const dir = makeDirtyRepo()
+
+  fs.writeFileSync(path.join(dir, 'staged-new.txt'), 'staged\n')
+  execFileSync('git', ['add', 'staged-new.txt'], { cwd: dir })
+
+  assert.deepEqual(await reviewRevert(dir, null, 'git'), { ok: true })
+  assert.equal(fs.readFileSync(path.join(dir, 'tracked.txt'), 'utf8'), 'tracked\n')
+  assert.equal(fs.existsSync(path.join(dir, 'new.txt')), false)
+  assert.equal(fs.existsSync(path.join(dir, 'staged-new.txt')), false)
+  assert.deepEqual(await changedPaths(dir), [])
+})
+
+test('reviewRevert removes new files before the first commit', async () => {
+  // An unborn HEAD has nothing to restore, but the new files still have to go.
+  const dir = makeTempDir()
+
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.writeFileSync(path.join(dir, 'staged.txt'), 'staged\n')
+  fs.writeFileSync(path.join(dir, 'loose.txt'), 'loose\n')
+  execFileSync('git', ['add', 'staged.txt'], { cwd: dir })
+
+  assert.deepEqual(await reviewRevert(dir, null, 'git'), { ok: true })
+  assert.equal(fs.existsSync(path.join(dir, 'staged.txt')), false)
+  assert.equal(fs.existsSync(path.join(dir, 'loose.txt')), false)
+})
+
+test('reviewRevert rejects on a git failure instead of reporting success', async () => {
+  const dir = makeTempDir()
+
+  fs.writeFileSync(path.join(dir, 'note.txt'), 'keep me\n')
+
+  await assert.rejects(() => reviewRevert(dir, 'note.txt', 'git'))
+  assert.equal(fs.readFileSync(path.join(dir, 'note.txt'), 'utf8'), 'keep me\n')
 })

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -410,14 +410,16 @@ async function reviewUnstage(repoPath, filePath, gitBin) {
   return { ok: true }
 }
 
-// Does HEAD carry anything matching this pathspec? False on an unborn HEAD,
-// where `ls-tree` has no commit to read and there is nothing to restore.
+// Does HEAD carry anything matching this pathspec? Verify the expected unborn
+// case separately so a real ls-tree failure still reaches the renderer.
 async function headHas(git, target) {
-  try {
-    return Boolean((await git.raw(['ls-tree', '--name-only', 'HEAD', ...target])).trim())
-  } catch {
+  const head = await git.raw(['rev-parse', '--verify', '--quiet', 'HEAD'])
+
+  if (!head.trim()) {
     return false
   }
+
+  return Boolean((await git.raw(['ls-tree', '--name-only', 'HEAD', ...target])).trim())
 }
 
 // Discard changes back to the committed state. Destructive — the renderer
@@ -430,7 +432,7 @@ async function reviewRevert(repoPath, filePath, gitBin) {
   // Unstage first: a *staged* new file is invisible to both commands below —
   // `checkout HEAD` can't restore what HEAD never had, and `clean` skips it as
   // tracked — so without this it survived the revert untouched.
-  await git.raw(['reset', '-q', 'HEAD', ...target])
+  await git.raw(filePath ? ['reset', '-q', 'HEAD', ...target] : ['reset', '-q'])
 
   // Restore only what HEAD actually carries; for anything else `clean` is the
   // whole job. Both commands now reject on failure, since neither is expected to

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -410,19 +410,36 @@ async function reviewUnstage(repoPath, filePath, gitBin) {
   return { ok: true }
 }
 
+// Does HEAD carry anything matching this pathspec? False on an unborn HEAD,
+// where `ls-tree` has no commit to read and there is nothing to restore.
+async function headHas(git, target) {
+  try {
+    return Boolean((await git.raw(['ls-tree', '--name-only', 'HEAD', ...target])).trim())
+  } catch {
+    return false
+  }
+}
+
 // Discard changes back to the committed state. Destructive — the renderer
 // confirms first. Restores tracked files and removes untracked ones.
 async function reviewRevert(repoPath, filePath, gitBin) {
   const cwd = resolveRequestedPathForIpc(repoPath, { purpose: 'Review revert' })
   const git = gitFor(cwd, gitBin)
+  const target = filePath ? ['--', filePath] : ['--', '.']
 
-  if (filePath) {
-    await git.raw(['checkout', 'HEAD', '--', filePath]).catch(() => undefined)
-    await git.raw(['clean', '-fd', '--', filePath]).catch(() => undefined)
-  } else {
-    await git.raw(['checkout', 'HEAD', '--', '.']).catch(() => undefined)
-    await git.raw(['clean', '-fd']).catch(() => undefined)
+  // Unstage first: a *staged* new file is invisible to both commands below —
+  // `checkout HEAD` can't restore what HEAD never had, and `clean` skips it as
+  // tracked — so without this it survived the revert untouched.
+  await git.raw(['reset', '-q', 'HEAD', ...target])
+
+  // Restore only what HEAD actually carries; for anything else `clean` is the
+  // whole job. Both commands now reject on failure, since neither is expected to
+  // fail on a path the review pane listed.
+  if (await headHas(git, target)) {
+    await git.raw(['checkout', 'HEAD', ...target])
   }
+
+  await git.raw(['clean', '-fd', ...target])
 
   return { ok: true }
 }

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -358,11 +358,26 @@ def review_unstage(cwd: str, file_path: str | None) -> dict:
     return {"ok": True}
 
 
+def _head_has(cwd: str, target: list[str]) -> bool:
+    """Does HEAD carry anything matching this pathspec? False on an unborn HEAD,
+    where ``ls-tree`` has no commit to read and there is nothing to restore."""
+    code, out, _ = _git(cwd, ["ls-tree", "--name-only", "HEAD", *target])
+    return code == 0 and bool(out.strip())
+
+
 def review_revert(cwd: str, file_path: str | None) -> dict:
     """Discard changes back to the committed state (restore tracked, remove untracked)."""
     target = ["--", file_path] if file_path else ["--", "."]
-    _git(cwd, ["checkout", "HEAD", *target])
-    _git(cwd, ["clean", "-fd", *target])
+    # Unstage first: a *staged* new file is invisible to both commands below —
+    # `checkout HEAD` can't restore what HEAD never had, and `clean` skips it as
+    # tracked — so without this it survived the revert untouched.
+    _git_ok(cwd, ["reset", "-q", "HEAD", *target])
+    # Restore only what HEAD actually carries; for anything else `clean` is the
+    # whole job. Both commands can now fail loudly, since neither is expected to
+    # fail on a path the review pane listed.
+    if _head_has(cwd, target):
+        _git_ok(cwd, ["checkout", "HEAD", *target])
+    _git_ok(cwd, ["clean", "-fd", *target])
     return {"ok": True}
 
 

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -359,10 +359,17 @@ def review_unstage(cwd: str, file_path: str | None) -> dict:
 
 
 def _head_has(cwd: str, target: list[str]) -> bool:
-    """Does HEAD carry anything matching this pathspec? False on an unborn HEAD,
-    where ``ls-tree`` has no commit to read and there is nothing to restore."""
-    code, out, _ = _git(cwd, ["ls-tree", "--name-only", "HEAD", *target])
-    return code == 0 and bool(out.strip())
+    """Does HEAD carry anything matching this pathspec?"""
+    code, _, err = _git(cwd, ["rev-parse", "--verify", "--quiet", "HEAD"])
+    if code == 1 and not err.strip():
+        return False  # Unborn HEAD: there is nothing to restore.
+    if code != 0:
+        raise RuntimeError(err.strip() or "git rev-parse HEAD failed")
+
+    code, out, err = _git(cwd, ["ls-tree", "--name-only", "HEAD", *target])
+    if code != 0:
+        raise RuntimeError(err.strip() or "git ls-tree HEAD failed")
+    return bool(out.strip())
 
 
 def review_revert(cwd: str, file_path: str | None) -> dict:
@@ -371,7 +378,8 @@ def review_revert(cwd: str, file_path: str | None) -> dict:
     # Unstage first: a *staged* new file is invisible to both commands below —
     # `checkout HEAD` can't restore what HEAD never had, and `clean` skips it as
     # tracked — so without this it survived the revert untouched.
-    _git_ok(cwd, ["reset", "-q", "HEAD", *target])
+    reset = ["reset", "-q", "HEAD", *target] if file_path else ["reset", "-q"]
+    _git_ok(cwd, reset)
     # Restore only what HEAD actually carries; for anything else `clean` is the
     # whole job. Both commands can now fail loudly, since neither is expected to
     # fail on a path the review pane listed.

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -31,6 +31,12 @@ def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
 
 
+def _review_paths(client, repo: Path) -> set[str]:
+    """Paths the review pane still lists — i.e. what git really reports as changed."""
+    body = client.get("/api/git/review/list", params={"path": str(repo)}).json()
+    return {file["path"] for file in body["files"]}
+
+
 @pytest.fixture
 def repo(tmp_path):
     root = tmp_path / "repo"
@@ -71,8 +77,94 @@ def test_stage_commit_roundtrip_clears_changes(client, repo):
     assert after["untracked"] == 1
 
 
+def test_revert_removes_a_staged_new_file(client, repo):
+    # Staging is one click away from reverting in the review pane, and a staged
+    # new file is exactly what `checkout HEAD` (not in HEAD) and `clean` (tracked
+    # in the index) both refuse to touch.
+    _git(repo, "add", "new.py")
+
+    assert client.post(
+        "/api/git/review/revert", json={"path": str(repo), "file": "new.py"}
+    ).json() == {"ok": True}
+
+    assert not (repo / "new.py").exists()
+    # Scoped: the unrelated tracked edit is left alone.
+    assert _review_paths(client, repo) == {"a.txt"}
 
 
+def test_revert_removes_a_plain_untracked_file(client, repo):
+    # `checkout HEAD` legitimately fails here (the path is not in HEAD); `clean`
+    # is the whole job, so that failure must not abort the revert.
+    assert client.post(
+        "/api/git/review/revert", json={"path": str(repo), "file": "new.py"}
+    ).json() == {"ok": True}
+
+    assert not (repo / "new.py").exists()
+    assert _review_paths(client, repo) == {"a.txt"}
+
+
+def test_revert_restores_a_staged_modification(client, repo):
+    _git(repo, "add", "a.txt")
+
+    assert client.post(
+        "/api/git/review/revert", json={"path": str(repo), "file": "a.txt"}
+    ).json() == {"ok": True}
+
+    assert (repo / "a.txt").read_text() == "one\ntwo\n"
+    assert _review_paths(client, repo) == {"new.py"}
+
+
+def test_revert_restores_a_staged_deletion(client, repo):
+    _git(repo, "rm", "-q", "-f", "a.txt")
+
+    assert client.post(
+        "/api/git/review/revert", json={"path": str(repo), "file": "a.txt"}
+    ).json() == {"ok": True}
+
+    assert (repo / "a.txt").read_text() == "one\ntwo\n"
+    assert _review_paths(client, repo) == {"new.py"}
+
+
+def test_revert_all_clears_staged_unstaged_and_untracked(client, repo):
+    (repo / "staged-new.txt").write_text("staged\n")
+    _git(repo, "add", "staged-new.txt")
+
+    assert client.post(
+        "/api/git/review/revert", json={"path": str(repo), "file": None}
+    ).json() == {"ok": True}
+
+    assert (repo / "a.txt").read_text() == "one\ntwo\n"
+    assert not (repo / "new.py").exists()
+    assert not (repo / "staged-new.txt").exists()
+    assert _review_paths(client, repo) == set()
+
+
+def test_revert_removes_new_files_before_the_first_commit(client, tmp_path):
+    # An unborn HEAD has nothing to restore, but the new files still have to go.
+    fresh = tmp_path / "fresh"
+    fresh.mkdir()
+    _git(fresh, "init", "-q")
+    (fresh / "staged.txt").write_text("staged\n")
+    (fresh / "loose.txt").write_text("loose\n")
+    _git(fresh, "add", "staged.txt")
+
+    assert client.post(
+        "/api/git/review/revert", json={"path": str(fresh), "file": None}
+    ).json() == {"ok": True}
+
+    assert not (fresh / "staged.txt").exists()
+    assert not (fresh / "loose.txt").exists()
+
+
+def test_revert_reports_a_git_failure_instead_of_ok(client, tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "note.txt").write_text("keep me\n")
+
+    response = client.post("/api/git/review/revert", json={"path": str(plain), "file": "note.txt"})
+
+    assert response.status_code == 400
+    assert (plain / "note.txt").read_text() == "keep me\n"
 
 
 def test_worktree_add_initializes_plain_folder(client, tmp_path):

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from hermes_cli import web_server
+from hermes_cli import web_git, web_server
 
 pytest.importorskip("starlette.testclient")
 from starlette.testclient import TestClient
@@ -154,6 +154,51 @@ def test_revert_removes_new_files_before_the_first_commit(client, tmp_path):
 
     assert not (fresh / "staged.txt").exists()
     assert not (fresh / "loose.txt").exists()
+
+
+def test_revert_all_does_not_require_head_during_reset(client, tmp_path, monkeypatch):
+    """Newer Git rejects an explicit HEAD in an unborn repo; bare reset does not."""
+    fresh = tmp_path / "fresh"
+    fresh.mkdir()
+    _git(fresh, "init", "-q")
+    (fresh / "staged.txt").write_text("staged\n")
+    (fresh / "loose.txt").write_text("loose\n")
+    _git(fresh, "add", "staged.txt")
+
+    real_git = web_git._git
+
+    def reject_unborn_head_reset(cwd, args, **kwargs):
+        if args[:3] == ["reset", "-q", "HEAD"]:
+            return 128, "", "fatal: ambiguous argument 'HEAD'"
+        return real_git(cwd, args, **kwargs)
+
+    monkeypatch.setattr(web_git, "_git", reject_unborn_head_reset)
+
+    response = client.post(
+        "/api/git/review/revert", json={"path": str(fresh), "file": None}
+    )
+
+    assert response.json() == {"ok": True}
+    assert not (fresh / "staged.txt").exists()
+    assert not (fresh / "loose.txt").exists()
+
+
+def test_revert_surfaces_ls_tree_failure_when_head_exists(client, repo, monkeypatch):
+    real_git = web_git._git
+
+    def fail_ls_tree(cwd, args, **kwargs):
+        if args and args[0] == "ls-tree":
+            return 1, "", "injected ls-tree failure"
+        return real_git(cwd, args, **kwargs)
+
+    monkeypatch.setattr(web_git, "_git", fail_ls_tree)
+
+    response = client.post(
+        "/api/git/review/revert", json={"path": str(repo), "file": "a.txt"}
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "injected ls-tree failure"
 
 
 def test_revert_reports_a_git_failure_instead_of_ok(client, tmp_path):


### PR DESCRIPTION
## What does this PR do?

Revert in the Desktop review pane does nothing to a file that is new and staged.

`review_revert` runs `git checkout HEAD -- <path>`, then `git clean -fd -- <path>`, discarding both exit codes:

- `checkout` exits 1, the path is not in HEAD
- `clean` exits 0 and skips the path, it is tracked in the index
- the op returns `{"ok": true}`, so the confirm dialog closes and nothing is reported

Same sequence in both Desktop transports: `hermes_cli/web_git.py::review_revert` (gateway, `POST /api/git/review/revert`) and `apps/desktop/electron/git-review-ops.ts::reviewRevert` (Electron, four `.catch(() => undefined)`).

Replaced with:

1. `git reset -q HEAD -- <path>`, which is what makes a staged new file reachable by `clean`
2. `git ls-tree --name-only HEAD -- <path>`, does HEAD carry the path
3. `git checkout HEAD -- <path>` only when it does
4. `git clean -fd -- <path>`

Testing `checkout`'s exit code instead would break the common case: for an untracked file it exits 1 by design and `clean` does the real work. The `ls-tree` probe separates the two.

The remaining commands are then expected to succeed, so failures propagate. `RuntimeError` becomes HTTP 400 through `_git_op` on the gateway; a rejected promise reaches the renderer's existing `notifyError` wrapper in Electron. Both module headers already describe mutations that way.

## Related Issue

No existing issue. Reproduction below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_git.py`: unstage first, restore only paths present in HEAD (new `_head_has` helper), `_git_ok` so failures raise, matching `review_stage` and `review_unstage`.
- `apps/desktop/electron/git-review-ops.ts`: same sequence, the swallows removed, single-file and all-files branches share one pathspec.
- `tests/hermes_cli/test_web_server_git.py` and `apps/desktop/electron/git-review-ops.test.ts`: 7 cases each on the existing temp-repo fixtures. Revert had no test coverage before.

Cases: staged new file; plain untracked file (pins exit 1 there as normal); staged modification; staged deletion; revert-all over a mixed staged/unstaged/untracked tree; repo with no commits yet (unborn HEAD, nothing to restore, files still removed); a git failure reporting an error instead of `ok`. Four of them fail on `main` in both suites. The other three pass on `main` and pin behavior the fix has to keep.

Reverting a staged file now unstages it, which is what makes the operation work. The dialog copy describes discarding changes and says nothing about the index, so the i18n strings are unchanged.

## How to Test

The git behavior, without the app:

```bash
cd "$(mktemp -d)" && git init -q . && git commit -qm init --allow-empty
echo 'print(1)' > new.py && git add new.py
git checkout HEAD -- new.py   # error: pathspec ... , exit 1
git clean -fd -- new.py       # exit 0, removes nothing
git status --porcelain        # A  new.py, still there
```

In the app: open the review pane on a repo with a new file, click Stage all, then Revert on that file. Before, the row stays and no error appears. After, the file is discarded.

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_server_git.py
npm run test:desktop:platforms --prefix apps/desktop   # vitest --project electron
```

Local results: 18 passed for the Python file, 791 passed and 2 skipped for the electron vitest project.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass: ran `scripts/run_tests.sh tests/hermes_cli/`, and the failures left over also fail on `main` on macOS (WSL/systemd detection, SIGTERM timing)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, git 2.53.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): no shell and no path assumptions, both backends pass plain argv to git
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A
