### PR TITLE
fix(telegram): keep plain DM messages in root chat

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3323,12 +3323,24 @@ class BasePlatformAdapter(ABC):
         self._topic_recovery_fn = fn  # type: ignore[attr-defined]
 
     def _apply_topic_recovery(self, event: MessageEvent) -> None:
-        """Rewrite ``event.source.thread_id`` in place if the hook returns one."""
+        """Rewrite ``event.source.thread_id`` in place if the hook returns one.
+
+        Telegram DM topic recovery is a fallback for replies whose topic
+        metadata was stripped. A plain root-chat message is an explicit choice
+        to use the lobby, so it must not be moved into the latest topic.
+        """
         recover = getattr(self, "_topic_recovery_fn", None)
         if recover is None:
             return
         source = getattr(event, "source", None)
         if source is None:
+            return
+        if (
+            _platform_name(getattr(source, "platform", None)) == "telegram"
+            and getattr(source, "chat_type", None) == "dm"
+            and str(getattr(source, "thread_id", None) or "") in {"", "1"}
+            and not getattr(event, "reply_to_message_id", None)
+        ):
             return
         try:
             recovered = recover(source)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3670,12 +3670,24 @@ class BasePlatformAdapter(ABC):
         self._topic_recovery_fn = fn  # type: ignore[attr-defined]
 
     def _apply_topic_recovery(self, event: MessageEvent) -> None:
-        """Rewrite ``event.source.thread_id`` in place if the hook returns one."""
+        """Rewrite ``event.source.thread_id`` in place if the hook returns one.
+
+        Telegram DM topic recovery is a fallback for replies whose topic
+        metadata was stripped. A plain root-chat message is an explicit choice
+        to use the lobby, so it must not be moved into the latest topic.
+        """
         recover = getattr(self, "_topic_recovery_fn", None)
         if recover is None:
             return
         source = getattr(event, "source", None)
         if source is None:
+            return
+        if (
+            _platform_name(getattr(source, "platform", None)) == "telegram"
+            and getattr(source, "chat_type", None) == "dm"
+            and str(getattr(source, "thread_id", None) or "") in {"", "1"}
+            and not getattr(event, "reply_to_message_id", None)
+        ):
             return
         try:
             recovered = recover(source)

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -108,6 +108,7 @@ def _make_adapter() -> BasePlatformAdapter:
     adapter._auto_tts_enabled_chats = set()
     adapter._auto_tts_disabled_chats = set()
     adapter._typing_paused = set()
+    adapter._streaming_tts_completed_turns = set()
     return adapter
 
 
@@ -148,7 +149,12 @@ async def test_non_dm_message_does_not_wait_for_topic_recovery_executor(monkeypa
 
 @pytest.mark.asyncio
 async def test_dm_topic_recovery_stays_offloaded(monkeypatch):
-    """Real Telegram DM topic recovery must still run outside the event loop."""
+    """Stripped Telegram DM replies still recover off the event loop.
+
+    Plain root-chat DMs (empty/``1`` thread, no reply) intentionally skip
+    recovery so lobby messages stay in the lobby. This regression covers the
+    remaining recovery path: a DM reply whose topic metadata was stripped.
+    """
     adapter = _make_adapter()
     recovery = MagicMock(return_value="topic-222")
     adapter.set_topic_recovery_fn(recovery)
@@ -161,6 +167,7 @@ async def test_dm_topic_recovery_stays_offloaded(monkeypatch):
 
     monkeypatch.setattr(asyncio, "to_thread", _inline_to_thread)
     event = _make_event("hello", chat_type="dm", thread_id="1")
+    event.reply_to_message_id = "10"
     original_source = event.source
 
     await adapter.handle_message(event)
@@ -170,6 +177,32 @@ async def test_dm_topic_recovery_stays_offloaded(monkeypatch):
     assert recovery.call_count == 1
     assert recovery.call_args.args[0] is original_source
     assert event.source.thread_id == "topic-222"
+
+
+@pytest.mark.asyncio
+async def test_plain_dm_root_message_skips_topic_recovery(monkeypatch):
+    """Plain root-chat DM messages must not be moved into the latest topic."""
+    adapter = _make_adapter()
+    recovery = MagicMock(return_value="topic-222")
+    adapter.set_topic_recovery_fn(recovery)
+    offloaded = False
+
+    async def _inline_to_thread(func, *args, **kwargs):
+        nonlocal offloaded
+        offloaded = True
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", _inline_to_thread)
+    event = _make_event("hello from lobby", chat_type="dm", thread_id="1")
+
+    await adapter.handle_message(event)
+    await asyncio.sleep(0)
+
+    # DM still enters the offloaded recovery wrapper, but plain root messages
+    # return before calling the recovery hook.
+    assert offloaded is True
+    recovery.assert_not_called()
+    assert event.source.thread_id == "1"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -68,6 +68,48 @@ def _make_event(chat_id: str, thread_id: str, message_id: str = "1") -> MessageE
 
 
 class TestBasePlatformTopicSessions:
+    @pytest.mark.parametrize("thread_id", [None, "1"])
+    def test_topic_recovery_keeps_plain_telegram_dm_in_root_chat(self, thread_id):
+        adapter = DummyTelegramAdapter()
+        recovery_calls = []
+        adapter.set_topic_recovery_fn(
+            lambda source: recovery_calls.append(source) or "222"
+        )
+        event = MessageEvent(
+            text="hello from the root chat",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+                user_id="user-1",
+                thread_id=thread_id,
+            ),
+        )
+
+        adapter._apply_topic_recovery(event)
+
+        assert event.source.thread_id == thread_id
+        assert recovery_calls == []
+
+    def test_topic_recovery_routes_stripped_telegram_dm_reply(self):
+        adapter = DummyTelegramAdapter()
+        adapter.set_topic_recovery_fn(lambda _source: "222")
+        event = MessageEvent(
+            text="reply whose topic metadata was stripped",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+                user_id="user-1",
+                thread_id="1",
+            ),
+            reply_to_message_id="10",
+        )
+
+        adapter._apply_topic_recovery(event)
+
+        assert event.source.thread_id == "222"
+
 
     @pytest.mark.asyncio
     async def test_handle_message_interrupts_same_topic(self, monkeypatch):

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -115,6 +115,51 @@ class TestTextBatching:
         assert "chunk 2" in text
         assert "chunk 3" in text
 
+    @pytest.mark.asyncio
+    async def test_dm_topic_batching_recovers_thread_before_keying(self):
+        """DM-topic text batches should use the recovered topic lane."""
+        adapter = _make_adapter()
+        adapter.set_topic_recovery_fn(
+            lambda source: "222" if str(source.thread_id or "") == "1" else None
+        )
+        event = MessageEvent(
+            text="hello from DM topic",
+            message_type=MessageType.TEXT,
+            reply_to_message_id="10",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+                user_id="user-1",
+                thread_id="1",
+            ),
+        )
+
+        adapter._enqueue_text_event(event)
+
+        def _key(thread_id: str) -> str:
+            return build_session_key(
+                SimpleNamespace(
+                    platform=Platform.TELEGRAM,
+                    chat_id="12345",
+                    chat_type="dm",
+                    thread_id=thread_id,
+                ),
+                group_sessions_per_user=True,
+                thread_sessions_per_user=False,
+            )
+
+        assert _key("222") in adapter._pending_text_batches
+        assert _key("1") not in adapter._pending_text_batches
+        assert event.source.thread_id == "222"
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.source.thread_id == "222"
+
+
 
     @pytest.mark.asyncio
     async def test_disconnected_adapter_drops_pending_media_group_flush_before_dispatch(self):

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -119,6 +119,51 @@ class TestTextBatching:
         assert "chunk 2" in text
         assert "chunk 3" in text
 
+    @pytest.mark.asyncio
+    async def test_dm_topic_batching_recovers_thread_before_keying(self):
+        """DM-topic text batches should use the recovered topic lane."""
+        adapter = _make_adapter()
+        adapter.set_topic_recovery_fn(
+            lambda source: "222" if str(source.thread_id or "") == "1" else None
+        )
+        event = MessageEvent(
+            text="hello from DM topic",
+            message_type=MessageType.TEXT,
+            reply_to_message_id="10",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+                user_id="user-1",
+                thread_id="1",
+            ),
+        )
+
+        adapter._enqueue_text_event(event)
+
+        def _key(thread_id: str) -> str:
+            return build_session_key(
+                SimpleNamespace(
+                    platform=Platform.TELEGRAM,
+                    chat_id="12345",
+                    chat_type="dm",
+                    thread_id=thread_id,
+                ),
+                group_sessions_per_user=True,
+                thread_sessions_per_user=False,
+            )
+
+        assert _key("222") in adapter._pending_text_batches
+        assert _key("1") not in adapter._pending_text_batches
+        assert event.source.thread_id == "222"
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.source.thread_id == "222"
+
+
 
     @pytest.mark.asyncio
     async def test_disconnected_adapter_drops_pending_media_group_flush_before_dispatch(self):


### PR DESCRIPTION
## What does this PR do?

Telegram DM topic recovery currently runs before session keying and can rewrite
a plain message from the root/General chat into the user's most recently active
topic. That bypasses the existing root-lobby behavior and sends the message down
an unrelated topic session.

This change keeps a root/General DM event in place when it has no reply anchor.
Recovery still runs for actual replies whose topic metadata was stripped by
Telegram.

This is the remaining root-message edge of the recovery behavior discussed in
#31086 and narrowed in #31444: explicit topic IDs are already trusted, while
root-shaped replies still need recovery.

## Related Issue

Related to #31086.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Skip topic recovery for plain Telegram root/General DM events.
- Preserve recovery when a root-shaped event carries a reply anchor.
- Cover both root encodings (`None` and `"1"`) and the stripped-reply case.
- Update the text-batching fixture so it explicitly represents a reply.

## How to Test

1. Run:

   ```bash
   scripts/run_tests.sh \
     tests/gateway/test_base_topic_sessions.py \
     tests/gateway/test_telegram_text_batching.py -q
   ```

2. Confirm plain root/General DM events remain in the root chat.
3. Confirm replies with stripped topic metadata recover to the bound topic.

## Checklist

### Code

- [x] I've read the contributing guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed PRs and issues for duplicates.
- [x] My PR contains only this fix and its regression tests.
- [x] The focused suite passes: 27 tests.
- [x] I've added behavior tests for the fix.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing configuration or API changes.
- [x] `cli-config.yaml.example`: N/A — no config changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow changes.
- [x] Cross-platform impact considered: the change is platform-gated to Telegram DM metadata and adds no OS-specific behavior.
- [x] Tool descriptions/schemas: N/A — no tool changes.

## Verification

- `scripts/run_tests.sh tests/gateway/test_base_topic_sessions.py tests/gateway/test_telegram_text_batching.py -q`: **27 passed**
- `scripts/run_tests.sh tests/gateway/ -q`: **10,881 passed**; six unrelated failures reproduce unchanged on current `main` in the same environment
- `ruff check` on all changed Python files: **passed**
- `scripts/check-windows-footguns.py --diff origin/main`: **passed**
- `git diff --check origin/main...HEAD`: **passed**

## Screenshots / Logs

N/A — routing behavior is covered by executable regression tests.
