### PR TITLE
fix(guardrails): update stale MCP tool names in idempotent allowlist

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -27,14 +27,14 @@ IDEMPOTENT_TOOL_NAMES = frozenset(
         "browser_snapshot",
         "browser_console",
         "browser_get_images",
-        "mcp_filesystem_read_file",
-        "mcp_filesystem_read_text_file",
-        "mcp_filesystem_read_multiple_files",
-        "mcp_filesystem_list_directory",
-        "mcp_filesystem_list_directory_with_sizes",
-        "mcp_filesystem_directory_tree",
-        "mcp_filesystem_get_file_info",
-        "mcp_filesystem_search_files",
+        "mcp__filesystem__read_file",
+        "mcp__filesystem__read_text_file",
+        "mcp__filesystem__read_multiple_files",
+        "mcp__filesystem__list_directory",
+        "mcp__filesystem__list_directory_with_sizes",
+        "mcp__filesystem__directory_tree",
+        "mcp__filesystem__get_file_info",
+        "mcp__filesystem__search_files",
     }
 )
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -131,6 +131,60 @@ def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_succes
         assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
 
 
+def test_mcp_filesystem_tools_are_classified_as_idempotent():
+    """MCP tools using the mcp__<server>__<tool> naming are in the idempotent set."""
+    from agent.tool_guardrails import IDEMPOTENT_TOOL_NAMES
+
+    mcp_read_tools = [
+        "mcp__filesystem__read_file",
+        "mcp__filesystem__read_text_file",
+        "mcp__filesystem__read_multiple_files",
+        "mcp__filesystem__list_directory",
+        "mcp__filesystem__list_directory_with_sizes",
+        "mcp__filesystem__directory_tree",
+        "mcp__filesystem__get_file_info",
+        "mcp__filesystem__search_files",
+    ]
+    for name in mcp_read_tools:
+        assert name in IDEMPOTENT_TOOL_NAMES, f"{name} should be in IDEMPOTENT_TOOL_NAMES"
+
+    # Old-style single-underscore names must NOT be present (they never match)
+    for name in [
+        "mcp_filesystem_read_file",
+        "mcp_filesystem_list_directory",
+    ]:
+        assert name not in IDEMPOTENT_TOOL_NAMES, f"{name} (old format) should NOT be in IDEMPOTENT_TOOL_NAMES"
+
+    # The guardrail controller actually fires for mcp__ tools
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
+    )
+    args = {"path": "/tmp/same.txt"}
+    result = "same contents"
+    assert controller.before_call("mcp__filesystem__read_file", args).action == "allow"
+    assert controller.after_call("mcp__filesystem__read_file", args, result, failed=False).action == "allow"
+    assert controller.before_call("mcp__filesystem__read_file", args).action == "allow"
+    warn = controller.after_call("mcp__filesystem__read_file", args, result, failed=False)
+    assert warn.action == "warn"
+    assert warn.code == "idempotent_no_progress_warning"
+
+
+def test_reset_for_turn_clears_bounded_guardrail_state():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, no_progress_block_after=2)
+    )
+    controller.after_call("web_search", {"query": "same"}, '{"error":"boom"}', failed=True)
+    controller.after_call("web_search", {"query": "same"}, '{"error":"boom"}', failed=True)
+    controller.after_call("read_file", {"path": "/tmp/x"}, "same", failed=False)
+    controller.after_call("read_file", {"path": "/tmp/x"}, "same", failed=False)
+
+    assert controller.before_call("web_search", {"query": "same"}).action == "block"
+    assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "block"
+
+    controller.reset_for_turn()
+
+    assert controller.before_call("web_search", {"query": "same"}).action == "allow"
+    assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
 
 
 


### PR DESCRIPTION
## Problem

`agent/tool_guardrails.py`'s `IDEMPOTENT_TOOL_NAMES` frozenset uses the old single-underscore naming convention (`mcp_filesystem_read_file`) which predates the `mcp__<server>__<tool>` double-underscore migration. These entries can never match the actual wire-format tool names, so the `idempotent_no_progress` guardrail cannot fire for any MCP filesystem tool — it's dead code for that entire tool class.

Partially addresses #71585 (naming portion; config half tracked by #71793)

## Triage / Root cause

The allowlist in `agent/tool_guardrails.py:30-37` was written before the MCP naming migration (commit `e01f58ff1`, 2026-07-05) that adopted `mcp__<server>__<tool>` as the standard format. The eight `mcp_filesystem_*` entries use the old `mcp_<server>_<tool>` single-underscore pattern and never match the actual tool names sent over the wire (now `mcp__filesystem__*`).

## Fix

- Updated all eight `IDEMPOTENT_TOOL_NAMES` entries from `mcp_<server>_<tool>` to `mcp__<server>__<tool>` format.
- Added a test (`test_mcp_filesystem_tools_are_classified_as_idempotent`) that verifies:
  - All eight `mcp__filesystem__*` entries are in the idempotent set.
  - Old-style single-underscore entries are NOT present.
  - The guardrail controller actually fires warnings for repeated `mcp__filesystem__read_file` calls.

## Verification

- Fix is a clean cherry-pick of `bb848d773` onto the restructured `main` (no conflicts).
- Code evidence: `_MCP_TOOL_PREFIX = "mcp__"` in `agent/anthropic_adapter.py:384` and `agent/transports/anthropic.py:91`; `f"mcp__{server}__{tool}"` in `agent/codex_runtime.py:474` and `agent/transports/codex_event_projector.py:222`.
- Test run: `python3 -m pytest tests/agent/test_tool_guardrails.py` → `24 passed in 0.23s` (including the new `test_mcp_filesystem_tools_are_classified_as_idempotent`), no regressions in the sibling guardrail tests. The test is a pure string-set membership + controller-state assertion with no external dependencies, so it exercises the real `IDEMPOTENT_TOOL_NAMES` frozenset and `ToolCallGuardrailController` directly.

## Notes / Risks

- This only covers the `filesystem` server entries that were pre-existing in the allowlist. Other MCP server tools (e.g. `mcp__github__*`) are not in the allowlist and are not affected.
- The fix is narrow: it updates the allowlist to match the naming convention the code already uses everywhere else.
- Supersedes the closed #71588 (same fix, rebased onto the restructured `main` after that branch diverged). The config-based extension half of #71585 is tracked separately by #71793.
