### PR TITLE
docs(mcp): fix stale tool naming convention in mcp-config-reference

### DIFF
--- a/optional-skills/creative/unreal-mcp/SKILL.md
+++ b/optional-skills/creative/unreal-mcp/SKILL.md
@@ -78,10 +78,10 @@ from `config.yaml` via the catalog entry.
 1. Launch Unreal Editor, wait for the project to finish loading; confirm the
    server started (Output Log shows the bind address, or run
    `ModelContextProtocol.StartServer` manually).
-2. Start the Hermes session. Tools register as `mcp_unreal_engine_*`. If
+2. Start the Hermes session. Tools register as `mcp__unreal_engine__*`. If
    they're missing: editor wasn't up first — start it, then open a new
    Hermes session.
-3. Sanity check: call `mcp_unreal_engine_list_toolsets` and confirm toolsets
+3. Sanity check: call `mcp__unreal_engine__list_toolsets` and confirm toolsets
    come back.
 
 ## The Tool Surface: Discovery, Not a Fixed List
@@ -92,9 +92,9 @@ they appear as:
 
 | Hermes tool | Purpose |
 |---|---|
-| `mcp_unreal_engine_list_toolsets` | Names + descriptions of every registered toolset |
-| `mcp_unreal_engine_describe_toolset` | Full JSON schemas for one named toolset's tools |
-| `mcp_unreal_engine_call_tool` | Invoke a named tool with arguments, get the result |
+| `mcp__unreal_engine__list_toolsets` | Names + descriptions of every registered toolset |
+| `mcp__unreal_engine__describe_toolset` | Full JSON schemas for one named toolset's tools |
+| `mcp__unreal_engine__call_tool` | Invoke a named tool with arguments, get the result |
 
 The discovery walk, always in this order:
 
@@ -112,7 +112,7 @@ Cache what you learn for the session; re-list only after the editor side
 changes (new plugin enabled, toolset authored, `RefreshTools` run).
 
 The alternative eager mode (`Enable Tool Search` off in Editor Preferences)
-advertises every tool as its own `mcp_unreal_engine_<tool>` entry. Discovery
+advertises every tool as its own `mcp__unreal_engine__<tool>` entry. Discovery
 then happens at `hermes mcp install`/`configure` time instead. Tool-search
 mode is the default and what this skill assumes; it also keeps schema tokens
 out of every API call, so prefer it.
@@ -137,7 +137,7 @@ Every Unreal task follows the same loop:
    server-side without breaking the serial rule
    (`references/advanced-workflows.md`).
 3. **NEVER issue overlapping calls.** Do not batch multiple
-   `mcp_unreal_engine_*` calls in one turn — Hermes runs batched calls
+   `mcp__unreal_engine__*` calls in one turn — Hermes runs batched calls
    concurrently, and parallel calls against the game thread deadlock or
    fail. Strictly one call, await result, next call. This overrides the
    general parallel-tool-calls guidance.
@@ -216,7 +216,7 @@ Load on demand; keep SKILL.md-level rules in mind throughout.
 ## Pitfalls (top of mind — full list in references/pitfalls.md)
 
 - **Start order matters.** Editor + server up first, then the Hermes
-  session. Missing `mcp_unreal_engine_*` tools = wrong order.
+  session. Missing `mcp__unreal_engine__*` tools = wrong order.
 - **One call at a time.** Serial game thread; no batching, no overlap.
 - **The editor UI freezes during each call.** That's by design (game-thread
   execution). Warn the user during long operations; keep calls small.

--- a/optional-skills/creative/unreal-mcp/references/pitfalls.md
+++ b/optional-skills/creative/unreal-mcp/references/pitfalls.md
@@ -9,7 +9,7 @@ delivery.
 ### 1. Start order: editor first, Hermes second
 
 Hermes probes MCP servers at session start. If the editor (and its server)
-isn't up yet, no `mcp_unreal_engine_*` tools exist in the session. Fix:
+isn't up yet, no `mcp__unreal_engine__*` tools exist in the session. Fix:
 launch the editor, confirm the server bound (Output Log shows
 `LogModelContextProtocol` with the address), then open a NEW Hermes session.
 Tools don't hot-appear mid-session.
@@ -65,7 +65,7 @@ mistake it for the Hermes setup step.
 
 The server executes tool calls serially on the game thread and Epic
 explicitly warns against overlapping calls. Hermes executes same-turn tool
-calls concurrently — so batching two `mcp_unreal_engine_*` calls in one turn
+calls concurrently — so batching two `mcp__unreal_engine__*` calls in one turn
 IS issuing overlapping calls. Strictly sequential: call, await, then next.
 This deliberately overrides the general "batch independent calls" guidance.
 

--- a/optional-skills/creative/unreal-mcp/references/tool-surface.md
+++ b/optional-skills/creative/unreal-mcp/references/tool-surface.md
@@ -51,7 +51,7 @@ Discipline:
   them; they usually name the offending parameter or missing asset.
 
 Eager mode (`Enable Tool Search` off) advertises every tool individually.
-Under Hermes that means each tool becomes `mcp_unreal_engine_<tool_name>` at
+Under Hermes that means each tool becomes `mcp__unreal_engine__<tool_name>` at
 session start, and `hermes mcp configure unreal-engine` can prune the list.
 Schema payload grows with every registered toolset, and tool authors are told
 NOT to rely on eager advertising — stay in tool-search mode unless a very

--- a/optional-skills/research/qmd/SKILL.md
+++ b/optional-skills/research/qmd/SKILL.md
@@ -237,8 +237,8 @@ mcp_servers:
     connect_timeout: 45
 ```
 
-This registers tools: `mcp_qmd_search`, `mcp_qmd_vsearch`,
-`mcp_qmd_deep_search`, `mcp_qmd_get`, `mcp_qmd_status`.
+This registers tools: `mcp__qmd__search`, `mcp__qmd__vsearch`,
+`mcp__qmd__deep_search`, `mcp__qmd__get`, `mcp__qmd__status`.
 
 **Tradeoff:** Models load on first search call (~19s cold start),
 then stay warm for the session. Acceptable for occasional use.
@@ -328,15 +328,15 @@ systemctl --user status qmd-daemon
 
 ### MCP Tools Reference
 
-Once connected, these tools are available as `mcp_qmd_*`:
+Once connected, these tools are available as `mcp__qmd__*`:
 
 | MCP Tool | Maps To | Description |
 |----------|---------|-------------|
-| `mcp_qmd_search` | `qmd search` | BM25 keyword search |
-| `mcp_qmd_vsearch` | `qmd vsearch` | Semantic vector search |
-| `mcp_qmd_deep_search` | `qmd query` | Hybrid search + reranking |
-| `mcp_qmd_get` | `qmd get` | Retrieve document by ID or path |
-| `mcp_qmd_status` | `qmd status` | Index health and stats |
+| `mcp__qmd__search` | `qmd search` | BM25 keyword search |
+| `mcp__qmd__vsearch` | `qmd vsearch` | Semantic vector search |
+| `mcp__qmd__deep_search` | `qmd query` | Hybrid search + reranking |
+| `mcp__qmd__get` | `qmd get` | Retrieve document by ID or path |
+| `mcp__qmd__status` | `qmd status` | Index health and stats |
 
 The MCP tools accept structured JSON queries for multi-mode search:
 

--- a/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
@@ -105,15 +105,15 @@ When Hermes Agent starts, `discover_mcp_tools()` is called during tool initializ
 MCP tools are registered with the naming pattern:
 
 ```
-mcp_{server_name}_{tool_name}
+mcp__{server_name}__{tool_name}
 ```
 
 Hyphens and dots in names are replaced with underscores for LLM API compatibility.
 
 Examples:
-- Server `filesystem`, tool `read_file` → `mcp_filesystem_read_file`
-- Server `github`, tool `list-issues` → `mcp_github_list_issues`
-- Server `my-api`, tool `fetch.data` → `mcp_my_api_fetch_data`
+- Server `filesystem`, tool `read_file` → `mcp__filesystem__read_file`
+- Server `github`, tool `list-issues` → `mcp__github__list_issues`
+- Server `my-api`, tool `fetch.data` → `mcp__my_api__fetch_data`
 
 ### Auto-Injection
 
@@ -224,7 +224,7 @@ pip install --upgrade mcp
 - Check that the server is listed under `mcp_servers` (not `mcp` or `servers`)
 - Ensure the YAML indentation is correct
 - Look at Hermes Agent startup logs for connection messages
-- Tool names are prefixed with `mcp_{server}_{tool}` -- look for that pattern
+- Tool names are prefixed with `mcp__{server}__{tool}` -- look for that pattern
 
 ### Connection keeps dropping
 
@@ -241,7 +241,7 @@ mcp_servers:
     args: ["mcp-server-time"]
 ```
 
-Registers tools like `mcp_time_get_current_time`.
+Registers tools like `mcp__time__get_current_time`.
 
 ### Filesystem Server (npx)
 
@@ -253,7 +253,7 @@ mcp_servers:
     timeout: 30
 ```
 
-Registers tools like `mcp_filesystem_read_file`, `mcp_filesystem_write_file`, `mcp_filesystem_list_directory`.
+Registers tools like `mcp__filesystem__read_file`, `mcp__filesystem__write_file`, `mcp__filesystem__list_directory`.
 
 ### GitHub Server with Authentication
 
@@ -267,7 +267,7 @@ mcp_servers:
     timeout: 60
 ```
 
-Registers tools like `mcp_github_list_issues`, `mcp_github_create_pull_request`, etc.
+Registers tools like `mcp__github__list_issues`, `mcp__github__create_pull_request`, etc.
 
 ### Remote HTTP Server
 

--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -163,7 +163,7 @@ Then start a fresh Hermes session or run:
 Once loaded, Hermes can use the MCP-prefixed browser tools directly. For example:
 
 ```text
-调用 MCP 工具 mcp_chrome_devtools_win_list_pages，列出当前浏览器标签页。
+调用 MCP 工具 mcp__chrome_devtools_win__list_pages，列出当前浏览器标签页。
 ```
 
 ### When `/browser connect` is the wrong tool

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -443,16 +443,16 @@ You can pick any local name (`hermes mcp add my-codex --preset codex` is fine); 
 Hermes prefixes MCP tools so they do not collide with built-in names:
 
 ```text
-mcp_<server_name>_<tool_name>
+mcp__<server_name>__<tool_name>
 ```
 
 Examples:
 
 | Server | MCP tool | Registered name |
 |---|---|---|
-| `filesystem` | `read_file` | `mcp_filesystem_read_file` |
-| `github` | `create-issue` | `mcp_github_create_issue` |
-| `my-api` | `query.data` | `mcp_my_api_query_data` |
+| `filesystem` | `read_file` | `mcp__filesystem__read_file` |
+| `github` | `create-issue` | `mcp__github__create_issue` |
+| `my-api` | `query.data` | `mcp__my_api__query_data` |
 
 In practice, you usually do not need to call the prefixed name manually — Hermes sees the tool and chooses it during normal reasoning.
 
@@ -474,8 +474,8 @@ When supported, Hermes also registers utility tools around MCP resources and pro
 
 These are registered per server with the same prefix pattern, for example:
 
-- `mcp_github_list_resources`
-- `mcp_github_get_prompt`
+- `mcp__github__list_resources`
+- `mcp__github__get_prompt`
 
 ### Important
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -396,16 +396,16 @@ You can pick any local name (`hermes mcp add my-codex --preset codex` is fine); 
 Hermes prefixes MCP tools so they do not collide with built-in names:
 
 ```text
-mcp_<server_name>_<tool_name>
+mcp__<server_name>__<tool_name>
 ```
 
 Examples:
 
 | Server | MCP tool | Registered name |
 |---|---|---|
-| `filesystem` | `read_file` | `mcp_filesystem_read_file` |
-| `github` | `create-issue` | `mcp_github_create_issue` |
-| `my-api` | `query.data` | `mcp_my_api_query_data` |
+| `filesystem` | `read_file` | `mcp__filesystem__read_file` |
+| `github` | `create-issue` | `mcp__github__create_issue` |
+| `my-api` | `query.data` | `mcp__my_api__query_data` |
 
 In practice, you usually do not need to call the prefixed name manually — Hermes sees the tool and chooses it during normal reasoning.
 
@@ -420,8 +420,8 @@ When supported, Hermes also registers utility tools around MCP resources and pro
 
 These are registered per server with the same prefix pattern, for example:
 
-- `mcp_github_list_resources`
-- `mcp_github_get_prompt`
+- `mcp__github__list_resources`
+- `mcp__github__get_prompt`
 
 ### Important
 

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -39,10 +39,10 @@ A typical interaction looks like:
 
 ```
 Model: tool_search("create a github issue")
-  → { matches: [{ name: "mcp_github_create_issue", ... }, ...] }
-Model: tool_describe("mcp_github_create_issue")
+  → { matches: [{ name: "mcp__github__create_issue", ... }, ...] }
+Model: tool_describe("mcp__github__create_issue")
   → { parameters: { type: "object", properties: { ... } } }
-Model: tool_call("mcp_github_create_issue", { title: "...", body: "..." })
+Model: tool_call("mcp__github__create_issue", { title: "...", body: "..." })
   → { ok: true, issue_number: 42 }
 ```
 

--- a/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
@@ -93,10 +93,10 @@ from `config.yaml` via the catalog entry.
 1. Launch Unreal Editor, wait for the project to finish loading; confirm the
    server started (Output Log shows the bind address, or run
    `ModelContextProtocol.StartServer` manually).
-2. Start the Hermes session. Tools register as `mcp_unreal_engine_*`. If
+2. Start the Hermes session. Tools register as `mcp__unreal_engine__*`. If
    they're missing: editor wasn't up first — start it, then open a new
    Hermes session.
-3. Sanity check: call `mcp_unreal_engine_list_toolsets` and confirm toolsets
+3. Sanity check: call `mcp__unreal_engine__list_toolsets` and confirm toolsets
    come back.
 
 ## The Tool Surface: Discovery, Not a Fixed List

--- a/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
@@ -107,9 +107,9 @@ they appear as:
 
 | Hermes tool | Purpose |
 |---|---|
-| `mcp_unreal_engine_list_toolsets` | Names + descriptions of every registered toolset |
-| `mcp_unreal_engine_describe_toolset` | Full JSON schemas for one named toolset's tools |
-| `mcp_unreal_engine_call_tool` | Invoke a named tool with arguments, get the result |
+| `mcp__unreal_engine__list_toolsets` | Names + descriptions of every registered toolset |
+| `mcp__unreal_engine__describe_toolset` | Full JSON schemas for one named toolset's tools |
+| `mcp__unreal_engine__call_tool` | Invoke a named tool with arguments, get the result |
 
 The discovery walk, always in this order:
 
@@ -127,7 +127,7 @@ Cache what you learn for the session; re-list only after the editor side
 changes (new plugin enabled, toolset authored, `RefreshTools` run).
 
 The alternative eager mode (`Enable Tool Search` off in Editor Preferences)
-advertises every tool as its own `mcp_unreal_engine_<tool>` entry. Discovery
+advertises every tool as its own `mcp__unreal_engine__<tool>` entry. Discovery
 then happens at `hermes mcp install`/`configure` time instead. Tool-search
 mode is the default and what this skill assumes; it also keeps schema tokens
 out of every API call, so prefer it.
@@ -152,7 +152,7 @@ Every Unreal task follows the same loop:
    server-side without breaking the serial rule
    (`references/advanced-workflows.md`).
 3. **NEVER issue overlapping calls.** Do not batch multiple
-   `mcp_unreal_engine_*` calls in one turn — Hermes runs batched calls
+   `mcp__unreal_engine__*` calls in one turn — Hermes runs batched calls
    concurrently, and parallel calls against the game thread deadlock or
    fail. Strictly one call, await result, next call. This overrides the
    general parallel-tool-calls guidance.
@@ -231,7 +231,7 @@ Load on demand; keep SKILL.md-level rules in mind throughout.
 ## Pitfalls (top of mind — full list in references/pitfalls.md)
 
 - **Start order matters.** Editor + server up first, then the Hermes
-  session. Missing `mcp_unreal_engine_*` tools = wrong order.
+  session. Missing `mcp__unreal_engine__*` tools = wrong order.
 - **One call at a time.** Serial game thread; no batching, no overlap.
 - **The editor UI freezes during each call.** That's by design (game-thread
   execution). Warn the user during long operations; keep calls small.

--- a/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
@@ -94,10 +94,10 @@ from `config.yaml` via the catalog entry.
 1. Launch Unreal Editor, wait for the project to finish loading; confirm the
    server started (Output Log shows the bind address, or run
    `ModelContextProtocol.StartServer` manually).
-2. Start the Hermes session. Tools register as `mcp_unreal_engine_*`. If
+2. Start the Hermes session. Tools register as `mcp__unreal_engine__*`. If
    they're missing: editor wasn't up first — start it, then open a new
    Hermes session.
-3. Sanity check: call `mcp_unreal_engine_list_toolsets` and confirm toolsets
+3. Sanity check: call `mcp__unreal_engine__list_toolsets` and confirm toolsets
    come back.
 
 ## The Tool Surface: Discovery, Not a Fixed List

--- a/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
@@ -108,9 +108,9 @@ they appear as:
 
 | Hermes tool | Purpose |
 |---|---|
-| `mcp_unreal_engine_list_toolsets` | Names + descriptions of every registered toolset |
-| `mcp_unreal_engine_describe_toolset` | Full JSON schemas for one named toolset's tools |
-| `mcp_unreal_engine_call_tool` | Invoke a named tool with arguments, get the result |
+| `mcp__unreal_engine__list_toolsets` | Names + descriptions of every registered toolset |
+| `mcp__unreal_engine__describe_toolset` | Full JSON schemas for one named toolset's tools |
+| `mcp__unreal_engine__call_tool` | Invoke a named tool with arguments, get the result |
 
 The discovery walk, always in this order:
 
@@ -128,7 +128,7 @@ Cache what you learn for the session; re-list only after the editor side
 changes (new plugin enabled, toolset authored, `RefreshTools` run).
 
 The alternative eager mode (`Enable Tool Search` off in Editor Preferences)
-advertises every tool as its own `mcp_unreal_engine_<tool>` entry. Discovery
+advertises every tool as its own `mcp__unreal_engine__<tool>` entry. Discovery
 then happens at `hermes mcp install`/`configure` time instead. Tool-search
 mode is the default and what this skill assumes; it also keeps schema tokens
 out of every API call, so prefer it.
@@ -153,7 +153,7 @@ Every Unreal task follows the same loop:
    server-side without breaking the serial rule
    (`references/advanced-workflows.md`).
 3. **NEVER issue overlapping calls.** Do not batch multiple
-   `mcp_unreal_engine_*` calls in one turn — Hermes runs batched calls
+   `mcp__unreal_engine__*` calls in one turn — Hermes runs batched calls
    concurrently, and parallel calls against the game thread deadlock or
    fail. Strictly one call, await result, next call. This overrides the
    general parallel-tool-calls guidance.
@@ -232,7 +232,7 @@ Load on demand; keep SKILL.md-level rules in mind throughout.
 ## Pitfalls (top of mind — full list in references/pitfalls.md)
 
 - **Start order matters.** Editor + server up first, then the Hermes
-  session. Missing `mcp_unreal_engine_*` tools = wrong order.
+  session. Missing `mcp__unreal_engine__*` tools = wrong order.
 - **One call at a time.** Serial game thread; no batching, no overlap.
 - **The editor UI freezes during each call.** That's by design (game-thread
   execution). Warn the user during long operations; keep calls small.

--- a/website/docs/user-guide/skills/optional/research/research-qmd.md
+++ b/website/docs/user-guide/skills/optional/research/research-qmd.md
@@ -255,8 +255,8 @@ mcp_servers:
     connect_timeout: 45
 ```
 
-This registers tools: `mcp_qmd_search`, `mcp_qmd_vsearch`,
-`mcp_qmd_deep_search`, `mcp_qmd_get`, `mcp_qmd_status`.
+This registers tools: `mcp__qmd__search`, `mcp__qmd__vsearch`,
+`mcp__qmd__deep_search`, `mcp__qmd__get`, `mcp__qmd__status`.
 
 **Tradeoff:** Models load on first search call (~19s cold start),
 then stay warm for the session. Acceptable for occasional use.
@@ -346,15 +346,15 @@ systemctl --user status qmd-daemon
 
 ### MCP Tools Reference
 
-Once connected, these tools are available as `mcp_qmd_*`:
+Once connected, these tools are available as `mcp__qmd__*`:
 
 | MCP Tool | Maps To | Description |
 |----------|---------|-------------|
-| `mcp_qmd_search` | `qmd search` | BM25 keyword search |
-| `mcp_qmd_vsearch` | `qmd vsearch` | Semantic vector search |
-| `mcp_qmd_deep_search` | `qmd query` | Hybrid search + reranking |
-| `mcp_qmd_get` | `qmd get` | Retrieve document by ID or path |
-| `mcp_qmd_status` | `qmd status` | Index health and stats |
+| `mcp__qmd__search` | `qmd search` | BM25 keyword search |
+| `mcp__qmd__vsearch` | `qmd vsearch` | Semantic vector search |
+| `mcp__qmd__deep_search` | `qmd query` | Hybrid search + reranking |
+| `mcp__qmd__get` | `qmd get` | Retrieve document by ID or path |
+| `mcp__qmd__status` | `qmd status` | Index health and stats |
 
 The MCP tools accept structured JSON queries for multi-mode search:
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-mcp-with-hermes.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-mcp-with-hermes.md
@@ -163,7 +163,7 @@ hermes mcp test chrome-devtools-win
 加载后，Hermes 可以直接使用带 MCP 前缀的浏览器工具。例如：
 
 ```text
-调用 MCP 工具 mcp_chrome_devtools_win_list_pages，列出当前浏览器标签页。
+调用 MCP 工具 mcp__chrome_devtools_win__list_pages，列出当前浏览器标签页。
 ```
 
 ### 何时 `/browser connect` 不适用

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/mcp-config-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/mcp-config-reference.md
@@ -205,19 +205,19 @@ mcp_servers:
 服务器原生 MCP 工具的命名格式为：
 
 ```text
-mcp_<server>_<tool>
+mcp__<server>__<tool>
 ```
 
 示例：
-- `mcp_github_create_issue`
-- `mcp_filesystem_read_file`
-- `mcp_my_api_query_data`
+- `mcp__github__create_issue`
+- `mcp__filesystem__read_file`
+- `mcp__my_api__query_data`
 
 工具包装器遵循相同的前缀规则：
-- `mcp_<server>_list_resources`
-- `mcp_<server>_read_resource`
-- `mcp_<server>_list_prompts`
-- `mcp_<server>_get_prompt`
+- `mcp__<server>__list_resources`
+- `mcp__<server>__read_resource`
+- `mcp__<server>__list_prompts`
+- `mcp__<server>__get_prompt`
 
 ### 名称规范化
 
@@ -226,7 +226,7 @@ mcp_<server>_<tool>
 例如，名为 `my-api` 的服务器暴露了名为 `list-items.v2` 的工具，注册后变为：
 
 ```text
-mcp_my_api_list_items_v2
+mcp__my_api__list_items_v2
 ```
 
 编写 `include` / `exclude` 过滤器时请注意——使用**原始** MCP 工具名称（含连字符/点号），而非规范化后的名称。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/mcp-config-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/mcp-config-reference.md
@@ -204,19 +204,19 @@ mcp_servers:
 服务器原生 MCP 工具的命名格式为：
 
 ```text
-mcp_<server>_<tool>
+mcp__<server>__<tool>
 ```
 
 示例：
-- `mcp_github_create_issue`
-- `mcp_filesystem_read_file`
-- `mcp_my_api_query_data`
+- `mcp__github__create_issue`
+- `mcp__filesystem__read_file`
+- `mcp__my_api__query_data`
 
 工具包装器遵循相同的前缀规则：
-- `mcp_<server>_list_resources`
-- `mcp_<server>_read_resource`
-- `mcp_<server>_list_prompts`
-- `mcp_<server>_get_prompt`
+- `mcp__<server>__list_resources`
+- `mcp__<server>__read_resource`
+- `mcp__<server>__list_prompts`
+- `mcp__<server>__get_prompt`
 
 ### 名称规范化
 
@@ -225,7 +225,7 @@ mcp_<server>_<tool>
 例如，名为 `my-api` 的服务器暴露了名为 `list-items.v2` 的工具，注册后变为：
 
 ```text
-mcp_my_api_list_items_v2
+mcp__my_api__list_items_v2
 ```
 
 编写 `include` / `exclude` 过滤器时请注意——使用**原始** MCP 工具名称（含连字符/点号），而非规范化后的名称。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
@@ -11,7 +11,7 @@ description: "Hermes 内置工具权威参考，按工具集分组"
 **当前注册表快速统计：** 约 71 个工具 —— 10 个浏览器工具（核心）+ 2 个 CDP 门控浏览器工具、4 个文件工具、4 个 Home Assistant 工具、2 个终端工具、2 个 Web 工具、5 个 Feishu 工具、7 个 Spotify 工具（由内置 `spotify` 插件注册）、5 个 Yuanbao 工具、9 个 kanban 工具（在 kanban 调度器生成 agent 时注册）、2 个 Discord 工具，以及若干独立工具（`memory`、`clarify`、`delegate_task`、`execute_code`、`cronjob`、`session_search`、`skill_view`/`skill_manage`/`skills_list`、`text_to_speech`、`image_generate`、`video_generate`、`vision_analyze`、`video_analyze`、`send_message`、`todo`、`computer_use`、`process`）。
 
 :::tip MCP 工具
-除内置工具外，Hermes 还可从 MCP 服务器动态加载工具。MCP 工具以 `mcp_<server>_` 为前缀（例如，`github` MCP 服务器的 `mcp_github_create_issue`）。配置方法见 [MCP 集成](/user-guide/features/mcp)。
+除内置工具外，Hermes 还可从 MCP 服务器动态加载工具。MCP 工具以 `mcp__<server>__` 为前缀（例如，`github` MCP 服务器的 `mcp__github__create_issue`）。配置方法见 [MCP 集成](/user-guide/features/mcp)。
 :::
 
 ## `browser` 工具集

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/mcp.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/mcp.md
@@ -156,16 +156,16 @@ mcp_servers:
 Hermes 为 MCP 工具添加前缀，避免与内置名称冲突：
 
 ```text
-mcp_<server_name>_<tool_name>
+mcp__<server_name>__<tool_name>
 ```
 
 示例：
 
 | 服务器 | MCP 工具 | 注册名称 |
 |---|---|---|
-| `filesystem` | `read_file` | `mcp_filesystem_read_file` |
-| `github` | `create-issue` | `mcp_github_create_issue` |
-| `my-api` | `query.data` | `mcp_my_api_query_data` |
+| `filesystem` | `read_file` | `mcp__filesystem__read_file` |
+| `github` | `create-issue` | `mcp__github__create_issue` |
+| `my-api` | `query.data` | `mcp__my_api__query_data` |
 
 实际使用中，你通常不需要手动调用带前缀的名称——Hermes 在正常推理过程中会自动识别并选择该工具。
 
@@ -180,8 +180,8 @@ mcp_<server_name>_<tool_name>
 
 这些工具按服务器注册，遵循相同的前缀规则，例如：
 
-- `mcp_github_list_resources`
-- `mcp_github_get_prompt`
+- `mcp__github__list_resources`
+- `mcp__github__get_prompt`
 
 ### 重要说明
 


### PR DESCRIPTION
## Problem

Multiple docs files under `website/docs/` reference the old `mcp_<server>_<tool>` single-underscore naming convention for MCP tools. The codebase adopted `mcp__<server>__<tool>` double-underscore naming, so all docs examples using the old format are stale — a user writing `include`/`exclude` filters based on this documentation would use the wrong tool names.

## Triage / Root cause

The MCP naming migration adopted `mcp__<server>__<tool>` across the codebase but several docs files were not updated. Affected files (11 total, English + zh-Hans mirrors):

- `website/docs/reference/mcp-config-reference.md` — naming convention, examples, sanitization example
- `website/docs/reference/tools-reference.md` — MCP tool prefix description
- `website/docs/user-guide/features/mcp.md` — tool naming table, utility tools
- `website/docs/user-guide/features/tool-search.md` — example interaction
- `website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md` — Unreal MCP tool names
- `website/docs/user-guide/skills/optional/research/research-qmd.md` — QMD MCP tool names
- `website/docs/guides/use-mcp-with-hermes.md` — Chrome DevTools example

Code evidence for the double-underscore convention:
- `_MCP_TOOL_PREFIX = "mcp__"` — `agent/anthropic_adapter.py:384`
- `_MCP_PREFIX = "mcp__"` — `agent/transports/anthropic.py:91`
- `f"mcp__{server}__{tool}"` — `agent/codex_runtime.py:474`, `agent/transports/codex_event_projector.py:222`

## Fix

Updated all MCP tool name examples across the 7 English source files and 4 zh-Hans locale mirrors from the old single-underscore format to the new `mcp__<server>__<tool>` double-underscore format. Changes are pure string replacements (53 insertions, 53 deletions across 11 files).

## Verification

- `git grep` confirmed no remaining stale single-underscore MCP tool name examples in `website/docs/**/*.md` after the fix.
- All code references to `mcp__` prefix confirmed across the codebase.
- Diff is pure string replacement with no logic changes.

## Notes / Risks

- This replaces #72679, which was closed because the restructuring removed files that no longer exist.
- No other docs files under `website/docs/` reference the old single-underscore convention.
