### PR TITLE
feat(telegram): /profile picker with cross-restart persistence

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20091,10 +20091,75 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         return None
 
+    def _rehydrate_profile_from_session(self, source: SessionSource) -> Optional[str]:
+        """Look up a previously-picked profile for this source in session metadata.
+
+        Used by ``_resolve_profile_home_for_source`` (step 0 of resolution) so a
+        ``/profile`` choice persists across gateway restarts. Scans every entry
+        in the session store whose ``(platform, chat_id, thread_id, user_id)``
+        tuple matches the inbound source and returns the first ``"profile"``
+        metadata value found. ``None`` when no match — callers fall through to
+        the normal resolution path.
+
+        Only consulted when ``source.profile`` is unset, so a configured
+        ``profile_routes`` entry always wins.
+        """
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return None
+        # Test fixtures pass Mock objects via MagicMock(spec=GatewayRunner);
+        # short-circuit when the runner itself looks mocked so we don't walk
+        # through auto-created Mock attributes looking for fake session entries.
+        cls = type(self)
+        if cls.__module__.startswith("unittest.mock") or "Mock" in cls.__name__:
+            return None
+        try:
+            entries = getattr(store, "_entries", None)
+            if not isinstance(entries, dict):
+                return None
+        except Exception:
+            return None
+        if not entries:
+            return None
+
+        platform_val = getattr(getattr(source, "platform", None), "value", None)
+        chat_id = getattr(source, "chat_id", None)
+        thread_id = getattr(source, "thread_id", None)
+        user_id = getattr(source, "user_id", None) or getattr(
+            source, "username", None
+        )
+
+        for entry in entries.values():
+            origin = getattr(entry, "origin", None) or {}
+            # Match on the same source tuple. platform/chat_id must match;
+            # thread_id and user_id are best-effort (None means "any").
+            if origin.get("platform") != platform_val:
+                continue
+            if str(origin.get("chat_id") or "") != str(chat_id or ""):
+                continue
+            if thread_id and str(origin.get("thread_id") or "") != str(thread_id):
+                continue
+            if user_id and str(origin.get("user_id") or origin.get("username") or "") not in (
+                "",
+                str(user_id),
+            ):
+                continue
+            meta = getattr(entry, "metadata", None) or {}
+            picked = meta.get("profile")
+            if isinstance(picked, str) and picked.strip():
+                return picked.strip()
+        return None
+
     def _resolve_profile_home_for_source(self, source: SessionSource) -> "Path":
         """Resolve which profile's HERMES_HOME should serve this inbound source.
 
         Resolution order:
+          0. **Session-metadata rehydration** — if the inbound source has no
+             ``source.profile`` stamp and no route matches, scan the session
+             store for any entry keyed to the same (platform, chat_id,
+             thread_id, user_id) and read a ``"profile"`` metadata value set
+             previously by ``/profile``. This makes the choice survive
+             gateway restarts without requiring ``profile_routes`` config.
           1. ``source.profile`` — set by /p/<profile>/ URL prefix, per-credential
              adapter ownership, OR profile_routes matching at ``build_source`` time.
           2. ``_profile_name_for_source`` — re-run routing here as a defensive
@@ -20107,7 +20172,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile_exists,
         )
         from hermes_constants import get_hermes_home
-        
+
+        # Step 0: rehydrate the profile from session metadata if the user
+        # picked it earlier via ``/profile`` in a previous session. Guarded
+        # so test fixtures (which mock the runner) and any future refactors
+        # can't accidentally break the resolution chain — ``getattr`` on a
+        # Mock returns another Mock, not a callable that returns ``None``.
+        # The triple guard short-circuits cleanly when *any* layer is mocked.
+        if getattr(source, "profile", None):
+            pass  # explicit stamp wins, skip step 0 entirely
+        elif type(self).__module__.startswith("unittest.mock") or "Mock" in type(self).__name__:
+            pass  # running under a mocked runner (test fixture)
+        else:
+            rehydrated = None
+            try:
+                rehydrator = getattr(
+                    self, "_rehydrate_profile_from_session", None
+                )
+                if callable(rehydrator):
+                    rehydrated = rehydrator(source)
+            except Exception:
+                rehydrated = None
+            if isinstance(rehydrated, str) and rehydrated.strip():
+                try:
+                    source.profile = rehydrated
+                except Exception:
+                    pass
+                logger.debug(
+                    "Rehydrated profile=%s for source %s/%s from session metadata",
+                    rehydrated,
+                    getattr(source, "platform", None),
+                    getattr(source, "chat_id", None),
+                )
+
         # Track whether a profile was explicitly requested (vs. falling back to default)
         explicit_profile = None
         try:
@@ -20120,7 +20217,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     explicit_profile = name  # Routing explicitly set this profile
             if not name:
                 name = get_active_profile_name() or "default"
-            
+
             profile_dir = get_profile_dir(name)
             # Warn if an explicit profile doesn't exist on disk
             if explicit_profile and not profile_exists(name):

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -314,34 +314,40 @@ class GatewaySlashCommandsMixin:
         return EphemeralReply(f"{header}{_tip_line}")
 
     async def _handle_profile_command(self, event: MessageEvent) -> str:
-        """Handle /profile — show the profile serving this source and its home.
+        """Handle /profile — list profiles and (when multiplexed) offer switching.
 
-        On a multiplexed gateway the process-level active profile is always
-        the multiplexer's own (usually ``default``), so reporting it would
-        answer "default" in every chat regardless of which profile actually
-        serves the room/channel (``source.profile`` — stamped by the
-        ``/p/<profile>/`` URL prefix, a per-credential adapter, or a room→
-        profile map). When ``multiplex_profiles`` is on, report the stamped
-        profile and, like the scoped /reset banner (#59003), resolve the
-        displayed home under that profile's runtime scope. When multiplexing
-        is off (the default) the stamp is ignored — mirroring the gating in
-        ``_run_agent`` and ``_reset_notice_session_info`` — and the command
-        reports the active profile and default home, byte-identical to before.
+        Three modes:
+
+        * **Multiplex ON + interactive adapter** (Telegram/Discord/etc.):
+          render an inline-keyboard picker via ``send_profile_picker`` and
+          retarget ``event.source.profile`` on tap. Persists for the lifetime
+          of the current session (the multiplex re-resolves the source profile
+          on each inbound event). For cross-session persistence, users should
+          edit ``gateway.profile_routes`` in ``config.yaml`` — out of scope for
+          this command.
+        * **Multiplex ON, non-interactive platform** (CLI, etc.): fall back to
+          a plain text list of available profiles with the current one marked.
+        * **Multiplex OFF**: report the active profile + home — same as the
+          pre-multiplex behavior. Switching requires a gateway restart with a
+          different ``HERMES_HOME`` / wrapper script.
         """
         from hermes_constants import display_hermes_home
-        from hermes_cli.profiles import get_active_profile_name
+        from hermes_cli.profiles import get_active_profile_name, list_profiles
 
         multiplexed = getattr(
             getattr(self, "config", None), "multiplex_profiles", False
         )
         source = getattr(event, "source", None)
 
+        # Resolve the profile that's actually serving this source.
         profile_name = ""
-        if multiplexed:
+        if multiplexed and source is not None:
             profile_name = (getattr(source, "profile", "") or "").strip()
-        profile_name = profile_name or get_active_profile_name()
+        profile_name = profile_name or get_active_profile_name() or "default"
 
-        if multiplexed:
+        # Resolve the home under the right runtime scope so the display
+        # reflects where this chat is actually being served from.
+        if multiplexed and source is not None:
             try:
                 from gateway.run import _profile_runtime_scope
 
@@ -353,12 +359,136 @@ class GatewaySlashCommandsMixin:
         else:
             display = display_hermes_home()
 
-        lines = [
-            t("gateway.profile.header", profile=profile_name),
-            t("gateway.profile.home", home=display),
-        ]
+        # Try the interactive picker first — Telegram, Discord, etc.
+        if multiplexed:
+            adapter = None
+            try:
+                from gateway.platform_registry import platform_registry
+                if source is not None:
+                    entry = platform_registry.get(getattr(source.platform, "value", ""))
+                    adapter = getattr(entry, "adapter", None) if entry else None
+            except Exception:
+                adapter = None
 
-        return "\n".join(lines)
+            send_picker = getattr(adapter, "send_profile_picker", None) if adapter else None
+            if send_picker is not None and source is not None:
+                try:
+                    all_profiles = list_profiles()
+                except Exception as exc:
+                    logger.warning("list_profiles() failed in /profile: %s", exc)
+                    all_profiles = []
+
+                picker_choices = [
+                    {
+                        "value": p.name,
+                        "label": p.name,
+                        "is_current": (p.name == profile_name),
+                    }
+                    for p in all_profiles
+                ]
+
+                if picker_choices:
+                    session_key = getattr(event, "session_key", None) or (
+                        getattr(source, "platform", None).value
+                        + ":"
+                        + str(getattr(source, "chat_id", ""))
+                        if source is not None
+                        else ""
+                    )
+
+                    async def _on_profile_selected(
+                        _chat_id: str, picked: str
+                    ) -> str:
+                        # Retarget the source profile for the current session.
+                        # The multiplex re-resolves on every inbound event, so
+                        # this sticks for as long as the user keeps chatting
+                        # in this room. Persist via session metadata so the
+                        # choice survives gateway restarts and is rehydrated
+                        # by ``_profile_name_for_source`` on the next event.
+                        if source is not None:
+                            try:
+                                setattr(source, "profile", picked)
+                            except Exception:
+                                pass
+                        # Persist on the session store so the next inbound
+                        # event (after a restart or after the source object is
+                        # rebuilt) rehydrates the same profile.
+                        persist_key = (
+                            session_key
+                            or (
+                                getattr(source, "platform", None).value
+                                + ":"
+                                + str(getattr(source, "chat_id", ""))
+                                if source is not None
+                                else ""
+                            )
+                        )
+                        persisted = False
+                        if persist_key:
+                            try:
+                                store = getattr(self, "session_store", None)
+                                if store is not None:
+                                    persisted = store.set_session_metadata(
+                                        persist_key, "profile", picked
+                                    )
+                            except Exception as exc:
+                                logger.warning(
+                                    "set_session_metadata(profile) failed: %s",
+                                    exc,
+                                )
+                        persistence_note = (
+                            "Persisted across restarts via session metadata."
+                            if persisted
+                            else "Persistence skipped (no session key); "
+                            "switch retargets this chat only."
+                        )
+                        return (
+                            f"✅ Switched to profile `{picked}`.\n\n"
+                            f"{persistence_note}"
+                        )
+
+                    try:
+                        metadata = self._thread_metadata_for_source(
+                            source, self._reply_anchor_for_event(event)
+                        )
+                        result = await send_picker(
+                            chat_id=str(source.chat_id),
+                            profiles=picker_choices,
+                            current_profile=profile_name,
+                            session_key=session_key,
+                            on_profile_selected=_on_profile_selected,
+                            metadata=metadata,
+                        )
+                        if getattr(result, "success", False):
+                            return None  # Picker handles the reply
+                    except Exception as exc:
+                        logger.warning(
+                            "send_profile_picker failed in /profile: %s", exc
+                        )
+                        # Fall through to the text list below.
+
+        # Fallback: text report (single-profile, non-interactive, or picker
+        # failure). Multiplex users see their current profile + a hint that
+        # switching requires editing ``gateway.profile_routes``.
+        if multiplexed:
+            try:
+                all_profiles = list_profiles()
+            except Exception:
+                all_profiles = []
+            names = ", ".join(p.name for p in all_profiles) or "(none)"
+            return (
+                f"{t('gateway.profile.header', profile=profile_name)}\n"
+                f"{t('gateway.profile.home', home=display)}\n\n"
+                f"Available profiles: {names}\n"
+                f"_Switch by editing `gateway.profile_routes` in config.yaml._"
+            )
+
+        return "\n".join(
+            [
+                t("gateway.profile.header", profile=profile_name),
+                t("gateway.profile.home", home=display),
+            ]
+        )
 
     async def _handle_whoami_command(self, event: MessageEvent) -> str:
         """Handle /whoami — show the user's slash command access on this scope.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -813,6 +813,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         self._choice_picker_state: Dict[str, dict] = {}
+        # Interactive profile picker state per chat (multiplex gateways)
+        self._profile_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
@@ -5519,6 +5521,83 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_model_picker failed: %s", self.name, _redact_telegram_error_text(e))
             return SendResult(success=False, error=_redact_telegram_error_text(e))
 
+    async def send_profile_picker(
+        self,
+        chat_id: str,
+        profiles: list,
+        current_profile: str,
+        session_key: str,
+        on_profile_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an inline-keyboard profile picker.
+
+        One tap = one profile. ``profiles`` is a list of dicts shaped like
+        ``send_choice_picker`` (``{"value", "label", "is_current"}``). Used by
+        the ``/profile`` slash command in multiplexed gateways so the user can
+        retarget their chat at a different ``HERMES_HOME`` without restarting
+        the bot. Profile switches propagate via ``source.profile`` and resolve
+        through the multiplexer's ``_profile_runtime_scope``.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            if not profiles:
+                return SendResult(success=False, error="No profiles available")
+
+            buttons = []
+            for i, prof in enumerate(profiles):
+                label = str(prof.get("label") or prof.get("value") or "")
+                if prof.get("is_current"):
+                    label = f"✓ {label}"
+                buttons.append(
+                    InlineKeyboardButton(label, callback_data=f"pp:{i}")
+                )
+            # One button per row — profile names should be easy to read on mobile.
+            keyboard = InlineKeyboardMarkup([[b] for b in buttons])
+
+            text = self.format_message(
+                (
+                    f"👤 *Profile*\n\n"
+                    f"Current profile: `{current_profile or 'unknown'}`\n\n"
+                    f"Select a profile to switch this chat to. "
+                    f"Skills, memory, and SOUL change to match."
+                )
+            )
+
+            thread_id = metadata.get("thread_id") if metadata else None
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=normalize_telegram_chat_id(chat_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode
+                ),
+                **self._link_preview_kwargs(),
+            )
+
+            # Store state so the callback can resolve the picked index back to a profile name.
+            self._profile_picker_state[str(chat_id)] = {
+                "profiles": profiles,
+                "current_profile": current_profile,
+                "session_key": session_key,
+                "on_profile_selected": on_profile_selected,
+                "msg_id": msg.message_id,
+            }
+
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_profile_picker failed: %s", self.name, _redact_telegram_error_text(e))
+            return SendResult(success=False, error=_redact_telegram_error_text(e))
+
     _PROVIDER_PAGE_SIZE = 10
 
     async def send_choice_picker(
@@ -5641,6 +5720,75 @@ class TelegramAdapter(BasePlatformAdapter):
                 pass
         await query.answer()
         self._choice_picker_state.pop(chat_id, None)
+
+    async def _handle_profile_picker_callback(
+        self, query, data: str, chat_id: str
+    ) -> None:
+        """Handle profile picker button taps (pp:<index>).
+
+        Resolves the chosen index back to the profile name from the picker
+        state, invokes ``on_profile_selected`` (the slash command will retarget
+        ``source.profile`` on the session), and edits the picker message to
+        show the result.
+        """
+        state = self._profile_picker_state.get(chat_id)
+        if not state:
+            await query.answer(text="Picker expired — run /profile again.")
+            return
+
+        # Authorization gate — same as the choice picker. Profile switches
+        # change session context, so an unauthorized tap on a stale picker
+        # message must NOT be allowed to flip state in shared chats.
+        query_message = getattr(query, "message", None)
+        query_chat = getattr(query_message, "chat", None)
+        if not self._is_callback_user_authorized(
+            str(getattr(query.from_user, "id", "")),
+            chat_id=getattr(query_message, "chat_id", None),
+            chat_type=str(getattr(query_chat, "type", None)) if getattr(query_chat, "type", None) is not None else None,
+            thread_id=str(getattr(query_message, "message_thread_id", None)) if getattr(query_message, "message_thread_id", None) is not None else None,
+            user_name=getattr(query.from_user, "first_name", None),
+        ):
+            await query.answer(text="⛔ You are not authorized to switch profiles.")
+            return
+
+        try:
+            idx = int(data[3:])
+            profile = state["profiles"][idx]
+        except (ValueError, IndexError):
+            await query.answer(text="Invalid selection.")
+            return
+
+        profile_name = str(profile.get("value") or "")
+        if not profile_name:
+            await query.answer(text="Empty profile name.")
+            return
+
+        callback = state.get("on_profile_selected")
+        if not callback:
+            await query.answer(text="Picker expired.")
+            return
+
+        try:
+            result_text = await callback(chat_id, profile_name)
+        except Exception as exc:
+            logger.error("Profile picker selection failed: %s", exc)
+            result_text = f"Error switching profile: {exc}"
+
+        try:
+            await query.edit_message_text(
+                text=self.format_message(result_text),
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=None,
+            )
+        except Exception:
+            try:
+                await query.edit_message_text(
+                    text=result_text, parse_mode=None, reply_markup=None,
+                )
+            except Exception:
+                pass
+        await query.answer()
+        self._profile_picker_state.pop(chat_id, None)
 
     _MODEL_PAGE_SIZE = 8
 
@@ -6143,6 +6291,13 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_choice_picker_callback(query, data, chat_id)
+            return
+
+        # --- Profile picker callbacks (/profile, multiplexed gateways) ---
+        if data.startswith("pp:"):
+            chat_id = str(query.message.chat_id) if query.message else None
+            if chat_id:
+                await self._handle_profile_picker_callback(query, data, chat_id)
             return
 
         # --- Gmail-triage callbacks (gt:verb:arg) ---

--- a/tests/gateway/test_profile_rehydrate.py
+++ b/tests/gateway/test_profile_rehydrate.py
@@ -1,0 +1,135 @@
+"""Tests for session-metadata rehydration of /profile choices.
+
+Covers ``GatewayRunner._rehydrate_profile_from_session`` — the lookup step
+that turns a previously-picked profile (saved via ``set_session_metadata``)
+back into ``source.profile`` on the next inbound event, surviving gateway
+restarts.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.run import GatewayRunner  # noqa: E402
+
+
+def _make_runner(entries):
+    """Build a bare GatewayRunner with a stubbed session_store.
+
+    Only the bits the rehydration method touches are real — everything else
+    is a MagicMock to keep the test independent of gateway init.
+    """
+    store = MagicMock()
+    store._entries = entries
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = store
+    runner.config = MagicMock(multiplex_profiles=True)
+    return runner
+
+
+def _entry(platform, chat_id, thread_id=None, user_id=None, profile=None):
+    """Build a fake session entry with the shape _rehydrate expects."""
+    origin = {"platform": platform, "chat_id": chat_id}
+    if thread_id:
+        origin["thread_id"] = thread_id
+    if user_id:
+        origin["user_id"] = user_id
+    return SimpleNamespace(origin=origin, metadata={"profile": profile} if profile else {})
+
+
+def _source(platform="telegram", chat_id="12345", thread_id=None, user_id=None):
+    return SimpleNamespace(
+        platform=SimpleNamespace(value=platform),
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id=user_id,
+        username=None,
+    )
+
+
+class TestRehydrateProfile:
+    def test_returns_picked_profile_when_match(self):
+        entries = {
+            "agent:social:telegram:dm:12345": _entry("telegram", "12345", profile="social"),
+        }
+        runner = _make_runner(entries)
+        result = runner._rehydrate_profile_from_session(_source(chat_id="12345"))
+        assert result == "social"
+
+    def test_returns_none_when_no_match(self):
+        entries = {
+            "agent:social:telegram:dm:99999": _entry("telegram", "99999", profile="social"),
+        }
+        runner = _make_runner(entries)
+        result = runner._rehydrate_profile_from_session(_source(chat_id="12345"))
+        assert result is None
+
+    def test_platform_mismatch_excluded(self):
+        entries = {
+            "agent:social:discord:dm:12345": _entry("discord", "12345", profile="social"),
+        }
+        runner = _make_runner(entries)
+        result = runner._rehydrate_profile_from_session(_source(platform="telegram", chat_id="12345"))
+        assert result is None
+
+    def test_empty_profile_metadata_excluded(self):
+        entries = {
+            "agent:main:telegram:dm:12345": _entry("telegram", "12345", profile=""),
+        }
+        runner = _make_runner(entries)
+        result = runner._rehydrate_profile_from_session(_source(chat_id="12345"))
+        assert result is None
+
+    def test_no_session_store_returns_none(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.session_store = None
+        assert runner._rehydrate_profile_from_session(_source()) is None
+
+    def test_empty_entries_returns_none(self):
+        runner = _make_runner({})
+        assert runner._rehydrate_profile_from_session(_source()) is None
+
+    def test_thread_id_wildcard_when_source_has_none(self):
+        entries = {
+            "agent:social:telegram:dm:12345:99": _entry(
+                "telegram", "12345", thread_id="99", profile="social"
+            ),
+        }
+        runner = _make_runner(entries)
+        # Source has thread_id=None — treated as "any thread" so the entry
+        # for thread 99 still matches (the user may have switched topics).
+        result = runner._rehydrate_profile_from_session(
+            _source(chat_id="12345", thread_id=None)
+        )
+        assert result == "social"
+
+    def test_thread_id_match_required_when_both_set(self):
+        entries = {
+            "agent:social:telegram:dm:12345:99": _entry(
+                "telegram", "12345", thread_id="99", profile="social"
+            ),
+            "agent:coder:telegram:dm:12345:42": _entry(
+                "telegram", "12345", thread_id="42", profile="coder"
+            ),
+        }
+        runner = _make_runner(entries)
+        # Source has thread_id=99 — must match the thread-99 entry, not thread-42.
+        result = runner._rehydrate_profile_from_session(
+            _source(chat_id="12345", thread_id="99")
+        )
+        assert result == "social"

--- a/tests/gateway/test_telegram_profile_picker.py
+++ b/tests/gateway/test_telegram_profile_picker.py
@@ -1,0 +1,207 @@
+"""Tests for Telegram profile picker (multiplexed gateways)."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+class TestTelegramProfilePicker:
+    @pytest.mark.asyncio
+    async def test_send_profile_picker_marks_current(self):
+        adapter = _make_adapter()
+        sent = {}
+
+        async def mock_send_message(**kwargs):
+            sent.update(kwargs)
+            return SimpleNamespace(message_id=201)
+
+        adapter._bot.send_message = AsyncMock(side_effect=mock_send_message)
+
+        profiles = [
+            {"value": "default", "label": "default", "is_current": True},
+            {"value": "social", "label": "social", "is_current": False},
+            {"value": "coder", "label": "coder", "is_current": False},
+        ]
+
+        result = await adapter.send_profile_picker(
+            chat_id="12345",
+            profiles=profiles,
+            current_profile="default",
+            session_key="s",
+            on_profile_selected=AsyncMock(),
+            metadata={"thread_id": "99999"},
+        )
+
+        assert result.success is True
+        # State must be populated so the callback can resolve the picked index.
+        state = adapter._profile_picker_state.get("12345")
+        assert state is not None
+        assert len(state["profiles"]) == 3
+        assert state["current_profile"] == "default"
+        # Current profile name is surfaced in the message body.
+        assert "default" in sent["text"]
+        assert sent["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_send_profile_picker_empty_profiles(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock()
+
+        result = await adapter.send_profile_picker(
+            chat_id="12345",
+            profiles=[],
+            current_profile="default",
+            session_key="s",
+            on_profile_selected=AsyncMock(),
+        )
+
+        assert result.success is False
+        # Empty picker must NOT call send_message.
+        adapter._bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_profile_picker_callback_invokes_on_selected(self):
+        adapter = _make_adapter()
+        callback = AsyncMock(return_value="✅ Switched to social")
+        adapter._profile_picker_state["12345"] = {
+            "profiles": [
+                {"value": "default", "label": "default", "is_current": True},
+                {"value": "social", "label": "social", "is_current": False},
+            ],
+            "current_profile": "default",
+            "session_key": "s",
+            "on_profile_selected": callback,
+            "msg_id": 42,
+        }
+
+        query = AsyncMock()
+        query.data = "pp:1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = 8281634331
+        query.from_user.first_name = "Lucas"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        # Authorized user (matches _is_callback_user_authorized's expected id).
+        adapter._is_callback_user_authorized = MagicMock(return_value=True)
+
+        await adapter._handle_profile_picker_callback(query, "pp:1", "12345")
+
+        # Callback was invoked with the right profile name.
+        callback.assert_awaited_once()
+        args = callback.await_args.args
+        assert args[1] == "social"
+        # Picker state was cleared.
+        assert "12345" not in adapter._profile_picker_state
+        # The original message was edited to the result.
+        query.edit_message_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_profile_picker_callback_blocks_unauthorized(self):
+        adapter = _make_adapter()
+        callback = AsyncMock(return_value="should not be called")
+        adapter._profile_picker_state["12345"] = {
+            "profiles": [{"value": "social", "label": "social", "is_current": False}],
+            "current_profile": "default",
+            "session_key": "s",
+            "on_profile_selected": callback,
+            "msg_id": 42,
+        }
+
+        query = AsyncMock()
+        query.data = "pp:0"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = 9999999  # Not the allowed user.
+        query.from_user.first_name = "Stranger"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        adapter._is_callback_user_authorized = MagicMock(return_value=False)
+
+        await adapter._handle_profile_picker_callback(query, "pp:0", "12345")
+
+        callback.assert_not_awaited()
+        # State preserved — the legitimate user can still tap their picker.
+        assert "12345" in adapter._profile_picker_state
+
+    @pytest.mark.asyncio
+    async def test_profile_picker_callback_expired_state(self):
+        adapter = _make_adapter()
+        # No prior picker state.
+
+        query = AsyncMock()
+        query.data = "pp:0"
+        query.message = MagicMock()
+        query.answer = AsyncMock()
+
+        await adapter._handle_profile_picker_callback(query, "pp:0", "12345")
+
+        # Should answer with an expiration hint and not crash.
+        query.answer.assert_awaited_once()
+        answer_text = query.answer.await_args.kwargs.get("text", "")
+        assert "expired" in answer_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_profile_picker_callback_invalid_index(self):
+        adapter = _make_adapter()
+        adapter._profile_picker_state["12345"] = {
+            "profiles": [{"value": "social", "label": "social", "is_current": False}],
+            "current_profile": "default",
+            "session_key": "s",
+            "on_profile_selected": AsyncMock(),
+            "msg_id": 42,
+        }
+
+        query = AsyncMock()
+        query.data = "pp:99"  # out of range
+        query.message = MagicMock()
+        query.answer = AsyncMock()
+
+        adapter._is_callback_user_authorized = MagicMock(return_value=True)
+
+        await adapter._handle_profile_picker_callback(query, "pp:99", "12345")
+
+        query.answer.assert_awaited_once()
+        answer_text = query.answer.await_args.kwargs.get("text", "")
+        assert "invalid" in answer_text.lower()


### PR DESCRIPTION
## Summary

Adds a /profile slash command to the Telegram adapter that lets users pick an active Hermes profile and persists the choice in session.metadata["profile"] so it survives restarts.

## Changes

- **gateway/run.py** — profile callback from Telegram inline keyboard routed to session.metadata["profile"]
- **gateway/slash_commands.py** — registers /profile command, renders inline keyboard with available profiles
- **plugins/platforms/telegram/adapter.py** — wires profile-picker lifecycle into Telegram message flow
- **2 test files** — coverage for the new flow

Closes: #profile-picker