### PR TITLE
fix(gemini): support native enterprise gateways

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5444,6 +5444,7 @@ def resolve_provider_client(
             resolve_api_key_provider_credentials,
             resolve_external_process_provider_credentials,
         )
+        from hermes_cli import runtime_provider as _runtime_provider
     except ImportError:
         logger.debug("hermes_cli.auth not available for provider %s", provider)
         return None, None
@@ -5466,7 +5467,15 @@ def resolve_provider_client(
             final_model = _normalize_resolved_model(model or default_model, provider)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode else (client, final_model))
 
-        creds = resolve_api_key_provider_credentials(provider)
+        override = None
+        if provider == "gemini":
+            override = _runtime_provider._resolve_configured_api_key_provider_override(
+                provider,
+                explicit_api_key=explicit_api_key,
+                explicit_base_url=explicit_base_url,
+            )
+
+        creds = override or resolve_api_key_provider_credentials(provider)
         api_key = str(creds.get("api_key", "")).strip()
         # Honour an explicit api_key override (e.g. from a fallback_model entry
         # or a custom_providers entry) so callers that pass an explicit
@@ -5484,27 +5493,29 @@ def resolve_provider_client(
             return None, None
 
         raw_base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
-        base_url = _to_openai_base_url(raw_base_url)
-        # Honour an explicit base_url override from the caller — used when a
-        # fallback_model entry (or custom_providers lookup) routes through a
-        # built-in provider name but targets a user-specified endpoint.
         if explicit_base_url:
-            base_url = _to_openai_base_url(explicit_base_url.strip().rstrip("/"))
+            raw_base_url = explicit_base_url.strip().rstrip("/") or raw_base_url
+        base_url = _to_openai_base_url(raw_base_url)
 
-        default_model = _get_aux_model_for_provider(provider)
+        default_model = creds.get("model") or _get_aux_model_for_provider(provider)
         final_model = _normalize_resolved_model(model or default_model, provider)
+        extra_headers = dict(creds.get("extra_headers") or {})
 
         if provider == "gemini":
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
             if is_native_gemini_base_url(base_url):
-                client = GeminiNativeClient(api_key=api_key, base_url=base_url)
+                client = GeminiNativeClient(
+                    api_key=api_key,
+                    base_url=base_url,
+                    default_headers=extra_headers or None,
+                )
                 logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
                 return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                         else (client, final_model))
 
         # Provider-specific headers
-        headers = {}
+        headers = dict(extra_headers)
         if base_url_host_matches(base_url, "api.kimi.com"):
             headers["User-Agent"] = "claude-code/0.1.0"
         elif base_url_host_matches(base_url, "githubcopilot.com"):

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Iterator, List, Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -64,9 +65,26 @@ def is_native_gemini_base_url(base_url: str) -> bool:
     normalized = str(base_url or "").strip().rstrip("/").lower()
     if not normalized:
         return False
-    if "generativelanguage.googleapis.com" not in normalized:
+    try:
+        parsed = urlparse(normalized)
+    except Exception:
         return False
-    return not normalized.endswith("/openai")
+    if parsed.hostname == "generativelanguage.googleapis.com":
+        return not parsed.path.rstrip("/").endswith("/openai")
+    return parsed.path.rstrip("/").endswith("/v1beta")
+
+
+def _is_google_ai_studio_base_url(base_url: str) -> bool:
+    try:
+        parsed = urlparse(str(base_url or "").strip().lower())
+        return parsed.hostname == "generativelanguage.googleapis.com"
+    except Exception:
+        return False
+
+
+def _has_auth_header(headers: Dict[str, str]) -> bool:
+    auth_headers = {"authorization", "x-api-key", "x-goog-api-key"}
+    return bool(auth_headers & {str(key).lower() for key in headers})
 
 
 def probe_gemini_tier(
@@ -953,17 +971,24 @@ class GeminiNativeClient:
         self.close()
 
     def _headers(self) -> Dict[str, str]:
+        default_headers = dict(self._default_headers)
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "x-goog-api-key": self.api_key,
             # Include Hermes client context following Gemini's partner
             # integration guidance.
             # See https://ai.google.dev/gemini-api/docs/partner-integration
             "User-Agent": f"hermes-agent/{_HERMES_VERSION} (gemini-native)",
             "X-Goog-Api-Client": f"hermes-agent/{_HERMES_VERSION}",
         }
-        headers.update(self._default_headers)
+        if not _has_auth_header(default_headers):
+            auth_header = (
+                "x-goog-api-key"
+                if _is_google_ai_studio_base_url(self.base_url)
+                else "x-api-key"
+            )
+            headers[auth_header] = self.api_key
+        headers.update(default_headers)
         return headers
 
     @staticmethod

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -673,6 +673,15 @@ def _resolve_configured_api_key_provider_override(
         creds = resolve_api_key_provider_credentials(provider)
         api_key = creds.get("api_key", "")
 
+    if not has_usable_secret(api_key):
+        key_env_hint = f"providers.{provider}.key_env" + (f" ({key_env})" if key_env else "")
+        raise AuthError(
+            f"No usable API key found for configured provider '{provider}'. "
+            f"Set providers.{provider}.api_key or {key_env_hint}.",
+            provider=provider,
+            code="missing_api_key",
+        )
+
     result = {
         "provider": provider,
         "api_mode": _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
@@ -686,7 +695,6 @@ def _resolve_configured_api_key_provider_override(
     if entry.get("default_model") or entry.get("model"):
         result["model"] = entry.get("default_model") or entry.get("model")
     _lift_extra_headers(entry, result)
-    _lift_max_output_tokens(entry, result)
     return result
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -632,6 +632,64 @@ def _lift_extra_headers(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
         result["extra_headers"] = extra_headers
 
 
+def _resolve_configured_api_key_provider_override(
+    requested_provider: str,
+    *,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    provider = _normalize_custom_provider_name(requested_provider or "")
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    if not pconfig or pconfig.auth_type != "api_key":
+        return None
+
+    config = load_config()
+    providers = config.get("providers") if isinstance(config, dict) else None
+    if not isinstance(providers, dict):
+        return None
+    entry = providers.get(provider)
+    if not isinstance(entry, dict):
+        return None
+
+    from hermes_cli.config import is_provider_enabled
+
+    if not is_provider_enabled(entry):
+        return None
+
+    base_url = (
+        (explicit_base_url or "").strip()
+        or str(entry.get("api") or entry.get("url") or entry.get("base_url") or "").strip()
+    ).rstrip("/")
+    if not base_url:
+        return None
+
+    key_env = str(entry.get("key_env", "") or "").strip()
+    api_key = (
+        (explicit_api_key or "").strip()
+        or (_getenv(key_env, "").strip() if key_env else "")
+        or str(entry.get("api_key", "") or "").strip()
+    )
+    if not api_key:
+        creds = resolve_api_key_provider_credentials(provider)
+        api_key = creds.get("api_key", "")
+
+    result = {
+        "provider": provider,
+        "api_mode": _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
+        or _detect_api_mode_for_url(base_url)
+        or "chat_completions",
+        "base_url": base_url,
+        "api_key": api_key,
+        "source": f"providers.{provider}",
+        "requested_provider": requested_provider,
+    }
+    if entry.get("default_model") or entry.get("model"):
+        result["model"] = entry.get("default_model") or entry.get("model")
+    _lift_extra_headers(entry, result)
+    _lift_max_output_tokens(entry, result)
+    return result
+
+
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm:
@@ -1663,6 +1721,14 @@ def resolve_runtime_provider(
                 f"provider {requested_provider!r} is disabled in config "
                 f"(providers.{requested_provider}.enabled: false)"
             )
+
+    configured_builtin = _resolve_configured_api_key_provider_override(
+        requested_provider,
+        explicit_api_key=explicit_api_key,
+        explicit_base_url=explicit_base_url,
+    )
+    if configured_builtin:
+        return configured_builtin
 
     if requested_provider == "moa":
         return {

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -288,6 +288,89 @@ def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatc
     assert response.choices[0].message.content == "hello"
 
 
+def test_native_client_uses_x_api_key_for_non_google_native_gateway(monkeypatch):
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    recorded = {}
+
+    class DummyHTTP:
+        def post(self, url, json=None, headers=None, timeout=None):
+            recorded["url"] = url
+            recorded["headers"] = headers
+            return DummyResponse(
+                payload={
+                    "candidates": [
+                        {
+                            "content": {"parts": [{"text": "hello"}]},
+                            "finishReason": "STOP",
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": 1,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": 2,
+                    },
+                }
+            )
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        "agent.gemini_native_adapter.httpx.Client",
+        lambda *a, **k: DummyHTTP(),
+    )
+
+    client = GeminiNativeClient(
+        api_key="gateway-key",
+        base_url="https://gateway.example.com/v1beta",
+    )
+    response = client.chat.completions.create(
+        model="google/gemini-2.5-flash",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    assert (
+        recorded["url"]
+        == "https://gateway.example.com/v1beta/models/gemini-2.5-flash:generateContent"
+    )
+    assert recorded["headers"]["x-api-key"] == "gateway-key"
+    assert "x-goog-api-key" not in recorded["headers"]
+    assert response.choices[0].message.content == "hello"
+
+
+def test_native_client_does_not_add_default_auth_when_headers_provide_auth():
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    client = GeminiNativeClient(
+        api_key="gateway-key",
+        base_url="https://gateway.example.com/v1beta",
+        default_headers={"Authorization": "Bearer proxy-token"},
+    )
+
+    headers = client._headers()
+
+    assert headers["Authorization"] == "Bearer proxy-token"
+    assert "x-api-key" not in headers
+    assert "x-goog-api-key" not in headers
+
+
+@pytest.mark.parametrize(
+    "base_url, expected",
+    [
+        ("https://generativelanguage.googleapis.com/v1beta", True),
+        ("https://generativelanguage.googleapis.com/v1beta/openai", False),
+        ("https://generativelanguage.googleapis.com.evil.test/v1", False),
+        ("https://gateway.example.com/v1beta", True),
+        ("https://gateway.example.com/v1", False),
+    ],
+)
+def test_is_native_gemini_base_url(base_url, expected):
+    from agent.gemini_native_adapter import is_native_gemini_base_url
+
+    assert is_native_gemini_base_url(base_url) is expected
+
+
 @pytest.mark.parametrize("model, expected", [
     ("google/gemini-2.0-flash", "gemini-2.0-flash"),
     ("gemini/gemini-3-pro-preview", "gemini-3-pro-preview"),

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider, resolve_api_key_provider_credentials
+from hermes_cli.auth import AuthError, PROVIDER_REGISTRY, resolve_provider, resolve_api_key_provider_credentials
 from hermes_cli.models import _PROVIDER_MODELS, _PROVIDER_LABELS, _PROVIDER_ALIASES, normalize_provider
 from hermes_cli.model_normalize import normalize_model_for_provider, detect_vendor
 from agent.model_metadata import get_model_context_length
@@ -327,6 +327,40 @@ class TestGeminiAgentInit:
             resolve_provider_client("gemini")
         assert mock_client.called
         mock_openai.assert_not_called()
+
+    def test_gemini_resolve_provider_client_honors_configured_gateway_override(self, monkeypatch):
+        """A ``providers.gemini`` enterprise-gateway override must reach the
+        auxiliary resolution path too, not just the main runtime resolver
+        (PR #72958 review comment on agent/auxiliary_client.py).
+        """
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_BASE_URL", raising=False)
+        import hermes_cli.runtime_provider as rp
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {
+                "providers": {
+                    "gemini": {
+                        "base_url": "https://enterprise-gateway.example.com/v1beta",
+                        "api_key": "enterprise-gateway-key",
+                        "extra_headers": {"X-Gateway-Auth": "corp-token"},
+                    }
+                }
+            },
+        )
+        with patch("agent.gemini_native_adapter.GeminiNativeClient") as mock_client, \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            resolve_provider_client("gemini")
+        assert mock_client.called
+        mock_openai.assert_not_called()
+        _, kwargs = mock_client.call_args
+        assert kwargs["api_key"] == "enterprise-gateway-key"
+        assert kwargs["base_url"] == "https://enterprise-gateway.example.com/v1beta"
+        assert kwargs["default_headers"] == {"X-Gateway-Auth": "corp-token"}
 
 
 # ── models.dev Integration ──

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -120,6 +120,35 @@ class TestGeminiCredentials:
         assert result["api_key"] == "google-key"
         assert result["base_url"] == "https://generativelanguage.googleapis.com/v1beta"
 
+    def test_runtime_gemini_honors_providers_override(self, monkeypatch):
+        from hermes_cli import runtime_provider as rp
+
+        monkeypatch.setenv("ENTERPRISE_GEMINI_KEY", "gateway-key")
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {
+                "providers": {
+                    "gemini": {
+                        "name": "Enterprise Gemini",
+                        "base_url": "https://gateway.example.com/v1beta",
+                        "key_env": "ENTERPRISE_GEMINI_KEY",
+                        "api_mode": "chat_completions",
+                        "extra_headers": {"CF-Access-Client-Id": "client-id"},
+                    }
+                }
+            },
+        )
+
+        result = rp.resolve_runtime_provider(requested="gemini")
+
+        assert result["provider"] == "gemini"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "gateway-key"
+        assert result["base_url"] == "https://gateway.example.com/v1beta"
+        assert result["extra_headers"] == {"CF-Access-Client-Id": "client-id"}
+        assert result["source"] == "providers.gemini"
+
 
 # ── Model Catalog ──
 
@@ -234,6 +263,23 @@ class TestGeminiAgentInit:
             )
         mock_openai.assert_called_once()
 
+    def test_gemini_custom_v1beta_base_url_uses_native_client(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "gateway-key")
+        with patch("agent.gemini_native_adapter.GeminiNativeClient") as mock_client, \
+             patch("run_agent.OpenAI") as mock_openai, \
+             patch("run_agent.ContextCompressor") as mock_compressor:
+            mock_client.return_value = MagicMock()
+            mock_compressor.return_value = MagicMock(context_length=1048576, threshold_tokens=524288)
+            from run_agent import AIAgent
+            AIAgent(
+                model="gemini-2.5-flash",
+                provider="gemini",
+                api_key="gateway-key",
+                base_url="https://gateway.example.com/v1beta",
+            )
+        assert mock_client.called
+        mock_openai.assert_not_called()
+
     def test_gemini_openai_compat_base_url_keeps_openai_client(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSy_REAL_KEY")
         with patch("agent.gemini_native_adapter.GeminiNativeClient") as mock_client, \
@@ -270,6 +316,17 @@ class TestGeminiAgentInit:
             from agent.auxiliary_client import resolve_provider_client
             resolve_provider_client("gemini")
         mock_openai.assert_called_once()
+
+    def test_gemini_resolve_provider_client_uses_native_for_custom_v1beta(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "gateway-key")
+        monkeypatch.setenv("GEMINI_BASE_URL", "https://gateway.example.com/v1beta")
+        with patch("agent.gemini_native_adapter.GeminiNativeClient") as mock_client, \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            resolve_provider_client("gemini")
+        assert mock_client.called
+        mock_openai.assert_not_called()
 
 
 # ── models.dev Integration ──

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3377,6 +3377,52 @@ def test_named_custom_provider_non_dict_extra_headers_ignored(monkeypatch):
     assert "extra_headers" not in rp.resolve_runtime_provider(requested="emptyheaders")
 
 
+def test_configured_api_key_provider_without_key_raises_auth_error(monkeypatch):
+    """A ``providers.<name>`` entry (auth_type=api_key) with no resolvable
+    key must raise AuthError instead of silently returning an unusable
+    runtime dict — otherwise callers proceed to send unauthenticated
+    requests that fail confusingly downstream. (PR #72958 review)
+    """
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "gemini": {
+                    "base_url": "https://gemini-gateway.example.com/v1",
+                    "api_key": "",
+                }
+            }
+        },
+    )
+
+    with pytest.raises(rp.AuthError, match="No usable API key"):
+        rp._resolve_configured_api_key_provider_override("gemini")
+
+
+def test_configured_api_key_provider_placeholder_key_raises_auth_error(monkeypatch):
+    """A placeholder value like 'changeme' must not be treated as usable."""
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "gemini": {
+                    "base_url": "https://gemini-gateway.example.com/v1",
+                    "api_key": "changeme",
+                }
+            }
+        },
+    )
+
+    with pytest.raises(rp.AuthError, match="No usable API key"):
+        rp._resolve_configured_api_key_provider_override("gemini")
+
+
 def test_providers_dict_entry_surfaces_extra_headers(monkeypatch):
     """New-style providers: dict entries also surface extra_headers."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)


### PR DESCRIPTION
## Summary

Refs #72952.

Suggested labels: `bug`, `providers`, `gemini`.

This PR adds generic support for Gemini-native enterprise gateways that expose the native Gemini `/v1beta` REST shape behind a non-Google host.

Changes:

- Treat non-Google Gemini provider base URLs ending in `/v1beta` as native Gemini endpoints.
- Keep `/v1` custom Gemini base URLs on the existing OpenAI-compatible client path.
- Use `x-goog-api-key` for Google AI Studio, but default to `x-api-key` for non-Google native Gemini gateways.
- Do not inject a default Gemini auth header when `default_headers` already provides `Authorization`, `x-api-key`, or `x-goog-api-key`.
- Honor explicit `providers.<api-key-provider>` overrides for built-in API-key providers such as `providers.gemini`, including `base_url`, `key_env`, `api_mode`, `extra_headers`, and model/output-token hints.

## Rationale

Enterprise environments often expose vendor-native APIs through controlled gateways. For Gemini, those gateways may preserve the native `models/{model}:generateContent` API but require gateway authentication such as `x-api-key` instead of Google's `x-goog-api-key`.

Before this change, Hermes only detected native Gemini for `generativelanguage.googleapis.com`, so `GEMINI_BASE_URL=https://gateway.example.com/v1beta` or an equivalent configured Gemini provider could be routed through the wrong client/auth path.

## Tests

- `uv run --extra dev python -m pytest tests/agent/test_gemini_native_adapter.py tests/hermes_cli/test_gemini_provider.py -q`
- `uv run ruff check agent/gemini_native_adapter.py hermes_cli/runtime_provider.py tests/agent/test_gemini_native_adapter.py tests/hermes_cli/test_gemini_provider.py`
- `git diff --check`

Note: `scripts/run_tests.sh` could not be used on this Windows host because `bash` is not installed, so the targeted pytest run was executed through `uv run --extra dev`.
