### PR TITLE
fix(gateway): pin lazy agent imports to runtime root

### DIFF
--- a/contributors/emails/deacon@botdoctor.io
+++ b/contributors/emails/deacon@botdoctor.io
@@ -1,0 +1,2 @@
+deacon-botdoctor
+# PR #72968 #72972 #72962 reworks

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2523,15 +2523,16 @@ class APIServerAdapter(BasePlatformAdapter):
         chain, and fails closed if the locked provider's credentials cannot
         be resolved.
         """
-        from run_agent import AIAgent
         from gateway.run import (
             _checkpoint_agent_kwargs,
             _current_max_iterations,
             _resolve_runtime_agent_kwargs,
             _resolve_gateway_model,
             _load_gateway_config,
+            _load_runtime_ai_agent_class,
             GatewayRunner,
         )
+        AIAgent = _load_runtime_ai_agent_class()
         from hermes_cli.tools_config import _get_platform_tools
 
         # Catch RuntimeError ONLY around this call, not the wider

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2860,15 +2860,16 @@ class APIServerAdapter(BasePlatformAdapter):
         chain, and fails closed if the locked provider's credentials cannot
         be resolved.
         """
-        from run_agent import AIAgent
         from gateway.run import (
             _checkpoint_agent_kwargs,
             _current_max_iterations,
             _resolve_runtime_agent_kwargs,
             _resolve_gateway_model,
             _load_gateway_config,
+            _load_runtime_ai_agent_class,
             GatewayRunner,
         )
+        AIAgent = _load_runtime_ai_agent_class()
         from hermes_cli.tools_config import _get_platform_tools
 
         # Catch RuntimeError ONLY around this call, not the wider

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16,13 +16,13 @@ Usage:
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
 try:
-    import hermes_bootstrap  # noqa: F401
+    import hermes_bootstrap
 except ModuleNotFoundError:
     # Graceful fallback when hermes_bootstrap isn't registered in the venv
     # yet — happens during partial ``hermes update`` where git-reset landed
     # new code but ``uv pip install -e .`` didn't finish.  Missing bootstrap
     # means UTF-8 stdio setup is skipped on Windows; POSIX is unaffected.
-    pass
+    hermes_bootstrap = None
 
 import asyncio
 import concurrent.futures
@@ -1696,6 +1696,58 @@ _ensure_ssl_certs()
 
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def _load_runtime_ai_agent_class():
+    """Resolve AIAgent from this gateway's immutable runtime or fail closed."""
+    # A connected gateway is not coherent if a lazy turn import can fall
+    # through to another checkout.
+    _runtime_root = Path(__file__).resolve().parent.parent
+    _runtime_entry = str(_runtime_root)
+    _expected_run_agent = (_runtime_root / "run_agent.py").resolve()
+
+    if hermes_bootstrap is not None:
+        hermes_bootstrap.harden_import_path(_runtime_entry)
+    else:
+        sys.path.insert(0, _runtime_entry)
+
+    _loaded_run_agent = sys.modules.get("run_agent")
+    if _loaded_run_agent is not None:
+        _loaded_file = getattr(_loaded_run_agent, "__file__", None)
+        if _loaded_file is not None:
+            _loaded_origin = Path(_loaded_file).resolve()
+            if _loaded_origin != _expected_run_agent:
+                raise RuntimeError(
+                    "runtime coherence violation: run_agent already loaded from "
+                    f"{_loaded_origin}, expected {_expected_run_agent}"
+                )
+
+    from run_agent import AIAgent as _RuntimeAIAgent
+
+    _actual_file = getattr(sys.modules["run_agent"], "__file__", None)
+    if _actual_file is not None:
+        _actual_origin = Path(_actual_file).resolve()
+        if _actual_origin != _expected_run_agent:
+            raise RuntimeError(
+                "runtime coherence violation: run_agent resolved from "
+                f"{_actual_origin}, expected {_expected_run_agent}"
+            )
+
+    _agent_init = sys.modules.get("agent.agent_init")
+    if _agent_init is not None:
+        _agent_init_file = getattr(_agent_init, "__file__", None)
+        if _agent_init_file is not None:
+            _agent_init_origin = Path(_agent_init_file).resolve()
+            try:
+                _agent_init_origin.relative_to(_runtime_root)
+            except ValueError as _exc:
+                raise RuntimeError(
+                    "runtime coherence violation: agent.agent_init resolved from "
+                    f"{_agent_init_origin}, expected root {_runtime_root}"
+                ) from _exc
+
+    return _RuntimeAIAgent
+
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home, get_hermes_home_override
@@ -16710,7 +16762,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                     try:
                         from agent.conversation_compression import CompressionCommitFence
-                        from run_agent import AIAgent
+                        AIAgent = _load_runtime_ai_agent_class()
 
                         _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
                             source=source,
@@ -19217,7 +19269,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         media_types: Optional[List[str]] = None,
     ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
-        from run_agent import AIAgent
+        AIAgent = _load_runtime_ai_agent_class()
 
         media_urls = media_urls or []
         media_types = media_types or []
@@ -24027,7 +24079,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 event_message_id=event_message_id,
             )
 
-        from run_agent import AIAgent
+        AIAgent = _load_runtime_ai_agent_class()
         import queue
 
         def _run_still_current() -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16,13 +16,13 @@ Usage:
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
 try:
-    import hermes_bootstrap  # noqa: F401
+    import hermes_bootstrap
 except ModuleNotFoundError:
     # Graceful fallback when hermes_bootstrap isn't registered in the venv
     # yet — happens during partial ``hermes update`` where git-reset landed
     # new code but ``uv pip install -e .`` didn't finish.  Missing bootstrap
     # means UTF-8 stdio setup is skipped on Windows; POSIX is unaffected.
-    pass
+    hermes_bootstrap = None
 
 import asyncio
 import concurrent.futures
@@ -2068,6 +2068,58 @@ _ensure_ssl_certs()
 
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def _load_runtime_ai_agent_class():
+    """Resolve AIAgent from this gateway's immutable runtime or fail closed."""
+    # A connected gateway is not coherent if a lazy turn import can fall
+    # through to another checkout.
+    _runtime_root = Path(__file__).resolve().parent.parent
+    _runtime_entry = str(_runtime_root)
+    _expected_run_agent = (_runtime_root / "run_agent.py").resolve()
+
+    if hermes_bootstrap is not None:
+        hermes_bootstrap.harden_import_path(_runtime_entry)
+    else:
+        sys.path.insert(0, _runtime_entry)
+
+    _loaded_run_agent = sys.modules.get("run_agent")
+    if _loaded_run_agent is not None:
+        _loaded_file = getattr(_loaded_run_agent, "__file__", None)
+        if _loaded_file is not None:
+            _loaded_origin = Path(_loaded_file).resolve()
+            if _loaded_origin != _expected_run_agent:
+                raise RuntimeError(
+                    "runtime coherence violation: run_agent already loaded from "
+                    f"{_loaded_origin}, expected {_expected_run_agent}"
+                )
+
+    from run_agent import AIAgent as _RuntimeAIAgent
+
+    _actual_file = getattr(sys.modules["run_agent"], "__file__", None)
+    if _actual_file is not None:
+        _actual_origin = Path(_actual_file).resolve()
+        if _actual_origin != _expected_run_agent:
+            raise RuntimeError(
+                "runtime coherence violation: run_agent resolved from "
+                f"{_actual_origin}, expected {_expected_run_agent}"
+            )
+
+    _agent_init = sys.modules.get("agent.agent_init")
+    if _agent_init is not None:
+        _agent_init_file = getattr(_agent_init, "__file__", None)
+        if _agent_init_file is not None:
+            _agent_init_origin = Path(_agent_init_file).resolve()
+            try:
+                _agent_init_origin.relative_to(_runtime_root)
+            except ValueError as _exc:
+                raise RuntimeError(
+                    "runtime coherence violation: agent.agent_init resolved from "
+                    f"{_agent_init_origin}, expected root {_runtime_root}"
+                ) from _exc
+
+    return _RuntimeAIAgent
+
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home, get_hermes_home_override
@@ -19673,7 +19725,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                     try:
                         from agent.conversation_compression import CompressionCommitFence
-                        from run_agent import AIAgent
+                        AIAgent = _load_runtime_ai_agent_class()
 
                         _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
                             source=source,
@@ -22672,7 +22724,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         media_types: Optional[List[str]] = None,
     ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
-        from run_agent import AIAgent
+        AIAgent = _load_runtime_ai_agent_class()
 
         media_urls = media_urls or []
         media_types = media_types or []
@@ -28320,7 +28372,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 event_message_id=event_message_id,
             )
 
-        from run_agent import AIAgent
+        AIAgent = _load_runtime_ai_agent_class()
         import queue
 
         def _run_still_current() -> bool:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3884,7 +3884,6 @@ class GatewaySlashCommandsMixin:
             return "\n".join(lines)
 
         try:
-            from run_agent import AIAgent
             from agent.manual_compression_feedback import summarize_manual_compression
             from agent.model_metadata import estimate_request_tokens_rough
 
@@ -3898,9 +3897,11 @@ class GatewaySlashCommandsMixin:
             # "local" vs "cli" mismatch.
             from gateway.run import (
                 _GATEWAY_HYGIENE_PLATFORM,
+                _load_runtime_ai_agent_class,
                 _platform_config_key,
                 _seed_hygiene_system_prompt,
             )
+            AIAgent = _load_runtime_ai_agent_class()
             platform_key = (
                 _platform_config_key(source.platform) if source.platform else None
             )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4326,7 +4326,6 @@ class GatewaySlashCommandsMixin:
             return "\n".join(lines)
 
         try:
-            from run_agent import AIAgent
             from agent.manual_compression_feedback import summarize_manual_compression
             from agent.model_metadata import estimate_request_tokens_rough
 
@@ -4340,9 +4339,11 @@ class GatewaySlashCommandsMixin:
             # "local" vs "cli" mismatch.
             from gateway.run import (
                 _GATEWAY_HYGIENE_PLATFORM,
+                _load_runtime_ai_agent_class,
                 _platform_config_key,
                 _seed_hygiene_system_prompt,
             )
+            AIAgent = _load_runtime_ai_agent_class()
             platform_key = (
                 _platform_config_key(source.platform) if source.platform else None
             )

--- a/tests/gateway/test_runtime_root_guard.py
+++ b/tests/gateway/test_runtime_root_guard.py
@@ -1,0 +1,65 @@
+"""Gateway lazy imports stay within the active source tree."""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from gateway import run as gateway_run
+
+
+def test_runtime_agent_resolves_from_gateway_source_root():
+    agent_class = gateway_run._load_runtime_ai_agent_class()
+    runtime_root = Path(gateway_run.__file__).resolve().parent.parent
+
+    assert agent_class.__name__ == "AIAgent"
+    assert Path(sys.modules["run_agent"].__file__).resolve() == (
+        runtime_root / "run_agent.py"
+    )
+
+
+def test_foreign_sys_path_entry_cannot_win(tmp_path, monkeypatch):
+    (tmp_path / "run_agent.py").write_text(
+        "class AIAgent: pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delitem(sys.modules, "run_agent", raising=False)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    gateway_run._load_runtime_ai_agent_class()
+
+    runtime_root = Path(gateway_run.__file__).resolve().parent.parent
+    assert Path(sys.modules["run_agent"].__file__).resolve() == (
+        runtime_root / "run_agent.py"
+    )
+
+
+def test_preloaded_foreign_run_agent_fails_closed(tmp_path, monkeypatch):
+    foreign = ModuleType("run_agent")
+    foreign.__file__ = str(tmp_path / "run_agent.py")
+    foreign.AIAgent = type("AIAgent", (), {})
+    monkeypatch.setitem(sys.modules, "run_agent", foreign)
+
+    with pytest.raises(RuntimeError, match="already loaded"):
+        gateway_run._load_runtime_ai_agent_class()
+
+
+def test_preloaded_foreign_agent_init_fails_closed(tmp_path, monkeypatch):
+    gateway_run._load_runtime_ai_agent_class()
+    foreign = ModuleType("agent.agent_init")
+    foreign.__file__ = str(tmp_path / "agent" / "agent_init.py")
+    monkeypatch.setitem(sys.modules, "agent.agent_init", foreign)
+
+    with pytest.raises(RuntimeError, match="agent.agent_init resolved"):
+        gateway_run._load_runtime_ai_agent_class()
+
+
+def test_api_server_create_agent_uses_runtime_root_loader():
+    """API server must not bypass the runtime-root pin with a bare import."""
+    import inspect
+    from gateway.platforms import api_server as api_mod
+
+    src = inspect.getsource(api_mod.APIServerAdapter._create_agent)
+    assert "_load_runtime_ai_agent_class" in src
+    assert "from run_agent import AIAgent" not in src

--- a/tests/gateway/test_runtime_root_guard.py
+++ b/tests/gateway/test_runtime_root_guard.py
@@ -55,11 +55,48 @@ def test_preloaded_foreign_agent_init_fails_closed(tmp_path, monkeypatch):
         gateway_run._load_runtime_ai_agent_class()
 
 
-def test_api_server_create_agent_uses_runtime_root_loader():
-    """API server must not bypass the runtime-root pin with a bare import."""
-    import inspect
-    from gateway.platforms import api_server as api_mod
+def test_api_server_create_agent_uses_runtime_root_loader(monkeypatch):
+    """The API server constructs the class returned by the guarded loader."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.api_server import APIServerAdapter
 
-    src = inspect.getsource(api_mod.APIServerAdapter._create_agent)
-    assert "_load_runtime_ai_agent_class" in src
-    assert "from run_agent import AIAgent" not in src
+    created = {}
+
+    class GuardedAgent:
+        def __init__(self, **kwargs):
+            created.update(kwargs)
+            self.model = kwargs["model"]
+            self.provider = kwargs.get("provider")
+
+    monkeypatch.setattr(
+        gateway_run, "_load_runtime_ai_agent_class", lambda: GuardedAgent
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "test-provider"},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: "test/model")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_current_max_iterations", lambda: 1)
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner,
+        "_load_fallback_model",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner,
+        "_load_reasoning_config",
+        staticmethod(lambda model="": None),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools", lambda *_: set()
+    )
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+    agent = adapter._create_agent(session_id="guard-test")
+
+    assert isinstance(agent, GuardedAgent)
+    assert created["model"] == "test/model"


### PR DESCRIPTION
## What does this PR do?

Keeps the gateway's lazy `AIAgent` imports in the same Hermes source tree as
the running gateway.

`gateway/run.py` imports `AIAgent` lazily in the main turn, background-task,
and session-hygiene paths. If another Hermes checkout is later placed ahead of
the active runtime on `sys.path`, or its file-backed `run_agent` module is
already cached, a long-lived gateway can otherwise mix code from two source
trees.

This change:

- reuses `hermes_bootstrap.harden_import_path()` before each lazy agent import;
- verifies file-backed `run_agent` resolves to the gateway's source root;
- rejects a loaded `agent.agent_init` from a different source root;
- leaves deliberate in-memory modules without a file origin usable by tests.

The guard fails closed with both the actual and expected paths instead of
continuing with a mixed runtime.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: route all three lazy `AIAgent` imports through one
  runtime-root loader.
- `tests/gateway/test_runtime_root_guard.py`: cover normal resolution, a
  competing `sys.path` entry, a preloaded foreign `run_agent`, and a foreign
  `agent.agent_init`.

No configuration, dependency, schema, or public API changes.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_runtime_root_guard.py -q`.
2. Run the affected gateway tests or the complete gateway suite:
   `scripts/run_tests.sh tests/gateway -q`.
3. Run `uv run ruff check gateway/run.py tests/gateway/test_runtime_root_guard.py`.
4. Run
   `python3 scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_runtime_root_guard.py`.

Verification on macOS 26.4 with the project Python 3.11.15 environment:

- focused regression tests: 4 passed;
- affected integration selection: 92 passed;
- complete gateway suite: 11,312 passed, with the same 6 unrelated
  platform/environment failures reproduced on the upstream base
  (`test_background_command`, `test_shutdown_forensics`,
  `test_systemd_notify`, and 3 `test_wecom_callback` cases);
- Ruff: clean;
- Windows footgun scan: clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed PRs/issues for runtime-root, wrong-checkout,
  and lazy-import equivalents; no duplicate was found
- [x] My PR contains **only** changes related to this fix
- [x] I've run the complete gateway suite; the contribution adds no failures
  relative to the upstream base
- [x] I've added tests for the bug
- [x] I've tested on macOS 26.4

### Documentation & Housekeeping

- [x] Documentation: N/A; no user-facing behavior or configuration changed
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture
  contract changed
- [x] Cross-platform impact considered; the path logic uses the existing
  cross-platform bootstrap helper and the Windows footgun scan is clean
- [x] Tool descriptions/schemas: N/A; no tool surface changed

## Screenshots / Logs

N/A — runtime import-coherence fix with automated regression coverage.
