### PR TITLE
fix: emit ACP tool completion on tool.completed, not only next step

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -125,14 +125,43 @@ def make_tool_progress_cb(
 
         tool_progress_callback(event_type: str, name: str, preview: str, args: dict, **kwargs)
 
-    Emits ``ToolCallStart`` for ``tool.started`` events and tracks IDs in a FIFO
-    queue per tool name so duplicate/parallel same-name calls still complete
-    against the correct ACP tool call.  Other event types (``tool.completed``,
-    ``reasoning.available``) are silently ignored.
+    Emits ``ToolCallStart`` for ``tool.started`` and ``ToolCallUpdate`` for
+    ``tool.completed``, tracking IDs in a FIFO queue per tool name so
+    duplicate/parallel same-name calls still complete against the correct ACP
+    tool call.  Other event types (``reasoning.available``) are ignored.
+
+    Completion is also emitted by ``make_step_cb`` from the *next* step's
+    ``prev_tools`` list.  Both paths consume the same FIFO entry, so whichever
+    fires first wins and the other becomes a no-op — no duplicate updates.
+    Handling ``tool.completed`` here is what closes tools of the **last** step
+    of a turn: there is no next step to carry them, so before this they stayed
+    pending forever in the client's UI.
     """
 
     def _tool_progress(event_type: str, name: str = None, preview: str = None, args: Any = None, **kwargs) -> None:
-        # Only emit ACP ToolCallStart for tool.started; ignore other event types
+        if event_type == "tool.completed":
+            queue = tool_call_ids.get(name or "")
+            if isinstance(queue, str):
+                queue = deque([queue])
+                tool_call_ids[name] = queue
+            if not queue:
+                # No matching start, or make_step_cb already completed it.
+                return
+            tc_id = queue.popleft()
+            meta = tool_call_meta.pop(tc_id, {})
+            if not queue:
+                tool_call_ids.pop(name, None)
+            result = kwargs.get("result")
+            update = build_tool_complete(
+                tc_id,
+                name,
+                result=str(result) if result is not None else None,
+                function_args=meta.get("args"),
+                snapshot=meta.get("snapshot"),
+            )
+            _send_update(conn, session_id, loop, update)
+            return
+
         if event_type != "tool.started":
             return
         if isinstance(args, str):

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -126,6 +126,76 @@ class TestToolProgressCallback:
             step_cb(2, [{"name": "terminal", "result": "ok-2"}])
             assert "terminal" not in tool_call_ids
 
+    def test_tool_completed_emits_update_without_next_step(self, mock_conn, event_loop_fixture):
+        """A tool completing in the last step of a turn must still be closed.
+
+        make_step_cb only reports the *previous* step's tools, so tools of the
+        final step before the answer never got a terminal update and stayed
+        pending in the client UI.
+        """
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb("tool.started", "read_file", None, {"path": "/etc/hosts"})
+            assert len(tool_call_ids["read_file"]) == 1
+            mock_rcts.reset_mock()
+
+            cb("tool.completed", "read_file", None, None, result="127.0.0.1 localhost")
+
+        mock_rcts.assert_called_once()
+        assert "read_file" not in tool_call_ids
+        assert tool_call_meta == {}
+
+    def test_tool_completed_and_step_cb_do_not_double_report(self, mock_conn, event_loop_fixture):
+        """Both completion paths share the FIFO entry — the second is a no-op."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        progress_cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        step_cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            progress_cb("tool.started", "terminal", "$ ls", {"command": "ls"})
+            mock_rcts.reset_mock()
+
+            progress_cb("tool.completed", "terminal", None, None, result="ok")
+            assert mock_rcts.call_count == 1
+
+            # The next step still lists the tool — must not emit a second update.
+            step_cb(1, [{"name": "terminal", "result": "ok"}])
+
+        assert mock_rcts.call_count == 1
+
+    def test_tool_completed_without_start_is_ignored(self, mock_conn, event_loop_fixture):
+        """A completion with no matching start must not invent a tool call."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+
+        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb("tool.completed", "terminal", None, None, result="ok")
+
+        mock_rcts.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Thinking callback


### PR DESCRIPTION
## Problem

`make_tool_progress_cb` emits `ToolCallStart` on `tool.started` and returns early on everything else — `tool.completed` included. Terminal updates come only from `make_step_cb`, which walks the *previous* step's `prev_tools` list.

Tools that run in the **last step of a turn** therefore never receive a terminal `ToolCallUpdate`: there is no next step to carry them. Their cards stay pending forever in the client UI.

## Evidence

Observed over ACP against a client that renders tool cards. One turn ending in a batch of `read_file` calls sent:

```
"sessionUpdate":"tool_call"          10
"sessionUpdate":"tool_call_update"    1
```

The single update belonged to a tool from an earlier step. The nine last-step calls never closed. With the fix, the same class of turn (eight `write_file` plus two `terminal`, ~12 minutes) sent 10 calls and 10 terminal updates, all `completed`.

## Fix

Handle `tool.completed` in the progress callback: pop the tool's FIFO entry, take its stored meta, and emit via the existing `build_tool_complete` — which already derives `failed` vs `completed` from the result, so error reporting comes along for free.

Both completion paths consume the same FIFO entry, so whichever fires first wins and the other becomes a no-op. No duplicate updates, no new bookkeeping.

The payload was already available: `agent/tool_executor.py` passes `result=`, `is_error=` and `duration=` with the `tool.completed` event.

## Tests

Three added to `tests/acp/test_events.py`:

- completion arrives with no following step;
- `tool.completed` and `make_step_cb` together emit exactly one update;
- a completion with no matching start is ignored rather than inventing a call.

Note on running them: the released `venv/` ships without pytest, so `scripts/run_tests.sh` reports "0 tests passed / No module named pytest". Layering pytest over that interpreter, `tests/acp/test_events.py` goes 19 → 22 passed. A baseline run of `tests/acp/ tests/acp_adapter/` on the unmodified tree gave the same failures before and after this change (83 failed / 238 passed → 83 failed / 241 passed); those pre-existing failures look like an artifact of not using the canonical runner.
