### PR TITLE
fix(desktop): keep /resume's free-text search typeable

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
@@ -172,6 +172,20 @@ describe('useComposerTrigger — free-text slash arguments', () => {
     expect(hook.result.current.triggerActiveExplicit).toBe(false)
   })
 
+  it('keeps a multi-word /resume search typeable instead of firing the picker action', () => {
+    // The session list always ends in a "Browse all sessions…" action row, so
+    // an accept here doesn't insert a chip — it empties the composer and opens
+    // the overlay, taking the half-typed query with it.
+    const editor = mountEditor('/resume my new')
+    const { hook } = mountTrigger(editor, [item('/resume', 'Sessions')])
+
+    act(() => hook.result.current.refreshTrigger())
+
+    expect(hook.result.current.slashFreeTextArgStage).toBe(true)
+    expect(hook.result.current.commitTypedSlashDirective()).toBe(false)
+    expect(composerPlainText(editor)).toBe('/resume my new')
+  })
+
   it('still commits a fully typed finite option as one directive chip', () => {
     const editor = mountEditor('/personality creative')
     const { hook } = mountTrigger(editor, [])

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -188,7 +188,13 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     description: 'Resume a saved session',
     aliases: ['/sessions', '/switch'],
     surface: picker('session'),
-    argumentMode: 'options'
+    // `mixed`, not `options`: the argument is a free-text search the picker
+    // fuzzy-matches against titles and previews, so multi-word queries have to
+    // stay typeable. Its completion list also always carries a trailing
+    // "Browse all sessions…" action row, which meant Space-to-accept could
+    // never fall through — the first space wiped the composer and threw the
+    // user into the overlay.
+    argumentMode: 'mixed'
   },
 
   // Backend-executed commands that render useful inline output.


### PR DESCRIPTION
Follow-up to [#72956](https://github.com/NousResearch/hermes-agent/pull/72956). That PR stopped Enter from swapping a half-typed free-text argument for a highlighted completion; auditing the rest of the argument-taking commands against the same failure mode turned up one more command that was still losing typed text.

`/resume` was classified as an `options` command, but its argument isn't a finite option — the picker fuzzy-matches it against session titles and previews, so `/resume auth refactor` is a legitimate query. Two things combined to make that untypeable:

- `options` mode accepts the highlighted completion on Space.
- The session completion list always ends in a "Browse all sessions…" action row, so the list is never empty and Space never falls through to typing a plain space.

The result is that the first space in a multi-word query accepts that action row, which empties the composer and opens the session overlay — taking the query with it. Verified against the real hook: `/resume my new` plus a space leaves the composer as `""`.

Classifying it as `mixed` puts it on the machinery [#72956](https://github.com/NousResearch/hermes-agent/pull/72956) added: spaces type through, the match list keeps narrowing as the query is refined, and Tab or arrow-then-Enter still accept a highlighted session.

## Audit notes

I joined all 57 argument-taking commands in `COMMAND_REGISTRY` against their desktop argument mode. The other modes are safe by construction — `text` and unclassified commands close the popover at the argument stage, and `mixed` is now guarded. Of the remaining `options` commands, `/handoff`, `/approvals`, `/skin`, `/personality`, and `/tools` take genuinely finite arguments.

`/pet scale <n>` and `/browser connect <url>` take a finite first token and a free-form second one, so the first token seals into a pill earlier than it needs to. No text is lost — `composerPlainText` round-trips a chip through `data-ref-text`, so `/browser connect http://127.0.0.1:9222` still submits intact — so I've left them alone rather than widen this PR.

## Test plan

- [x] `npx vitest run src/app` — 1075 passing, including a new case asserting `/resume my new` survives the argument stage
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on the changed files