### PR TITLE
feat(windows): allow configured gateway task name

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -723,6 +723,12 @@ max_concurrent_sessions: null
 # explicitly want one shared "room brain" per group/channel.
 group_sessions_per_user: true
 
+# Optional Windows Scheduled Task identity. Profiles default to
+# Hermes_Gateway_<profile>; set this only when Hermes must manage an existing
+# externally named task.
+# gateway:
+#   windows_task_name: My_Hermes_Gateway
+
 # ─────────────────────────────────────────────────────────────────────────────
 # API Server — per-client model routing
 # ─────────────────────────────────────────────────────────────────────────────

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -892,6 +892,12 @@ group_sessions_per_user: true
 # dashboard:
 #   startup_orphan_sweep: true
 
+# Optional Windows Scheduled Task identity. Profiles default to
+# Hermes_Gateway_<profile>; set this only when Hermes must manage an existing
+# externally named task.
+# gateway:
+#   windows_task_name: My_Hermes_Gateway
+
 # ─────────────────────────────────────────────────────────────────────────────
 # API Server — per-client model routing
 # ─────────────────────────────────────────────────────────────────────────────

--- a/contributors/emails/deacon@botdoctor.io
+++ b/contributors/emails/deacon@botdoctor.io
@@ -1,0 +1,2 @@
+deacon-botdoctor
+# PR #72968 #72972 #72962 reworks

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2452,6 +2452,11 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Windows only: manage this exact Scheduled Task instead of the
+        # profile-derived Hermes_Gateway[_profile] default. Keep empty unless
+        # an external supervisor already owns the task identity.
+        "windows_task_name": "",
+
         # Durable delivery-obligation ledger: final agent responses are
         # recorded in state.db around the platform send, and a gateway that
         # died between finalize and platform ACK redelivers the stored

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2977,6 +2977,11 @@ DEFAULT_CONFIG = {
         # the historical serve-all behavior; [] serves only the default.
         "multiplex_profile_allowlist": None,
 
+        # Windows only: manage this exact Scheduled Task instead of the
+        # profile-derived Hermes_Gateway[_profile] default. Keep empty unless
+        # an external supervisor already owns the task identity.
+        "windows_task_name": "",
+
         # Durable delivery-obligation ledger: final agent responses are
         # recorded in state.db around the platform send, and a gateway that
         # died between finalize and platform ACK redelivers the stored

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -296,12 +296,27 @@ def get_task_name() -> str:
 
     Default profile: ``Hermes_Gateway``
     Named profile X: ``Hermes_Gateway_<X>``
+
+    Optional override: ``gateway.windows_task_name`` when Hermes must manage
+    an existing externally named task.
     """
     _assert_windows()
-    # Local import to avoid circular module initialization during hermes_cli boot.
+    # Local imports avoid circular module initialization during hermes_cli boot.
     from hermes_cli.gateway import _profile_suffix
+    from hermes_cli.config import load_config_readonly
 
     suffix = _profile_suffix()
+    config = load_config_readonly()
+    gateway_config = config.get("gateway") if isinstance(config, dict) else None
+    override = (
+        str(gateway_config.get("windows_task_name") or "").strip()
+        if isinstance(gateway_config, dict)
+        else ""
+    )
+    if override:
+        if not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", override):
+            raise ValueError("invalid gateway.windows_task_name")
+        return override
     if not suffix:
         return _TASK_NAME_DEFAULT
     return f"{_TASK_NAME_DEFAULT}_{suffix}"

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -292,12 +292,27 @@ def get_task_name() -> str:
 
     Default profile: ``Hermes_Gateway``
     Named profile X: ``Hermes_Gateway_<X>``
+
+    Optional override: ``gateway.windows_task_name`` when Hermes must manage
+    an existing externally named task.
     """
     _assert_windows()
-    # Local import to avoid circular module initialization during hermes_cli boot.
+    # Local imports avoid circular module initialization during hermes_cli boot.
     from hermes_cli.gateway import _profile_suffix
+    from hermes_cli.config import load_config_readonly
 
     suffix = _profile_suffix()
+    config = load_config_readonly()
+    gateway_config = config.get("gateway") if isinstance(config, dict) else None
+    override = (
+        str(gateway_config.get("windows_task_name") or "").strip()
+        if isinstance(gateway_config, dict)
+        else ""
+    )
+    if override:
+        if not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", override):
+            raise ValueError("invalid gateway.windows_task_name")
+        return override
     if not suffix:
         return _TASK_NAME_DEFAULT
     return f"{_TASK_NAME_DEFAULT}_{suffix}"

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import hermes_cli.config as config
 import hermes_cli.gateway as gateway
 import hermes_cli.gateway_windows as gateway_windows
 import hermes_cli.setup as setup
@@ -23,6 +24,48 @@ def test_schtasks_encoding_falls_back_to_utf8(monkeypatch):
     monkeypatch.setattr(gateway_windows.locale, "getpreferredencoding", lambda *a, **k: "")
     assert gateway_windows._schtasks_encoding() == "utf-8"
 
+
+
+def test_task_name_uses_valid_configured_override(monkeypatch):
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway, "_profile_suffix", lambda: "alice")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"gateway": {"windows_task_name": "Hermes-Owned_Alice"}},
+    )
+
+    assert gateway_windows.get_task_name() == "Hermes-Owned_Alice"
+
+
+def test_task_name_rejects_unsafe_configured_override(monkeypatch):
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway, "_profile_suffix", lambda: "alice")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"gateway": {"windows_task_name": "../other-task"}},
+    )
+
+    with pytest.raises(ValueError, match="gateway.windows_task_name"):
+        gateway_windows.get_task_name()
+
+
+def test_task_name_keeps_profile_default_without_override(monkeypatch):
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway, "_profile_suffix", lambda: "alice")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"gateway": {}},
+    )
+
+    assert gateway_windows.get_task_name() == "Hermes_Gateway_alice"
+
+
+def test_task_name_config_key_is_supported():
+    # Schema walk only — no freeze on DEFAULT_CONFIG literal value.
+    assert config._validate_config_key("gateway.windows_task_name") == (True, None)
+
+
+def test_schtasks_encoding_falls_back_when_locale_raises(monkeypatch):
     def _boom(*args, **kwargs):
         raise RuntimeError("locale exploded")
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import hermes_cli.config as config
 import hermes_cli.gateway as gateway
 import hermes_cli.gateway_windows as gateway_windows
 import hermes_cli.setup as setup
@@ -17,6 +18,48 @@ def test_schtasks_encoding_falls_back_to_utf8(monkeypatch):
     monkeypatch.setattr(gateway_windows.locale, "getpreferredencoding", lambda *a, **k: "")
     assert gateway_windows._schtasks_encoding() == "utf-8"
 
+
+
+def test_task_name_uses_valid_configured_override(monkeypatch):
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway, "_profile_suffix", lambda: "alice")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"gateway": {"windows_task_name": "Hermes-Owned_Alice"}},
+    )
+
+    assert gateway_windows.get_task_name() == "Hermes-Owned_Alice"
+
+
+def test_task_name_rejects_unsafe_configured_override(monkeypatch):
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway, "_profile_suffix", lambda: "alice")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"gateway": {"windows_task_name": "../other-task"}},
+    )
+
+    with pytest.raises(ValueError, match="gateway.windows_task_name"):
+        gateway_windows.get_task_name()
+
+
+def test_task_name_keeps_profile_default_without_override(monkeypatch):
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway, "_profile_suffix", lambda: "alice")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"gateway": {}},
+    )
+
+    assert gateway_windows.get_task_name() == "Hermes_Gateway_alice"
+
+
+def test_task_name_config_key_is_supported():
+    # Schema walk only — no freeze on DEFAULT_CONFIG literal value.
+    assert config._validate_config_key("gateway.windows_task_name") == (True, None)
+
+
+def test_schtasks_encoding_falls_back_when_locale_raises(monkeypatch):
     def _boom(*args, **kwargs):
         raise RuntimeError("locale exploded")
 


### PR DESCRIPTION
## What does this PR do?

Adds one optional Windows-only configuration key:

```yaml
gateway:
  windows_task_name: My_Hermes_Gateway
```

Hermes currently derives the Scheduled Task identity from the active profile:
`Hermes_Gateway` or `Hermes_Gateway_<profile>`. That is the right default, but
it cannot manage an existing task whose stable identity is owned by an external
supervisor or deployment system.

When configured, every existing Windows gateway lifecycle path that uses
`get_task_name()` receives the same explicit identity: installation,
registration/status queries, stop/uninstall, and generated task/startup
artifact paths. With no override, profile-derived behavior is unchanged.

## Related Issue

No issue.

Related but distinct: #69743 preserves the exact identity of protected Windows
tasks during updater pause/resume. This PR defines an optional canonical
identity for the regular Windows gateway lifecycle itself.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway_windows.py`
  - reads `gateway.windows_task_name` in the existing canonical
    `get_task_name()` funnel
  - validates explicit identities against a conservative 1–128 character
    allowlist before any `schtasks` operation
  - retains the existing profile-derived fallback
- `hermes_cli/config.py`
  - registers the key in the canonical default schema so
    `hermes config set gateway.windows_task_name ...` accepts it
- `cli-config.yaml.example`
  - documents the Windows-only, externally-owned-task use case
- `tests/hermes_cli/test_gateway_windows.py`
  - covers override selection, unsafe input rejection, fallback compatibility,
    and config-schema acceptance

## Compatibility and security

- The default is empty, so existing task names and profile behavior do not
  change.
- Explicit names are limited to ASCII letters, digits, `_`, `.`, and `-`, with
  a maximum length of 128 characters.
- Invalid configured values fail before a task query, creation, stop, or
  deletion can target an unintended identity.
- No command construction, privilege path, dependency, service, or persisted
  runtime schema changes.

## How to Test

1. On Windows, set
   `hermes config set gateway.windows_task_name My_Hermes_Gateway`.
2. Run `hermes gateway install`, `status`, `stop`, and `uninstall`; verify each
   operation targets `My_Hermes_Gateway`.
3. Remove the key and repeat with a named profile; verify the existing
   `Hermes_Gateway_<profile>` identity is retained.
4. Run:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py \
     tests/hermes_cli/test_set_config_value.py tests/gateway/test_config.py
   ruff check hermes_cli/config.py hermes_cli/gateway_windows.py \
     tests/hermes_cli/test_gateway_windows.py
   python3 scripts/check-windows-footguns.py hermes_cli/config.py \
     hermes_cli/gateway_windows.py tests/hermes_cli/test_gateway_windows.py
   ```

Local verification on macOS 26.4 / Python 3.11.15:

- 43/43 Windows gateway tests pass.
- 285/285 affected Windows/config tests pass. Two pre-existing Slack
  environment-bridge cases were flaky on their first isolated subprocess and
  passed on the runner's clean retry.
- Ruff, Windows-footgun scan, and `git diff --check` pass.
- A complete local suite was attempted; it is not claimable in this environment
  because optional ACP tests fail collection without the `acp` extra. More than
  9,000 other tests passed before that non-actionable run was stopped. GitHub CI
  remains the authoritative full-suite result.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4, Python 3.11.15; Windows behavior is unit-tested through the existing platform seams

The complete-suite limitation is disclosed above; all focused and affected
tests pass.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

`CONTRIBUTING.md`/`AGENTS.md` and tool schemas are N/A: this adds no workflow,
architecture, or tool-interface change.
