### PR TITLE
fix(doctor): use `docker version` instead of `docker info` for socket-proxy compatibility

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1722,7 +1722,13 @@ def run_doctor(args):
         if _safe_which("docker"):
             # Check if docker daemon is running
             try:
-                result = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
+                # Use "docker version" instead of "docker info" because the
+                # /info API endpoint is often blocked by socket-proxy
+                # containers (e.g. tecnativa/docker-socket-proxy), producing
+                # a false "docker daemon not running".  "docker version"
+                # uses the /version endpoint which is safe and honors
+                # DOCKER_HOST when set to a TCP proxy (#72927).
+                result = subprocess.run(["docker", "version"], capture_output=True, timeout=10)
             except subprocess.TimeoutExpired:
                 result = None
             if result is not None and result.returncode == 0:


### PR DESCRIPTION
## Problem

`hermes doctor` reports "docker daemon not running" (false negative) when the Docker terminal backend uses `DOCKER_HOST` via a TCP socket-proxy (e.g. `tecnativa/docker-socket-proxy`) instead of a bind-mounted `/var/run/docker.sock`.

The health check uses `docker info` which hits the Docker API `/info` endpoint. Socket-proxy containers restrict this endpoint by default, causing a false negative even though Docker is fully functional.

## Fix

Changed the health check from `docker info` to `docker version`. The `/version` endpoint is safe and rarely blocked by socket proxies. Additionally, `docker version` respects `DOCKER_HOST` when set to a TCP proxy, making the check work with both bind-mount and TCP-proxy Docker access patterns.

## Testing

- Syntax/import verified: `python3 -c "import ast; ast.parse(open('hermes_cli/doctor.py').read())"`
- No existing doctor unit tests for this specific check
- The fix is a one-line command change (`docker info` → `docker version`) — the surrounding error-handling logic (timeout, returncode check) remains unchanged

Closes #72927