### PR TITLE
fix(skills): avoid repeated optional backfill scans

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -997,6 +997,37 @@ class TestSyncSkills:
 
         assert result["optional_provenance_backfilled"] == []
 
+    def test_relocated_backfill_indexes_active_tree_once(self, tmp_path):
+        """Relocated optional backfill should not rescan active skills per candidate."""
+        bundled = self._setup_bundled(tmp_path)
+        optional = tmp_path / "optional-skills"
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        for name in ("alpha", "beta", "gamma"):
+            optional_skill = optional / "new" / name
+            optional_skill.mkdir(parents=True)
+            skill_text = f"---\nname: {name}\n---\n# {name}\n"
+            (optional_skill / "SKILL.md").write_text(skill_text)
+
+            active = skills_dir / "old" / name
+            active.mkdir(parents=True)
+            (active / "SKILL.md").write_text(skill_text)
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync._get_optional_dir", return_value=optional):
+                from tools import skills_sync as sync_module
+
+                original = sync_module._index_active_skill_dirs_by_folder_name
+                with patch(
+                    "tools.skills_sync._index_active_skill_dirs_by_folder_name",
+                    wraps=original,
+                ) as indexed:
+                    result = sync_skills(quiet=True)
+
+        assert result["optional_provenance_backfilled"] == ["alpha", "beta", "gamma"]
+        assert indexed.call_count == 1
+
     def test_repair_official_optional_restores_reorganized_skill_with_backup(self, tmp_path):
         bundled = self._setup_bundled(tmp_path)
         optional = tmp_path / "optional-skills"

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -440,6 +440,37 @@ def _find_installed_skill_dir_by_name(skill_dir_name: str) -> Optional[Path]:
     return matches[0]
 
 
+def _index_active_skill_dirs_by_folder_name() -> Dict[str, List[Path]]:
+    """Index installed skill directories by folder name for optional backfill."""
+    index: Dict[str, List[Path]] = {}
+    if not SKILLS_DIR.exists():
+        return index
+
+    skills_root = SKILLS_DIR.resolve()
+    for skill_md in SKILLS_DIR.rglob("SKILL.md"):
+        if is_excluded_skill_path(skill_md):
+            continue
+        candidate = skill_md.parent
+        try:
+            candidate.resolve().relative_to(skills_root)
+        except (OSError, ValueError):
+            continue
+        index.setdefault(candidate.name, []).append(candidate)
+    return index
+
+
+def _unique_active_skill_dir_by_folder_name(
+    index: Dict[str, List[Path]], skill_dir_name: str
+) -> Optional[Path]:
+    """Return a unique installed skill directory from a precomputed index."""
+    if not skill_dir_name:
+        return None
+    matches = index.get(skill_dir_name, [])
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
 def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
     """Mark already-present official optional skills as hub-installed.
 
@@ -467,6 +498,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
 
     backfilled: List[str] = []
     changed = False
+    active_dirs_by_name: Optional[Dict[str, List[Path]]] = None
     for skill_md in sorted(optional_dir.rglob("SKILL.md")):
         if is_excluded_skill_path(skill_md):
             continue
@@ -486,7 +518,9 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
             # silently skips them forever. Fall back to a unique
             # same-directory-name match anywhere in the tree, then still
             # require a byte-identical hash below before claiming provenance.
-            dest = _find_installed_skill_dir_by_name(src.name)
+            if active_dirs_by_name is None:
+                active_dirs_by_name = _index_active_skill_dirs_by_folder_name()
+            dest = _unique_active_skill_dir_by_folder_name(active_dirs_by_name, src.name)
             if dest is None:
                 continue
             try:


### PR DESCRIPTION
## Summary

- pre-index active skill directories once during optional provenance backfill
- reuse the index for relocated optional skill lookup instead of rescanning `SKILLS_DIR`
- add a regression test that verifies relocated backfill builds the active tree index once

Fixes #72495.
Refs #72970.

## Why

`sync_skills()` runs on CLI startup. `_backfill_optional_provenance()` iterates optional skills, and the relocated-skill fallback previously called `_find_installed_skill_dir_by_name()` per candidate. That helper recursively scans `SKILLS_DIR` with `rglob("SKILL.md")`, so startup can repeatedly walk the active skills tree even when there is nothing to backfill.

On a Windows installation with 69 bundled skills, the local measurements were:

```text
before: _backfill_optional_provenance ~5.685s, sync_skills ~7.008s
after:  _backfill_optional_provenance ~0.095s, sync_skills ~0.564s
```

The byte-identical hash check is preserved before provenance is written.

## Tests

```text
python -m py_compile tools\skills_sync.py
uv run pytest tests\tools\test_skills_sync.py -q -k "optional_provenance or relocated_backfill or repair_official_optional"
```

The focused pytest selection passes locally on Windows:

```text
8 passed, 73 deselected
```

I also ran the full `tests/tools/test_skills_sync.py` file on Windows. It has one pre-existing Windows path-separator failure unrelated to this change:

```text
TestComputeRelativeDest.test_preserves_category_structure
assert str(dest).endswith("mlops/axolotl")
```

The path on Windows ends with `mlops\axolotl`.
