### PR TITLE
fix(desktop): preserve failed voice recordings

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8635,9 +8635,9 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
   })
 }
 
-// Secondary "session windows" — one extra OS window per chat so a user can
-// work with multiple chats side by side. The registry guarantees one window
-// per sessionId (re-opening focuses the existing window) and self-cleans on
+// Secondary "session windows" — one extra OS window per profile/chat identity
+// so a user can work with multiple chats side by side. The registry guarantees
+// one window per profile + sessionId (re-opening focuses it) and self-cleans on
 // close. The primary mainWindow is never tracked here. Pure logic + the URL
 // builder live in session-windows.ts so they stay unit-testable.
 const sessionWindows = createSessionWindowRegistry()
@@ -8658,7 +8658,11 @@ function focusWindow(win) {
   win.focus()
 }
 
-function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?: boolean } = {}) {
+function spawnSecondaryWindow({
+  profile,
+  sessionId,
+  watch
+}: { profile?: string; sessionId?: string; watch?: boolean } = {}) {
   const icon = getAppIconPath()
 
   const win = new BrowserWindow({
@@ -8703,6 +8707,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     win,
     buildSessionWindowUrl(sessionId, {
       devServer: DEV_SERVER,
+      profile,
       rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
       watch
     }),
@@ -8713,8 +8718,8 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
 }
 
 // Open (or focus) a standalone window for a single chat session.
-function createSessionWindow(sessionId, { watch = false } = {}) {
-  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, watch }))
+function createSessionWindow(sessionId, { profile, watch = false }: { profile?: string; watch?: boolean } = {}) {
+  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ profile, sessionId, watch }), profile)
 }
 
 // Additional full "instance" windows — peers of the primary that render the
@@ -9440,7 +9445,13 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
     return { ok: false, error: 'invalid-session-id' }
   }
 
-  createSessionWindow(sessionId.trim(), { watch: opts?.watch === true })
+  const profile = typeof opts?.profile === 'string' ? opts.profile.trim() : ''
+
+  if (profile && profile !== 'default' && !PROFILE_NAME_RE.test(profile)) {
+    return { ok: false, error: 'invalid-profile' }
+  }
+
+  createSessionWindow(sessionId.trim(), { profile: profile || undefined, watch: opts?.watch === true })
 
   return { ok: true }
 })

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -88,6 +88,15 @@ test('buildSessionWindowUrl adds the watch flag for spectator windows, before th
   assert.equal(url, 'http://localhost:5173/?win=secondary&watch=1#/abc')
 })
 
+test('buildSessionWindowUrl carries an encoded profile before the hash route', () => {
+  const url = buildSessionWindowUrl('abc', {
+    devServer: 'http://localhost:5173',
+    profile: 'profile with spaces'
+  })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary&profile=profile+with+spaces#/abc')
+})
+
 test('instanceWindowBounds cascades a new window off its source bounds', () => {
   const bounds = instanceWindowBounds({ x: 100, y: 120, width: 1400, height: 900 }, { width: 1, height: 1 })
 
@@ -118,6 +127,63 @@ test('registry opens one window per session and focuses on re-open', () => {
   assert.equal(first, second)
   assert.equal(registry.size, 1)
   assert.equal(win.calls.focus, 1, 'second open focuses the existing window')
+})
+
+test('registry distinguishes the same session id in different profiles', () => {
+  const registry = createSessionWindowRegistry()
+  const first = makeFakeWindow()
+  const second = makeFakeWindow()
+  let built = 0
+
+  registry.openOrFocus(
+    's1',
+    () => {
+      built += 1
+
+      return first
+    },
+    'profile-a'
+  )
+  registry.openOrFocus(
+    's1',
+    () => {
+      built += 1
+
+      return second
+    },
+    'profile-b'
+  )
+
+  const reopened = registry.openOrFocus(
+    's1',
+    () => {
+      built += 1
+
+      return makeFakeWindow()
+    },
+    'profile-a'
+  )
+
+  assert.equal(built, 2)
+  assert.equal(registry.size, 2)
+  assert.equal(reopened, first)
+  assert.equal(first.calls.focus, 1)
+  assert.equal(second.calls.focus, 0)
+})
+
+test('registry identity cannot collide through an in-band session-id delimiter', () => {
+  const registry = createSessionWindowRegistry()
+  const unprofiled = makeFakeWindow()
+  const profiled = makeFakeWindow()
+
+  registry.openOrFocus('work\0same', () => unprofiled)
+  registry.openOrFocus('same', () => profiled, 'work')
+
+  assert.equal(registry.size, 2)
+  assert.equal(registry.get('work\0same'), unprofiled)
+  assert.equal(registry.get('same', 'work'), profiled)
+  assert.equal(unprofiled.calls.focus, 0)
+  assert.equal(profiled.calls.focus, 0)
 })
 
 test('registry restores + shows a minimized/hidden window on re-open', () => {

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -51,9 +51,20 @@ function chatWindowWebPreferences(preloadPath: string) {
 // renderer reads the flag from window.location.search to suppress the install /
 // onboarding overlays and the global session sidebar. `watch=1` marks a
 // spectator window (e.g. a running subagent's session): the renderer resumes it
-// lazily so the gateway never builds an agent just to stream into it.
-function buildSessionWindowUrl(sessionId: string, { devServer, rendererIndexPath, watch }: any = {}) {
-  const query = `?win=secondary${watch ? '&watch=1' : ''}`
+// lazily so the gateway never builds an agent just to stream into it. `profile`
+// binds the otherwise non-global stored id to the database that owns it.
+function buildSessionWindowUrl(sessionId: string, { devServer, profile, rendererIndexPath, watch }: any = {}) {
+  const params = new URLSearchParams({ win: 'secondary' })
+
+  if (watch) {
+    params.set('watch', '1')
+  }
+
+  if (typeof profile === 'string' && profile.trim()) {
+    params.set('profile', profile.trim())
+  }
+
+  const query = `?${params.toString()}`
   const route = `#/${encodeURIComponent(sessionId)}`
 
   if (devServer) {
@@ -87,20 +98,26 @@ function instanceWindowBounds(base: { x: number; y: number; width: number; heigh
   }
 }
 
-// A small registry keyed by sessionId that guarantees one window per chat:
-// opening a session that already has a live window focuses it instead of
-// spawning a duplicate, and a window removes itself from the registry when it
-// closes. The actual BrowserWindow construction is injected (the `factory`) so
-// this module stays free of Electron and is unit-testable.
+// A small registry keyed by profile + sessionId that guarantees one window per
+// chat identity: reopening the same identity focuses it, while an equal id from
+// another profile gets its own window. A window removes itself from the registry
+// when it closes. BrowserWindow construction is injected (`factory`) so this
+// module stays free of Electron and is unit-testable.
 function createSessionWindowRegistry() {
   const windows = new Map()
 
-  function openOrFocus(sessionId, factory) {
-    const key = typeof sessionId === 'string' ? sessionId.trim() : ''
+  const identityKey = (sessionId, profile) =>
+    JSON.stringify([typeof profile === 'string' ? profile.trim() || null : null, sessionId])
 
-    if (!key) {
+  function openOrFocus(sessionId, factory, profile = undefined) {
+    const normalizedSessionId = typeof sessionId === 'string' ? sessionId.trim() : ''
+    const normalizedProfile = typeof profile === 'string' ? profile.trim() : ''
+
+    if (!normalizedSessionId) {
       return null
     }
+
+    const key = identityKey(normalizedSessionId, normalizedProfile)
 
     const existing = windows.get(key)
 
@@ -119,7 +136,7 @@ function createSessionWindowRegistry() {
       return existing
     }
 
-    const win = factory(key)
+    const win = factory(normalizedSessionId)
 
     if (!win) {
       return null
@@ -139,8 +156,8 @@ function createSessionWindowRegistry() {
 
   return {
     openOrFocus,
-    get: key => windows.get(key),
-    has: key => windows.has(key),
+    get: (sessionId, profile = undefined) => windows.get(identityKey(sessionId, profile)),
+    has: (sessionId, profile = undefined) => windows.has(identityKey(sessionId, profile)),
     get size() {
       return windows.size
     }

--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -97,7 +97,7 @@ describe('session drop targeting across stacked tabs', () => {
 
     dragTo(row, 980, 400)
 
-    expect(openSessionTile).toHaveBeenCalledWith('dragged', 'right', 'session-tile:visible', undefined)
+    expect(openSessionTile).toHaveBeenCalledWith('dragged', 'right', 'session-tile:visible', undefined, 'default')
     expect(requestComposerInsertRefs).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -184,7 +184,7 @@ export function startSessionDrag(
 
     onCommit() {
       if (split) {
-        openSessionTile(payload.id, split.pos, split.anchor, split.before)
+        openSessionTile(payload.id, split.pos, split.anchor, split.before, payload.profile)
         // A tile for this session may already exist (openSessionTile is
         // idempotent — e.g. persisted from an earlier run): a drop must never
         // feel dead, so front/unhide/un-dismiss it either way.

--- a/apps/desktop/src/app/chat/session-tile-row.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-row.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { $sessions } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
+import { tileOwnerProfile } from './session-tile'
 import { listTileSessionRow } from './session-tile-actions'
 
 const STORED = 'stored-tab'
@@ -41,8 +43,20 @@ function seed(preview: string, sessions: SessionInfo[] = $sessions.get()) {
 }
 
 describe('listTileSessionRow', () => {
-  beforeEach(() => $sessions.set([]))
-  afterEach(() => $sessions.set([]))
+  beforeEach(() => {
+    $sessions.set([])
+    $sessionTiles.set([])
+  })
+  afterEach(() => {
+    $sessions.set([])
+    $sessionTiles.set([])
+  })
+
+  it('keeps the persisted owner after the session row ages out of bounded caches', () => {
+    $sessionTiles.set([{ profile: 'medical', storedSessionId: STORED }])
+
+    expect(tileOwnerProfile(STORED)).toBe('medical')
+  })
 
   it("lists an unlisted ⌘T tab from the user's first message", () => {
     expect(seed('fix the tab titles')).toBe(true)

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -50,8 +50,10 @@ import {
   $sessionStates,
   $sessionTiles,
   closeSessionTile,
-  discardSessionTile,
+  discardSessionTileAt,
+  locateSessionTile,
   patchSessionTile,
+  patchSessionTileAt,
   type SessionTile,
   sessionTileDelegate
 } from '@/store/session-states'
@@ -117,6 +119,7 @@ function TileChat({
   const queryClient = useQueryClient()
   const { selectModel } = useModelControls({ queryClient, requestGateway })
   const activeGatewayProfile = useStore($activeGatewayProfile)
+  const tileProfile = useTileMenuRow(storedSessionId).profile
   const cwd = useStore(view.$cwd)
   const gatewayOpen = useStore($gatewayState) === 'open'
 
@@ -185,7 +188,9 @@ function TileChat({
           onSubmit={actions.submitText}
           onThreadMessagesChange={actions.handleThreadMessagesChange}
           onToggleSelectedPin={() => undefined}
-          onTranscribeAudio={async audio => (await transcribeAudio(await blobToDataUrl(audio), audio.type)).transcript}
+          onTranscribeAudio={async audio =>
+            (await transcribeAudio(await blobToDataUrl(audio), audio.type, tileProfile)).transcript
+          }
         />
       </ComposerScopeProvider>
     </SessionViewProvider>
@@ -197,7 +202,8 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const tile = tiles.find(t => t.storedSessionId === storedSessionId)
   const runtimeId = tile?.runtimeId ?? null
   const gatewayOpen = useStore($gatewayState) === 'open'
-  const resumingRef = useRef(false)
+  const resumeAttemptsRef = useRef(new Map<string, Promise<{ profile?: string; runtimeId: string }>>())
+  const tileBucketProfile = locateSessionTile(storedSessionId)?.bucketProfile
   const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
 
   // A tab-strip "+"/⌘T tab is created UNLISTED — its session stays out of
@@ -251,39 +257,65 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   // session.resume before the gateway is OPEN. Persisted tiles mount at boot
   // while it's still connecting — an ungated resume rejected there and
   // latched every restored tile into the error card.
-  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (!gatewayOpen || runtimeId || tile?.error || resumingRef.current) {
+    if (!gatewayOpen || runtimeId || tile?.error) {
       return
     }
 
     const delegate = sessionTileDelegate()
+    const location = locateSessionTile(storedSessionId)
 
-    if (!delegate) {
+    if (!delegate || !location) {
       return
     }
 
-    resumingRef.current = true
+    const attemptKey = `${location.bucketProfile}\u0000${location.profile ?? ''}\u0000${storedSessionId}`
+    const existingAttempt = resumeAttemptsRef.current.get(attemptKey)
+    const attempt = existingAttempt ?? delegate.resumeTile(storedSessionId, tile?.profile)
 
-    delegate
-      .resumeTile(storedSessionId)
-      .then(id => patchSessionTile(storedSessionId, { error: undefined, runtimeId: id }))
+    if (!existingAttempt) {
+      resumeAttemptsRef.current.set(attemptKey, attempt)
+    }
+
+    // React may reuse this pane when two profile buckets contain the same
+    // stored id. Each effect subscribes to the bucket-stable attempt, while
+    // cleanup prevents a completion from an unmounted/switched incarnation
+    // from mutating a later tile with that id. Strict-mode effect replay
+    // reuses the same promise instead of issuing a duplicate resume.
+    let active = true
+
+    void attempt
+      .then(({ profile, runtimeId: id }) => {
+        if (active) {
+          patchSessionTileAt(location, { error: undefined, profile, runtimeId: id })
+        }
+      })
       .catch((err: unknown) => {
+        if (!active) {
+          return
+        }
+
         const message = err instanceof Error ? err.message : String(err)
 
         // A gone session (404 / "Session not found") is terminal — a stale or
         // cross-profile persisted tile. Discard it instead of latching an error
         // that re-retries on every reconnect (the "Session not found" spam).
         if (/session not found|\b404\b/i.test(message)) {
-          discardSessionTile(storedSessionId)
+          discardSessionTileAt(location)
         } else {
-          patchSessionTile(storedSessionId, { error: message })
+          patchSessionTileAt(location, { error: message })
         }
       })
       .finally(() => {
-        resumingRef.current = false
+        if (resumeAttemptsRef.current.get(attemptKey) === attempt) {
+          resumeAttemptsRef.current.delete(attemptKey)
+        }
       })
-  }, [gatewayOpen, runtimeId, storedSessionId, tile?.error])
+
+    return () => {
+      active = false
+    }
+  }, [gatewayOpen, runtimeId, storedSessionId, tile?.error, tile?.profile, tileBucketProfile])
 
   // The gateway (re)opening invalidates any latched error — it likely came
   // from a not-yet-open gateway or the previous connection. Clearing it
@@ -344,6 +376,15 @@ export function tileStoredRow(storedSessionId: string): SessionInfo | undefined 
   )
 }
 
+/** Durable profile owner for backend routing. Prefer the persisted tile field;
+ *  bounded session/project caches are presentation fallbacks only. */
+export function tileOwnerProfile(storedSessionId: string): string | undefined {
+  return (
+    $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.profile ??
+    tileStoredRow(storedSessionId)?.profile
+  )
+}
+
 function tileTitle(storedSessionId: string): string {
   const stored = tileStoredRow(storedSessionId)
 
@@ -356,7 +397,7 @@ function tileTitle(storedSessionId: string): string {
 function tileDragPayload(storedSessionId: string): SessionDragPayload {
   const stored = tileStoredRow(storedSessionId)
 
-  return { id: storedSessionId, profile: stored?.profile ?? '', title: tileTitle(storedSessionId) }
+  return { id: storedSessionId, profile: tileOwnerProfile(storedSessionId) ?? '', title: tileTitle(storedSessionId) }
 }
 
 // ---------------------------------------------------------------------------
@@ -434,10 +475,12 @@ function useTileMenuRow(storedSessionId: string): { pinId: string; profile?: str
   const subscribe = useCallback((onChange: () => void) => {
     const offSessions = $sessions.listen(onChange)
     const offTree = $projectTree.listen(onChange)
+    const offTiles = $sessionTiles.listen(onChange)
 
     return () => {
       offSessions()
       offTree()
+      offTiles()
     }
   }, [])
 
@@ -445,7 +488,7 @@ function useTileMenuRow(storedSessionId: string): { pinId: string; profile?: str
     const stored = tileStoredRow(storedSessionId)
     const pinId = stored ? sessionPinId(stored) : storedSessionId
     const title = tileTitle(storedSessionId)
-    const profile = stored?.profile
+    const profile = tileOwnerProfile(storedSessionId)
     const key = `${pinId}\u0000${title}\u0000${profile ?? ''}`
 
     if (cache.current?.key !== key) {
@@ -484,10 +527,10 @@ export function SessionTabMenu({
   return (
     <span className="contents" onContextMenu={event => event.stopPropagation()}>
       <SessionContextMenu
-        onArchive={() => void sessionTileDelegate()?.archiveSession(storedSessionId)}
-        onBranch={() => void sessionTileDelegate()?.branchSession(storedSessionId)}
+        onArchive={() => void sessionTileDelegate()?.archiveSession(storedSessionId, profile)}
+        onBranch={() => void sessionTileDelegate()?.branchSession(storedSessionId, profile)}
         onClose={onClose}
-        onDelete={() => void sessionTileDelegate()?.deleteSession(storedSessionId)}
+        onDelete={() => void sessionTileDelegate()?.deleteSession(storedSessionId, profile)}
         onHideTabBar={onHideTabBar}
         onPin={() => (pinned ? unpinSession(pinId) : pinSession(pinId))}
         pinned={pinned}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -172,7 +172,7 @@ function useSessionActions({
               // Stack into the MAIN zone as a tab (center dock; the strip
               // sticky-shows on gain) — the door to the tab bar. Focuses first
               // if the session is already on screen.
-              openSession(sessionId, () => undefined, 'tab')
+              openSession(sessionId, () => undefined, 'tab', profile)
             }
           })
         ]
@@ -185,7 +185,7 @@ function useSessionActions({
             label: r.newWindow,
             onSelect: () => {
               triggerHaptic('selection')
-              openSession(sessionId, () => undefined, 'window')
+              openSession(sessionId, () => undefined, 'window', profile)
             }
           })
         ]

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -175,7 +175,7 @@ function SidebarSessionRowImpl({
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
-              openSession(session.id, () => undefined, 'tab')
+              openSession(session.id, () => undefined, 'tab', session.profile)
             }
           }}
           onClick={event => {
@@ -186,7 +186,7 @@ function SidebarSessionRowImpl({
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
-              openSession(session.id, () => undefined, 'window')
+              openSession(session.id, () => undefined, 'window', session.profile)
 
               return
             }
@@ -196,7 +196,7 @@ function SidebarSessionRowImpl({
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
-              openSession(session.id, () => undefined, 'tab')
+              openSession(session.id, () => undefined, 'tab', session.profile)
 
               return
             }

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -79,7 +79,7 @@ export function useQuickEntryBridge({ startFreshSessionDraft, submitText }: Quic
         if (delegate) {
           void delegate
             .resumeTile(target)
-            .then(runtimeId => delegate.submitToSession(runtimeId, text))
+            .then(({ runtimeId }) => delegate.submitToSession(runtimeId, text))
             // A dead/undeliverable target must not swallow the prompt.
             .catch(() => void submitTextRef.current(text))
 

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -2,18 +2,39 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HermesModule from '@/hermes'
-import { setSessions } from '@/store/session'
-import { sessionTileDelegate } from '@/store/session-states'
-import type { SessionInfo } from '@/types/hermes'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $selectedStoredSessionId, setSessions } from '@/store/session'
+import {
+  $sessionTiles,
+  closeSessionTile,
+  discardSessionTile,
+  locateSessionTile,
+  openSessionTile,
+  patchSessionTile,
+  patchSessionTileAt,
+  sessionTileDelegate
+} from '@/store/session-states'
+import type { SessionInfo, SessionResumeResponse } from '@/types/hermes'
 
 import { useSessionTileDelegate } from './use-session-tile-delegate'
 
 vi.mock('@/hermes', async importActual => ({
   ...(await importActual<typeof HermesModule>()),
+  getSession: vi.fn(),
   getSessionMessages: vi.fn(async () => ({ messages: [], session_id: '' }))
 }))
 
-const { getSessionMessages } = await import('@/hermes')
+const { getSession, getSessionMessages } = await import('@/hermes')
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
 
 const row = (over: Partial<SessionInfo>): SessionInfo =>
   ({
@@ -50,12 +71,19 @@ function renderTile(requestGateway: ReturnType<typeof vi.fn>) {
 
 describe('useSessionTileDelegate resumeTile', () => {
   beforeEach(() => {
+    $activeGatewayProfile.set('default')
+    $selectedStoredSessionId.set(null)
     setSessions([])
+    $sessionTiles.set([])
+    vi.mocked(getSession).mockReset()
     vi.mocked(getSessionMessages).mockClear()
   })
 
   afterEach(() => {
+    $activeGatewayProfile.set('default')
+    $selectedStoredSessionId.set(null)
     setSessions([])
+    $sessionTiles.set([])
   })
 
   it('carries the owning profile into a cold tile resume so it cannot fork profiles', async () => {
@@ -64,21 +92,27 @@ describe('useSessionTileDelegate resumeTile', () => {
     // conversation into the wrong profile (#67603). The owning profile must ride
     // both the transcript prefetch and the resume RPC.
     setSessions([row({ id: 'stored-x', profile: 'ai-engineer' })])
+    $sessionTiles.set([{ storedSessionId: 'stored-x' }])
 
     const requestGateway = vi.fn(async (method: string) =>
       method === 'session.resume' ? ({ session_id: 'runtime-1' } as never) : ({} as never)
     )
 
     renderTile(requestGateway)
-    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-x')
+    const location = locateSessionTile('stored-x')!
+    const resumed = await sessionTileDelegate()!.resumeTile('stored-x')
+    patchSessionTileAt(location, { profile: resumed.profile, runtimeId: resumed.runtimeId })
 
-    expect(runtimeId).toBe('runtime-1')
+    expect(resumed).toEqual({ profile: 'ai-engineer', runtimeId: 'runtime-1' })
     expect(getSessionMessages).toHaveBeenCalledWith('stored-x', 'ai-engineer')
     expect(requestGateway).toHaveBeenCalledWith('session.resume', {
       session_id: 'stored-x',
       cols: 96,
       profile: 'ai-engineer'
     })
+    expect($sessionTiles.get()).toContainEqual(
+      expect.objectContaining({ profile: 'ai-engineer', storedSessionId: 'stored-x' })
+    )
   })
 
   it('resolves and carries a default-profile session explicitly', async () => {
@@ -96,5 +130,165 @@ describe('useSessionTileDelegate resumeTile', () => {
       cols: 96,
       profile: 'default'
     })
+  })
+
+  it('does not reuse an id-only warm runtime when the tile has an explicit owner', async () => {
+    const storedSessionId = 'same-id'
+    $sessionTiles.set([{ profile: 'profile-b', storedSessionId }])
+
+    const requestGateway = vi.fn(async (method: string) =>
+      method === 'session.resume' ? ({ session_id: 'runtime-b' } as never) : ({} as never)
+    )
+
+    renderHook(() =>
+      useSessionTileDelegate({
+        archiveSession: vi.fn(async () => undefined),
+        branchStoredSession: vi.fn(async () => undefined),
+        executeSlashCommand: vi.fn(async () => undefined) as never,
+        removeSession: vi.fn(async () => undefined),
+        requestGateway: requestGateway as never,
+        runtimeIdByStoredSessionIdRef: { current: new Map([[storedSessionId, 'runtime-a']]) },
+        sessionStateByRuntimeIdRef: {
+          current: new Map([['runtime-a', { messages: [], storedSessionId } as never]])
+        },
+        updateSessionState: vi.fn()
+      })
+    )
+
+    expect(await sessionTileDelegate()!.resumeTile(storedSessionId, 'profile-b')).toEqual({
+      profile: 'profile-b',
+      runtimeId: 'runtime-b'
+    })
+    expect(getSessionMessages).toHaveBeenCalledWith(storedSessionId, 'profile-b')
+    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
+      session_id: storedSessionId,
+      cols: 96,
+      profile: 'profile-b'
+    })
+  })
+
+  it('rejects a stale resume after an equal-id tile changes owners', async () => {
+    const storedSessionId = 'retargeted-same-id'
+    $sessionTiles.set([{ profile: 'profile-a', storedSessionId }])
+    const location = locateSessionTile(storedSessionId)!
+    const resume = deferred<SessionResumeResponse>()
+
+    const requestGateway = vi.fn((method: string) =>
+      method === 'session.resume' ? resume.promise : Promise.resolve({})
+    )
+
+    renderTile(requestGateway)
+    const pending = sessionTileDelegate()!.resumeTile(storedSessionId, 'profile-a')
+
+    openSessionTile(storedSessionId, 'right', undefined, undefined, 'profile-b')
+    resume.resolve({ session_id: 'runtime-a' } as SessionResumeResponse)
+    const stale = await pending
+
+    expect(patchSessionTileAt(location, { profile: stale.profile, runtimeId: stale.runtimeId })).toBe(false)
+    expect($sessionTiles.get()).toContainEqual(
+      expect.objectContaining({ profile: 'profile-b', runtimeId: undefined, storedSessionId })
+    )
+  })
+
+  it('forwards the durable owner to destructive tile actions', async () => {
+    const archiveSession = vi.fn(async () => undefined)
+    const branchStoredSession = vi.fn(async () => undefined)
+    const removeSession = vi.fn(async () => undefined)
+
+    renderHook(() =>
+      useSessionTileDelegate({
+        archiveSession,
+        branchStoredSession,
+        executeSlashCommand: vi.fn(async () => undefined) as never,
+        removeSession,
+        requestGateway: vi.fn() as never,
+        runtimeIdByStoredSessionIdRef: { current: new Map() },
+        sessionStateByRuntimeIdRef: { current: new Map() },
+        updateSessionState: vi.fn()
+      })
+    )
+
+    await sessionTileDelegate()!.archiveSession('same-id', 'profile-b')
+    await sessionTileDelegate()!.branchSession('same-id', 'profile-b')
+    await sessionTileDelegate()!.deleteSession('same-id', 'profile-b')
+
+    expect(archiveSession).toHaveBeenCalledWith('same-id', 'profile-b')
+    expect(branchStoredSession).toHaveBeenCalledWith('same-id', 'profile-b')
+    expect(removeSession).toHaveBeenCalledWith('same-id', 'profile-b')
+  })
+
+  it('backfills the origin bucket after a profile switch without touching a duplicate id', async () => {
+    const storedSessionId = 'duplicate-across-profile-buckets'
+    const originBucket = 'resume-race-origin'
+    const activeBucket = 'resume-race-active'
+
+    $activeGatewayProfile.set(originBucket)
+    openSessionTile(storedSessionId, 'right', undefined, undefined, originBucket)
+    // Simulate an older v2 record whose bucket is known but owner was not yet
+    // persisted.
+    patchSessionTile(storedSessionId, { profile: undefined })
+
+    $activeGatewayProfile.set(activeBucket)
+    openSessionTile(storedSessionId, 'right', undefined, undefined, 'other-owner')
+    $activeGatewayProfile.set(originBucket)
+
+    const lookup = deferred<SessionInfo>()
+    vi.mocked(getSession).mockReturnValueOnce(lookup.promise)
+
+    const requestGateway = vi.fn(async (method: string) =>
+      method === 'session.resume' ? ({ session_id: 'runtime-origin' } as never) : ({} as never)
+    )
+
+    renderTile(requestGateway)
+    const location = locateSessionTile(storedSessionId)!
+    const pending = sessionTileDelegate()!.resumeTile(storedSessionId)
+
+    // Settle profile discovery only after the visible bucket has changed.
+    $activeGatewayProfile.set(activeBucket)
+    lookup.resolve(row({ id: storedSessionId, profile: 'resolved-owner' }))
+    const resumed = await pending
+    patchSessionTileAt(location, { profile: resumed.profile, runtimeId: resumed.runtimeId })
+
+    expect($sessionTiles.get()).toEqual([expect.objectContaining({ profile: 'other-owner', storedSessionId })])
+
+    $activeGatewayProfile.set(originBucket)
+    expect($sessionTiles.get()).toEqual([expect.objectContaining({ profile: 'resolved-owner', storedSessionId })])
+
+    discardSessionTile(storedSessionId)
+    $activeGatewayProfile.set(activeBucket)
+    discardSessionTile(storedSessionId)
+  })
+
+  it('does not resurrect a tile closed while profile resolution is pending', async () => {
+    const storedSessionId = 'closed-during-profile-resolution'
+    const originBucket = 'resume-race-closed'
+
+    $activeGatewayProfile.set(originBucket)
+    openSessionTile(storedSessionId, 'right', undefined, undefined, originBucket)
+    patchSessionTile(storedSessionId, { profile: undefined })
+
+    const lookup = deferred<SessionInfo>()
+    vi.mocked(getSession).mockReturnValueOnce(lookup.promise)
+
+    const requestGateway = vi.fn(async (method: string) =>
+      method === 'session.resume' ? ({ session_id: 'runtime-closed' } as never) : ({} as never)
+    )
+
+    renderTile(requestGateway)
+    const location = locateSessionTile(storedSessionId)!
+    const pending = sessionTileDelegate()!.resumeTile(storedSessionId)
+
+    closeSessionTile(storedSessionId)
+    lookup.resolve(row({ id: storedSessionId, profile: 'resolved-owner' }))
+    const resumed = await pending
+    patchSessionTileAt(location, { profile: resumed.profile, runtimeId: resumed.runtimeId })
+
+    expect($sessionTiles.get()).toEqual([])
+
+    // Switching away and back hydrates from the persisted bucket map. The
+    // absent tile proves the delayed backfill did not recreate it there.
+    $activeGatewayProfile.set('default')
+    $activeGatewayProfile.set(originBucket)
+    expect($sessionTiles.get()).toEqual([])
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 
 import { getSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
-import { publishSessionState, setSessionTileDelegate } from '@/store/session-states'
+import { locateSessionTile, publishSessionState, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
@@ -13,10 +13,10 @@ import type { GatewayRequester } from '../types'
 type SessionStateCache = ReturnType<typeof useSessionStateCache>
 
 interface SessionTileDelegateParams {
-  archiveSession: (storedSessionId: string) => Promise<unknown>
-  branchStoredSession: (storedSessionId: string) => Promise<unknown>
+  archiveSession: (storedSessionId: string, profile?: string) => Promise<unknown>
+  branchStoredSession: (storedSessionId: string, profile?: string) => Promise<unknown>
   executeSlashCommand: ReturnType<typeof usePromptActions>['executeSlashCommand']
-  removeSession: (storedSessionId: string) => Promise<unknown>
+  removeSession: (storedSessionId: string, profile?: string) => Promise<unknown>
   requestGateway: GatewayRequester
   runtimeIdByStoredSessionIdRef: SessionStateCache['runtimeIdByStoredSessionIdRef']
   sessionStateByRuntimeIdRef: SessionStateCache['sessionStateByRuntimeIdRef']
@@ -42,14 +42,14 @@ export function useSessionTileDelegate({
 }: SessionTileDelegateParams): void {
   useEffect(() => {
     setSessionTileDelegate({
-      archiveSession: async storedSessionId => {
-        await archiveSession(storedSessionId)
+      archiveSession: async (storedSessionId, profile) => {
+        await archiveSession(storedSessionId, profile)
       },
-      branchSession: async storedSessionId => {
-        await branchStoredSession(storedSessionId)
+      branchSession: async (storedSessionId, profile) => {
+        await branchStoredSession(storedSessionId, profile)
       },
-      deleteSession: async storedSessionId => {
-        await removeSession(storedSessionId)
+      deleteSession: async (storedSessionId, profile) => {
+        await removeSession(storedSessionId, profile)
       },
       executeSlash: async (rawCommand, sessionId) => {
         await executeSlashCommand(rawCommand, { sessionId })
@@ -57,14 +57,27 @@ export function useSessionTileDelegate({
       interruptSession: async runtimeId => {
         await requestGateway('session.interrupt', { session_id: runtimeId })
       },
-      resumeTile: async storedSessionId => {
-        const existing = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+      resumeTile: async (storedSessionId, ownerProfile) => {
+        // Capture the visible tile's persistence bucket before the first await.
+        // Profile switches replace `$sessionTiles`, and stored ids can collide
+        // across buckets, so delayed owner backfills must not use the bucket
+        // that happens to be active when resolution finishes.
+        const tileLocation = locateSessionTile(storedSessionId)
+        const explicitProfile = ownerProfile?.trim()
+
+        // A quick-entry target has no durable tile identity, so retain the
+        // existing warm shortcut there. A tile does: even a legacy ownerless
+        // tile must resolve its profile before trusting an id-only cache,
+        // because stored ids can collide across independent profile DBs.
+        const existing =
+          !tileLocation && !explicitProfile ? runtimeIdByStoredSessionIdRef.current.get(storedSessionId) : undefined
+
         const cached = existing ? sessionStateByRuntimeIdRef.current.get(existing) : undefined
 
         if (existing && cached?.storedSessionId === storedSessionId) {
           publishSessionState(existing, cached)
 
-          return existing
+          return { runtimeId: existing }
         }
 
         // Resolve the owning profile before binding a runtime. A tile can open a
@@ -72,8 +85,12 @@ export function useSessionTileDelegate({
         // reading messages) without a profile lets the gateway fall back to the
         // launch-profile DB and fork the conversation into the wrong profile —
         // the same cross-profile bleed the recovery resumes had (#67603).
-        const profile = await resolveSessionProfile(storedSessionId)
+        const profile = explicitProfile || (await resolveSessionProfile(storedSessionId))
 
+        // Older v2 tile records predate durable ownership. Return the resolved
+        // owner with the runtime so SessionTilePane can publish both in one
+        // bucket/owner compare-and-set. That atomic handoff prevents a delayed
+        // resume from rebinding a same-id tile retargeted to another profile.
         const [prefetch, resumed] = await Promise.all([
           getSessionMessages(storedSessionId, profile).catch(() => null),
           requestGateway<SessionResumeResponse>('session.resume', {
@@ -100,7 +117,7 @@ export function useSessionTileDelegate({
           storedSessionId
         )
 
-        return runtimeId
+        return { profile: profile || undefined, runtimeId }
       },
       submitToSession: async (runtimeId, text) => {
         await requestGateway('prompt.submit', { session_id: runtimeId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -65,7 +65,7 @@ import {
 } from '@/store/session'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord } from '@/store/wake-word'
-import { isSecondaryWindow } from '@/store/windows'
+import { isSecondaryWindow, secondaryWindowProfile } from '@/store/windows'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
 import { requestComposerInsert } from '../chat/composer/focus'
@@ -863,7 +863,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     // Already on screen (open tile, or the main session)? Jump to its tab;
     // otherwise load it into main. Same door every other session link uses.
     onResumeSession: sessionId => openSession(sessionId, navigate),
-    onRetryResume: sessionId => void resumeSession(sessionId, true),
+    onRetryResume: sessionId => {
+      const profile = secondaryWindowProfile()
+
+      void (profile ? resumeSession(sessionId, true, profile) : resumeSession(sessionId, true))
+    },
     onSteer: steerPrompt,
     onSubmit: submitText,
     onThreadMessagesChange: handleThreadMessagesChange,

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -120,6 +120,14 @@ describe('openSession', () => {
     expect(navigate).toHaveBeenCalledWith('/c/s1')
   })
 
+  it('keeps an explicit owner in a tile instead of losing it in an id-only route', () => {
+    focusOpenSession.mockReturnValue(null)
+    openSession('same-id', navigate, 'in-place', 'profile-b')
+
+    expect(openSessionTile).toHaveBeenCalledWith('same-id', 'center', undefined, undefined, 'profile-b')
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
   it('tab focuses an existing open session instead of stacking another', () => {
     focusOpenSession.mockReturnValue('tile')
     openSession('s1', navigate, 'tab')
@@ -133,6 +141,13 @@ describe('openSession', () => {
     openSession('s1', navigate, 'tab')
     expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
     expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('passes a known owner profile to a newly stacked tile', () => {
+    focusOpenSession.mockReturnValue(null)
+    openSession('s1', navigate, 'tab', 'work')
+    expect(focusOpenSession).toHaveBeenCalledWith('s1', 'work')
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center', undefined, undefined, 'work')
   })
 
   it('stack focuses a session that is already on screen', () => {
@@ -159,6 +174,15 @@ describe('openSession', () => {
     expect(reuseBlankDraftTile).toHaveBeenCalledWith('s1')
     expect(openSessionTile).not.toHaveBeenCalled()
     expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('keeps a known owner profile when stack reuses a blank draft tab', () => {
+    $selectedStoredSessionId.set('s0')
+    focusOpenSession.mockReturnValue(null)
+    reuseBlankDraftTile.mockReturnValue(true)
+    openSession('s1', navigate, 'stack', 'work')
+    expect(reuseBlankDraftTile).toHaveBeenCalledWith('s1', 'work')
+    expect(openSessionTile).not.toHaveBeenCalled()
   })
 
   it('stack prefers the session already on screen over a blank draft tab', () => {
@@ -188,6 +212,11 @@ describe('openSession', () => {
     openSession('s1', navigate, 'window')
     expect(openSessionInNewWindow).toHaveBeenCalledWith('s1')
     expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
+  it('keeps a known owner profile when opening a native window', () => {
+    openSession('s1', navigate, 'window', 'work')
+    expect(openSessionInNewWindow).toHaveBeenCalledWith('s1', { profile: 'work' })
   })
 
   it('window falls back to a tab when pop-out is unavailable', () => {

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -68,11 +68,15 @@ export function openSessionIntentFromModifiers(
 /**
  * @param navigate Required for `in-place` (route into main when not on screen).
  *   `tab` / `window` ignore it — pass a no-op when you don't have a router handle.
+ * @param ownerProfile Authoritative profile for a newly-created session tile.
+ *   Optional so same-profile callers and older references keep their existing
+ *   behavior; cross-profile surfaces should pass the owner they already know.
  */
 export function openSession(
   storedSessionId: string,
   navigate: OpenSessionNavigate,
-  intent: OpenSessionIntent = 'in-place'
+  intent: OpenSessionIntent = 'in-place',
+  ownerProfile?: string
 ): void {
   if (!storedSessionId) {
     return
@@ -82,7 +86,9 @@ export function openSession(
 
   if (resolved === 'window') {
     if (canOpenSessionWindow()) {
-      void openSessionInNewWindow(storedSessionId)
+      void (ownerProfile
+        ? openSessionInNewWindow(storedSessionId, { profile: ownerProfile })
+        : openSessionInNewWindow(storedSessionId))
 
       return
     }
@@ -106,18 +112,26 @@ export function openSession(
     // Already on screen? Front it. openSessionTile would no-op on main without
     // focusing, or try to relocate an existing tile — neither is right for a
     // soft "open beside" link.
-    if (focusOpenSession(storedSessionId)) {
+    if (ownerProfile ? focusOpenSession(storedSessionId, ownerProfile) : focusOpenSession(storedSessionId)) {
       return
     }
 
     // Nothing to jump to, but an open tab may still be an empty "New session" —
     // that's the tab the user would have typed into, so spend it rather than
     // stacking a second blank one beside it.
-    if (spendBlankDraft && reuseBlankDraftTile(storedSessionId)) {
+    const reusedBlankDraft =
+      spendBlankDraft &&
+      (ownerProfile ? reuseBlankDraftTile(storedSessionId, ownerProfile) : reuseBlankDraftTile(storedSessionId))
+
+    if (reusedBlankDraft) {
       return
     }
 
-    openSessionTile(storedSessionId, 'center')
+    if (ownerProfile) {
+      openSessionTile(storedSessionId, 'center', undefined, undefined, ownerProfile)
+    } else {
+      openSessionTile(storedSessionId, 'center')
+    }
 
     return
   }
@@ -126,7 +140,19 @@ export function openSession(
   // otherwise load it into main. From a full page (artifacts, skills, …) a
   // `'main'` hit still has to route back: fronting the workspace tab alone
   // leaves the page showing.
-  if (focusedSessionNeedsRoute(focusOpenSession(storedSessionId), $workspaceIsPage.get())) {
+  const focused = ownerProfile ? focusOpenSession(storedSessionId, ownerProfile) : focusOpenSession(storedSessionId)
+
+  if (focusedSessionNeedsRoute(focused, $workspaceIsPage.get())) {
+    // A plain route contains only the stored id. When the caller knows an
+    // explicit owner, navigating would discard the only disambiguator (and a
+    // same pathname would not even retrigger resume). Keep the identity intact
+    // by opening the profile-bound tile instead.
+    if (ownerProfile) {
+      openSessionTile(storedSessionId, 'center', undefined, undefined, ownerProfile)
+
+      return
+    }
+
     navigate(sessionRoute(storedSessionId))
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $resumeExhaustedSessionId, setResumeExhaustedSessionId } from '@/store/session'
 import { markSelectionRestore } from '@/store/session-states'
+import type * as WindowsModule from '@/store/windows'
+import { secondaryWindowProfile } from '@/store/windows'
 
 import { useRouteResume } from './use-route-resume'
 
@@ -11,6 +13,10 @@ import { useRouteResume } from './use-route-resume'
 // in the real store (covered by session-states.test.ts). Mock the module so the
 // store's side effects (persistence listeners) stay out of this harness.
 vi.mock('@/store/session-states', () => ({ markSelectionRestore: vi.fn() }))
+vi.mock('@/store/windows', async importActual => ({
+  ...(await importActual<typeof WindowsModule>()),
+  secondaryWindowProfile: vi.fn(() => undefined)
+}))
 
 interface HarnessProps {
   activeSessionId: null | string
@@ -20,7 +26,7 @@ interface HarnessProps {
   freshDraftReady: boolean
   gatewayState: string
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  resumeSession: (sessionId: string, focus: boolean, profile?: string) => Promise<unknown>
   resumeFailedSessionId?: null | string
   resumeExhaustedSessionId?: null | string
   routedSessionId: null | string
@@ -40,6 +46,7 @@ describe('useRouteResume', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    vi.mocked(secondaryWindowProfile).mockReturnValue(undefined)
   })
 
   it('does not re-resume the old session during a /:sid -> /new transition', () => {
@@ -198,6 +205,31 @@ describe('useRouteResume', () => {
     expect(resumeSession).toHaveBeenCalledWith('session-2', true)
   })
 
+  it('binds a secondary-window route to its explicit owner profile', () => {
+    vi.mocked(secondaryWindowProfile).mockReturnValue('profile-b')
+    const resumeSession = vi.fn(async () => undefined)
+
+    render(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={{ current: null }}
+        creatingSessionRef={{ current: false }}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/same-id"
+        resumeSession={resumeSession}
+        routedSessionId="same-id"
+        runtimeIdByStoredSessionIdRef={{ current: new Map() }}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={{ current: null }}
+        startFreshSessionDraft={vi.fn()}
+      />
+    )
+
+    expect(resumeSession).toHaveBeenCalledWith('same-id', true, 'profile-b')
+  })
+
   it('arms the boot-restore one-shot for the FIRST resume only (⌘R tab persistence)', () => {
     // Factory mocks survive restoreAllMocks — drop calls earlier tests made.
     vi.mocked(markSelectionRestore).mockClear()
@@ -311,6 +343,7 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     cleanup()
     vi.useRealTimers()
     vi.restoreAllMocks()
+    vi.mocked(secondaryWindowProfile).mockReturnValue(undefined)
     setResumeExhaustedSessionId(null)
   })
 
@@ -353,6 +386,19 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     vi.advanceTimersByTime(1_000)
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+  })
+
+  it('keeps the secondary-window owner on bounded retry', () => {
+    vi.useFakeTimers()
+    vi.mocked(secondaryWindowProfile).mockReturnValue('profile-b')
+    const resumeSession = vi.fn(async () => undefined)
+
+    render(<RouteResumeHarness {...strandedProps(resumeSession)} resumeFailedSessionId="session-1" />)
+    resumeSession.mockClear()
+
+    vi.advanceTimersByTime(1_000)
+
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, 'profile-b')
   })
 
   it('does NOT retry a failed session that is not the routed one', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -3,6 +3,7 @@ import { type MutableRefObject, useEffect, useRef } from 'react'
 import { isNewChatRoute } from '@/app/routes'
 import { setResumeExhaustedSessionId } from '@/store/session'
 import { markSelectionRestore } from '@/store/session-states'
+import { secondaryWindowProfile } from '@/store/windows'
 
 interface RouteResumeOptions {
   activeSessionId: string | null
@@ -12,7 +13,7 @@ interface RouteResumeOptions {
   freshDraftReady: boolean
   gatewayState: string | undefined
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  resumeSession: (sessionId: string, focus: boolean, profile?: string) => Promise<unknown>
   // Stored-session id whose most recent resume failed terminally (set by
   // useSessionActions, mirrored from $resumeFailedSessionId). While this equals
   // routedSessionId the window would otherwise latch on the loader forever, so
@@ -83,6 +84,7 @@ export function useRouteResume({
   selectedStoredSessionIdRef,
   startFreshSessionDraft
 }: RouteResumeOptions) {
+  const routeOwnerProfile = secondaryWindowProfile()
   const lastPathnameRef = useRef<string | null>(null)
   const seenGatewayStateRef = useRef(false)
   const wasGatewayOpenRef = useRef(false)
@@ -165,7 +167,9 @@ export function useRouteResume({
         }
 
         bootResumeRef.current = false
-        void resumeSession(routedSessionId, true)
+        void (routeOwnerProfile
+          ? resumeSession(routedSessionId, true, routeOwnerProfile)
+          : resumeSession(routedSessionId, true))
       }
 
       return
@@ -190,6 +194,7 @@ export function useRouteResume({
     gatewayState,
     locationPathname,
     resumeSession,
+    routeOwnerProfile,
     routedSessionId,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
@@ -288,7 +293,7 @@ export function useRouteResume({
       // having fired. A flapping backend could then hit MAX in a couple of
       // re-renders with far fewer than MAX real attempts. (Point 3)
       retryAttemptRef.current += 1
-      void resumeSession(sessionId, true)
+      void (routeOwnerProfile ? resumeSession(sessionId, true, routeOwnerProfile) : resumeSession(sessionId, true))
     }, resumeRetryDelayMs(attempt))
 
     return () => clearTimeout(timer)
@@ -300,6 +305,7 @@ export function useRouteResume({
     resumeSession,
     resumeFailedSessionId,
     resumeExhaustedSessionId,
+    routeOwnerProfile,
     routedSessionId,
     selectedStoredSessionIdRef
   ])

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -67,7 +67,13 @@ import {
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { isWatchWindow } from '@/store/windows'
-import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
+import type {
+  SessionCreateResponse,
+  SessionInfo,
+  SessionMessage,
+  SessionResumeResponse,
+  UsageStats
+} from '@/types/hermes'
 
 import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
@@ -131,6 +137,13 @@ function applyStoredUsage(stored: { input_tokens?: number | null; output_tokens?
   const output = stored.output_tokens || 0
 
   setCurrentUsage(current => ({ ...current, input, output, total: input + output }))
+}
+
+function sessionMatchesOwner(session: SessionInfo, storedSessionId: string, ownerProfile?: string): boolean {
+  return (
+    sessionMatchesStoredId(session, storedSessionId) &&
+    (!ownerProfile || normalizeProfileKey(session.profile) === normalizeProfileKey(ownerProfile))
+  )
 }
 
 function reconcileAuthoritativeMessages(
@@ -536,10 +549,15 @@ export function useSessionActions({
   }, [navigate, selectedStoredSessionId])
 
   const resumeSession = useCallback(
-    async (storedSessionId: string, replaceRoute = false) => {
+    async (storedSessionId: string, replaceRoute = false, ownerProfile?: string) => {
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
-      const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId
+      const explicitOwner = ownerProfile?.trim() ? normalizeProfileKey(ownerProfile) : null
+
+      const resumedSameSelectedSession =
+        selectedStoredSessionIdRef.current === storedSessionId &&
+        (!explicitOwner || normalizeProfileKey($activeGatewayProfile.get()) === explicitOwner)
+
       const resumeStartMessages = resumedSameSelectedSession ? $messages.get() : []
 
       const isCurrentResume = () =>
@@ -568,7 +586,15 @@ export function useSessionActions({
       // now-redundant tile so main owns it. Runs before the async awaits below (and
       // before the selection listener homes focus) so the tile is gone the same tick
       // the route takes over; the warm cache/runtime binding survives for main to reuse.
-      if ($sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
+      if (
+        $sessionTiles
+          .get()
+          .some(
+            tile =>
+              tile.storedSessionId === storedSessionId &&
+              (!explicitOwner || normalizeProfileKey(tile.profile) === explicitOwner)
+          )
+      ) {
         closeSessionTile(storedSessionId)
       }
 
@@ -592,6 +618,14 @@ export function useSessionActions({
       // mismatch the mapping is cross-wired: purge both sides and report a miss
       // so the caller falls through to a full resume that rebinds a correct id.
       const takeWarmCache = (): { runtimeId: string; state: ClientSessionState } | null => {
+        // The legacy reverse map is keyed only by stored id. An explicit owner
+        // (secondary window / profile-qualified route) makes an equal id from
+        // another profile distinguishable, so fail closed to a scoped resume
+        // rather than rendering an unverifiable warm runtime.
+        if (explicitOwner) {
+          return null
+        }
+
         const runtimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
         const state = runtimeId ? sessionStateByRuntimeIdRef.current.get(runtimeId) : undefined
 
@@ -623,8 +657,11 @@ export function useSessionActions({
       // gateway call (no-op when it's already on that profile / single-profile).
       // resolveStoredSession finds the row by id (cheap), so an uncached pasted
       // id loads as fast as a sidebar click instead of hanging on a list scan.
-      const storedForProfile = await resolveStoredSession(storedSessionId)
-      const sessionProfile = storedForProfile?.profile
+      const storedForProfile = explicitOwner
+        ? $sessions.get().find(session => sessionMatchesOwner(session, storedSessionId, explicitOwner))
+        : await resolveStoredSession(storedSessionId)
+
+      const sessionProfile = explicitOwner ?? storedForProfile?.profile
 
       if (resumeRequestRef.current !== requestId) {
         return
@@ -642,7 +679,8 @@ export function useSessionActions({
         const cachedState = warmHit.state
 
         const stored =
-          $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
+          $sessions.get().find(session => sessionMatchesOwner(session, storedSessionId, sessionProfile)) ??
+          storedForProfile
 
         let cachedViewState =
           !cachedState.model && stored?.model != null
@@ -829,7 +867,8 @@ export function useSessionActions({
       setSessionStartedAt(Date.now())
 
       const stored =
-        $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
+        $sessions.get().find(session => sessionMatchesOwner(session, storedSessionId, sessionProfile)) ??
+        storedForProfile
 
       applyStoredSessionPreviewRuntimeInfo(stored)
 
@@ -1193,7 +1232,7 @@ export function useSessionActions({
         // chat exactly where it is. Prime the tile with the create runtime so it
         // skips a redundant resume. Do NOT select it as the primary session
         // first — openSessionTile no-ops when the id is already primary.
-        openSessionTile(routedSessionId, 'center')
+        openSessionTile(routedSessionId, 'center', undefined, undefined, profile ?? undefined)
         patchSessionTile(routedSessionId, { runtimeId: branched.session_id })
         revealTreePane(`session-tile:${routedSessionId}`)
         broadcastSessionsChanged()
@@ -1272,7 +1311,7 @@ export function useSessionActions({
       // miss: resolve it (cache → active backend → cross-profile) so the branch
       // is created on the parent's OWNING profile, not whichever is live (#67603).
       const stored =
-        $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
+        $sessions.get().find(session => sessionMatchesOwner(session, storedSessionId, sessionProfile ?? undefined)) ??
         (sessionProfile ? undefined : await resolveStoredSession(storedSessionId))
 
       const profile = sessionProfile ?? stored?.profile
@@ -1299,11 +1338,16 @@ export function useSessionActions({
   )
 
   const removeSession = useCallback(
-    async (storedSessionId: string) => {
+    async (storedSessionId: string, ownerProfile?: string) => {
       clearNotifications()
 
-      const removed = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
-      const wasSelected = selectedStoredSessionId === storedSessionId
+      const removed = $sessions.get().find(session => sessionMatchesOwner(session, storedSessionId, ownerProfile))
+      const targetProfile = ownerProfile || removed?.profile
+
+      const selectedOwnerMatches =
+        !targetProfile || normalizeProfileKey($activeGatewayProfile.get()) === normalizeProfileKey(targetProfile)
+
+      const wasSelected = selectedStoredSessionId === storedSessionId && selectedOwnerMatches
       const closingRuntimeId = wasSelected ? activeSessionId : null
       const previousMessages = $messages.get()
       const previousPinned = $pinnedSessionIds.get()
@@ -1312,7 +1356,7 @@ export function useSessionActions({
       const removedPinId = removed ? sessionPinId(removed) : storedSessionId
       const removedIds = [storedSessionId, removed?.id, removed?._lineage_root_id]
 
-      setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      setSessions(prev => prev.filter(session => !sessionMatchesOwner(session, storedSessionId, targetProfile)))
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
       // row in lockstep. Pin the tombstone against the projects.tree prune while
@@ -1332,8 +1376,11 @@ export function useSessionActions({
           await requestGateway('session.close', { session_id: closingRuntimeId }).catch(() => undefined)
         }
 
-        await deleteSession(storedSessionId, removed?.profile)
-        clearQueuedPrompts(storedSessionId)
+        await deleteSession(storedSessionId, targetProfile)
+
+        if (!ownerProfile) {
+          clearQueuedPrompts(storedSessionId)
+        }
 
         if (closingRuntimeId) {
           clearQueuedPrompts(closingRuntimeId)
@@ -1342,17 +1389,35 @@ export function useSessionActions({
         // A tiled copy of this session must not outlive it: collapse the pane
         // and evict its mirrored runtime state so nothing submits to (or renders)
         // a deleted session.
-        const tiledRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
-        closeSessionTile(storedSessionId)
+        const targetTile = $sessionTiles
+          .get()
+          .find(
+            tile =>
+              tile.storedSessionId === storedSessionId &&
+              (!targetProfile || normalizeProfileKey(tile.profile) === normalizeProfileKey(targetProfile))
+          )
+
+        const tiledRuntimeId = targetTile?.runtimeId
+
+        if (targetTile) {
+          closeSessionTile(storedSessionId)
+        }
 
         if (tiledRuntimeId) {
-          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          if (runtimeIdByStoredSessionIdRef.current.get(storedSessionId) === tiledRuntimeId) {
+            runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          }
+
+          clearQueuedPrompts(tiledRuntimeId)
           sessionStateByRuntimeIdRef.current.delete(tiledRuntimeId)
           dropSessionState(tiledRuntimeId)
         }
       } catch (err) {
         if (removed) {
-          setSessions(prev => [removed, ...prev])
+          setSessions(prev => [
+            removed,
+            ...prev.filter(session => !sessionMatchesOwner(session, storedSessionId, targetProfile))
+          ])
         }
 
         untombstoneSessions(removedIds)
@@ -1400,11 +1465,16 @@ export function useSessionActions({
   )
 
   const archiveSession = useCallback(
-    async (storedSessionId: string) => {
+    async (storedSessionId: string, ownerProfile?: string) => {
       clearNotifications()
 
-      const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
-      const wasSelected = selectedStoredSessionId === storedSessionId
+      const archived = $sessions.get().find(session => sessionMatchesOwner(session, storedSessionId, ownerProfile))
+      const targetProfile = ownerProfile || archived?.profile
+
+      const selectedOwnerMatches =
+        !targetProfile || normalizeProfileKey($activeGatewayProfile.get()) === normalizeProfileKey(targetProfile)
+
+      const wasSelected = selectedStoredSessionId === storedSessionId && selectedOwnerMatches
       const previousPinned = $pinnedSessionIds.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
       // live tip after compression. Drop both so the pin can't linger.
@@ -1412,7 +1482,7 @@ export function useSessionActions({
       const archivedIds = [storedSessionId, archived?.id, archived?._lineage_root_id]
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
-      setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      setSessions(prev => prev.filter(session => !sessionMatchesOwner(session, storedSessionId, targetProfile)))
       tombstoneSessions(archivedIds)
       beginSessionMutation(archivedIds)
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
@@ -1422,13 +1492,28 @@ export function useSessionActions({
       }
 
       try {
-        await setSessionArchived(storedSessionId, true, archived?.profile)
+        await setSessionArchived(storedSessionId, true, targetProfile)
+
         // An archived session is hidden from the sidebar; its tile must go too.
-        const tiledRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
-        closeSessionTile(storedSessionId)
+        const targetTile = $sessionTiles
+          .get()
+          .find(
+            tile =>
+              tile.storedSessionId === storedSessionId &&
+              (!targetProfile || normalizeProfileKey(tile.profile) === normalizeProfileKey(targetProfile))
+          )
+
+        const tiledRuntimeId = targetTile?.runtimeId
+
+        if (targetTile) {
+          closeSessionTile(storedSessionId)
+        }
 
         if (tiledRuntimeId) {
-          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          if (runtimeIdByStoredSessionIdRef.current.get(storedSessionId) === tiledRuntimeId) {
+            runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          }
+
           sessionStateByRuntimeIdRef.current.delete(tiledRuntimeId)
           dropSessionState(tiledRuntimeId)
         }
@@ -1436,7 +1521,10 @@ export function useSessionActions({
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
       } catch (err) {
         if (archived) {
-          setSessions(prev => [archived, ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))])
+          setSessions(prev => [
+            archived,
+            ...prev.filter(session => !sessionMatchesOwner(session, storedSessionId, targetProfile))
+          ])
         }
 
         untombstoneSessions(archivedIds)

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -454,6 +454,12 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     enabled: 'Speech To Text',
     echoTranscripts: 'Echo Transcripts',
     provider: 'Speech-To-Text Provider',
+    recovery: {
+      enabled: 'Preserve Failed Recordings',
+      retentionHours: 'Recovery Retention',
+      maxEntries: 'Recovery Recording Limit',
+      maxTotalMb: 'Recovery Storage Limit'
+    },
     local: {
       model: 'Local Transcription Model',
       language: 'Transcription Language'
@@ -624,6 +630,13 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   stt: {
     enabled: 'Enable local or provider-backed speech transcription.',
     echoTranscripts: 'Post the raw 🎙️ transcript of voice messages back to the chat.',
+    recovery: {
+      enabled: 'Keep a private, bounded copy of desktop recordings only when transcription fails.',
+      retentionHours:
+        'Hours failed recordings remain recoverable. Files are pruned on the next Hermes cache access. Zero disables recovery.',
+      maxEntries: 'Maximum number of failed recordings retained per profile.',
+      maxTotalMb: 'Maximum storage in MiB for failed recordings per profile.'
+    },
     elevenlabs: {
       languageCode: 'Optional ISO-639-3 language code. Blank lets ElevenLabs auto-detect.'
     }
@@ -711,6 +724,10 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.enabled',
       'stt.echo_transcripts',
       'stt.provider',
+      'stt.recovery.enabled',
+      'stt.recovery.retention_hours',
+      'stt.recovery.max_entries',
+      'stt.recovery.max_total_mb',
       'voice.auto_tts',
       'tts.edge.voice',
       'tts.openai.model',

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -443,7 +443,7 @@ const DirectiveImage: FC<{ id: string; label: string }> = ({ id, label }) => {
  *  from under the chat you're reading). Lazy-imports so the composer's rich
  *  editor can pull this module in without booting the profile/REST stack. */
 function openSessionRef(value: string) {
-  const { sessionId } = parseSessionRefValue(value)
+  const { profile, sessionId } = parseSessionRefValue(value)
 
   if (!sessionId) {
     return
@@ -451,7 +451,7 @@ function openSessionRef(value: string) {
 
   triggerHaptic('selection')
   // navigate is unused for the `tab` intent (focus-or-tile only).
-  void import('@/app/open-session').then(({ openSession }) => openSession(sessionId, () => undefined, 'tab'))
+  void import('@/app/open-session').then(({ openSession }) => openSession(sessionId, () => undefined, 'tab', profile))
 }
 
 /** A `@session:<profile>/<id>` reference in the user transcript (directive

--- a/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
@@ -27,7 +27,9 @@ describe('session refs open the session', () => {
 
     fireEvent.click(await screen.findByTitle('work/20260101_abc123'))
 
-    await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab'))
+    await vi.waitFor(() =>
+      expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab', 'work')
+    )
   })
 
   it('opens the session from a chip in the user transcript', async () => {
@@ -38,6 +40,8 @@ describe('session refs open the session', () => {
     expect(chip.tagName).toBe('BUTTON')
     fireEvent.click(chip)
 
-    await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab'))
+    await vi.waitFor(() =>
+      expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab', 'work')
+    )
   })
 })

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -33,7 +33,10 @@ declare global {
       // with an error code when the sessionId is empty/invalid. `watch` opens
       // a spectator window (lazy resume — no agent build) for live-streaming
       // a running subagent's session.
-      openSessionWindow: (sessionId: string, opts?: { watch?: boolean }) => Promise<{ ok: boolean; error?: string }>
+      openSessionWindow: (
+        sessionId: string,
+        opts?: { profile?: string; watch?: boolean }
+      ) => Promise<{ ok: boolean; error?: string }>
       // Open a new full-chrome app window — a peer instance of the primary that
       // renders the complete app against the shared backend, so the user can run
       // multiple GUI windows at once.

--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -57,6 +57,7 @@ describe('backend action helpers are profile-scoped', () => {
     void updateHermes()
     void checkHermesUpdate()
     void getActionStatus('gateway-restart')
+    void transcribeAudio('data:audio/webm;base64,aGVsbG8=', 'audio/webm')
 
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('coder')

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -37,6 +37,7 @@ describe('Hermes REST helpers', () => {
 
   beforeEach(() => {
     resetSidebarBatchCapability()
+    setApiRequestProfile(null)
     api = vi.fn().mockResolvedValue(emptySessionsResponse)
     Object.defineProperty(window, 'hermesDesktop', {
       configurable: true,
@@ -389,6 +390,24 @@ describe('Hermes REST helpers', () => {
       path: '/api/audio/transcribe',
       timeoutMs: AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS
     })
+  })
+
+  it('routes transcription to an explicitly owning profile', async () => {
+    api.mockResolvedValueOnce({
+      ok: true,
+      provider: 'openai',
+      transcript: 'profiled transcription'
+    })
+    setApiRequestProfile('active-profile')
+
+    await transcribeAudio('data:audio/webm;base64,AA==', 'audio/webm', 'session-owner')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/audio/transcribe',
+        profile: 'session-owner'
+      })
+    )
   })
 
   it('defaults model options to configured providers only', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1557,11 +1557,15 @@ export function getActionStatus(name: string, lines = 200): Promise<ActionStatus
   })
 }
 
-export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<AudioTranscriptionResponse> {
+export function transcribeAudio(
+  dataUrl: string,
+  mimeType?: string,
+  profile?: string
+): Promise<AudioTranscriptionResponse> {
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
+    ...profileScoped(profile),
     path: '/api/audio/transcribe',
     method: 'POST',
-    ...profileScoped(),
     body: {
       data_url: dataUrl,
       mime_type: mimeType

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -115,13 +115,15 @@ export const ar = defineLocale({
     updateReadyMessage: count => `${count} تغيير جديد متاح.`,
     seeWhatsNew: 'عرض الجديد',
     errors: {
+      copySttRecoveryCommand: 'نسخ أمر الاستعادة',
       elevenLabsNeedsKey: 'يتطلب ElevenLabs STT المفتاح ELEVENLABS_API_KEY.',
       elevenLabsRejectedKey: 'رفض ElevenLabs مفتاح API (401).',
       methodNotAllowed: 'رفضت خلفية سطح المكتب هذا الطلب (405 Method Not Allowed). جرب إعادة تشغيل Hermes Desktop.',
       microphonePermission: 'تم رفض إذن الميكروفون.',
       openaiRejectedApiKey: 'رفض OpenAI مفتاح API.',
       openaiRejectedApiKeyWithStatus: status => `رفض OpenAI مفتاح API (${status} invalid_api_key).`,
-      openaiTtsNeedsKey: 'يتطلب OpenAI TTS المفتاح VOICE_TOOLS_OPENAI_KEY أو OPENAI_API_KEY.'
+      openaiTtsNeedsKey: 'يتطلب OpenAI TTS المفتاح VOICE_TOOLS_OPENAI_KEY أو OPENAI_API_KEY.',
+      sttRecordingPreserved: recoveryId => `تم الاحتفاظ بالتسجيل للاستعادة (المعرف: ${recoveryId}).`
     },
     voice: {
       configureSpeechToText: 'اضبط تحويل الكلام إلى نص لاستخدام وضع الصوت.',
@@ -503,6 +505,10 @@ export const ar = defineLocale({
       'voice.autoTts': 'قراءة الردود صوتياً',
       'stt.enabled': 'تحويل الكلام إلى نص',
       'stt.provider': 'مزود تحويل الكلام إلى نص',
+      'stt.recovery.enabled': 'الاحتفاظ بالتسجيلات الفاشلة',
+      'stt.recovery.retentionHours': 'مدة الاحتفاظ للاستعادة',
+      'stt.recovery.maxEntries': 'حد تسجيلات الاستعادة',
+      'stt.recovery.maxTotalMb': 'حد مساحة تخزين الاستعادة',
       'stt.local.model': 'نموذج التفريغ المحلي',
       'stt.local.language': 'لغة التفريغ',
       'stt.openai.model': 'نموذج OpenAI STT',
@@ -580,6 +586,11 @@ export const ar = defineLocale({
       'tts.xai.language': 'رمز لغة النطق، مثل en.',
       'tts.neutts.device': 'جهاز الاستدلال المحلي لـ NeuTTS.',
       'stt.enabled': 'يفعل التفريغ الصوتي المحلي أو عبر مزود.',
+      'stt.recovery.enabled': 'يحتفظ بصورة خاصة ومحدودة من تسجيلات سطح المكتب عند فشل التفريغ.',
+      'stt.recovery.retentionHours':
+        'عدد الساعات التي تظل فيها التسجيلات الفاشلة قابلة للاستعادة. تنظف الملفات عند وصول Hermes التالي إلى ذاكرة التخزين المؤقت. القيمة 0 تعطل الاستعادة.',
+      'stt.recovery.maxEntries': 'الحد الأقصى لعدد التسجيلات الفاشلة المحتفظ بها لكل ملف شخصي.',
+      'stt.recovery.maxTotalMb': 'الحد الأقصى لمساحة التسجيلات الفاشلة بالميبيبايت لكل ملف شخصي.',
       'stt.elevenlabs.languageCode': 'رمز لغة ISO-639-3 اختياري. اتركه فارغاً للاكتشاف التلقائي.',
       'updates.nonInteractiveLocalChanges':
         'عندما يحدّث Hermes نفسه من التطبيق دون موجه طرفية، احتفظ بتعديلات المصدر المحلية أو تجاهلها.'

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -130,6 +130,7 @@ export const en: Translations = {
     updateReadyMessage: count => `${count} new change${count === 1 ? '' : 's'} available.`,
     seeWhatsNew: "See what's new",
     errors: {
+      copySttRecoveryCommand: 'Copy recovery command',
       elevenLabsNeedsKey: 'ElevenLabs STT needs ELEVENLABS_API_KEY.',
       elevenLabsRejectedKey: 'ElevenLabs rejected the API key (401).',
       gatewayAuthFailed: 'Gateway authentication failed — check your API_SERVER_KEY.',
@@ -138,7 +139,8 @@ export const en: Translations = {
       microphonePermission: 'Microphone permission was denied.',
       openaiRejectedApiKey: 'OpenAI rejected the API key.',
       openaiRejectedApiKeyWithStatus: status => `OpenAI rejected the API key (${status} invalid_api_key).`,
-      openaiTtsNeedsKey: 'OpenAI TTS needs VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY.'
+      openaiTtsNeedsKey: 'OpenAI TTS needs VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY.',
+      sttRecordingPreserved: recoveryId => `Recording preserved for recovery (ID: ${recoveryId}).`
     },
     voice: {
       configureSpeechToText: 'Configure speech-to-text to use voice mode.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -131,6 +131,7 @@ export const ja = defineLocale({
     updateReadyMessage: count => `${count} 件の新しい変更が利用可能です。`,
     seeWhatsNew: '新機能を見る',
     errors: {
+      copySttRecoveryCommand: '復旧コマンドをコピー',
       elevenLabsNeedsKey: 'ElevenLabs STT には ELEVENLABS_API_KEY が必要です。',
       elevenLabsRejectedKey: 'ElevenLabs が API キーを拒否しました (401)。',
       gatewayAuthFailed: 'ゲートウェイ認証に失敗しました — API_SERVER_KEY を確認してください。',
@@ -139,7 +140,8 @@ export const ja = defineLocale({
       microphonePermission: 'マイクのアクセス許可が拒否されました。',
       openaiRejectedApiKey: 'OpenAI が API キーを拒否しました。',
       openaiRejectedApiKeyWithStatus: status => `OpenAI が API キーを拒否しました (${status} invalid_api_key)。`,
-      openaiTtsNeedsKey: 'OpenAI TTS には VOICE_TOOLS_OPENAI_KEY または OPENAI_API_KEY が必要です。'
+      openaiTtsNeedsKey: 'OpenAI TTS には VOICE_TOOLS_OPENAI_KEY または OPENAI_API_KEY が必要です。',
+      sttRecordingPreserved: recoveryId => `録音は復旧用に保持されました（ID: ${recoveryId}）。`
     },
     voice: {
       configureSpeechToText: '音声モードを使用するには音声認識を設定してください。',
@@ -454,6 +456,12 @@ export const ja = defineLocale({
       stt: {
         enabled: '音声認識',
         provider: '音声認識プロバイダー',
+        recovery: {
+          enabled: '失敗した録音を保持',
+          retentionHours: '復旧用の保持時間',
+          maxEntries: '復旧用録音の上限',
+          maxTotalMb: '復旧用ストレージの上限'
+        },
         local: {
           model: 'ローカル文字起こしモデル',
           language: '文字起こし言語'
@@ -601,6 +609,13 @@ export const ja = defineLocale({
       },
       stt: {
         enabled: 'ローカルまたはプロバイダーによる音声文字起こしを有効にします。',
+        recovery: {
+          enabled: 'デスクトップの文字起こしに失敗した録音を、非公開かつ上限付きで保持します。',
+          retentionHours:
+            '失敗した録音を復旧できる時間です。ファイルは次回の Hermes キャッシュアクセス時に削除されます。0 で無効になります。',
+          maxEntries: 'プロファイルごとに保持する失敗録音の最大件数です。',
+          maxTotalMb: 'プロファイルごとに失敗録音へ使用できる最大容量（MiB）です。'
+        },
         elevenlabs: {
           languageCode: '任意の ISO-639-3 言語コードです。空欄なら ElevenLabs が自動検出します。'
         }

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -172,6 +172,7 @@ export interface Translations {
     updateReadyMessage: (count: number) => string
     seeWhatsNew: string
     errors: {
+      copySttRecoveryCommand: string
       elevenLabsNeedsKey: string
       elevenLabsRejectedKey: string
       gatewayAuthFailed: string
@@ -180,6 +181,7 @@ export interface Translations {
       openaiRejectedApiKey: string
       openaiRejectedApiKeyWithStatus: (status: string) => string
       openaiTtsNeedsKey: string
+      sttRecordingPreserved: (recoveryId: string) => string
     }
     voice: {
       configureSpeechToText: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -127,6 +127,7 @@ export const zhHant = defineLocale({
     updateReadyMessage: count => `有 ${count} 項新變更可用。`,
     seeWhatsNew: '查看新增內容',
     errors: {
+      copySttRecoveryCommand: '複製復原指令',
       elevenLabsNeedsKey: 'ElevenLabs STT 需要 ELEVENLABS_API_KEY。',
       elevenLabsRejectedKey: 'ElevenLabs 拒絕了該 API 金鑰 (401)。',
       gatewayAuthFailed: '閘道認證失敗 — 請檢查你的 API_SERVER_KEY。',
@@ -134,7 +135,8 @@ export const zhHant = defineLocale({
       microphonePermission: '麥克風權限已被拒絕。',
       openaiRejectedApiKey: 'OpenAI 拒絕了該 API 金鑰。',
       openaiRejectedApiKeyWithStatus: status => `OpenAI 拒絕了該 API 金鑰 (${status} invalid_api_key)。`,
-      openaiTtsNeedsKey: 'OpenAI TTS 需要 VOICE_TOOLS_OPENAI_KEY 或 OPENAI_API_KEY。'
+      openaiTtsNeedsKey: 'OpenAI TTS 需要 VOICE_TOOLS_OPENAI_KEY 或 OPENAI_API_KEY。',
+      sttRecordingPreserved: recoveryId => `錄音已保留，可用於復原（ID：${recoveryId}）。`
     },
     voice: {
       configureSpeechToText: '設定語音轉文字後即可使用語音模式。',
@@ -442,6 +444,12 @@ export const zhHant = defineLocale({
       stt: {
         enabled: '語音轉文字',
         provider: '語音轉文字提供方',
+        recovery: {
+          enabled: '保留失敗的錄音',
+          retentionHours: '復原保留時間',
+          maxEntries: '復原錄音數量上限',
+          maxTotalMb: '復原儲存空間上限'
+        },
         local: {
           model: '本機轉寫模型',
           language: '轉寫語言'
@@ -588,6 +596,12 @@ export const zhHant = defineLocale({
       },
       stt: {
         enabled: '啟用本機或提供方支援的語音轉寫。',
+        recovery: {
+          enabled: '以私密且有界的方式保留桌面端轉寫失敗的錄音。',
+          retentionHours: '失敗錄音可復原的時數。檔案會在 Hermes 下次存取快取時清理。設為 0 可停用復原。',
+          maxEntries: '每個設定檔最多保留的失敗錄音數量。',
+          maxTotalMb: '每個設定檔用於失敗錄音的最大儲存空間（MiB）。'
+        },
         elevenlabs: {
           languageCode: '可選的 ISO-639-3 語言代碼。留空讓 ElevenLabs 自動偵測。'
         }

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -127,6 +127,7 @@ export const zh: Translations = {
     updateReadyMessage: count => `有 ${count} 项新更改可用。`,
     seeWhatsNew: '查看更新内容',
     errors: {
+      copySttRecoveryCommand: '复制恢复命令',
       elevenLabsNeedsKey: 'ElevenLabs STT 需要 ELEVENLABS_API_KEY。',
       elevenLabsRejectedKey: 'ElevenLabs 拒绝了该 API key (401)。',
       gatewayAuthFailed: '网关认证失败 — 请检查你的 API_SERVER_KEY。',
@@ -134,7 +135,8 @@ export const zh: Translations = {
       microphonePermission: '麦克风权限已被拒绝。',
       openaiRejectedApiKey: 'OpenAI 拒绝了该 API key。',
       openaiRejectedApiKeyWithStatus: status => `OpenAI 拒绝了该 API key (${status} invalid_api_key)。`,
-      openaiTtsNeedsKey: 'OpenAI TTS 需要 VOICE_TOOLS_OPENAI_KEY 或 OPENAI_API_KEY。'
+      openaiTtsNeedsKey: 'OpenAI TTS 需要 VOICE_TOOLS_OPENAI_KEY 或 OPENAI_API_KEY。',
+      sttRecordingPreserved: recoveryId => `录音已保留，可用于恢复（ID：${recoveryId}）。`
     },
     voice: {
       configureSpeechToText: '配置语音转文字后即可使用语音模式。',
@@ -566,6 +568,12 @@ export const zh: Translations = {
       stt: {
         enabled: '语音转文字',
         provider: '语音转文字提供方',
+        recovery: {
+          enabled: '保留失败的录音',
+          retentionHours: '恢复保留时长',
+          maxEntries: '恢复录音数量上限',
+          maxTotalMb: '恢复存储上限'
+        },
         local: {
           model: '本地转写模型',
           language: '转写语言'
@@ -712,6 +720,12 @@ export const zh: Translations = {
       },
       stt: {
         enabled: '启用本地或提供方支持的语音转写。',
+        recovery: {
+          enabled: '以私密且有界的方式保留桌面端转写失败的录音。',
+          retentionHours: '失败录音可恢复的小时数。文件会在 Hermes 下次访问缓存时清理。设为 0 可禁用恢复。',
+          maxEntries: '每个配置文件最多保留的失败录音数量。',
+          maxTotalMb: '每个配置文件用于失败录音的最大存储空间（MiB）。'
+        },
         elevenlabs: {
           languageCode: '可选的 ISO-639-3 语言代码。留空让 ElevenLabs 自动检测。'
         }

--- a/apps/desktop/src/store/notifications.test.ts
+++ b/apps/desktop/src/store/notifications.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from 'vitest'
+import { beforeEach, expect, test, vi } from 'vitest'
 
 import { $notifications, clearNotifications, notifyError } from './notifications'
 
@@ -31,4 +31,57 @@ test('provider invalid_api_key error still maps to the OpenAI summary', () => {
   )
 
   expect(lastMessage()).toMatch(/OpenAI rejected the API key/i)
+})
+
+test('recoverable STT errors surface the ID and a copyable recovery command', () => {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText }
+  })
+  const recoveryId = 'a'.repeat(32)
+
+  notifyError(
+    new Error(
+      `400: ${JSON.stringify({
+        detail: `Transcription failed. On the backend run hermes stt recovery retry ${recoveryId}.`,
+        error_code: 'provider_error',
+        recovery_available: true,
+        recovery_id: recoveryId
+      })}`
+    ),
+    'Voice transcription failed'
+  )
+
+  const notification = $notifications.get()[0]
+  expect(notification?.message).toContain(recoveryId)
+  expect(notification?.message).not.toBe('Voice transcription failed')
+  expect(notification?.action?.label).toMatch(/recovery command/i)
+  notification?.action?.onClick()
+  expect(writeText).toHaveBeenCalledWith(`hermes stt recovery retry ${recoveryId}`)
+})
+
+test('recoverable STT errors copy the owning profile in the recovery command', () => {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText }
+  })
+  const recoveryId = 'b'.repeat(32)
+
+  notifyError(
+    new Error(
+      `400: ${JSON.stringify({
+        detail: `Transcription failed. Run hermes -p coder stt recovery retry ${recoveryId}.`,
+        error_code: 'provider_error',
+        recovery_available: true,
+        recovery_id: recoveryId,
+        recovery_profile: 'coder'
+      })}`
+    ),
+    'Voice transcription failed'
+  )
+
+  $notifications.get()[0]?.action?.onClick()
+  expect(writeText).toHaveBeenCalledWith(`hermes -p coder stt recovery retry ${recoveryId}`)
 })

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -122,14 +122,39 @@ function summarizeErrorMessage(message: string, fallback: string) {
   return message.length > 180 ? fallback : message || fallback
 }
 
-function readableError(error: unknown, fallback: string): { message: string; detail?: string } {
+function recoveryIdFromError(message: string): string | undefined {
+  if (!/"recovery_available"\s*:\s*true/i.test(message)) {
+    return undefined
+  }
+
+  return message.match(/"recovery_id"\s*:\s*"([0-9a-f]{32})"/i)?.[1]
+}
+
+function recoveryProfileFromError(message: string): string | undefined {
+  return message.match(/"recovery_profile"\s*:\s*"([a-z0-9][a-z0-9_-]{0,63})"/i)?.[1]
+}
+
+function readableError(
+  error: unknown,
+  fallback: string
+): { message: string; detail?: string; recoveryId?: string; recoveryProfile?: string } {
   const raw = error instanceof Error ? error.message : typeof error === 'string' ? error : fallback
   const unwrapped = raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw
   const cleaned = cleanErrorText(unwrapped)
   const detail = cleaned.match(/"detail"\s*:\s*"([^"]+)"/)?.[1] ?? cleaned
-  const summary = summarizeErrorMessage(detail, fallback)
+  const recoveryId = recoveryIdFromError(cleaned)
+  const recoveryProfile = recoveryId ? recoveryProfileFromError(cleaned) : undefined
 
-  return { message: summary, detail: detail === summary ? undefined : detail }
+  const summary = recoveryId
+    ? translateNow('notifications.errors.sttRecordingPreserved', recoveryId)
+    : summarizeErrorMessage(detail, fallback)
+
+  return {
+    message: summary,
+    detail: detail === summary ? undefined : detail,
+    recoveryId,
+    recoveryProfile
+  }
 }
 
 export function notify(input: NotificationInput): string {
@@ -170,11 +195,26 @@ export function notify(input: NotificationInput): string {
 export function notifyError(error: unknown, fallback: string): string {
   const readable = readableError(error, fallback)
 
+  const recoveryCommand = readable.recoveryId
+    ? `hermes ${readable.recoveryProfile ? `-p ${readable.recoveryProfile} ` : ''}stt recovery retry ${readable.recoveryId}`
+    : undefined
+
   return notify({
     kind: 'error',
     title: fallback,
     message: readable.message,
-    detail: readable.detail
+    detail: readable.detail,
+    action: recoveryCommand
+      ? {
+          label: translateNow('notifications.errors.copySttRecoveryCommand'),
+          onClick: () => {
+            const writeText =
+              window.hermesDesktop?.writeClipboard ?? navigator.clipboard?.writeText?.bind(navigator.clipboard)
+
+            void writeText?.(recoveryCommand)
+          }
+        }
+      : undefined
   })
 }
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -3,15 +3,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClientSessionState } from '@/app/types'
 import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $selectedStoredSessionId } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
 import {
+  $sessionStates,
+  $sessionTiles,
   blankDraftTile,
   focusedSessionNeedsRoute,
   markSelectionRestore,
+  openSessionTile,
   orderTilesByTree,
+  resetTileRuntimeBindings,
+  reuseBlankDraftTile,
   selectionHomesToWorkspace
 } from '@/store/session-states'
+
+afterEach(() => {
+  $activeGatewayProfile.set('default')
+  $selectedStoredSessionId.set(null)
+  $sessionTiles.set([])
+})
 
 const tile = (storedSessionId: string): SessionTile => ({ storedSessionId })
 const tilePane = (id: string) => `session-tile:${id}`
@@ -137,6 +149,19 @@ describe('blankDraftTile', () => {
     expect(blankDraftTile([bound('a', 'run-a')], { 'run-a': state(2) })).toBeNull()
     expect(blankDraftTile([], {})).toBeNull()
   })
+
+  it('preserves the target owner when a cross-profile session reuses a blank draft', () => {
+    $selectedStoredSessionId.set(null)
+    $sessionTiles.set([bound('draft', 'run-draft')])
+    $sessionStates.set({ 'run-draft': state(0) })
+
+    expect(reuseBlankDraftTile('remote-session', 'medical')).toBe(true)
+    expect($sessionTiles.get()).toEqual([
+      expect.objectContaining({ profile: 'medical', storedSessionId: 'remote-session' })
+    ])
+
+    $sessionStates.set({})
+  })
 })
 
 // ⌘⇧T used to only restore `$sessionTiles`. Adoption inserts silently
@@ -144,7 +169,7 @@ describe('blankDraftTile', () => {
 // Real path: register, adopt, focus — same as paneMirror + reopen.
 describe('reopenLastClosedTile focuses the restored tab', () => {
   beforeEach(() => {
-    window.localStorage.clear()
+    window.localStorage?.clear()
     vi.resetModules()
   })
 
@@ -225,5 +250,47 @@ describe('reopenLastClosedTile focuses the restored tab', () => {
     expect(states.$sessionTiles.get().some(t => t.storedSessionId === 'closed')).toBe(true)
     expect(findGroupOfPane(tree.$layoutTree.get()!, tilePane('closed'))?.active).toBe(tilePane('closed'))
     expect(tree.$activeTreeGroup.get()).toBe('grp-main')
+  })
+})
+
+describe('session tile profile persistence', () => {
+  it('retains the owning profile when runtime bindings reset for resume', () => {
+    $sessionTiles.set([{ profile: 'medical', runtimeId: 'runtime-1', storedSessionId: 'stored-1' }])
+
+    resetTileRuntimeBindings()
+
+    expect($sessionTiles.get()).toEqual([{ profile: 'medical', storedSessionId: 'stored-1' }])
+  })
+
+  it('clears a live runtime when an equal id is retargeted to another profile', () => {
+    $selectedStoredSessionId.set(null)
+    $layoutTree.set(group(['workspace', tilePane('same-id')], { active: 'workspace', id: 'main' }))
+    $sessionTiles.set([
+      {
+        anchor: 'workspace',
+        dir: 'center',
+        profile: 'profile-a',
+        runtimeId: 'runtime-a',
+        storedSessionId: 'same-id'
+      }
+    ])
+
+    openSessionTile('same-id', 'center', 'workspace', undefined, 'profile-b')
+
+    expect($sessionTiles.get()).toContainEqual(
+      expect.objectContaining({ profile: 'profile-b', runtimeId: undefined, storedSessionId: 'same-id' })
+    )
+  })
+
+  it('allows an equal selected id to open when its explicit owner is different', () => {
+    $activeGatewayProfile.set('profile-a')
+    $selectedStoredSessionId.set('same-id')
+    $sessionTiles.set([])
+
+    openSessionTile('same-id', 'center', 'workspace', undefined, 'profile-b')
+
+    expect($sessionTiles.get()).toContainEqual(
+      expect.objectContaining({ profile: 'profile-b', storedSessionId: 'same-id' })
+    )
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -289,6 +289,9 @@ export type TileDock = 'center' | SplitDir
 export interface SessionTile {
   /** Stored session id — the durable identity (runtime ids are ephemeral). */
   storedSessionId: string
+  /** Owning profile — persisted because sidebar/project rows are bounded
+   *  caches and may evict an idle open tile's session metadata. */
+  profile?: string
   /** Dock against `anchor` on adoption (default right; center = stack). */
   dir?: TileDock
   /** Pane to dock against (a drop's target zone) — default the workspace.
@@ -304,12 +307,11 @@ export interface SessionTile {
   error?: string
 }
 
-// Tiles are persisted PER PROFILE: a session belongs to one profile, and the
-// single live gateway is scoped to one profile at a time, so a tile only makes
-// sense while its profile is active. Switching profiles swaps the visible set
-// (and drops runtime bindings so each tile re-resumes against the now-current
-// gateway — which also settles the "tile resumes against the wrong backend" and
-// "stale runtime after respawn" bugs by construction).
+// Tiles are bucketed by the rail profile active when they were opened. Each
+// tile also persists its session's exact owner because the all-profiles view
+// can open a cross-profile session and bounded sidebar/project caches may later
+// evict that row. Switching rail profiles swaps the visible bucket and drops
+// runtime bindings; the persisted owner still routes resume/STT correctly.
 const TILES_KEY = 'hermes.desktop.sessionTiles.v2'
 const LEGACY_TILES_KEY = 'hermes.desktop.sessionTiles.v1'
 const TILE_PANE_PREFIX = 'session-tile:'
@@ -317,16 +319,17 @@ const TILE_PANE_PREFIX = 'session-tile:'
 /** Persisted placement — `dir` + strip slot (`before`) + dock `anchor` so a
  *  restart / profile swap re-adopts tiles in the same order, not all stacked
  *  right of workspace. */
-type StoredTile = Pick<SessionTile, 'anchor' | 'before' | 'dir' | 'storedSessionId'>
+type StoredTile = Pick<SessionTile, 'anchor' | 'before' | 'dir' | 'profile' | 'storedSessionId'>
 
 const toStored = (t: SessionTile): StoredTile => ({
   anchor: t.anchor,
   before: t.before,
   dir: t.dir,
+  profile: typeof t.profile === 'string' && t.profile.trim() ? normalizeProfileKey(t.profile) : undefined,
   storedSessionId: t.storedSessionId
 })
 
-function parseTileList(value: unknown): StoredTile[] {
+function parseTileList(value: unknown, fallbackProfile?: string): StoredTile[] {
   return Array.isArray(value)
     ? value
         .filter((t): t is SessionTile => Boolean(t && typeof (t as SessionTile).storedSessionId === 'string'))
@@ -337,6 +340,12 @@ function parseTileList(value: unknown): StoredTile[] {
             anchor: typeof raw.anchor === 'string' ? raw.anchor : undefined,
             before: typeof raw.before === 'string' || raw.before === null ? raw.before : undefined,
             dir: raw.dir,
+            profile:
+              typeof raw.profile === 'string' && raw.profile.trim()
+                ? normalizeProfileKey(raw.profile)
+                : fallbackProfile
+                  ? normalizeProfileKey(fallbackProfile)
+                  : undefined,
             storedSessionId: raw.storedSessionId
           }
         })
@@ -349,6 +358,10 @@ function loadTilesByProfile(): Record<string, StoredTile[]> {
 
   if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
     for (const [profile, list] of Object.entries(parsed as Record<string, unknown>)) {
+      // A v2 bucket records the rail profile that was visible when a tile was
+      // opened, not necessarily the session's owner: All Profiles can place a
+      // cross-profile session in that bucket. Leave pre-owner records unknown
+      // until cold resume resolves and persists the authoritative profile.
       const tiles = parseTileList(list)
 
       if (tiles.length > 0) {
@@ -358,7 +371,7 @@ function loadTilesByProfile(): Record<string, StoredTile[]> {
   }
 
   // Migrate a v1 flat list into the default profile, then retire the key.
-  const legacy = parseTileList(readJson<unknown>(LEGACY_TILES_KEY))
+  const legacy = parseTileList(readJson<unknown>(LEGACY_TILES_KEY), 'default')
 
   if (legacy.length > 0) {
     const key = normalizeProfileKey('default')
@@ -416,8 +429,113 @@ if (!isSecondaryWindow()) {
   })
 }
 
+/** Stable address of a tile inside the profile bucket where it was opened.
+ *  Stored session ids are not globally unique across profiles, and the active
+ *  bucket can change while an async resume is in flight. */
+export interface SessionTileLocation {
+  bucketProfile: string
+  profile?: string
+  storedSessionId: string
+}
+
+const sameTileOwner = (left?: string, right?: string): boolean => {
+  const normalizedLeft = left?.trim() ? normalizeProfileKey(left) : undefined
+  const normalizedRight = right?.trim() ? normalizeProfileKey(right) : undefined
+
+  return normalizedLeft === normalizedRight
+}
+
+/** Capture the visible tile's bucket before crossing an async boundary.
+ *  Secondary windows neither own nor persist session tiles. */
+export function locateSessionTile(storedSessionId: string): SessionTileLocation | null {
+  const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
+
+  if (isSecondaryWindow() || !tile) {
+    return null
+  }
+
+  return { bucketProfile: profileKey(), profile: tile.profile, storedSessionId }
+}
+
+/** Patch one exact tile without consulting the profile active at settle time.
+ *  False means the origin tile was closed meanwhile; stale completions never
+ *  recreate it. Runtime/error fields remain live-only through `toStored`. */
+export function patchSessionTileAt(location: SessionTileLocation, patch: Partial<SessionTile>): boolean {
+  if (isSecondaryWindow()) {
+    return false
+  }
+
+  const bucketProfile = normalizeProfileKey(location.bucketProfile)
+  const active = bucketProfile === profileKey()
+  const current: SessionTile[] = active ? $sessionTiles.get() : [...(tilesByProfile[bucketProfile] ?? [])]
+
+  const index = current.findIndex(
+    tile => tile.storedSessionId === location.storedSessionId && sameTileOwner(tile.profile, location.profile)
+  )
+
+  if (index < 0) {
+    return false
+  }
+
+  const next = current.map((tile, tileIndex) => (tileIndex === index ? { ...tile, ...patch } : tile))
+  tilesByProfile[bucketProfile] = next.map(toStored)
+  persistTiles()
+
+  if (active) {
+    $sessionTiles.set(next)
+  }
+
+  return true
+}
+
+/** Discard one exact tile after an async failure. Like `patchSessionTileAt`,
+ *  this is bucket-stable and refuses to delete an equal id in another profile
+ *  after the UI switches. */
+export function discardSessionTileAt(location: SessionTileLocation): boolean {
+  if (isSecondaryWindow()) {
+    return false
+  }
+
+  const bucketProfile = normalizeProfileKey(location.bucketProfile)
+  const active = bucketProfile === profileKey()
+  const current: SessionTile[] = active ? $sessionTiles.get() : [...(tilesByProfile[bucketProfile] ?? [])]
+
+  const tile = current.find(
+    candidate =>
+      candidate.storedSessionId === location.storedSessionId && sameTileOwner(candidate.profile, location.profile)
+  )
+
+  if (!tile) {
+    return false
+  }
+
+  if (active && tile.runtimeId) {
+    dropSessionState(tile.runtimeId)
+  }
+
+  const next = current.filter(candidate => candidate.storedSessionId !== location.storedSessionId)
+
+  if (next.length > 0) {
+    tilesByProfile[bucketProfile] = next.map(toStored)
+  } else {
+    delete tilesByProfile[bucketProfile]
+  }
+
+  persistTiles()
+
+  if (active) {
+    $sessionTiles.set(next)
+  }
+
+  return true
+}
+
 export function patchSessionTile(storedSessionId: string, patch: Partial<SessionTile>) {
-  saveTiles($sessionTiles.get().map(t => (t.storedSessionId === storedSessionId ? { ...t, ...patch } : t)))
+  const location = locateSessionTile(storedSessionId)
+
+  if (location) {
+    patchSessionTileAt(location, patch)
+  }
 }
 
 /** Drop live runtime bindings so every tile re-resumes — used on gateway
@@ -438,11 +556,11 @@ export function resetTileRuntimeBindings() {
 
 export interface SessionTileDelegate {
   /** Archive a stored session (the sidebar's archive, incl. tile cleanup). */
-  archiveSession(storedSessionId: string): Promise<void>
+  archiveSession(storedSessionId: string, profile?: string): Promise<void>
   /** Branch a stored session into a new chat (the sidebar's branch). */
-  branchSession(storedSessionId: string): Promise<void>
+  branchSession(storedSessionId: string, profile?: string): Promise<void>
   /** Delete a stored session (the sidebar's delete, incl. tile cleanup). */
-  deleteSession(storedSessionId: string): Promise<void>
+  deleteSession(storedSessionId: string, profile?: string): Promise<void>
   /** Run a slash command against a tile's session (app-level effects — e.g.
    *  branch/handoff — act on the main surface, as they should). */
   executeSlash(rawCommand: string, sessionId: string): Promise<void>
@@ -450,7 +568,7 @@ export interface SessionTileDelegate {
   interruptSession(runtimeId: string): Promise<void>
   /** Bind a live runtime id for a stored session (resume without touching
    *  the main view). Returns the runtime id, or throws. */
-  resumeTile(storedSessionId: string): Promise<string>
+  resumeTile(storedSessionId: string, profile?: string): Promise<{ profile?: string; runtimeId: string }>
   /** Submit a prompt to a tile's live session. */
   submitToSession(runtimeId: string, text: string): Promise<void>
   /** THE session-state write path — routes through the wiring cache so the
@@ -532,23 +650,42 @@ export function openSessionTile(
   storedSessionId: string,
   dir: TileDock = 'right',
   anchor?: string,
-  before?: null | string
+  before?: null | string,
+  profile?: string
 ) {
   const tiles = $sessionTiles.get()
+  const existing = tiles.find(t => t.storedSessionId === storedSessionId)
+  const explicitOwner = profile?.trim()
+  // A new local tile belongs to the active backend. An older persisted tile
+  // with no owner is different: its rail bucket is not authoritative in All
+  // Profiles, so preserve `undefined` until session lookup backfills it.
+  const ownerProfile = explicitOwner ? normalizeProfileKey(explicitOwner) : existing ? existing.profile : profileKey()
 
-  if (storedSessionId === $selectedStoredSessionId.get()) {
+  if (
+    storedSessionId === $selectedStoredSessionId.get() &&
+    (!explicitOwner || normalizeProfileKey($activeGatewayProfile.get()) === ownerProfile)
+  ) {
     return
   }
 
   const dock = anchor ?? focusedSessionTabAnchor() ?? undefined
 
-  if (!tiles.some(t => t.storedSessionId === storedSessionId)) {
-    saveTiles([...tiles, { anchor: dock, before, dir, storedSessionId }])
+  if (!existing) {
+    saveTiles([...tiles, { anchor: dock, before, dir, profile: ownerProfile, storedSessionId }])
     // Adoption is async via the registry — order sync runs after the move path
     // below; a brand-new tile's strip slot is already in `before`.
 
     return
   }
+
+  // A stored id is only unique inside its profile database. When an explicit
+  // owner points at a different profile, this is not a move of the existing
+  // conversation: it is a retarget of the pane. Clear the live binding so the
+  // pane cannot render or submit through the previous profile's runtime while
+  // its durable owner is updated.
+  const ownerChanged =
+    Boolean(explicitOwner) &&
+    (!existing.profile || normalizeProfileKey(existing.profile) !== normalizeProfileKey(ownerProfile))
 
   // Already open: relocate the existing pane to the drop target (pane-mirror
   // only docks on first adoption, so a re-drag must move the tree pane itself).
@@ -557,8 +694,16 @@ export function openSessionTile(
 
   if (target) {
     moveTreePane(`${TILE_PANE_PREFIX}${storedSessionId}`, { before: before ?? null, groupId: target, pos: dir })
-    patchSessionTile(storedSessionId, { anchor: dock, before: before ?? undefined, dir })
+    patchSessionTile(storedSessionId, {
+      anchor: dock,
+      before: before ?? undefined,
+      dir,
+      profile: ownerProfile,
+      ...(ownerChanged ? { error: undefined, runtimeId: undefined } : {})
+    })
     syncTileStripOrder()
+  } else if (ownerChanged) {
+    patchSessionTile(storedSessionId, { error: undefined, profile: ownerProfile, runtimeId: undefined })
   }
 }
 
@@ -601,8 +746,18 @@ export function nextSessionTileForWorkspace(): null | string {
  *  Callers that own the router need the `'main'` vs `'tile'` distinction: a
  *  `'main'` hit only reaches the screen if the workspace pane is actually
  *  showing the chat, whereas a tile renders in its own pane regardless. */
-export function focusOpenSession(storedSessionId: string): 'main' | 'tile' | null {
-  if ($sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
+export function focusOpenSession(storedSessionId: string, ownerProfile?: string): 'main' | 'tile' | null {
+  const expectedOwner = ownerProfile?.trim() ? normalizeProfileKey(ownerProfile) : null
+
+  const matchingTile = $sessionTiles
+    .get()
+    .find(
+      tile =>
+        tile.storedSessionId === storedSessionId &&
+        (!expectedOwner || (tile.profile && normalizeProfileKey(tile.profile) === expectedOwner))
+    )
+
+  if (matchingTile) {
     const paneId = `${TILE_PANE_PREFIX}${storedSessionId}`
     revealTreePane(paneId) // un-dismiss + adopt + front in its group
     const tree = $layoutTree.get()
@@ -617,7 +772,10 @@ export function focusOpenSession(storedSessionId: string): 'main' | 'tile' | nul
 
   // Already the main session: front the workspace tab and drop tile focus so
   // the readouts + sidebar highlight come home (a no-op when main is focused).
-  if (storedSessionId === $selectedStoredSessionId.get()) {
+  if (
+    storedSessionId === $selectedStoredSessionId.get() &&
+    (!expectedOwner || normalizeProfileKey($activeGatewayProfile.get()) === expectedOwner)
+  ) {
     revealTreePane('workspace')
     noteActiveTreeGroup(null)
 
@@ -658,7 +816,7 @@ export function blankDraftTile(
  *  False when there's no such tab, so the caller can fall back. The spent draft
  *  is DISCARDED rather than closed: it never held a conversation, so ⌘⇧T
  *  resurrecting it would just restore an empty tab. */
-export function reuseBlankDraftTile(storedSessionId: string): boolean {
+export function reuseBlankDraftTile(storedSessionId: string, ownerProfile?: string): boolean {
   const tile = blankDraftTile($sessionTiles.get(), $sessionStates.get())
 
   if (!tile || tile.storedSessionId === storedSessionId) {
@@ -666,7 +824,7 @@ export function reuseBlankDraftTile(storedSessionId: string): boolean {
   }
 
   discardSessionTile(tile.storedSessionId)
-  openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before)
+  openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before, ownerProfile)
   revealTreePane(`${TILE_PANE_PREFIX}${storedSessionId}`)
 
   return true
@@ -682,7 +840,13 @@ export function closeSessionTile(storedSessionId: string) {
   const tile = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)
 
   if (tile) {
-    closedStack().push({ anchor: tile.anchor, before: tile.before, dir: tile.dir, storedSessionId })
+    closedStack().push({
+      anchor: tile.anchor,
+      before: tile.before,
+      dir: tile.dir,
+      profile: tile.profile,
+      storedSessionId
+    })
   }
 
   saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
@@ -693,13 +857,11 @@ export function closeSessionTile(storedSessionId: string) {
  *  would just 404 again) and evicts any cached state. This is what clears the
  *  "Session not found" resume spam from stale/cross-profile persisted tiles. */
 export function discardSessionTile(storedSessionId: string) {
-  const runtimeId = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)?.runtimeId
+  const location = locateSessionTile(storedSessionId)
 
-  if (runtimeId) {
-    dropSessionState(runtimeId)
+  if (location) {
+    discardSessionTileAt(location)
   }
-
-  saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
 }
 
 /** ⌘⇧T — reopen the most recently closed tab where it was, then focus it.
@@ -717,7 +879,7 @@ export function reopenLastClosedTile(): void {
     }
 
     if (!$sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
-      openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before)
+      openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before, tile.profile)
       focusOpenSession(storedSessionId)
 
       return

--- a/apps/desktop/src/store/session-tile-persistence.test.ts
+++ b/apps/desktop/src/store/session-tile-persistence.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const TILES_KEY = 'hermes.desktop.sessionTiles.v2'
+
+const values = new Map<string, string>()
+
+const localStorageStub: Storage = {
+  clear: () => values.clear(),
+  getItem: key => values.get(key) ?? null,
+  key: index => [...values.keys()][index] ?? null,
+  get length() {
+    return values.size
+  },
+  removeItem: key => void values.delete(key),
+  setItem: (key, value) => void values.set(key, String(value))
+}
+
+describe('session tile profile migration', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: localStorageStub })
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('does not mistake an old v2 rail bucket for the session owner', async () => {
+    window.localStorage.setItem(
+      TILES_KEY,
+      JSON.stringify({ default: [{ dir: 'center', storedSessionId: 'cross-profile-session' }] })
+    )
+
+    const { $sessionTiles, patchSessionTile } = await import('./session-states')
+
+    expect($sessionTiles.get()).toEqual([
+      {
+        anchor: undefined,
+        before: undefined,
+        dir: 'center',
+        profile: undefined,
+        storedSessionId: 'cross-profile-session'
+      }
+    ])
+
+    patchSessionTile('cross-profile-session', { runtimeId: 'runtime-1' })
+
+    const persisted = JSON.parse(window.localStorage.getItem(TILES_KEY) ?? '{}') as Record<
+      string,
+      Array<{ profile?: string; storedSessionId: string }>
+    >
+
+    expect(persisted.default).toEqual([{ storedSessionId: 'cross-profile-session', dir: 'center' }])
+  })
+})

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { canOpenNewWindow, canOpenSessionWindow, openNewWindow, openSessionInNewWindow } from './windows'
+import {
+  canOpenNewWindow,
+  canOpenSessionWindow,
+  openNewWindow,
+  openSessionInNewWindow,
+  secondaryWindowProfile
+} from './windows'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
@@ -50,6 +56,17 @@ describe('canOpenSessionWindow', () => {
   })
 })
 
+describe('secondaryWindowProfile', () => {
+  it('reads the real pre-hash profile query used by secondary windows', () => {
+    const previous = `${window.location.pathname}${window.location.search}${window.location.hash}`
+    window.history.replaceState(null, '', '/?win=secondary&profile=profile-b#/same-id')
+
+    expect(secondaryWindowProfile()).toBe('profile-b')
+
+    window.history.replaceState(null, '', previous)
+  })
+})
+
 describe('openSessionInNewWindow', () => {
   it('no-ops without a session id', async () => {
     const open = vi.fn().mockResolvedValue({ ok: true })
@@ -86,6 +103,16 @@ describe('openSessionInNewWindow', () => {
     await openSessionInNewWindow('s1', { watch: true })
 
     expect(open).toHaveBeenCalledWith('s1', { watch: true })
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('forwards the authoritative profile for profile-qualified windows', async () => {
+    const open = vi.fn().mockResolvedValue({ ok: true })
+    installBridge(open)
+
+    await openSessionInNewWindow('s1', { profile: 'work', watch: true })
+
+    expect(open).toHaveBeenCalledWith('s1', { profile: 'work', watch: true })
     expect(notifyError).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -51,6 +51,19 @@ export function isWatchWindow(): boolean {
   return result
 }
 
+/** Authoritative owner carried by a profile-qualified secondary-session URL. */
+export function secondaryWindowProfile(): string | undefined {
+  if (!isSecondaryWindow()) {
+    return undefined
+  }
+
+  try {
+    return new URLSearchParams(window.location.search).get('profile')?.trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
 // True when running inside the Electron desktop shell (the preload bridge is
 // present). The "open in new window" affordance is desktop-only.
 export function canOpenSessionWindow(): boolean {
@@ -81,7 +94,10 @@ async function runWindowOpen(call: () => Promise<WindowOpenResult>, failMessage:
 // Open (or focus) a standalone OS window for a single chat session. No-ops
 // gracefully outside Electron so callers can wire it unconditionally.
 // `watch: true` opens a spectator window (lazy resume, live-mirror stream).
-export async function openSessionInNewWindow(sessionId: string, opts?: { watch?: boolean }): Promise<void> {
+export async function openSessionInNewWindow(
+  sessionId: string,
+  opts?: { profile?: string; watch?: boolean }
+): Promise<void> {
   if (!sessionId || !canOpenSessionWindow()) {
     return
   }

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1150,6 +1150,13 @@ platform_toolsets:
 # Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
 stt:
   enabled: true
+  # Desktop recordings are retained only after failed transcription. The
+  # private per-profile cache is excluded from backups and pruned oldest-first.
+  recovery:
+    enabled: true
+    retention_hours: 24       # 0 disables retention; hard-capped at 7 days
+    max_entries: 50           # hard-capped at 500 recordings
+    max_total_mb: 500         # hard-capped at 2048 MiB
   # provider: "local"          # auto-detected if omitted
   local:
     model: "base"              # tiny | base | small | medium | large-v3 | turbo

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1411,6 +1411,16 @@ DEFAULT_CONFIG = {
         # the raw transcript is also echoed back to the user as a 🎙️ message.
         # Set false to keep STT for the agent while suppressing that user-facing echo.
         "echo_transcripts": True,
+        # Desktop uploads are staged before transcription and retained only
+        # when STT fails. The cache is private, profile-scoped, excluded from
+        # backups/exports, and bounded by all three limits below. Set enabled
+        # false (or any numeric limit to 0) to restore ephemeral-only behavior.
+        "recovery": {
+            "enabled": True,
+            "retention_hours": 24,
+            "max_entries": 50,
+            "max_total_mb": 500,
+        },
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "deepinfra"
         # Global language hint applied to EVERY provider unless a per-provider
         # language overrides it. Defaults to "en" — Whisper auto-detection

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10467,7 +10467,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "model", "monitoring", "pairing", "pets", "plugins", "portal", "profile",
         "project", "proxy",
         "prompt-size",
-        "send", "sessions", "setup",
+        "send", "sessions", "setup", "stt",
         "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "whatsapp-cloud", "chat", "secrets", "security",
         # Help-ish invocations — plugin commands not being listed in
@@ -11214,6 +11214,13 @@ def main():
         return 0
 
     egress_parser.set_defaults(func=_dispatch_egress)
+
+    # =========================================================================
+    # stt recovery command — retry/export recordings retained after failure
+    # =========================================================================
+    from hermes_cli.stt_recovery_cli import register_cli as _register_stt_cli
+
+    _register_stt_cli(subparsers)
 
     # =========================================================================
     # migrate command

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -115,6 +115,8 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
 #   backups             — `hermes backup` archives
 #   state-snapshots     — quick-backup snapshot trees
 #   checkpoints         — session checkpoint data
+#   .cache              — private/regenerable runtime data, including retained
+#                         STT failure audio
 _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "state.db",
     "state.db-wal",
@@ -123,6 +125,7 @@ _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "backups",
     "state-snapshots",
     "checkpoints",
+    ".cache",
 })
 
 # Marker file written by `hermes profile create --no-skills`.  When present in
@@ -251,7 +254,7 @@ _RESERVED_NAMES = frozenset({
 # Hermes subcommands that cannot be used as profile names/aliases
 _HERMES_SUBCOMMANDS = frozenset({
     "chat", "model", "gateway", "setup", "whatsapp", "login", "logout",
-    "status", "cron", "doctor", "dump", "config", "pairing", "skills", "tools",
+    "status", "cron", "doctor", "dump", "config", "pairing", "skills", "tools", "stt",
     "mcp", "sessions", "insights", "version", "update", "uninstall",
     "profile", "plugins", "honcho", "acp",
 })
@@ -1930,15 +1933,23 @@ def export_profile(name: str, output_path: str) -> Path:
             result = shutil.make_archive(base, "gztar", tmpdir, "default")
             return Path(result)
 
-    # Named profiles — stage a filtered copy to exclude credentials
+    # Named profiles — stage a filtered copy to exclude credentials and
+    # private/regenerable runtime caches (including STT recovery audio).
     with tempfile.TemporaryDirectory() as tmpdir:
         staged = Path(tmpdir) / canon
         _CREDENTIAL_FILES = {"auth.json", ".env"}
+
+        def _named_export_ignore(directory: str, contents: List[str]) -> set[str]:
+            ignored = _CREDENTIAL_FILES & set(contents)
+            if Path(directory) == profile_dir:
+                ignored.update({".cache"} & set(contents))
+            return ignored
+
         shutil.copytree(
             profile_dir,
             staged,
             symlinks=True,
-            ignore=lambda d, contents: _CREDENTIAL_FILES & set(contents),
+            ignore=_named_export_ignore,
         )
         result = shutil.make_archive(base, "gztar", tmpdir, canon)
         return Path(result)

--- a/hermes_cli/stt_recovery.py
+++ b/hermes_cli/stt_recovery.py
@@ -1,0 +1,1090 @@
+"""Bounded, profile-scoped recovery storage for failed STT recordings.
+
+The desktop transcription endpoint receives the only durable copy of a
+browser recording.  This module publishes that copy before STT starts, keeps
+it when transcription fails, and removes it after a successful result.
+
+Recovery entries deliberately live below ``.cache``: voice recordings are
+private, short-lived runtime data and must not be copied into Hermes backups
+or profile exports.  Callers identify entries only by opaque IDs; absolute
+storage paths never cross an API boundary.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+import errno
+import json
+import logging
+import math
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import threading
+import time
+from typing import Any, Iterator, Mapping, Optional
+import uuid
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+try:  # POSIX cross-process lock.
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:  # Windows cross-process byte-range lock.
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+RECOVERY_RELATIVE_DIR = Path(".cache") / "stt-recovery"
+
+_SCHEMA_VERSION = 1
+_RECOVERY_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_STAGING_DIR_RE = re.compile(r"^\.tmp-[0-9a-f]{32}$")
+_SAFE_SUFFIX_RE = re.compile(r"^\.[a-z0-9]{1,8}$")
+_SAFE_PROVIDER_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+_ORPHAN_STALE_SECONDS = 60 * 60
+_CLOCK_SKEW_SECONDS = 5 * 60
+
+_DEFAULT_RETENTION_HOURS = 24.0
+_DEFAULT_MAX_ENTRIES = 50
+_DEFAULT_MAX_TOTAL_MB = 500.0
+_MAX_RETENTION_HOURS = 24.0 * 7
+_MAX_ENTRIES = 500
+_MAX_TOTAL_MB = 2048.0
+
+_PROCESS_LOCK = threading.RLock()
+
+
+def _bounded_number(
+    value: Any,
+    *,
+    default: float,
+    minimum: float,
+    maximum: float,
+) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not parsed >= 0:  # also rejects NaN
+        return default
+    return min(max(parsed, minimum), maximum)
+
+
+@dataclass(frozen=True)
+class RecoveryPolicy:
+    """Validated limits for one profile's recovery cache."""
+
+    enabled: bool = True
+    retention_seconds: float = _DEFAULT_RETENTION_HOURS * 3600
+    max_entries: int = _DEFAULT_MAX_ENTRIES
+    max_total_bytes: int = int(_DEFAULT_MAX_TOTAL_MB * 1024 * 1024)
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> "RecoveryPolicy":
+        stt = config.get("stt")
+        stt = stt if isinstance(stt, Mapping) else {}
+        raw = stt.get("recovery")
+        raw = raw if isinstance(raw, Mapping) else {}
+
+        enabled_value = raw.get("enabled", True)
+        enabled = enabled_value if isinstance(enabled_value, bool) else True
+        retention_hours = _bounded_number(
+            raw.get("retention_hours", _DEFAULT_RETENTION_HOURS),
+            default=_DEFAULT_RETENTION_HOURS,
+            minimum=0,
+            maximum=_MAX_RETENTION_HOURS,
+        )
+        max_entries = int(
+            _bounded_number(
+                raw.get("max_entries", _DEFAULT_MAX_ENTRIES),
+                default=_DEFAULT_MAX_ENTRIES,
+                minimum=0,
+                maximum=_MAX_ENTRIES,
+            )
+        )
+        max_total_mb = _bounded_number(
+            raw.get("max_total_mb", _DEFAULT_MAX_TOTAL_MB),
+            default=_DEFAULT_MAX_TOTAL_MB,
+            minimum=0,
+            maximum=_MAX_TOTAL_MB,
+        )
+
+        # Any zero limit is an explicit, fail-closed way to disable retention.
+        enabled = bool(
+            enabled and retention_hours > 0 and max_entries > 0 and max_total_mb > 0
+        )
+        return cls(
+            enabled=enabled,
+            retention_seconds=retention_hours * 3600,
+            max_entries=max_entries,
+            max_total_bytes=int(max_total_mb * 1024 * 1024),
+        )
+
+    @property
+    def retention_hours(self) -> float:
+        return self.retention_seconds / 3600
+
+
+@dataclass(frozen=True)
+class RecoveryRecord:
+    recovery_id: str
+    directory: Path
+    audio_path: Path
+    status: str
+    created_at: float
+    expires_at: float
+    byte_size: int
+    mime_type: str
+    attempts: int
+    provider: Optional[str] = None
+    failure_code: Optional[str] = None
+
+
+class SttRecoveryCache:
+    """Atomic, bounded storage for one profile's failed STT uploads."""
+
+    def __init__(
+        self,
+        policy: RecoveryPolicy,
+        *,
+        hermes_home: Optional[Path] = None,
+        now: Any = time.time,
+    ) -> None:
+        self.policy = policy
+        self.root = (hermes_home or get_hermes_home()) / RECOVERY_RELATIVE_DIR
+        self._now = now
+        self._attempt_leases: dict[tuple[str, int], int] = {}
+
+    def close(self) -> None:
+        """Release any live-attempt leases owned by this cache instance."""
+        for fd in tuple(self._attempt_leases.values()):
+            self._close_attempt_lease(fd)
+        self._attempt_leases.clear()
+
+    def __del__(self) -> None:  # pragma: no cover - deterministic in callers
+        self.close()
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Mapping[str, Any],
+        *,
+        hermes_home: Optional[Path] = None,
+    ) -> "SttRecoveryCache":
+        return cls(RecoveryPolicy.from_config(config), hermes_home=hermes_home)
+
+    def stage_audio(
+        self,
+        audio: bytes,
+        *,
+        suffix: str,
+        mime_type: str,
+        source: str = "desktop",
+    ) -> Optional[RecoveryRecord]:
+        """Publish an immutable recording before STT begins.
+
+        Returns ``None`` when retention is disabled, the configured byte cap
+        cannot fit the recording, or recovery storage is unavailable.  A
+        caller may still transcribe from an ordinary temporary file in that
+        case; recovery must never make working STT unavailable.
+        """
+        if not self.policy.enabled or not audio:
+            return None
+        if len(audio) > self.policy.max_total_bytes:
+            return None
+        if not _SAFE_SUFFIX_RE.fullmatch(suffix):
+            raise ValueError("Unsafe STT recovery suffix")
+
+        recovery_id = uuid.uuid4().hex
+        created_at = float(self._now())
+        expires_at = created_at + self.policy.retention_seconds
+        audio_name = f"audio{suffix}"
+        manifest = {
+            "schema_version": _SCHEMA_VERSION,
+            "recovery_id": recovery_id,
+            "status": "transcribing",
+            "created_at": created_at,
+            "updated_at": created_at,
+            "expires_at": expires_at,
+            "audio_file": audio_name,
+            "byte_size": len(audio),
+            "mime_type": str(mime_type)[:128],
+            "source": str(source)[:32],
+            "attempts": 1,
+            "provider": None,
+            "failure_code": None,
+        }
+
+        staging: Optional[Path] = None
+        published: Optional[Path] = None
+        lease_fd: Optional[int] = None
+        try:
+            self._ensure_root()
+            with self._locked():
+                self._prune_locked(reserve_entries=1, reserve_bytes=len(audio))
+                records = self._records_locked()
+                orphan_entries, orphan_bytes = self._owned_orphan_usage_locked()
+                if len(records) + orphan_entries + 1 > self.policy.max_entries:
+                    return None
+                if (
+                    sum(record.byte_size for record in records)
+                    + orphan_bytes
+                    + len(audio)
+                    > self.policy.max_total_bytes
+                ):
+                    return None
+
+                staging = self.root / f".tmp-{recovery_id}"
+                final_dir = self.root / recovery_id
+                os.mkdir(staging, 0o700)
+                if os.name == "posix":
+                    os.chmod(staging, 0o700)
+                self._write_private_bytes(staging / audio_name, audio)
+                atomic_json_write(staging / "manifest.json", manifest, mode=0o600)
+                self._fsync_directory(staging)
+                os.replace(staging, final_dir)
+                staging = None
+                published = final_dir
+                # The root lock prevents prune/claim from observing this
+                # record before its live-attempt lease is held. Acquiring only
+                # after rename also avoids Windows rename failures caused by
+                # an open file inside the staging directory.
+                lease_fd = self._acquire_attempt_lease(final_dir)
+                if lease_fd is None:
+                    raise OSError("Could not acquire STT recovery attempt lease")
+                record = self._record_from_directory(final_dir)
+                if record is None:
+                    raise OSError("Could not validate staged STT recovery record")
+                self._attempt_leases[(recovery_id, 1)] = lease_fd
+                lease_fd = None
+                published = None
+                self._fsync_directory(self.root)
+                return record
+        except (OSError, ValueError, TypeError):
+            logger.warning("Could not stage STT recovery audio", exc_info=True)
+            return None
+        finally:
+            if lease_fd is not None:
+                self._close_attempt_lease(lease_fd)
+            if staging is not None:
+                self._remove_directory(staging)
+            if published is not None:
+                self._remove_directory(published)
+
+    def mark_failed_attempt(
+        self,
+        recovery_id: str,
+        *,
+        attempts: int,
+        failure_code: str,
+        provider: Optional[str] = None,
+        expected_status: str = "transcribing",
+    ) -> Optional[RecoveryRecord]:
+        """Retain one exact attempt as failed without storing raw error text.
+
+        The state and attempt checks are a compare-and-swap guard: a delayed
+        worker must never overwrite or delete a newer manual retry.
+        """
+        if (
+            expected_status not in {"transcribing", "delivering", "failed"}
+            or attempts < 1
+        ):
+            return None
+        if (
+            expected_status in {"transcribing", "delivering"}
+            and (recovery_id, attempts) not in self._attempt_leases
+        ):
+            return None
+        try:
+            with self._locked_existing_root() as available:
+                if not available:
+                    return None
+                return self._mark_failed_locked(
+                    recovery_id,
+                    attempts=attempts,
+                    expected_status=expected_status,
+                    failure_code=failure_code,
+                    provider=provider,
+                )
+        except OSError:
+            logger.warning(
+                "Could not retain failed STT recovery id=%s",
+                recovery_id,
+                exc_info=True,
+            )
+            return None
+
+    def claim_retry(self, recovery_id: str) -> Optional[RecoveryRecord]:
+        """Atomically claim a failed recording for a manual retry."""
+        try:
+            with self._locked_existing_root() as available:
+                if not available:
+                    return None
+                self._prune_locked()
+                record = self._get_record_locked(recovery_id)
+                if (
+                    record is None
+                    or record.status != "failed"
+                    or record.expires_at <= float(self._now())
+                ):
+                    return None
+                lease_fd = self._acquire_attempt_lease(record.directory)
+                if lease_fd is None:
+                    return None
+                manifest = self._read_manifest(record.directory)
+                if manifest is None:
+                    self._close_attempt_lease(lease_fd)
+                    return None
+                manifest.update({
+                    "status": "transcribing",
+                    "updated_at": float(self._now()),
+                    "attempts": record.attempts + 1,
+                    "failure_code": None,
+                })
+                try:
+                    atomic_json_write(
+                        record.directory / "manifest.json",
+                        manifest,
+                        mode=0o600,
+                    )
+                except OSError:
+                    self._close_attempt_lease(lease_fd)
+                    return None
+                updated = self._record_from_directory(record.directory)
+                if updated is None or updated.status != "transcribing":
+                    self._close_attempt_lease(lease_fd)
+                    return None
+                self._attempt_leases[(updated.recovery_id, updated.attempts)] = lease_fd
+                return updated
+        except OSError:
+            return None
+
+    def mark_delivering_attempt(
+        self,
+        recovery_id: str,
+        *,
+        attempts: int,
+    ) -> Optional[RecoveryRecord]:
+        """Protect an attempt while its transcript is being delivered."""
+        if (recovery_id, attempts) not in self._attempt_leases:
+            return None
+        try:
+            with self._locked_existing_root() as available:
+                if not available:
+                    return None
+                record = self._get_record_locked(recovery_id)
+                if (
+                    record is None
+                    or record.status != "transcribing"
+                    or record.attempts != attempts
+                ):
+                    return None
+                manifest = self._read_manifest(record.directory)
+                if manifest is None:
+                    return None
+                manifest.update({
+                    "status": "delivering",
+                    "updated_at": float(self._now()),
+                    "failure_code": None,
+                })
+                try:
+                    atomic_json_write(
+                        record.directory / "manifest.json",
+                        manifest,
+                        mode=0o600,
+                    )
+                except OSError:
+                    return None
+                updated = self._record_from_directory(record.directory)
+                if (
+                    updated is None
+                    or updated.status != "delivering"
+                    or updated.attempts != attempts
+                ):
+                    return None
+                return updated
+        except OSError:
+            return None
+
+    def discard_failed(self, recovery_id: str) -> bool:
+        """Delete one retryable failure; never unlink an active worker input."""
+        try:
+            with self._locked_existing_root() as available:
+                if not available:
+                    return False
+                self._prune_locked()
+                record = self._get_record_locked(recovery_id)
+                if record is None or record.status != "failed":
+                    return False
+                return self._remove_directory(record.directory)
+        except OSError:
+            return False
+
+    def discard_attempt(
+        self,
+        recovery_id: str,
+        *,
+        attempts: int,
+        expected_status: str,
+    ) -> bool:
+        """Finalize only the exact transcription attempt owned by the caller."""
+        if expected_status not in {"transcribing", "delivering", "failed"}:
+            return False
+        if expected_status in {"transcribing", "delivering"}:
+            return self.complete_attempt(
+                recovery_id,
+                attempts=attempts,
+                expected_status=expected_status,
+            )
+        try:
+            with self._locked_existing_root() as available:
+                if not available:
+                    return False
+                record = self._get_record_locked(recovery_id)
+                if (
+                    record is None
+                    or record.status != expected_status
+                    or record.attempts != attempts
+                ):
+                    return False
+                return self._remove_directory(record.directory)
+        except OSError:
+            return False
+
+    def complete_attempt(
+        self,
+        recovery_id: str,
+        *,
+        attempts: int,
+        expected_status: str,
+    ) -> bool:
+        """Delete a successful attempt or queue deletion for the next access."""
+        if expected_status not in {"transcribing", "delivering"}:
+            return False
+        if (recovery_id, attempts) not in self._attempt_leases:
+            return False
+        try:
+            with self._locked_existing_root() as available:
+                if not available:
+                    return False
+                record = self._get_record_locked(recovery_id)
+                if (
+                    record is None
+                    or record.status != expected_status
+                    or record.attempts != attempts
+                ):
+                    return False
+                # Commit the non-retryable state while the attempt lease is
+                # still held. A crash after transcript delivery can now only
+                # leave cleanup_pending on disk, never an abandoned active
+                # entry that pruning could turn back into a retryable failure.
+                committed = self._mark_cleanup_pending_locked(record)
+                if committed is None:
+                    return False
+                self._release_attempt_lease(recovery_id, attempts)
+                # Antivirus/indexer locks on Windows can make deletion
+                # transiently fail. cleanup_pending is pruned on every future
+                # cache access, and is never listable/claimable for retry.
+                self._remove_directory(record.directory)
+                return True
+        except OSError:
+            return False
+
+    def get_record(self, recovery_id: str) -> Optional[RecoveryRecord]:
+        try:
+            with self._locked_existing_root() as available:
+                if not available:
+                    return None
+                self._prune_locked()
+                record = self._get_record_locked(recovery_id)
+                if record is None or not self._record_is_publicly_available(
+                    record,
+                    float(self._now()),
+                ):
+                    return None
+                return record
+        except OSError:
+            return None
+
+    def list_records(self) -> list[RecoveryRecord]:
+        if not self.root.is_dir() or self.root.is_symlink():
+            return []
+        try:
+            with self._locked():
+                self._prune_locked()
+                now = float(self._now())
+                return sorted(
+                    (
+                        record
+                        for record in self._records_locked()
+                        if self._record_is_publicly_available(record, now)
+                    ),
+                    key=lambda item: item.created_at,
+                )
+        except OSError:
+            return []
+
+    def prune(self) -> None:
+        if not self.root.is_dir() or self.root.is_symlink():
+            return
+        try:
+            with self._locked():
+                self._prune_locked()
+        except OSError:
+            logger.warning("Could not prune STT recovery cache", exc_info=True)
+
+    def _ensure_root(self) -> None:
+        self.root.mkdir(parents=True, mode=0o700, exist_ok=True)
+        root_stat = self.root.lstat()
+        if not stat.S_ISDIR(root_stat.st_mode) or stat.S_ISLNK(root_stat.st_mode):
+            raise OSError("STT recovery root is not a private directory")
+        if os.name == "posix":
+            os.chmod(self.root, 0o700)
+
+    @contextlib.contextmanager
+    def _locked(self) -> Iterator[None]:
+        self._ensure_root()
+        with _PROCESS_LOCK:
+            if fcntl is None and msvcrt is None:  # pragma: no cover - exotic fallback
+                yield
+                return
+
+            lock_path = self.root / ".lock"
+            flags = os.O_RDWR | os.O_CREAT
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            fd = os.open(lock_path, flags, 0o600)
+            try:
+                if hasattr(os, "fchmod"):
+                    os.fchmod(fd, 0o600)
+                if fcntl is not None:
+                    fcntl.flock(fd, fcntl.LOCK_EX)
+                    try:
+                        yield
+                    finally:
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                else:  # pragma: no cover - Windows
+                    assert msvcrt is not None
+                    if os.fstat(fd).st_size == 0:
+                        os.write(fd, b"\0")
+                    os.lseek(fd, 0, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                    try:
+                        yield
+                    finally:
+                        os.lseek(fd, 0, os.SEEK_SET)
+                        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            finally:
+                os.close(fd)
+
+    @contextlib.contextmanager
+    def _locked_existing_root(self) -> Iterator[bool]:
+        try:
+            root_stat = self.root.lstat()
+        except OSError:
+            yield False
+            return
+        if not stat.S_ISDIR(root_stat.st_mode) or stat.S_ISLNK(root_stat.st_mode):
+            yield False
+            return
+        with self._locked():
+            yield True
+
+    def _prune_locked(
+        self, *, reserve_entries: int = 0, reserve_bytes: int = 0
+    ) -> None:
+        now = float(self._now())
+        self._remove_orphan_staging_dirs()
+        self._remove_stale_owned_orphans(now)
+        records = self._records_locked()
+
+        for record in records:
+            if record.status == "cleanup_pending":
+                self._remove_directory(record.directory)
+        records = self._records_locked()
+
+        # New records acquire their OS lease under this same root lock before
+        # becoming observable. Therefore an active schema-v1 record without a
+        # held lease is authoritatively abandoned and can be retried at once.
+        for record in records:
+            if record.status not in {"transcribing", "delivering"}:
+                continue
+            if not self._attempt_lease_is_held(record):
+                self._mark_failed_locked(
+                    record.recovery_id,
+                    attempts=record.attempts,
+                    expected_status=record.status,
+                    failure_code="interrupted",
+                    provider=record.provider,
+                )
+
+        records = self._records_locked()
+        for record in records:
+            if record.status == "failed" and record.expires_at <= now:
+                if self._mark_cleanup_pending_locked(record) is not None:
+                    self._remove_directory(record.directory)
+
+        records = self._records_locked()
+        orphan_entries, orphan_bytes = self._owned_orphan_usage_locked()
+        target_entries = max(
+            self.policy.max_entries - reserve_entries - orphan_entries,
+            0,
+        )
+        target_bytes = max(
+            self.policy.max_total_bytes - reserve_bytes - orphan_bytes,
+            0,
+        )
+        total_bytes = sum(record.byte_size for record in records)
+        failed_oldest = sorted(
+            (record for record in records if record.status == "failed"),
+            key=lambda item: item.created_at,
+        )
+        while failed_oldest and (
+            len(records) > target_entries or total_bytes > target_bytes
+        ):
+            victim = failed_oldest.pop(0)
+            if self._remove_directory(victim.directory):
+                records = [
+                    record
+                    for record in records
+                    if record.recovery_id != victim.recovery_id
+                ]
+                total_bytes -= victim.byte_size
+
+    def _mark_cleanup_pending_locked(
+        self,
+        record: RecoveryRecord,
+    ) -> Optional[RecoveryRecord]:
+        """Atomically make a record inaccessible before best-effort deletion."""
+        manifest = self._read_manifest(record.directory)
+        if manifest is None:
+            return None
+        try:
+            manifest_attempts = int(manifest.get("attempts") or 1)
+        except (TypeError, ValueError):
+            return None
+        if (
+            manifest.get("status") != record.status
+            or manifest_attempts != record.attempts
+        ):
+            return None
+        manifest.update({
+            "status": "cleanup_pending",
+            "updated_at": float(self._now()),
+            "provider": None,
+            "failure_code": None,
+        })
+        try:
+            atomic_json_write(
+                record.directory / "manifest.json",
+                manifest,
+                mode=0o600,
+            )
+        except (OSError, TypeError, ValueError):
+            return None
+        updated = self._record_from_directory(record.directory)
+        if (
+            updated is None
+            or updated.status != "cleanup_pending"
+            or updated.attempts != record.attempts
+        ):
+            return None
+        return updated
+
+    def _mark_failed_locked(
+        self,
+        recovery_id: str,
+        *,
+        attempts: int,
+        expected_status: str,
+        failure_code: str,
+        provider: Optional[str],
+    ) -> Optional[RecoveryRecord]:
+        record = self._get_record_locked(recovery_id)
+        if (
+            record is None
+            or record.attempts != attempts
+            or record.status != expected_status
+        ):
+            return None
+        manifest = self._read_manifest(record.directory)
+        if manifest is None:
+            return None
+        failed_at = float(self._now())
+        manifest.update({
+            "status": "failed",
+            "updated_at": failed_at,
+            # Retention starts when an attempt fails, not when a potentially
+            # long transcription began.
+            "expires_at": failed_at + self.policy.retention_seconds,
+            "provider": self._safe_provider(provider),
+            "failure_code": self._safe_failure_code(failure_code),
+        })
+        try:
+            atomic_json_write(
+                record.directory / "manifest.json",
+                manifest,
+                mode=0o600,
+            )
+        except OSError:
+            logger.warning(
+                "Could not update STT recovery manifest id=%s",
+                recovery_id,
+                exc_info=True,
+            )
+            return None
+        self._release_attempt_lease(recovery_id, attempts)
+        updated = self._record_from_directory(record.directory)
+        return updated if updated is not None and updated.status == "failed" else None
+
+    def _records_locked(self) -> list[RecoveryRecord]:
+        records: list[RecoveryRecord] = []
+        try:
+            children = list(self.root.iterdir())
+        except OSError:
+            return records
+        for child in children:
+            if not _RECOVERY_ID_RE.fullmatch(child.name):
+                continue
+            record = self._record_from_directory(child)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def _get_record_locked(self, recovery_id: str) -> Optional[RecoveryRecord]:
+        if not _RECOVERY_ID_RE.fullmatch(str(recovery_id)):
+            return None
+        return self._record_from_directory(self.root / recovery_id)
+
+    def _record_from_directory(self, directory: Path) -> Optional[RecoveryRecord]:
+        try:
+            directory_stat = directory.lstat()
+            if not stat.S_ISDIR(directory_stat.st_mode) or stat.S_ISLNK(
+                directory_stat.st_mode
+            ):
+                return None
+            manifest = self._read_manifest(directory)
+            if manifest is None:
+                return None
+            recovery_id = str(manifest.get("recovery_id") or "")
+            if recovery_id != directory.name or not _RECOVERY_ID_RE.fullmatch(
+                recovery_id
+            ):
+                return None
+            if manifest.get("schema_version") != _SCHEMA_VERSION:
+                return None
+            audio_name = str(manifest.get("audio_file") or "")
+            if Path(audio_name).name != audio_name or not audio_name.startswith(
+                "audio."
+            ):
+                return None
+            audio_path = directory / audio_name
+            audio_stat = audio_path.lstat()
+            if not stat.S_ISREG(audio_stat.st_mode) or stat.S_ISLNK(audio_stat.st_mode):
+                return None
+            status_value = str(manifest.get("status") or "")
+            if status_value not in {
+                "transcribing",
+                "delivering",
+                "failed",
+                "cleanup_pending",
+            }:
+                return None
+            created_at = float(manifest["created_at"])
+            updated_at = float(manifest["updated_at"])
+            expires_at = float(manifest["expires_at"])
+            now = float(self._now())
+            if any(
+                not math.isfinite(value) or value < 0
+                for value in (created_at, updated_at, expires_at, now)
+            ):
+                return None
+            # Reject corrupt-but-finite epochs that could crash datetime
+            # formatting or keep an active entry alive forever. The small
+            # skew allowance avoids losing recovery after a minor clock step.
+            if created_at > now + _CLOCK_SKEW_SECONDS:
+                return None
+            if updated_at > now + _CLOCK_SKEW_SECONDS:
+                return None
+            if updated_at + _CLOCK_SKEW_SECONDS < created_at:
+                return None
+            if expires_at + _CLOCK_SKEW_SECONDS < created_at:
+                return None
+            latest_reasonable_base = max(created_at, updated_at, now)
+            if expires_at > (
+                latest_reasonable_base
+                + (_MAX_RETENTION_HOURS * 3600)
+                + _CLOCK_SKEW_SECONDS
+            ):
+                return None
+            return RecoveryRecord(
+                recovery_id=recovery_id,
+                directory=directory,
+                audio_path=audio_path,
+                status=status_value,
+                created_at=created_at,
+                expires_at=expires_at,
+                byte_size=int(audio_stat.st_size),
+                mime_type=str(manifest.get("mime_type") or "application/octet-stream"),
+                attempts=max(int(manifest.get("attempts") or 1), 1),
+                provider=self._safe_provider(manifest.get("provider")),
+                failure_code=self._safe_failure_code(manifest.get("failure_code")),
+            )
+        except (OSError, KeyError, TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _read_manifest(directory: Path) -> Optional[dict[str, Any]]:
+        path = directory / "manifest.json"
+        try:
+            path_stat = path.lstat()
+            if not stat.S_ISREG(path_stat.st_mode) or stat.S_ISLNK(path_stat.st_mode):
+                return None
+            with path.open("r", encoding="utf-8") as handle:
+                value = json.load(handle)
+            return value if isinstance(value, dict) else None
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    @staticmethod
+    def _write_private_bytes(path: Path, data: bytes) -> None:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags, 0o600)
+        try:
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb") as handle:
+                fd = -1
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            if fd >= 0:
+                os.close(fd)
+
+    def _acquire_attempt_lease(self, directory: Path) -> Optional[int]:
+        """Acquire a non-blocking OS lease for one live transcription."""
+        path = directory / ".lease"
+        flags = os.O_RDWR | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            fd = os.open(path, flags, 0o600)
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise OSError("STT recovery lease is not a regular file")
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            elif msvcrt is not None:  # pragma: no cover - Windows
+                if os.fstat(fd).st_size == 0:
+                    os.write(fd, b"\0")
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            else:  # pragma: no cover - exotic fallback
+                os.close(fd)
+                return None
+            return fd
+        except OSError as exc:
+            if "fd" in locals():
+                os.close(fd)
+            if exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                logger.warning(
+                    "Could not acquire STT recovery attempt lease", exc_info=True
+                )
+            return None
+
+    @staticmethod
+    def _close_attempt_lease(fd: int) -> None:
+        try:
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            elif msvcrt is not None:  # pragma: no cover - Windows
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+        finally:
+            os.close(fd)
+
+    def _release_attempt_lease(self, recovery_id: str, attempts: int) -> None:
+        fd = self._attempt_leases.pop((recovery_id, attempts), None)
+        if fd is not None:
+            self._close_attempt_lease(fd)
+
+    def _attempt_lease_is_held(self, record: RecoveryRecord) -> bool:
+        if (record.recovery_id, record.attempts) in self._attempt_leases:
+            return True
+        fd = self._acquire_attempt_lease(record.directory)
+        if fd is None:
+            # Contention or an unreadable lease must fail closed: pruning a
+            # live worker's immutable input is worse than delayed cleanup.
+            return True
+        self._close_attempt_lease(fd)
+        return False
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        if os.name != "posix":  # pragma: no cover - not supported on Windows
+            return
+        try:
+            fd = os.open(path, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(fd)
+        except OSError:
+            pass
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _remove_directory(path: Path) -> bool:
+        try:
+            path_stat = path.lstat()
+            if not stat.S_ISDIR(path_stat.st_mode) or stat.S_ISLNK(path_stat.st_mode):
+                return False
+            shutil.rmtree(path)
+            return True
+        except OSError:
+            return False
+
+    def _remove_orphan_staging_dirs(self) -> None:
+        """Remove crash leftovers while holding the cross-process lock.
+
+        A live stager holds this same lock from directory creation through
+        atomic publish, so every matching staging directory visible here is
+        necessarily orphaned and can be removed immediately.
+        """
+        try:
+            children = list(self.root.iterdir())
+        except OSError:
+            return
+        for child in children:
+            if not _STAGING_DIR_RE.fullmatch(child.name):
+                continue
+            try:
+                child_stat = child.lstat()
+                if stat.S_ISDIR(child_stat.st_mode) and not stat.S_ISLNK(
+                    child_stat.st_mode
+                ):
+                    self._remove_directory(child)
+            except OSError:
+                continue
+
+    def _remove_stale_owned_orphans(self, now: float) -> None:
+        """Bound corrupt/unsupported UUID directories by a hard privacy TTL."""
+        try:
+            children = list(self.root.iterdir())
+        except OSError:
+            return
+        for child in children:
+            if not _RECOVERY_ID_RE.fullmatch(child.name):
+                continue
+            if self._record_from_directory(child) is not None:
+                continue
+            try:
+                child_stat = child.lstat()
+                if (
+                    stat.S_ISDIR(child_stat.st_mode)
+                    and not stat.S_ISLNK(child_stat.st_mode)
+                    and now - child_stat.st_mtime >= _ORPHAN_STALE_SECONDS
+                ):
+                    self._remove_directory(child)
+            except OSError:
+                continue
+
+    def _owned_orphan_usage_locked(self) -> tuple[int, int]:
+        """Account non-symlink UUID directories that cannot be parsed."""
+        entries = 0
+        total_bytes = 0
+        try:
+            children = list(self.root.iterdir())
+        except OSError:
+            return entries, total_bytes
+        for child in children:
+            if not _RECOVERY_ID_RE.fullmatch(child.name):
+                continue
+            if self._record_from_directory(child) is not None:
+                continue
+            try:
+                child_stat = child.lstat()
+            except OSError:
+                continue
+            if not stat.S_ISDIR(child_stat.st_mode) or stat.S_ISLNK(child_stat.st_mode):
+                continue
+            entries += 1
+            total_bytes += self._regular_file_bytes(child)
+        return entries, total_bytes
+
+    @staticmethod
+    def _regular_file_bytes(directory: Path) -> int:
+        total = 0
+        for dirpath, dirnames, filenames in os.walk(directory, followlinks=False):
+            base = Path(dirpath)
+            safe_dirs: list[str] = []
+            for name in dirnames:
+                try:
+                    mode = (base / name).lstat().st_mode
+                except OSError:
+                    continue
+                if stat.S_ISDIR(mode) and not stat.S_ISLNK(mode):
+                    safe_dirs.append(name)
+            dirnames[:] = safe_dirs
+            for name in filenames:
+                try:
+                    file_stat = (base / name).lstat()
+                except OSError:
+                    continue
+                if stat.S_ISREG(file_stat.st_mode) and not stat.S_ISLNK(
+                    file_stat.st_mode
+                ):
+                    total += int(file_stat.st_size)
+        return total
+
+    @staticmethod
+    def _safe_provider(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text if _SAFE_PROVIDER_RE.fullmatch(text) else None
+
+    @staticmethod
+    def _record_is_publicly_available(
+        record: RecoveryRecord,
+        now: float,
+    ) -> bool:
+        if record.status == "cleanup_pending":
+            return False
+        return not (record.status == "failed" and record.expires_at <= now)
+
+    @staticmethod
+    def _safe_failure_code(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip().lower().replace("-", "_")
+        return text if re.fullmatch(r"[a-z0-9_]{1,64}", text) else "unknown_error"
+
+
+def recovery_expiry_iso(record: RecoveryRecord) -> str:
+    """Return a stable UTC timestamp suitable for CLI/API messages."""
+    from datetime import datetime, timezone
+
+    return (
+        datetime
+        .fromtimestamp(record.expires_at, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )

--- a/hermes_cli/stt_recovery_cli.py
+++ b/hermes_cli/stt_recovery_cli.py
@@ -1,0 +1,349 @@
+"""Built-in ``hermes stt recovery`` commands."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+from typing import Optional
+
+from agent.redact import redact_sensitive_text
+from hermes_cli.config import load_config
+from hermes_cli.stt_recovery import (
+    RecoveryRecord,
+    SttRecoveryCache,
+    recovery_expiry_iso,
+)
+
+
+def register_cli(subparsers) -> None:
+    """Attach the STT recovery command tree to the top-level parser."""
+    stt_parser = subparsers.add_parser(
+        "stt",
+        help="Manage speech-to-text configuration and recovery",
+    )
+    stt_subparsers = stt_parser.add_subparsers(dest="stt_command")
+    recovery_parser = stt_subparsers.add_parser(
+        "recovery",
+        help="Recover desktop recordings retained after STT failures",
+    )
+    recovery_subparsers = recovery_parser.add_subparsers(dest="recovery_command")
+
+    list_parser = recovery_subparsers.add_parser(
+        "list",
+        aliases=["ls"],
+        help="List retained recordings",
+    )
+    list_parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON"
+    )
+    list_parser.set_defaults(func=_cmd_list)
+
+    retry_parser = recovery_subparsers.add_parser(
+        "retry",
+        help="Retry transcription and remove the recording after output is delivered",
+    )
+    retry_parser.add_argument(
+        "recovery_id", help="Opaque recovery ID from the STT error"
+    )
+    retry_parser.set_defaults(func=_cmd_retry)
+
+    save_parser = recovery_subparsers.add_parser(
+        "save",
+        help="Export the original recording without changing the retained copy",
+    )
+    save_parser.add_argument(
+        "recovery_id", help="Opaque recovery ID from the STT error"
+    )
+    save_parser.add_argument("output", help="Destination file or existing directory")
+    save_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing destination file atomically",
+    )
+    save_parser.set_defaults(func=_cmd_save)
+
+    discard_parser = recovery_subparsers.add_parser(
+        "discard",
+        aliases=["rm"],
+        help="Permanently delete one retained recording",
+    )
+    discard_parser.add_argument(
+        "recovery_id", help="Opaque recovery ID from the STT error"
+    )
+    discard_parser.set_defaults(func=_cmd_discard)
+
+    def _show_help(_args: argparse.Namespace) -> int:
+        recovery_parser.print_help()
+        return 0
+
+    recovery_parser.set_defaults(func=_show_help)
+    stt_parser.set_defaults(func=_show_help)
+
+
+def _cache() -> SttRecoveryCache:
+    return SttRecoveryCache.from_config(load_config())
+
+
+def _record_payload(record: RecoveryRecord) -> dict[str, object]:
+    return {
+        "recovery_id": record.recovery_id,
+        "status": record.status,
+        "created_at": datetime
+        .fromtimestamp(
+            record.created_at,
+            tz=timezone.utc,
+        )
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "expires_at": recovery_expiry_iso(record),
+        "byte_size": record.byte_size,
+        "mime_type": record.mime_type,
+        "attempts": record.attempts,
+        "provider": record.provider,
+        "failure_code": record.failure_code,
+    }
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    records = _cache().list_records()
+    if args.json:
+        print(json.dumps([_record_payload(record) for record in records], indent=2))
+        return 0
+    if not records:
+        print("No retained STT recordings.")
+        return 0
+
+    print("RECOVERY ID                      STATUS        SIZE       EXPIRES (UTC)")
+    for record in records:
+        size = _human_bytes(record.byte_size)
+        print(
+            f"{record.recovery_id}  {record.status:<12}  {size:>9}  "
+            f"{recovery_expiry_iso(record)}"
+        )
+    return 0
+
+
+def _cmd_retry(args: argparse.Namespace) -> int:
+    cache = _cache()
+    record = cache.claim_retry(args.recovery_id)
+    if record is None:
+        print(
+            "Recovery entry was not found, expired, or is already being retried.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        from tools.voice_mode import transcribe_recording
+
+        result = transcribe_recording(str(record.audio_path))
+        if not isinstance(result, Mapping):
+            raise TypeError("STT provider returned an invalid result")
+        result = dict(result)
+        raw_transcript = result.get("transcript")
+        if raw_transcript is not None and not isinstance(raw_transcript, str):
+            raise TypeError("STT provider returned an invalid transcript")
+        raw_provider = result.get("provider")
+        provider = (
+            raw_provider
+            if isinstance(raw_provider, str)
+            and re.fullmatch(r"[A-Za-z0-9._-]{1,64}", raw_provider)
+            else None
+        )
+    except (KeyboardInterrupt, SystemExit):
+        cache.mark_failed_attempt(
+            record.recovery_id,
+            attempts=record.attempts,
+            failure_code="retry_interrupted",
+        )
+        raise
+    except Exception as exc:
+        cache.mark_failed_attempt(
+            record.recovery_id,
+            attempts=record.attempts,
+            failure_code="unexpected_error",
+        )
+        safe_error = redact_sensitive_text(str(exc), force=True)
+        print(f"Transcription retry failed: {safe_error}", file=sys.stderr)
+        print("The original recording is still retained.", file=sys.stderr)
+        return 1
+
+    if result.get("success") is not True:
+        cache.mark_failed_attempt(
+            record.recovery_id,
+            attempts=record.attempts,
+            failure_code="provider_error",
+            provider=provider,
+        )
+        raw_error = result.get("error")
+        safe_error = redact_sensitive_text(
+            raw_error if isinstance(raw_error, str) else "Transcription failed",
+            force=True,
+        )
+        print(f"Transcription retry failed: {safe_error}", file=sys.stderr)
+        print("The original recording is still retained.", file=sys.stderr)
+        return 1
+
+    transcript = (result.get("transcript") or "").strip()
+    if not transcript:
+        cache.mark_failed_attempt(
+            record.recovery_id,
+            attempts=record.attempts,
+            failure_code="no_speech",
+            provider=provider,
+        )
+        print(
+            "The retry returned no speech; the original recording is still retained.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Keep the immutable input in a non-evictable, non-claimable state while
+    # stdout receives the only transcript copy. A hard process crash is
+    # detected by the released OS lease; ordinary delivery failures become
+    # immediately retryable below.
+    delivery = cache.mark_delivering_attempt(
+        record.recovery_id,
+        attempts=record.attempts,
+    )
+    delivery_status = "delivering" if delivery is not None else "transcribing"
+    try:
+        print(transcript)
+        # Deletion is the commit boundary: if stdout is a broken pipe or
+        # otherwise cannot deliver the transcript, flush raises and the
+        # original survives in a retryable state.
+        sys.stdout.flush()
+    except BaseException:
+        cache.mark_failed_attempt(
+            record.recovery_id,
+            attempts=record.attempts,
+            expected_status=delivery_status,
+            failure_code="delivery_interrupted",
+            provider=provider,
+        )
+        raise
+    if not cache.complete_attempt(
+        record.recovery_id,
+        attempts=record.attempts,
+        expected_status=delivery_status,
+    ):
+        cache.mark_failed_attempt(
+            record.recovery_id,
+            attempts=record.attempts,
+            expected_status=delivery_status,
+            failure_code="cleanup_error",
+            provider=provider,
+        )
+        print(
+            "Warning: transcription succeeded, but cleanup could not be committed; "
+            "the recording remains retained.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def _cmd_save(args: argparse.Namespace) -> int:
+    record = _cache().get_record(args.recovery_id)
+    if record is None:
+        print("Recovery entry was not found or has expired.", file=sys.stderr)
+        return 1
+
+    destination = Path(args.output).expanduser()
+    if destination.is_dir():
+        destination = (
+            destination / f"stt-{record.recovery_id}{record.audio_path.suffix}"
+        )
+    try:
+        _copy_private_file(record.audio_path, destination, force=bool(args.force))
+    except FileExistsError:
+        print(f"Destination already exists: {destination}", file=sys.stderr)
+        print("Pass --force to replace it atomically.", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        safe_error = redact_sensitive_text(str(exc), force=True)
+        print(f"Could not save recording: {safe_error}", file=sys.stderr)
+        return 1
+
+    print(f"Saved recording to {destination}")
+    return 0
+
+
+def _cmd_discard(args: argparse.Namespace) -> int:
+    if not _cache().discard_failed(args.recovery_id):
+        print("Recovery entry was not found or has expired.", file=sys.stderr)
+        return 1
+    print(f"Discarded STT recovery {args.recovery_id}.")
+    return 0
+
+
+def _copy_private_file(source: Path, destination: Path, *, force: bool) -> None:
+    """Copy a validated recovery audio file with no world-readable window."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists() and not force:
+        raise FileExistsError(destination)
+
+    source_flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        source_flags |= os.O_NOFOLLOW
+    source_fd = os.open(source, source_flags)
+    temp_path: Optional[Path] = None
+    output_fd = -1
+    try:
+        if not stat.S_ISREG(os.fstat(source_fd).st_mode):
+            raise OSError("Recovery audio is not a regular file")
+
+        if force:
+            output_fd, raw_temp_path = tempfile.mkstemp(
+                prefix=f".{destination.name}.",
+                suffix=".tmp",
+                dir=str(destination.parent),
+            )
+            temp_path = Path(raw_temp_path)
+        else:
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            output_fd = os.open(destination, flags, 0o600)
+
+        if hasattr(os, "fchmod"):
+            os.fchmod(output_fd, 0o600)
+        while True:
+            chunk = os.read(source_fd, 1024 * 1024)
+            if not chunk:
+                break
+            view = memoryview(chunk)
+            while view:
+                written = os.write(output_fd, view)
+                view = view[written:]
+        os.fsync(output_fd)
+        os.close(output_fd)
+        output_fd = -1
+        if temp_path is not None:
+            os.replace(temp_path, destination)
+            temp_path = None
+    finally:
+        os.close(source_fd)
+        if output_fd >= 0:
+            os.close(output_fd)
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+
+
+def _human_bytes(value: int) -> str:
+    size = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if size < 1024 or unit == "GiB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{value} B"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,7 +48,7 @@ import zipfile
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Mapping, Optional, Tuple
 
 import yaml
 
@@ -4223,60 +4223,220 @@ async def transcribe_audio_upload(
     if len(audio_bytes) > _MAX_TRANSCRIPTION_UPLOAD_BYTES:
         raise HTTPException(status_code=413, detail="Audio recording is too large")
 
+    from agent.redact import redact_sensitive_text
+    from hermes_cli.stt_recovery import SttRecoveryCache, recovery_expiry_iso
+    from tools.voice_mode import transcribe_recording
+
     temp_path = ""
+    recovery = None
+    cache = None
+    transcription_task = None
+    suffix = _audio_extension_for_mime(mime_type)
+    recovery_profile = _stt_recovery_cli_profile(profile)
+
+    def _failure_response(
+        status_code: int,
+        error_code: str,
+        *,
+        provider: Optional[str] = None,
+    ):
+        retained = recovery
+        if retained is not None and cache is not None:
+            retained = cache.mark_failed_attempt(
+                retained.recovery_id,
+                attempts=retained.attempts,
+                failure_code=error_code,
+                provider=provider,
+            )
+        if retained is not None and retained.status == "failed":
+            recovery_id = retained.recovery_id
+            recovery_command = "hermes "
+            if recovery_profile is not None:
+                recovery_command += f"-p {recovery_profile} "
+            recovery_command += f"stt recovery retry {recovery_id}"
+            detail = (
+                "Transcription failed. Audio is recoverable until "
+                f"{recovery_expiry_iso(retained)}. On the Hermes backend host, "
+                f"run `{recovery_command}`."
+            )
+            content = {
+                "detail": detail,
+                "error_code": error_code,
+                "recovery_available": True,
+                "recovery_id": recovery_id,
+                "expires_at": recovery_expiry_iso(retained),
+            }
+            if recovery_profile is not None:
+                content["recovery_profile"] = recovery_profile
+            return JSONResponse(status_code=status_code, content=content)
+        return JSONResponse(
+            status_code=status_code,
+            content={
+                "detail": (
+                    "Transcription failed, and Hermes could not preserve the "
+                    "recording for recovery."
+                ),
+                "error_code": error_code,
+                "recovery_available": False,
+            },
+        )
+
     try:
-        suffix = _audio_extension_for_mime(mime_type)
-        with tempfile.NamedTemporaryFile(
-            prefix="hermes-desktop-voice-",
-            suffix=suffix,
-            delete=False,
-        ) as tmp:
-            tmp.write(audio_bytes)
-            temp_path = tmp.name
+        # The profile scope selects both the STT provider configuration and
+        # the per-profile recovery root. asyncio.to_thread copies ContextVars;
+        # run_in_executor does not, which previously routed remote/profile STT
+        # through the dashboard process's default profile.
+        with _config_profile_scope(profile):
+            cache = SttRecoveryCache.from_config(load_config())
+            try:
+                recovery = cache.stage_audio(
+                    audio_bytes,
+                    suffix=suffix,
+                    mime_type=normalized_mime_type,
+                )
+            except Exception:
+                # Recovery is best-effort: a storage bug or unavailable cache
+                # must not break transcription that would otherwise succeed.
+                _log.warning("Desktop STT recovery staging failed", exc_info=True)
+                recovery = None
+            if recovery is not None:
+                audio_path = str(recovery.audio_path)
+            else:
+                with tempfile.NamedTemporaryFile(
+                    prefix="hermes-desktop-voice-",
+                    suffix=suffix,
+                    delete=False,
+                ) as tmp:
+                    # Publish the name before the first write so even a
+                    # partial disk-full failure is cleaned up in ``finally``.
+                    temp_path = tmp.name
+                    tmp.write(audio_bytes)
+                audio_path = temp_path
 
-        # transcribe_recording (not raw transcribe_audio): filters Whisper
-        # hallucinations and maps provider "empty transcript" errors to a
-        # successful empty result — the live voice loop treats "" as silence
-        # and re-listens instead of surfacing a 400 on every quiet turn.
-        from tools.voice_mode import transcribe_recording
+            # transcribe_recording (not raw transcribe_audio): filters Whisper
+            # hallucinations and maps provider "empty transcript" errors to a
+            # successful empty result — the live voice loop treats "" as silence
+            # and re-listens instead of surfacing a 400 on every quiet turn.
+            transcription_task = asyncio.create_task(
+                asyncio.to_thread(transcribe_recording, audio_path)
+            )
+            result = await asyncio.shield(transcription_task)
+            if not isinstance(result, Mapping):
+                raise TypeError("STT provider returned an invalid result")
+            result = dict(result)
+            raw_provider = result.get("provider")
+            if not (
+                isinstance(raw_provider, str)
+                and re.fullmatch(r"[A-Za-z0-9._-]{1,64}", raw_provider)
+            ):
+                result["provider"] = None
+            raw_transcript = result.get("transcript")
+            if raw_transcript is not None and not isinstance(raw_transcript, str):
+                raise TypeError("STT provider returned an invalid transcript")
+            transcript = (raw_transcript or "").strip()
+    except asyncio.CancelledError:
+        if transcription_task is not None:
+            # shield() leaves the worker alive after the HTTP task is
+            # cancelled. Keep the record in its active state until the worker
+            # has finished reading it, then make it immediately retryable. If
+            # recovery is disabled/unavailable, defer temp cleanup for the same
+            # reason instead of unlinking a file the worker is still reading.
+            cancelled_temp_path = temp_path
+            temp_path = ""
 
-        def _transcribe_scoped():
-            # Home-only scope (contextvar), NOT _profile_scope: transcription
-            # blocks for the provider round-trip and _profile_scope holds a
-            # process-global skills lock for its entire body (see the MCP
-            # probe above). STT only needs config/.env resolution, which the
-            # contextvar override provides inside this worker thread.
-            with _config_profile_scope(profile):
-                return transcribe_recording(temp_path)
+            def _retain_cancelled_record(done_task):
+                provider = None
+                if not done_task.cancelled():
+                    try:
+                        completed = done_task.result()
+                        if isinstance(completed, Mapping):
+                            raw_provider = completed.get("provider")
+                            if (
+                                isinstance(raw_provider, str)
+                                and re.fullmatch(
+                                    r"[A-Za-z0-9._-]{1,64}", raw_provider
+                                )
+                            ):
+                                provider = raw_provider
+                    except Exception:
+                        pass
+                if recovery is not None and cache is not None:
+                    cache.mark_failed_attempt(
+                        recovery.recovery_id,
+                        attempts=recovery.attempts,
+                        failure_code="request_cancelled",
+                        provider=provider,
+                    )
+                if cancelled_temp_path:
+                    try:
+                        os.unlink(cancelled_temp_path)
+                    except OSError:
+                        pass
 
-        loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, _transcribe_scoped)
-    except HTTPException:
+            transcription_task.add_done_callback(_retain_cancelled_record)
         raise
+    except HTTPException as exc:
+        if transcription_task is None:
+            raise
+        # Provider/helper HTTPExceptions are implementation details once the
+        # worker has started. Return the same credential-safe structured error
+        # even when recovery was disabled or staging was unavailable.
+        _log.error(
+            "Desktop voice transcription raised HTTP %s",
+            exc.status_code,
+        )
+        return _failure_response(500, "unexpected_error")
     except Exception as exc:
-        _log.exception("Desktop voice transcription failed")
-        raise HTTPException(status_code=500, detail=f"Transcription failed: {exc}")
+        safe_error = redact_sensitive_text(str(exc), force=True)
+        _log.error("Desktop voice transcription failed: %s", safe_error)
+        return _failure_response(500, "unexpected_error")
     finally:
+        # Only the non-recoverable fallback uses a conventional temp file.
+        # A staged recovery file is discarded below on success and retained
+        # on every failure/cancellation path.
         if temp_path:
             try:
                 os.unlink(temp_path)
             except OSError:
                 pass
 
-    if not result.get("success"):
-        err = result.get("error") or "Transcription failed"
-        # An empty transcript means no speech was detected — a normal outcome
-        # for VAD/continuous voice loops (e.g. a wake-word conversation
-        # re-listening on silence), not an error. Return an empty transcript so
-        # the client quietly re-listens instead of surfacing a "transcription
-        # failed" toast on every silent gap.
-        if "empty transcript" in err.lower():
-            return {"ok": True, "transcript": "", "provider": result.get("provider")}
-        raise HTTPException(status_code=400, detail=err)
+    if result.get("success") is not True:
+        raw_error = result.get("error")
+        # Preserve the pre-recovery Desktop contract for providers (including
+        # command/custom providers) that signal silence only through their
+        # legacy error text and omit the newer ``no_speech`` flag. Treat only
+        # this narrow result as success: an empty/missing transcript can also
+        # accompany auth, network, or provider failures and must stay
+        # recoverable.
+        if isinstance(raw_error, str) and "empty transcript" in raw_error.lower():
+            transcript = ""
+        else:
+            provider = result.get("provider")
+            return _failure_response(
+                400,
+                "provider_error",
+                provider=str(provider) if provider else None,
+            )
+
+    if recovery is not None and cache is not None:
+        if not cache.complete_attempt(
+            recovery.recovery_id,
+            attempts=recovery.attempts,
+            expected_status="transcribing",
+        ):
+            # The transcript has not crossed the response boundary yet. If we
+            # cannot durably commit the non-retryable cleanup state, report a
+            # failure and retain the source instead of risking silent loss or
+            # a later duplicate retry of an already-accepted transcript.
+            return _failure_response(
+                500,
+                "cleanup_error",
+                provider=result.get("provider"),
+            )
 
     return {
         "ok": True,
-        "transcript": str(result.get("transcript") or "").strip(),
+        "transcript": transcript,
         "provider": result.get("provider"),
     }
 
@@ -12938,6 +13098,33 @@ def _profile_cli_args(profile: Optional[str]) -> List[str]:
     from hermes_cli import profiles as profiles_mod
     _resolve_profile_dir(requested)
     return ["-p", profiles_mod.normalize_profile_name(requested)]
+
+
+def _stt_recovery_cli_profile(profile: Optional[str]) -> Optional[str]:
+    """Return the named profile needed to address this request's cache.
+
+    Shared remote backends receive an explicit query profile, while Electron's
+    local profile pool routes to a process already launched with that profile's
+    HERMES_HOME and intentionally omits the query parameter. Cover both without
+    exposing arbitrary/custom filesystem paths in the recovery response.
+    """
+    requested = (profile or "").strip()
+    if requested and requested.lower() != "current":
+        args = _profile_cli_args(requested)
+        return args[1] if args else None
+
+    launch_home = get_process_hermes_home()
+    if launch_home.parent.name != "profiles":
+        return None
+
+    from hermes_cli import profiles as profiles_mod
+
+    try:
+        candidate = profiles_mod.normalize_profile_name(launch_home.name)
+        profiles_mod.validate_profile_name(candidate)
+    except ValueError:
+        return None
+    return None if candidate == "default" else candidate
 
 
 def _hub_action_name(verb: str, key: str) -> str:

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -121,6 +121,14 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_excludes_stt_recovery_audio(self):
+        """Private failed recordings must never enter full Hermes backups."""
+        from hermes_cli.backup import _should_exclude
+
+        assert _should_exclude(
+            Path(".cache/stt-recovery/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/audio.webm")
+        )
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -151,6 +151,25 @@ class TestCreateProfile:
         assert (profile_dir / ".env").read_text().strip() == "KEY=val"
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
 
+    def test_clone_all_excludes_stt_recovery_cache(self, profile_env):
+        default_home = profile_env / ".hermes"
+        (default_home / "memories").mkdir(exist_ok=True)
+        (default_home / "memories" / "note.md").write_text("remember this")
+        recovery_audio = (
+            default_home
+            / ".cache"
+            / "stt-recovery"
+            / ("a" * 32)
+            / "audio.webm"
+        )
+        recovery_audio.parent.mkdir(parents=True)
+        recovery_audio.write_bytes(b"private voice")
+
+        profile_dir = create_profile("coder", clone_all=True, no_alias=True)
+
+        assert (profile_dir / "memories" / "note.md").read_text() == "remember this"
+        assert not (profile_dir / ".cache").exists()
+
 
 
 
@@ -600,6 +619,15 @@ class TestExportImport:
         mem_dir = default_dir / "memories"
         mem_dir.mkdir(exist_ok=True)
         (mem_dir / "MEMORY.md").write_text("remember this")
+        recovery_audio = (
+            default_dir
+            / ".cache"
+            / "stt-recovery"
+            / ("b" * 32)
+            / "audio.webm"
+        )
+        recovery_audio.parent.mkdir(parents=True)
+        recovery_audio.write_bytes(b"private voice")
 
         output = tmp_path / "export" / "default.tar.gz"
         output.parent.mkdir(parents=True, exist_ok=True)
@@ -612,6 +640,27 @@ class TestExportImport:
         assert "default/.env" not in names  # credentials excluded
         assert "default/SOUL.md" in names
         assert "default/memories/MEMORY.md" in names
+        assert not any("stt-recovery" in name for name in names)
+
+    def test_named_export_excludes_stt_recovery_cache(self, profile_env, tmp_path):
+        profile_dir = create_profile("coder", no_alias=True)
+        recovery_audio = (
+            profile_dir
+            / ".cache"
+            / "stt-recovery"
+            / ("c" * 32)
+            / "audio.webm"
+        )
+        recovery_audio.parent.mkdir(parents=True)
+        recovery_audio.write_bytes(b"private voice")
+
+        output = tmp_path / "export" / "coder.tar.gz"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        export_profile("coder", str(output))
+
+        with tarfile.open(str(output), "r:gz") as tf:
+            names = tf.getnames()
+        assert not any("stt-recovery" in name for name in names)
 
 
     def test_export_default_handles_broken_symlinks(self, profile_env, tmp_path):
@@ -814,6 +863,5 @@ class TestProfilesToServe:
         assert set(serve) == {"default", "coder", "writer"}
         assert serve["default"] == _get_default_hermes_home()
         assert serve["coder"] == get_profile_dir("coder")
-
 
 

--- a/tests/hermes_cli/test_stt_recovery.py
+++ b/tests/hermes_cli/test_stt_recovery.py
@@ -1,0 +1,670 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import json
+import os
+from pathlib import Path
+import stat
+
+import pytest
+
+import hermes_cli.stt_recovery as stt_recovery
+from hermes_cli.stt_recovery import RecoveryPolicy, SttRecoveryCache
+
+
+def _policy(
+    *,
+    retention_seconds: float = 3600,
+    max_entries: int = 5,
+    max_total_bytes: int = 1024,
+) -> RecoveryPolicy:
+    return RecoveryPolicy(
+        enabled=True,
+        retention_seconds=retention_seconds,
+        max_entries=max_entries,
+        max_total_bytes=max_total_bytes,
+    )
+
+
+def test_policy_defaults_are_bounded_and_zero_disables_recovery():
+    defaults = RecoveryPolicy.from_config({})
+    assert defaults.enabled is True
+    assert defaults.retention_hours == 24
+    assert defaults.max_entries == 50
+    assert defaults.max_total_bytes == 500 * 1024 * 1024
+
+    disabled = RecoveryPolicy.from_config({"stt": {"recovery": {"retention_hours": 0}}})
+    assert disabled.enabled is False
+
+    bounded = RecoveryPolicy.from_config({
+        "stt": {
+            "recovery": {
+                "retention_hours": 9999,
+                "max_entries": 9999,
+                "max_total_mb": 9999,
+            }
+        }
+    })
+    assert bounded.retention_hours == 168
+    assert bounded.max_entries == 500
+    assert bounded.max_total_bytes == 2048 * 1024 * 1024
+
+
+def test_stage_and_mark_failed_preserve_exact_private_original(tmp_path):
+    cache = SttRecoveryCache(_policy(), hermes_home=tmp_path)
+    original = b"\x1aE\xdf\xa3original-webm-bytes"
+
+    staged = cache.stage_audio(
+        original,
+        suffix=".webm",
+        mime_type="audio/webm;codecs=opus",
+    )
+    assert staged is not None
+    failed = cache.mark_failed_attempt(
+        staged.recovery_id,
+        attempts=staged.attempts,
+        failure_code="provider_error",
+        provider="openai",
+    )
+
+    assert failed is not None
+    assert failed.status == "failed"
+    assert failed.audio_path.read_bytes() == original
+    manifest = json.loads(
+        (failed.directory / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["provider"] == "openai"
+    assert manifest["failure_code"] == "provider_error"
+    assert "path" not in manifest
+    assert "error" not in manifest
+
+    if os.name == "posix":
+        assert stat.S_IMODE(cache.root.stat().st_mode) == 0o700
+        assert stat.S_IMODE(failed.directory.stat().st_mode) == 0o700
+        assert stat.S_IMODE(failed.audio_path.stat().st_mode) == 0o600
+        assert (
+            stat.S_IMODE((failed.directory / "manifest.json").stat().st_mode) == 0o600
+        )
+        assert stat.S_IMODE((cache.root / ".lock").stat().st_mode) == 0o600
+
+
+def test_discard_requires_failed_state_and_exact_attempt(tmp_path):
+    cache = SttRecoveryCache(_policy(), hermes_home=tmp_path)
+    staged = cache.stage_audio(b"voice", suffix=".wav", mime_type="audio/wav")
+    assert staged is not None
+
+    assert cache.discard_failed(staged.recovery_id) is False
+    assert (
+        cache.discard_attempt(
+            staged.recovery_id,
+            attempts=staged.attempts + 1,
+            expected_status="transcribing",
+        )
+        is False
+    )
+    assert (
+        cache.discard_attempt(
+            staged.recovery_id,
+            attempts=staged.attempts,
+            expected_status="transcribing",
+        )
+        is True
+    )
+    assert not staged.directory.exists()
+    assert cache.discard_failed("../outside") is False
+
+
+def test_successful_attempt_retries_cleanup_without_becoming_retryable(
+    tmp_path,
+    monkeypatch,
+):
+    cache = SttRecoveryCache(_policy(), hermes_home=tmp_path)
+    staged = cache.stage_audio(b"voice", suffix=".wav", mime_type="audio/wav")
+    assert staged is not None
+    remove_directory = cache._remove_directory
+    monkeypatch.setattr(cache, "_remove_directory", lambda path: False)
+
+    assert cache.complete_attempt(
+        staged.recovery_id,
+        attempts=staged.attempts,
+        expected_status="transcribing",
+    )
+    assert cache.get_record(staged.recovery_id) is None
+    assert cache.list_records() == []
+    manifest = json.loads(
+        (staged.directory / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["status"] == "cleanup_pending"
+    assert cache.claim_retry(staged.recovery_id) is None
+    assert cache.discard_failed(staged.recovery_id) is False
+
+    monkeypatch.setattr(cache, "_remove_directory", remove_directory)
+    cache.prune()
+    assert not staged.directory.exists()
+
+
+def test_successful_attempt_keeps_lease_when_cleanup_commit_fails(
+    tmp_path,
+    monkeypatch,
+):
+    cache = SttRecoveryCache(_policy(), hermes_home=tmp_path)
+    staged = cache.stage_audio(b"voice", suffix=".wav", mime_type="audio/wav")
+    assert staged is not None
+
+    real_atomic_json_write = stt_recovery.atomic_json_write
+    monkeypatch.setattr(
+        stt_recovery,
+        "atomic_json_write",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    assert not cache.complete_attempt(
+        staged.recovery_id,
+        attempts=staged.attempts,
+        expected_status="transcribing",
+    )
+    assert (staged.recovery_id, staged.attempts) in cache._attempt_leases
+    retained = cache.get_record(staged.recovery_id)
+    assert retained is not None
+    assert retained.status == "transcribing"
+
+    monkeypatch.setattr(stt_recovery, "atomic_json_write", real_atomic_json_write)
+    failed = cache.mark_failed_attempt(
+        staged.recovery_id,
+        attempts=staged.attempts,
+        failure_code="cleanup_error",
+    )
+    assert failed is not None
+    assert failed.status == "failed"
+
+
+def test_prune_enforces_entry_and_byte_caps_oldest_first(tmp_path):
+    now = [1000.0]
+    cache = SttRecoveryCache(
+        _policy(max_entries=2, max_total_bytes=6),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+
+    first = cache.stage_audio(b"aaa", suffix=".wav", mime_type="audio/wav")
+    assert first is not None
+    cache.mark_failed_attempt(
+        first.recovery_id,
+        attempts=first.attempts,
+        failure_code="provider_error",
+    )
+    now[0] += 1
+    second = cache.stage_audio(b"bbb", suffix=".wav", mime_type="audio/wav")
+    assert second is not None
+    cache.mark_failed_attempt(
+        second.recovery_id,
+        attempts=second.attempts,
+        failure_code="provider_error",
+    )
+    now[0] += 1
+    third = cache.stage_audio(b"ccc", suffix=".wav", mime_type="audio/wav")
+    assert third is not None
+    cache.mark_failed_attempt(
+        third.recovery_id,
+        attempts=third.attempts,
+        failure_code="provider_error",
+    )
+
+    ids = {record.recovery_id for record in cache.list_records()}
+    assert ids == {second.recovery_id, third.recovery_id}
+    assert not first.directory.exists()
+
+
+def test_active_record_is_not_evicted_to_make_room(tmp_path):
+    cache = SttRecoveryCache(
+        _policy(max_entries=1, max_total_bytes=10),
+        hermes_home=tmp_path,
+    )
+    active = cache.stage_audio(b"one", suffix=".wav", mime_type="audio/wav")
+    assert active is not None
+
+    assert cache.stage_audio(b"two", suffix=".wav", mime_type="audio/wav") is None
+    assert active.audio_path.read_bytes() == b"one"
+
+
+def test_expired_failure_and_crash_staging_are_pruned(tmp_path):
+    now = [1000.0]
+    cache = SttRecoveryCache(
+        _policy(retention_seconds=10),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    failed = cache.stage_audio(b"old", suffix=".wav", mime_type="audio/wav")
+    assert failed is not None
+    cache.mark_failed_attempt(
+        failed.recovery_id,
+        attempts=failed.attempts,
+        failure_code="provider_error",
+    )
+
+    staging = cache.root / (".tmp-" + "a" * 32)
+    staging.mkdir(mode=0o700)
+    os.utime(staging, (now[0] - 7200, now[0] - 7200))
+    now[0] += 11
+    cache.prune()
+
+    assert not failed.directory.exists()
+    assert not staging.exists()
+
+
+def test_expired_failure_is_hidden_before_physical_deletion(tmp_path, monkeypatch):
+    now = [1000.0]
+    cache = SttRecoveryCache(
+        _policy(retention_seconds=10),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    failed = cache.stage_audio(b"private", suffix=".wav", mime_type="audio/wav")
+    assert failed is not None
+    cache.mark_failed_attempt(
+        failed.recovery_id,
+        attempts=failed.attempts,
+        failure_code="provider_error",
+    )
+    remove_directory = cache._remove_directory
+    monkeypatch.setattr(cache, "_remove_directory", lambda path: False)
+
+    now[0] += 11
+    assert cache.get_record(failed.recovery_id) is None
+    assert cache.list_records() == []
+    assert cache.claim_retry(failed.recovery_id) is None
+    assert cache.discard_failed(failed.recovery_id) is False
+    manifest = json.loads(
+        (failed.directory / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["status"] == "cleanup_pending"
+
+    monkeypatch.setattr(cache, "_remove_directory", remove_directory)
+    cache.prune()
+    assert not failed.directory.exists()
+
+
+def test_expired_failure_is_hidden_when_tombstone_commit_fails(
+    tmp_path,
+    monkeypatch,
+):
+    now = [1000.0]
+    cache = SttRecoveryCache(
+        _policy(retention_seconds=10),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    failed = cache.stage_audio(b"private", suffix=".wav", mime_type="audio/wav")
+    assert failed is not None
+    cache.mark_failed_attempt(
+        failed.recovery_id,
+        attempts=failed.attempts,
+        failure_code="provider_error",
+    )
+    monkeypatch.setattr(cache, "_remove_directory", lambda path: False)
+    monkeypatch.setattr(
+        stt_recovery,
+        "atomic_json_write",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("read only")),
+    )
+
+    now[0] += 11
+    assert cache.get_record(failed.recovery_id) is None
+    assert cache.list_records() == []
+    assert cache.claim_retry(failed.recovery_id) is None
+    manifest = json.loads(
+        (failed.directory / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["status"] == "failed"
+
+
+def test_capacity_delete_failure_preserves_existing_recoverable_records(
+    tmp_path,
+    monkeypatch,
+):
+    cache = SttRecoveryCache(
+        _policy(max_entries=2, max_total_bytes=10),
+        hermes_home=tmp_path,
+    )
+    first = cache.stage_audio(b"one", suffix=".wav", mime_type="audio/wav")
+    assert first is not None
+    cache.mark_failed_attempt(
+        first.recovery_id,
+        attempts=first.attempts,
+        failure_code="provider_error",
+    )
+    second = cache.stage_audio(b"two", suffix=".wav", mime_type="audio/wav")
+    assert second is not None
+    cache.mark_failed_attempt(
+        second.recovery_id,
+        attempts=second.attempts,
+        failure_code="provider_error",
+    )
+    monkeypatch.setattr(cache, "_remove_directory", lambda path: False)
+
+    assert cache.stage_audio(b"new", suffix=".wav", mime_type="audio/wav") is None
+    records = cache.list_records()
+    assert {record.recovery_id for record in records} == {
+        first.recovery_id,
+        second.recovery_id,
+    }
+    assert all(record.status == "failed" for record in records)
+
+
+def test_failure_retention_starts_when_transcription_fails(tmp_path):
+    now = [1000.0]
+    cache = SttRecoveryCache(
+        _policy(retention_seconds=10),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    staged = cache.stage_audio(b"slow", suffix=".wav", mime_type="audio/wav")
+    assert staged is not None
+
+    now[0] += 9
+    failed = cache.mark_failed_attempt(
+        staged.recovery_id,
+        attempts=staged.attempts,
+        failure_code="provider_error",
+    )
+    assert failed is not None
+    assert failed.expires_at == 1019.0
+
+    now[0] = 1011.0
+    assert cache.get_record(staged.recovery_id) is not None
+    now[0] = 1020.0
+    assert cache.get_record(staged.recovery_id) is None
+    assert cache.claim_retry(staged.recovery_id) is None
+
+
+def test_failed_transition_reports_only_durable_retryable_state(
+    tmp_path,
+    monkeypatch,
+):
+    cache = SttRecoveryCache(_policy(), hermes_home=tmp_path)
+    staged = cache.stage_audio(b"voice", suffix=".wav", mime_type="audio/wav")
+    assert staged is not None
+
+    monkeypatch.setattr(
+        stt_recovery,
+        "atomic_json_write",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    assert (
+        cache.mark_failed_attempt(
+            staged.recovery_id,
+            attempts=staged.attempts,
+            failure_code="provider_error",
+        )
+        is None
+    )
+    retained = cache.get_record(staged.recovery_id)
+    assert retained is not None
+    assert retained.status == "transcribing"
+
+
+def test_abandoned_transcribing_record_becomes_retryable_immediately(tmp_path):
+    now = [1000.0]
+    cache = SttRecoveryCache(
+        _policy(retention_seconds=7200),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    staged = cache.stage_audio(b"voice", suffix=".ogg", mime_type="audio/ogg")
+    assert staged is not None
+
+    # Simulate a crashed worker: the OS releases this lease when its process
+    # exits, while the published manifest remains active on disk.
+    cache._release_attempt_lease(staged.recovery_id, staged.attempts)
+    records = cache.list_records()
+
+    assert len(records) == 1
+    assert records[0].status == "failed"
+    assert records[0].failure_code == "interrupted"
+    claimed = cache.claim_retry(staged.recovery_id)
+    assert claimed is not None
+    assert claimed.status == "transcribing"
+    assert claimed.attempts == 2
+
+
+def test_abandoned_delivery_becomes_retryable_immediately(tmp_path):
+    now = [1000.0]
+    cache = SttRecoveryCache(
+        _policy(retention_seconds=7200),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    staged = cache.stage_audio(b"voice", suffix=".ogg", mime_type="audio/ogg")
+    assert staged is not None
+    delivering = cache.mark_delivering_attempt(
+        staged.recovery_id,
+        attempts=staged.attempts,
+    )
+    assert delivering is not None
+    assert cache.claim_retry(staged.recovery_id) is None
+
+    cache._release_attempt_lease(delivering.recovery_id, delivering.attempts)
+    retained = cache.get_record(staged.recovery_id)
+
+    assert retained is not None
+    assert retained.status == "failed"
+    assert retained.failure_code == "interrupted"
+    assert retained.expires_at == now[0] + cache.policy.retention_seconds
+
+
+def test_live_attempt_lease_prevents_time_only_reclassification(tmp_path):
+    now = [1000.0]
+    worker_cache = SttRecoveryCache(
+        _policy(retention_seconds=7200),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    staged = worker_cache.stage_audio(
+        b"slow local model",
+        suffix=".wav",
+        mime_type="audio/wav",
+    )
+    assert staged is not None
+
+    now[0] += 7200
+    observer_cache = SttRecoveryCache(
+        _policy(retention_seconds=7200),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    observed = observer_cache.get_record(staged.recovery_id)
+
+    assert observed is not None
+    assert observed.status == "transcribing"
+    assert observer_cache.claim_retry(staged.recovery_id) is None
+
+
+def test_late_attempt_cannot_overwrite_or_delete_newer_retry(tmp_path):
+    cache = SttRecoveryCache(_policy(), hermes_home=tmp_path)
+    first = cache.stage_audio(b"voice", suffix=".wav", mime_type="audio/wav")
+    assert first is not None
+    failed = cache.mark_failed_attempt(
+        first.recovery_id,
+        attempts=first.attempts,
+        failure_code="provider_error",
+    )
+    assert failed is not None
+    second = cache.claim_retry(first.recovery_id)
+    assert second is not None
+
+    assert (
+        cache.mark_failed_attempt(
+            first.recovery_id,
+            attempts=first.attempts,
+            failure_code="late_callback",
+        )
+        is None
+    )
+    assert (
+        cache.discard_attempt(
+            first.recovery_id,
+            attempts=first.attempts,
+            expected_status="transcribing",
+        )
+        is False
+    )
+    current = cache.get_record(first.recovery_id)
+    assert current is not None
+    assert current.status == "transcribing"
+    assert current.attempts == second.attempts
+
+
+def test_corrupt_unknown_and_symlink_entries_are_never_followed(tmp_path):
+    cache = SttRecoveryCache(_policy(), hermes_home=tmp_path)
+    cache.root.mkdir(parents=True)
+
+    unknown = cache.root / "keep-me"
+    unknown.write_text("user data", encoding="utf-8")
+    corrupt = cache.root / ("b" * 32)
+    corrupt.mkdir()
+    (corrupt / "manifest.json").write_text("not json", encoding="utf-8")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    symlink = cache.root / ("c" * 32)
+    try:
+        symlink.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+
+    cache.prune()
+
+    assert unknown.read_text(encoding="utf-8") == "user data"
+    assert corrupt.exists()
+    assert symlink.is_symlink()
+    assert outside.exists()
+    assert cache.get_record("../outside") is None
+
+
+def test_recovery_root_symlink_is_fail_closed(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "sentinel"
+    sentinel.write_bytes(b"private")
+
+    cache = SttRecoveryCache(_policy(), hermes_home=tmp_path / "profile")
+    cache.root.parent.mkdir(parents=True)
+    try:
+        cache.root.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+
+    assert cache.stage_audio(b"voice", suffix=".wav", mime_type="audio/wav") is None
+    assert cache.get_record("a" * 32) is None
+    assert cache.claim_retry("a" * 32) is None
+    assert cache.discard_failed("a" * 32) is False
+    cache.prune()
+    assert sentinel.read_bytes() == b"private"
+    assert cache.root.is_symlink()
+
+
+def test_corrupt_uuid_directories_are_bounded_and_count_toward_capacity(tmp_path):
+    now = [10_000.0]
+    cache = SttRecoveryCache(
+        _policy(max_entries=2, max_total_bytes=5),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    cache.root.mkdir(parents=True)
+
+    recent = cache.root / ("d" * 32)
+    recent.mkdir()
+    (recent / "partial").write_bytes(b"12345")
+    assert cache.stage_audio(b"x", suffix=".wav", mime_type="audio/wav") is None
+
+    old = cache.root / ("e" * 32)
+    old.mkdir()
+    (old / "broken").write_bytes(b"x")
+    os.utime(old, (now[0] - 3601, now[0] - 3601))
+    cache.prune()
+    assert recent.exists()
+    assert not old.exists()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("created_at", float("nan")),
+        ("updated_at", float("inf")),
+        ("expires_at", 1e300),
+        ("updated_at", 1e9),
+    ],
+)
+def test_corrupt_manifest_timestamps_are_rejected_and_eventually_pruned(
+    tmp_path,
+    field,
+    value,
+):
+    now = [10_000.0]
+    cache = SttRecoveryCache(
+        _policy(),
+        hermes_home=tmp_path,
+        now=lambda: now[0],
+    )
+    staged = cache.stage_audio(b"voice", suffix=".wav", mime_type="audio/wav")
+    assert staged is not None
+    cache._release_attempt_lease(staged.recovery_id, staged.attempts)
+
+    manifest_path = staged.directory / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest[field] = value
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    assert cache.get_record(staged.recovery_id) is None
+    assert staged.directory.exists()
+
+    old = now[0] - 3601
+    os.utime(staged.directory, (old, old))
+    cache.prune()
+    assert not staged.directory.exists()
+
+
+def test_invalid_suffix_and_oversized_record_are_not_published(tmp_path):
+    cache = SttRecoveryCache(
+        _policy(max_total_bytes=4),
+        hermes_home=tmp_path,
+    )
+
+    with pytest.raises(ValueError):
+        cache.stage_audio(b"abc", suffix="../../wav", mime_type="audio/wav")
+    assert cache.stage_audio(b"abcde", suffix=".wav", mime_type="audio/wav") is None
+    assert not cache.root.exists()
+
+
+def test_concurrent_stage_and_prune_publish_only_complete_unique_records(tmp_path):
+    cache = SttRecoveryCache(
+        _policy(max_entries=10, max_total_bytes=50),
+        hermes_home=tmp_path,
+    )
+
+    def stage(index: int):
+        record = cache.stage_audio(
+            bytes([index]) * 5,
+            suffix=".wav",
+            mime_type="audio/wav",
+        )
+        if record is not None:
+            return cache.mark_failed_attempt(
+                record.recovery_id,
+                attempts=record.attempts,
+                failure_code="provider_error",
+            )
+        return None
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        published = [record for record in pool.map(stage, range(20)) if record]
+
+    records = cache.list_records()
+    assert 1 <= len(records) <= 10
+    assert len({record.recovery_id for record in published}) == len(published)
+    assert len({record.recovery_id for record in records}) == len(records)
+    assert sum(record.byte_size for record in records) <= 50
+    for record in records:
+        assert record.status == "failed"
+        assert record.audio_path.is_file()
+        assert (record.directory / "manifest.json").is_file()
+    assert not any(child.name.startswith(".tmp-") for child in cache.root.iterdir())

--- a/tests/hermes_cli/test_stt_recovery_cli.py
+++ b/tests/hermes_cli/test_stt_recovery_cli.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import stat
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.config import DEFAULT_CONFIG
+from hermes_cli.stt_recovery import SttRecoveryCache
+from hermes_cli import stt_recovery_cli
+
+
+def _failed_record(audio: bytes = b"voice"):
+    cache = SttRecoveryCache.from_config(DEFAULT_CONFIG)
+    staged = cache.stage_audio(audio, suffix=".webm", mime_type="audio/webm")
+    assert staged is not None
+    failed = cache.mark_failed_attempt(
+        staged.recovery_id,
+        attempts=staged.attempts,
+        failure_code="provider_error",
+    )
+    assert failed is not None
+    return cache, failed
+
+
+def test_parser_registers_documented_command_tree():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    stt_recovery_cli.register_cli(subparsers)
+
+    args = parser.parse_args(["stt", "recovery", "retry", "a" * 32])
+
+    assert args.command == "stt"
+    assert args.stt_command == "recovery"
+    assert args.recovery_command == "retry"
+    assert args.func is stt_recovery_cli._cmd_retry
+
+
+def test_list_json_never_exposes_storage_path(_isolate_hermes_home, capsys):
+    _, failed = _failed_record()
+
+    assert stt_recovery_cli._cmd_list(SimpleNamespace(json=True)) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["recovery_id"] == failed.recovery_id
+    assert "path" not in payload[0]
+
+
+def test_retry_prints_transcript_before_discard(
+    _isolate_hermes_home,
+    monkeypatch,
+    capsys,
+):
+    import tools.transcription_tools as transcription_tools
+
+    cache, failed = _failed_record()
+    monkeypatch.setattr(
+        transcription_tools,
+        "transcribe_audio",
+        lambda path, model=None: {
+            "success": True,
+            "transcript": "recovered transcript",
+            "provider": "test",
+        },
+    )
+
+    result = stt_recovery_cli._cmd_retry(
+        SimpleNamespace(recovery_id=failed.recovery_id)
+    )
+
+    assert result == 0
+    assert capsys.readouterr().out == "recovered transcript\n"
+    assert cache.get_record(failed.recovery_id) is None
+
+
+def test_failed_retry_redacts_error_and_keeps_original(
+    _isolate_hermes_home,
+    monkeypatch,
+    capsys,
+):
+    import tools.transcription_tools as transcription_tools
+
+    cache, failed = _failed_record(b"important")
+    secret = "sk-proj-this-must-not-print"
+    monkeypatch.setattr(
+        transcription_tools,
+        "transcribe_audio",
+        lambda path, model=None: {
+            "success": False,
+            "error": f"Authorization: Bearer {secret}",
+            "provider": "openai",
+        },
+    )
+
+    result = stt_recovery_cli._cmd_retry(
+        SimpleNamespace(recovery_id=failed.recovery_id)
+    )
+
+    assert result == 1
+    stderr = capsys.readouterr().err
+    assert secret not in stderr
+    retained = cache.get_record(failed.recovery_id)
+    assert retained is not None
+    assert retained.audio_path.read_bytes() == b"important"
+
+
+def test_empty_retry_keeps_original(_isolate_hermes_home, monkeypatch, capsys):
+    import tools.transcription_tools as transcription_tools
+
+    cache, failed = _failed_record(b"possibly speech")
+    monkeypatch.setattr(
+        transcription_tools,
+        "transcribe_audio",
+        lambda path, model=None: {
+            "success": True,
+            "transcript": "",
+            "provider": "test",
+        },
+    )
+
+    result = stt_recovery_cli._cmd_retry(
+        SimpleNamespace(recovery_id=failed.recovery_id)
+    )
+
+    assert result == 1
+    assert "still retained" in capsys.readouterr().err
+    retained = cache.get_record(failed.recovery_id)
+    assert retained is not None
+    assert retained.failure_code == "no_speech"
+
+
+def test_malformed_provider_result_keeps_original(
+    _isolate_hermes_home,
+    monkeypatch,
+    capsys,
+):
+    import tools.voice_mode as voice_mode
+
+    cache, failed = _failed_record(b"important")
+    monkeypatch.setattr(
+        voice_mode,
+        "transcribe_recording",
+        lambda path: None,
+    )
+
+    result = stt_recovery_cli._cmd_retry(
+        SimpleNamespace(recovery_id=failed.recovery_id)
+    )
+
+    assert result == 1
+    assert "invalid result" in capsys.readouterr().err
+    retained = cache.get_record(failed.recovery_id)
+    assert retained is not None
+    assert retained.status == "failed"
+    assert retained.failure_code == "unexpected_error"
+    assert retained.audio_path.read_bytes() == b"important"
+
+
+def test_truthy_non_boolean_success_keeps_original(
+    _isolate_hermes_home,
+    monkeypatch,
+    capsys,
+):
+    import tools.transcription_tools as transcription_tools
+
+    cache, failed = _failed_record(b"important")
+    monkeypatch.setattr(
+        transcription_tools,
+        "transcribe_audio",
+        lambda path, model=None: {
+            "success": "true",
+            "transcript": "must not be trusted",
+            "provider": "test",
+        },
+    )
+
+    result = stt_recovery_cli._cmd_retry(
+        SimpleNamespace(recovery_id=failed.recovery_id)
+    )
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "must not be trusted" not in captured.out
+    retained = cache.get_record(failed.recovery_id)
+    assert retained is not None
+    assert retained.failure_code == "provider_error"
+    assert retained.audio_path.read_bytes() == b"important"
+
+
+def test_stdout_flush_failure_leaves_retryable_record(
+    _isolate_hermes_home,
+    monkeypatch,
+):
+    import tools.transcription_tools as transcription_tools
+
+    cache, failed = _failed_record(b"important")
+    monkeypatch.setattr(
+        transcription_tools,
+        "transcribe_audio",
+        lambda path, model=None: {
+            "success": True,
+            "transcript": "recovered transcript",
+            "provider": "test",
+        },
+    )
+
+    class BrokenStdout:
+        def write(self, value):
+            return len(value)
+
+        def flush(self):
+            raise BrokenPipeError("consumer closed")
+
+    original_stdout = stt_recovery_cli.sys.stdout
+    try:
+        stt_recovery_cli.sys.stdout = BrokenStdout()
+        with pytest.raises(BrokenPipeError):
+            stt_recovery_cli._cmd_retry(SimpleNamespace(recovery_id=failed.recovery_id))
+    finally:
+        stt_recovery_cli.sys.stdout = original_stdout
+
+    retained = cache.get_record(failed.recovery_id)
+    assert retained is not None
+    assert retained.status == "failed"
+    assert retained.failure_code == "delivery_interrupted"
+    assert retained.audio_path.read_bytes() == b"important"
+
+
+def test_save_exports_exact_bytes_privately_without_discard(
+    _isolate_hermes_home,
+    tmp_path,
+    capsys,
+):
+    cache, failed = _failed_record(b"original-container")
+    destination = tmp_path / "saved.webm"
+
+    result = stt_recovery_cli._cmd_save(
+        SimpleNamespace(
+            recovery_id=failed.recovery_id,
+            output=str(destination),
+            force=False,
+        )
+    )
+
+    assert result == 0
+    assert destination.read_bytes() == b"original-container"
+    assert cache.get_record(failed.recovery_id) is not None
+    assert str(destination) in capsys.readouterr().out
+    if os.name == "posix":
+        assert stat.S_IMODE(destination.stat().st_mode) == 0o600
+
+
+def test_save_refuses_overwrite_without_force(
+    _isolate_hermes_home,
+    tmp_path,
+    capsys,
+):
+    _, failed = _failed_record()
+    destination = tmp_path / "existing.webm"
+    destination.write_bytes(b"keep")
+
+    result = stt_recovery_cli._cmd_save(
+        SimpleNamespace(
+            recovery_id=failed.recovery_id,
+            output=str(destination),
+            force=False,
+        )
+    )
+
+    assert result == 1
+    assert destination.read_bytes() == b"keep"
+    assert "--force" in capsys.readouterr().err
+
+
+def test_discard_rejects_non_opaque_id(_isolate_hermes_home, capsys):
+    result = stt_recovery_cli._cmd_discard(
+        SimpleNamespace(recovery_id="../../config.yaml")
+    )
+
+    assert result == 1
+    assert "not found" in capsys.readouterr().err

--- a/tests/hermes_cli/test_web_server_audio_recovery.py
+++ b/tests/hermes_cli/test_web_server_audio_recovery.py
@@ -1,0 +1,392 @@
+"""Focused endpoint tests for durable Desktop STT recovery."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+import threading
+
+import pytest
+
+from hermes_cli.config import DEFAULT_CONFIG
+from hermes_cli.stt_recovery import SttRecoveryCache
+
+
+@pytest.fixture
+def client(_isolate_hermes_home, monkeypatch):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(
+        hermes_state,
+        "DEFAULT_DB_PATH",
+        get_hermes_home() / "state.db",
+    )
+    test_client = TestClient(app)
+    test_client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    try:
+        yield test_client
+    finally:
+        test_client.close()
+
+
+def _post_audio(client, audio: bytes = b"long irreplaceable recording"):
+    encoded = base64.b64encode(audio).decode("ascii")
+    return client.post(
+        "/api/audio/transcribe",
+        json={
+            "data_url": f"data:audio/webm;base64,{encoded}",
+            "mime_type": "audio/webm;codecs=opus",
+        },
+    )
+
+
+def test_audio_transcription_success_discards_staged_recording(client, monkeypatch):
+    import tools.voice_mode as voice_mode
+
+    observed = {}
+
+    def transcribe(path):
+        observed["path"] = Path(path)
+        observed["bytes"] = Path(path).read_bytes()
+        return {
+            "success": True,
+            "transcript": "hello from voice mode",
+            "provider": "test",
+        }
+
+    monkeypatch.setattr(voice_mode, "transcribe_recording", transcribe)
+
+    response = _post_audio(client)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "transcript": "hello from voice mode",
+        "provider": "test",
+    }
+    assert observed["bytes"] == b"long irreplaceable recording"
+    assert not observed["path"].exists()
+    assert SttRecoveryCache.from_config(DEFAULT_CONFIG).list_records() == []
+
+
+def test_legacy_empty_transcript_failure_is_silence_and_is_cleaned_up(
+    client,
+    monkeypatch,
+):
+    """Legacy providers omit ``no_speech`` and identify silence by error text."""
+    import tools.voice_mode as voice_mode
+
+    monkeypatch.setattr(
+        voice_mode,
+        "transcribe_recording",
+        lambda path: {
+            "success": False,
+            "transcript": "",
+            "error": "ElevenLabs STT returned empty transcript",
+            "provider": "elevenlabs",
+        },
+    )
+
+    response = _post_audio(client)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "transcript": "",
+        "provider": "elevenlabs",
+    }
+    assert SttRecoveryCache.from_config(DEFAULT_CONFIG).list_records() == []
+
+
+def test_explicit_no_speech_is_silence_and_is_cleaned_up(client, monkeypatch):
+    import tools.transcription_tools as transcription_tools
+
+    monkeypatch.setattr(
+        transcription_tools,
+        "transcribe_audio",
+        lambda path, model=None: {
+            "success": False,
+            "transcript": "",
+            "error": "provider returned no speech",
+            "no_speech": True,
+        },
+    )
+
+    response = _post_audio(client)
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert response.json()["transcript"] == ""
+    assert SttRecoveryCache.from_config(DEFAULT_CONFIG).list_records() == []
+
+
+def test_provider_failure_retains_original_with_opaque_id(client, monkeypatch):
+    import tools.voice_mode as voice_mode
+    from hermes_constants import get_hermes_home
+
+    secret_error = "Authorization: Bearer sk-proj-this-must-never-leak"
+    monkeypatch.setattr(
+        voice_mode,
+        "transcribe_recording",
+        lambda path: {
+            "success": False,
+            "error": secret_error,
+            "provider": "openai",
+        },
+    )
+    original = b"long irreplaceable recording"
+
+    response = _post_audio(client, original)
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error_code"] == "provider_error"
+    assert body["recovery_available"] is True
+    assert secret_error not in response.text
+    assert str(get_hermes_home()) not in response.text
+    recovery_id = body["recovery_id"]
+    assert len(recovery_id) == 32
+    recovery_dir = get_hermes_home() / ".cache" / "stt-recovery" / recovery_id
+    assert (recovery_dir / "audio.webm").read_bytes() == original
+    manifest = json.loads((recovery_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["status"] == "failed"
+    assert manifest["failure_code"] == "provider_error"
+    assert secret_error not in json.dumps(manifest)
+
+
+def test_exception_is_redacted_and_recoverable(client, monkeypatch):
+    import tools.voice_mode as voice_mode
+    from hermes_constants import get_hermes_home
+
+    def fail_transcription(path):
+        raise RuntimeError("api_key=sk-proj-private-value")
+
+    monkeypatch.setattr(voice_mode, "transcribe_recording", fail_transcription)
+
+    response = _post_audio(client)
+
+    assert response.status_code == 500
+    assert response.json()["error_code"] == "unexpected_error"
+    assert response.json()["recovery_available"] is True
+    assert "sk-proj-private-value" not in response.text
+    assert str(get_hermes_home()) not in response.text
+
+
+def test_cleanup_commit_failure_retains_original(client, monkeypatch):
+    import hermes_cli.stt_recovery as stt_recovery
+    import tools.voice_mode as voice_mode
+
+    real_atomic_json_write = stt_recovery.atomic_json_write
+
+    def fail_cleanup_commit(path, payload, *args, **kwargs):
+        if payload.get("status") == "cleanup_pending":
+            raise OSError("disk full")
+        return real_atomic_json_write(path, payload, *args, **kwargs)
+
+    monkeypatch.setattr(stt_recovery, "atomic_json_write", fail_cleanup_commit)
+    monkeypatch.setattr(
+        voice_mode,
+        "transcribe_recording",
+        lambda path: {
+            "success": True,
+            "transcript": "not delivered yet",
+            "provider": "test",
+        },
+    )
+    original = b"must survive cleanup commit failure"
+
+    response = _post_audio(client, original)
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error_code"] == "cleanup_error"
+    assert body["recovery_available"] is True
+    assert "not delivered yet" not in response.text
+    retained = SttRecoveryCache.from_config(DEFAULT_CONFIG).get_record(
+        body["recovery_id"]
+    )
+    assert retained is not None
+    assert retained.status == "failed"
+    assert retained.failure_code == "cleanup_error"
+    assert retained.audio_path.read_bytes() == original
+
+
+def test_deferred_physical_cleanup_does_not_mask_success(client, monkeypatch):
+    import hermes_cli.stt_recovery as stt_recovery
+    import tools.voice_mode as voice_mode
+    from hermes_constants import get_hermes_home
+
+    monkeypatch.setattr(
+        stt_recovery.SttRecoveryCache,
+        "_remove_directory",
+        staticmethod(lambda path: False),
+    )
+    monkeypatch.setattr(
+        voice_mode,
+        "transcribe_recording",
+        lambda path: {
+            "success": True,
+            "transcript": "cleanup may wait",
+            "provider": "test",
+        },
+    )
+
+    response = _post_audio(client)
+
+    assert response.status_code == 200
+    assert response.json()["transcript"] == "cleanup may wait"
+    manifests = list(
+        (get_hermes_home() / ".cache" / "stt-recovery").glob("*/manifest.json")
+    )
+    assert len(manifests) == 1
+    manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
+    assert manifest["status"] == "cleanup_pending"
+    assert SttRecoveryCache.from_config(DEFAULT_CONFIG).list_records() == []
+
+
+def test_staging_failure_does_not_break_successful_transcription(client, monkeypatch):
+    import hermes_cli.stt_recovery as stt_recovery
+    import tools.voice_mode as voice_mode
+
+    monkeypatch.setattr(
+        stt_recovery.SttRecoveryCache,
+        "stage_audio",
+        lambda self, *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        voice_mode,
+        "transcribe_recording",
+        lambda path: {
+            "success": True,
+            "transcript": "fallback worked",
+            "provider": "test",
+        },
+    )
+
+    response = _post_audio(client)
+
+    assert response.status_code == 200
+    assert response.json()["transcript"] == "fallback worked"
+
+
+def test_staging_failure_does_not_claim_recovery(client, monkeypatch):
+    import hermes_cli.stt_recovery as stt_recovery
+    import tools.voice_mode as voice_mode
+
+    monkeypatch.setattr(
+        stt_recovery.SttRecoveryCache,
+        "stage_audio",
+        lambda self, *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        voice_mode,
+        "transcribe_recording",
+        lambda path: {
+            "success": False,
+            "error": "provider unavailable",
+            "provider": "test",
+        },
+    )
+
+    response = _post_audio(client)
+
+    assert response.status_code == 400
+    assert response.json()["recovery_available"] is False
+    assert "recovery_id" not in response.json()
+
+
+@pytest.mark.parametrize(
+    "result, expected_status",
+    [
+        (None, 500),
+        (
+            {
+                "success": True,
+                "transcript": {"not": "text"},
+                "provider": "test",
+            },
+            500,
+        ),
+        (
+            {
+                "success": "true",
+                "transcript": "must not be trusted",
+                "provider": "test",
+            },
+            400,
+        ),
+    ],
+)
+def test_malformed_provider_results_are_recoverable(
+    client,
+    monkeypatch,
+    result,
+    expected_status,
+):
+    import tools.voice_mode as voice_mode
+
+    monkeypatch.setattr(voice_mode, "transcribe_recording", lambda path: result)
+
+    response = _post_audio(client)
+
+    assert response.status_code == expected_status
+    assert response.json()["recovery_available"] is True
+    assert "must not be trusted" not in response.text
+
+
+def test_request_cancellation_keeps_worker_input_retryable(monkeypatch):
+    import hermes_cli.web_server as web_server
+    import tools.voice_mode as voice_mode
+
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    observed = {}
+
+    def blocking_transcription(path):
+        observed["path"] = Path(path)
+        started.set()
+        assert release.wait(timeout=5)
+        observed["bytes"] = Path(path).read_bytes()
+        finished.set()
+        return {"success": True, "transcript": "too late", "provider": "test"}
+
+    monkeypatch.setattr(voice_mode, "transcribe_recording", blocking_transcription)
+
+    async def run_and_cancel():
+        payload = web_server.AudioTranscriptionRequest(
+            data_url="data:audio/webm;base64,aGVsbG8=",
+            mime_type="audio/webm",
+        )
+        task = asyncio.create_task(web_server.transcribe_audio_upload(payload))
+        assert await asyncio.to_thread(started.wait, 2)
+        task.cancel()
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert observed["path"].exists()
+        finally:
+            release.set()
+            assert await asyncio.to_thread(finished.wait, 2)
+            for _ in range(100):
+                records = SttRecoveryCache.from_config(DEFAULT_CONFIG).list_records()
+                if records and records[0].failure_code == "request_cancelled":
+                    return records
+                await asyncio.sleep(0.01)
+        raise AssertionError("cancelled recording did not become retryable")
+
+    records = asyncio.run(run_and_cancel())
+
+    assert len(records) == 1
+    assert records[0].status == "failed"
+    assert records[0].failure_code == "request_cancelled"
+    assert observed["bytes"] == b"hello"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1770,6 +1770,11 @@ stt:
   echo_transcripts: true       # Post raw transcripts back to the chat as 🎙️ "..." (default: true)
   provider: "local"            # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "deepinfra" | ...
   language: "en"               # GLOBAL language hint for every provider (per-provider language wins); set "" for auto-detect
+  recovery:
+    enabled: true              # Preserve desktop recordings when STT fails
+    retention_hours: 24        # 0 disables recovery; maximum 168 (7 days)
+    max_entries: 50            # Per-profile recording cap; maximum 500
+    max_total_mb: 500          # Per-profile byte cap; maximum 2048 MiB
   local:
     model: "base"              # tiny, base, small, medium, large-v3
     language: ""               # per-provider override of stt.language
@@ -1789,6 +1794,21 @@ stt:
 Language resolution is the same for **every** STT provider (local, groq, openai, mistral, xai, elevenlabs, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is `stt.language: "en"`** — Whisper auto-detection frequently misidentifies short or accented clips, which shows up as voice notes transcribed in the wrong language. Non-English speakers should set `stt.language` to their language code once (e.g. `"es"`, `"zh"`, `"uk"`); set it to `""` to restore auto-detection for multilingual use.
 
 Set `stt.echo_transcripts: false` when the gateway should transcribe voice notes for the agent but must not post the raw transcript back to the chat (for example, customer-facing WhatsApp bots).
+
+### Failed recording recovery
+
+Desktop recordings are written to a private, profile-scoped cache before transcription starts. A successful transcription (including a successful empty/no-speech result) removes the cached audio immediately. Provider errors, unexpected failures, and interrupted HTTP requests retain the original bytes for the configured interval, counted from the latest failure. Expired entries become unavailable immediately on the next recovery lookup. Their files are physically pruned the next time Hermes accesses this cache (there is no background cleanup while Hermes is stopped), followed by the oldest failures until both the entry and storage limits are satisfied.
+
+```bash
+hermes stt recovery list
+hermes stt recovery retry <recovery-id>
+hermes stt recovery save <recovery-id> ./recording.webm
+hermes stt recovery discard <recovery-id>
+```
+
+Run recovery commands on the Hermes backend host and select the same profile that received the recording (for example, `hermes -p coder stt recovery list`). This matters when Desktop is connected to a remote backend. Recovery IDs are opaque; the API never exposes backend filesystem paths. The cache stores no transcript, provider exception, or credential material, and `.cache` is excluded from Hermes backups, profile exports, and `--clone-all` profile copies. On POSIX systems its directory is owner-only (`0700`) and its files are `0600`; on Windows Hermes relies on the account's inherited filesystem ACLs.
+
+This feature protects recordings when STT itself fails. It does not yet keep successful audio until the desktop acknowledges that the returned transcript was inserted into the composer; a connection loss after successful STT can therefore still lose that narrow delivery window.
 
 Provider behavior:
 


### PR DESCRIPTION
## Summary

Desktop currently deletes its uploaded recording in `finally`, so a provider error, timeout, cancellation, or malformed response can destroy a long recording before the user has any recovery path. The raw provider exception can also cross the API boundary and expose credential-bearing details.

This change makes Desktop STT failure-safe:

- stage the original upload atomically in a private, profile-scoped cache before transcription starts;
- retain it only on failure/interruption, with configurable TTL, entry, and byte caps (24h / 50 / 500 MiB by default; hard-capped at 7d / 500 / 2048 MiB);
- coordinate concurrent server/CLI processes with root locks, per-attempt OS leases, CAS attempt transitions, and durable `cleanup_pending` tombstones;
- expose `hermes stt recovery list|retry|save|discard` for explicit recovery;
- return only structured, opaque recovery metadata to Desktop and redact provider errors, filesystem paths, and credential material;
- give the Desktop error toast a localized **Copy recovery command** action, including the correct profile for local pooled or remote backends;
- keep recovery audio out of profile clone/export and backup flows;
- persist each tile's authoritative profile owner so recovery actions remain correctly scoped after bounded session metadata is evicted.

Related: #37889, #37890, #53488, #66626.

## Maintainer review follow-up

The latest revision addresses both automated review comments:

- established no-speech results still return `200` with an empty transcript and remove the staged recording;
- async profile resolution patches the captured origin tile, not whichever profile bucket becomes active later.

The same review exposed adjacent equal-ID/profile races. The final revision therefore carries the authoritative owner through tab focus, native-window IPC/URL routing, resume/retry, branch/archive/delete, and live-runtime binding. Async resume completion uses an owner-aware compare-and-set, and the native-window registry uses an unambiguous tuple key. These paths have adversarial duplicate-ID, profile-switch, stale-completion, URL-parser, and delimiter-collision tests.

## Lifecycle and privacy

The cache lives under `<HERMES_HOME>/.cache/stt-recovery/`. POSIX directories/files are created as `0700`/`0600`; Windows uses the account's inherited ACLs. Manifests contain no transcript, raw exception, absolute path, or credential material. Expired entries are hidden immediately and pruned on the next cache access; there is no background service while Hermes is stopped.

Recovery is enabled by default to prevent silent data loss. Operators can disable it or reduce its limits through `stt.recovery`. This is an explicit privacy/reliability trade-off: physical expiry is access-triggered, while confidentiality is constrained by owner-only storage, opaque IDs, bounded retention/capacity, export/backup exclusion, and no remote list/read endpoint.

A validated successful transcript commits deletion before the response is returned. This PR intentionally does not add a renderer acknowledgement protocol, so the narrow case where the connection drops after successful STT but before Desktop inserts the returned transcript remains documented follow-up scope.

## Validation

- selected Python recovery/web/profile/backup suite: **345 passed**;
- complete Desktop UI suite: **355 files, 3153 tests passed**;
- complete Electron suite: **74 files passed, 1 skipped; 870 tests passed, 2 skipped**;
- Desktop TypeScript typecheck, strict ESLint, and Prettier checks passed;
- Ruff, `ty`, `git diff --check`, and the Windows-path production scan passed;
- full diff security review: all **44/44** source-like worklist rows and **6/6** candidates closed; no reportable or deferred security findings.

## Scope

This protects recordings submitted through Desktop/WebUI `/api/audio/transcribe`. Inbound voice messages handled by messaging-platform adapters use a separate pipeline and are unchanged.
