### PR TITLE
fix(teams): authenticate pasted image downloads

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -813,7 +813,10 @@ class TeamsAdapter(BasePlatformAdapter):
         bot bearer token. No other host may receive that token.
         """
         from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
-        from gateway.platforms.base import _ssrf_redirect_guard
+        from gateway.platforms.base import (
+            _read_httpx_body_with_limit,
+            _ssrf_redirect_guard,
+        )
 
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
@@ -833,12 +836,12 @@ class TeamsAdapter(BasePlatformAdapter):
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
-                url,
-                headers=headers,
-            )
-            response.raise_for_status()
-            return response.content
+            async with client.stream("GET", url, headers=headers) as response:
+                response.raise_for_status()
+                return await _read_httpx_body_with_limit(
+                    response,
+                    media_type="attachment",
+                )
 
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
         """Process an incoming Teams message and dispatch to the gateway."""

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -28,7 +28,7 @@ import json
 import logging
 import os
 from typing import Any, Dict, Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 # httpx is imported lazily — only the ``_write_summary_via_incoming_webhook``
 # code path actually constructs an ``AsyncClient``. Top-level import here
@@ -95,7 +95,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
-    cache_image_from_url,
+    cache_image_from_bytes,
     cache_media_bytes,
 )
 
@@ -805,18 +805,28 @@ class TeamsAdapter(BasePlatformAdapter):
         logger.info("[teams] Disconnected")
 
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
-        """Download attachment bytes with SSRF protection.
+        """Download attachment bytes with SSRF and token-exfiltration protection.
 
-        Teams file attachments carry pre-authenticated SharePoint download
-        URLs (no extra auth header needed). Validates the URL against the
-        SSRF guard and follows redirects through the shared redirect guard,
-        matching the cache_*_from_url helpers in gateway.platforms.base.
+        SharePoint file-download URLs are pre-authenticated and receive no bot
+        credential. Bot Framework attachment URLs are protected, so requests
+        to the explicit Bot Framework host allowlist receive the SDK-managed
+        bot bearer token. No other host may receive that token.
         """
         from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
         from gateway.platforms.base import _ssrf_redirect_guard
 
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
+
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
+        hostname = (urlparse(url).hostname or "").lower()
+        if hostname in _ALLOWED_TEAMS_SERVICE_HOSTS:
+            if self._app is None:
+                raise RuntimeError("Teams app cannot acquire a Bot Framework attachment token")
+            token = await self._app._get_bot_token()
+            if not token:
+                raise RuntimeError("Teams app returned no Bot Framework attachment token")
+            headers["Authorization"] = f"Bearer {token}"
 
         async with create_ssrf_safe_async_client(
             timeout=timeout,
@@ -825,7 +835,7 @@ class TeamsAdapter(BasePlatformAdapter):
         ) as client:
             response = await client.get(
                 url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
+                headers=headers,
             )
             response.raise_for_status()
             return response.content
@@ -930,7 +940,14 @@ class TeamsAdapter(BasePlatformAdapter):
 
             if content_url and content_type.startswith("image/"):
                 try:
-                    cached = await cache_image_from_url(content_url)
+                    data = await self._fetch_attachment_bytes(content_url)
+                    image_ext = {
+                        "image/jpeg": ".jpg",
+                        "image/png": ".png",
+                        "image/gif": ".gif",
+                        "image/webp": ".webp",
+                    }.get(content_type, ".jpg")
+                    cached = cache_image_from_bytes(data, ext=image_ext)
                     if cached:
                         media_urls.append(cached)
                         media_types.append(content_type)

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -804,7 +804,12 @@ class TeamsAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
 
-    async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
+    async def _fetch_attachment_bytes(
+        self,
+        url: str,
+        timeout: float = 30.0,
+        retries: int = 2,
+    ) -> bytes:
         """Download attachment bytes with SSRF and token-exfiltration protection.
 
         SharePoint file-download URLs are pre-authenticated and receive no bot
@@ -831,17 +836,40 @@ class TeamsAdapter(BasePlatformAdapter):
                 raise RuntimeError("Teams app returned no Bot Framework attachment token")
             headers["Authorization"] = f"Bearer {token}"
 
+        import httpx
+
         async with create_ssrf_safe_async_client(
             timeout=timeout,
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            async with client.stream("GET", url, headers=headers) as response:
-                response.raise_for_status()
-                return await _read_httpx_body_with_limit(
-                    response,
-                    media_type="attachment",
-                )
+            for attempt in range(retries + 1):
+                try:
+                    async with client.stream("GET", url, headers=headers) as response:
+                        response.raise_for_status()
+                        return await _read_httpx_body_with_limit(
+                            response,
+                            media_type="attachment",
+                        )
+                except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+                    if (
+                        isinstance(exc, httpx.HTTPStatusError)
+                        and exc.response.status_code < 429
+                    ):
+                        raise
+                    if attempt >= retries:
+                        raise
+                    wait = 1.5 * (attempt + 1)
+                    logger.debug(
+                        "[teams] Attachment download retry %d/%d after %.1fs: %s",
+                        attempt + 1,
+                        retries,
+                        wait,
+                        type(exc).__name__,
+                    )
+                    await asyncio.sleep(wait)
+
+        raise RuntimeError("Teams attachment download exhausted without a result")
 
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
         """Process an incoming Teams message and dispatch to the gateway."""

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -827,8 +827,17 @@ class TeamsAdapter(BasePlatformAdapter):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
 
         headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
-        hostname = (urlparse(url).hostname or "").lower()
+        parsed_url = urlparse(url)
+        hostname = (parsed_url.hostname or "").lower()
         if hostname in _ALLOWED_TEAMS_SERVICE_HOSTS:
+            try:
+                port = parsed_url.port
+            except ValueError as exc:
+                raise ValueError("Invalid Bot Framework attachment URL port") from exc
+            if parsed_url.scheme.lower() != "https" or port not in (None, 443):
+                raise ValueError(
+                    "Refusing insecure Bot Framework attachment URL; HTTPS on port 443 is required"
+                )
             if self._app is None:
                 raise RuntimeError("Teams app cannot acquire a Bot Framework attachment token")
             token = await self._app._get_bot_token()

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -830,17 +830,98 @@ class TestTeamsAttachmentClassification:
         assert event.media_types == ["application/pdf"]
 
     @pytest.mark.anyio
+    async def test_bot_framework_download_adds_sdk_bearer_token(self, monkeypatch):
+        adapter = self._make_adapter()
+        adapter._app._get_bot_token = AsyncMock(return_value="bot-token")
+        response = SimpleNamespace(
+            content=b"protected image",
+            raise_for_status=MagicMock(),
+        )
+        client = SimpleNamespace(get=AsyncMock(return_value=response))
+
+        class ClientContext:
+            async def __aenter__(self):
+                return client
+
+            async def __aexit__(self, *_args):
+                return False
+
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: True)
+        monkeypatch.setattr(
+            "tools.url_safety.create_ssrf_safe_async_client",
+            lambda **_kwargs: ClientContext(),
+        )
+
+        data = await adapter._fetch_attachment_bytes(
+            "https://smba.trafficmanager.net/amer/tenant/v3/attachments/1/views/original"
+        )
+
+        assert data == b"protected image"
+        request_headers = client.get.await_args.kwargs["headers"]
+        assert request_headers["Authorization"] == "Bearer bot-token"
+
+    @pytest.mark.anyio
+    async def test_non_bot_framework_download_never_receives_bot_token(self, monkeypatch):
+        adapter = self._make_adapter()
+        adapter._app._get_bot_token = AsyncMock(return_value="bot-token")
+        response = SimpleNamespace(content=b"file", raise_for_status=MagicMock())
+        client = SimpleNamespace(get=AsyncMock(return_value=response))
+
+        class ClientContext:
+            async def __aenter__(self):
+                return client
+
+            async def __aexit__(self, *_args):
+                return False
+
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: True)
+        monkeypatch.setattr(
+            "tools.url_safety.create_ssrf_safe_async_client",
+            lambda **_kwargs: ClientContext(),
+        )
+
+        await adapter._fetch_attachment_bytes(
+            "https://contoso.sharepoint.com/download/image.png"
+        )
+
+        adapter._app._get_bot_token.assert_not_awaited()
+        request_headers = client.get.await_args.kwargs["headers"]
+        assert "Authorization" not in request_headers
+
+    @pytest.mark.anyio
+    async def test_protected_image_uses_authenticated_attachment_download(self):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"\x89PNG fake")
+        cache_image_bytes = MagicMock(return_value="/tmp/protected-image.png")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_teams_mod, "cache_image_from_bytes", cache_image_bytes, raising=False)
+            activity = self._make_activity([self._image_attachment()])
+            await adapter._on_message(self._make_ctx(activity))
+
+        adapter._fetch_attachment_bytes.assert_awaited_once_with(
+            "https://smba.example.com/img.png"
+        )
+        cache_image_bytes.assert_called_once_with(b"\x89PNG fake", ext=".png")
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/protected-image.png"]
+        assert event.media_types == ["image/png"]
+
+    @pytest.mark.anyio
     async def test_mixed_image_and_document_prefers_document(self):
         from gateway.platforms.base import MessageType
 
         adapter = self._make_adapter()
         adapter._fetch_attachment_bytes = AsyncMock(return_value=b"%PDF-1.4 fake")
 
-        async def fake_cache_image(url, *a, **kw):
+        def fake_cache_image(data, *a, **kw):
             return "/tmp/img.png"
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(_teams_mod, "cache_image_from_url", fake_cache_image)
+            mp.setattr(_teams_mod, "cache_image_from_bytes", fake_cache_image)
             activity = self._make_activity([
                 self._image_attachment(),
                 self._file_download_attachment(),
@@ -868,12 +949,13 @@ class TestTeamsAttachmentClassification:
         from gateway.platforms.base import MessageType
 
         adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"\x89PNG fake")
 
-        async def fake_cache_image(url, *a, **kw):
+        def fake_cache_image(data, *a, **kw):
             return "/tmp/img.png"
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(_teams_mod, "cache_image_from_url", fake_cache_image)
+            mp.setattr(_teams_mod, "cache_image_from_bytes", fake_cache_image)
             activity = self._make_activity([self._image_attachment()])
             await adapter._on_message(self._make_ctx(activity))
 

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -833,11 +833,23 @@ class TestTeamsAttachmentClassification:
     async def test_bot_framework_download_adds_sdk_bearer_token(self, monkeypatch):
         adapter = self._make_adapter()
         adapter._app._get_bot_token = AsyncMock(return_value="bot-token")
+        async def chunks():
+            yield b"protected image"
+
         response = SimpleNamespace(
-            content=b"protected image",
+            headers={},
+            aiter_bytes=chunks,
             raise_for_status=MagicMock(),
         )
-        client = SimpleNamespace(get=AsyncMock(return_value=response))
+
+        class ResponseContext:
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *_args):
+                return False
+
+        client = SimpleNamespace(stream=MagicMock(return_value=ResponseContext()))
 
         class ClientContext:
             async def __aenter__(self):
@@ -857,15 +869,30 @@ class TestTeamsAttachmentClassification:
         )
 
         assert data == b"protected image"
-        request_headers = client.get.await_args.kwargs["headers"]
+        request_headers = client.stream.call_args.kwargs["headers"]
         assert request_headers["Authorization"] == "Bearer bot-token"
 
     @pytest.mark.anyio
     async def test_non_bot_framework_download_never_receives_bot_token(self, monkeypatch):
         adapter = self._make_adapter()
         adapter._app._get_bot_token = AsyncMock(return_value="bot-token")
-        response = SimpleNamespace(content=b"file", raise_for_status=MagicMock())
-        client = SimpleNamespace(get=AsyncMock(return_value=response))
+        async def chunks():
+            yield b"file"
+
+        response = SimpleNamespace(
+            headers={},
+            aiter_bytes=chunks,
+            raise_for_status=MagicMock(),
+        )
+
+        class ResponseContext:
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *_args):
+                return False
+
+        client = SimpleNamespace(stream=MagicMock(return_value=ResponseContext()))
 
         class ClientContext:
             async def __aenter__(self):
@@ -885,8 +912,47 @@ class TestTeamsAttachmentClassification:
         )
 
         adapter._app._get_bot_token.assert_not_awaited()
-        request_headers = client.get.await_args.kwargs["headers"]
+        request_headers = client.stream.call_args.kwargs["headers"]
         assert "Authorization" not in request_headers
+
+    @pytest.mark.anyio
+    async def test_attachment_download_enforces_inbound_media_cap(self, monkeypatch):
+        adapter = self._make_adapter()
+        response = SimpleNamespace(
+            headers={"content-length": "5"},
+            raise_for_status=MagicMock(),
+        )
+
+        class ResponseContext:
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *_args):
+                return False
+
+        client = SimpleNamespace(stream=MagicMock(return_value=ResponseContext()))
+
+        class ClientContext:
+            async def __aenter__(self):
+                return client
+
+            async def __aexit__(self, *_args):
+                return False
+
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: True)
+        monkeypatch.setattr(
+            "tools.url_safety.create_ssrf_safe_async_client",
+            lambda **_kwargs: ClientContext(),
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base.get_inbound_media_max_bytes",
+            lambda: 4,
+        )
+
+        with pytest.raises(ValueError, match="Inbound attachment payload is too large"):
+            await adapter._fetch_attachment_bytes(
+                "https://contoso.sharepoint.com/download/oversized.png"
+            )
 
     @pytest.mark.anyio
     async def test_protected_image_uses_authenticated_attachment_download(self):

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -955,6 +955,73 @@ class TestTeamsAttachmentClassification:
             )
 
     @pytest.mark.anyio
+    async def test_attachment_download_retries_transient_http_status(self, monkeypatch):
+        adapter = self._make_adapter()
+        request = httpx.Request(
+            "GET",
+            "https://contoso.sharepoint.com/download/image.png",
+        )
+        retry_response = httpx.Response(429, request=request)
+        retry_error = httpx.HTTPStatusError(
+            "rate limited",
+            request=request,
+            response=retry_response,
+        )
+        first_response = SimpleNamespace(
+            headers={},
+            raise_for_status=MagicMock(side_effect=retry_error),
+        )
+
+        async def chunks():
+            yield b"image bytes"
+
+        second_response = SimpleNamespace(
+            headers={},
+            aiter_bytes=chunks,
+            raise_for_status=MagicMock(),
+        )
+
+        class ResponseContext:
+            def __init__(self, response):
+                self.response = response
+
+            async def __aenter__(self):
+                return self.response
+
+            async def __aexit__(self, *_args):
+                return False
+
+        client = SimpleNamespace(
+            stream=MagicMock(
+                side_effect=[
+                    ResponseContext(first_response),
+                    ResponseContext(second_response),
+                ]
+            )
+        )
+
+        class ClientContext:
+            async def __aenter__(self):
+                return client
+
+            async def __aexit__(self, *_args):
+                return False
+
+        sleep = AsyncMock()
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: True)
+        monkeypatch.setattr(
+            "tools.url_safety.create_ssrf_safe_async_client",
+            lambda **_kwargs: ClientContext(),
+        )
+        monkeypatch.setattr(_teams_mod.asyncio, "sleep", sleep)
+
+        data = await adapter._fetch_attachment_bytes(str(request.url))
+
+        assert data == b"image bytes"
+        assert client.stream.call_count == 2
+        sleep.assert_awaited_once_with(1.5)
+
+    @pytest.mark.anyio
     async def test_protected_image_uses_authenticated_attachment_download(self):
         from gateway.platforms.base import MessageType
 

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -873,6 +873,28 @@ class TestTeamsAttachmentClassification:
         assert request_headers["Authorization"] == "Bearer bot-token"
 
     @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://smba.trafficmanager.net/amer/tenant/v3/attachments/1/views/original",
+            "https://smba.trafficmanager.net:444/amer/tenant/v3/attachments/1/views/original",
+        ],
+    )
+    async def test_bot_framework_token_requires_https_default_port(
+        self,
+        monkeypatch,
+        url,
+    ):
+        adapter = self._make_adapter()
+        adapter._app._get_bot_token = AsyncMock(return_value="bot-token")
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: True)
+
+        with pytest.raises(ValueError, match="HTTPS on port 443 is required"):
+            await adapter._fetch_attachment_bytes(url)
+
+        adapter._app._get_bot_token.assert_not_awaited()
+
+    @pytest.mark.anyio
     async def test_non_bot_framework_download_never_receives_bot_token(self, monkeypatch):
         adapter = self._make_adapter()
         adapter._app._get_bot_token = AsyncMock(return_value="bot-token")


### PR DESCRIPTION
## Summary

- download protected Teams/Bot Framework image attachments through the adapter's authenticated attachment path
- acquire the bearer token from the initialized Teams SDK app and attach it only for allowlisted Bot Framework hosts
- cache downloaded image bytes with the correct image extension while preserving SSRF and token-exfiltration protections
- add regression coverage for authenticated Bot Framework downloads, non-Bot-Framework token isolation, and pasted-image event routing

## Root cause

Teams pasted images arrive as protected `smba.trafficmanager.net/.../v3/attachments/.../views/original` URLs. The image path used the generic unauthenticated `cache_image_from_url`, which returned HTTP 401 and left the agent with text only.

## Validation

- `uv run --extra dev python -m pytest tests/gateway/test_teams.py -o 'addopts=' -q` — 60 passed
- `uv run --extra dev --extra teams python -m pytest tests/gateway/test_teams.py tests/gateway/test_teams_pipeline_runtime_wiring.py tests/plugins/test_teams_pipeline_plugin.py tests/hermes_cli/test_teams_pipeline_plugin_cli.py -o 'addopts=' -q` — 90 passed
- `uv run --extra dev ruff check plugins/platforms/teams/adapter.py tests/gateway/test_teams.py` — passed
- live credentialed download of the previously failing Teams attachment — 215,594-byte PNG returned with a valid PNG signature
- restarted the Gilbert profile gateway; local `/health` returns `ok` and port 3985 is listening

## Security

The Bot Framework bearer token is only attached when the parsed hostname exactly matches the existing Bot Framework service-host allowlist. SharePoint and other pre-authenticated attachment URLs never receive the bot token. Existing SSRF URL and redirect guards remain in place.
