### PR TITLE
fix(gateway): preserve memory provider prompt during hygiene compression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -85,6 +85,7 @@ _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+_GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
@@ -321,6 +322,43 @@ def _non_conversational_metadata(
     merged = dict(metadata or {})
     merged["non_conversational"] = True
     return merged
+
+
+def _seed_hygiene_system_prompt(
+    agent: Any,
+    session_db: Any,
+    session_id: str,
+) -> bool:
+    """Keep gateway hygiene from rebuilding a live session's system prompt.
+
+    The hygiene helper intentionally skips memory-provider initialization.
+    Compression is allowed to persist a system prompt, so letting that helper
+    rebuild one would strip external provider blocks from the live session.
+    Seed the exact persisted prompt instead.  When no usable prompt can be
+    restored, seed an empty cache entry.  Compression either preserves that
+    unusable value or rebuilds with the hygiene-only platform marker; the real
+    turn will rebuild either form with its fully initialized providers.
+    """
+    stored_prompt = ""
+    if session_db is not None and session_id:
+        try:
+            session_row = session_db.get_session(session_id)
+            if isinstance(session_row, dict):
+                raw_prompt = session_row.get("system_prompt")
+                if isinstance(raw_prompt, str) and raw_prompt.strip():
+                    stored_prompt = raw_prompt
+        except Exception as exc:
+            logger.warning(
+                "Session hygiene could not restore the system prompt for "
+                "session %s: %s. Preserving an empty prompt so the live "
+                "turn rebuilds it with its configured providers.",
+                session_id,
+                exc,
+                exc_info=True,
+            )
+
+    agent._cached_system_prompt = stored_prompt
+    return bool(stored_prompt)
 
 
 def _is_transient_network_error(exc: BaseException) -> bool:
@@ -13644,6 +13682,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     session_id=session_entry.session_id,
                                     session_db=_hyg_session_db,
                                 )
+                                _seed_hygiene_system_prompt(
+                                    _hyg_agent,
+                                    _hyg_session_db,
+                                    session_entry.session_id,
+                                )
+                                # If compression must rebuild instead of retaining
+                                # the cached prompt, make the persisted result
+                                # deliberately stale for every real gateway surface.
+                                _hyg_agent.platform = _GATEWAY_HYGIENE_PLATFORM
                                 _hyg_cleanup_deferred = False
                                 try:
                                     # Gateway hygiene runs before the user turn

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -326,8 +326,7 @@ def _non_conversational_metadata(
 
 def _seed_hygiene_system_prompt(
     agent: Any,
-    session_db: Any,
-    session_id: str,
+    session_row: Optional[Dict[str, Any]],
 ) -> bool:
     """Keep gateway hygiene from rebuilding a live session's system prompt.
 
@@ -340,22 +339,10 @@ def _seed_hygiene_system_prompt(
     turn will rebuild either form with its fully initialized providers.
     """
     stored_prompt = ""
-    if session_db is not None and session_id:
-        try:
-            session_row = session_db.get_session(session_id)
-            if isinstance(session_row, dict):
-                raw_prompt = session_row.get("system_prompt")
-                if isinstance(raw_prompt, str) and raw_prompt.strip():
-                    stored_prompt = raw_prompt
-        except Exception as exc:
-            logger.warning(
-                "Session hygiene could not restore the system prompt for "
-                "session %s: %s. Preserving an empty prompt so the live "
-                "turn rebuilds it with its configured providers.",
-                session_id,
-                exc,
-                exc_info=True,
-            )
+    if isinstance(session_row, dict):
+        raw_prompt = session_row.get("system_prompt")
+        if isinstance(raw_prompt, str) and raw_prompt.strip():
+            stored_prompt = raw_prompt
 
     agent._cached_system_prompt = stored_prompt
     return bool(stored_prompt)
@@ -13671,6 +13658,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             ]
 
                             if len(_hyg_msgs) >= 4:
+                                try:
+                                    _hyg_session_row = await self._session_db.get_session(
+                                        session_entry.session_id
+                                    )
+                                except Exception as exc:
+                                    _hyg_session_row = None
+                                    logger.warning(
+                                        "Session hygiene could not restore the system "
+                                        "prompt for session %s: %s. Preserving an empty "
+                                        "prompt so the live turn rebuilds it with its "
+                                        "configured providers.",
+                                        session_entry.session_id,
+                                        exc,
+                                        exc_info=True,
+                                    )
                                 _hyg_session_db = getattr(self._session_db, "_db", self._session_db)
                                 _hyg_agent = AIAgent(
                                     **_hyg_runtime,
@@ -13684,8 +13686,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 )
                                 _seed_hygiene_system_prompt(
                                     _hyg_agent,
-                                    _hyg_session_db,
-                                    session_entry.session_id,
+                                    _hyg_session_row,
                                 )
                                 # If compression must rebuild instead of retaining
                                 # the cached prompt, make the persisted result

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -1094,15 +1094,26 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
-    fake_db = object()
+    stored_system_prompt = (
+        "You are Hermes.\n\n"
+        "<memory_provider_context>\n"
+        "Pinboard provider instructions\n"
+        "</memory_provider_context>"
+    )
+    fake_db = MagicMock()
+    fake_db.get_session.return_value = {
+        "system_prompt": stored_system_prompt,
+    }
 
     class FakeInPlaceCompressAgent:
         last_instance = None
 
         def __init__(self, **kwargs):
             self.model = kwargs.get("model")
+            self.platform = kwargs.get("platform")
             self.session_id = kwargs.get("session_id", "fake-session")
             self._session_db = kwargs.get("session_db")
+            self._cached_system_prompt = None
             self.compression_in_place = False
             self._last_compaction_in_place = False
             self.context_compressor = SimpleNamespace(
@@ -1118,6 +1129,8 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
         def _compress_context(self, messages, *_args, **_kwargs):
             assert self.compression_in_place is True
             assert self._session_db is fake_db
+            assert self.platform == "gateway_hygiene"
+            assert self._cached_system_prompt == stored_system_prompt
             self._last_compaction_in_place = True
             return ([{"role": "assistant", "content": "compressed in place"}], None)
 
@@ -1190,6 +1203,7 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     assert result == "ok"
     agent = FakeInPlaceCompressAgent.last_instance
     assert agent is not None
+    fake_db.get_session.assert_called_once_with("sess-1")
     agent.context_compressor.bind_session_state.assert_called_once_with(fake_db, "sess-1")
     # In-place compaction already persisted via archive_and_compact() —
     # rewrite_transcript would replace_messages(active_only=False) and DELETE
@@ -1429,7 +1443,7 @@ def _make_progress_runner(monkeypatch, tmp_path, agent_cls, cfg_text):
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
     cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text(cfg_text)
+    cfg_path.write_text(cfg_text, encoding="utf-8")
 
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -1101,9 +1101,14 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
         "</memory_provider_context>"
     )
     fake_db = MagicMock()
-    fake_db.get_session.return_value = {
-        "system_prompt": stored_system_prompt,
-    }
+    async_session_db = SimpleNamespace(
+        _db=fake_db,
+        get_session=AsyncMock(
+            return_value={
+                "system_prompt": stored_system_prompt,
+            }
+        ),
+    )
 
     class FakeInPlaceCompressAgent:
         last_instance = None
@@ -1165,7 +1170,7 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     runner._running_agents = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
-    runner._session_db = SimpleNamespace(_db=fake_db)
+    runner._session_db = async_session_db
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
     runner._run_agent = AsyncMock(
@@ -1203,7 +1208,7 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     assert result == "ok"
     agent = FakeInPlaceCompressAgent.last_instance
     assert agent is not None
-    fake_db.get_session.assert_called_once_with("sess-1")
+    async_session_db.get_session.assert_awaited_once_with("sess-1")
     agent.context_compressor.bind_session_state.assert_called_once_with(fake_db, "sess-1")
     # In-place compaction already persisted via archive_and_compact() —
     # rewrite_transcript would replace_messages(active_only=False) and DELETE


### PR DESCRIPTION
## What does this PR do?

Gateway session hygiene compresses oversized messaging transcripts with a temporary `AIAgent` that intentionally uses `skip_memory=True`. Context compression can rebuild and persist that helper's system prompt, which strips external `MemoryProvider.system_prompt_block()` content from the live session even though the provider loads before the next user-turn API call.

This change seeds the hygiene helper with the exact system prompt already persisted for the live session. If no usable prompt exists, or compression must rebuild because built-in memory changed, the helper uses a hygiene-only platform marker so the next real gateway turn rejects that persisted prompt as stale and rebuilds it after initializing the configured memory provider.

## Related Issue

Discord support report: https://discord.com/channels/1053877538025386074/1531439166871568394

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: preserve the live session's stored system prompt across pre-turn hygiene compression and mark any hygiene-only rebuild as stale for real gateway surfaces.
- `tests/gateway/test_session_hygiene.py`: extend the existing in-place hygiene regression to require exact prompt preservation and the hygiene fallback marker; use explicit UTF-8 in the touched hygiene config helper required by the blocking Windows-footgun check.

## How to Test

1. Start from a gateway session whose persisted system prompt includes an external memory-provider block and whose transcript exceeds the session-hygiene compression threshold.
2. Trigger a new messaging turn and verify the pre-turn hygiene agent receives the existing prompt byte-for-byte before in-place compression.
3. Verify a prompt rebuilt without a stored prompt carries `Platform: gateway_hygiene`, causing the real Telegram/Discord/etc. agent to reject it as stale and rebuild with its initialized provider.

Focused validation run on Windows 11:

- `python -m py_compile gateway/run.py tests/gateway/test_session_hygiene.py`
- `python scripts/check-windows-footguns.py --all` (`830` files scanned, clean)
- Focused runtime assertions for stored-prompt seeding, missing-prompt fallback, and live-platform rejection of the hygiene marker
- `git diff HEAD^ --check`

The pytest regression was added but pytest was not run locally due workstation resource-safety constraints. Full-suite coverage is left to GitHub CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, focused static and runtime assertions listed above

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. The focused validation results are listed under How to Test.
