### PR TITLE
test(agent): pin the failover redecoration wiring in the retry loop

### DIFF
--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -9,6 +9,7 @@ gpt-5.4-mini after a Codex usage-limit 429.
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from agent.chat_completion_helpers import rewrite_prompt_model_identity
 from agent.conversation_loop import (
@@ -469,3 +470,136 @@ class TestPeelReferenceGuidanceRoundTrip:
         ]
         peeled = peel_reference_guidance(messages, self._GUIDANCE)
         assert peeled == messages[:-1]
+
+
+class TestFailoverRedecorationWiring:
+    """#72869 gap: the retry loop must actually call
+    ``_redecorate_prompt_cache_for_provider`` at the top of each attempt.
+
+    The existing redecoration-policy tests call the helper directly and
+    none exercises the retry-loop wiring, so deleting the call site inside
+    ``run_conversation``'s retry loop (``agent/conversation_loop.py``
+    ~line 2001) leaves this whole file green while the #72626 regression
+    comes back. This drives the real retry loop
+    through ``AIAgent.run_conversation`` and inspects the actual outgoing
+    kwargs for the post-failover attempt.
+    """
+
+    def _agent_with_fallback(self):
+        # Imported here, not at module level: importing run_agent at collection
+        # time runs its loader before the autouse HERMES_HOME isolation
+        # fixture, reading the real Hermes home.
+        from run_agent import AIAgent
+
+        fb_chain = [
+            {
+                "provider": "openrouter",
+                "model": "anthropic/claude-opus-4.7",
+                "base_url": "https://openrouter.ai/api/v1",
+            }
+        ]
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key="primkey",
+                base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+                provider="zai",
+                model="glm-5.1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=fb_chain,
+            )
+        agent.client = MagicMock()
+        return agent
+
+    def test_retry_loop_redecorates_after_failover(self):
+        agent = self._agent_with_fallback()
+        # zai is not an Anthropic-caching route -> primary starts cache-off.
+        assert agent._use_prompt_caching is False
+
+        class _RateLimitError(Exception):
+            status_code = 429
+
+            def __init__(self):
+                super().__init__("Error code: 429 - rate limit exceeded")
+                self.response = SimpleNamespace(headers={})
+                self.body = {"error": {"message": "rate limit exceeded"}}
+
+        def _mock_response(content):
+            msg = SimpleNamespace(content=content, tool_calls=None)
+            choice = SimpleNamespace(message=msg, finish_reason="stop")
+            return SimpleNamespace(choices=[choice], model="fallback/model", usage=None)
+
+        sent_kwargs = []
+
+        def fake_api_call(api_kwargs):
+            sent_kwargs.append(api_kwargs)
+            if len(sent_kwargs) == 1:
+                raise _RateLimitError()
+            return _mock_response("answered via fallback")
+
+        mock_fb_client = MagicMock()
+        mock_fb_client.api_key = "fb-key"
+        mock_fb_client.base_url = "https://openrouter.ai/api/v1"
+        mock_fb_client._custom_headers = None
+        mock_fb_client.default_headers = None
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("agent.agent_runtime_helpers.time.sleep"),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(mock_fb_client, "anthropic/claude-opus-4.7"),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+            patch("agent.model_metadata.get_model_context_length", return_value=200000),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert len(sent_kwargs) == 2, "expected the primary attempt + one post-failover retry"
+        assert agent._fallback_activated is True
+        # openrouter + a claude-named model is a real cache-on route (envelope
+        # layout) -- the policy flip must be genuine, not stubbed.
+        assert agent._use_prompt_caching is True
+
+        def _part_markers(messages):
+            # Only markers the openrouter envelope layout honors: inside a
+            # non-empty content part. A top-level-only marker is ignored by
+            # the provider, so it must NOT satisfy this test (a mutant that
+            # stamps messages[0]["cache_control"] kept the suite green).
+            count = 0
+            for msg in messages:
+                content = msg.get("content")
+                if isinstance(content, list):
+                    for part in content:
+                        if (
+                            isinstance(part, dict)
+                            and "cache_control" in part
+                            and (part.get("text") or part.get("type") != "text")
+                        ):
+                            count += 1
+            return count
+
+        primary_markers = _count_cache_markers(sent_kwargs[0].get("messages") or [])
+        fallback_part_markers = _part_markers(sent_kwargs[1].get("messages") or [])
+        assert primary_markers == 0, "primary (cache-off) request must carry no cache_control"
+        assert fallback_part_markers > 0, (
+            "the post-failover request never got cache markers in positions "
+            "the envelope layout honors (content parts) -- the retry loop "
+            "must call _redecorate_prompt_cache_for_provider before "
+            "rebuilding kwargs each attempt (agent/conversation_loop.py "
+            "~line 2001). The redecoration-policy tests call the helper "
+            "directly; only this test exercises the wiring."
+        )

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -51,6 +51,24 @@ def _count_cache_markers(messages):
     return count
 
 
+def _part_markers(messages):
+    # Only markers the openrouter envelope layout honors: inside a
+    # non-empty content part. A top-level-only marker is ignored by
+    # the provider, so it must not satisfy the wiring tests.
+    count = 0
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if (
+                    isinstance(part, dict)
+                    and "cache_control" in part
+                    and (part.get("text") or part.get("type") != "text")
+                ):
+                    count += 1
+    return count
+
+
 def _cache_agent(
     *,
     use_caching,
@@ -370,19 +388,28 @@ class TestFailoverRedecorationWiring:
     kwargs for the post-failover attempt.
     """
 
-    def _agent_with_fallback(self):
+    def _agent_with_fallback(
+        self,
+        *,
+        base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+        provider="zai",
+        model="glm-5.1",
+        fallback_model=None,
+    ):
         # Imported here, not at module level: importing run_agent at collection
         # time runs its loader before the autouse HERMES_HOME isolation
         # fixture, reading the real Hermes home.
         from run_agent import AIAgent
 
-        fb_chain = [
-            {
-                "provider": "openrouter",
-                "model": "anthropic/claude-opus-4.7",
-                "base_url": "https://openrouter.ai/api/v1",
-            }
-        ]
+        fb_chain = fallback_model
+        if fb_chain is None:
+            fb_chain = [
+                {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.7",
+                    "base_url": "https://openrouter.ai/api/v1",
+                }
+            ]
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
@@ -390,9 +417,9 @@ class TestFailoverRedecorationWiring:
         ):
             agent = AIAgent(
                 api_key="primkey",
-                base_url="https://open.bigmodel.cn/api/coding/paas/v4",
-                provider="zai",
-                model="glm-5.1",
+                base_url=base_url,
+                provider=provider,
+                model=model,
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -459,24 +486,6 @@ class TestFailoverRedecorationWiring:
         # layout) -- the policy flip must be genuine, not stubbed.
         assert agent._use_prompt_caching is True
 
-        def _part_markers(messages):
-            # Only markers the openrouter envelope layout honors: inside a
-            # non-empty content part. A top-level-only marker is ignored by
-            # the provider, so it must NOT satisfy this test (a mutant that
-            # stamps messages[0]["cache_control"] kept the suite green).
-            count = 0
-            for msg in messages:
-                content = msg.get("content")
-                if isinstance(content, list):
-                    for part in content:
-                        if (
-                            isinstance(part, dict)
-                            and "cache_control" in part
-                            and (part.get("text") or part.get("type") != "text")
-                        ):
-                            count += 1
-            return count
-
         primary_markers = _count_cache_markers(sent_kwargs[0].get("messages") or [])
         fallback_part_markers = _part_markers(sent_kwargs[1].get("messages") or [])
         assert primary_markers == 0, "primary (cache-off) request must carry no cache_control"
@@ -487,4 +496,80 @@ class TestFailoverRedecorationWiring:
             "rebuilding kwargs each attempt (agent/conversation_loop.py "
             "~line 2001). The redecoration-policy tests call the helper "
             "directly; only this test exercises the wiring."
+        )
+
+    def test_retry_loop_strips_cache_markers_on_failover_to_non_caching_route(self):
+        agent = self._agent_with_fallback(
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            model="anthropic/claude-opus-4.7",
+            fallback_model=[
+                {
+                    "provider": "zai",
+                    "model": "glm-5.1",
+                    "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+                }
+            ],
+        )
+        assert agent._use_prompt_caching is True
+
+        class _RateLimitError(Exception):
+            status_code = 429
+
+            def __init__(self):
+                super().__init__("Error code: 429 - rate limit exceeded")
+                self.response = SimpleNamespace(headers={})
+                self.body = {"error": {"message": "rate limit exceeded"}}
+
+        def _mock_response(content):
+            msg = SimpleNamespace(content=content, tool_calls=None)
+            choice = SimpleNamespace(message=msg, finish_reason="stop")
+            return SimpleNamespace(choices=[choice], model="fallback/model", usage=None)
+
+        sent_kwargs = []
+
+        def fake_api_call(api_kwargs):
+            sent_kwargs.append(api_kwargs)
+            if len(sent_kwargs) == 1:
+                raise _RateLimitError()
+            return _mock_response("answered via fallback")
+
+        mock_fb_client = MagicMock()
+        mock_fb_client.api_key = "fb-key"
+        mock_fb_client.base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
+        mock_fb_client._custom_headers = None
+        mock_fb_client.default_headers = None
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("agent.agent_runtime_helpers.time.sleep"),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(mock_fb_client, "glm-5.1"),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+            patch("agent.model_metadata.get_model_context_length", return_value=200000),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert len(sent_kwargs) == 2, "expected the primary attempt + one post-failover retry"
+        assert agent._fallback_activated is True
+        assert agent._use_prompt_caching is False
+
+        primary_part_markers = _part_markers(sent_kwargs[0].get("messages") or [])
+        fallback_markers = _count_cache_markers(sent_kwargs[1].get("messages") or [])
+        assert primary_part_markers > 0, (
+            "primary (cache-on) request must carry cache_control in content parts"
+        )
+        assert fallback_markers == 0, (
+            "the post-failover request leaked stale cache_control markers into "
+            "a non-caching route"
         )

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -9,6 +9,7 @@ gpt-5.4-mini after a Codex usage-limit 429.
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from agent.chat_completion_helpers import rewrite_prompt_model_identity
 from agent.conversation_loop import (
@@ -354,3 +355,136 @@ class TestPeelReferenceGuidanceRoundTrip:
         ]
         peeled = peel_reference_guidance(messages, self._GUIDANCE)
         assert peeled == messages[:-1]
+
+
+class TestFailoverRedecorationWiring:
+    """#72869 gap: the retry loop must actually call
+    ``_redecorate_prompt_cache_for_provider`` at the top of each attempt.
+
+    The existing redecoration-policy tests call the helper directly and
+    none exercises the retry-loop wiring, so deleting the call site inside
+    ``run_conversation``'s retry loop (``agent/conversation_loop.py``
+    ~line 2001) leaves this whole file green while the #72626 regression
+    comes back. This drives the real retry loop
+    through ``AIAgent.run_conversation`` and inspects the actual outgoing
+    kwargs for the post-failover attempt.
+    """
+
+    def _agent_with_fallback(self):
+        # Imported here, not at module level: importing run_agent at collection
+        # time runs its loader before the autouse HERMES_HOME isolation
+        # fixture, reading the real Hermes home.
+        from run_agent import AIAgent
+
+        fb_chain = [
+            {
+                "provider": "openrouter",
+                "model": "anthropic/claude-opus-4.7",
+                "base_url": "https://openrouter.ai/api/v1",
+            }
+        ]
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key="primkey",
+                base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+                provider="zai",
+                model="glm-5.1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=fb_chain,
+            )
+        agent.client = MagicMock()
+        return agent
+
+    def test_retry_loop_redecorates_after_failover(self):
+        agent = self._agent_with_fallback()
+        # zai is not an Anthropic-caching route -> primary starts cache-off.
+        assert agent._use_prompt_caching is False
+
+        class _RateLimitError(Exception):
+            status_code = 429
+
+            def __init__(self):
+                super().__init__("Error code: 429 - rate limit exceeded")
+                self.response = SimpleNamespace(headers={})
+                self.body = {"error": {"message": "rate limit exceeded"}}
+
+        def _mock_response(content):
+            msg = SimpleNamespace(content=content, tool_calls=None)
+            choice = SimpleNamespace(message=msg, finish_reason="stop")
+            return SimpleNamespace(choices=[choice], model="fallback/model", usage=None)
+
+        sent_kwargs = []
+
+        def fake_api_call(api_kwargs):
+            sent_kwargs.append(api_kwargs)
+            if len(sent_kwargs) == 1:
+                raise _RateLimitError()
+            return _mock_response("answered via fallback")
+
+        mock_fb_client = MagicMock()
+        mock_fb_client.api_key = "fb-key"
+        mock_fb_client.base_url = "https://openrouter.ai/api/v1"
+        mock_fb_client._custom_headers = None
+        mock_fb_client.default_headers = None
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("agent.agent_runtime_helpers.time.sleep"),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(mock_fb_client, "anthropic/claude-opus-4.7"),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+            patch("agent.model_metadata.get_model_context_length", return_value=200000),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert len(sent_kwargs) == 2, "expected the primary attempt + one post-failover retry"
+        assert agent._fallback_activated is True
+        # openrouter + a claude-named model is a real cache-on route (envelope
+        # layout) -- the policy flip must be genuine, not stubbed.
+        assert agent._use_prompt_caching is True
+
+        def _part_markers(messages):
+            # Only markers the openrouter envelope layout honors: inside a
+            # non-empty content part. A top-level-only marker is ignored by
+            # the provider, so it must NOT satisfy this test (a mutant that
+            # stamps messages[0]["cache_control"] kept the suite green).
+            count = 0
+            for msg in messages:
+                content = msg.get("content")
+                if isinstance(content, list):
+                    for part in content:
+                        if (
+                            isinstance(part, dict)
+                            and "cache_control" in part
+                            and (part.get("text") or part.get("type") != "text")
+                        ):
+                            count += 1
+            return count
+
+        primary_markers = _count_cache_markers(sent_kwargs[0].get("messages") or [])
+        fallback_part_markers = _part_markers(sent_kwargs[1].get("messages") or [])
+        assert primary_markers == 0, "primary (cache-off) request must carry no cache_control"
+        assert fallback_part_markers > 0, (
+            "the post-failover request never got cache markers in positions "
+            "the envelope layout honors (content parts) -- the retry loop "
+            "must call _redecorate_prompt_cache_for_provider before "
+            "rebuilding kwargs each attempt (agent/conversation_loop.py "
+            "~line 2001). The redecoration-policy tests call the helper "
+            "directly; only this test exercises the wiring."
+        )

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -51,6 +51,24 @@ def _count_cache_markers(messages):
     return count
 
 
+def _part_markers(messages):
+    # Only markers the openrouter envelope layout honors: inside a
+    # non-empty content part. A top-level-only marker is ignored by
+    # the provider, so it must not satisfy the wiring tests.
+    count = 0
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if (
+                    isinstance(part, dict)
+                    and "cache_control" in part
+                    and (part.get("text") or part.get("type") != "text")
+                ):
+                    count += 1
+    return count
+
+
 def _cache_agent(
     *,
     use_caching,
@@ -485,19 +503,28 @@ class TestFailoverRedecorationWiring:
     kwargs for the post-failover attempt.
     """
 
-    def _agent_with_fallback(self):
+    def _agent_with_fallback(
+        self,
+        *,
+        base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+        provider="zai",
+        model="glm-5.1",
+        fallback_model=None,
+    ):
         # Imported here, not at module level: importing run_agent at collection
         # time runs its loader before the autouse HERMES_HOME isolation
         # fixture, reading the real Hermes home.
         from run_agent import AIAgent
 
-        fb_chain = [
-            {
-                "provider": "openrouter",
-                "model": "anthropic/claude-opus-4.7",
-                "base_url": "https://openrouter.ai/api/v1",
-            }
-        ]
+        fb_chain = fallback_model
+        if fb_chain is None:
+            fb_chain = [
+                {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.7",
+                    "base_url": "https://openrouter.ai/api/v1",
+                }
+            ]
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
@@ -505,9 +532,9 @@ class TestFailoverRedecorationWiring:
         ):
             agent = AIAgent(
                 api_key="primkey",
-                base_url="https://open.bigmodel.cn/api/coding/paas/v4",
-                provider="zai",
-                model="glm-5.1",
+                base_url=base_url,
+                provider=provider,
+                model=model,
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -574,24 +601,6 @@ class TestFailoverRedecorationWiring:
         # layout) -- the policy flip must be genuine, not stubbed.
         assert agent._use_prompt_caching is True
 
-        def _part_markers(messages):
-            # Only markers the openrouter envelope layout honors: inside a
-            # non-empty content part. A top-level-only marker is ignored by
-            # the provider, so it must NOT satisfy this test (a mutant that
-            # stamps messages[0]["cache_control"] kept the suite green).
-            count = 0
-            for msg in messages:
-                content = msg.get("content")
-                if isinstance(content, list):
-                    for part in content:
-                        if (
-                            isinstance(part, dict)
-                            and "cache_control" in part
-                            and (part.get("text") or part.get("type") != "text")
-                        ):
-                            count += 1
-            return count
-
         primary_markers = _count_cache_markers(sent_kwargs[0].get("messages") or [])
         fallback_part_markers = _part_markers(sent_kwargs[1].get("messages") or [])
         assert primary_markers == 0, "primary (cache-off) request must carry no cache_control"
@@ -602,4 +611,80 @@ class TestFailoverRedecorationWiring:
             "rebuilding kwargs each attempt (agent/conversation_loop.py "
             "~line 2001). The redecoration-policy tests call the helper "
             "directly; only this test exercises the wiring."
+        )
+
+    def test_retry_loop_strips_cache_markers_on_failover_to_non_caching_route(self):
+        agent = self._agent_with_fallback(
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            model="anthropic/claude-opus-4.7",
+            fallback_model=[
+                {
+                    "provider": "zai",
+                    "model": "glm-5.1",
+                    "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+                }
+            ],
+        )
+        assert agent._use_prompt_caching is True
+
+        class _RateLimitError(Exception):
+            status_code = 429
+
+            def __init__(self):
+                super().__init__("Error code: 429 - rate limit exceeded")
+                self.response = SimpleNamespace(headers={})
+                self.body = {"error": {"message": "rate limit exceeded"}}
+
+        def _mock_response(content):
+            msg = SimpleNamespace(content=content, tool_calls=None)
+            choice = SimpleNamespace(message=msg, finish_reason="stop")
+            return SimpleNamespace(choices=[choice], model="fallback/model", usage=None)
+
+        sent_kwargs = []
+
+        def fake_api_call(api_kwargs):
+            sent_kwargs.append(api_kwargs)
+            if len(sent_kwargs) == 1:
+                raise _RateLimitError()
+            return _mock_response("answered via fallback")
+
+        mock_fb_client = MagicMock()
+        mock_fb_client.api_key = "fb-key"
+        mock_fb_client.base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
+        mock_fb_client._custom_headers = None
+        mock_fb_client.default_headers = None
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("agent.agent_runtime_helpers.time.sleep"),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(mock_fb_client, "glm-5.1"),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+            patch("agent.model_metadata.get_model_context_length", return_value=200000),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert len(sent_kwargs) == 2, "expected the primary attempt + one post-failover retry"
+        assert agent._fallback_activated is True
+        assert agent._use_prompt_caching is False
+
+        primary_part_markers = _part_markers(sent_kwargs[0].get("messages") or [])
+        fallback_markers = _count_cache_markers(sent_kwargs[1].get("messages") or [])
+        assert primary_part_markers > 0, (
+            "primary (cache-on) request must carry cache_control in content parts"
+        )
+        assert fallback_markers == 0, (
+            "the post-failover request leaked stale cache_control markers into "
+            "a non-caching route"
         )


### PR DESCRIPTION
Follow-up to #72869. In my review there (https://github.com/NousResearch/hermes-agent/pull/72869#pullrequestreview-4790860051) I measured a detection gap: severing the `_redecorate_prompt_cache_for_provider` call in the retry loop leaves the whole redecoration suite green, because the tests drive the helper directly. The exact bug #72869 fixed could come back with a green suite.

This adds one wiring test that drives `AIAgent.run_conversation` end to end: cache-off primary, first attempt fails with a 429-class error, `_try_activate_fallback` flips to an openrouter cache-on route, and the second outgoing request's kwargs must carry `cache_control` in positions the envelope layout honors (inside non-empty content parts; a top-level-only marker does not pass, since the provider ignores those).

Kill-power, measured three ways on this branch:

- wiring intact: 24 passed
- wiring severed (call replaced with `pass`): exactly this test fails, the other 23 stay green
- wiring replaced with a top-level-only marker stamp: this test fails

The mock seam is `_interruptible_api_call`, the same one `tests/run_agent/test_32646_fallback_429_after_timeout.py` already uses, so the captured kwargs are the real `_build_api_kwargs` output for the post-failover attempt.
