### PR TITLE
fix(agent): shut down sockets on httpx mount pools during interrupt abort

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3258,75 +3258,139 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
     return changed
 
 
+def _iter_httpx_pool_objects(http_client: Any):
+    """Yield httpcore pool objects reachable from an httpx client.
+
+    Hermes' keepalive client (#10324 / ``_build_keepalive_http_client``) and
+    any ``HTTP(S)_PROXY`` configuration put live connections on *mounted*
+    transports (``client._mounts``), not only on the default
+    ``client._transport``. Walking the default transport alone makes
+    ``force_close_tcp_sockets`` return 0 while a stream is still mid-recv —
+    the interrupt logs success and the provider keeps burning the slot
+    (#72975).
+    """
+    seen_pools: set[int] = set()
+
+    def _emit(pool: Any):
+        if pool is None:
+            return
+        marker = id(pool)
+        if marker in seen_pools:
+            return
+        seen_pools.add(marker)
+        yield pool
+
+    def _pools_for_transport(transport: Any):
+        if transport is None:
+            return
+        # Normal httpx.HTTPTransport / HTTPProxy-as-transport: connections
+        # live under ``_pool``. HTTPProxy itself *is* a ConnectionPool and
+        # may be mounted directly — then ``_connections`` is on the
+        # transport.
+        pool = getattr(transport, "_pool", None)
+        if pool is not None:
+            yield from _emit(pool)
+            return
+        if getattr(transport, "_connections", None) is not None:
+            yield from _emit(transport)
+
+    try:
+        yield from _pools_for_transport(getattr(http_client, "_transport", None))
+        mounts = getattr(http_client, "_mounts", None) or {}
+        for _pattern, mounted in list(mounts.items()):
+            yield from _pools_for_transport(mounted)
+    except Exception:
+        return
+
+
+def _connection_candidates(conn: Any):
+    """Walk nested ``_connection`` wrappers (proxy tunnel → HTTP11/2)."""
+    seen: set[int] = set()
+    stack = [conn]
+    while stack:
+        candidate = stack.pop()
+        if candidate is None:
+            continue
+        marker = id(candidate)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        yield candidate
+        inner = getattr(candidate, "_connection", None)
+        if inner is not None and id(inner) not in seen:
+            stack.append(inner)
+
+
 def _iter_pool_sockets(client: Any):
     """Yield raw sockets reachable from an OpenAI/httpx client pool.
 
     httpcore 1.x stores the concrete HTTP11/HTTP2 connection under
     ``conn._connection``; older versions exposed stream attributes directly
-    on the pool entry. Keep the traversal defensive because these are private
-    transport internals and vary across httpx/httpcore releases.
+    on the pool entry. Proxy tunnels wrap another layer
+    (``TunnelHTTPConnection`` / ``ForwardHTTPConnection``). Keep the
+    traversal defensive because these are private transport internals and
+    vary across httpx/httpcore releases.
+
+    Also walks ``httpx`` mount transports — see ``_iter_httpx_pool_objects``.
     """
     try:
         http_client = getattr(client, "_client", None)
         if http_client is None:
-            return
-        transport = getattr(http_client, "_transport", None)
-        if transport is None:
-            return
-        pool = getattr(transport, "_pool", None)
-        if pool is None:
-            return
+            # Some SDK wrappers *are* the httpx client (or expose the pool
+            # directly). Fall through so mount-aware discovery still runs.
+            http_client = client
+        pools = list(_iter_httpx_pool_objects(http_client))
+    except Exception:
+        return
+
+    if not pools:
+        return
+
+    seen: set[int] = set()
+    for pool in pools:
         connections = (
             getattr(pool, "_connections", None)
             or getattr(pool, "_pool", None)
             or []
         )
-    except Exception:
-        return
-
-    seen: set[int] = set()
-    for conn in list(connections):
-        candidates = [conn]
-        inner = getattr(conn, "_connection", None)
-        if inner is not None:
-            candidates.append(inner)
-        for candidate in candidates:
-            stream = (
-                getattr(candidate, "_network_stream", None)
-                or getattr(candidate, "_stream", None)
-            )
-            if stream is None:
-                continue
-            sock = getattr(stream, "_sock", None)
-            if sock is None:
-                get_extra_info = getattr(stream, "get_extra_info", None)
-                if callable(get_extra_info):
-                    try:
-                        sock = get_extra_info("socket")
-                    except Exception:
-                        sock = None
-            if sock is None:
-                wrapped = getattr(stream, "stream", None)
-                if wrapped is not None:
-                    sock = getattr(wrapped, "_sock", None)
-            if sock is None:
-                # anyio-backed streams expose the raw socket through
-                # SocketAttribute.raw_socket when available.
-                wrapped = getattr(stream, "_stream", None)
-                extra = getattr(wrapped, "extra", None)
-                if callable(extra):
-                    try:
-                        from anyio.abc import SocketAttribute
-                        sock = extra(SocketAttribute.raw_socket)
-                    except Exception:
-                        sock = None
-            if sock is None:
-                continue
-            marker = id(sock)
-            if marker in seen:
-                continue
-            seen.add(marker)
-            yield sock
+        for conn in list(connections):
+            for candidate in _connection_candidates(conn):
+                stream = (
+                    getattr(candidate, "_network_stream", None)
+                    or getattr(candidate, "_stream", None)
+                )
+                if stream is None:
+                    continue
+                sock = getattr(stream, "_sock", None)
+                if sock is None:
+                    get_extra_info = getattr(stream, "get_extra_info", None)
+                    if callable(get_extra_info):
+                        try:
+                            sock = get_extra_info("socket")
+                        except Exception:
+                            sock = None
+                if sock is None:
+                    wrapped = getattr(stream, "stream", None)
+                    if wrapped is not None:
+                        sock = getattr(wrapped, "_sock", None)
+                if sock is None:
+                    # anyio-backed streams expose the raw socket through
+                    # SocketAttribute.raw_socket when available.
+                    wrapped = getattr(stream, "_stream", None)
+                    extra = getattr(wrapped, "extra", None)
+                    if callable(extra):
+                        try:
+                            from anyio.abc import SocketAttribute
+                            sock = extra(SocketAttribute.raw_socket)
+                        except Exception:
+                            sock = None
+                if sock is None:
+                    continue
+                marker = id(sock)
+                if marker in seen:
+                    continue
+                seen.add(marker)
+                yield sock
 
 
 def cleanup_dead_connections(agent) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4688,12 +4688,23 @@ class AIAgent:
             return
         try:
             shutdown_count = self._force_close_tcp_sockets(client)
-            logger.info(
+            # tcp_force_closed=0 means the stranger-thread abort found no
+            # sockets to shut down — the worker stays blocked in recv and the
+            # provider keeps the slot (#72975). Surface that as WARNING so it
+            # cannot be mistaken for a successful abort in the logs.
+            _log = logger.warning if shutdown_count == 0 else logger.info
+            _log(
                 "OpenAI client aborted (%s, shared=False, tcp_force_closed=%d, "
-                "deferred_close=stranger_thread) %s",
+                "deferred_close=stranger_thread) %s%s",
                 reason,
                 shutdown_count,
                 self._client_log_context(),
+                (
+                    " — no sockets found; in-flight request may keep running "
+                    "until the provider finishes"
+                    if shutdown_count == 0
+                    else ""
+                ),
             )
         except Exception as exc:
             logger.debug(
@@ -4783,13 +4794,23 @@ class AIAgent:
             return
         try:
             shutdown_count = self._force_close_tcp_sockets(client)
-            logger.info(
+            # Same visibility contract as the OpenAI abort path (#72975):
+            # zero sockets shut down means the abort did not unblock the
+            # worker — log WARNING, not a success-shaped INFO.
+            _log = logger.warning if shutdown_count == 0 else logger.info
+            _log(
                 "Anthropic client aborted (%s, shared=False, tcp_force_closed=%d, "
-                "deferred_close=stranger_thread) provider=%s model=%s",
+                "deferred_close=stranger_thread) provider=%s model=%s%s",
                 reason,
                 shutdown_count,
                 getattr(self, "provider", None),
                 getattr(self, "model", None),
+                (
+                    " — no sockets found; in-flight request may keep running "
+                    "until the provider finishes"
+                    if shutdown_count == 0
+                    else ""
+                ),
             )
         except Exception as exc:
             logger.debug(

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -224,3 +224,68 @@ def test_force_close_tcp_sockets_descends_httpcore_1_connection_wrapper():
     # #29507: close() must NOT be called from this helper — the owning
     # httpx worker thread releases the FD, not us.
     assert sock.close_calls == 0
+
+
+def test_force_close_tcp_sockets_finds_sockets_on_httpx_mounts():
+    """HTTP(S)_PROXY / keepalive mounts put live sockets on ``_mounts``.
+
+    #72975: walking only ``_transport`` returned tcp_force_closed=0 while the
+    stream was still mid-recv on a mounted proxy pool, so interrupt logged
+    success and the provider kept the slot for minutes.
+    """
+    from agent.agent_runtime_helpers import force_close_tcp_sockets
+
+    class FakeSocket:
+        def __init__(self):
+            self.shutdown_calls = 0
+            self.close_calls = 0
+
+        def shutdown(self, _how):
+            self.shutdown_calls += 1
+
+        def close(self):
+            self.close_calls += 1
+
+    sock = FakeSocket()
+    stream = SimpleNamespace(_sock=sock)
+    # TunnelHTTPConnection-shaped: outer proxy wrapper → HTTP11 stream.
+    http11 = SimpleNamespace(_network_stream=stream)
+    tunnel = SimpleNamespace(_connection=http11)
+    mount_pool = SimpleNamespace(_connections=[tunnel])
+    mount_transport = SimpleNamespace(_pool=mount_pool)
+    # Default transport is empty — the failing layout from #72975.
+    empty_pool = SimpleNamespace(_connections=[])
+    default_transport = SimpleNamespace(_pool=empty_pool)
+    http_client = SimpleNamespace(
+        _transport=default_transport,
+        _mounts={"https://": mount_transport},
+    )
+    openai_client = SimpleNamespace(_client=http_client)
+
+    assert force_close_tcp_sockets(openai_client) == 1
+    assert sock.shutdown_calls == 1
+    assert sock.close_calls == 0
+
+
+def test_force_close_tcp_sockets_walks_nested_connection_wrappers():
+    """Forward/tunnel proxies nest HTTPConnection under another ``_connection``."""
+    from agent.agent_runtime_helpers import force_close_tcp_sockets
+
+    class FakeSocket:
+        def __init__(self):
+            self.shutdown_calls = 0
+
+        def shutdown(self, _how):
+            self.shutdown_calls += 1
+
+    sock = FakeSocket()
+    stream = SimpleNamespace(_sock=sock)
+    http11 = SimpleNamespace(_network_stream=stream)
+    http_conn = SimpleNamespace(_connection=http11)  # HTTPConnection wrapper
+    forward = SimpleNamespace(_connection=http_conn)  # ForwardHTTPConnection
+    pool = SimpleNamespace(_connections=[forward])
+    transport = SimpleNamespace(_pool=pool)
+    openai_client = SimpleNamespace(_client=SimpleNamespace(_transport=transport, _mounts={}))
+
+    assert force_close_tcp_sockets(openai_client) == 1
+    assert sock.shutdown_calls == 1

--- a/tests/run_agent/test_tls_fd_recycle_corruption.py
+++ b/tests/run_agent/test_tls_fd_recycle_corruption.py
@@ -392,6 +392,32 @@ def test_agent_abort_request_openai_client_does_not_call_client_close(caplog):
     ), f"missing abort log line; got: {msgs!r}"
 
 
+def test_agent_abort_request_openai_client_warns_when_no_sockets(caplog):
+    """tcp_force_closed=0 must not look like a successful abort (#72975)."""
+    from run_agent import AIAgent
+
+    # Client with an empty pool — abort finds nothing to shut down.
+    empty_pool = SimpleNamespace(_connections=[])
+    transport = SimpleNamespace(_pool=empty_pool)
+    http_client = SimpleNamespace(_transport=transport, _mounts={})
+    client = SimpleNamespace(_client=http_client, close=MagicMock())
+
+    agent = AIAgent.__new__(AIAgent)
+    agent._client_log_context = lambda: "provider=test"
+
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        agent._abort_request_openai_client(client, reason="stream_interrupt_abort")
+
+    client.close.assert_not_called()
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any(
+        "OpenAI client aborted (stream_interrupt_abort" in m
+        and "tcp_force_closed=0" in m
+        and "no sockets found" in m
+        for m in msgs
+    ), f"missing ineffective-abort WARNING; got: {msgs!r}"
+
+
 def test_agent_abort_request_openai_client_null_client_is_noop():
     """A ``None`` client must short-circuit cleanly (defensive)."""
     from run_agent import AIAgent


### PR DESCRIPTION
## Summary
- Stranger-thread interrupt abort (`force_close_tcp_sockets`) only walked the default `httpx` `_transport` pool. With `HTTP(S)_PROXY` (and other mounted transports), the live stream sits on `client._mounts`, so abort logged `tcp_force_closed=0` and left the request running for minutes while the user thought it was cancelled ([#72975](https://github.com/NousResearch/hermes-agent/issues/72975)).
- Walk mount pools + nested proxy `_connection` wrappers (tunnel/forward), and log **WARNING** (not success-shaped INFO) when an abort still finds no sockets.

Does not revert the #29507 stranger-thread `shutdown`-only contract — still never `sock.close()` / `client.close()` from the poll thread.

## Test plan
- [x] `scripts/run_tests.sh tests/run_agent/test_create_openai_client_reuse.py::test_force_close_tcp_sockets_* tests/run_agent/test_tls_fd_recycle_corruption.py`
- [x] Local repro: keepalive OpenAI client via `HTTPS_PROXY` mid-stream — `force_close_tcp_sockets` goes from `0` → `1` after the fix
- [ ] Interrupt a long local/`llama-server` stream under `HTTPS_PROXY` and confirm the provider slot frees promptly (no multi-minute leak)