### PR TITLE
fix(cli): stop shredding an existing MEMORY.md on hermes import-agent

### DIFF
--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -40,11 +40,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import sys
+import tempfile
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
 
@@ -205,14 +210,68 @@ def extract_markdown_entries(text: str) -> List[str]:
 
 
 def parse_existing_memory_entries(path: Path) -> List[str]:
+    """Parse the DESTINATION memory store into entries.
+
+    ``memories/MEMORY.md`` is the entry-delimited store written by
+    ``MemoryStore._write_file`` (tools/memory_tool.py), not a markdown
+    document, so this splits on ``ENTRY_DELIMITER`` only — exactly what
+    ``MemoryStore._parse_entries`` does.  A store with no delimiter (a single
+    entry, or one that was hand-edited / shell-appended) is therefore ONE
+    intact entry.
+
+    Do NOT fall back to :func:`extract_markdown_entries` here.  That extractor
+    is correct for CLAUDE.md / AGENTS.md *sources*, but it drops fenced code
+    blocks and table rows and splits a block into one entry per bullet — and
+    the merged result is written straight back over the user's store, so the
+    loss is permanent.
+    """
     if not path.exists():
         return []
     raw = read_text(path)
     if not raw.strip():
         return []
-    if ENTRY_DELIMITER in raw:
-        return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
-    return extract_markdown_entries(raw)
+    return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
+
+
+def backup_memory_file(path: Path) -> Optional[Path]:
+    """Snapshot ``path`` before a destructive rewrite; return the backup path.
+
+    Restores parity with the openclaw migration script this module was ported
+    from, which calls ``maybe_backup(destination)`` before rewriting a memory
+    store.  Uses the same ``<name>.bak.<unix_ts>`` naming as
+    ``MemoryStore._backup_drifted_file``.  Returns None when there is nothing
+    to back up.
+    """
+    if not path.exists():
+        return None
+    backup = path.with_suffix(path.suffix + f".bak.{int(time.time())}")
+    shutil.copy2(path, backup)
+    return backup
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` via temp file + atomic rename.
+
+    Mirrors ``MemoryStore._write_file``: an interrupted or failed write can
+    never leave a truncated memory store on disk, and readers always see
+    either the old complete file or the new one.  ``atomic_replace`` also
+    keeps a symlinked destination a symlink.
+    """
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), suffix=".tmp", prefix=".import_"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        atomic_replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def merge_entries(
@@ -513,9 +572,19 @@ class AgentImporter:
             return
         if self.execute:
             destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_text(
+            try:
+                backup = backup_memory_file(destination)
+            except OSError as exc:
+                # Never rewrite the store when the safety net failed.
+                self.record(kind, source, destination, "error",
+                            f"Could not back up existing memory file: {exc}",
+                            **details)
+                return
+            if backup is not None:
+                details["backup"] = str(backup)
+            atomic_write_text(
+                destination,
                 ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""),
-                encoding="utf-8",
             )
             self.record(kind, source, destination, "imported", **details)
         else:

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -450,14 +450,21 @@ def rebrand_text(text: str) -> str:
 
 
 def parse_existing_memory_entries(path: Path) -> List[str]:
+    """Parse a DESTINATION Hermes memory store (memories/MEMORY.md, USER.md).
+
+    Splits on ``ENTRY_DELIMITER`` only, matching ``MemoryStore._parse_entries``
+    in ``tools/memory_tool.py``: a store with no delimiter is ONE intact entry.
+    Do NOT fall back to :func:`extract_markdown_entries` — it is the *source*
+    parser (workspace/MEMORY.md and friends), it drops fenced code blocks and
+    table rows and splits a block into one entry per bullet, and the merged
+    result is written back over the destination.
+    """
     if not path.exists():
         return []
     raw = read_text(path)
     if not raw.strip():
         return []
-    if ENTRY_DELIMITER in raw:
-        return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
-    return extract_markdown_entries(raw)
+    return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
 
 
 def extract_markdown_entries(text: str) -> List[str]:

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -17,11 +17,13 @@ import pytest
 import yaml
 
 from hermes_cli.agent_import import (
+    ENTRY_DELIMITER,
     AgentImporter,
     claude_rule_to_command_pattern,
     detect_agents,
     extract_markdown_entries,
     is_secret_key,
+    parse_existing_memory_entries,
     sanitize_mcp_env,
 )
 
@@ -484,6 +486,86 @@ class TestMergeSemantics:
         assert (hermes_home / "memories" / "MEMORY.md").read_text() == first
         memory_items = [i for i in report["items"] if i["kind"] == "claude-md"]
         assert memory_items[0]["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# The DESTINATION memories/MEMORY.md is a §-delimited store, not a document
+# ---------------------------------------------------------------------------
+
+# A realistic hand-edited store: one entry, no "§", with a fenced code block
+# and a markdown table — exactly the content extract_markdown_entries() drops.
+EXISTING_MEMORY = """Homelab runbook. Restart the ingress controller with:
+
+```bash
+kubectl -n ingress rollout restart deploy/nginx
+```
+
+Escalation ladder:
+
+| Severity | Contact | Window |
+|----------|---------|--------|
+| SEV1     | on-call | 15m    |
+| SEV2     | #ops    | 4h     |
+
+Never page for SEV3.
+"""
+
+
+class TestExistingMemoryStorePreserved:
+    """An import must not shred the memory store it merges into.
+
+    ``memories/MEMORY.md`` is the entry-delimited store written by
+    ``MemoryStore._write_file``; a single-entry or hand-edited store contains
+    no ``§`` delimiter.  Parsing it with the *source* markdown extractor drops
+    code blocks and table rows and splits one entry into fragments, and the
+    merged result is written straight back over the file.
+    """
+
+    @pytest.fixture()
+    def seeded_home(self, hermes_home):
+        memory = hermes_home / "memories" / "MEMORY.md"
+        memory.parent.mkdir(parents=True, exist_ok=True)
+        memory.write_text(EXISTING_MEMORY, encoding="utf-8")
+        return hermes_home
+
+    def test_undelimited_store_is_one_entry(self, seeded_home):
+        path = seeded_home / "memories" / "MEMORY.md"
+        assert ENTRY_DELIMITER not in path.read_text(encoding="utf-8")
+        assert parse_existing_memory_entries(path) == [EXISTING_MEMORY.strip()]
+
+    def test_agrees_with_memory_store_parser(self, seeded_home):
+        from tools.memory_tool import MemoryStore
+
+        path = seeded_home / "memories" / "MEMORY.md"
+        raw = path.read_text(encoding="utf-8")
+        assert parse_existing_memory_entries(path) == MemoryStore._parse_entries(raw)
+
+    def test_import_preserves_existing_entry_verbatim(
+            self, claude_tree, seeded_home):
+        path = seeded_home / "memories" / "MEMORY.md"
+        run_import("claude-code", claude_tree, seeded_home, execute=True)
+        entries = path.read_text(encoding="utf-8").split(ENTRY_DELIMITER)
+        # The pre-existing store survives byte-intact as a SINGLE entry ...
+        assert entries[0] == EXISTING_MEMORY.strip()
+        # ... including the parts the markdown extractor would have dropped.
+        assert "kubectl -n ingress rollout restart deploy/nginx" in entries[0]
+        assert "| SEV1     | on-call | 15m    |" in entries[0]
+        # ... and the imported entries are still appended after it.
+        assert any("type hints" in e for e in entries[1:])
+
+    def test_import_backs_up_the_previous_store(self, claude_tree, seeded_home):
+        memories = seeded_home / "memories"
+        run_import("claude-code", claude_tree, seeded_home, execute=True)
+        backups = sorted(memories.glob("MEMORY.md.bak.*"))
+        assert len(backups) == 1
+        assert backups[0].read_text(encoding="utf-8") == EXISTING_MEMORY
+
+    def test_dry_run_leaves_the_store_untouched(self, claude_tree, seeded_home):
+        memories = seeded_home / "memories"
+        run_import("claude-code", claude_tree, seeded_home, execute=False)
+        assert (memories / "MEMORY.md").read_text(
+            encoding="utf-8") == EXISTING_MEMORY
+        assert not list(memories.glob("MEMORY.md.bak.*"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -56,6 +56,32 @@ def test_extract_markdown_entries_promotes_heading_context():
     assert "Tyler Williams > Active Projects: Hermes Agent" in entries
 
 
+def test_parse_existing_memory_entries_keeps_undelimited_store_intact(tmp_path):
+    """The DESTINATION store is §-delimited, not a markdown document.
+
+    ``migrate_memory`` and ``migrate_daily_memory`` read the Hermes-side
+    memories/MEMORY.md (and USER.md) and write the merged result back over it.
+    A store with no delimiter is ONE entry — running the source markdown
+    extractor over it would drop the code block and the table row below.
+    """
+    mod = load_module()
+    raw = (
+        "Homelab runbook. Restart the ingress controller with:\n"
+        "\n"
+        "```bash\n"
+        "kubectl -n ingress rollout restart deploy/nginx\n"
+        "```\n"
+        "\n"
+        "| Severity | Contact | Window |\n"
+        "| SEV1     | on-call | 15m    |\n"
+    )
+    path = tmp_path / "MEMORY.md"
+    path.write_text(raw, encoding="utf-8")
+
+    assert mod.ENTRY_DELIMITER not in raw
+    assert mod.parse_existing_memory_entries(path) == [raw.strip()]
+
+
 def test_merge_entries_respects_limit_and_reports_overflow():
     mod = load_module()
     existing = ["alpha"]


### PR DESCRIPTION
## This is a sibling follow-up to #72190 (commit `24c3c27b`)

- **What #72190 covered:** it added `hermes import-agent`, porting the memory-entry merge primitives out of `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` so the command works without the optional migration skill installed.
- **What #72190 did NOT touch:** the ported `parse_existing_memory_entries()` is applied to the **destination** memory store, and the port dropped the `maybe_backup(destination)` call the openclaw script makes before rewriting that store.
- **What this adds:** parse the destination with delimiter-only semantics (matching `MemoryStore._parse_entries`), plus a `.bak` snapshot and an atomic write before the destructive rewrite — and the same parse fix at the sibling sites in the openclaw script the code was ported from.

## What does this PR do?

`hermes import-agent claude-code` can silently destroy an existing `HERMES_HOME/memories/MEMORY.md` and still print `✓ Imported` / `Import complete.`

`memories/MEMORY.md` is the `§`-delimited memory store written by `MemoryStore._write_file` (`tools/memory_tool.py`) — the file's own header comment in `agent_import.py:52` says so. It is **not** a markdown document. But `parse_existing_memory_entries()` fell back to `extract_markdown_entries()` whenever the destination contained no `\n§\n`:

```python
if ENTRY_DELIMITER in raw:
    return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
return extract_markdown_entries(raw)          # <-- the bug
```

`extract_markdown_entries()` is the parser for **source** files (`CLAUDE.md` / `AGENTS.md`), and it is lossy by design: `if in_code_block: continue` deletes fenced code blocks, the `stripped.startswith("|") and stripped.endswith("|")` branch deletes table rows, every bullet becomes its own entry, and paragraphs are reflowed. The merged result is then written straight back over the user's file.

The trigger is not exotic: a `MEMORY.md` holding exactly one entry, or one that was hand-edited or shell-appended — precisely the "external drift" case #30877 was written to defend — contains no delimiter and takes the lossy branch. Reproduced against `main` with a 262-char store:

```
delimiter present in file?  False
MemoryStore._parse_entries      -> 1 entry, kubectl block + table intact
parse_existing_memory_entries   -> 3 fragments
kubectl command survived?   False
escalation table survived?  False
262 chars -> 145 chars, written back to MEMORY.md, reported as "Imported"
```

The fix parses the destination the way the authoritative parser does — split on `ENTRY_DELIMITER` only, so a store with no delimiter is **one intact entry** (`MemoryStore._parse_entries`, `tools/memory_tool.py:776-783`, whose comment is explicit that this exists for consistency with `_write_file`). `extract_markdown_entries()` itself is unchanged and still used on the sources, where it is correct.

It also restores the safety net the port dropped: the openclaw script calls `self.maybe_backup(destination)` before its write (`openclaw_to_hermes.py:1196`), and `agent_import.py` did not. This snapshots the store to `<name>.bak.<unix_ts>` (same naming as `MemoryStore._backup_drifted_file`), refuses to rewrite if the snapshot fails, and writes via temp file + `atomic_replace` — mirroring `MemoryStore._write_file` and merged #55863 `fix(journey): atomic memory writes`, so an interrupted import cannot leave a truncated store and a symlinked `MEMORY.md` stays a symlink.

**Precedent:** #71004 `fix(memory): don't wipe MEMORY.md when a read-modify-write reads it as unreadable` merged three days ago — same file, same read-modify-write-wipe class of bug. #30877 installed the external-drift guard that this new writer bypassed.

### Sibling-site sweep (closed)

`grep -rn "extract_markdown_entries\|parse_existing_memory_entries\|merge_entries\|ENTRY_DELIMITER" --include='*.py' .` returns 6 non-test sites across 2 files. All 6 are covered:

| site | where | covered by |
|---|---|---|
| lossy fallback (definition) | `hermes_cli/agent_import.py:207` | delimiter-only parse |
| destination read | `hermes_cli/agent_import.py` `_merge_memory_entries` | via the definition (reached from `import_context_file` and `import_memories_dir`) |
| clobbering write | `hermes_cli/agent_import.py` `_merge_memory_entries` | `.bak` snapshot + atomic write |
| lossy fallback (definition) | `openclaw_to_hermes.py:452` | delimiter-only parse |
| destination read | `openclaw_to_hermes.py` `migrate_memory()` | via the definition — verified: its destinations are `memories/MEMORY.md` and `memories/USER.md`, both `§`-delimited stores |
| destination read | `openclaw_to_hermes.py` `migrate_daily_memory()` | via the definition — verified: destination is `memories/MEMORY.md` |

The openclaw script already backs its destination up via `maybe_backup()`, so only the parse needed fixing there.

Deliberately **excluded**, with reasons:

- `tools/memory_tool.py` — holds the *correct* parser; it is the reference, not a defect site. Not touched.
- `hermes_cli/web_server.py`, `hermes_cli/claw.py` — read/list `MEMORY.md` but never re-parse-and-rewrite it.
- the `config.yaml` merges in the same file — they use `yaml.safe_load`, which is the correct parser for that destination.
- surfacing `overflowed_entries` in the import report reason — a real gap, but a different concern; left out to keep this single-purpose.

## Related Issue

No filed issue — this is a regression in `hermes_cli/agent_import.py`, which was added yesterday by #72190 (`24c3c27b`, 2026-07-26). Reported here rather than opened as a separate issue because the fix is in hand.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/agent_import.py`
  - `parse_existing_memory_entries()` — split on `ENTRY_DELIMITER` only, matching `MemoryStore._parse_entries`; a destination with no delimiter is one intact entry. Docstring states why the markdown extractor must not be used here.
  - new `backup_memory_file()` — snapshots the store to `<name>.bak.<unix_ts>` before a destructive rewrite; returns `None` when there is nothing to back up.
  - new `atomic_write_text()` — temp file + `fsync` + `utils.atomic_replace`, mirroring `MemoryStore._write_file`.
  - `_merge_memory_entries()` — back up, record the backup path in the item details, then write atomically. A failed backup is recorded as an `error` and the store is left untouched rather than rewritten without a safety net.
- `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py`
  - `parse_existing_memory_entries()` — same delimiter-only fix for `hermes claw migrate`'s `migrate_memory()` / `migrate_daily_memory()` destinations.
- `tests/hermes_cli/test_agent_import.py` — new `TestExistingMemoryStorePreserved` (5 tests).
- `tests/skills/test_openclaw_migration.py` — new unit test for the openclaw sibling site.

## How to Test

Reproduce on `main`:

1. Seed a single-entry store with a code block and a table:
   ```bash
   mkdir -p ~/.hermes/memories
   printf 'Homelab runbook. Restart the ingress controller with:\n\n```bash\nkubectl -n ingress rollout restart deploy/nginx\n```\n\n| Severity | Contact | Window |\n| SEV1     | on-call | 15m    |\n' > ~/.hermes/memories/MEMORY.md
   ```
2. `hermes import-agent claude-code --yes`
3. On `main`: the command prints `✓ Imported` / `Import complete.`, and `~/.hermes/memories/MEMORY.md` has lost the `kubectl` line and the table row, with the remaining prose split into separate entries. With this PR: the original text survives byte-intact as the first `§`-delimited entry, the imported entries are appended after it, and `~/.hermes/memories/MEMORY.md.bak.<ts>` holds the pre-import file.

Automated coverage:

```
uv run --extra dev pytest tests/hermes_cli/test_agent_import.py tests/skills/test_openclaw_migration.py -q
```

Regression guard — with the two production hunks reverted to `main` and the new tests in place:

```
5 failed, 98 passed
FAILED tests/hermes_cli/test_agent_import.py::TestExistingMemoryStorePreserved::test_undelimited_store_is_one_entry
FAILED tests/hermes_cli/test_agent_import.py::TestExistingMemoryStorePreserved::test_agrees_with_memory_store_parser
FAILED tests/hermes_cli/test_agent_import.py::TestExistingMemoryStorePreserved::test_import_preserves_existing_entry_verbatim
FAILED tests/hermes_cli/test_agent_import.py::TestExistingMemoryStorePreserved::test_import_backs_up_the_previous_store
FAILED tests/skills/test_openclaw_migration.py::test_parse_existing_memory_entries_keeps_undelimited_store_intact
```

With the fix restored: `103 passed`.

The failure on `main` is the shredder, not a cosmetic mismatch:

```
At index 0 diff:
  'Homelab runbook. Restart the ingress controller with:'
!= 'Homelab runbook. Restart the ingress controller with:\n\n```bash\nkubectl -n ingress
   rollout restart deploy/nginx\n```\n\n| Severity | Contact | Window |\n| SEV1     | on-call | 15m    |'
```

**Existing coverage gap this closes:** the suite had `test_existing_allowlist_preserved` for `config.yaml` but no `MEMORY.md` equivalent, and `test_reimport_is_idempotent_for_memory` starts from an empty home — so the first import always produced a delimited file and the buggy branch was never exercised.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused and adjacent suites instead (`tests/hermes_cli/`, `tests/skills/`); not ticking this because I did not run the full tree locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the three touched/added functions state the destination-vs-source parser contract
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — the write path reuses `utils.atomic_replace`, which the repo already relies on for Windows/`EXDEV`/`EBUSY` and symlink cases; the temp file is created in the destination directory so the rename stays on one filesystem
- [x] N/A — no tool descriptions or schemas changed
