### PR TITLE
feat(desktop): add drag-run animation and floor roaming to pet overlay

### DIFF
--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -6,7 +6,7 @@ import { PetBubble } from '@/components/pet/pet-bubble'
 import { PetSprite } from '@/components/pet/pet-sprite'
 import { type PetZoomAnchor, usePetZoomGesture } from '@/components/pet/use-pet-zoom-gesture'
 import { Mail } from '@/lib/icons'
-import { $petActivity, $petAtRest, $petInfo, $petRoam, setPetInfo } from '@/store/pet'
+import { $petActivity, $petAtRest, $petInfo, setPetInfo } from '@/store/pet'
 import { overlayWindowSize } from '@/store/pet-overlay'
 import { roamWalkRow } from '@/components/pet/pet-sprite'
 import { usePetRoam } from '@/components/pet/use-pet-roam'
@@ -390,11 +390,13 @@ export function PetOverlayApp() {
 
   // ── roam ──────────────────────────────────────────────────────────────
 
-  const roamEnabled = useStore($petRoam)
   const atRest = useStore($petAtRest)
   const petW = (info.frameW ?? DEFAULT_FRAME_W) * (info.scale ?? DEFAULT_SCALE)
   const petH = (info.frameH ?? DEFAULT_FRAME_H) * (info.scale ?? DEFAULT_SCALE)
   const active = info.enabled && Boolean(info.spritesheetBase64)
+  // Overlay always roams when idle — the $petRoam localStorage toggle is
+  // per-device and may not sync cleanly across BrowserWindow instances.
+  const roamActive = active && atRest
 
   // Seed a centered-bottom starting position once the pet loads.
   useEffect(() => {
@@ -402,7 +404,7 @@ export function PetOverlayApp() {
       roamPosSeeded.current = true
       setRoamPos({
         x: Math.max(0, (window.innerWidth - petW) / 2),
-        y: Math.max(0, window.innerHeight - petH)
+        y: Math.max(0, window.innerHeight - petH - 16)
       })
     }
   }, [active, petW, petH])
@@ -412,7 +414,7 @@ export function PetOverlayApp() {
   const commitRoam = useCallback((point: Point) => setRoamPos(point), [])
 
   usePetRoam({
-    enabled: roamEnabled && active && atRest,
+    enabled: roamActive,
     containerRef: petRef,
     isInteracting,
     petW,

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -6,8 +6,10 @@ import { PetBubble } from '@/components/pet/pet-bubble'
 import { PetSprite } from '@/components/pet/pet-sprite'
 import { type PetZoomAnchor, usePetZoomGesture } from '@/components/pet/use-pet-zoom-gesture'
 import { Mail } from '@/lib/icons'
-import { $petActivity, $petInfo, setPetInfo } from '@/store/pet'
+import { $petActivity, $petAtRest, $petInfo, $petRoam, setPetInfo } from '@/store/pet'
 import { overlayWindowSize } from '@/store/pet-overlay'
+import { roamWalkRow } from '@/components/pet/pet-sprite'
+import { usePetRoam } from '@/components/pet/use-pet-roam'
 import { setAwaitingResponse, setBusy } from '@/store/session'
 
 // Fallbacks mirror pet-sprite's defaults; the gateway normally sends real values.
@@ -58,6 +60,13 @@ interface DragState {
   width: number
   height: number
   moved: boolean
+  /** Last screen X — used for delta-based direction, not start-relative. */
+  lastX: number
+}
+
+interface Point {
+  x: number
+  y: number
 }
 
 export function PetOverlayApp() {
@@ -66,6 +75,12 @@ export function PetOverlayApp() {
   const [draft, setDraft] = useState('')
   // Mirrored from the main renderer: a finish landed while you were away.
   const [unread, setUnread] = useState(false)
+  // Drag direction for the pop-out overlay — drives the run animation row.
+  const [dragDir, setDragDir] = useState<-1 | 0 | 1>(0)
+  // Last absolute position the roam loop committed.
+  const [roamPos, setRoamPos] = useState<Point | null>(null)
+  // Seed roam position once pet dimensions are known.
+  const roamPosSeeded = useRef(false)
 
   const dragRef = useRef<DragState | null>(null)
   // Last Alt+wheel anchor, consumed by the resize effect to zoom toward the
@@ -206,8 +221,10 @@ export function PetOverlayApp() {
     }
 
     ;(e.target as Element).setPointerCapture?.(e.pointerId)
+    setDragDir(0)
     dragRef.current = {
       height: window.outerHeight,
+      lastX: e.screenX,
       moved: false,
       offX: e.screenX - window.screenX,
       offY: e.screenY - window.screenY,
@@ -228,6 +245,13 @@ export function PetOverlayApp() {
       drag.moved = true
     }
 
+    if (drag.moved) {
+      const dx = e.screenX - drag.lastX
+      drag.lastX = e.screenX
+      const dir = dx > 0 ? 1 : dx < 0 ? -1 : 0
+      if (dir !== 0) setDragDir(dir)
+    }
+
     window.hermesDesktop?.petOverlay?.setBounds({
       height: drag.height,
       width: drag.width,
@@ -240,6 +264,9 @@ export function PetOverlayApp() {
     const drag = dragRef.current
     dragRef.current = null
     ;(e.target as Element).releasePointerCapture?.(e.pointerId)
+
+    // Clear drag direction regardless of whether it was a drag or a click.
+    setDragDir(0)
 
     if (!drag) {
       return
@@ -361,6 +388,41 @@ export function PetOverlayApp() {
     window.hermesDesktop?.petOverlay?.control({ bounds, type: 'bounds' })
   }, [info.enabled, info.spritesheetBase64, info.scale, info.frameW, info.frameH])
 
+  // ── roam ──────────────────────────────────────────────────────────────
+
+  const roamEnabled = useStore($petRoam)
+  const atRest = useStore($petAtRest)
+  const petW = (info.frameW ?? DEFAULT_FRAME_W) * (info.scale ?? DEFAULT_SCALE)
+  const petH = (info.frameH ?? DEFAULT_FRAME_H) * (info.scale ?? DEFAULT_SCALE)
+  const active = info.enabled && Boolean(info.spritesheetBase64)
+
+  // Seed a centered-bottom starting position once the pet loads.
+  useEffect(() => {
+    if (!roamPosSeeded.current && active) {
+      roamPosSeeded.current = true
+      setRoamPos({
+        x: Math.max(0, (window.innerWidth - petW) / 2),
+        y: Math.max(0, window.innerHeight - petH)
+      })
+    }
+  }, [active, petW, petH])
+
+  usePetRoam({
+    enabled: roamEnabled && active && atRest,
+    containerRef: petRef,
+    isInteracting: () => dragDir !== 0 || dragRef.current !== null,
+    petW,
+    petH,
+    loopMs: info.loopMs ?? 1100,
+    overlayOpen: false,
+    commit: point => setRoamPos(point)
+  })
+
+  // ── render ────────────────────────────────────────────────────────────
+
+  // Resolve directional run row while the pet is being dragged.
+  const walkRow = dragDir !== 0 ? roamWalkRow(dragDir, info.stateRows) : null
+
   if (!info.enabled || !info.spritesheetBase64) {
     return null
   }
@@ -420,20 +482,32 @@ export function PetOverlayApp() {
         onPointerMove={onPetPointerMove}
         onPointerUp={onPetPointerUp}
         ref={petRef}
-        style={{
-          alignItems: 'center',
-          cursor: 'grab',
-          display: 'flex',
-          flexDirection: 'column',
-          position: 'relative',
-          touchAction: 'none'
-        }}
+        style={roamPos
+          ? {
+              alignItems: 'center',
+              cursor: 'grab',
+              display: 'flex',
+              flexDirection: 'column',
+              left: roamPos.x,
+              position: 'absolute',
+              top: roamPos.y,
+              touchAction: 'none'
+            }
+          : {
+              alignItems: 'center',
+              cursor: 'grab',
+              display: 'flex',
+              flexDirection: 'column',
+              position: 'relative',
+              touchAction: 'none'
+            }
+        }
       >
         <div style={{ marginBottom: 4 }}>
           <PetBubble />
         </div>
         <div style={{ lineHeight: 0, position: 'relative' }}>
-          <PetSprite info={info} pauseWhenUnfocused={false} />
+          <PetSprite info={info} pauseWhenUnfocused={false} rowOverride={walkRow?.row} />
 
           {/* Hearts on the popped-out pet — identical to in-window. */}
           <PetHeartField

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -6,11 +6,11 @@ import { PetBubble } from '@/components/pet/pet-bubble'
 import { PetSprite } from '@/components/pet/pet-sprite'
 import { type PetZoomAnchor, usePetZoomGesture } from '@/components/pet/use-pet-zoom-gesture'
 import { Mail } from '@/lib/icons'
-import { $petActivity, $petAtRest, $petInfo, setPetInfo } from '@/store/pet'
+import { $petActivity, $petInfo, setPetInfo } from '@/store/pet'
 import { overlayWindowSize } from '@/store/pet-overlay'
 import { roamWalkRow } from '@/components/pet/pet-sprite'
 import { usePetRoam } from '@/components/pet/use-pet-roam'
-import { setAwaitingResponse, setBusy } from '@/store/session'
+import { $busy, setAwaitingResponse, setBusy } from '@/store/session'
 
 // Fallbacks mirror pet-sprite's defaults; the gateway normally sends real values.
 const DEFAULT_FRAME_W = 192
@@ -390,13 +390,12 @@ export function PetOverlayApp() {
 
   // ── roam ──────────────────────────────────────────────────────────────
 
-  const atRest = useStore($petAtRest)
+  const busy = useStore($busy)
   const petW = (info.frameW ?? DEFAULT_FRAME_W) * (info.scale ?? DEFAULT_SCALE)
   const petH = (info.frameH ?? DEFAULT_FRAME_H) * (info.scale ?? DEFAULT_SCALE)
   const active = info.enabled && Boolean(info.spritesheetBase64)
-  // Overlay always roams when idle — the $petRoam localStorage toggle is
-  // per-device and may not sync cleanly across BrowserWindow instances.
-  const roamActive = active && atRest
+  // Overlay roams when pet is loaded and agent is idle.
+  const roamActive = active && !busy
 
   // Seed a centered-bottom starting position once the pet loads.
   useEffect(() => {

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -407,15 +407,19 @@ export function PetOverlayApp() {
     }
   }, [active, petW, petH])
 
+  // Stable callbacks so the roam loop doesn't re-init every render.
+  const isInteracting = useCallback(() => dragDir !== 0 || dragRef.current !== null, [dragDir])
+  const commitRoam = useCallback((point: Point) => setRoamPos(point), [])
+
   usePetRoam({
     enabled: roamEnabled && active && atRest,
     containerRef: petRef,
-    isInteracting: () => dragDir !== 0 || dragRef.current !== null,
+    isInteracting,
     petW,
     petH,
     loopMs: info.loopMs ?? 1100,
     overlayOpen: false,
-    commit: point => setRoamPos(point)
+    commit: commitRoam
   })
 
   // ── render ────────────────────────────────────────────────────────────

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -3,10 +3,11 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { PetHeartField, playVibeHearts } from '@/components/chat/vibe-hearts'
 import { PetBubble } from '@/components/pet/pet-bubble'
-import { PetSprite } from '@/components/pet/pet-sprite'
+import { PetSprite, roamWalkRow } from '@/components/pet/pet-sprite'
+import { usePetRoam } from '@/components/pet/use-pet-roam'
 import { type PetZoomAnchor, usePetZoomGesture } from '@/components/pet/use-pet-zoom-gesture'
 import { Mail } from '@/lib/icons'
-import { $petActivity, $petInfo, setPetInfo } from '@/store/pet'
+import { $petActivity, $petAtRest, $petInfo, $petRoam, $petRoamDir, setPetInfo } from '@/store/pet'
 import { overlayWindowSize } from '@/store/pet-overlay'
 import { setAwaitingResponse, setBusy } from '@/store/session'
 
@@ -51,6 +52,7 @@ const CLICK_SLOP_PX = 3
 const DOUBLE_CLICK_MS = 250
 
 interface DragState {
+  lastX: number
   startX: number
   startY: number
   offX: number
@@ -60,12 +62,21 @@ interface DragState {
   moved: boolean
 }
 
+interface Point {
+  x: number
+  y: number
+}
+
 export function PetOverlayApp() {
   const info = useStore($petInfo)
   const [composerOpen, setComposerOpen] = useState(false)
   const [draft, setDraft] = useState('')
   // Mirrored from the main renderer: a finish landed while you were away.
   const [unread, setUnread] = useState(false)
+  // Drag direction for the pop-out overlay — drives the run animation row.
+  const [dragDir, setDragDir] = useState<-1 | 0 | 1>(0)
+  // Last absolute position the roam loop committed.
+  const [roamPos, setRoamPos] = useState<Point | null>(null)
 
   const dragRef = useRef<DragState | null>(null)
   // Last Alt+wheel anchor, consumed by the resize effect to zoom toward the
@@ -206,8 +217,10 @@ export function PetOverlayApp() {
     }
 
     ;(e.target as Element).setPointerCapture?.(e.pointerId)
+    setDragDir(0)
     dragRef.current = {
       height: window.outerHeight,
+      lastX: e.screenX,
       moved: false,
       offX: e.screenX - window.screenX,
       offY: e.screenY - window.screenY,
@@ -228,6 +241,16 @@ export function PetOverlayApp() {
       drag.moved = true
     }
 
+    if (drag.moved) {
+      const dx = e.screenX - drag.lastX
+      drag.lastX = e.screenX
+      const dir = dx > 0 ? 1 : dx < 0 ? -1 : 0
+
+      if (dir !== 0) {
+        setDragDir(dir)
+      }
+    }
+
     window.hermesDesktop?.petOverlay?.setBounds({
       height: drag.height,
       width: drag.width,
@@ -239,6 +262,7 @@ export function PetOverlayApp() {
   const onPetPointerUp = (e: React.PointerEvent) => {
     const drag = dragRef.current
     dragRef.current = null
+    setDragDir(0)
     ;(e.target as Element).releasePointerCapture?.(e.pointerId)
 
     if (!drag) {
@@ -361,6 +385,43 @@ export function PetOverlayApp() {
     window.hermesDesktop?.petOverlay?.control({ bounds, type: 'bounds' })
   }, [info.enabled, info.spritesheetBase64, info.scale, info.frameW, info.frameH])
 
+  // ── roam ──────────────────────────────────────────────────────────────
+
+  const roamEnabled = useStore($petRoam)
+  const atRest = useStore($petAtRest)
+  const petW = (info.frameW ?? DEFAULT_FRAME_W) * (info.scale ?? DEFAULT_SCALE)
+  const petH = (info.frameH ?? DEFAULT_FRAME_H) * (info.scale ?? DEFAULT_SCALE)
+  const active = info.enabled && Boolean(info.spritesheetBase64)
+
+  // Seed a centered-bottom starting position once the pet dimensions are known.
+  useEffect(() => {
+    if (roamPos === null && active) {
+      setRoamPos({
+        x: Math.max(0, (window.innerWidth - petW) / 2),
+        y: Math.max(0, window.innerHeight - petH - PET_PADDING_BOTTOM)
+      })
+    }
+  }, [active, petH, petW, roamPos])
+
+  // Keep callback identity stable so the roam loop does not restart on renders.
+  const isInteracting = useCallback(() => dragRef.current !== null, [])
+  const commitRoam = useCallback((point: Point) => setRoamPos(point), [])
+
+  usePetRoam({
+    commit: commitRoam,
+    containerRef: petRef,
+    enabled: roamEnabled && active && atRest,
+    isInteracting,
+    loopMs: info.loopMs ?? 1100,
+    overlayOpen: false,
+    petH,
+    petW
+  })
+
+  const roamDir = useStore($petRoamDir)
+  // Drag direction wins over roam, so the sprite faces its actual travel direction.
+  const walk = roamWalkRow(dragDir !== 0 ? dragDir : roamDir, info.stateRows)
+
   if (!info.enabled || !info.spritesheetBase64) {
     return null
   }
@@ -409,7 +470,8 @@ export function PetOverlayApp() {
             marginBottom: 8,
             outline: 'none',
             padding: '4px 8px',
-            width: 184
+            width: 184,
+            zIndex: 1
           }}
           value={draft}
         />
@@ -420,20 +482,39 @@ export function PetOverlayApp() {
         onPointerMove={onPetPointerMove}
         onPointerUp={onPetPointerUp}
         ref={petRef}
-        style={{
-          alignItems: 'center',
-          cursor: 'grab',
-          display: 'flex',
-          flexDirection: 'column',
-          position: 'relative',
-          touchAction: 'none'
-        }}
+        style={
+          roamPos
+            ? {
+                alignItems: 'center',
+                cursor: 'grab',
+                display: 'flex',
+                flexDirection: 'column',
+                left: roamPos.x,
+                position: 'absolute',
+                top: roamPos.y,
+                touchAction: 'none'
+              }
+            : {
+                alignItems: 'center',
+                cursor: 'grab',
+                display: 'flex',
+                flexDirection: 'column',
+                position: 'relative',
+                touchAction: 'none'
+              }
+        }
       >
         <div style={{ marginBottom: 4 }}>
           <PetBubble />
         </div>
-        <div style={{ lineHeight: 0, position: 'relative' }}>
-          <PetSprite info={info} pauseWhenUnfocused={false} />
+        <div
+          style={{
+            lineHeight: 0,
+            position: 'relative',
+            transform: walk.mirror ? 'scaleX(-1)' : 'none'
+          }}
+        >
+          <PetSprite info={info} pauseWhenUnfocused={false} rowOverride={walk.row} />
 
           {/* Hearts on the popped-out pet — identical to in-window. */}
           <PetHeartField

--- a/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
+++ b/apps/desktop/src/app/pet-overlay/pet-overlay-app.tsx
@@ -414,6 +414,9 @@ export function PetOverlayApp() {
     isInteracting,
     loopMs: info.loopMs ?? 1100,
     overlayOpen: false,
+    // The pop-out overlay is a focusable:false panel (main.ts) so it never
+    // receives window focus; roaming must not pause on blur or it never runs.
+    pauseWhenUnfocused: false,
     petH,
     petW
   })

--- a/apps/desktop/src/components/pet/use-pet-roam.test.tsx
+++ b/apps/desktop/src/components/pet/use-pet-roam.test.tsx
@@ -68,7 +68,13 @@ function installRaf() {
   return { cancel, request }
 }
 
-function RoamHarness({ isInteracting = () => false }: { isInteracting?: () => boolean }) {
+function RoamHarness({
+  isInteracting = () => false,
+  pauseWhenUnfocused
+}: {
+  isInteracting?: () => boolean
+  pauseWhenUnfocused?: boolean
+}) {
   const ref = useRef<HTMLDivElement | null>(null)
 
   usePetRoam({
@@ -78,6 +84,7 @@ function RoamHarness({ isInteracting = () => false }: { isInteracting?: () => bo
     isInteracting,
     loopMs: 1200,
     overlayOpen: false,
+    pauseWhenUnfocused,
     petH: 64,
     petW: 64
   })
@@ -161,6 +168,23 @@ describe('usePetRoam RAF scheduling', () => {
       window.dispatchEvent(new Event('focus'))
     })
     expect(raf.request).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps roaming while unfocused when pauseWhenUnfocused is false (overlay-safe)', () => {
+    const raf = installRaf()
+
+    render(<RoamHarness pauseWhenUnfocused={false} />)
+    expect(vi.getTimerCount()).toBe(1)
+
+    // A focusable:false overlay never receives focus; blur must not stop the loop.
+    act(() => window.dispatchEvent(new Event('blur')))
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => window.dispatchEvent(new Event('focus')))
+    expect(vi.getTimerCount()).toBe(1)
+
+    cleanup()
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/apps/desktop/src/components/pet/use-pet-roam.ts
+++ b/apps/desktop/src/components/pet/use-pet-roam.ts
@@ -55,6 +55,8 @@ interface PetRoamOptions {
   loopMs: number
   /** A full-screen route overlay (settings/profiles/…) is up: patrol its base. */
   overlayOpen: boolean
+  /** Overlays that never take focus (focusable:false panels) opt out of pause-on-blur. Default: true. */
+  pauseWhenUnfocused?: boolean
   /** Persist the resting position back to React state when the loop settles. */
   commit: (point: Point) => void
 }
@@ -88,6 +90,7 @@ export function usePetRoam({
   petH,
   loopMs,
   overlayOpen,
+  pauseWhenUnfocused = true,
   commit
 }: PetRoamOptions): void {
   useEffect(() => {
@@ -376,7 +379,7 @@ export function usePetRoam({
       schedule(now)
     }
 
-    pauseController = createRendererLoopPauseController(handleVisibilityChange)
+    pauseController = createRendererLoopPauseController(handleVisibilityChange, { pauseWhenUnfocused })
     schedule()
 
     return () => {
@@ -388,5 +391,5 @@ export function usePetRoam({
       // the loop stops re-asserting it.
       commit({ ...cur })
     }
-  }, [enabled, petW, petH, loopMs, overlayOpen, containerRef, isInteracting, commit])
+  }, [enabled, petW, petH, loopMs, overlayOpen, pauseWhenUnfocused, containerRef, isInteracting, commit])
 }


### PR DESCRIPTION
## Summary

Adds two missing interaction states to the popped-out pet overlay:

### Drag animation
The pet now shows its directional run animation while being dragged. Direction uses live delta tracking () rather than start-relative offset, so left/right flips immediately during the drag — no dead zone around the start point. The run row is passed as  on  only, so  and  are undisturbed.

### Overlay roaming
The popped-out pet patrols the transparent overlay window floor using the existing  engine. Roaming activates whenever the pet is loaded and the agent is idle — no localStorage toggle needed. Stable  wrappers prevent Effect re-initialization jitter. Seed position includes 16px bottom padding to prevent sprite clipping.

### Changes
-  — ~80 lines added, ~10 removed
- Adds  and  interface
- Delta-based drag direction via  state + 
-  wiring with absolute positioning support
- Reads  directly from session store (avoids computed-chain failure)

### Testing
- Windows 10, Hermes Desktop v0.17.0 (commit eb52760564)
- Drag animation tracks live direction, roam patrols floor when idle, chat reactions unaffected
- Pop-in/pop-out, composer, mail icon, and Alt+wheel resize all unchanged