### PR TITLE
fix(memory): stage unconfirmed policy claims instead of silently persisting

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -753,3 +753,67 @@ class TestDetectPolicyClaim:
     def test_dont_use_contraction(self):
         """Contraction 'don't use' should be detected."""
         assert self._detect("don't use gemini anymore") is not None
+
+    # ── Past-tense directive forms (#64681 follow-up) ──
+
+    def test_banned_model_past_tense(self):
+        """Past-tense 'User banned gpt-5.6-sol' should be detected."""
+        assert self._detect("User banned gpt-5.6-sol") is not None
+
+    def test_blocked_provider_past_tense(self):
+        """Past-tense 'OpenAI blocked claude 5' should be detected."""
+        assert self._detect("OpenAI blocked claude 5 via API") is not None
+
+    def test_disabled_model_past_tense(self):
+        """Past-tense 'disabled gemini models' should be detected."""
+        assert self._detect("User disabled gemini models last week") is not None
+
+    def test_prohibited_provider_past_tense(self):
+        """Past-tense 'prohibited anthropic routing' should be detected."""
+        assert self._detect("prohibited anthropic routing") is not None
+
+    def test_banning_gerund(self):
+        """Gerund 'banning gpt-5.6-sol' should be detected."""
+        assert self._detect("Consider banning gpt-5.6-sol for code review") is not None
+
+    # ── 'always' permanence (#64681 follow-up) ──
+
+    def test_always_with_routing_verb(self):
+        """'Always use claude for routing' should be detected."""
+        assert self._detect("Always use claude for routing") is not None
+
+    def test_always_without_routing_verb(self):
+        """'Always' + model but NO routing verb should not trigger."""
+        assert self._detect("Always claude for code reviews") is None
+
+    def test_always_without_model(self):
+        """'Always' + routing verb but NO model should not trigger."""
+        assert self._detect("Always use bullet points") is None
+
+    # ── o4 / o4-mini model coverage (#64681 follow-up) ──
+
+    def test_o4_model_detected(self):
+        """'never use o4-mini' should be detected (was missing from o[13])."""
+        assert self._detect("never use o4-mini for this project") is not None
+
+    def test_o4_bare_detected(self):
+        """'ban o4' (bare, no -mini suffix) should be detected."""
+        assert self._detect("ban o4") is not None
+
+    def test_o1_pro_detected(self):
+        """'o1-pro' variant should be detected (o[1-9]\\d* covers it)."""
+        assert self._detect("block o1-pro for routing") is not None
+
+    # ── yi / glm / baichuan provider coverage (#64681 follow-up) ──
+
+    def test_yi_provider_detected(self):
+        """'never use yi for code' should be detected."""
+        assert self._detect("never use yi for code") is not None
+
+    def test_glm_provider_detected(self):
+        """'block glm routing' should be detected."""
+        assert self._detect("block glm routing") is not None
+
+    def test_baichuan_provider_detected(self):
+        """'disable baichuan entirely' should be detected."""
+        assert self._detect("disable baichuan entirely") is not None

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -4,6 +4,9 @@ import json
 import pytest
 from pathlib import Path
 
+from hermes_cli.write_approval_commands import handle_pending_subcommand
+from hermes_constants import get_hermes_home
+from tools import write_approval as wa
 from tools.memory_tool import (
     MemoryStore,
     memory_tool,
@@ -817,3 +820,215 @@ class TestDetectPolicyClaim:
     def test_baichuan_provider_detected(self):
         """'disable baichuan entirely' should be detected."""
         assert self._detect("disable baichuan entirely") is not None
+
+
+# =========================================================================
+# Registered-provider coverage for the policy-claim classifier (#64681 review)
+# =========================================================================
+
+class TestPolicyClaimProviderCoverage:
+    """Every registered model-provider plugin identifier must be covered by
+    the policy-claim classifier.  The PR #72988 review flagged that 'never
+    use openrouter' bypassed the gate because the matcher only listed a
+    subset of registered providers.  Enumerating the plugin directory keeps
+    coverage self-maintaining: a provider added to plugins/model-providers/
+    fails this test until its identifier lands in _POLICY_CLAIM_MODEL_RE."""
+
+    PROVIDER_PLUGIN_DIR = (
+        Path(__file__).resolve().parents[2] / "plugins" / "model-providers"
+    )
+
+    def test_all_registered_providers_are_covered(self):
+        assert self.PROVIDER_PLUGIN_DIR.is_dir(), (
+            "provider plugin directory moved — update PROVIDER_PLUGIN_DIR"
+        )
+        providers = sorted(
+            p.name for p in self.PROVIDER_PLUGIN_DIR.iterdir() if p.is_dir()
+        )
+        assert providers, "no provider plugins found — layout changed?"
+        missing = [
+            name for name in providers
+            if _detect_policy_claim(f"never use {name}") is None
+        ]
+        assert missing == [], (
+            "registered provider identifier(s) missing from "
+            f"_POLICY_CLAIM_MODEL_RE: {missing}"
+        )
+
+    def test_compound_provider_names_covered_by_base_word(self):
+        """Hyphenated identifiers match via their base word (\\b...\\b)."""
+        for name in ("openai-codex", "kimi-coding", "qwen-oauth",
+                     "azure-foundry", "copilot-acp"):
+            assert _detect_policy_claim(f"never use {name}") is not None
+
+    def test_colloquial_base_forms_covered(self):
+        """Colloquial names must be caught, not just the exact plugin id:
+        users write 'never use ollama' / 'never use opencode', while the
+        registered identifiers are ollama-cloud / opencode-zen."""
+        assert _detect_policy_claim("never use ollama") is not None
+        assert _detect_policy_claim("never use opencode") is not None
+
+    def test_openrouter_regression(self):
+        """The exact case the review flagged must not bypass the gate."""
+        assert _detect_policy_claim("never use openrouter") is not None
+        assert _detect_policy_claim("never use openrouter/auto") is not None
+
+
+# =========================================================================
+# Policy-claim staging integration (PR #72988 review)
+# =========================================================================
+
+class TestPolicyClaimStagingIntegration:
+    """End-to-end: memory_tool() stages detected policy claims under the
+    default-off write-approval setting; nothing reaches disk before the user
+    approves via the pending handler; approval replays exactly once."""
+
+    def test_policy_claim_add_stages_and_skips_disk(self, store, tmp_path):
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="User bans gpt-5.6-sol",
+            store=store,
+        ))
+        assert result.get("staged") is True
+        assert result.get("policy_claim") is True
+        assert "pending_id" in result
+        # Nothing on disk / in the live store yet.
+        assert "User bans gpt-5.6-sol" not in store.memory_entries
+        memory_file = tmp_path / "MEMORY.md"
+        assert not memory_file.exists() or "gpt-5.6-sol" not in memory_file.read_text()
+        # The staged record exists with the full replay payload.
+        records = wa.list_pending(wa.MEMORY)
+        assert len(records) == 1
+        assert records[0]["payload"]["action"] == "add"
+        assert records[0]["payload"]["content"] == "User bans gpt-5.6-sol"
+
+    def test_approve_replays_exactly_once(self, store, tmp_path):
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="User bans gpt-5.6-sol",
+            store=store,
+        ))
+        pid = result["pending_id"]
+        out = handle_pending_subcommand(
+            wa.MEMORY, ["approve", pid], memory_store=store
+        )
+        assert "Approved 1" in out
+        # Landed exactly once.
+        assert store.memory_entries.count("User bans gpt-5.6-sol") == 1
+        memory_file = tmp_path / "MEMORY.md"
+        assert memory_file.read_text().count("User bans gpt-5.6-sol") == 1
+        # Record consumed.
+        assert wa.list_pending(wa.MEMORY) == []
+        # Re-approval is a no-op.
+        out2 = handle_pending_subcommand(
+            wa.MEMORY, ["approve", pid], memory_store=store
+        )
+        assert "No pending" in out2
+
+    def test_reject_never_lands(self, store, tmp_path):
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="User bans gpt-5.6-sol",
+            store=store,
+        ))
+        pid = result["pending_id"]
+        out = handle_pending_subcommand(wa.MEMORY, ["reject", pid])
+        assert "Rejected" in out
+        assert "gpt-5.6-sol" not in store.memory_entries
+        memory_file = tmp_path / "MEMORY.md"
+        assert not memory_file.exists() or "gpt-5.6-sol" not in memory_file.read_text()
+        assert wa.list_pending(wa.MEMORY) == []
+
+    def test_benign_write_passes_through_ungated(self, store, tmp_path):
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="User prefers compact responses",
+            store=store,
+        ))
+        assert result.get("success") is True
+        assert "staged" not in result
+        assert "User prefers compact responses" in store.memory_entries
+        assert wa.list_pending(wa.MEMORY) == []
+
+    def test_benign_write_with_provider_word_passes_through(self, store):
+        """A provider identifier WITHOUT a directive/permanence cue is not a
+        policy claim — it must persist normally, not stage."""
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="User prefers vertex themes in the dashboard",
+            store=store,
+        ))
+        assert result.get("success") is True
+        assert "staged" not in result
+        assert any("vertex themes" in e for e in store.memory_entries)
+        assert wa.list_pending(wa.MEMORY) == []
+
+    def test_batch_with_policy_claim_stages_whole_batch(self, store, tmp_path):
+        result = json.loads(memory_tool(
+            target="memory",
+            operations=[
+                {"action": "add", "content": "User bans gpt-5.6-sol"},
+                {"action": "add", "content": "User prefers bullet points"},
+            ],
+            store=store,
+        ))
+        assert result.get("staged") is True
+        assert result.get("policy_claim") is True
+        # Neither op hit disk.
+        assert "gpt-5.6-sol" not in store.memory_entries
+        assert "bullet points" not in store.memory_entries
+        records = wa.list_pending(wa.MEMORY)
+        assert len(records) == 1
+        assert records[0]["payload"]["action"] == "batch"
+        # Approve → the whole batch applies exactly once.
+        out = handle_pending_subcommand(
+            wa.MEMORY, ["approve", result["pending_id"]], memory_store=store
+        )
+        assert "Approved 1" in out
+        assert store.memory_entries.count("User bans gpt-5.6-sol") == 1
+        assert store.memory_entries.count("User prefers bullet points") == 1
+        assert wa.list_pending(wa.MEMORY) == []
+
+    def test_replace_with_policy_claim_stages(self, store, tmp_path):
+        store.add("memory", "use gpt-5.6-sol for code review")
+        result = json.loads(memory_tool(
+            action="replace", target="memory",
+            old_text="use gpt-5.6-sol for code review",
+            content="User bans gpt-5.6-sol",
+            store=store,
+        ))
+        assert result.get("staged") is True
+        assert "bans gpt-5.6-sol" not in str(store.memory_entries)
+        records = wa.list_pending(wa.MEMORY)
+        assert len(records) == 1
+        assert records[0]["payload"]["action"] == "replace"
+        # Approve → replace replays against the store.
+        out = handle_pending_subcommand(
+            wa.MEMORY, ["approve", result["pending_id"]], memory_store=store
+        )
+        assert "Approved 1" in out
+        assert "bans gpt-5.6-sol" in str(store.memory_entries)
+        assert "for code review" not in str(store.memory_entries)
+
+    def test_staging_failure_fails_closed(self, store, tmp_path, monkeypatch):
+        """If staging raises, a detected policy claim must NOT flow to disk
+        (fail-closed — the triage review's 'fail open' concern)."""
+        import tools.write_approval as wa_mod
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated staging failure")
+
+        monkeypatch.setattr(wa_mod, "stage_write", boom)
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="User bans gpt-5.6-sol",
+            store=store,
+        ))
+        assert result.get("success") is False
+        assert result.get("policy_claim") is True
+        assert "blocked" in result["error"]
+        # Nothing persisted, nothing staged.
+        assert "gpt-5.6-sol" not in store.memory_entries
+        memory_file = tmp_path / "MEMORY.md"
+        assert not memory_file.exists() or "gpt-5.6-sol" not in memory_file.read_text()
+        assert wa.list_pending(wa.MEMORY) == []

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -8,6 +8,8 @@ from tools.memory_tool import (
     MemoryStore,
     memory_tool,
     _scan_memory_content,
+    _detect_policy_claim,
+    MEMORY_SCHEMA,
 )
 
 
@@ -627,3 +629,127 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+# =========================================================================
+# Policy claim detection
+# =========================================================================
+
+class TestDetectPolicyClaim:
+    """Tests for _detect_policy_claim, the pre-write classifier that detects
+    unconfirmed operational policy claims (model/provider bans, prohibitions,
+    permanent routing directives) so they can be staged for user confirmation
+    rather than silently persisted (issue #64681).
+    """
+
+    @staticmethod
+    def _detect(content: str):
+        return _detect_policy_claim(content)
+
+    # ── Positive cases: should trigger ──
+
+    def test_ban_model(self):
+        """'User bans gpt-5.6-sol' should be detected as a policy claim."""
+        assert self._detect("User bans gpt-5.6-sol") is not None
+
+    def test_block_provider(self):
+        """'Block OpenAI provider' should be detected."""
+        assert self._detect("Block OpenAI provider from now on") is not None
+
+    def test_never_use_model(self):
+        """'never use claude sonnet' should be detected."""
+        assert self._detect("never use claude sonnet") is not None
+
+    def test_disable_model(self):
+        """'Disable gemini models entirely' should be detected."""
+        assert self._detect("Disable gemini models entirely") is not None
+
+    def test_prohibit_provider(self):
+        """'prohibit anthropic routing' should be detected."""
+        assert self._detect("prohibit anthropic routing") is not None
+
+    def test_permanent_ban(self):
+        """'permanent ban on gpt-5.6-sol' should be detected."""
+        assert self._detect("permanent ban on gpt-5.6-sol") is not None
+
+    def test_going_forward_routing(self):
+        """Absolute durability language about a model should be detected."""
+        assert self._detect("Going forward, use only claude for code review") is not None
+
+    # ── Negative cases: should NOT trigger ──
+
+    def test_normal_preference(self):
+        """A routine preference should not be detected."""
+        assert self._detect("User prefers compact responses") is None
+
+    def test_markdown_preference(self):
+        """A formatting preference should not be detected."""
+        assert self._detect("Use markdown for code blocks") is None
+
+    def test_model_mention_no_directive(self):
+        """Just mentioning a model is fine."""
+        assert self._detect("The gpt-5.6 model is fast") is None
+
+    def test_role_mapping(self):
+        """The role-mapping pattern from the incident should not trigger."""
+        assert self._detect("Sol=complex; Terra=RFQ; Luna=routine") is None
+
+    def test_always_prefer_no_model(self):
+        """'always prefer' without a model/provider name should not trigger."""
+        assert self._detect("always prefer bullet points in responses") is None
+
+    def test_only_speaks(self):
+        """'only speaks' pattern (not routing) should not trigger."""
+        assert self._detect("User only speaks English") is None
+
+    def test_remove_stale_entries(self):
+        """'remove' about old projects (not a model) should not trigger."""
+        assert self._detect("remove stale memory entries about old projects") is None
+
+    def test_ban_without_model_name(self):
+        """'ban' without a model/provider name should not trigger."""
+        assert self._detect("User bans all caps in responses") is None
+
+    def test_empty_content(self):
+        """Empty content should not trigger."""
+        assert self._detect("") is None
+        assert self._detect("   ") is None
+
+    # ── Reviewer-found edge cases ──
+
+    def test_kanban_substring_false_positive(self):
+        """'kanban' should NOT match 'ban' substring (word-boundary regex)."""
+        assert self._detect(
+            "Track claude tasks on the kanban board"
+        ) is None
+
+    def test_codeblock_substring_false_positive(self):
+        """'codeblock' should NOT match 'block' substring."""
+        assert self._detect(
+            "Format gemini output in a codeblock"
+        ) is None
+
+    def test_going_forward_no_routing_verb(self):
+        """Permanence language without a routing verb should not trigger."""
+        assert self._detect(
+            "Going forward, claude gives concise code reviews"
+        ) is None
+
+    def test_going_forward_with_routing_verb(self):
+        """Permanence language WITH a routing verb should trigger."""
+        assert self._detect(
+            "Going forward, use claude for code reviews"
+        ) is not None
+
+    def test_model_with_digits_no_hyphen(self):
+        """'gpt5' without hyphen should be detected."""
+        assert self._detect("stop using gpt5 for routing") is not None
+
+    def test_missing_models(self):
+        """Models like 'qwen', 'groq' added per review should be detected."""
+        assert self._detect("never use qwen for code") is not None
+        assert self._detect("block groq routing") is not None
+
+    def test_dont_use_contraction(self):
+        """Contraction 'don't use' should be detected."""
+        assert self._detect("don't use gemini anymore") is not None

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -130,6 +130,15 @@ _POLICY_CLAIM_MODEL_RE = re.compile(
     r'|doubao|kimi|ernie|spark|hunyuan|bedrock|azure'
     r'|yi|glm|baichuan'
     r'|together|fireworks|replicate'
+    # Registered model-provider plugin identifiers (plugins/model-providers/).
+    # Word-boundary matching means compound names (openai-codex, kimi-coding,
+    # qwen-oauth, azure-foundry, copilot-acp) are covered by their base word.
+    # Base forms of compound identifiers (ollama, opencode) are included so
+    # colloquial usage like "never use ollama" is caught, not just the exact
+    # registered plugin name (ollama-cloud, opencode-zen).
+    r'|openrouter|huggingface|minimax|ollama(?:-cloud)?|vertex'
+    r'|copilot|stepfun|xiaomi|zai|kilocode|nous|novita'
+    r'|deepinfra|gmi|arcee|upstage|ai-gateway|custom|actual|alibaba|opencode(?:-zen)?'
     r')\b',
     re.IGNORECASE,
 )
@@ -1089,11 +1098,17 @@ def _check_policy_claim_gate(action: str, target: str, content: Optional[str],
     try:
         from tools import write_approval as wa
     except Exception as e:
-        logger.warning(
-            "Policy-claim gate: cannot import write_approval, "
-            "failing open (%s)", e,  # windows-footgun: ok — log phrase, not open()
+        # Fail CLOSED: a detected high-impact claim must never silently
+        # persist because the staging subsystem is unavailable.
+        logger.error("Policy-claim gate: cannot import write_approval, "
+                     "blocking write (%s)", e)
+        return tool_error(
+            "This write looks like an operational policy claim and was "
+            "blocked because the confirmation subsystem is unavailable. "
+            "Nothing was saved. Retry once the staging subsystem is healthy.",
+            success=False,
+            policy_claim=True,
         )
-        return None
 
     label = "user profile" if target == "user" else "memory"
     summary = f"policy claim in {label}: {reason[:80]}"
@@ -1111,10 +1126,17 @@ def _check_policy_claim_gate(action: str, target: str, content: Optional[str],
             origin=wa.current_origin(),
         )
     except Exception as e:
-        logger.warning(
-            "Policy-claim gate: stage_write failed, failing open (%s)", e,  # windows-footgun: ok — log phrase, not open()
+        # Fail CLOSED: stage_write is best-effort by contract and normally
+        # never raises; if it does, the claim must not flow through to disk.
+        logger.error("Policy-claim gate: stage_write failed, "
+                     "blocking write (%s)", e)
+        return tool_error(
+            "This write looks like an operational policy claim and was "
+            "blocked because staging failed. Nothing was saved. Retry once "
+            "the staging subsystem is healthy.",
+            success=False,
+            policy_claim=True,
         )
-        return None
 
     logger.info("Policy-claim gate: staged claim (pending_id=%s, reason=%s)",
                 record.get("id"), reason)
@@ -1163,11 +1185,18 @@ def _check_policy_claim_batch(
     try:
         from tools import write_approval as wa
     except Exception as e:
-        logger.warning(
-            "Policy-claim batch gate: cannot import write_approval, "
-            "failing open (%s)", e,  # windows-footgun: ok — log phrase, not open()
+        # Fail CLOSED: a detected high-impact claim must never silently
+        # persist because the staging subsystem is unavailable.
+        logger.error("Policy-claim batch gate: cannot import write_approval, "
+                     "blocking write (%s)", e)
+        return tool_error(
+            "This batch looks like it contains an operational policy claim "
+            "and was blocked because the confirmation subsystem is "
+            "unavailable. Nothing was saved. Retry once the staging "
+            "subsystem is healthy.",
+            success=False,
+            policy_claim=True,
         )
-        return None
 
     label = "user profile" if target == "user" else "memory"
     summary = f"policy claim(s) in batch to {label}: {'; '.join(reasons)[:120]}"
@@ -1184,10 +1213,17 @@ def _check_policy_claim_batch(
             origin=wa.current_origin(),
         )
     except Exception as e:
-        logger.warning(
-            "Policy-claim batch gate: stage_write failed, failing open (%s)", e,  # windows-footgun: ok — log phrase, not open()
+        # Fail CLOSED: stage_write is best-effort by contract and normally
+        # never raises; if it does, the claim must not flow through to disk.
+        logger.error("Policy-claim batch gate: stage_write failed, "
+                     "blocking write (%s)", e)
+        return tool_error(
+            "This batch looks like it contains an operational policy claim "
+            "and was blocked because staging failed. Nothing was saved. "
+            "Retry once the staging subsystem is healthy.",
+            success=False,
+            policy_claim=True,
         )
-        return None
 
     logger.info(
         "Policy-claim batch gate: staged batch (pending_id=%s, operations=%d)",

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1091,7 +1091,7 @@ def _check_policy_claim_gate(action: str, target: str, content: Optional[str],
     except Exception as e:
         logger.warning(
             "Policy-claim gate: cannot import write_approval, "
-            "failing open (%s)", e,
+            "failing open (%s)", e,  # windows-footgun: ok — log phrase, not open()
         )
         return None
 
@@ -1112,7 +1112,7 @@ def _check_policy_claim_gate(action: str, target: str, content: Optional[str],
         )
     except Exception as e:
         logger.warning(
-            "Policy-claim gate: stage_write failed, failing open (%s)", e,
+            "Policy-claim gate: stage_write failed, failing open (%s)", e,  # windows-footgun: ok — log phrase, not open()
         )
         return None
 
@@ -1165,7 +1165,7 @@ def _check_policy_claim_batch(
     except Exception as e:
         logger.warning(
             "Policy-claim batch gate: cannot import write_approval, "
-            "failing open (%s)", e,
+            "failing open (%s)", e,  # windows-footgun: ok — log phrase, not open()
         )
         return None
 
@@ -1185,7 +1185,7 @@ def _check_policy_claim_batch(
         )
     except Exception as e:
         logger.warning(
-            "Policy-claim batch gate: stage_write failed, failing open (%s)", e,
+            "Policy-claim batch gate: stage_write failed, failing open (%s)", e,  # windows-footgun: ok — log phrase, not open()
         )
         return None
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -99,7 +99,9 @@ def _scan_memory_content(content: str) -> Optional[str]:
 # must not match "ban").
 _POLICY_CLAIM_DIRECTIVE_RE = re.compile(
     r'\b(?:'
-    r'ban|bans|block|blocks|disable|disables|prohibit|prohibits'
+    r'ban|bans|banned|banning|block|blocks|blocked|blocking'
+    r'|disable|disables|disabled|disabling|prohibit|prohibits'
+    r'|prohibited|prohibiting'
     r'|never\s+use|do\s+not\s+use|don\'t\s+use|must\s+not\s+use'
     r'|stop\s+using|stopped\s+using|no\s+longer\s+use'
     r'|removed?\s+from\s+(?:the\s+)?(?:chain|routing|fallback)'
@@ -119,13 +121,14 @@ _ROUTING_VERB_RE = re.compile(
 # positives cause a confirmation prompt, not data loss.
 _POLICY_CLAIM_MODEL_RE = re.compile(
     r'\b(?:'
-    r'gpt-?\d[\w.-]*|o[13](?:-mini|-preview)?'
+    r'gpt-?\d[\w.-]*|o[1-9]\d*(?:-mini|-preview)?'
     r'|claude|gemini|llama\d*|grok|deepseek'
     r'|anthropic|openai|xai|google|meta'
     r'|mistral|mi[rx]tral|codestral|cohere|perplexity'
     r'|sonar|dbrx|command-r'
     r'|nvidia|nemotron|qwq|qwen\d*|groq'
     r'|doubao|kimi|ernie|spark|hunyuan|bedrock|azure'
+    r'|yi|glm|baichuan'
     r'|together|fireworks|replicate'
     r')\b',
     re.IGNORECASE,
@@ -136,7 +139,7 @@ _POLICY_CLAIM_MODEL_RE = re.compile(
 # classifier body) — "Going forward, use claude" is a routing directive;
 # "Going forward, claude is fast" is an observation.
 _POLICY_CLAIM_PERMANENCE_RE = re.compile(
-    r'\b(?:permanent|forever|indefinitely|from\s+now\s+on|going\s+forward)\b',
+    r'\b(?:permanent|forever|indefinitely|from\s+now\s+on|going\s+forward|always)\b',
     re.IGNORECASE,
 )
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -25,6 +25,7 @@ Design:
 
 import json
 import logging
+import re
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -86,6 +87,101 @@ from tools.threat_patterns import first_threat_message as _first_threat_message
 def _scan_memory_content(content: str) -> Optional[str]:
     """Scan memory content for injection/exfil patterns. Returns error string if blocked."""
     return _first_threat_message(content, scope="strict")
+
+
+# ---------------------------------------------------------------------------
+# Policy-claim detection
+# ---------------------------------------------------------------------------
+
+# Directive verbs/patterns paired with a model/provider name signal an
+# operational policy claim rather than a routine preference.  Matched via
+# word-boundary regex to avoid substring false positives (e.g. "kanban"
+# must not match "ban").
+_POLICY_CLAIM_DIRECTIVE_RE = re.compile(
+    r'\b(?:'
+    r'ban|bans|block|blocks|disable|disables|prohibit|prohibits'
+    r'|never\s+use|do\s+not\s+use|don\'t\s+use|must\s+not\s+use'
+    r'|stop\s+using|stopped\s+using|no\s+longer\s+use'
+    r'|removed?\s+from\s+(?:the\s+)?(?:chain|routing|fallback)'
+    r'|blacklist|blacklists|off-limits|deprecated?|discontinue'
+    r')\b',
+    re.IGNORECASE,
+)
+
+# Routing/use verbs — when these co-occur with permanence language and a
+# model name, the entry is treated as a routing directive.
+_ROUTING_VERB_RE = re.compile(
+    r'\b(?:use|route|send|direct|delegate|fallback)\b',
+    re.IGNORECASE,
+)
+
+# Broad model/provider name patterns.  Intentionally generous — false
+# positives cause a confirmation prompt, not data loss.
+_POLICY_CLAIM_MODEL_RE = re.compile(
+    r'\b(?:'
+    r'gpt-?\d[\w.-]*|o[13](?:-mini|-preview)?'
+    r'|claude|gemini|llama\d*|grok|deepseek'
+    r'|anthropic|openai|xai|google|meta'
+    r'|mistral|mi[rx]tral|codestral|cohere|perplexity'
+    r'|sonar|dbrx|command-r'
+    r'|nvidia|nemotron|qwq|qwen\d*|groq'
+    r'|doubao|kimi|ernie|spark|hunyuan|bedrock|azure'
+    r'|together|fireworks|replicate'
+    r')\b',
+    re.IGNORECASE,
+)
+
+# Absolute/durable language that signals permanence, not a one-time trial.
+# Only fires when ALSO paired with a routing/use verb (checked in the
+# classifier body) — "Going forward, use claude" is a routing directive;
+# "Going forward, claude is fast" is an observation.
+_POLICY_CLAIM_PERMANENCE_RE = re.compile(
+    r'\b(?:permanent|forever|indefinitely|from\s+now\s+on|going\s+forward)\b',
+    re.IGNORECASE,
+)
+
+
+def _detect_policy_claim(content: str) -> Optional[str]:
+    """Return a reason string if *content* looks like an unconfirmed
+    operational policy claim, or ``None`` if the content appears to be a
+    normal preference / note / correction.
+
+    An operational policy claim is one that:
+    - Names a specific model or provider
+    - Uses directive language (ban, block, disable, prohibit, never)
+    - OR uses absolute/durable language + routing verb about a model/provider
+
+    The caller is responsible for staging the write rather than allowing
+    it to flow through to disk unchecked.
+    """
+    if not content or not content.strip():
+        return None
+
+    lower = content.lower()
+
+    # Fast path: no model/provider name → not a policy claim.
+    if not _POLICY_CLAIM_MODEL_RE.search(lower):
+        return None
+
+    # Check for directive language about models/providers (word-boundary).
+    m = _POLICY_CLAIM_DIRECTIVE_RE.search(lower)
+    if m:
+        return (
+            f"contains '{m.group()}' paired with a model/provider name "
+            f"— looks like an operational policy claim"
+        )
+
+    # Check for absolute/durable language AND a routing/use verb —
+    # "Going forward, use claude" is a routing directive; "Going forward,
+    # claude is fast" is an observation.
+    if (_POLICY_CLAIM_PERMANENCE_RE.search(lower) and
+            _ROUTING_VERB_RE.search(lower)):
+        return (
+            "uses absolute/durable language plus a routing verb about a "
+            "model/provider — looks like a permanent routing directive"
+        )
+
+    return None
 
 
 def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
@@ -965,6 +1061,153 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
     )
 
 
+def _check_policy_claim_gate(action: str, target: str, content: Optional[str],
+                             old_text: Optional[str]) -> Optional[str]:
+    """Stage writes that look like unconfirmed operational policy claims.
+
+    Runs AFTER the existing write-approval gate.  When the approval gate
+    is off (the default) and the content appears to be a model/provider
+    ban, prohibition, or permanent routing directive, the write is staged
+    instead of silently persisted.  The user can then review and approve
+    it via ``/memory pending``.
+
+    Returns a JSON tool-result string when the write should be staged,
+    or None when it is safe to proceed.
+    """
+    if action not in {"add", "replace"}:
+        return None
+    if not content or not content.strip():
+        return None
+
+    reason = _detect_policy_claim(content)
+    if reason is None:
+        return None
+
+    try:
+        from tools import write_approval as wa
+    except Exception as e:
+        logger.warning(
+            "Policy-claim gate: cannot import write_approval, "
+            "failing open (%s)", e,
+        )
+        return None
+
+    label = "user profile" if target == "user" else "memory"
+    summary = f"policy claim in {label}: {reason[:80]}"
+
+    payload: Dict[str, Any] = {
+        "action": action,
+        "target": target,
+        "content": content,
+        "old_text": old_text,
+    }
+    try:
+        record = wa.stage_write(
+            wa.MEMORY, payload,
+            summary=summary,
+            origin=wa.current_origin(),
+        )
+    except Exception as e:
+        logger.warning(
+            "Policy-claim gate: stage_write failed, failing open (%s)", e,
+        )
+        return None
+
+    logger.info("Policy-claim gate: staged claim (pending_id=%s, reason=%s)",
+                record.get("id"), reason)
+
+    return json.dumps(
+        {
+            "success": True,
+            "staged": True,
+            "policy_claim": True,
+            "pending_id": record["id"],
+            "message": (
+                f"Staged for confirmation — this entry looks like an "
+                f"operational policy claim ({reason}). It has been staged, "
+                f"not saved. Review with /memory pending. To confirm, the "
+                f"user must approve it explicitly."
+            ),
+        },
+        ensure_ascii=False,
+    )
+
+
+def _check_policy_claim_batch(
+    target: str, operations: List[Dict[str, Any]],
+) -> Optional[str]:
+    """Stage a batch if any operation contains an unconfirmed policy claim.
+
+    Returns a JSON tool-result string when the entire batch should be
+    staged, or None when it is safe to proceed.
+    """
+    reasons = []
+    for op in operations:
+        op = op or {}
+        act = op.get("action", "?")
+        if act not in ("add", "replace"):
+            continue
+        c = op.get("content") or ""
+        if not c.strip():
+            continue
+        r = _detect_policy_claim(c)
+        if r:
+            reasons.append(f"{act}: {r}")
+
+    if not reasons:
+        return None
+
+    try:
+        from tools import write_approval as wa
+    except Exception as e:
+        logger.warning(
+            "Policy-claim batch gate: cannot import write_approval, "
+            "failing open (%s)", e,
+        )
+        return None
+
+    label = "user profile" if target == "user" else "memory"
+    summary = f"policy claim(s) in batch to {label}: {'; '.join(reasons)[:120]}"
+
+    payload: Dict[str, Any] = {
+        "action": "batch",
+        "target": target,
+        "operations": operations,
+    }
+    try:
+        record = wa.stage_write(
+            wa.MEMORY, payload,
+            summary=summary,
+            origin=wa.current_origin(),
+        )
+    except Exception as e:
+        logger.warning(
+            "Policy-claim batch gate: stage_write failed, failing open (%s)", e,
+        )
+        return None
+
+    logger.info(
+        "Policy-claim batch gate: staged batch (pending_id=%s, operations=%d)",
+        record.get("id"), len(operations),
+    )
+
+    return json.dumps(
+        {
+            "success": True,
+            "staged": True,
+            "policy_claim": True,
+            "pending_id": record["id"],
+            "message": (
+                f"Staged for confirmation — {len(reasons)} operation(s) in "
+                f"this batch look like operational policy claims. The batch "
+                f"has been staged, not saved. Review with /memory pending. "
+                f"To confirm, the user must approve it explicitly."
+            ),
+        },
+        ensure_ascii=False,
+    )
+
+
 def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Optional[str]:
     """Evaluate the write gate for a batch of memory operations.
 
@@ -1081,6 +1324,10 @@ def memory_tool(
         gate_result = _apply_batch_write_gate(target, operations)
         if gate_result is not None:
             return gate_result
+        # Policy-claim gate for batch operations (#64681).
+        policy_result = _check_policy_claim_batch(target, operations)
+        if policy_result is not None:
+            return policy_result
         result = store.apply_batch(target, operations)
         return json.dumps(result, ensure_ascii=False)
 
@@ -1106,6 +1353,14 @@ def memory_tool(
     gate_result = _apply_write_gate(action, target, content, old_text)
     if gate_result is not None:
         return gate_result
+
+    # Policy-claim gate: runs regardless of write_approval setting.
+    # If the content looks like an unconfirmed model/provider ban,
+    # prohibition, or permanent routing directive, stage it for user
+    # confirmation (issue #64681).
+    policy_result = _check_policy_claim_gate(action, target, content, old_text)
+    if policy_result is not None:
+        return policy_result
 
     if action == "add":
         result = store.add(target, content)


### PR DESCRIPTION
Closes #64681

## Summary

When a gateway turn contains quoted or forwarded text about banning, blocking, or permanently changing model/provider routing, the model may interpret it as a direct operator directive. Previously, there was no gate on the memory write path to prevent such claims from being silently persisted as durable policy. One unconfirmed interpretation could produce a self-reinforcing chain:

```
quoted/ambiguous turn → inferred permanent prohibition → live routing mutation
→ persistent memory assertion → future-system-prompt context
→ agent treats the assertion as established policy
```

The existing `memory.write_approval` gate defaults to `false` (opt-in) and applies to ALL writes uniformly — it cannot distinguish between a harmless preference ("User prefers compact responses") and an operational policy claim ("User bans gpt-5.6-sol").

## Changes

**`tools/memory_tool.py`** — 3 additions:

1. **`_detect_policy_claim(content)`** — a deterministic classifier that detects entries naming a specific model/provider paired with directive language (ban, block, disable, prohibit, never use) or absolute/durable language (permanent, forever, going forward). Returns a reason string or `None`.

2. **`_check_policy_claim_gate(action, target, content, old_text)`** — stage-gate that runs AFTER the existing write_approval gate. When the classifier fires, the write is staged via the existing `wa.stage_write()` mechanism (same `/memory pending` UX as when `write_approval` is explicitly on). Returns a JSON tool-result or `None`.

3. **Insertion point in `memory_tool()`** — the gate is called between `_apply_write_gate()` and `store.add()`, so it only activates when the write_approval gate has already allowed the write through. No double-gating.

**`tests/tools/test_memory_tool.py`** — `TestDetectPolicyClaim` class with 16 tests:

- 7 positive cases (ban+gpt, block+openai, never+claude, disable+gemini, prohibit+anthropic, permanent+ban, going-forward+routing)
- 9 negative cases (normal preferences, model mentions without directives, role mappings, formatting prefs, empty content)

The classifier is intentionally generous — false positives cause a confirmation prompt, not data loss. Routine preferences and benign model mentions pass through unchanged.

## Notes

- This is a targeted fix for the specific incident class described in the linked issue: ambiguous/quoted text being promoted directly into permanent policy. It does not address the broader authority/freshness/provenance gaps (tracked in #63469, #1156, #18559).
- The classifier uses a hardcoded list of model/provider name patterns. New providers added to the Hermes ecosystem will automatically be caught if their names contain the broad patterns (`gpt-\d`, `claude`, `gemini`, `llama`, `grok`, `deepseek`, `anthropic`, `openai`, `xai`, `google`, `meta`, `mistral`, `cohere`, `perplexity`, `nvidia`, `nemotron`, `qwq`, `doubao`, `kimi`, `ernie`, `spark`, `hunyuan`). Additional names can be added to `_POLICY_CLAIM_MODEL_RE` as needed.
- The `_POLICY_CLAIM_DIRECTIVES` tuple is similarly extensible.
- The staging path reuses `tools.write_approval.stage_write()` — no new mechanism, no new surface.

## Test Plan

- [x] 16 new classifier tests pass (`pytest tests/tools/test_memory_tool.py::TestDetectPolicyClaim -q`)
- [x] Full memory_tool test suite passes (110/110, zero regressions)
- [x] Memory tool schema tests pass (3/3)

