### PR TITLE
fix(plugins): reserve lifecycle correlation IDs atomically

### DIFF
--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -152,7 +152,11 @@ class _Registry:
     def __init__(self) -> None:
         self.lock = threading.RLock()
         self.records: dict[str, _Record] = {}
-        self.correlations: dict[tuple[Optional[str], str], str] = {}
+        # ``None`` reserves a correlation ID while its child is being built.
+        # Child construction happens outside ``lock`` and may be slow, so the
+        # reservation closes the check-then-build race without blocking status,
+        # cancellation, or result lookups for existing children.
+        self.correlations: dict[tuple[Optional[str], str], Optional[str]] = {}
 
 
 _REGISTRY = _Registry()
@@ -207,55 +211,79 @@ class SubagentLifecycleService:
                 "parent_session_id does not match the active session."
             )
         correlation_key = (parent_session_id, request.correlation_id or "")
+        correlation_reserved = bool(request.correlation_id)
         with _REGISTRY.lock:
             self._cleanup_locked()
             if request.correlation_id and correlation_key in _REGISTRY.correlations:
                 raise SubagentLifecycleError(
                     "Duplicate correlation_id for this parent session."
                 )
+            if correlation_reserved:
+                _REGISTRY.correlations[correlation_key] = None
 
-        # Delegate construction remains internal so plugin code never imports
-        # private delegation helpers or manipulates the active-child registry.
-        from tools.delegate_tool import (
-            _build_child_preserving_parent_tools,
-            DEFAULT_MAX_ITERATIONS,
-        )
+        try:
+            # Delegate construction remains internal so plugin code never imports
+            # private delegation helpers or manipulates the active-child registry.
+            from tools.delegate_tool import (
+                _build_child_preserving_parent_tools,
+                DEFAULT_MAX_ITERATIONS,
+            )
 
-        child = _build_child_preserving_parent_tools(
-            task_index=0,
-            goal=request.goal,
-            context=request.context,
-            toolsets=list(request.allowed_toolsets)
-            if request.allowed_toolsets
-            else None,
-            model=request.model,
-            max_iterations=DEFAULT_MAX_ITERATIONS,
-            task_count=1,
-            parent_agent=parent,
-            role=request.role,
-        )
-        subagent_id = str(getattr(child, "_subagent_id", "") or "")
-        if not subagent_id:
-            raise SubagentLifecycleError("Hermes failed to assign a child identity.")
-        created = time.time()
-        handle = SubagentHandle(
-            PUBLIC_CONTRACT_VERSION,
-            subagent_id,
-            parent_session_id,
-            request.correlation_id,
-            created,
-            getattr(child, "provider", None),
-            getattr(child, "model", None),
-            getattr(child, "_delegate_role", request.role),
-            int(getattr(child, "_delegate_depth", 1) or 1),
-            self._capability(subagent_id, parent_session_id, created),
-        )
-        record = _Record(handle, SubagentState.PENDING, created, agent=child)
+            child = _build_child_preserving_parent_tools(
+                task_index=0,
+                goal=request.goal,
+                context=request.context,
+                toolsets=list(request.allowed_toolsets)
+                if request.allowed_toolsets
+                else None,
+                model=request.model,
+                max_iterations=DEFAULT_MAX_ITERATIONS,
+                task_count=1,
+                parent_agent=parent,
+                role=request.role,
+            )
+            subagent_id = str(getattr(child, "_subagent_id", "") or "")
+            if not subagent_id:
+                raise SubagentLifecycleError("Hermes failed to assign a child identity.")
+            created = time.time()
+            handle = SubagentHandle(
+                PUBLIC_CONTRACT_VERSION,
+                subagent_id,
+                parent_session_id,
+                request.correlation_id,
+                created,
+                getattr(child, "provider", None),
+                getattr(child, "model", None),
+                getattr(child, "_delegate_role", request.role),
+                int(getattr(child, "_delegate_depth", 1) or 1),
+                self._capability(subagent_id, parent_session_id, created),
+            )
+            record = _Record(handle, SubagentState.PENDING, created, agent=child)
+        except BaseException:
+            if correlation_reserved:
+                with _REGISTRY.lock:
+                    if _REGISTRY.correlations.get(correlation_key) is None:
+                        _REGISTRY.correlations.pop(correlation_key, None)
+            raise
         with _REGISTRY.lock:
             _REGISTRY.records[subagent_id] = record
-            if request.correlation_id:
+            if correlation_reserved:
                 _REGISTRY.correlations[correlation_key] = subagent_id
-        record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        try:
+            record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        except BaseException:
+            # Registration and executor submission are one launch transaction.
+            # A rejected submission must not strand a PENDING record or make the
+            # caller's correlation ID permanently unusable.
+            with _REGISTRY.lock:
+                if _REGISTRY.records.get(subagent_id) is record:
+                    _REGISTRY.records.pop(subagent_id, None)
+                if (
+                    correlation_reserved
+                    and _REGISTRY.correlations.get(correlation_key) == subagent_id
+                ):
+                    _REGISTRY.correlations.pop(correlation_key, None)
+            raise
         return handle
 
     def status(self, handle: SubagentHandle) -> SubagentStatus:

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -1,6 +1,8 @@
 """Contract tests for the public plugin subagent lifecycle API."""
 
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -80,6 +82,85 @@ def test_duplicate_correlation_and_permission_validation(lifecycle):
         )
     with pytest.raises(SubagentLifecycleError, match="working_directory"):
         lifecycle.launch(SubagentLaunchRequest(goal="x", working_directory="C:/"))
+    lifecycle.wait(handle, timeout_seconds=1)
+
+
+def test_duplicate_correlation_is_reserved_during_child_construction(
+    lifecycle, monkeypatch
+):
+    first_build_started = threading.Event()
+    release_first_build = threading.Event()
+    build_count = iter(range(2))
+
+    def slow_build(**_kwargs):
+        ident = next(build_count)
+        if ident == 0:
+            first_build_started.set()
+            assert release_first_build.wait(timeout=1)
+        return FakeChild(f"sa-race-{ident}")
+
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_preserving_parent_tools", slow_build
+    )
+    request = SubagentLaunchRequest(goal="x", correlation_id="same-concurrent")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(lifecycle.launch, request)
+        assert first_build_started.wait(timeout=1)
+        second = executor.submit(lifecycle.launch, request)
+        try:
+            with pytest.raises(SubagentLifecycleError, match="Duplicate"):
+                second.result(timeout=1)
+        finally:
+            release_first_build.set()
+        handle = first.result(timeout=1)
+
+    assert handle.correlation_id == "same-concurrent"
+    lifecycle.wait(handle, timeout_seconds=1)
+
+
+def test_failed_child_build_releases_correlation_reservation(lifecycle, monkeypatch):
+    attempts = iter(range(2))
+
+    def build(**_kwargs):
+        if next(attempts) == 0:
+            raise RuntimeError("build failed")
+        return FakeChild("sa-retry")
+
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_preserving_parent_tools", build
+    )
+    request = SubagentLaunchRequest(goal="x", correlation_id="retry-after-failure")
+
+    with pytest.raises(RuntimeError, match="build failed"):
+        lifecycle.launch(request)
+    handle = lifecycle.launch(request)
+
+    assert handle.subagent_id == "sa-retry"
+    lifecycle.wait(handle, timeout_seconds=1)
+
+
+def test_failed_executor_submission_rolls_back_record_and_correlation(
+    lifecycle, monkeypatch
+):
+    import agent.subagent_lifecycle as lifecycle_module
+
+    executor = lifecycle_module._EXECUTOR
+    real_submit = executor.submit
+
+    def reject_submission(*_args, **_kwargs):
+        raise RuntimeError("executor rejected")
+
+    monkeypatch.setattr(executor, "submit", reject_submission)
+    request = SubagentLaunchRequest(goal="x", correlation_id="retry-after-reject")
+
+    with pytest.raises(RuntimeError, match="executor rejected"):
+        lifecycle.launch(request)
+
+    monkeypatch.setattr(executor, "submit", real_submit)
+    handle = lifecycle.launch(request)
+
+    assert handle.correlation_id == "retry-after-reject"
     lifecycle.wait(handle, timeout_seconds=1)
 
 


### PR DESCRIPTION
## Summary

- reserve non-empty, parent-scoped lifecycle `correlation_id` values before child construction
- reject concurrent duplicate launches instead of allowing both through the check/build gap
- roll back reservations and pending records when child construction or executor submission fails
- add deterministic concurrency and failure-retry regression tests

## Problem

The public lifecycle API merged in #72501 documents correlation-ID deduplication, but `launch()` checked the registry before constructing the child and registered the correlation afterward. Two concurrent calls could both pass the check and launch separate children with the same parent/correlation pair.

## Fix

The registry now uses a pending reservation while construction occurs outside the registry lock. Registration plus executor submission is transactional: failed construction or rejected submission removes the exact reservation/record so a later retry can proceed.

No public API, handle schema, configuration, or documented behavior changes.

## Verification

- `uv run --frozen --extra dev pytest -q tests/agent/test_subagent_lifecycle.py tests/hermes_cli/test_plugins.py` — 137 passed
- `uv run --frozen --extra dev ruff check agent/subagent_lifecycle.py tests/agent/test_subagent_lifecycle.py` — passed
- `git diff --check origin/main...HEAD` — passed
- independent closeout review found no remaining correctness, concurrency, cleanup, API, or test-determinism blockers

Follow-up to #72501 and the lifecycle contract tracked in #65447.