### PR TITLE
fix(desktop): send a message edit when the arrow is clicked

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -555,7 +555,17 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
     }
 
     setSubmitting(true)
-    aui.composer().send()
+
+    // `aui.composer().send()` throws "Composer is not available" when the edit
+    // composer core has been torn down (e.g. a blur-driven cancel raced the
+    // click). Reset `submitting` on failure so the arrow can't wedge on `true`
+    // and leave revert as the only way out (#49903 is the same unguarded-core
+    // hazard on the main composer).
+    try {
+      aui.composer().send()
+    } catch {
+      setSubmitting(false)
+    }
   }
 
   const handleEditBlur = useCallback(
@@ -590,7 +600,15 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         }
 
         closeTrigger()
-        aui.composer().cancel()
+
+        // Swallow the unbound-core throw: if the composer core was already torn
+        // down (a send/cancel raced this timer), cancel() throws "Composer is
+        // not available" as an uncaught renderer error. Nothing to cancel then.
+        try {
+          aui.composer().cancel()
+        } catch {
+          // Composer core already gone — the edit is closing anyway.
+        }
       }, 80)
     },
     [aui, closeTrigger, submitting, syncDraftFromEditor]
@@ -786,6 +804,13 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
                   submitEdit(editor)
                 }
               }}
+              // Keep focus in the editor on click: macOS doesn't focus a button
+              // on mousedown, so without this the arrow-click blurs the editor,
+              // the blur timer cancels the edit (tearing down the composer
+              // core), and the click's send() then throws against a dead core —
+              // the edit silently never sends. The restore button guards the
+              // same way.
+              onPointerDown={event => event.preventDefault()}
               title={copy.sendEdited}
               type="button"
             >

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit-gesture.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit-gesture.test.tsx
@@ -1,0 +1,151 @@
+import { type AppendMessage, AssistantRuntimeProvider, ExportedMessageRepository, type ThreadMessage } from '@assistant-ui/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+
+import { Thread } from '.'
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+afterEach(() => {
+  cleanup()
+})
+
+function stubOffsetDimension(
+  prop: 'offsetHeight' | 'offsetWidth',
+  clientProp: 'clientHeight' | 'clientWidth',
+  fallback: number
+) {
+  const previous = Object.getOwnPropertyDescriptor(HTMLElement.prototype, prop)
+
+  Object.defineProperty(HTMLElement.prototype, prop, {
+    configurable: true,
+    get() {
+      return previous?.get?.call(this) || (this as HTMLElement)[clientProp] || fallback
+    }
+  })
+}
+
+stubOffsetDimension('offsetWidth', 'clientWidth', 800)
+stubOffsetDimension('offsetHeight', 'clientHeight', 600)
+
+function userMessage(): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'edit me please' }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function assistantMessage(): ThreadMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'done' }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: { unstable_state: null, unstable_annotations: [], unstable_data: [], steps: [], custom: {} }
+  } as ThreadMessage
+}
+
+function Harness({ onEdit }: { onEdit: (message: AppendMessage) => Promise<void> }) {
+  const repository = ExportedMessageRepository.fromArray([userMessage(), assistantMessage()])
+
+  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
+    messageRepository: repository,
+    isRunning: false,
+    setMessages: () => {},
+    onNew: async () => {},
+    onEdit,
+    onCancel: async () => {},
+    onReload: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread cwd={null} gateway={null} sessionId="session-1" />
+    </AssistantRuntimeProvider>
+  )
+}
+
+// Regression for the desktop "editing a message, clicking the arrow does
+// nothing — I have to click revert" report.
+//
+// On macOS a <button> does NOT take DOM focus on mousedown, so clicking the
+// send arrow blurs the contenteditable (relatedTarget = null). The blur
+// schedules an 80ms timer that cancels the edit, tearing down the assistant-ui
+// edit-composer core. When the click's send() then runs, and again when the
+// blur timer fires, cancel()/send() on a torn-down core throw "Composer is not
+// available". The throw wedged the arrow (submitting stuck true) so only revert
+// worked.
+//
+// The blur throw fires from a real setTimeout, which jsdom routes to Node as an
+// `uncaughtException` (not a DOM error event), so a window 'error' probe misses
+// it. Capture process-level uncaught exceptions for the duration of the gesture
+// instead — an unguarded throw registers here and fails the test.
+describe('edit send arrow — macOS click gesture (blur races cancel)', () => {
+  it('sends without an uncaught "Composer is not available" when the arrow-click blurs the editor', async () => {
+    const uncaught: unknown[] = []
+    const onUncaught = (err: unknown) => {
+      uncaught.push(err)
+    }
+
+    process.on('uncaughtException', onUncaught)
+
+    try {
+      const onEdit = vi.fn(async () => {})
+      render(<Harness onEdit={onEdit} />)
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+      const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+
+      await act(async () => {
+        editor.focus()
+        editor.textContent = 'edited then clicked the arrow'
+        fireEvent.input(editor)
+      })
+
+      const send = await screen.findByRole('button', { name: 'Send edited message' })
+
+      // The real gesture: mousedown on the arrow (no focus on macOS) blurs the
+      // editor to <body>, then the click fires the send, then the blur's 80ms
+      // cancel timer runs on the now-torn-down core. Wait past 80ms so the timer
+      // completes within the captured window.
+      await act(async () => {
+        fireEvent.pointerDown(send)
+        editor.blur()
+        fireEvent.click(send)
+        await new Promise(resolve => setTimeout(resolve, 200))
+      })
+
+      await waitFor(() => {
+        expect(onEdit).toHaveBeenCalledTimes(1)
+      })
+
+      const composerErrors = uncaught.filter(err => /Composer is not available/.test(String(err)))
+
+      expect(composerErrors).toEqual([])
+    } finally {
+      process.off('uncaughtException', onUncaught)
+    }
+  })
+})


### PR DESCRIPTION
Clicking the edit composer's send arrow did nothing — the edit only went through if you clicked revert. Enter worked; the arrow didn't, which made it feel broken.

On macOS a `<button>` takes no focus on mousedown, so the arrow-click blurred the contenteditable. The blur's 80ms timer then cancelled the edit and tore down the assistant-ui composer core, and the click's `send()` threw `"Composer is not available"` against the dead core. `submitEdit` had already set `submitting = true`, so the arrow wedged and only revert worked. Enter never hit this because it doesn't blur the editor.

The fix guards focus on the send button with `onPointerDown` `preventDefault()`, the same way the restore button already does, so the click never blurs the editor and the core stays bound. `send()` and the blur-timer `cancel()` are also wrapped in the #49903 unguarded-core swallow so a raced teardown can never wedge the arrow or leak an uncaught renderer error.

Regression test reproduces the real macOS gesture (mousedown-doesn't-focus → blur → cancel races send); it fails on `main` and passes with the fix.