### PR TITLE
fix(memory): support managed-cloud dependency installs

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -162,12 +162,12 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
 
     print(f"\n  Installing dependencies: {', '.join(missing)}")
 
-    from hermes_cli.tools_config import _pip_install
+    from tools.lazy_deps import install_specs
 
     manual_cmd = f"uv pip install {' '.join(missing)}"
     try:
-        result = _pip_install(["--quiet"] + missing, timeout=120)
-        if result.returncode == 0:
+        result = install_specs(tuple(missing), timeout=120)
+        if result.success:
             print(f"  ✓ Installed {', '.join(missing)}")
         else:
             print(f"  ⚠ Failed to install {', '.join(missing)}")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5901,16 +5901,23 @@ def _install_memory_provider_pip_dependencies(dependencies: List[str]) -> List[D
             _command_result(kind="pip", name=", ".join(dependencies), status="already_installed")
         ]
 
-    uv_path = shutil.which("uv")
-    if uv_path:
-        command: Any = [uv_path, "pip", "install", "--python", sys.executable, "--quiet", *missing]
-        display = f"uv pip install --python {sys.executable} {' '.join(missing)}"
-    else:
-        command = [sys.executable, "-m", "pip", "install", "--quiet", *missing]
-        display = f"{sys.executable} -m pip install {' '.join(missing)}"
+    # Use the same installer as first-use lazy dependencies.  On the managed
+    # image the active venv is intentionally sealed and
+    # HERMES_LAZY_INSTALL_TARGET points at a writable durable volume; invoking
+    # uv with ``--python sys.executable`` here bypassed that target and made
+    # every dashboard-driven provider install fail with EACCES (#72981).
+    from tools.lazy_deps import install_specs
+
+    display = f"hermes dependency installer {' '.join(missing)}"
 
     try:
-        completed = _run_setup_command(command, display=display, timeout=240)
+        installed = install_specs(tuple(missing), timeout=240)
+        completed = subprocess.CompletedProcess(
+            args=display,
+            returncode=0 if installed.success else 1,
+            stdout=installed.stdout,
+            stderr=installed.stderr,
+        )
     except Exception as exc:
         return [
             _command_result(

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -516,10 +516,10 @@ def _ensure_sdk_installed() -> bool:
         return False
 
     print("  Installing honcho-ai...", flush=True)
-    from hermes_cli.tools_config import _pip_install
+    from tools.lazy_deps import install_specs
 
-    result = _pip_install(["honcho-ai==2.2.0"])
-    if result.returncode == 0:
+    result = install_specs(("honcho-ai==2.2.0",))
+    if result.success:
         print("  Installed.\n")
         return True
     else:

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -293,11 +293,11 @@ def test_install_dependencies_force_reinstalls_versioned_specs(tmp_path, monkeyp
 
     installed = []
 
-    def fake_pip_install(args, timeout=120):
-        installed.append(args)
-        return SimpleNamespace(returncode=0, stderr="")
+    def fake_install_specs(specs, timeout=120):
+        installed.append(specs)
+        return SimpleNamespace(success=True, stderr="")
 
-    monkeypatch.setattr("hermes_cli.tools_config._pip_install", fake_pip_install)
+    monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
 
     memory_setup._install_dependencies("mem0", force=True)
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -787,6 +787,43 @@ class TestWebServerEndpoints:
         assert providers["honcho"]["setup"]["dependencies_installed"] is True
         assert providers["honcho"]["status"] == "needs_config"
 
+    def test_memory_provider_setup_uses_durable_lazy_installer(
+        self, monkeypatch, tmp_path
+    ):
+        import tools.lazy_deps as lazy_deps
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+        monkeypatch.setenv(
+            "HERMES_LAZY_INSTALL_TARGET", str(tmp_path / "lazy-packages")
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"allow_lazy_installs": True}},
+        )
+        monkeypatch.setattr(web_server, "_dependency_importable", lambda dep: False)
+
+        captured = {}
+
+        def fake_install(specs, *, timeout=300):
+            captured["specs"] = specs
+            captured["timeout"] = timeout
+            captured["target"] = os.environ.get("HERMES_LAZY_INSTALL_TARGET")
+            return lazy_deps._InstallResult(True, "installed", "")
+
+        monkeypatch.setattr(lazy_deps, "_venv_pip_install", fake_install)
+
+        results = web_server._install_memory_provider_pip_dependencies(
+            ["honcho-ai==2.2.0"]
+        )
+
+        assert results[0]["status"] == "installed"
+        assert captured == {
+            "specs": ("honcho-ai==2.2.0",),
+            "timeout": 240,
+            "target": str(tmp_path / "lazy-packages"),
+        }
+
     def test_post_memory_provider_setup_runs_declared_external_install(self, monkeypatch):
         import subprocess
 

--- a/tests/tools/test_lazy_deps_durable_target.py
+++ b/tests/tools/test_lazy_deps_durable_target.py
@@ -88,6 +88,60 @@ class TestGatingWithTarget:
         )
         assert ld._allow_lazy_installs() is True
 
+    def test_setup_specs_use_durable_installer(self, monkeypatch, tmp_path):
+        target = tmp_path / "lazy"
+        monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(target))
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {}, raising=False
+        )
+
+        captured = {}
+
+        def fake_install(specs, *, timeout=300):
+            captured["specs"] = specs
+            captured["timeout"] = timeout
+            return ld._InstallResult(True, "ok", "")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+
+        result = ld.install_specs(("honcho-ai==2.2.0",), timeout=240)
+
+        assert result.success
+        assert captured == {
+            "specs": ("honcho-ai==2.2.0",),
+            "timeout": 240,
+        }
+
+    def test_setup_specs_block_when_sealed_without_target(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {}, raising=False
+        )
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *args, **kwargs: pytest.fail("installer must not run"),
+        )
+
+        result = ld.install_specs(("honcho-ai==2.2.0",))
+
+        assert not result.success
+        assert "sealed without a durable install target" in result.stderr
+
+    def test_setup_specs_reject_unsafe_manifest_value(self, monkeypatch):
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *args, **kwargs: pytest.fail("installer must not run"),
+        )
+
+        result = ld.install_specs(("honcho-ai; touch /tmp/nope",))
+
+        assert not result.success
+        assert "unsafe spec" in result.stderr
+
 
 # ---------------------------------------------------------------------------
 # ABI stamp / durable-store rebuild safety

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -755,6 +755,43 @@ def feature_missing(feature: str) -> tuple[str, ...]:
     return tuple(s for s in feature_specs(feature) if not _is_satisfied(s))
 
 
+def install_specs(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
+    """Install trusted setup-time specs through the lazy-dependency backend.
+
+    Memory-provider setup surfaces read dependency specs from a discovered
+    plugin manifest rather than from :data:`LAZY_DEPS`.  They still need the
+    same immutable-image behavior as ``ensure()``: honor the user's lazy
+    install kill switch, redirect into ``HERMES_LAZY_INSTALL_TARGET`` when
+    configured, constrain shared dependencies, and activate the durable
+    target on ``sys.path``.
+
+    Specs are restricted to the same package/version grammar accepted by
+    ``ensure()``.  Callers remain responsible for deciding which manifest is
+    trusted and whether a package is already installed.
+    """
+    normalized = tuple(str(spec).strip() for spec in specs if str(spec).strip())
+    if not normalized:
+        return _InstallResult(True, "", "")
+
+    for spec in normalized:
+        if not _spec_is_safe(spec):
+            return _InstallResult(
+                False,
+                "",
+                f"refusing to install unsafe spec {spec!r}",
+            )
+
+    if not _allow_lazy_installs():
+        return _InstallResult(
+            False,
+            "",
+            "lazy installs disabled (security.allow_lazy_installs=false or "
+            "the active venv is sealed without a durable install target)",
+        )
+
+    return _venv_pip_install(normalized, timeout=timeout)
+
+
 def ensure(feature: str, *, prompt: bool = True) -> None:
     """Make sure all packages for ``feature`` are importable.
 


### PR DESCRIPTION
## Summary

- route dashboard memory-provider installs through the existing durable lazy-dependency backend
- use the same guarded path from generic memory setup and the Honcho CLI
- reject unsafe manifest specs and honor both the user kill switch and immutable-image durable target

## Reproduction / cause

On the managed image, `/opt/hermes/.venv` is intentionally sealed and `HERMES_LAZY_INSTALL_TARGET` points to writable durable storage. The dashboard setup endpoint bypassed that mechanism and invoked `uv pip install --python sys.executable`, which attempted to write directly into `/opt/hermes/.venv` and failed with EACCES.

Closes #72981.

## Validation

- `scripts/run_tests.sh tests/tools/test_lazy_deps_durable_target.py tests/hermes_cli/test_memory_setup.py tests/hermes_cli/test_web_server.py tests/honcho_plugin/test_cli.py -q`
  - 596 passed
- `ruff check` on all changed Python files
- `git diff --check`

No credentials or managed-instance data are included.