### PR TITLE
fix: harden safe mode and write approval gates

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -82,6 +82,15 @@ class SubdirectoryHintTracker:
 
         Returns formatted hint text to append to the tool result, or None.
         """
+        # Safe/ignore-rules sessions must remain governance-isolated for their
+        # entire lifetime. Startup suppression is insufficient because this
+        # tracker otherwise discovers AGENTS.md/CLAUDE.md lazily after tools run.
+        if (
+            os.environ.get("HERMES_SAFE_MODE") == "1"
+            or os.environ.get("HERMES_IGNORE_RULES") == "1"
+        ):
+            return None
+
         dirs = self._extract_directories(tool_name, tool_args)
         if not dirs:
             return None

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -7,6 +7,13 @@ from unittest.mock import patch
 from agent.subdirectory_hints import SubdirectoryHintTracker
 
 
+@pytest.fixture(autouse=True)
+def clear_context_suppression_env(monkeypatch):
+    """Each test opts into safe/ignore mode explicitly when needed."""
+    monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+    monkeypatch.delenv("HERMES_IGNORE_RULES", raising=False)
+
+
 @pytest.fixture
 def project(tmp_path):
     """Create a mock project tree with hint files in subdirectories."""
@@ -41,6 +48,28 @@ def project(tmp_path):
 
 class TestSubdirectoryHintTracker:
     """Unit tests for SubdirectoryHintTracker."""
+
+    def test_safe_mode_disables_progressive_discovery(self, project, monkeypatch):
+        """Safe mode must never inject newly discovered governance files."""
+        monkeypatch.setenv("HERMES_SAFE_MODE", "1")
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(project / "backend" / "src" / "main.py")}
+        )
+
+        assert result is None
+
+    def test_ignore_rules_disables_progressive_discovery(self, project, monkeypatch):
+        """The explicit ignore-rules contract also covers lazy discovery."""
+        monkeypatch.setenv("HERMES_IGNORE_RULES", "1")
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(project / "backend" / "src" / "main.py")}
+        )
+
+        assert result is None
 
     def test_working_dir_not_loaded(self, project):
         """Working dir is pre-marked as loaded (startup handles it)."""

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -48,6 +48,23 @@ def test_invalid_subsystem_is_off(hermes_home):
     assert wa.write_approval_enabled("bogus") is False
 
 
+def test_config_read_failure_blocks_mutation(hermes_home, monkeypatch):
+    """An unreadable approval config must never be interpreted as gate-off."""
+    from tools import write_approval as wa
+
+    def fail_load():
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fail_load)
+
+    decision = wa.evaluate_gate(wa.MEMORY)
+
+    assert decision.blocked is True
+    assert decision.allow is False
+    assert decision.stage is False
+    assert "approval configuration" in decision.message.lower()
+
+
 def test_normalize_enabled_coerces_values():
     from tools import write_approval as wa
     # Real bools pass through.
@@ -76,6 +93,52 @@ def test_memory_gate_off_allows_write(hermes_home):
     assert r["success"] is True
     assert r["entry_count"] == 1
     assert wa.pending_count("memory") == 0
+
+
+def test_memory_gate_import_failure_blocks(hermes_home, monkeypatch):
+    """A broken approval subsystem must not silently permit memory writes."""
+    import builtins
+    import tools.memory_tool as memory_mod
+
+    real_import = builtins.__import__
+
+    def fail_gate_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tools" and "write_approval" in fromlist:
+            raise ImportError("approval module unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_gate_import)
+
+    raw_result = memory_mod._apply_write_gate("add", "memory", "x", None)
+    assert raw_result is not None
+    result = json.loads(raw_result)
+
+    assert result["success"] is False
+    assert "approval" in result["error"].lower()
+
+
+def test_batch_memory_gate_import_failure_blocks(hermes_home, monkeypatch):
+    """A broken approval subsystem must not silently permit batch memory writes."""
+    import builtins
+    import tools.memory_tool as memory_mod
+
+    real_import = builtins.__import__
+
+    def fail_gate_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tools" and "write_approval" in fromlist:
+            raise ImportError("approval module unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_gate_import)
+
+    raw_result = memory_mod._apply_batch_write_gate(
+        "memory", [{"action": "add", "content": "x"}]
+    )
+    assert raw_result is not None
+    result = json.loads(raw_result)
+
+    assert result["success"] is False
+    assert "approval" in result["error"].lower()
 
 
 def test_memory_gate_on_no_interactive_stages(hermes_home):
@@ -183,6 +246,30 @@ def test_skill_gate_off_allows_create(hermes_home):
     r = json.loads(smt.skill_manage("create", "free-skill", content=_SKILL))
     assert r.get("success") is True
     assert wa.pending_count("skills") == 0
+
+
+def test_skill_gate_import_failure_blocks(hermes_home, monkeypatch):
+    """A broken approval subsystem must not silently permit skill writes."""
+    import builtins
+    import tools.skill_manager_tool as skill_mod
+
+    real_import = builtins.__import__
+
+    def fail_gate_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tools" and "write_approval" in fromlist:
+            raise ImportError("approval module unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_gate_import)
+
+    raw_result = skill_mod._apply_skill_write_gate(
+        "create", "blocked-skill", content=_SKILL
+    )
+    assert raw_result is not None
+    result = json.loads(raw_result)
+
+    assert result["success"] is False
+    assert "approval" in result["error"].lower()
 
 
 def test_skill_gate_on_always_stages(hermes_home):

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -939,10 +939,11 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
 
     try:
         from tools import write_approval as wa
-    except Exception:
-        # If the gate module can't load, fail open (current behaviour) rather
-        # than blocking all memory writes.
-        return None
+    except Exception as exc:
+        return tool_error(
+            f"Memory write blocked: approval subsystem unavailable ({exc}).",
+            success=False,
+        )
 
     # Build a small inline summary/detail for the foreground approval prompt.
     label = "user profile" if target == "user" else "memory"
@@ -992,8 +993,11 @@ def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Op
     """
     try:
         from tools import write_approval as wa
-    except Exception:
-        return None
+    except Exception as exc:
+        return tool_error(
+            f"Memory write blocked: approval subsystem unavailable ({exc}).",
+            success=False,
+        )
 
     label = "user profile" if target == "user" else "memory"
     summary = f"apply {len(operations)} op(s) to {label}"

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1345,8 +1345,11 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
 
     try:
         from tools import write_approval as wa
-    except Exception:
-        return None  # fail open
+    except Exception as exc:
+        return tool_error(
+            f"Skill write blocked: approval subsystem unavailable ({exc}).",
+            success=False,
+        )
 
     decision = wa.evaluate_gate(wa.SKILLS)
     if decision.allow:

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -71,22 +71,32 @@ CONFIG_KEY = "write_approval"
 # Config resolution
 # ---------------------------------------------------------------------------
 
+def _read_write_approval_enabled(subsystem: str) -> bool:
+    """Resolve the gate from config, propagating read failures to the caller."""
+    if subsystem not in _SUBSYSTEMS:
+        return False
+    from hermes_cli.config import load_config, cfg_get
+
+    cfg = load_config()
+    raw = cfg_get(cfg, subsystem, CONFIG_KEY, default=False)
+    return _normalize_enabled(raw)
+
+
 def write_approval_enabled(subsystem: str) -> bool:
     """Return whether the approval gate is enabled for ``subsystem``.
 
     Reads ``<subsystem>.write_approval`` from config.yaml. Defaults to
-    ``False`` (gate off — writes flow freely) for any unset / invalid value so
-    existing installs keep their current behaviour until the user opts in.
+    ``False`` for an unset value. If config cannot be read, fail closed by
+    reporting the gate as enabled; mutation paths use the stricter resolver
+    in :func:`evaluate_gate` and block rather than staging.
     """
     if subsystem not in _SUBSYSTEMS:
         return False
     try:
-        from hermes_cli.config import load_config, cfg_get
-        cfg = load_config()
-        raw = cfg_get(cfg, subsystem, CONFIG_KEY, default=False)
-    except Exception:
-        return False
-    return _normalize_enabled(raw)
+        return _read_write_approval_enabled(subsystem)
+    except Exception as exc:
+        logger.error("Could not resolve %s write approval; failing closed: %s", subsystem, exc)
+        return True
 
 
 def _normalize_enabled(value: Any) -> bool:
@@ -267,11 +277,24 @@ def evaluate_gate(subsystem: str, *, inline_summary: str = "",
         gate on, memory + gateway/script/bg   → stage
         gate on, skills (any origin)          → stage (too big to review inline)
 
-    Note: there is no config-driven "blocked" outcome — the gate only ever
-    delays a write for approval, never silently refuses it. ``blocked`` is
-    still produced when the user *actively denies* an inline prompt.
+    With a valid configuration there is no config-driven ``blocked`` outcome:
+    the gate delays writes for approval, and an explicit inline denial blocks.
+    If approval configuration cannot be resolved, the safe fallback is also a
+    blocked decision so a control-plane failure cannot silently enable writes.
     """
-    if not write_approval_enabled(subsystem):
+    try:
+        gate_enabled = _read_write_approval_enabled(subsystem)
+    except Exception as exc:
+        logger.error("Could not resolve %s write approval; blocking mutation: %s", subsystem, exc)
+        return GateDecision(
+            blocked=True,
+            message=(
+                f"{subsystem.capitalize()} write blocked: approval configuration "
+                "could not be read. No change was staged or saved."
+            ),
+        )
+
+    if not gate_enabled:
         return GateDecision(allow=True)
 
     background = is_background()


### PR DESCRIPTION
## Summary
- suppress progressive AGENTS.md/CLAUDE.md discovery when safe mode or ignore-rules mode is active
- fail closed when memory or skill write-approval configuration cannot be read
- fail closed for single-memory, batch-memory, and skill writes when the approval subsystem cannot load
- add regression coverage for each hardened path

## Verification
- runtime negative controls confirmed no subdirectory governance injection in safe mode
- `74 passed` in the focused safe-mode/write-approval suite
- `git diff --check` passed
- independent pre-commit review found no blocking security or logic defects

## Scope
Tracked changes are limited to six implementation/test files; containment configuration is unchanged.