### PR TITLE
fix(agent): preserve Codex watchdog error causality

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -681,7 +681,8 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     type(e).__name__,
                 )
                 return
-            result["error"] = e
+            if result["error"] is None:
+                result["error"] = e
         finally:
             _close_request_client_once("request_complete")
 
@@ -883,6 +884,17 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
                     f"Reconnecting."
                 )
+            if result["error"] is None and result["response"] is None:
+                if _silent_hint:
+                    result["error"] = TimeoutError(
+                        f"Codex stream produced no bytes within {int(_elapsed)}s "
+                        f"(TTFB threshold: {int(_ttfb_timeout)}s). {_silent_hint}"
+                    )
+                else:
+                    result["error"] = TimeoutError(
+                        f"Codex stream produced no bytes within {int(_elapsed)}s "
+                        f"(TTFB threshold: {int(_ttfb_timeout)}s)"
+                    )
             try:
                 _close_request_client_once("codex_ttfb_kill")
             except Exception:
@@ -896,17 +908,6 @@ def interruptible_api_call(agent, api_kwargs: dict):
             )
             # Wait briefly for the worker to notice the closed connection.
             t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
-                if _silent_hint:
-                    result["error"] = TimeoutError(
-                        f"Codex stream produced no bytes within {int(_elapsed)}s "
-                        f"(TTFB threshold: {int(_ttfb_timeout)}s). {_silent_hint}"
-                    )
-                else:
-                    result["error"] = TimeoutError(
-                        f"Codex stream produced no bytes within {int(_elapsed)}s "
-                        f"(TTFB threshold: {int(_ttfb_timeout)}s)"
-                    )
             break
 
         # Stream-idle detector: the Codex backend emitted at least one SSE
@@ -933,6 +934,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 f"after first byte (model: {api_kwargs.get('model', 'unknown')}). "
                 f"Reconnecting."
             )
+            if result["error"] is None and result["response"] is None:
+                result["error"] = TimeoutError(
+                    f"Codex stream produced no SSE events for {int(_event_stale_elapsed)}s "
+                    f"after first byte (threshold: {int(_codex_idle_timeout)}s)"
+                )
             try:
                 _close_request_client_once("codex_stream_idle_kill")
             except Exception:
@@ -941,11 +947,6 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 f"codex stream killed after {int(_event_stale_elapsed)}s with no SSE events"
             )
             t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
-                result["error"] = TimeoutError(
-                    f"Codex stream produced no SSE events for {int(_event_stale_elapsed)}s "
-                    f"after first byte (threshold: {int(_codex_idle_timeout)}s)"
-                )
             break
 
         # Stale-call detector: kill the connection if no response
@@ -977,6 +978,18 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
                     f"Aborting call."
                 )
+            if result["error"] is None and result["response"] is None:
+                if _silent_hint:
+                    result["error"] = TimeoutError(
+                        f"Non-streaming API call timed out after {int(_elapsed)}s "
+                        f"with no response (threshold: {int(_stale_timeout)}s). "
+                        f"{_silent_hint}"
+                    )
+                else:
+                    result["error"] = TimeoutError(
+                        f"Non-streaming API call timed out after {int(_elapsed)}s "
+                        f"with no response (threshold: {int(_stale_timeout)}s)"
+                    )
             try:
                 # #67142: routes by client kind — anthropic now aborts the
                 # request-local client's sockets from this poll (stranger)
@@ -992,18 +1005,6 @@ def interruptible_api_call(agent, api_kwargs: dict):
             )
             # Wait briefly for the thread to notice the closed connection.
             t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
-                if _silent_hint:
-                    result["error"] = TimeoutError(
-                        f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s). "
-                        f"{_silent_hint}"
-                    )
-                else:
-                    result["error"] = TimeoutError(
-                        f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s)"
-                    )
             break
 
         if agent._interrupt_requested:

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -17,6 +17,7 @@ stall.
 from __future__ import annotations
 
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
@@ -55,6 +56,109 @@ def _make_codex_agent(tmp_path, monkeypatch):
         agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 60.0
     )
     return agent
+
+
+def _install_watchdog_abort_transport_race(agent, monkeypatch, *, first_event: bool):
+    """Make the worker publish its abort-caused transport error before main resumes."""
+    abort_called = threading.Event()
+    worker_closed = threading.Event()
+    closes: list[str | None] = []
+    dummy_client = SimpleNamespace()
+
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+
+    def abort_client(_client, reason=None):
+        closes.append(reason)
+        abort_called.set()
+        assert worker_closed.wait(5), "worker did not unwind after watchdog abort"
+
+    def close_client(_client, reason=None):
+        closes.append(reason)
+        if reason == "request_complete":
+            worker_closed.set()
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        if first_event:
+            agent._codex_stream_last_event_ts = time.time()
+        assert abort_called.wait(10), "watchdog did not abort the request"
+        raise RuntimeError("transport closed by watchdog abort")
+
+    monkeypatch.setattr(agent, "_abort_request_openai_client", abort_client)
+    monkeypatch.setattr(agent, "_close_request_openai_client", close_client)
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+    return closes
+
+
+class ProviderStatusError(RuntimeError):
+    status_code = 429
+
+
+def test_ttfb_watchdog_abort_transport_error_stays_timeout(tmp_path, monkeypatch):
+    """The transport error caused by the TTFB watchdog abort is not the result."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "1")
+    closes = _install_watchdog_abort_transport_race(
+        agent, monkeypatch, first_event=False
+    )
+
+    with pytest.raises(TimeoutError) as excinfo:
+        h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+
+    assert "TTFB" in str(excinfo.value)
+    assert "codex_ttfb_kill" in closes
+
+
+def test_event_idle_watchdog_abort_transport_error_stays_timeout(tmp_path, monkeypatch):
+    """The transport error caused by the idle watchdog abort is not the result."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "10")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "1")
+    closes = _install_watchdog_abort_transport_race(
+        agent, monkeypatch, first_event=True
+    )
+
+    with pytest.raises(TimeoutError) as excinfo:
+        h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+
+    assert "after first byte" in str(excinfo.value)
+    assert "codex_stream_idle_kill" in closes
+    assert "codex_ttfb_kill" not in closes
+
+
+def test_published_status_error_wins_over_later_ttfb_deadline(tmp_path, monkeypatch):
+    """Do not overwrite a provider/status error already published by the worker."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "1")
+    provider_error = ProviderStatusError("rate limited")
+    release_close = threading.Event()
+    close_started = threading.Event()
+    dummy_client = SimpleNamespace()
+
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(agent, "_run_codex_stream", lambda *a, **k: (_ for _ in ()).throw(provider_error))
+    monkeypatch.setattr(agent, "_abort_request_openai_client", lambda *a, **k: release_close.set())
+
+    def close_client(_client, reason=None):
+        if reason == "request_complete":
+            close_started.set()
+            assert release_close.wait(5), "test did not release worker close"
+
+    monkeypatch.setattr(agent, "_close_request_openai_client", close_client)
+
+    try:
+        with pytest.raises(ProviderStatusError) as excinfo:
+            h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+    finally:
+        release_close.set()
+
+    assert excinfo.value is provider_error
+    assert close_started.is_set()
 
 
 def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Preserves exception causality when a Codex TTFB or event-idle watchdog races the provider worker.

- Transport failures caused by the watchdog abort remain `TimeoutError`.
- Genuine provider, authentication, rate-limit, and status errors remain their original exceptions even when they arrive at the deadline.
- Existing first-byte and event-idle timeout behavior is unchanged.

This is the Codex watchdog successor to the corresponding slice of #72853.

## Related Issue

Supersedes the Codex watchdog portion of #72853.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`: track whether the watchdog owns the abort before converting the resulting transport error to a timeout.
- `tests/agent/test_codex_ttfb_watchdog.py`: cover TTFB and event-idle abort races plus genuine provider-error preservation.

## How to Test

1. `HERMES_PYTHON=<python> scripts/run_tests.sh tests/agent/test_codex_ttfb_watchdog.py --file-retries 0 -q`
2. Confirm all 25 tests pass.
3. Run Ruff, `scripts/check-windows-footguns.py --all`, and `git diff --check`.

Exact local validation base: `dbc18c6d62c02c664c94978120df972d01ca0fe7`  
Exact candidate: `d3876bf432551edcc0030ed8f79c3ea8aa718b27`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Focused suite: 25 passed, 0 failed. Final combined tree `95b25573b2c13c82880e5906b2f473ac0d657b90`: 48,759 passed, 1 failed—the detailed-health test owned by #72582. The #71581 snapshot test passed on retry; an unrelated interrupt race also passed on retry and in five isolated no-retry runs.
