### PR TITLE
fix(gui): require npm only for desktop build paths

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6587,15 +6587,7 @@ def cmd_gui(args: argparse.Namespace):
     force_build = getattr(args, "force_build", False)
 
     packaged_executable = _desktop_packaged_executable(desktop_dir)
-
-    if source_mode or not skip_build:
-        npm = _resolve_node_runtime_npm()
-        if not npm:
-            print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
-            print("Install Node.js, then run:  hermes gui")
-            sys.exit(1)
-    else:
-        npm = None
+    npm = None
 
     if skip_build:
         if source_mode:
@@ -6629,6 +6621,11 @@ def cmd_gui(args: argparse.Namespace):
             build_label = "source build" if source_mode else "packaged app"
             print(f"✓ Desktop {build_label} is up to date (content stamp matches)")
         else:
+            npm = _resolve_node_runtime_npm()
+            if not npm:
+                print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
+                print("Install Node.js, then run:  hermes gui")
+                sys.exit(1)
             print("→ Installing desktop workspace dependencies...")
             # Put the Hermes-managed Node on PATH so npm's child scripts (which
             # shell out to bare `node`, e.g. electron-winstaller's
@@ -6768,6 +6765,12 @@ def cmd_gui(args: argparse.Namespace):
         return
 
     if source_mode:
+        if npm is None:
+            npm = _resolve_node_runtime_npm()
+            if not npm:
+                print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
+                print("Install Node.js, then run:  hermes gui")
+                sys.exit(1)
         print("→ Launching Hermes Desktop from source build...")
         launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
         sys.exit(launch_result.returncode)

--- a/tests/hermes_cli/test_desktop_exe_integrity.py
+++ b/tests/hermes_cli/test_desktop_exe_integrity.py
@@ -536,7 +536,7 @@ def test_build_only_fails_when_pack_produces_corrupt_exe(tmp_path, monkeypatch, 
     install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
     pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \
@@ -570,7 +570,7 @@ def test_build_only_succeeds_with_valid_exe(tmp_path, monkeypatch, capsys):
     install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
     pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -363,6 +363,27 @@ def test_desktop_build_stamp_skips_build_when_up_to_date(tmp_path, monkeypatch):
     mock_run.assert_called_once()  # only the launch call, no build
 
 
+def test_up_to_date_packaged_gui_launch_skips_npm_resolution(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value=None) as mock_resolve, \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    mock_resolve.assert_not_called()
+    mock_install.assert_not_called()
+    assert mock_run.call_args.args[0] == [str(packaged_exe)]
+
+
 def test_desktop_force_build_overrides_stamp(tmp_path, monkeypatch):
     """--force-build forces a rebuild even when the stamp says up-to-date."""
     root = _make_desktop_tree(tmp_path)


### PR DESCRIPTION
## What does this PR do?

Makes npm resolution lazy for the native desktop command.

An existing packaged desktop app can launch when its content stamp is current even if Node/npm is unavailable. Actual build, install, and source-launch paths still resolve npm and fail with the existing clear message when it is missing.

This is the desktop GUI successor to the corresponding slice of #72853.

## Related Issue

Supersedes the desktop GUI portion of #72853.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: resolve npm only after deciding a build is required, or immediately before a source launch that needs npm.
- `tests/hermes_cli/test_gui_command.py`: prove an up-to-date packaged launch never resolves npm.
- `tests/hermes_cli/test_desktop_exe_integrity.py`: mock the real npm resolver seam used by build-only behavior.

## How to Test

1. `HERMES_PYTHON=<python> scripts/run_tests.sh tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_desktop_exe_integrity.py --file-retries 0 -q`
2. Confirm all 95 tests pass.
3. Run Ruff, `scripts/check-windows-footguns.py --all`, and `git diff --check`.

Exact local validation base: `dbc18c6d62c02c664c94978120df972d01ca0fe7`  
Exact candidate: `a42f48ed4791269f4ea97a208ffff30585ce17c9`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Focused suite: 95 passed, 0 failed. Final combined tree `95b25573b2c13c82880e5906b2f473ac0d657b90`: 48,759 passed, 1 failed—the detailed-health test owned by #72582. The #71581 snapshot test passed on retry; an unrelated interrupt race also passed on retry and in five isolated no-retry runs.
