### PR TITLE
fix(tests): verify owned process groups before signaling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -658,36 +658,96 @@ def _live_system_guard(request, monkeypatch):
     import subprocess as _subprocess
 
     test_pid = _os.getpid()
-    # Capture the test process's existing children at fixture start —
-    # any *new* children spawned by the test are also allowlisted via
-    # the live psutil walk below. Static set keeps the fast path cheap.
+    # Capture the test process's existing children at fixture start by
+    # identity, not raw PID. PIDs/PGIDs are reusable live-system integers.
     try:
         import psutil as _psutil
-        _initial_children = {
-            c.pid for c in _psutil.Process(test_pid).children(recursive=True)
-        }
+
+        _initial_children = {}
+        for child in _psutil.Process(test_pid).children(recursive=True):
+            try:
+                _initial_children[child.pid] = child.create_time()
+            except Exception:
+                pass
     except Exception:
         _psutil = None
-        _initial_children = set()
+        _initial_children = {}
+
+    _recorded_children = {}
+    _MISSING = object()
+
+    def _is_no_such_process(exc: Exception) -> bool:
+        if isinstance(exc, ProcessLookupError):
+            return True
+        return _psutil is not None and isinstance(
+            exc, getattr(_psutil, "NoSuchProcess", ())
+        )
+
+    def _current_create_time(pid: int):
+        if _psutil is None:
+            return None
+        try:
+            return _psutil.Process(pid).create_time()
+        except Exception as exc:
+            if _is_no_such_process(exc):
+                raise ProcessLookupError(pid) from exc
+            return None
+
+    def _record_child(pid) -> None:
+        try:
+            pid = int(pid)
+        except Exception:
+            return
+        if pid <= 0:
+            return
+        try:
+            create_time = _current_create_time(pid)
+        except ProcessLookupError:
+            return
+        _recorded_children[pid] = create_time
+
+    def _identity_matches(pid: int, expected_create_time) -> bool:
+        if expected_create_time is None:
+            return False
+        return _current_create_time(pid) == expected_create_time
+
+    def _recorded_identity_matches(pid: int):
+        expected = _recorded_children.get(pid, _MISSING)
+        if expected is _MISSING:
+            return None
+        return _identity_matches(pid, expected)
+
+    def _recorded_child_owns_process_group(pid: int) -> bool:
+        try:
+            if _recorded_identity_matches(pid) is not True:
+                return False
+        except ProcessLookupError:
+            return False
+        if not hasattr(_os, "getsid"):
+            return False
+        try:
+            return _os.getpgid(pid) == pid and _os.getsid(pid) == pid
+        except Exception:
+            return False
 
     def _is_own_subtree(pid: int) -> bool:
-        # PID 0 means "our own process group"; -1 means "every process we
-        # can signal". Both are dangerous when paired with SIGTERM/SIGKILL,
-        # but pid 0 is technically scoped to our group so allow it; pid -1
-        # is treated as foreign (refuse).
-        if pid == 0:
-            return True
-        if pid < 0:
+        # PID 0 means "our own process group" and negative PIDs target process
+        # groups or every signalable process. Destructive uses are never safe.
+        if pid <= 0:
             return False
-        if pid == test_pid or pid in _initial_children:
+        if pid == test_pid:
             return True
+        if pid in _initial_children:
+            try:
+                return _identity_matches(pid, _initial_children[pid])
+            except ProcessLookupError:
+                return False
         if _psutil is None:
             return False
         try:
             walker = _psutil.Process(pid)
         except Exception:
-            # Stale PID — kill would be a no-op anyway, allow it.
-            return True
+            return False
         try:
             for parent in walker.parents():
                 if parent.pid == test_pid:
@@ -706,7 +766,18 @@ def _live_system_guard(request, monkeypatch):
         # test_entire_tree_is_sigkilled_not_just_parent.
         if int(sig) == 0:
             return real_kill(pid, sig, *args, **kwargs)
-        if _is_own_subtree(int(pid)):
+        pid_int = int(pid)
+        try:
+            recorded_match = _recorded_identity_matches(pid_int)
+        except ProcessLookupError:
+            raise
+        if recorded_match is False:
+            raise RuntimeError(
+                f"tests/conftest.py live-system guard: blocked os.kill("
+                f"{pid}, {sig}) — recorded child PID identity is stale or "
+                "unverifiable."
+            )
+        if recorded_match is True or _is_own_subtree(pid_int):
             return real_kill(pid, sig, *args, **kwargs)
         raise RuntimeError(
             f"tests/conftest.py live-system guard: blocked os.kill("
@@ -722,24 +793,22 @@ def _live_system_guard(request, monkeypatch):
     monkeypatch.setattr(_os, "kill", _guarded_kill)
 
     # ``os.killpg`` is the same risk class — sends a signal to every
-    # process in a group. The gateway is a session leader (its own
-    # PGID == its PID), so killpg(gateway_pid, SIGTERM) is a one-shot
-    # kill of the live process. Allow it only when the target PGID is
-    # the test process's own group.
+    # process in a group. A PGID is not process identity, so destructive
+    # group signals are allowed only for a recorded child that still proves
+    # it owns a fresh session/process group (start_new_session=True).
     if hasattr(_os, "killpg"):
         real_killpg = _os.killpg
-        own_pgid = _os.getpgrp()
 
         def _guarded_killpg(pgid, sig, *args, **kwargs):
             # Signal 0 is a pure liveness probe — never destructive.
             if int(sig) == 0:
                 return real_killpg(pgid, sig, *args, **kwargs)
-            if int(pgid) == own_pgid or _is_own_subtree(int(pgid)):
+            if _recorded_child_owns_process_group(int(pgid)):
                 return real_killpg(pgid, sig, *args, **kwargs)
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
-                f"os.killpg({pgid}, {sig}) — PGID is outside the test "
-                "process group. See _live_system_guard for the why."
+                f"killpg({pgid}, {sig}) — PGID ownership is stale or "
+                "unverifiable. See _live_system_guard for the why."
             )
 
         monkeypatch.setattr(_os, "killpg", _guarded_killpg)
@@ -891,6 +960,7 @@ def _live_system_guard(request, monkeypatch):
             def __init__(self, cmd, *args, **kwargs):
                 _check_subprocess_cmd("Popen", cmd)
                 super().__init__(cmd, *args, **kwargs)
+                _record_child(self.pid)
 
         _GuardedPopen.__name__ = "Popen"
         _GuardedPopen.__qualname__ = "Popen"
@@ -963,11 +1033,15 @@ def _live_system_guard(request, monkeypatch):
             _check_subprocess_cmd(
                 "asyncio.create_subprocess_exec", [program, *args]
             )
-            return await real_async_exec(program, *args, **kwargs)
+            proc = await real_async_exec(program, *args, **kwargs)
+            _record_child(proc.pid)
+            return proc
 
         async def _guarded_async_shell(cmd, *args, **kwargs):
             _check_subprocess_cmd("asyncio.create_subprocess_shell", cmd)
-            return await real_async_shell(cmd, *args, **kwargs)
+            proc = await real_async_shell(cmd, *args, **kwargs)
+            _record_child(proc.pid)
+            return proc
 
         monkeypatch.setattr(_asyncio, "create_subprocess_exec", _guarded_async_exec)
         monkeypatch.setattr(

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import signal
 import subprocess
 import threading
 import time
@@ -4747,7 +4748,11 @@ def test_dispatch_once_integrates_stale_detection(kanban_home, monkeypatch):
     """dispatch_once with stale_timeout_seconds reclaims stale running tasks."""
     import hermes_cli.kanban_db as _kb
 
+    signals = []
     monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(
+        _kb.os, "kill", lambda pid, sig: signals.append((pid, sig))
+    )
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="stale-dispatch", assignee="worker")
@@ -4772,6 +4777,7 @@ def test_dispatch_once_integrates_stale_detection(kanban_home, monkeypatch):
         )
         assert t in res.stale, "Stale task should appear in result.stale"
         assert kb.get_task(conn, t).status == "ready"
+        assert signals == [(99999, signal.SIGTERM)]
 
 
 def test_dispatch_once_stale_disabled_when_timeout_zero(kanban_home, monkeypatch):

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import sys
 import types
 
 import pytest
@@ -29,9 +30,86 @@ import pytest
 FOREIGN_PID = 1
 
 
+_SLEEP_FOR_TEST = "import time; time.sleep(30)"
+_PID_ZERO_CANARY_CHILD = "HERMES_LIVE_GUARD_PID_ZERO_CANARY_CHILD"
+
+
+def _sleeping_child(**kwargs) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [sys.executable, "-c", _SLEEP_FOR_TEST],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        **kwargs,
+    )
+
+
+def _cleanup_child(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=2)
+    except (ProcessLookupError, subprocess.TimeoutExpired):
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=2)
+
+
+def _patch_psutil_process_for_pid(
+    monkeypatch: pytest.MonkeyPatch,
+    pid: int,
+    *,
+    parents: list[int] | None = None,
+    create_time_delta: float = 0.0,
+    access_denied: bool = False,
+    no_such_process: bool = False,
+) -> None:
+    import psutil
+
+    real_process = psutil.Process
+
+    class FakeProcess:
+        def __init__(self, current_pid: int):
+            if current_pid == pid and no_such_process:
+                raise psutil.NoSuchProcess(pid)
+            self.pid = current_pid
+            self._real = real_process(current_pid)
+
+        def create_time(self):
+            if self.pid == pid and access_denied:
+                raise psutil.AccessDenied(pid=pid)
+            value = self._real.create_time()
+            if self.pid == pid:
+                return value + create_time_delta
+            return value
+
+        def parents(self):
+            if self.pid == pid and parents is not None:
+                return [types.SimpleNamespace(pid=parent) for parent in parents]
+            return self._real.parents()
+
+        def __getattr__(self, name: str):
+            return getattr(self._real, name)
+
+    monkeypatch.setattr(psutil, "Process", FakeProcess)
+
+
+def _stub_systemctl(tmp_path, monkeypatch) -> None:
+    stub = tmp_path / "systemctl"
+    stub.write_text(
+        "#!/bin/sh\nprintf 'stub-systemctl:%s\\n' \"$*\"\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
 # ──────────────────── fail-closed self-protection ──────────────
 #
-# This file executes REAL kill primitives — os.kill(-1, SIGTERM), os.killpg,
+# This file executes REAL kill primitives — os.kill(-1, SIGTERM), killpg,
 # pkill -f python — and depends entirely on the autouse ``_live_system_guard``
 # fixture in tests/conftest.py to intercept them. That makes the canary
 # fail-OPEN: in any collection context where this file is present but its home
@@ -76,7 +154,7 @@ def _refuse_to_fire_live_weapons(request):
             "REFUSING TO RUN: the live-system guard from tests/conftest.py is "
             "not active in this interpreter (os.kill is still the raw C "
             "builtin). This canary file executes real kill primitives — "
-            "os.kill(-1, SIGTERM), os.killpg, pkill -f python — and relies on "
+            "os.kill(-1, SIGTERM), killpg, pkill -f python — and relies on "
             "the guard to intercept them; unguarded, they SIGTERM every process "
             "the current user owns. This usually means the file was collected "
             "without its home tests/conftest.py (note: a test*.py copy glob "
@@ -116,10 +194,184 @@ def test_os_kill_blocks_negative_one():
         os.kill(-1, signal.SIGTERM)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX PID-zero semantics")
+def test_os_kill_blocks_destructive_zero_pid():
+    """A broken guard may kill only the isolated child session, never pytest's parent."""
+    if os.environ.get(_PID_ZERO_CANARY_CHILD) == "1":
+        with pytest.raises(RuntimeError, match="live-system guard"):
+            os.kill(0, signal.SIGTERM)
+        return
+
+    env = os.environ.copy()
+    env[_PID_ZERO_CANARY_CHILD] = "1"
+    test_node = f"{__file__}::test_os_kill_blocks_destructive_zero_pid"
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", test_node],
+        env=env,
+        capture_output=True,
+        text=True,
+        start_new_session=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 @pytest.mark.skipif(not hasattr(os, "killpg"), reason="killpg POSIX-only")
 def test_os_killpg_blocks_foreign_pgid():
     with pytest.raises(RuntimeError, match="live-system guard"):
-        os.killpg(FOREIGN_PID, signal.SIGTERM)
+        os.killpg(FOREIGN_PID, signal.SIGTERM)  # windows-footgun: ok — POSIX-only
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="killpg POSIX-only")
+def test_recorded_new_session_child_killpg_passes_with_hidden_parent_chain(
+    monkeypatch,
+):
+    proc = _sleeping_child(start_new_session=True)
+    try:
+        with monkeypatch.context() as mp:
+            _patch_psutil_process_for_pid(mp, proc.pid, parents=[])
+            os.killpg(proc.pid, signal.SIGTERM)  # windows-footgun: ok — POSIX-only
+        proc.wait(timeout=2)
+    finally:
+        _cleanup_child(proc)
+    assert proc.returncode in {-signal.SIGTERM, 128 + int(signal.SIGTERM)}
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="killpg POSIX-only")
+def test_recorded_non_session_leader_child_killpg_is_blocked():
+    proc = _sleeping_child()
+    try:
+        with pytest.raises(RuntimeError, match="live-system guard"):
+            os.killpg(proc.pid, signal.SIGTERM)  # windows-footgun: ok — POSIX-only
+        assert proc.poll() is None
+    finally:
+        _cleanup_child(proc)
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="killpg POSIX-only")
+def test_recorded_exited_new_session_child_killpg_is_blocked():
+    proc = _sleeping_child(start_new_session=True)
+    pid = proc.pid
+    try:
+        os.kill(pid, signal.SIGTERM)
+        proc.wait(timeout=2)
+        with pytest.raises(RuntimeError, match="live-system guard"):
+            os.killpg(pid, signal.SIGTERM)  # windows-footgun: ok — POSIX-only
+    finally:
+        _cleanup_child(proc)
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="killpg POSIX-only")
+@pytest.mark.parametrize(
+    "identity_override",
+    [
+        {"create_time_delta": 1000.0},
+        {"access_denied": True},
+    ],
+    ids=["mismatched", "unverifiable"],
+)
+def test_recorded_new_session_child_killpg_requires_current_identity(
+    monkeypatch, identity_override
+):
+    proc = _sleeping_child(start_new_session=True)
+    try:
+        with monkeypatch.context() as mp:
+            _patch_psutil_process_for_pid(mp, proc.pid, **identity_override)
+            with pytest.raises(RuntimeError, match="live-system guard"):
+                os.killpg(proc.pid, signal.SIGTERM)  # windows-footgun: ok — POSIX-only
+        assert proc.poll() is None
+    finally:
+        _cleanup_child(proc)
+
+
+def test_recorded_child_mismatched_identity_blocks_os_kill(monkeypatch):
+    proc = _sleeping_child()
+    try:
+        with monkeypatch.context() as mp:
+            _patch_psutil_process_for_pid(
+                mp,
+                proc.pid,
+                parents=[os.getpid()],
+                create_time_delta=1000.0,
+            )
+            with pytest.raises(RuntimeError, match="live-system guard"):
+                os.kill(proc.pid, signal.SIGTERM)
+        assert proc.poll() is None
+    finally:
+        _cleanup_child(proc)
+
+
+def test_recorded_child_unverifiable_identity_blocks_os_kill(monkeypatch):
+    proc = _sleeping_child()
+    try:
+        with monkeypatch.context() as mp:
+            _patch_psutil_process_for_pid(
+                mp,
+                proc.pid,
+                parents=[os.getpid()],
+                access_denied=True,
+            )
+            with pytest.raises(RuntimeError, match="live-system guard"):
+                os.kill(proc.pid, signal.SIGTERM)
+        assert proc.poll() is None
+    finally:
+        _cleanup_child(proc)
+
+
+def test_recorded_child_missing_during_identity_check_raises_process_lookup(
+    monkeypatch,
+):
+    proc = _sleeping_child()
+    try:
+        with monkeypatch.context() as mp:
+            _patch_psutil_process_for_pid(mp, proc.pid, no_such_process=True)
+            with pytest.raises(ProcessLookupError):
+                os.kill(proc.pid, signal.SIGTERM)
+        assert proc.poll() is None
+    finally:
+        _cleanup_child(proc)
+
+
+@pytest.mark.parametrize("use_shell", [False, True], ids=["exec", "shell"])
+def test_asyncio_recorded_child_kill_passes_with_hidden_parent_chain(
+    monkeypatch, use_shell
+):
+    import asyncio
+
+    async def _exercise():
+        if use_shell:
+            command = subprocess.list2cmdline(
+                [sys.executable, "-c", _SLEEP_FOR_TEST]
+            )
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                _SLEEP_FOR_TEST,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        try:
+            with monkeypatch.context() as mp:
+                _patch_psutil_process_for_pid(mp, proc.pid, parents=[])
+                os.kill(proc.pid, signal.SIGTERM)
+            await asyncio.wait_for(proc.wait(), timeout=2)
+        finally:
+            if proc.returncode is None:
+                try:
+                    os.kill(proc.pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+                except ProcessLookupError:
+                    pass
+                await asyncio.wait_for(proc.wait(), timeout=2)
+        assert proc.returncode in {-signal.SIGTERM, 128 + int(signal.SIGTERM)}
+
+    asyncio.run(_exercise())
 
 
 # ──────────────────── subprocess regex bypasses ────────────────
@@ -278,51 +530,50 @@ def test_subprocess_killall_hermes_blocked():
 # ──────────────────── pass-through cases (must NOT raise) ──────
 
 
-def test_systemctl_status_passes_through():
+def test_systemctl_status_passes_through(tmp_path, monkeypatch):
     """Read-only systemctl probes (status/show/list-units) are fine."""
-    # Run with check=False so we don't fail on the gateway's exit code.
+    _stub_systemctl(tmp_path, monkeypatch)
     r = subprocess.run(
         ["systemctl", "--user", "status", "hermes-gateway", "--no-pager"],
         capture_output=True,
         text=True,
         check=False,
     )
-    assert r is not None  # Did not raise — the guard let it through.
+    assert "stub-systemctl:" in r.stdout
 
 
-def test_systemctl_show_passes_through():
+def test_systemctl_show_passes_through(tmp_path, monkeypatch):
+    _stub_systemctl(tmp_path, monkeypatch)
     r = subprocess.run(
         ["systemctl", "--user", "show", "hermes-gateway", "--no-pager"],
         capture_output=True,
         text=True,
         check=False,
     )
-    assert r is not None
+    assert "stub-systemctl:" in r.stdout
 
 
-def test_systemctl_list_units_passes_through():
+def test_systemctl_list_units_passes_through(tmp_path, monkeypatch):
+    _stub_systemctl(tmp_path, monkeypatch)
     r = subprocess.run(
         ["systemctl", "--user", "list-units", "fake-not-real-unit*", "--no-pager"],
         capture_output=True,
         text=True,
         check=False,
     )
-    assert r is not None
+    assert "stub-systemctl:" in r.stdout
 
 
-def test_systemctl_unrelated_unit_passes_through():
-    """systemctl restart of a non-hermes unit is allowed (we only protect hermes)."""
-    # Use --dry-run so we don't actually try to restart anything; just
-    # verify the guard doesn't block the call. systemctl supports
-    # --dry-run via the privileged API; on user scope it usually fails
-    # quickly without side effects.
+def test_systemctl_unrelated_unit_passes_through(tmp_path, monkeypatch):
+    """Read-only systemctl probes of non-Hermes units are allowed."""
+    _stub_systemctl(tmp_path, monkeypatch)
     r = subprocess.run(
         ["systemctl", "--user", "show", "fake-not-real-unit"],
         capture_output=True,
         text=True,
         check=False,
     )
-    assert r is not None
+    assert "stub-systemctl:" in r.stdout
 
 
 def test_kill_own_subtree_passes_through():
@@ -348,7 +599,13 @@ def test_subprocess_pkill_with_unrelated_pattern_passes_through():
 
 def test_normal_subprocess_run_passes_through():
     """Plain non-systemctl subprocess.run should work normally."""
-    r = subprocess.run(["echo", "hello"], capture_output=True, text=True)
+    r = subprocess.run(
+        ["echo", "hello"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
     assert r.stdout.strip() == "hello"
 
 
@@ -356,6 +613,7 @@ def test_normal_subprocess_run_passes_through():
 
 
 @pytest.mark.live_system_guard_bypass
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal-0 probe")
 def test_bypass_marker_disables_guard():
     """The bypass marker exists for tests that genuinely need real signal delivery
     (e.g. PTY tests SIGINTing their own child). Verify it works.
@@ -366,4 +624,4 @@ def test_bypass_marker_disables_guard():
     # With bypass, the guard yields without installing the monkeypatch,
     # so we get the real os.kill. Calling os.kill(os.getpid(), 0) just
     # checks that the PID exists — harmless.
-    os.kill(os.getpid(), 0)  # No exception — guard is OFF.
+    os.kill(os.getpid(), 0)  # windows-footgun: ok — POSIX-only signal-0 probe

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -138,8 +138,13 @@ class TestStdioPidTracking:
             _orphan_stdio_pids.add(fake_pid)
             _orphan_stdio_pid_servers[fake_pid] = "orphan"
 
-        # Should not raise (ProcessLookupError is caught)
-        _kill_orphaned_mcp_children()
+        # Should not raise when the signal proves the recorded PID is gone.
+        with patch(
+            "tools.mcp_tool.os.kill", side_effect=ProcessLookupError
+        ) as mock_kill:
+            _kill_orphaned_mcp_children()
+
+        mock_kill.assert_called_once_with(fake_pid, signal.SIGTERM)
 
         with _lock:
             assert fake_pid not in _orphan_stdio_pids


### PR DESCRIPTION
## What does this PR do?

Makes the test suite's live-system process guard fail closed before destructive process-group cleanup.

A destructive `killpg` now passes only for a child recorded with its PID creation time that still owns both its process group and session. Destructive PID-zero signals and reused, mismatched, unverifiable, non-session-leader, parent, and unrelated targets remain blocked. A recorded child that has already exited raises `ProcessLookupError` without raw signaling, preserving normal subprocess cleanup. Signal 0 remains a harmless liveness probe.

This is the process-safety successor to the corresponding slice of #72853.

## Related Issue

Supersedes the live-system guard portion of #72853.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/conftest.py`: record sync/async child identity with creation time, reject stale identity lookups without raw-signal fallthrough, and require current session/process-group ownership before destructive signaling.
- `tests/test_live_system_guard_self_test.py`: add positive and fail-closed process canaries, including PID-zero and asyncio shell registration; replace host `systemctl` calls with a temporary PATH stub.
- Existing Kanban and MCP fake-PID tests now stub and assert their destructive signal seams instead of reaching the host process table.

## How to Test

1. `HERMES_PYTHON=<python> scripts/run_tests.sh tests/test_live_system_guard_self_test.py tests/tools/test_interrupt.py tests/test_run_tests_parallel.py tests/tools/test_process_registry.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_mcp_stability.py tests/agent/lsp/test_client_e2e.py tests/agent/lsp/test_stale_diagnostics.py --file-retries 0 -q`
2. Confirm all 398 tests pass, including 47 live-system guard canaries.
3. Run Ruff, `scripts/check-windows-footguns.py --all`, and `git diff --check`.

Exact local validation base: `dbc18c6d62c02c664c94978120df972d01ca0fe7`  
Exact candidate: `5687437100571a92e453189f1f3794dd62b29e4b`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Focused suite: 398 passed, 0 failed; both LSP files also passed five consecutive no-retry runs. Final combined tree `95b25573b2c13c82880e5906b2f473ac0d657b90`: 48,759 passed, 1 failed—the detailed-health test owned by #72582. The #71581 snapshot test passed on retry; an unrelated interrupt race also passed on retry and in five isolated no-retry runs. Windows footgun scan passed all 830 scanned files.
