### PR TITLE
test: isolate cross-platform host assumptions

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -720,7 +720,7 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
             token = run_oauth_setup_token()
 
         assert token == "from-cred-file"
@@ -738,7 +738,7 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
             token = run_oauth_setup_token()
 
         assert token == "from-env-var"
@@ -751,7 +751,7 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
             token = run_oauth_setup_token()
 
         assert token is None

--- a/tests/agent/test_credential_pool_oat_authtype.py
+++ b/tests/agent/test_credential_pool_oat_authtype.py
@@ -128,6 +128,12 @@ def test_profile_global_fallback_normalizes_in_memory_without_writing(tmp_path, 
             }],
         },
     }))
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_hermes_oauth_credentials", lambda: None
+    )
 
     from agent.credential_pool import load_pool
 

--- a/tests/cli/test_chat_q_exit_clear.py
+++ b/tests/cli/test_chat_q_exit_clear.py
@@ -94,6 +94,7 @@ def test_single_query_main_skips_clear_on_exit_summary(monkeypatch):
                 clear_calls.append("CLEARED")  # should NOT happen
 
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "worktree", False)
     monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
     monkeypatch.setattr(
         cli_mod,

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -181,6 +181,7 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
             calls.append("summary")
 
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "worktree", False)
     monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         cli_mod,
@@ -254,6 +255,7 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "worktree", False)
     monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         cli_mod,

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -352,13 +352,13 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            assert _os.path.realpath(mock_adapter.send_voice.call_args.kwargs["audio_path"]) == _os.path.realpath(_ogg)
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            assert _os.path.realpath(mock_adapter.send_video.call_args.kwargs["video_path"]) == _os.path.realpath(_mp4)
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            assert _os.path.realpath(mock_adapter.send_image_file.call_args.kwargs["image_path"]) == _os.path.realpath(_png)
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            assert _os.path.realpath(mock_adapter.send_document.call_args.kwargs["file_path"]) == _os.path.realpath(_pdf)
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -18,6 +18,9 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
     with sqlite3.connect(home / "state.db") as conn:
         conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        "gateway.readiness._probe_disk", lambda _home: {"status": "ok"}
+    )
 
     result = collect_runtime_readiness(
         configured_model="test/model",

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -167,7 +167,7 @@ async def test_startup_aborts_when_restart_begins_during_platform_connect(tmp_pa
     telegram.disconnect = disconnect_and_release
     runner._create_adapter = MagicMock(side_effect=[telegram, slack])
 
-    result = await asyncio.wait_for(runner.start(), timeout=2)
+    result = await asyncio.wait_for(runner.start(), timeout=15)
 
     assert result is True
     assert telegram.disconnected is True

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import sys
 
 import pytest
 
@@ -31,7 +32,8 @@ def test_notify_sends_real_unix_datagram(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
+    not sys.platform.startswith("linux") or not hasattr(socket, "AF_UNIX"),
+    reason="abstract Unix sockets are Linux-only",
 )
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1299,6 +1299,9 @@ class TestProfileRestoration:
         hermes_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.check_alias_collision", lambda _name: None
+        )
 
         # Mock the wrapper dir to be inside tmp_path
         wrapper_dir = tmp_path / ".local" / "bin"

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -178,10 +178,18 @@ class TestGenerateZsh:
                 [
                     "zsh",
                     "-fc",
-                    f"autoload -Uz compinit && compinit -D; source {path}; [[ ${{_comps[hermes]}} == _hermes ]]",
+                    "for dir in $fpath; do "
+                    "[[ -r $dir/compinit ]] && { fpath=($dir); break; }; "
+                    "done; autoload -Uz compinit && compinit -D; "
+                    f"source {path}; [[ ${{_comps[hermes]}} == _hermes ]]",
                 ],
                 capture_output=True,
                 text=True,
+                env={
+                    **os.environ,
+                    "HOME": os.path.dirname(path),
+                    "ZDOTDIR": os.path.dirname(path),
+                },
             )
             assert result.returncode == 0, result.stderr
             assert result.stderr == ""

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -122,6 +122,10 @@ class TestWslSystemdOperational:
 class TestSupportsSystemdServicesWSL:
     """Test that supports_systemd_services() handles WSL correctly."""
 
+    @pytest.fixture(autouse=True)
+    def _systemctl_available(self, monkeypatch):
+        monkeypatch.setattr(gateway.shutil, "which", lambda _name: "/usr/bin/systemctl")
+
     def test_wsl_with_systemd(self, monkeypatch):
         """WSL + working systemd → True."""
         monkeypatch.setattr(gateway, "is_linux", lambda: True)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -566,7 +566,8 @@ class TestDeleteProfile:
         profile_dir = create_profile("coder", no_alias=True)
         assert profile_dir.is_dir()
         # Mock gateway import to avoid real systemd/launchd interaction
-        with patch("hermes_cli.profiles._cleanup_gateway_service"):
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles._profile_bound_backend_pids", return_value=[]):
             delete_profile("coder", yes=True)
         assert not profile_dir.is_dir()
 
@@ -583,6 +584,7 @@ class TestDeleteProfile:
         set_active_profile("coder")
 
         with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles._profile_bound_backend_pids", return_value=[]), \
              patch("hermes_cli.profiles.time.sleep"), \
              patch("hermes_cli.profiles.shutil.rmtree", side_effect=PermissionError("locked")):
             with pytest.raises(RuntimeError, match="Could not remove profile directory"):
@@ -1847,7 +1849,8 @@ class TestEdgeCases:
         set_active_profile("coder")
         assert get_active_profile() == "coder"
 
-        with patch("hermes_cli.profiles._cleanup_gateway_service"):
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles._profile_bound_backend_pids", return_value=[]):
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -7,6 +7,8 @@ implementation in this same file once that phase ships.
 """
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from hermes_cli.service_manager import (
@@ -450,8 +452,9 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
-        f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
+    expected_event_mode = 0o1730 if sys.platform == "darwin" else 0o3730
+    assert stat.S_IMODE(event.stat().st_mode) == expected_event_mode, (
+        f"event/ mode = {oct(event.stat().st_mode)}, want {oct(expected_event_mode)}"
     )
 
     # supervise/ dir.
@@ -462,7 +465,7 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
+    assert stat.S_IMODE(supervise_event.stat().st_mode) == expected_event_mode
 
     # supervise/control FIFO.
     control = supervise / "control"
@@ -497,7 +500,8 @@ def test_seed_supervise_skeleton_handles_log_subservice(tmp_path) -> None:
     log_control = log_supervise / "control"
 
     assert log_event.is_dir()
-    assert stat.S_IMODE(log_event.stat().st_mode) == 0o3730
+    expected_event_mode = 0o1730 if sys.platform == "darwin" else 0o3730
+    assert stat.S_IMODE(log_event.stat().st_mode) == expected_event_mode
     assert log_supervise.is_dir()
     assert log_supervise_event.is_dir()
     assert log_control.exists() and stat.S_ISFIFO(log_control.stat().st_mode)

--- a/tests/hermes_cli/test_signal_handler_kanban_worker.py
+++ b/tests/hermes_cli/test_signal_handler_kanban_worker.py
@@ -103,6 +103,20 @@ def _is_alive_like_dispatcher(pid: int) -> bool:
                         break
         except (FileNotFoundError, PermissionError, OSError):
             pass
+    elif sys.platform == "darwin":
+        try:
+            status = subprocess.run(
+                ["ps", "-o", "stat=", "-p", str(pid)],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=False,
+            )
+            if status.returncode != 0 or "Z" in status.stdout:
+                return False
+        except (OSError, subprocess.SubprocessError):
+            pass
     return True
 
 
@@ -200,31 +214,60 @@ def test_sigterm_without_kanban_task_env_uses_keyboard_interrupt_path():
         _cleanup(proc)
 
 
-def test_real_handler_uses_os_exit_for_kanban_workers():
-    """Source-level invariant: cli.py's _signal_handler_q must call
-    os._exit(0) when HERMES_KANBAN_TASK is set.
+def test_real_handler_uses_os_exit_for_kanban_workers(monkeypatch):
+    """The registered production handler exits a dispatcher worker directly."""
+    import logging
+    from types import SimpleNamespace
 
-    Catches the case where someone refactors the handler and accidentally
-    drops the env-gated exit, restoring the bug. Reading cli.py directly is
-    cheap and avoids the heavy CLI import.
-    """
-    import pathlib
+    import cli as cli_mod
 
-    cli_path = (
-        pathlib.Path(__file__).resolve().parent.parent.parent / "cli.py"
-    )
-    src = cli_path.read_text()
-    # Locate the handler body.
-    start = src.find("def _signal_handler_q(signum, frame):")
-    assert start != -1, "cli.py is missing _signal_handler_q"
-    # Look ahead for the env-gated os._exit call within ~80 lines.
-    body = src[start : start + 4000]
-    assert "HERMES_KANBAN_TASK" in body, (
-        "_signal_handler_q must gate its kanban-worker exit path on "
-        "HERMES_KANBAN_TASK — see #28181"
-    )
-    assert "os._exit(0)" in body, (
-        "_signal_handler_q must call os._exit(0) for kanban workers — "
-        "raising KeyboardInterrupt orphans the process when non-daemon "
-        "threads are alive (see #28181)"
-    )
+    handlers = {}
+    interrupts = []
+
+    class FakeAgent:
+        session_id = "signal-test"
+        platform = "cli"
+
+        def interrupt(self, reason):
+            interrupts.append(reason)
+
+    class FakeCLI:
+        system_prompt = ""
+
+        def __init__(self, **_kwargs):
+            self.console = SimpleNamespace(print=lambda *_a, **_kw: None)
+            self.session_id = "signal-test"
+            self.agent = FakeAgent()
+
+        def _claim_active_session(self, *_args, **_kwargs):
+            return True
+
+        def _show_security_advisories(self):
+            pass
+
+        def chat(self, *_args, **_kwargs):
+            return "done"
+
+        def _print_exit_summary(self, **_kwargs):
+            pass
+
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "worktree", False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda *_args: None)
+    monkeypatch.setattr(cli_mod, "_arm_exit_watchdog_on_shutdown_signal", lambda: None)
+    monkeypatch.setattr(signal, "signal", lambda sig, handler: handlers.setdefault(sig, handler))
+    monkeypatch.setattr(signal, "alarm", lambda _seconds: None)
+    monkeypatch.setattr(logging, "shutdown", lambda: None)
+
+    cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test_28181")
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(cli_mod.os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as exc:
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+
+    assert exc.value.code == 0
+    assert interrupts == [f"received signal {signal.SIGTERM}"]

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -655,7 +655,11 @@ def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
     try:
         server._start_agent_build(sid, session)
         assert built.wait(timeout=2)
+        assert ready.wait(timeout=2)
     finally:
+        if stop := session.get("_notif_stop"):
+            assert isinstance(stop, threading.Event)
+            stop.set()
         server._sessions.pop(sid, None)
 
     assert seen == [str(profile_home)]
@@ -710,7 +714,11 @@ def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path)
     try:
         server._start_agent_build(sid, session)
         assert built.wait(timeout=2)
+        assert ready.wait(timeout=2)
     finally:
+        if stop := session.get("_notif_stop"):
+            assert isinstance(stop, threading.Event)
+            stop.set()
         server._sessions.pop(sid, None)
 
     assert scopes == [{"PROXMOX_TOKEN": "grace-secret"}]
@@ -3123,6 +3131,9 @@ def test_init_session_fires_reset_hook(monkeypatch):
 
     monkeypatch.setattr(_approval, "register_gateway_notify", lambda key, cb: None)
     monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_args: threading.Event()
+    )
 
     sid = "sid"
     try:
@@ -4019,14 +4030,8 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
         assert nested_started.wait(timeout=5)
         threads[0].join(timeout=5)
         assert not threads[0].is_alive()
-        # Membership, not order: the completion_queue is process-global, and
-        # notification pollers leaked by earlier session.init tests in this
-        # file legitimately steal-and-requeue foreign-session events (see
-        # _notification_poller_loop's belongs-elsewhere branch), rotating the
-        # queue. The requeue contract is that batch_2 and batch_3 both remain
-        # queued (never consumed) while batch_1's turn is in flight — so drain
-        # with a deadline (an event may be transiently held by a poller
-        # mid-cycle) and assert exactly {batch_2, batch_3} come back.
+        # Queue order is an implementation detail. The contract is that batch_2
+        # and batch_3 both remain queued while batch_1's turn is in flight.
         queued: dict = {}
         deadline = time.time() + 5.0
         while time.time() < deadline and set(queued) != {

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -156,8 +156,11 @@ class TestDetectDangerousRm:
 
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
         with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+            temp_dir = os.path.realpath("/tmp")
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                assert detect_dangerous_command(
+                    f"rm -f {temp_dir}/{prefix}example.py"
+                ) == (
                     False,
                     None,
                     None,

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1902,7 +1902,8 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_window_id == 2
         assert backend._last_app == "Chrome"
 
-    def test_linux_default_capture_skips_gnome_shell_helper(self):
+    def test_linux_default_capture_skips_gnome_shell_helper(self, monkeypatch):
+        monkeypatch.setattr("tools.computer_use.cua_backend.sys.platform", "linux")
         windows = [
             {"app_name": "", "pid": 100, "window_id": 1,
              "is_on_screen": None, "title": "@!1921,0;BDHF", "z_index": 0},

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 
 import pytest
@@ -37,9 +38,27 @@ def test_real_read_tool_binaries_confirm_option_ownership(
     [
         ("rg", ["--pre", "-payload-marker", "needle", "{input}"], None, False),
         ("rg", ["--hostname-bin=-payload-marker", "needle", "{input}"], None, False),
-        ("sort", ["--buffer-size=1K", "--compress-program", "-payload-marker"], "{bulk}", False),
+        pytest.param(
+            "sort",
+            ["--buffer-size=1K", "--compress-program", "-payload-marker"],
+            "{bulk}",
+            False,
+            marks=pytest.mark.skipif(
+                sys.platform == "darwin",
+                reason="BSD sort has no --compress-program option",
+            ),
+        ),
         ("ag", ["--pager=-payload-marker", "needle", "{input}"], None, True),
-        ("man", ["--pager", "-payload-marker", "ls"], None, True),
+        pytest.param(
+            "man",
+            ["--pager", "-payload-marker", "ls"],
+            None,
+            True,
+            marks=pytest.mark.skipif(
+                sys.platform == "darwin",
+                reason="BSD man accepts -P but not --pager",
+            ),
+        ),
         ("man", ["-P", "-payload-marker", "ls"], None, True),
     ],
 )
@@ -70,7 +89,11 @@ def test_real_binaries_execute_leading_dash_program_payload(
     }
     argv = [tool, *resolved_args]
     if needs_tty:
-        argv = ["script", "-qec", shlex.join(argv), "/dev/null"]
+        argv = (
+            ["script", "-q", "/dev/null", *argv]
+            if sys.platform == "darwin"
+            else ["script", "-qec", shlex.join(argv), "/dev/null"]
+        )
 
     subprocess.run(argv, input=input_text, text=True, capture_output=True, env=env, timeout=20)
 

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            os.path.realpath("/tmp/out.txt"), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -182,7 +185,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "foo", "bar", False
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -195,7 +200,9 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "x", "y", True
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):


### PR DESCRIPTION
## What does this PR do?

Makes existing tests hermetic across macOS, Linux, Windows, WSL, and minimal-PATH environments without changing production behavior.

The patch isolates HOME/config/worktree state, mocks host-only service/process seams, uses platform-compatible command fixtures, narrows Darwin exclusions to unsupported payloads, and replaces a pre-existing source-reading signal test with runtime behavior coverage.

This is the test-portability successor to the corresponding slice of #72853.

## Related Issue

Supersedes the remaining test-portability portion of #72853.

Overlap intentionally excluded:

- Snapshot publication and `mktemp` changes remain owned by #71581 from @tachyon-r.
- Detailed-health disk-probe isolation remains owned by #72582 from @Salmisaari.

No code from those contributions is copied here.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Isolate HOME, HERMES_HOME, worktree config, credential, completion, backup, and gateway state in existing tests.
- Replace host service/process assumptions with mocked command seams.
- Use platform-compatible execution-flag payloads and skip only the unsupported Darwin `man` case.
- Replace source inspection in `test_signal_handler_kanban_worker.py` with runtime signal-registration behavior tests.
- Wait for agent-build threads to finish and stop their notification pollers before restoring test mocks.

## How to Test

1. Run the 19 changed test files through `scripts/run_tests.sh`.
2. Confirm all 1,917 tests pass.
3. Run Ruff, `scripts/check-windows-footguns.py --all`, and `git diff --check`.

Exact local validation base: `dbc18c6d62c02c664c94978120df972d01ca0fe7`  
Exact candidate: `1a4b205620a045e7f972c05284a6864bcb696d8c`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added or improved tests for these contracts
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Focused suite: 1,917 passed, 0 failed. Final combined tree `95b25573b2c13c82880e5906b2f473ac0d657b90`: 48,759 passed, 1 failed—the detailed-health test owned by #72582. The #71581 snapshot test passed on retry; an unrelated interrupt race also passed on retry and in five isolated no-retry runs.
