### PR TITLE
fix(desktop): zero Tip skipDelayDuration so the hover delay actually sticks

### DIFF
--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -16,6 +16,11 @@ const HasTooltipProvider = React.createContext(false)
 
 function TooltipProvider({
   delayDuration = 0,
+  // Radix's "skip" grace: after one tip opens, every trigger touched within
+  // this window opens INSTANTLY, delay bypassed. Its 300ms default meant a
+  // cursor sweeping the chrome still flashed a trail of tips despite the
+  // hover delay. Zero it so each tip independently honors `delayDuration`.
+  skipDelayDuration = 0,
   // Tips are labels, not interactive surfaces. Hoverable content + Radix's
   // pointer-grace bridge is what leaves tips stuck open — especially over
   // Electron `-webkit-app-region: drag` chrome where pointermove never fires
@@ -28,6 +33,7 @@ function TooltipProvider({
       data-slot="tooltip-provider"
       delayDuration={delayDuration}
       disableHoverableContent={disableHoverableContent}
+      skipDelayDuration={skipDelayDuration}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary

Follow-up to [#72985](https://github.com/NousResearch/hermes-agent/pull/72985). That PR gave `Tip` a 200ms hover delay, but tips still felt instant while sweeping the chrome. The culprit is Radix's `skipDelayDuration` — after the first tip opens, every trigger touched within that window (default 300ms) opens *instantly*, delay bypassed. So the first tip waited but its neighbors fired on contact.

Zero `skipDelayDuration` on the provider so each tip independently honors its 200ms delay. No more trail when the cursor moves across the titlebar tools / tabs.

## Test plan
- [ ] Hover one tool, then sweep to an adjacent one within ~300ms — the second tip now waits ~200ms instead of appearing instantly.
- [ ] A single deliberate hover still opens after ~200ms.