### PR TITLE
feat(discord): add durable thread run lifecycle

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5398,7 +5398,46 @@ class BasePlatformAdapter(ABC):
                 typing_task,
                 metadata=_thread_metadata,
             )
-        
+
+        _post_delivery_callback_fired = False
+
+        async def _fire_post_delivery_callback() -> None:
+            """Fire this run's callbacks once, before any queued turn starts."""
+            nonlocal _post_delivery_callback_fired
+            if _post_delivery_callback_fired:
+                return
+            _post_delivery_callback_fired = True
+
+            # The generation is bound while the handler runs. Read it only
+            # after that await, but before a queued follow-up can rebind the
+            # shared active-session event to its own generation.
+            callback_generation = getattr(
+                interrupt_event,
+                "_hermes_run_generation",
+                None,
+            )
+            if hasattr(self, "pop_post_delivery_callback"):
+                post_callback = self.pop_post_delivery_callback(
+                    session_key,
+                    generation=callback_generation,
+                )
+            else:
+                post_callback = getattr(self, "_post_delivery_callbacks", {}).pop(
+                    session_key,
+                    None,
+                )
+            if not callable(post_callback):
+                return
+            try:
+                post_result = post_callback()
+                if inspect.isawaitable(post_result):
+                    await asyncio.wait_for(
+                        post_result,
+                        timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
+                    )
+            except Exception:
+                pass
+
         try:
             await self._run_processing_hook("on_processing_start", event)
 
@@ -5836,6 +5875,11 @@ class BasePlatformAdapter(ABC):
                 if _active is not None:
                     _active.clear()
                 await _stop_typing_task()
+                # Drain this turn's deferred output before handing the shared
+                # session slot to the next generation. Otherwise the follow-up
+                # can replace the callback slot before this turn's callback is
+                # popped, dropping terminal notices and other deferred work.
+                await _fire_post_delivery_callback()
                 # Spawn a fresh task for the pending message instead of
                 # recursing.  Issue #17758: `await
                 # self._process_message_background(...)` here grew the
@@ -5893,38 +5937,9 @@ class BasePlatformAdapter(ABC):
             # leave the typing refresh task running indefinitely.
             await _stop_typing_task()
             # Fire any one-shot post-delivery callback registered for this
-            # session (e.g. deferred background-review notifications).
-            #
-            # Snapshot the callback generation HERE (after the agent has run),
-            # not at the top of this task.  _hermes_run_generation is set on
-            # the interrupt event by GatewayRunner._bind_adapter_run_generation
-            # during _handle_message_with_agent — which happens DURING the
-            # self._message_handler(event) await above.  Snapshotting earlier
-            # always captured None, which bypassed the generation-ownership
-            # check in pop_post_delivery_callback and let stale runs fire a
-            # fresher run's callbacks.
-            _callback_generation = getattr(
-                interrupt_event,
-                "_hermes_run_generation",
-                None,
-            )
-            if hasattr(self, "pop_post_delivery_callback"):
-                _post_cb = self.pop_post_delivery_callback(
-                    session_key,
-                    generation=_callback_generation,
-                )
-            else:
-                _post_cb = getattr(self, "_post_delivery_callbacks", {}).pop(session_key, None)
-            if callable(_post_cb):
-                try:
-                    _post_result = _post_cb()
-                    if inspect.isawaitable(_post_result):
-                        await asyncio.wait_for(
-                            _post_result,
-                            timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
-                        )
-                except (asyncio.TimeoutError, Exception):
-                    pass
+            # run. Queued-turn handoff may already have fired it before
+            # spawning the next generation; the helper is idempotent.
+            await _fire_post_delivery_callback()
             # Some adapters keep platform-level typing tasks.  If callback
             # work or a late refresh recreated one, make one final bounded stop
             # before releasing the session guard.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10985,19 +10985,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             or not getattr(source, "thread_id", None)
         ):
             return
-        adapter = adapter or self._adapter_for_source(source)
-        setter = getattr(adapter, "set_run_lifecycle_outcome", None)
-        register = getattr(adapter, "register_run_lifecycle_terminal", None)
-        if callable(setter):
-            setter(event, outcome)
-        if callable(register):
-            register(event)
-        pop_callback = getattr(adapter, "pop_post_delivery_callback", None)
-        callback = (
-            pop_callback(session_key, generation=generation)
-            if callable(pop_callback)
-            else None
-        )
+        try:
+            adapter = adapter or self._adapter_for_source(source)
+            setter = getattr(adapter, "set_run_lifecycle_outcome", None)
+            register = getattr(adapter, "register_run_lifecycle_terminal", None)
+            if callable(setter):
+                setter(event, outcome)
+            if callable(register):
+                register(event)
+            pop_callback = getattr(adapter, "pop_post_delivery_callback", None)
+            callback = (
+                pop_callback(session_key, generation=generation)
+                if callable(pop_callback)
+                else None
+            )
+        except Exception:
+            logger.debug(
+                "Recursive Discord run lifecycle bookkeeping failed for %s",
+                session_key,
+                exc_info=True,
+            )
+            return
         if not callable(callback):
             return
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10903,6 +10903,100 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         return switched
 
+    @staticmethod
+    def _run_lifecycle_outcome_from_result(result: Any) -> str:
+        if isinstance(result, dict):
+            if result.get("timed_out"):
+                return "timeout"
+            if result.get("interrupted"):
+                return "stopped"
+            if result.get("failed"):
+                return "failed"
+        return "success"
+
+    async def _begin_recursive_discord_run_lifecycle(
+        self,
+        event: Optional[MessageEvent],
+        *,
+        session_key: str,
+        generation: Optional[int],
+    ) -> Any:
+        """Start lifecycle state for an in-band queued Discord event."""
+        if event is None:
+            return None
+        source = getattr(event, "source", None)
+        if (
+            source is None
+            or source.platform != Platform.DISCORD
+            or not getattr(source, "thread_id", None)
+        ):
+            return None
+        adapter = self._adapter_for_source(source)
+        begin = getattr(adapter, "begin_run_lifecycle", None)
+        if not callable(begin):
+            return None
+        try:
+            await asyncio.wait_for(
+                begin(event, session_key=session_key, generation=generation),
+                timeout=5.0,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug(
+                "Recursive Discord run lifecycle start failed for %s",
+                session_key,
+                exc_info=True,
+            )
+        return adapter
+
+    async def _finish_recursive_discord_run_lifecycle(
+        self,
+        event: Optional[MessageEvent],
+        *,
+        session_key: str,
+        generation: Optional[int],
+        outcome: str,
+        adapter: Any = None,
+    ) -> None:
+        """Flush deferred output and one terminal marker before the next turn."""
+        if event is None:
+            return
+        source = getattr(event, "source", None)
+        if (
+            source is None
+            or source.platform != Platform.DISCORD
+            or not getattr(source, "thread_id", None)
+        ):
+            return
+        adapter = adapter or self._adapter_for_source(source)
+        setter = getattr(adapter, "set_run_lifecycle_outcome", None)
+        register = getattr(adapter, "register_run_lifecycle_terminal", None)
+        if callable(setter):
+            setter(event, outcome)
+        if callable(register):
+            register(event)
+        pop_callback = getattr(adapter, "pop_post_delivery_callback", None)
+        callback = (
+            pop_callback(session_key, generation=generation)
+            if callable(pop_callback)
+            else None
+        )
+        if not callable(callback):
+            return
+        try:
+            callback_result = callback()
+            if inspect.isawaitable(callback_result):
+                await asyncio.wait_for(callback_result, timeout=30.0)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug(
+                "Recursive Discord run lifecycle finalization failed for %s",
+                session_key,
+                exc_info=True,
+            )
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -12475,25 +12569,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _run_lifecycle_adapter = None
         if source.platform == Platform.DISCORD and getattr(source, "thread_id", None):
             _run_lifecycle_adapter = self._adapter_for_source(source)
-            _begin_run_lifecycle = getattr(
-                _run_lifecycle_adapter, "begin_run_lifecycle", None
-            )
-            if callable(_begin_run_lifecycle):
-                try:
-                    await asyncio.wait_for(
-                        _begin_run_lifecycle(
-                            event,
-                            session_key=_quick_key,
-                            generation=_run_generation,
-                        ),
-                        timeout=5.0,
-                    )
-                except Exception as _lifecycle_exc:
-                    logger.debug(
-                        "Discord run lifecycle start failed for %s: %s",
-                        _quick_key,
-                        _lifecycle_exc,
-                    )
 
         def _set_run_lifecycle_outcome(outcome: str) -> None:
             setter = getattr(
@@ -12511,6 +12586,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         try:
+            # Keep startup inside the cleanup-owning try: cancellation while
+            # Discord is posting the durable marker must still classify the
+            # turn as stopped and release its sentinel/lease.
+            if _run_lifecycle_adapter is not None:
+                _begin_run_lifecycle = getattr(
+                    _run_lifecycle_adapter, "begin_run_lifecycle", None
+                )
+                if callable(_begin_run_lifecycle):
+                    try:
+                        await asyncio.wait_for(
+                            _begin_run_lifecycle(
+                                event,
+                                session_key=_quick_key,
+                                generation=_run_generation,
+                            ),
+                            timeout=5.0,
+                        )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as _lifecycle_exc:
+                        logger.debug(
+                            "Discord run lifecycle start failed for %s: %s",
+                            _quick_key,
+                            _lifecycle_exc,
+                        )
+
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             if isinstance(_agent_result, dict):
                 if _agent_result.get("timed_out"):
@@ -14227,6 +14328,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                lifecycle_event=event,
             )
 
             # Stop persistent typing indicator now that the agent is done.
@@ -14898,6 +15000,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
             except Exception:
                 logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
+            # The user-facing error below is intentionally returned as a
+            # normal string so BasePlatformAdapter can deliver it. Preserve
+            # the semantic run failure on the event before that string reaches
+            # the outer classifier, which otherwise sees a successful return.
+            try:
+                _lifecycle_adapter = self._adapter_for_source(source)
+                _set_lifecycle_outcome = getattr(
+                    _lifecycle_adapter, "set_run_lifecycle_outcome", None
+                )
+                if callable(_set_lifecycle_outcome):
+                    _set_lifecycle_outcome(event, "failed")
+            except Exception:
+                logger.debug(
+                    "Failed to classify caught agent exception for Discord lifecycle",
+                    exc_info=True,
+                )
             # Log full details server-side only; never expose raw exception
             # types or messages to end users (info-leakage risk).
             status_hint = ""
@@ -20290,6 +20408,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        lifecycle_event: Optional[MessageEvent] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -20308,6 +20427,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                lifecycle_event=lifecycle_event,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -20319,6 +20439,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                lifecycle_event=lifecycle_event,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -20440,6 +20561,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        lifecycle_event: Optional[MessageEvent] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -23507,34 +23629,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Queued follow-up for session %s: skipping resend because final streamed delivery was confirmed.",
                             session_key or "?",
                         )
-                    # Release deferred bg-review notifications now that the
-                    # first response has been delivered.  Pop from the
-                    # adapter's callback dict (prevents double-fire in
-                    # base.py's finally block) and call it.
-                    if getattr(type(adapter), "pop_post_delivery_callback", None) is not None:
-                        _bg_cb = adapter.pop_post_delivery_callback(
-                            session_key,
-                            generation=run_generation,
-                        )
-                        if callable(_bg_cb):
-                            try:
-                                _bg_result = _bg_cb()
-                                if inspect.isawaitable(_bg_result):
-                                    await _bg_result
-                            except Exception:
-                                pass
-                    elif adapter and hasattr(adapter, "_post_delivery_callbacks"):
-                        _bg_cb = adapter._post_delivery_callbacks.pop(session_key, None)
-                        if callable(_bg_cb):
-                            try:
-                                _bg_result = _bg_cb()
-                                if inspect.isawaitable(_bg_result):
-                                    await _bg_result
-                            except Exception:
-                                pass
                 # else: interrupted — discard the interrupted response ("Operation
                 # interrupted." is just noise; the user already knows they sent a
                 # new message).
+
+                _has_discord_lifecycle = bool(
+                    lifecycle_event is not None
+                    and getattr(lifecycle_event, "source", None) is not None
+                    and lifecycle_event.source.platform == Platform.DISCORD
+                    and getattr(lifecycle_event.source, "thread_id", None)
+                )
+                if _has_discord_lifecycle:
+                    await self._finish_recursive_discord_run_lifecycle(
+                        lifecycle_event,
+                        session_key=session_key,
+                        generation=run_generation,
+                        outcome=self._run_lifecycle_outcome_from_result(result),
+                        adapter=adapter,
+                    )
+                # Preserve the existing cross-platform deferred-callback drain
+                # when this turn has no Discord lifecycle marker.
+                elif getattr(type(adapter), "pop_post_delivery_callback", None) is not None:
+                    _bg_cb = adapter.pop_post_delivery_callback(
+                        session_key,
+                        generation=run_generation,
+                    )
+                    if callable(_bg_cb):
+                        try:
+                            _bg_result = _bg_cb()
+                            if inspect.isawaitable(_bg_result):
+                                await _bg_result
+                        except Exception:
+                            pass
+                elif adapter and hasattr(adapter, "_post_delivery_callbacks"):
+                    _bg_cb = adapter._post_delivery_callbacks.pop(session_key, None)
+                    if callable(_bg_cb):
+                        try:
+                            _bg_result = _bg_cb()
+                            if inspect.isawaitable(_bg_result):
+                                await _bg_result
+                        except Exception:
+                            pass
 
                 updated_history = result.get("messages", history)
                 next_source = source
@@ -23574,6 +23709,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
 
+                _next_lifecycle_adapter = None
+                try:
+                    _next_lifecycle_adapter = await self._begin_recursive_discord_run_lifecycle(
+                        pending_event,
+                        session_key=next_session_key,
+                        generation=run_generation,
+                    )
+                except asyncio.CancelledError:
+                    # begin_run_lifecycle stores its state before awaiting the
+                    # Discord send, so a cancellation can still produce a
+                    # truthful stopped marker without leaking into the next run.
+                    await asyncio.shield(
+                        self._finish_recursive_discord_run_lifecycle(
+                            pending_event,
+                            session_key=next_session_key,
+                            generation=run_generation,
+                            outcome="stopped",
+                        )
+                    )
+                    raise
+
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
                 # typing task is still alive but may be stale.
@@ -23603,18 +23759,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # what the follow-up's guard will consult.  Fail-safe in helper.
                 await self._refresh_agent_cache_message_count(session_key, session_id)
 
-                followup_result = await self._run_agent(
-                    message=next_message,
-                    context_prompt=context_prompt,
-                    history=updated_history,
-                    source=next_source,
-                    session_id=session_id,
-                    session_key=next_session_key,
-                    run_generation=run_generation,
-                    _interrupt_depth=_interrupt_depth + 1,
-                    event_message_id=next_message_id,
-                    channel_prompt=next_channel_prompt,
-                )
+                try:
+                    followup_result = await self._run_agent(
+                        message=next_message,
+                        context_prompt=context_prompt,
+                        history=updated_history,
+                        source=next_source,
+                        session_id=session_id,
+                        session_key=next_session_key,
+                        run_generation=run_generation,
+                        _interrupt_depth=_interrupt_depth + 1,
+                        event_message_id=next_message_id,
+                        channel_prompt=next_channel_prompt,
+                        lifecycle_event=pending_event,
+                    )
+                except asyncio.CancelledError:
+                    await asyncio.shield(
+                        self._finish_recursive_discord_run_lifecycle(
+                            pending_event,
+                            session_key=next_session_key,
+                            generation=run_generation,
+                            outcome="stopped",
+                            adapter=_next_lifecycle_adapter,
+                        )
+                    )
+                    raise
+                except Exception:
+                    await self._finish_recursive_discord_run_lifecycle(
+                        pending_event,
+                        session_key=next_session_key,
+                        generation=run_generation,
+                        outcome="failed",
+                        adapter=_next_lifecycle_adapter,
+                    )
+                    raise
+                else:
+                    await self._finish_recursive_discord_run_lifecycle(
+                        pending_event,
+                        session_key=next_session_key,
+                        generation=run_generation,
+                        outcome=self._run_lifecycle_outcome_from_result(followup_result),
+                        adapter=_next_lifecycle_adapter,
+                    )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12466,8 +12466,63 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
+        # Discord's typing indicator and parent-message reaction are both
+        # transient/easy to miss once an auto-thread opens. Start the durable
+        # in-thread lifecycle only after this request has passed command,
+        # authorization, drain, and concurrency gates and has claimed a real
+        # agent slot. Adapters without the explicit lifecycle capability are
+        # untouched.
+        _run_lifecycle_adapter = None
+        if source.platform == Platform.DISCORD and getattr(source, "thread_id", None):
+            _run_lifecycle_adapter = self._adapter_for_source(source)
+            _begin_run_lifecycle = getattr(
+                _run_lifecycle_adapter, "begin_run_lifecycle", None
+            )
+            if callable(_begin_run_lifecycle):
+                try:
+                    await asyncio.wait_for(
+                        _begin_run_lifecycle(
+                            event,
+                            session_key=_quick_key,
+                            generation=_run_generation,
+                        ),
+                        timeout=5.0,
+                    )
+                except Exception as _lifecycle_exc:
+                    logger.debug(
+                        "Discord run lifecycle start failed for %s: %s",
+                        _quick_key,
+                        _lifecycle_exc,
+                    )
+
+        def _set_run_lifecycle_outcome(outcome: str) -> None:
+            setter = getattr(
+                _run_lifecycle_adapter, "set_run_lifecycle_outcome", None
+            )
+            if not callable(setter):
+                return
+            try:
+                setter(event, outcome)
+            except Exception:
+                logger.debug(
+                    "Discord run lifecycle outcome update failed for %s",
+                    _quick_key,
+                    exc_info=True,
+                )
+
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            if isinstance(_agent_result, dict):
+                if _agent_result.get("timed_out"):
+                    _set_run_lifecycle_outcome("timeout")
+                elif _agent_result.get("interrupted"):
+                    _set_run_lifecycle_outcome("stopped")
+                elif _agent_result.get("failed"):
+                    _set_run_lifecycle_outcome("failed")
+                else:
+                    _set_run_lifecycle_outcome("success")
+            else:
+                _set_run_lifecycle_outcome("success")
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
             # either mark it done, pause it (budget), or enqueue a
@@ -12497,6 +12552,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as _goal_exc:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
+        except asyncio.CancelledError:
+            _set_run_lifecycle_outcome("stopped")
+            raise
+        except Exception:
+            _set_run_lifecycle_outcome("failed")
+            raise
         finally:
             # MoA one-shot restore must run on EVERY exit path, not just
             # success. The restore data lives on the per-turn event object
@@ -23227,6 +23288,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "tools": tools_holder[0] or [],
                     "history_offset": 0,
                     "failed": True,
+                    "timed_out": True,
                 }
 
             # Track fallback model state: if the agent switched to a

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10904,6 +10904,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return switched
 
     @staticmethod
+    def _event_for_pending_text(
+        pending_event: Optional[MessageEvent],
+        pending_text: Optional[str],
+        source: SessionSource,
+    ) -> Optional[MessageEvent]:
+        """Give string-only interrupt/steer turns normal lifecycle identity."""
+        if pending_event is not None or not pending_text:
+            return pending_event
+        return MessageEvent(
+            text=pending_text,
+            message_type=MessageType.TEXT,
+            source=source,
+            metadata={"_synthetic_pending_followup": True},
+        )
+
+    @staticmethod
     def _run_lifecycle_outcome_from_result(result: Any) -> str:
         if isinstance(result, dict):
             if result.get("timed_out"):
@@ -22932,6 +22948,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "completed": result_holder[0].get("completed") if result_holder[0] else None,
                 "interrupted": result_holder[0].get("interrupted", False) if result_holder[0] else False,
                 "partial": result_holder[0].get("partial", False) if result_holder[0] else False,
+                "failed": result_holder[0].get("failed", False) if result_holder[0] else False,
+                "timed_out": result_holder[0].get("timed_out", False) if result_holder[0] else False,
                 "error": result_holder[0].get("error") if result_holder[0] else None,
                 "interrupt_message": result_holder[0].get("interrupt_message") if result_holder[0] else None,
                 # Soft lock-contention defer (#69870 consumer): distinct from
@@ -23541,6 +23559,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 pending_event = None
                 pending = None
+
+            pending_event = self._event_for_pending_text(
+                pending_event,
+                pending,
+                source,
+            )
 
             if pending_event or pending:
                 logger.debug("Processing pending message: '%s...'", pending[:40])

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10987,25 +10987,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
         try:
             adapter = adapter or self._adapter_for_source(source)
-            setter = getattr(adapter, "set_run_lifecycle_outcome", None)
-            register = getattr(adapter, "register_run_lifecycle_terminal", None)
-            if callable(setter):
-                setter(event, outcome)
-            if callable(register):
-                register(event)
-            pop_callback = getattr(adapter, "pop_post_delivery_callback", None)
-            callback = (
-                pop_callback(session_key, generation=generation)
-                if callable(pop_callback)
-                else None
-            )
         except Exception:
             logger.debug(
-                "Recursive Discord run lifecycle bookkeeping failed for %s",
+                "Recursive Discord lifecycle adapter lookup failed for %s",
                 session_key,
                 exc_info=True,
             )
             return
+
+        try:
+            setter = getattr(adapter, "set_run_lifecycle_outcome", None)
+            if callable(setter):
+                setter(event, outcome)
+        except Exception:
+            logger.debug(
+                "Recursive Discord lifecycle outcome update failed for %s",
+                session_key,
+                exc_info=True,
+            )
+
+        try:
+            register = getattr(adapter, "register_run_lifecycle_terminal", None)
+            if callable(register):
+                register(event)
+        except Exception:
+            logger.debug(
+                "Recursive Discord lifecycle terminal registration failed for %s",
+                session_key,
+                exc_info=True,
+            )
+
+        callback = None
+        try:
+            pop_callback = getattr(adapter, "pop_post_delivery_callback", None)
+            if callable(pop_callback):
+                callback = pop_callback(session_key, generation=generation)
+        except Exception:
+            logger.debug(
+                "Recursive Discord lifecycle callback pop failed for %s",
+                session_key,
+                exc_info=True,
+            )
         if not callable(callback):
             return
         try:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2826,6 +2826,100 @@ class DiscordAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"}
 
+    @staticmethod
+    def _run_lifecycle_metadata(event: MessageEvent) -> Dict[str, Any]:
+        """Build thread-strict, non-conversational metadata for run markers."""
+        metadata: Dict[str, Any] = {
+            "non_conversational": True,
+            "non_conversational_history": True,
+        }
+        source = getattr(event, "source", None)
+        thread_id = getattr(source, "thread_id", None)
+        if thread_id:
+            metadata["thread_id"] = str(thread_id)
+        return metadata
+
+    @staticmethod
+    def _format_run_lifecycle_elapsed(seconds: float) -> str:
+        elapsed = max(0, int(seconds))
+        if elapsed < 60:
+            return f"{elapsed}s"
+        minutes, seconds = divmod(elapsed, 60)
+        if minutes < 60:
+            return f"{minutes}m {seconds:02d}s"
+        hours, minutes = divmod(minutes, 60)
+        return f"{hours}h {minutes:02d}m"
+
+    def set_run_lifecycle_outcome(self, event: MessageEvent, outcome: str) -> None:
+        """Record a more specific terminal outcome for an active Discord run."""
+        metadata = getattr(event, "metadata", None)
+        state = metadata.get("_discord_run_lifecycle") if isinstance(metadata, dict) else None
+        if not isinstance(state, dict):
+            return
+        normalized = str(outcome or "").strip().lower()
+        if normalized in {"success", "failed", "stopped", "timeout"}:
+            state["outcome"] = normalized
+
+    async def begin_run_lifecycle(
+        self,
+        event: MessageEvent,
+        *,
+        session_key: str,
+        generation: Optional[int] = None,
+    ) -> None:
+        """Post the durable start marker and defer one fresh terminal marker."""
+        if not isinstance(getattr(event, "metadata", None), dict):
+            event.metadata = {}
+        existing = event.metadata.get("_discord_run_lifecycle")
+        if isinstance(existing, dict):
+            return
+
+        state: Dict[str, Any] = {
+            "started_at": time.monotonic(),
+            "outcome": "success",
+            "terminal_sent": False,
+            "terminal_registered": False,
+            "session_key": session_key,
+            "generation": generation,
+        }
+        event.metadata["_discord_run_lifecycle"] = state
+
+        async def _send_terminal() -> None:
+            if state.get("terminal_sent"):
+                return
+            state["terminal_sent"] = True
+            labels = {
+                "success": "✅ Run complete",
+                "failed": "❌ Run failed",
+                "stopped": "⏹️ Run stopped",
+                "timeout": "⚠️ Run timed out",
+            }
+            label = labels.get(str(state.get("outcome") or ""), labels["failed"])
+            elapsed = self._format_run_lifecycle_elapsed(
+                time.monotonic() - float(state["started_at"])
+            )
+            delivery_adapter = self._final_delivery_adapter(event.source)
+            await delivery_adapter.send(
+                event.source.chat_id,
+                f"{label} · {elapsed}",
+                metadata=self._run_lifecycle_metadata(event),
+            )
+
+        # Register this only from ``on_processing_complete``. Other features
+        # may register deferred deliveries while the agent runs; appending the
+        # lifecycle callback after those guarantees the terminal marker is the
+        # last post-delivery message in the thread.
+        state["terminal_callback"] = _send_terminal
+        try:
+            delivery_adapter = self._final_delivery_adapter(event.source)
+            await delivery_adapter.send(
+                event.source.chat_id,
+                "⏳ Run started",
+                metadata=self._run_lifecycle_metadata(event),
+            )
+        except Exception as exc:
+            logger.debug("[%s] Run lifecycle start send failed: %s", self.name, exc)
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction and record durable handling state."""
         message = event.raw_message
@@ -2839,7 +2933,26 @@ class DiscordAdapter(BasePlatformAdapter):
         )
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for final reaction and durable state."""
+        """Swap the in-progress reaction and finalize the durable run outcome."""
+        metadata = getattr(event, "metadata", None)
+        state = metadata.get("_discord_run_lifecycle") if isinstance(metadata, dict) else None
+        if outcome == ProcessingOutcome.CANCELLED:
+            self.set_run_lifecycle_outcome(event, "stopped")
+        elif outcome == ProcessingOutcome.FAILURE:
+            if not isinstance(state, dict) or state.get("outcome") != "timeout":
+                self.set_run_lifecycle_outcome(event, "failed")
+
+        if isinstance(state, dict) and not state.get("terminal_registered"):
+            callback = state.get("terminal_callback")
+            session_key = state.get("session_key")
+            if callable(callback) and session_key:
+                self.register_post_delivery_callback(
+                    str(session_key),
+                    callback,
+                    generation=state.get("generation"),
+                )
+                state["terminal_registered"] = True
+
         await asyncio.to_thread(
             self._record_discord_processing_complete,
             event,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2857,8 +2857,14 @@ class DiscordAdapter(BasePlatformAdapter):
         if not isinstance(state, dict):
             return
         normalized = str(outcome or "").strip().lower()
-        if normalized in {"success", "failed", "stopped", "timeout"}:
-            state["outcome"] = normalized
+        if normalized not in {"success", "failed", "stopped", "timeout"}:
+            return
+        current = str(state.get("outcome") or "").strip().lower()
+        # A generic successful return/delivery must not erase a semantic
+        # failure already recorded inside a caught execution path.
+        if normalized == "success" and current in {"failed", "stopped", "timeout"}:
+            return
+        state["outcome"] = normalized
 
     async def begin_run_lifecycle(
         self,
@@ -2920,6 +2926,22 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] Run lifecycle start send failed: %s", self.name, exc)
 
+    def register_run_lifecycle_terminal(self, event: MessageEvent) -> None:
+        """Append this event's terminal marker after existing deferred output."""
+        metadata = getattr(event, "metadata", None)
+        state = metadata.get("_discord_run_lifecycle") if isinstance(metadata, dict) else None
+        if not isinstance(state, dict) or state.get("terminal_registered"):
+            return
+        callback = state.get("terminal_callback")
+        session_key = state.get("session_key")
+        if callable(callback) and session_key:
+            self.register_post_delivery_callback(
+                str(session_key),
+                callback,
+                generation=state.get("generation"),
+            )
+            state["terminal_registered"] = True
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction and record durable handling state."""
         message = event.raw_message
@@ -2942,16 +2964,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if not isinstance(state, dict) or state.get("outcome") != "timeout":
                 self.set_run_lifecycle_outcome(event, "failed")
 
-        if isinstance(state, dict) and not state.get("terminal_registered"):
-            callback = state.get("terminal_callback")
-            session_key = state.get("session_key")
-            if callable(callback) and session_key:
-                self.register_post_delivery_callback(
-                    str(session_key),
-                    callback,
-                    generation=state.get("generation"),
-                )
-                state["terminal_registered"] = True
+        self.register_run_lifecycle_terminal(event)
 
         await asyncio.to_thread(
             self._record_discord_processing_complete,

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -41,6 +41,7 @@ def _ensure_discord_mock():
 _ensure_discord_mock()
 
 from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from gateway.run import GatewayRunner  # noqa: E402
 
 
 class FakeTree:
@@ -350,6 +351,28 @@ async def test_discord_run_lifecycle_maps_terminal_outcomes(
 
 
 @pytest.mark.asyncio
+async def test_discord_run_lifecycle_success_cannot_downgrade_prior_failure(adapter):
+    event = _make_event(
+        "9b",
+        SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock()),
+    )
+    event.source.chat_type = "thread"
+    event.source.thread_id = "456"
+    session_key = build_session_key(event.source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="status"))
+
+    await adapter.begin_run_lifecycle(event, session_key=session_key, generation=5)
+    adapter.set_run_lifecycle_outcome(event, "failed")
+    adapter.set_run_lifecycle_outcome(event, "success")
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+    callback = adapter.pop_post_delivery_callback(session_key, generation=5)
+
+    assert callback is not None
+    await callback()
+    assert adapter.send.await_args_list[-1].args[1].startswith("❌ Run failed · ")
+
+
+@pytest.mark.asyncio
 async def test_discord_run_terminal_precedes_queued_followup_start(adapter):
     raw_message = SimpleNamespace(
         add_reaction=AsyncMock(),
@@ -426,3 +449,53 @@ async def test_discord_run_terminal_precedes_queued_followup_start(adapter):
         "first deferred output",
     ]
     assert first_terminal_indices == [3]
+
+
+@pytest.mark.asyncio
+async def test_recursive_discord_lifecycle_finishes_prior_run_before_next_start(adapter):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.DISCORD: adapter}
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        thread_id="456",
+        chat_type="thread",
+        user_id="user",
+    )
+    first = MessageEvent(text="first", message_type=MessageType.TEXT, source=source)
+    second = MessageEvent(text="second", message_type=MessageType.TEXT, source=source)
+    session_key = build_session_key(source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="message"))
+
+    await adapter.begin_run_lifecycle(first, session_key=session_key, generation=8)
+
+    async def deferred_delivery():
+        await adapter.send(
+            source.chat_id,
+            "first deferred output",
+            metadata={"thread_id": source.thread_id},
+        )
+
+    adapter.register_post_delivery_callback(
+        session_key,
+        deferred_delivery,
+        generation=8,
+    )
+    await runner._finish_recursive_discord_run_lifecycle(
+        first,
+        session_key=session_key,
+        generation=8,
+        outcome="success",
+        adapter=adapter,
+    )
+    await runner._begin_recursive_discord_run_lifecycle(
+        second,
+        session_key=session_key,
+        generation=8,
+    )
+
+    contents = [call.args[1] for call in adapter.send.await_args_list]
+    assert contents[0] == "⏳ Run started"
+    assert contents[1] == "first deferred output"
+    assert contents[2].startswith("✅ Run complete · ")
+    assert contents[3] == "⏳ Run started"

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -246,3 +246,183 @@ async def test_on_processing_complete_cancelled_removes_eyes_without_terminal_re
 
     raw_message.remove_reaction.assert_awaited_once_with("👀", adapter._client.user)
     raw_message.add_reaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_run_lifecycle_sends_start_then_response_then_fresh_terminal_message(adapter):
+    raw_message = SimpleNamespace(
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+    event = _make_event("8", raw_message)
+    event.source.chat_type = "thread"
+    event.source.thread_id = "456"
+    session_key = build_session_key(event.source)
+
+    async def handler(current_event):
+        await adapter.begin_run_lifecycle(
+            current_event,
+            session_key=session_key,
+            generation=3,
+        )
+
+        async def deferred_delivery():
+            await adapter.send(
+                current_event.source.chat_id,
+                "deferred output",
+                metadata={"thread_id": "456"},
+            )
+
+        adapter.register_post_delivery_callback(
+            session_key,
+            deferred_delivery,
+            generation=3,
+        )
+        return "answer"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter.send = AsyncMock(
+        side_effect=[
+            SendResult(success=True, message_id="start"),
+            SendResult(success=True, message_id="answer"),
+            SendResult(success=True, message_id="deferred"),
+            SendResult(success=True, message_id="terminal"),
+        ]
+    )
+    adapter._keep_typing = hold_typing
+
+    await adapter._process_message_background(event, session_key)
+
+    sent = adapter.send.await_args_list
+    contents = [
+        call.args[1] if len(call.args) > 1 else call.kwargs["content"]
+        for call in sent
+    ]
+    assert contents[:3] == ["⏳ Run started", "answer", "deferred output"]
+    assert contents[3].startswith("✅ Run complete · ")
+    assert sent[0].kwargs["metadata"]["thread_id"] == "456"
+    assert sent[3].kwargs["metadata"]["thread_id"] == "456"
+    assert sent[0].kwargs["metadata"]["non_conversational"] is True
+    assert sent[3].kwargs["metadata"]["non_conversational"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("processing_outcome", "lifecycle_outcome", "prefix"),
+    [
+        (ProcessingOutcome.SUCCESS, "timeout", "⚠️ Run timed out · "),
+        (ProcessingOutcome.FAILURE, None, "❌ Run failed · "),
+        (ProcessingOutcome.CANCELLED, None, "⏹️ Run stopped · "),
+    ],
+)
+async def test_discord_run_lifecycle_maps_terminal_outcomes(
+    adapter,
+    processing_outcome,
+    lifecycle_outcome,
+    prefix,
+):
+    event = _make_event("9", SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock()))
+    event.source.chat_type = "thread"
+    event.source.thread_id = "456"
+    session_key = build_session_key(event.source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="status"))
+
+    await adapter.begin_run_lifecycle(event, session_key=session_key, generation=4)
+    if lifecycle_outcome:
+        adapter.set_run_lifecycle_outcome(event, lifecycle_outcome)
+    await adapter.on_processing_complete(event, processing_outcome)
+    callback = adapter.pop_post_delivery_callback(session_key, generation=4)
+
+    assert callback is not None
+    await callback()
+    await callback()
+
+    terminal_contents = [
+        call.args[1]
+        for call in adapter.send.await_args_list
+        if call.args[1] != "⏳ Run started"
+    ]
+    assert len(terminal_contents) == 1
+    assert terminal_contents[0].startswith(prefix)
+
+
+@pytest.mark.asyncio
+async def test_discord_run_terminal_precedes_queued_followup_start(adapter):
+    raw_message = SimpleNamespace(
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+    first = _make_event("10", raw_message)
+    first.source.chat_type = "thread"
+    first.source.thread_id = "456"
+    second = _make_event("11", raw_message)
+    second.source.chat_type = "thread"
+    second.source.thread_id = "456"
+    session_key = build_session_key(first.source)
+    second_started = asyncio.Event()
+    release_second = asyncio.Event()
+    turns = 0
+
+    async def handler(current_event):
+        nonlocal turns
+        turns += 1
+        generation = turns
+        interrupt_event = adapter._active_sessions[session_key]
+        setattr(interrupt_event, "_hermes_run_generation", generation)
+        await adapter.begin_run_lifecycle(
+            current_event,
+            session_key=session_key,
+            generation=generation,
+        )
+        if turns == 1:
+            async def deferred_delivery():
+                await adapter.send(
+                    current_event.source.chat_id,
+                    "first deferred output",
+                    metadata={"thread_id": "456"},
+                )
+
+            adapter.register_post_delivery_callback(
+                session_key,
+                deferred_delivery,
+                generation=generation,
+            )
+            adapter._pending_messages[session_key] = second
+            return "first answer"
+        second_started.set()
+        await release_second.wait()
+        return "second answer"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="message"))
+    adapter._keep_typing = hold_typing
+
+    await adapter._process_message_background(first, session_key)
+    await asyncio.wait_for(second_started.wait(), timeout=1.0)
+    release_second.set()
+    task = adapter._session_tasks.get(session_key)
+    if task is not None:
+        await asyncio.wait_for(task, timeout=1.0)
+
+    contents = [
+        call.args[1] if len(call.args) > 1 else call.kwargs["content"]
+        for call in adapter.send.await_args_list
+    ]
+    second_start_index = contents.index("⏳ Run started", 1)
+    first_terminal_indices = [
+        index
+        for index, text in enumerate(contents)
+        if text.startswith("✅ Run complete · ") and index < second_start_index
+    ]
+    assert contents[:3] == [
+        "⏳ Run started",
+        "first answer",
+        "first deferred output",
+    ]
+    assert first_terminal_indices == [3]

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -265,20 +265,27 @@ def test_nonempty_agent_result_preserves_failure_and_timeout_flags():
 @pytest.mark.parametrize("failing_stage", ["set", "register", "pop"])
 async def test_recursive_lifecycle_setup_failures_are_best_effort(failing_stage):
     runner, _adapter, event = _make_discord_runner_and_event()
+    calls = []
+
+    async def deferred_callback():
+        calls.append("callback")
 
     class FailingLifecycleAdapter:
         def set_run_lifecycle_outcome(self, _event, _outcome):
+            calls.append("set")
             if failing_stage == "set":
                 raise RuntimeError("setter failed")
 
         def register_run_lifecycle_terminal(self, _event):
+            calls.append("register")
             if failing_stage == "register":
                 raise RuntimeError("registration failed")
 
         def pop_post_delivery_callback(self, _session_key, *, generation=None):
+            calls.append("pop")
             if failing_stage == "pop":
                 raise RuntimeError("pop failed")
-            return None
+            return deferred_callback
 
     await runner._finish_recursive_discord_run_lifecycle(
         event,
@@ -287,6 +294,11 @@ async def test_recursive_lifecycle_setup_failures_are_best_effort(failing_stage)
         outcome="success",
         adapter=FailingLifecycleAdapter(),
     )
+
+    expected = ["set", "register", "pop"]
+    if failing_stage != "pop":
+        expected.append("callback")
+    assert calls == expected
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -28,12 +28,15 @@ class _FakeAdapter:
         self.interrupted_sessions = []
         self.lifecycle_starts = []
         self.lifecycle_outcomes = []
+        self.begin_lifecycle_error = None
 
     async def send(self, chat_id, text, **kwargs):
         pass
 
     async def begin_run_lifecycle(self, event, *, session_key, generation=None):
         self.lifecycle_starts.append((event, session_key, generation))
+        if self.begin_lifecycle_error is not None:
+            raise self.begin_lifecycle_error
 
     def set_run_lifecycle_outcome(self, event, outcome):
         self.lifecycle_outcomes.append((event, outcome))
@@ -217,6 +220,20 @@ async def test_discord_agent_run_marks_lifecycle_stopped_when_cancelled():
             await runner._handle_message(event)
 
     assert adapter.lifecycle_outcomes == [(event, "stopped")]
+
+
+@pytest.mark.asyncio
+async def test_discord_start_cancellation_marks_stopped_and_releases_session_slot():
+    runner, adapter, event = _make_discord_runner_and_event()
+    session_key = build_session_key(event.source)
+    adapter.begin_lifecycle_error = asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._handle_message(event)
+
+    assert adapter.lifecycle_outcomes == [(event, "stopped")]
+    assert session_key not in runner._running_agents
+    assert session_key not in getattr(runner, "_active_session_leases", {})
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -262,6 +262,54 @@ def test_nonempty_agent_result_preserves_failure_and_timeout_flags():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("failing_stage", ["set", "register", "pop"])
+async def test_recursive_lifecycle_setup_failures_are_best_effort(failing_stage):
+    runner, _adapter, event = _make_discord_runner_and_event()
+
+    class FailingLifecycleAdapter:
+        def set_run_lifecycle_outcome(self, _event, _outcome):
+            if failing_stage == "set":
+                raise RuntimeError("setter failed")
+
+        def register_run_lifecycle_terminal(self, _event):
+            if failing_stage == "register":
+                raise RuntimeError("registration failed")
+
+        def pop_post_delivery_callback(self, _session_key, *, generation=None):
+            if failing_stage == "pop":
+                raise RuntimeError("pop failed")
+            return None
+
+    await runner._finish_recursive_discord_run_lifecycle(
+        event,
+        session_key=build_session_key(event.source),
+        generation=4,
+        outcome="success",
+        adapter=FailingLifecycleAdapter(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_recursive_lifecycle_callback_cancellation_still_propagates():
+    runner, _adapter, event = _make_discord_runner_and_event()
+
+    async def cancelled_callback():
+        raise asyncio.CancelledError()
+
+    adapter = MagicMock()
+    adapter.pop_post_delivery_callback.return_value = cancelled_callback
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._finish_recursive_discord_run_lifecycle(
+            event,
+            session_key=build_session_key(event.source),
+            generation=5,
+            outcome="stopped",
+            adapter=adapter,
+        )
+
+
+@pytest.mark.asyncio
 async def test_non_discord_agent_run_does_not_emit_run_lifecycle():
     runner = _make_runner()
     event = _make_event()

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -26,9 +26,17 @@ class _FakeAdapter:
         self._pending_messages = {}
         self._active_sessions = {}
         self.interrupted_sessions = []
+        self.lifecycle_starts = []
+        self.lifecycle_outcomes = []
 
     async def send(self, chat_id, text, **kwargs):
         pass
+
+    async def begin_run_lifecycle(self, event, *, session_key, generation=None):
+        self.lifecycle_starts.append((event, session_key, generation))
+
+    def set_run_lifecycle_outcome(self, event, outcome):
+        self.lifecycle_outcomes.append((event, outcome))
 
     async def interrupt_session_activity(self, session_key, chat_id):
         self.interrupted_sessions.append((session_key, chat_id))
@@ -73,6 +81,27 @@ def _make_event(text="hello", chat_id="12345"):
         user_id="u1",
     )
     return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
+
+
+def _make_discord_runner_and_event():
+    runner = _make_runner()
+    adapter = _FakeAdapter()
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="12345",
+        thread_id="45678",
+        chat_type="thread",
+        user_id="u1",
+    )
+    return runner, adapter, MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
 
 
 # ------------------------------------------------------------------
@@ -146,6 +175,80 @@ async def test_sentinel_cleaned_up_on_exception():
     assert session_key not in runner._running_agents, (
         "Sentinel must be removed even if handler raises"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agent_result", "expected_outcome"),
+    [
+        ({"final_response": "", "failed": False}, "success"),
+        ({"final_response": "", "failed": True}, "failed"),
+        ({"final_response": "", "failed": True, "timed_out": True}, "timeout"),
+        ({"final_response": "", "interrupted": True}, "stopped"),
+    ],
+)
+async def test_discord_agent_run_starts_lifecycle_and_classifies_result(
+    agent_result,
+    expected_outcome,
+):
+    runner, adapter, event = _make_discord_runner_and_event()
+    session_key = build_session_key(event.source)
+
+    async def mock_inner(self_inner, ev, src, qk, generation):
+        assert adapter.lifecycle_starts == [(event, session_key, generation)]
+        return agent_result
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        await runner._handle_message(event)
+
+    assert len(adapter.lifecycle_starts) == 1
+    assert adapter.lifecycle_outcomes == [(event, expected_outcome)]
+
+
+@pytest.mark.asyncio
+async def test_discord_agent_run_marks_lifecycle_stopped_when_cancelled():
+    runner, adapter, event = _make_discord_runner_and_event()
+
+    async def mock_inner(self_inner, ev, src, qk, generation):
+        raise asyncio.CancelledError
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        with pytest.raises(asyncio.CancelledError):
+            await runner._handle_message(event)
+
+    assert adapter.lifecycle_outcomes == [(event, "stopped")]
+
+
+@pytest.mark.asyncio
+async def test_non_discord_agent_run_does_not_emit_run_lifecycle():
+    runner = _make_runner()
+    event = _make_event()
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    async def mock_inner(self_inner, ev, src, qk, generation):
+        return {"final_response": "", "failed": False}
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        await runner._handle_message(event)
+
+    assert adapter.lifecycle_starts == []
+    assert adapter.lifecycle_outcomes == []
+
+
+@pytest.mark.asyncio
+async def test_discord_dm_does_not_emit_thread_run_lifecycle():
+    runner, adapter, event = _make_discord_runner_and_event()
+    event.source.chat_type = "dm"
+    event.source.thread_id = None
+
+    async def mock_inner(self_inner, ev, src, qk, generation):
+        return {"final_response": "", "failed": False}
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        await runner._handle_message(event)
+
+    assert adapter.lifecycle_starts == []
+    assert adapter.lifecycle_outcomes == []
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -236,6 +236,31 @@ async def test_discord_start_cancellation_marks_stopped_and_releases_session_slo
     assert session_key not in getattr(runner, "_active_session_leases", {})
 
 
+def test_string_only_followup_gets_a_lifecycle_event():
+    runner, _adapter, original = _make_discord_runner_and_event()
+
+    event = runner._event_for_pending_text(None, "continue with this", original.source)
+
+    assert event is not None
+    assert event.text == "continue with this"
+    assert event.message_type == MessageType.TEXT
+    assert event.source is original.source
+    assert event.metadata.get("_synthetic_pending_followup") is True
+
+
+def test_nonempty_agent_result_preserves_failure_and_timeout_flags():
+    import inspect
+
+    source = inspect.getsource(GatewayRunner._run_agent_inner)
+    titled_return = source.index("# Auto-generate session title")
+    return_start = source.index('"final_response": final_response', titled_return)
+    return_end = source.index('"tools": tools_holder[0]', return_start)
+    nonempty_result = source[return_start:return_end]
+
+    assert '"failed"' in nonempty_result
+    assert '"timed_out"' in nonempty_result
+
+
 @pytest.mark.asyncio
 async def test_non_discord_agent_run_does_not_emit_run_lifecycle():
     runner = _make_runner()

--- a/website/docs/product/discord-run-lifecycle.md
+++ b/website/docs/product/discord-run-lifecycle.md
@@ -1,0 +1,46 @@
+---
+title: "Discord Run Lifecycle"
+description: "Product contract for visible Discord agent run state"
+---
+
+# Discord Run Lifecycle
+
+## Product
+
+Hermes exposes a durable, in-thread lifecycle for every Discord agent run that has a real thread destination, so a user can tell whether the agent accepted the request, is still working, and how the run ended without relying on Discord's transient typing indicator.
+
+## User story
+
+As a Discord user working with Hermes in a thread, I can see an immediate start marker and a final bottom-of-thread terminal marker, so I never have to infer run state from typing presence, reactions on the parent message, or an earlier edited progress bubble.
+
+## Required behavior
+
+1. Once a Discord request is accepted for agent execution, Hermes posts a new message in the run's actual destination thread: `⏳ Run started`.
+2. Existing typing indicators, processing reactions, streamed output, and tool-progress messages remain available as secondary feedback.
+3. The normal answer and generated output are delivered before the terminal marker.
+4. Hermes then appends exactly one new terminal message at the bottom of the same thread:
+   - `✅ Run complete · <elapsed>` for success;
+   - `⏹️ Run stopped · <elapsed>` for user interruption or cancellation;
+   - `❌ Run failed · <elapsed>` for an execution failure;
+   - `⚠️ Run timed out · <elapsed>` for a timeout.
+5. A safe, short reason may follow stopped, failed, or timed-out states. Internal exception details, credentials, and provider payloads must not be exposed.
+6. Lifecycle delivery is best-effort and must never replace, suppress, or change the run's actual answer or outcome.
+7. This contract applies to Discord only. Other messaging platforms retain their existing behavior unless they adopt an equivalent contract explicitly.
+
+## Boundaries and non-goals
+
+- The typing indicator is not made authoritative; Discord may hide it.
+- Reactions remain enabled and retain their existing meaning.
+- The start and terminal messages are non-conversational gateway metadata and must not become assistant transcript content or history boundaries.
+- This feature does not add job persistence or imply that a run survives gateway process termination.
+- This feature does not expose chain-of-thought or private reasoning.
+
+## Acceptance criteria
+
+- A Discord thread receives the start marker before model/tool output.
+- Successful output is followed by one fresh completion marker.
+- Cancellation/interruption, failure, and timeout each produce the matching fresh terminal marker.
+- Lifecycle messages target the actual thread rather than only the parent-channel starter message.
+- Duplicate completion callbacks cannot produce duplicate terminal markers.
+- Lifecycle send failures do not alter the underlying run outcome.
+- Existing Discord reaction, typing, streaming, and response tests remain green.

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -38,6 +38,8 @@ Hermes on Discord is not a webhook that replies statelessly. It runs through the
 
 That matters because behavior in a busy server depends on both Discord routing and Hermes session policy.
 
+For the authoritative user-visible start, progress, and terminal-state behavior of an agent run, see the [Discord Run Lifecycle](../../product/discord-run-lifecycle.md) product contract.
+
 ### Session Model in Discord
 
 By default:


### PR DESCRIPTION
## Summary

- add an immediate, durable `⏳ Run started` marker for Discord agent runs with a real thread destination
- append exactly one fresh terminal message after all normal and deferred output (`✅` complete, `⏹️` stopped, `❌` failed, or `⚠️` timed out)
- classify inactivity timeouts explicitly and preserve existing typing/reaction behavior
- give queued, interrupt-message, and pending-steer follow-up turns their own ordered lifecycle, flushing the prior run first
- preserve semantic `failed`/`timed_out` outcomes even when the agent returns non-empty friendly error text
- document the permanent Discord run-lifecycle product contract

## Product behavior

The start and terminal markers are thread-strict and non-conversational. Discord DMs, non-thread channels, and other platforms are unchanged. Lifecycle-delivery failures remain best-effort and do not replace the agent response.

## Tests

- latest affected-surface run: `238 passed, 1 deselected`
  - the deselected media-path test was separately exercised; it conflicts with the neutral `HOME` needed by three `/profile` path-format tests in this relocated-temp environment
- full single-process `tests/gateway`: `11,274 passed, 60 skipped, 30 failed` in 8m15s
  - no modified test failed
  - failures were confined to unmodified optional-platform/environment-sensitive suites
- `ruff check` passed for all changed Python files
- `git diff --check` passed
- Docusaurus generated `website/build/product/discord-run-lifecycle/index.html`

## Review status

Independent reviews found and drove fixes for cancellation cleanup, recursive queued-turn lifecycle ownership, caught/non-empty failure classification, and string-only interrupt/steer lifecycle identity. Final independent exact-candidate review of commit `6a06edc10`: no findings. The reviewer verified failure isolation, deferred-callback draining, cancellation propagation, and recursive callers; 47 focused tests passed in its checkout.

## Environment notes

The repository's default 48-worker gateway runner exceeded this container's thread/process allowance. A first single-process retry used the 512MB `/tmp` tmpfs and failed when it filled. Relocating `TMPDIR` and `HERMES_HOME` to the main filesystem produced the complete broad-suite result above.
