### PR TITLE
fix(slack): never lose an inbound event without a trace

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2331,6 +2331,55 @@ class SlackAdapter(BasePlatformAdapter):
         """Scope Slack's workspace-local event/message ids for deduplication."""
         return f"{team_id}:{event_id}" if team_id else str(event_id)
 
+    def _slack_event_dedup_id(
+        self, event: dict, payload: Optional[dict] = None
+    ) -> str:
+        """Return the deduplication id claimed for *event*, or "" if none."""
+        event_ts = event.get("_slack_changed_event_ts") or event.get("ts", "")
+        if not event_ts:
+            return ""
+        return self._workspace_event_id(self._event_team_id(event, payload), event_ts)
+
+    @staticmethod
+    def _slack_event_coords(event: dict) -> str:
+        """Describe an inbound event for logs — metadata only, never text."""
+        return "type={} subtype={} channel={} ts={} thread_ts={} user={}".format(
+            event.get("type") or "message",
+            event.get("subtype") or "-",
+            event.get("channel") or "-",
+            event.get("ts") or "-",
+            event.get("thread_ts") or "-",
+            event.get("user") or "-",
+        )
+
+    def _release_slack_event_claim(
+        self, event: dict, payload: Optional[dict] = None
+    ) -> None:
+        """Hand an undelivered event's dedup slot back for a retry.
+
+        Best-effort by construction: this only ever runs on a path that is
+        already failing, so it must not raise a second exception over the
+        first one.
+        """
+        try:
+            self._dedup.discard(self._slack_event_dedup_id(event, payload))
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("[Slack] Could not release dedup claim", exc_info=True)
+
+    def _log_slack_discard(self, event: dict, reason: str) -> None:
+        """Account for an inbound event the ingress deliberately drops.
+
+        Every filter in ``_route_slack_message`` funnels through here so a
+        Slack event can never leave the gateway without a trace: an operator
+        holding a Slack ts can always find out whether we received it and why
+        it produced no reply.
+        """
+        logger.info(
+            "[Slack] Discarded inbound event (%s): %s",
+            reason,
+            self._slack_event_coords(event),
+        )
+
     @staticmethod
     def _workspace_message_marker(team_id: str, message_id: str) -> Any:
         """Return an in-memory routing marker without changing legacy no-team tests."""
@@ -5225,7 +5274,40 @@ class SlackAdapter(BasePlatformAdapter):
     async def _handle_slack_message(
         self, event: dict, payload: Optional[dict] = None
     ) -> None:
-        """Handle an incoming Slack message event."""
+        """Deliver an inbound Slack event, accounting for every outcome.
+
+        This is the sole ingress for Slack traffic, so it owns the guarantee
+        that an event either reaches the gateway or says why it did not.
+        Routing does a lot of best-effort enrichment (user/channel name
+        lookups, thread backfill, file downloads) against the Slack Web API;
+        each of those helpers degrades on its own today, but nothing bounded
+        the ingress as a whole. An unexpected failure anywhere in that chain
+        therefore destroyed a valid @mention with no record of the ts, and —
+        because the deduplication claim was taken up front — permanently
+        suppressed the sibling ``app_mention`` Slack fires for the same
+        message and every Socket Mode redelivery of it.
+
+        Releasing the claim on failure mirrors the Discord adapter, which
+        already calls ``_dedup.discard`` when a handoff is cancelled or
+        raises.
+        """
+        try:
+            await self._route_slack_message(event, payload)
+        except asyncio.CancelledError:
+            self._release_slack_event_claim(event, payload)
+            raise
+        except Exception:
+            self._release_slack_event_claim(event, payload)
+            logger.error(
+                "[Slack] Inbound event lost before dispatch: %s",
+                self._slack_event_coords(event),
+                exc_info=True,
+            )
+
+    async def _route_slack_message(
+        self, event: dict, payload: Optional[dict] = None
+    ) -> None:
+        """Filter, enrich, and route an incoming Slack message event."""
         # DEBUG entry log — fires BEFORE any filtering so users debugging
         # bot-to-bot interop, allow_bots config, or SLACK_ALLOWED_USERS
         # drops can confirm whether the event actually arrived from Slack
@@ -5251,6 +5333,7 @@ class SlackAdapter(BasePlatformAdapter):
         if event.get("subtype") == "message_changed":
             updated_message = event.get("message")
             if not isinstance(updated_message, dict):
+                self._log_slack_discard(event, "edit carries no message body")
                 return
 
             original_message_ts = str(updated_message.get("ts") or "")
@@ -5258,6 +5341,7 @@ class SlackAdapter(BasePlatformAdapter):
                 original_message_ts
                 and original_message_ts in self._processed_message_ts
             ):
+                self._log_slack_discard(event, "edit of an already-handled message")
                 return
             edited = updated_message.get("edited")
             edited_ts = ""
@@ -5286,11 +5370,9 @@ class SlackAdapter(BasePlatformAdapter):
         # Scope the dedup id by workspace: Slack event ts values are only
         # unique within one workspace, so two teams' events with the same ts
         # must not suppress each other.
-        event_ts = event.get("_slack_changed_event_ts") or event.get("ts", "")
-        dedup_team_id = self._event_team_id(event, payload)
-        if event_ts and self._dedup.is_duplicate(
-            self._workspace_event_id(dedup_team_id, event_ts)
-        ):
+        dedup_id = self._slack_event_dedup_id(event, payload)
+        if dedup_id and self._dedup.is_duplicate(dedup_id):
+            self._log_slack_discard(event, "duplicate of an already-claimed event")
             return
 
         channel_id = event.get("channel", "")
@@ -5323,26 +5405,27 @@ class SlackAdapter(BasePlatformAdapter):
         if sender_is_bot:
             allow_bots = self._slack_allow_bots()
             if allow_bots == "none":
+                self._log_slack_discard(event, "bot-authored sender, allow_bots=none")
                 return
             elif allow_bots == "mentions":
                 # Include Block-Kit-only mentions, not just the flat text (#52387)
                 text_check = _slack_mention_detection_text(event)
                 if self._bot_user_id and f"<@{self._bot_user_id}>" not in text_check:
-                    logger.debug(
-                        "[Slack] Dropping bot message under allow_bots=mentions: "
-                        "no <@%s> mention in flat text or blocks",
-                        self._bot_user_id,
+                    self._log_slack_discard(
+                        event, "bot-authored sender without a mention, allow_bots=mentions"
                     )
                     return
             # "all" falls through to process the message
             # Always ignore our own messages to prevent echo loops
             if msg_user and self._bot_user_id and msg_user == self._bot_user_id:
+                self._log_slack_discard(event, "our own message")
                 return
 
         # Ignore message deletions. Edits are normalized above so an @mention
         # added by edit can still wake the bot once.
         subtype = event.get("subtype")
         if subtype == "message_deleted":
+            self._log_slack_discard(event, "message deleted")
             return
 
         original_text = event.get("text", "")
@@ -5633,17 +5716,19 @@ class SlackAdapter(BasePlatformAdapter):
             if sender_is_bot_user:
                 allow_bots = self._slack_allow_bots()
                 if allow_bots == "none":
+                    self._log_slack_discard(event, "resolved bot user, allow_bots=none")
                     return
                 if allow_bots == "mentions" and not is_mentioned:
+                    self._log_slack_discard(
+                        event, "resolved bot user without a mention, allow_bots=mentions"
+                    )
                     return
 
         if not is_one_to_one_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)
             allowed_channels = self._slack_allowed_channels()
             if allowed_channels and channel_id not in allowed_channels:
-                logger.debug(
-                    "[Slack] Ignoring message in non-allowed channel: %s", channel_id
-                )
+                self._log_slack_discard(event, "channel not in allowed_channels")
                 return
 
             # A message that opens by @mentioning another user is directed at
@@ -5657,10 +5742,7 @@ class SlackAdapter(BasePlatformAdapter):
                 and not self._slack_message_mentions_self(routing_text, self_uids)
                 and self._slack_message_addressed_to_other_user(routing_text, self_uids)
             ):
-                logger.debug(
-                    "[Slack] Ignoring message addressed to another user in channel %s",
-                    channel_id,
-                )
+                self._log_slack_discard(event, "addressed to another user")
                 return
 
             if force_process:
@@ -5683,25 +5765,21 @@ class SlackAdapter(BasePlatformAdapter):
                     and is_thread_reply
                     and not is_mentioned
                 ):
-                    logger.debug(
-                        "[Slack] Ignoring thread reply without mention "
-                        "(thread_require_mention=true): channel=%s thread_ts=%s",
-                        channel_id,
-                        event_thread_ts,
+                    self._log_slack_discard(
+                        event, "thread reply without mention, thread_require_mention=true"
                     )
                     return
             elif self._slack_strict_mention() and not is_mentioned:
-                return  # Strict mode: ignore until @-mentioned again
+                # Strict mode: ignore until @-mentioned again.
+                self._log_slack_discard(event, "no mention, strict_mention=true")
+                return
             elif (
                 self._slack_thread_require_mention()
                 and is_thread_reply
                 and not is_mentioned
             ):
-                logger.debug(
-                    "[Slack] Ignoring thread reply without mention "
-                    "(thread_require_mention=true): channel=%s thread_ts=%s",
-                    channel_id,
-                    event_thread_ts,
+                self._log_slack_discard(
+                    event, "thread reply without mention, thread_require_mention=true"
                 )
                 return
             elif not is_mentioned:
@@ -5713,6 +5791,7 @@ class SlackAdapter(BasePlatformAdapter):
                     is_thread_reply=is_thread_reply,
                     chat_type="dm" if is_dm else "group",
                 ):
+                    self._log_slack_discard(event, "no mention and nothing to wake on")
                     return
 
         if is_mentioned:

--- a/tests/gateway/test_slack_event_reliability.py
+++ b/tests/gateway/test_slack_event_reliability.py
@@ -1,0 +1,277 @@
+"""Slack inbound event reliability — no event may vanish without a trace.
+
+``SlackAdapter._handle_slack_message`` is the single ingress for every inbound
+Slack event (``message``, ``app_mention``, file shares, reaction routes). Two
+invariants are asserted here:
+
+1.  **Delivery is accounted for.** If anything between socket receipt and
+    ``handle_message()`` raises, the event must produce an ERROR that names it
+    (channel / ts / thread_ts) and must RELEASE its deduplication claim, so the
+    sibling ``app_mention`` Slack fires for the same @mention — or a Socket
+    Mode redelivery — can still be processed. The Discord adapter already
+    releases the claim on a failed handoff
+    (``_dedup.discard`` in ``_scan_recent_discord_messages``); Slack did not,
+    so a mid-flight failure swallowed the message permanently and silently.
+
+2.  **Every intentional discard is logged.** The bare ``return`` filters in the
+    ingress (dedup hit, ``allow_bots``, ``message_deleted``, strict mention,
+    unmentioned non-wake) emitted nothing at INFO, so a filtered event left no
+    trace at all and was indistinguishable from an event Slack never sent.
+
+Regression for the incident where an @mention posted in a thread while another
+gateway turn was active never reached the gateway and never appeared in logs.
+"""
+
+import asyncio
+import logging
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler", slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+ADAPTER_LOGGER = "plugins.platforms.slack.adapter"
+
+BOT_USER_ID = "U0BFVBD9H19"
+CHANNEL_ID = "C0BK9LZFYFM"
+THREAD_TS = "1785180592.650829"
+MESSAGE_TS = "1785180644.192059"
+TEAM_ID = "T0BF6M0M2AZ"
+SENDER_ID = "U_BROCK"
+
+
+def _make_adapter(**extra):
+    adapter = SlackAdapter(
+        PlatformConfig(enabled=True, token="xoxb-test", extra=dict(extra))
+    )
+    adapter.platform = Platform.SLACK
+    adapter._bot_user_id = BOT_USER_ID
+    adapter._resolve_user_is_bot = AsyncMock(return_value=False)
+    adapter._resolve_user_name = AsyncMock(return_value="brock")
+    adapter._resolve_channel_name = AsyncMock(return_value="robert-ops-shadow")
+    adapter._fetch_thread_context = AsyncMock(return_value="")
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _mention_in_thread(**overrides):
+    """The incident event: an @mention posted as a reply in an existing thread."""
+    event = {
+        "type": "message",
+        "channel": CHANNEL_ID,
+        "channel_type": "channel",
+        "ts": MESSAGE_TS,
+        "thread_ts": THREAD_TS,
+        "team": TEAM_ID,
+        "user": SENDER_ID,
+        "client_msg_id": "cmid-incident",
+        "text": f"<@{BOT_USER_ID}> do you see any duplicate subscriptions?",
+    }
+    event.update(overrides)
+    return event
+
+
+def _discard_records(caplog):
+    """Log records that name the discarded event's Slack coordinates."""
+    return [
+        record
+        for record in caplog.records
+        if MESSAGE_TS in record.getMessage() and CHANNEL_ID in record.getMessage()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. Delivery accounting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_healthy_mention_in_thread_is_delivered():
+    """Control: the incident event reaches the gateway on the happy path."""
+    adapter = _make_adapter()
+
+    await adapter._handle_slack_message(_mention_in_thread())
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ingress_failure_is_logged_with_event_coordinates(caplog):
+    """A mid-flight failure must name the lost event, not vanish."""
+    adapter = _make_adapter()
+    adapter._resolve_channel_name = AsyncMock(side_effect=RuntimeError("ratelimited"))
+
+    with caplog.at_level(logging.INFO, logger=ADAPTER_LOGGER):
+        await adapter._handle_slack_message(_mention_in_thread())
+
+    assert adapter.handle_message.await_count == 0
+    failures = [r for r in _discard_records(caplog) if r.levelno >= logging.ERROR]
+    assert failures, (
+        "a Slack event lost before delivery produced no ERROR naming it — "
+        f"records: {[r.getMessage() for r in caplog.records]}"
+    )
+    assert THREAD_TS in failures[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_ingress_failure_releases_dedup_claim_so_sibling_event_delivers():
+    """Slack fires ``message`` AND ``app_mention`` for one @mention.
+
+    The two share an event ts, so whichever reaches the deduplicator first
+    claims it. If that one dies mid-flight the claim must be released, or the
+    sibling — the user's only remaining chance to be heard — is swallowed.
+    """
+    adapter = _make_adapter()
+    adapter._resolve_channel_name = AsyncMock(side_effect=RuntimeError("ratelimited"))
+
+    await adapter._handle_slack_message(_mention_in_thread())
+    assert adapter.handle_message.await_count == 0
+
+    # The sibling app_mention for the very same user action.
+    adapter._resolve_channel_name = AsyncMock(return_value="robert-ops-shadow")
+    await adapter._handle_slack_message(_mention_in_thread(type="app_mention"))
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_successful_delivery_keeps_dedup_claim():
+    """The release must not weaken redelivery suppression on the happy path."""
+    adapter = _make_adapter()
+
+    await adapter._handle_slack_message(_mention_in_thread())
+    await adapter._handle_slack_message(_mention_in_thread(type="app_mention"))
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ingress_failure_does_not_break_the_socket_listener():
+    """Bolt's listener must not see the exception — the ingress owns it."""
+    adapter = _make_adapter()
+    adapter._resolve_channel_name = AsyncMock(side_effect=RuntimeError("ratelimited"))
+
+    await adapter._handle_slack_message(_mention_in_thread())
+
+
+@pytest.mark.asyncio
+async def test_cancellation_releases_the_claim_and_still_propagates():
+    """Shutdown must stay cancellable, but must not eat the event either."""
+    adapter = _make_adapter()
+    adapter._resolve_channel_name = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._handle_slack_message(_mention_in_thread())
+
+    adapter._resolve_channel_name = AsyncMock(return_value="robert-ops-shadow")
+    await adapter._handle_slack_message(_mention_in_thread())
+
+    adapter.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 2. Discard observability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_event_discard_is_logged(caplog):
+    adapter = _make_adapter()
+    await adapter._handle_slack_message(_mention_in_thread())
+    caplog.clear()
+
+    with caplog.at_level(logging.INFO, logger=ADAPTER_LOGGER):
+        await adapter._handle_slack_message(_mention_in_thread(type="app_mention"))
+
+    records = _discard_records(caplog)
+    assert records, "a deduplicated Slack event produced no log line"
+    assert any("duplicate" in r.getMessage().lower() for r in records)
+
+
+@pytest.mark.asyncio
+async def test_deleted_message_discard_is_logged(caplog):
+    adapter = _make_adapter()
+
+    with caplog.at_level(logging.INFO, logger=ADAPTER_LOGGER):
+        await adapter._handle_slack_message(
+            _mention_in_thread(subtype="message_deleted")
+        )
+
+    assert adapter.handle_message.await_count == 0
+    assert _discard_records(caplog), "a deleted-message event produced no log line"
+
+
+@pytest.mark.asyncio
+async def test_bot_sender_discard_is_logged(caplog):
+    """``allow_bots=none`` drops bot-authored events — say so."""
+    adapter = _make_adapter(allow_bots="none")
+    adapter._resolve_user_is_bot = AsyncMock(return_value=True)
+
+    with caplog.at_level(logging.INFO, logger=ADAPTER_LOGGER):
+        await adapter._handle_slack_message(
+            _mention_in_thread(bot_id="B123", client_msg_id=None)
+        )
+
+    assert adapter.handle_message.await_count == 0
+    assert _discard_records(caplog), "a bot-filtered event produced no log line"
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_thread_reply_discard_is_logged(caplog):
+    """The default require_mention path drops ambient chatter — say so."""
+    adapter = _make_adapter(require_mention=True)
+
+    with caplog.at_level(logging.INFO, logger=ADAPTER_LOGGER):
+        await adapter._handle_slack_message(
+            _mention_in_thread(text="ambient chatter with no mention")
+        )
+
+    assert adapter.handle_message.await_count == 0
+    assert _discard_records(caplog), "an unmentioned event produced no log line"
+
+
+@pytest.mark.asyncio
+async def test_discard_log_never_contains_message_text(caplog):
+    """Discard logs are metadata only — they must not leak message content."""
+    secret = "customer-id-12345-private"
+    adapter = _make_adapter(require_mention=True)
+
+    with caplog.at_level(logging.DEBUG, logger=ADAPTER_LOGGER):
+        await adapter._handle_slack_message(_mention_in_thread(text=secret))
+
+    assert adapter.handle_message.await_count == 0
+    assert secret not in caplog.text

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -401,7 +401,7 @@ def test_reaction_guard_pinned_to_production_expression():
     (back to ``is_dm or is_mentioned``, which reacts to unmentioned MPIMs)
     fails here instead of silently passing a self-referential lambda.
     """
-    src = inspect.getsource(SlackAdapter._handle_slack_message)
+    src = inspect.getsource(SlackAdapter._route_slack_message)
     assert "(is_one_to_one_dm or is_mentioned)" in src, (
         "reaction guard no longer keys off is_one_to_one_dm — an unmentioned "
         "MPIM would react again (regression of the group-DM fix)"


### PR DESCRIPTION
## Symptom

A valid `@mention` in a Slack channel produced no reply and left no trace in the gateway logs, while Socket Mode stayed connected and both the bot and app tokens were healthy. Reposting the same text hours later was answered in six seconds.

Because there was no log line for the lost event, the failure was indistinguishable from "Slack never delivered it."

## Root cause

`_handle_slack_message` claimed the event's deduplication slot up front, then ran a long best-effort enrichment chain (user/channel name lookups, thread backfill, file downloads) against the Slack Web API with no guard around the ingress as a whole.

Each of those helpers degrades on its own, so the "an event always reaches the gateway or is deliberately filtered" invariant held only as long as every callee kept holding it. Any unexpected failure in that chain:

1. destroyed a valid mention with no record of its `ts`, and
2. never released the dedup claim, which also suppressed the sibling `app_mention` Slack fires for the same message **and** every Socket Mode redelivery of it.

So a single transient failure turned one dropped event into a permanently unanswerable message.

Separately, ten filters in the ingress returned bare, and the only entry log is DEBUG-gated. At the gateway's normal INFO level, a deliberately filtered event and a never-received event looked identical.

## Fix

- `_handle_slack_message` becomes a thin bounded ingress that wraps the routing body (extracted unchanged as `_route_slack_message`), releases the dedup claim when delivery does not happen, and logs an ERROR naming the lost event.
- `asyncio.CancelledError` releases the claim and still propagates.
- Releasing on a failed handoff mirrors the Discord adapter, which already calls `_dedup.discard` when dispatch is cancelled or raises.
- All ten silent filters now report through one `_log_slack_discard` helper naming channel, ts, thread, and reason — **metadata only, never message text**.

No behavior change to session keys, thread semantics, or control commands.

## Verification

New regression suite `tests/gateway/test_slack_event_reliability.py` (11 tests).

RED was reconstructed independently: in a throwaway worktree at this commit with **only** the production file reverted to its parent, **8 of 11 fail** with stack traces landing on real production lines.

```
8 failed, 3 passed in 0.53s
```

GREEN with the fix, across the reliability, Slack, and mention suites:

```
=== Summary: 3 files, 516 tests passed, 0 failed (100% complete) in 7.5s (32 workers) ===
```

`ruff check` (the blocking rule set, PLW1514) passes on both changed files.

The wider `tests/gateway/` run has pre-existing failures unrelated to this change; counted on both sides, the parent commit has **19** and this commit has **16** in the same files, so this change adds none.
