### PR TITLE
fix(gateway): derive the /whoami floor from _ALWAYS_ALLOWED_FOR_USERS

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -381,7 +381,10 @@ class GatewaySlashCommandsMixin:
         (admin / user / unrestricted), and the slash commands they can
         actually run on this scope.
         """
-        from gateway.slash_access import policy_for_source as _policy_for_source
+        from gateway.slash_access import (
+            _ALWAYS_ALLOWED_FOR_USERS,
+            policy_for_source as _policy_for_source,
+        )
 
         source = event.source
         policy = _policy_for_source(self.config, source)
@@ -407,7 +410,11 @@ class GatewaySlashCommandsMixin:
             )
 
         # Non-admin user. Show what's actually reachable.
-        floor = ["help", "whoami"]  # mirrors slash_access._ALWAYS_ALLOWED_FOR_USERS
+        # Derived from the constant rather than restated as a literal: a second
+        # copy of this list can drift from _ALWAYS_ALLOWED_FOR_USERS, and then
+        # /whoami under-reports what the user can actually run. sorted() gives a
+        # stable order and reproduces the previous literal exactly.
+        floor = sorted(_ALWAYS_ALLOWED_FOR_USERS)
         configured = sorted(policy.user_allowed_commands)
         # Combine + dedupe, preserve order: floor first, then operator additions.
         seen: set[str] = set()

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -185,6 +185,20 @@ async def test_non_admin_with_empty_user_commands_gets_floor_only():
     whoami_result = await runner._handle_message(_make_event("/whoami", _make_source(user_id="999")))
     assert "Tier: user" in whoami_result
 
+    # ...and it lists the ENTIRE always-allowed floor. With user_allowed_commands
+    # empty, the floor is the only possible source of these entries, so this is the
+    # only place a floor that has drifted from _ALWAYS_ALLOWED_FOR_USERS is visible.
+    # Iterating the constant (rather than a literal) means the test cannot drift
+    # from it either.
+    from gateway.slash_access import _ALWAYS_ALLOWED_FOR_USERS
+
+    for cmd in sorted(_ALWAYS_ALLOWED_FOR_USERS):
+        assert f"/{cmd}" in whoami_result, (
+            f"/whoami omitted always-allowed command /{cmd} for a non-admin with "
+            f"user_allowed_commands=[]; the display floor has drifted from "
+            f"_ALWAYS_ALLOWED_FOR_USERS"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Gate ALLOW — admin and listed user


### PR DESCRIPTION
## Problem

`_handle_whoami_command` restates the always-allowed command floor as a literal:

```python
floor = ["help", "whoami"]  # mirrors slash_access._ALWAYS_ALLOWED_FOR_USERS
```

The comment is accurate and the two are **currently in sync**, so there is no
user-visible bug today. This removes the duplication before it drifts.

The failure mode if it does drift is quiet and asymmetric. `/whoami` is how a
non-admin discovers which commands they may run, so an under-populated floor tells
them a command is unavailable while `SlashAccessPolicy.can_run` executes it happily.
Enforcement and discovery disagree, and only discovery is wrong — which makes it
look like a permissions problem rather than a display problem.

I hit this in a downstream fork that had added a third entry to
`_ALWAYS_ALLOWED_FOR_USERS`: the constant and this literal silently diverged, and
`/whoami` stopped listing the new command.

## Fix

`sorted(_ALWAYS_ALLOWED_FOR_USERS)` — reproduces the previous literal exactly and
gives a stable order.

## The test could not observe the floor

`test_non_admin_with_empty_user_commands_gets_floor_only` asserted only
`"Tier: user" in whoami_result`. It never inspected the listing, so it passes with
any floor contents.

That test matters because it is the **only** one in the file with
`user_allowed_commands: []`, which makes it the only place the floor is the sole
source of the listing. Its sibling `test_whoami_non_admin_lists_runnable_commands`
passes `user_allowed_commands: ["status", "model"]`, so its assertions are satisfied
by the *configured* list and pass regardless of the floor.

I verified the gap is real by mutation: with the old literal restored and a third
command in the constant, the whole file stayed green. The test now iterates the
constant, so it cannot drift from it either.

## Notes

- Display-only. `SlashAccessPolicy.can_run` is untouched, so there is no
  authorization change.
- Deriving the floor requires importing `_ALWAYS_ALLOWED_FOR_USERS` across modules.
  I kept it function-local to match the existing `policy_for_source` import style,
  but if you would rather expose a public accessor on `slash_access` I am happy to
  switch to that.
- There is a sibling instance of the same duplication I did **not** touch, to keep
  this PR to one concern: the admin-denial preview builds
  `allowed_preview = sorted(policy.user_allowed_commands)` and omits the floor
  entirely, so a denied non-admin is told "You can run: …" without `/help` or
  `/whoami`. Happy to fix it here or in a follow-up — your call.

## Verification

```
scripts/run_tests.sh tests/gateway/test_slash_access_dispatch.py tests/gateway/test_slash_access.py -q
=== Summary: 2 files, 42 tests passed, 0 failed ===
```