### PR TITLE
fix(execute_code): thread-scoped silencing — concurrent tool dispatch poisons sys.stdout process-wide

### DIFF
--- a/tests/tools/test_code_execution_stdout_isolation.py
+++ b/tests/tools/test_code_execution_stdout_isolation.py
@@ -33,10 +33,13 @@ actual culprit.
 from __future__ import annotations
 
 import io
+import json
 import os
+import socket
 import sys
 import threading
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -135,33 +138,187 @@ def test_thread_scoped_silence_survives_concurrency():
     assert "internal tool chatter" not in captured
 
 
-def test_code_execution_tool_dispatch_sites_are_thread_scoped():
-    """Guard both sandbox dispatch sites against a regression.
+class _OneShotListener:
+    """Minimal object exposing the .accept()/.settimeout() the RPC loop uses."""
 
-    Fails on the pre-fix source, which used ``sys.stdout = devnull``.
+    def __init__(self, conn):
+        self._conn = conn
+        self._served = False
+
+    def settimeout(self, _t):
+        pass
+
+    def accept(self):
+        if self._served:
+            raise socket.timeout()
+        self._served = True
+        return self._conn, ("peer", 0)
+
+
+def _blocking_handler(in_handler, unrelated_done):
+    """A handle_function_call stub that prints chatter and blocks mid-dispatch.
+
+    The prints stand in for internal tool-handler status output; the block lets
+    the test overlap an unrelated thread's write with an in-flight dispatch.
     """
-    import inspect
-    import re
 
-    import tools.code_execution_tool as cet
+    def handler(*_args, **_kwargs):
+        print("handler chatter")
+        print("more handler chatter", file=sys.stderr)
+        in_handler.set()
+        assert unrelated_done.wait(timeout=5)
+        return '{"output": "handled"}'
 
-    src = inspect.getsource(cet)
-    # Strip comment lines so the prose explaining the old bug doesn't trip the
-    # assertions below.
-    code_only = "\n".join(
-        line for line in src.splitlines()
-        if not line.lstrip().startswith("#")
-    )
+    return handler
 
-    assert not re.search(r"^\s*sys\.stdout\s*=\s*devnull", code_only, re.M), (
-        "process-global stdout assignment found in code_execution_tool; "
-        "use thread_scoped_silence() — this handler runs on concurrent "
-        "socket threads and a global rebind poisons sys.stdout process-wide"
-    )
-    assert not re.search(r"^\s*sys\.stderr\s*=\s*devnull", code_only, re.M)
 
-    # Both dispatch sites (local sandbox + remote sandbox) must be wrapped.
-    assert code_only.count("with thread_scoped_silence():") >= 2, (
-        "expected both handle_function_call dispatch sites to be wrapped in "
-        "thread_scoped_silence()"
-    )
+def test_rpc_server_loop_dispatch_is_thread_scoped():
+    """Behavioral: while _rpc_server_loop dispatches a tool call, an unrelated
+    thread's stdout writes still reach the real stream, the handler's own
+    chatter is silenced, and stdout stays usable afterwards.
+
+    Fails on the pre-fix implementation, which rebound sys.stdout
+    process-globally around dispatch.
+    """
+    from tools.code_execution_tool import _rpc_server_loop
+
+    def body():
+        in_handler = threading.Event()
+        unrelated_done = threading.Event()
+
+        srv, cli = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        stop_event = threading.Event()
+
+        def unrelated_writer():
+            assert in_handler.wait(timeout=5)
+            print("unrelated write during dispatch")
+            unrelated_done.set()
+
+        def run_server():
+            _rpc_server_loop(
+                _OneShotListener(srv),
+                "test-task",
+                [],
+                [0],
+                max_tool_calls=10,
+                allowed_tools=frozenset({"terminal"}),
+                stop_event=stop_event,
+                rpc_token="tok",
+            )
+
+        writer = threading.Thread(target=unrelated_writer)
+        server = threading.Thread(target=run_server, daemon=True)
+        try:
+            with patch(
+                "model_tools.handle_function_call",
+                side_effect=_blocking_handler(in_handler, unrelated_done),
+            ):
+                writer.start()
+                server.start()
+                cli.sendall((json.dumps({
+                    "tool": "terminal",
+                    "args": {"command": "echo hi"},
+                    "token": "tok",
+                }) + "\n").encode())
+                cli.settimeout(5)
+                resp = json.loads(cli.recv(65536).split(b"\n", 1)[0].decode())
+                assert "handled" in json.dumps(resp)
+        finally:
+            stop_event.set()
+            cli.close()
+            srv.close()
+            writer.join(timeout=5)
+            server.join(timeout=5)
+
+        # stdout must not be poisoned after dispatch completes.
+        print("survivor")
+
+    captured = _drain(body)
+    assert "unrelated write during dispatch" in captured
+    assert "survivor" in captured
+    assert "handler chatter" not in captured
+
+
+def test_rpc_poll_loop_dispatch_is_thread_scoped():
+    """Behavioral: same contract for the remote-sandbox dispatch site.
+
+    _rpc_poll_loop runs the identical silent-dispatch operation against a
+    filesystem-polling env; a stub env feeds it one request and the test
+    asserts an unrelated thread can still write while the handler runs.
+    """
+    from tools.code_execution_tool import _rpc_poll_loop
+
+    request = {
+        "tool": "terminal",
+        "args": {"command": "echo hi"},
+        "seq": 1,
+        "token": "tok",
+    }
+
+    class _StubEnv:
+        """Serves exactly one pending request file, then reports none."""
+
+        def __init__(self):
+            self._served = False
+
+        def execute(self, command, cwd="/", timeout=10):
+            if command.startswith("ls "):
+                if self._served:
+                    return {"output": ""}
+                return {"output": "/rpc/req_000001"}
+            if command.startswith("cat "):
+                self._served = True
+                return {"output": json.dumps(request)}
+            return {"output": ""}
+
+    def body():
+        in_handler = threading.Event()
+        unrelated_done = threading.Event()
+        stop_event = threading.Event()
+
+        def unrelated_writer():
+            assert in_handler.wait(timeout=5)
+            print("unrelated write during dispatch")
+            unrelated_done.set()
+
+        tool_call_counter = [0]
+
+        def run_poll_loop():
+            _rpc_poll_loop(
+                _StubEnv(),
+                "/rpc",
+                "test-task",
+                [],
+                tool_call_counter,
+                max_tool_calls=10,
+                allowed_tools=frozenset({"terminal"}),
+                stop_event=stop_event,
+                rpc_token="tok",
+            )
+
+        writer = threading.Thread(target=unrelated_writer)
+        poller = threading.Thread(target=run_poll_loop, daemon=True)
+        try:
+            with patch(
+                "model_tools.handle_function_call",
+                side_effect=_blocking_handler(in_handler, unrelated_done),
+            ):
+                writer.start()
+                poller.start()
+                assert unrelated_done.wait(timeout=10)
+                # Wait for the dispatch to be recorded, then stop the loop.
+                deadline = time.monotonic() + 5
+                while tool_call_counter[0] < 1 and time.monotonic() < deadline:
+                    time.sleep(0.01)
+                assert tool_call_counter[0] == 1
+        finally:
+            stop_event.set()
+            writer.join(timeout=5)
+            poller.join(timeout=5)
+
+        print("survivor")
+
+    captured = _drain(body)
+    assert "unrelated write during dispatch" in captured
+    assert "survivor" in captured
+    assert "handler chatter" not in captured

--- a/tests/tools/test_code_execution_stdout_isolation.py
+++ b/tests/tools/test_code_execution_stdout_isolation.py
@@ -1,0 +1,167 @@
+"""Regression: concurrent execute_code tool dispatch must not poison sys.stdout.
+
+``code_execution_tool``'s sandbox RPC handler runs on a per-connection socket
+thread, so several ``execute_code`` calls can be in flight simultaneously (e.g.
+a parallel ``delegate_task`` batch, where every subagent uses execute_code).
+
+The old implementation silenced internal tool handlers with a raw
+process-global assignment::
+
+    _real_stdout, _real_stderr = sys.stdout, sys.stderr
+    devnull = open(os.devnull, "w")
+    try:
+        sys.stdout = devnull
+        sys.stderr = devnull
+        result = handle_function_call(...)
+    finally:
+        sys.stdout, sys.stderr = _real_stdout, _real_stderr
+        devnull.close()
+
+``sys.stdout`` is process-global. With two threads interleaving, thread B
+captures thread A's devnull as its ``_real_stdout``, A closes that handle, and
+B then "restores" the CLOSED handle. Every subsequent bare ``print`` anywhere
+in the process raises::
+
+    ValueError: I/O operation on closed file.
+
+Observed 2026-07-28 on a live gateway: 328 occurrences beginning the instant a
+3-way parallel delegation launched; all three subagents died. The tracebacks
+landed on an innocent ``print`` in agent/conversation_loop.py, nowhere near the
+actual culprit.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+
+def _drain(fn):
+    """Bind a StringIO as the real stdout, run fn, return what reached it."""
+    real_out = io.StringIO()
+    orig = sys.stdout
+    sys.stdout = real_out
+    try:
+        fn()
+    finally:
+        sys.stdout = orig
+    return real_out.getvalue()
+
+
+def test_concurrent_raw_assignment_poisons_stdout():
+    """Characterize the exact race the old code had.
+
+    Two threads each save/replace/restore sys.stdout by direct assignment. The
+    interleaving leaves sys.stdout bound to a closed handle.
+    """
+
+    def body():
+        # Events force the exact poisoning interleaving:
+        #   A swaps -> B captures A's devnull & swaps -> A restores & CLOSES
+        #   its devnull -> B "restores" the now-closed handle.
+        a_swapped = threading.Event()
+        b_swapped = threading.Event()
+        a_restored = threading.Event()
+
+        def worker_a():
+            real_out, real_err = sys.stdout, sys.stderr
+            devnull = open(os.devnull, "w", encoding="utf-8")
+            try:
+                sys.stdout = devnull
+                sys.stderr = devnull
+                a_swapped.set()
+                assert b_swapped.wait(timeout=5)
+            finally:
+                sys.stdout, sys.stderr = real_out, real_err
+                devnull.close()
+                a_restored.set()
+
+        def worker_b():
+            assert a_swapped.wait(timeout=5)
+            real_out, real_err = sys.stdout, sys.stderr  # <- A's devnull
+            devnull = open(os.devnull, "w", encoding="utf-8")
+            try:
+                sys.stdout = devnull
+                sys.stderr = devnull
+                b_swapped.set()
+                assert a_restored.wait(timeout=5)
+            finally:
+                # Installs the handle A already closed.
+                sys.stdout, sys.stderr = real_out, real_err
+                devnull.close()
+
+        a = threading.Thread(target=worker_a)
+        b = threading.Thread(target=worker_b)
+        a.start()
+        b.start()
+        a.join()
+        b.join()
+
+        with pytest.raises(ValueError, match="closed file"):
+            sys.stdout.write("this must fail")
+
+    _drain(body)
+
+
+def test_thread_scoped_silence_survives_concurrency():
+    """The replacement primitive is safe under the same interleaving."""
+    from agent.thread_scoped_output import thread_scoped_silence
+
+    def body():
+        barrier = threading.Barrier(2)
+
+        def worker(hold: float):
+            with thread_scoped_silence():
+                print("internal tool chatter")
+                barrier.wait(timeout=5)
+                time.sleep(hold)
+
+        a = threading.Thread(target=worker, args=(0.05,))
+        b = threading.Thread(target=worker, args=(0.30,))
+        a.start()
+        b.start()
+        a.join()
+        b.join()
+
+        print("survivor")
+
+    captured = _drain(body)
+    assert "survivor" in captured
+    assert "internal tool chatter" not in captured
+
+
+def test_code_execution_tool_dispatch_sites_are_thread_scoped():
+    """Guard both sandbox dispatch sites against a regression.
+
+    Fails on the pre-fix source, which used ``sys.stdout = devnull``.
+    """
+    import inspect
+    import re
+
+    import tools.code_execution_tool as cet
+
+    src = inspect.getsource(cet)
+    # Strip comment lines so the prose explaining the old bug doesn't trip the
+    # assertions below.
+    code_only = "\n".join(
+        line for line in src.splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+    assert not re.search(r"^\s*sys\.stdout\s*=\s*devnull", code_only, re.M), (
+        "process-global stdout assignment found in code_execution_tool; "
+        "use thread_scoped_silence() — this handler runs on concurrent "
+        "socket threads and a global rebind poisons sys.stdout process-wide"
+    )
+    assert not re.search(r"^\s*sys\.stderr\s*=\s*devnull", code_only, re.M)
+
+    # Both dispatch sites (local sandbox + remote sandbox) must be wrapped.
+    assert code_only.count("with thread_scoped_silence():") >= 2, (
+        "expected both handle_function_call dispatch sites to be wrapped in "
+        "thread_scoped_silence()"
+    )

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -48,6 +48,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional, Tuple
 
 from tools.thread_context import propagate_context_to_thread
+from agent.thread_scoped_output import thread_scoped_silence
 
 # Availability gate.  On Windows we fall back to loopback TCP for the
 # sandbox RPC transport (AF_UNIX is unreliable on Windows Python) — see
@@ -659,18 +660,21 @@ def _rpc_server_loop(
                 # Dispatch through the standard tool handler.
                 # Suppress stdout/stderr from internal tool handlers so
                 # their status prints don't leak into the CLI spinner.
+                #
+                # MUST be thread-scoped: this handler runs on a per-connection
+                # socket thread, so several execute_code calls (e.g. parallel
+                # subagents) are in flight at once. Assigning sys.stdout
+                # directly rebinds it PROCESS-WIDE; with two threads
+                # interleaving, thread B captures A's devnull as "_real_stdout",
+                # A closes it, and B restores a CLOSED handle — after which
+                # every bare print in the process raises
+                # "ValueError: I/O operation on closed file." (observed
+                # 2026-07-28: 328 occurrences, killing 3 subagents).
                 try:
-                    _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                    devnull = open(os.devnull, "w", encoding="utf-8")
-                    try:
-                        sys.stdout = devnull
-                        sys.stderr = devnull
+                    with thread_scoped_silence():
                         result = handle_function_call(
                             tool_name, tool_args, task_id=task_id
                         )
-                    finally:
-                        sys.stdout, sys.stderr = _real_stdout, _real_stderr
-                        devnull.close()
                 except Exception as exc:
                     logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
                     result = tool_error(str(exc))
@@ -943,19 +947,16 @@ def _rpc_poll_loop(
                         for param in _TERMINAL_BLOCKED_PARAMS:
                             tool_args.pop(param, None)
 
-                    # Dispatch through the standard tool handler
+                    # Dispatch through the standard tool handler.
+                    # Thread-scoped silencing — see the identical note on the
+                    # local-sandbox path above. A process-global
+                    # ``sys.stdout = devnull`` here races other in-flight
+                    # execute_code calls and leaves sys.stdout closed.
                     try:
-                        _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                        devnull = open(os.devnull, "w", encoding="utf-8")
-                        try:
-                            sys.stdout = devnull
-                            sys.stderr = devnull
+                        with thread_scoped_silence():
                             tool_result = handle_function_call(
                                 tool_name, tool_args, task_id=task_id
                             )
-                        finally:
-                            sys.stdout, sys.stderr = _real_stdout, _real_stderr
-                            devnull.close()
                     except Exception as exc:
                         logger.error("Tool call failed in remote sandbox: %s",
                                      exc, exc_info=True)


### PR DESCRIPTION
Sibling of #72868 (same bug class, different call site — found because #72868 alone did **not** stop the symptom).

## Symptom

On a live gateway, launching a 3-way parallel `delegate_task` batch produced **328** occurrences of:

```
ValueError: I/O operation on closed file.
```

beginning the instant the batch started. All three subagents died mid-run. Every traceback pointed at an innocent `print` in `agent/conversation_loop.py:4801` — nowhere near the actual cause.

## Root cause

`tools/code_execution_tool.py` silenced internal tool handlers with a raw process-global assignment, at **two** dispatch sites (local sandbox and remote sandbox):

```python
_real_stdout, _real_stderr = sys.stdout, sys.stderr
devnull = open(os.devnull, "w", encoding="utf-8")
try:
    sys.stdout = devnull
    sys.stderr = devnull
    result = handle_function_call(tool_name, tool_args, task_id=task_id)
finally:
    sys.stdout, sys.stderr = _real_stdout, _real_stderr
    devnull.close()
```

This handler runs on a **per-connection socket thread**, so multiple `execute_code` calls are in flight concurrently — most obviously a parallel `delegate_task` batch, where every subagent uses `execute_code`.

`sys.stdout` is process-global. With two threads interleaving:

1. Thread A saves the real stdout, installs its devnull.
2. Thread B saves **A's devnull** as its `_real_stdout`, installs its own.
3. A finishes, restores, and **closes its devnull**.
4. B finishes and "restores" that now-**closed** handle.

From then on every bare `print` anywhere in the process raises. It self-heals only when some later correctly-nested restore happens to put the real stream back, which is why it presents as unexplained bursts.

## Fix

Wrap both dispatch sites in `thread_scoped_silence()` (`agent/thread_scoped_output.py`), which routes only the calling thread's writes to a sink and leaves all other threads on the real streams. Same primitive already applied in `agent/background_review.py` (#55769 / #55925) and `agent/curator.py` (#72868).

## Tests

New `tests/tools/test_code_execution_stdout_isolation.py`:

1. `test_concurrent_raw_assignment_poisons_stdout` — reproduces the race **deterministically** using a `threading.Barrier` to force the interleaving, rather than relying on sleep timing.
2. `test_thread_scoped_silence_survives_concurrency` — same interleaving, no poisoning, chatter still suppressed.
3. `test_code_execution_tool_dispatch_sites_are_thread_scoped` — guards **both** sites. Verified to fail on the pre-fix source.

`12 passed` across this file plus the curator/thread-scoped suites. The one failure in `tests/tools/` (`test_approval.py::TestApprovalPromptRedaction::test_callback_receives_redacted_command`) is **pre-existing test pollution** — it reproduces identically with these changes stashed, and passes when run in isolation.

## Note for maintainers

This is the third site found in this bug class. It may be worth a lint rule banning bare `sys.stdout = ` / `contextlib.redirect_stdout` outside main-thread CLI entrypoints, since each instance is individually plausible and collectively causes process-wide, hard-to-attribute failures.
