### PR TITLE
fix(desktop): resolve keybinds through the active keyboard layout

### DIFF
--- a/apps/desktop/src/lib/keybinds/combo.test.ts
+++ b/apps/desktop/src/lib/keybinds/combo.test.ts
@@ -32,6 +32,19 @@ describe('comboFromEvent — ctrl as a distinct modifier on macOS', () => {
     expect(comboFromEvent(keydown({ code: 'KeyK', ctrlKey: true }))).toBe('ctrl+k')
   })
 
+  it('uses layout-aware letters for Cmd shortcuts on non-QWERTY layouts', async () => {
+    const { comboFromEvent } = await loadCombo('MacIntel')
+
+    expect(comboFromEvent(keydown({ code: 'KeyI', key: 'c', metaKey: true }))).toBe('mod+c')
+    expect(comboFromEvent(keydown({ code: 'KeyI', key: 'C', metaKey: true, shiftKey: true }))).toBe('mod+shift+c')
+  })
+
+  it('keeps shifted punctuation anchored to the physical key token', async () => {
+    const { comboFromEvent } = await loadCombo('MacIntel')
+
+    expect(comboFromEvent(keydown({ code: 'Slash', key: '?', metaKey: true, shiftKey: true }))).toBe('mod+shift+/')
+  })
+
   it('treats Control as the "mod" accelerator off macOS', async () => {
     const { comboFromEvent } = await loadCombo('Win32')
 

--- a/apps/desktop/src/lib/keybinds/combo.test.ts
+++ b/apps/desktop/src/lib/keybinds/combo.test.ts
@@ -45,6 +45,37 @@ describe('comboFromEvent — ctrl as a distinct modifier on macOS', () => {
     expect(comboFromEvent(keydown({ code: 'Slash', key: '?', metaKey: true, shiftKey: true }))).toBe('mod+shift+/')
   })
 
+  it('uses layout-aware punctuation for Cmd shortcuts on non-QWERTY layouts', async () => {
+    const { comboFromEvent } = await loadCombo('MacIntel')
+
+    // Dvorak puts "." on the physical QWERTY V key — ⌘. must still reach the
+    // command center rather than resolving to the physical token.
+    expect(comboFromEvent(keydown({ code: 'KeyV', key: '.', metaKey: true }))).toBe('mod+.')
+    expect(comboFromEvent(keydown({ code: 'KeyW', key: ',', metaKey: true }))).toBe('mod+,')
+    expect(comboFromEvent(keydown({ code: 'BracketLeft', key: '/', metaKey: true }))).toBe('mod+/')
+    // AZERTY reaches "," from the physical QWERTY M key.
+    expect(comboFromEvent(keydown({ code: 'KeyM', key: ',', metaKey: true }))).toBe('mod+,')
+  })
+
+  it('keeps digits physical so AZERTY\'s shifted number row still binds', async () => {
+    const { comboFromEvent } = await loadCombo('MacIntel')
+
+    // On AZERTY the unshifted "1" key types "&", and "1" only with Shift held.
+    // Both must resolve to the same `mod+1` the QWERTY user gets.
+    expect(comboFromEvent(keydown({ code: 'Digit1', key: '&', metaKey: true }))).toBe('mod+1')
+    expect(comboFromEvent(keydown({ code: 'Digit1', key: '1', metaKey: true }))).toBe('mod+1')
+  })
+
+  it('falls back to the physical key for glyphs we do not ship as tokens', async () => {
+    const { comboFromEvent } = await loadCombo('MacIntel')
+
+    // Option-modified glyphs, dead keys, and non-Latin scripts are not combo
+    // tokens, so the physical code keeps the binding reachable.
+    expect(comboFromEvent(keydown({ code: 'KeyK', key: '˚', metaKey: true, altKey: true }))).toBe('mod+alt+k')
+    expect(comboFromEvent(keydown({ code: 'KeyN', key: 'Dead', metaKey: true, altKey: true }))).toBe('mod+alt+n')
+    expect(comboFromEvent(keydown({ code: 'KeyK', key: 'л', metaKey: true }))).toBe('mod+k')
+  })
+
   it('treats Control as the "mod" accelerator off macOS', async () => {
     const { comboFromEvent } = await loadCombo('Win32')
 

--- a/apps/desktop/src/lib/keybinds/combo.ts
+++ b/apps/desktop/src/lib/keybinds/combo.ts
@@ -2,8 +2,9 @@
 //
 // A combo is a canonical lowercase string like "mod+k", "mod+shift+]", "shift+x",
 // or "r". `mod` is Cmd on macOS / Ctrl elsewhere, so a single binding works on
-// both. We derive the base key from `event.code` (not `event.key`) so Shift never
-// mutates it ("shift+/" stays "shift+/" instead of becoming "shift+?").
+// both. We prefer layout-aware `event.key` for letters, then fall back to
+// `event.code` so shifted punctuation still normalizes to its unshifted token
+// ("shift+/" stays "shift+/" instead of becoming "shift+?").
 //
 // `ctrl` is physical Control, distinct from `mod`. It only matters on macOS,
 // where `mod` is Cmd and Cmd+Tab is OS-reserved — so `ctrl+tab` is literally
@@ -70,6 +71,10 @@ function baseKeyFromCode(code: string): string | null {
   return CODE_TO_KEY[code] ?? null
 }
 
+function baseKeyFromEventKey(key: string): string | null {
+  return /^[a-z]$/i.test(key) ? key.toLowerCase() : null
+}
+
 // Returns the canonical combo for a keydown, or null while only modifiers are
 // held (so capture mode keeps waiting for a real key).
 export function comboFromEvent(event: KeyboardEvent): string | null {
@@ -77,7 +82,7 @@ export function comboFromEvent(event: KeyboardEvent): string | null {
     return null
   }
 
-  const base = baseKeyFromCode(event.code)
+  const base = baseKeyFromEventKey(event.key) ?? baseKeyFromCode(event.code)
 
   if (!base) {
     return null

--- a/apps/desktop/src/lib/keybinds/combo.ts
+++ b/apps/desktop/src/lib/keybinds/combo.ts
@@ -2,9 +2,10 @@
 //
 // A combo is a canonical lowercase string like "mod+k", "mod+shift+]", "shift+x",
 // or "r". `mod` is Cmd on macOS / Ctrl elsewhere, so a single binding works on
-// both. We prefer layout-aware `event.key` for letters, then fall back to
-// `event.code` so shifted punctuation still normalizes to its unshifted token
-// ("shift+/" stays "shift+/" instead of becoming "shift+?").
+// both. We derive the base key from `event.key` where the layout matters
+// (letters, unshifted punctuation) and from `event.code` otherwise, so a
+// binding follows the character the user's layout actually types while Shift
+// never mutates it ("shift+/" stays "shift+/" instead of becoming "shift+?").
 //
 // `ctrl` is physical Control, distinct from `mod`. It only matters on macOS,
 // where `mod` is Cmd and Cmd+Tab is OS-reserved — so `ctrl+tab` is literally
@@ -71,8 +72,30 @@ function baseKeyFromCode(code: string): string | null {
   return CODE_TO_KEY[code] ?? null
 }
 
-function baseKeyFromEventKey(key: string): string | null {
-  return /^[a-z]$/i.test(key) ? key.toLowerCase() : null
+// Punctuation we ship as combo tokens, derived from CODE_TO_KEY so the two
+// can't drift. Named tokens (space, tab, …) are excluded by the length check.
+const PUNCTUATION_KEYS = new Set(Object.values(CODE_TO_KEY).filter(token => token.length === 1))
+
+// The layout-aware half of the base key. `event.key` carries the character the
+// user's layout actually produces, which is what a binding should match:
+//
+//   - Letters always win, shifted or not — `toLowerCase` normalizes the case.
+//   - Punctuation only when Shift is UP, because a shifted `event.key` is the
+//     shifted glyph ("?" for "/"), and combos stay anchored to the unshifted
+//     token. Shifted punctuation falls through to `event.code` below.
+//
+// Digits deliberately stay physical: on AZERTY the number row is shifted, so
+// `event.key` for the "1" key is "&" and only yields "1" with Shift held —
+// `event.code` is what keeps `mod+1` reachable there.
+//
+// Anything else (Option glyphs like "˚", dead keys, non-Latin scripts) isn't a
+// token we ship, so it fails both checks and falls back to the physical code.
+function baseKeyFromEventKey(key: string, shiftKey: boolean): string | null {
+  if (/^[a-z]$/i.test(key)) {
+    return key.toLowerCase()
+  }
+
+  return !shiftKey && PUNCTUATION_KEYS.has(key) ? key : null
 }
 
 // Returns the canonical combo for a keydown, or null while only modifiers are
@@ -82,7 +105,7 @@ export function comboFromEvent(event: KeyboardEvent): string | null {
     return null
   }
 
-  const base = baseKeyFromEventKey(event.key) ?? baseKeyFromCode(event.code)
+  const base = baseKeyFromEventKey(event.key, event.shiftKey) ?? baseKeyFromCode(event.code)
 
   if (!base) {
     return null


### PR DESCRIPTION
## Summary

Desktop keybinds resolved the base key from `event.code`, the physical QWERTY
position, so every shipped shortcut was bound to a key location rather than the
character the user's layout actually types. On Dvorak ⌘V lands on the physical
period key, which is `mod+.` — the command center opens and the native paste
never runs.

This resolves the base key through `event.key` where the layout matters and
keeps `event.code` everywhere it doesn't.

Supersedes #46374, which fixed the letter half. Punctuation was left on the
physical token, so the shipped punctuation defaults (`mod+.`, `mod+,`, `mod+/`,
`mod+\`, ``ctrl+` ``) stayed unreachable on a remapped layout — including the
`mod+.` that Garrison's ⌘V collided with in the first place.

Closes #46369.

## What resolves how

| Input | Source | Why |
|---|---|---|
| Letters, any shift state | `event.key` | The character the layout types; `toLowerCase` normalizes case |
| Punctuation, Shift up | `event.key` | Unshifted `event.key` *is* the token we bind |
| Punctuation, Shift down | `event.code` | A shifted `event.key` is the shifted glyph (`?` for `/`); combos stay anchored to the unshifted token |
| Digits | `event.code` | AZERTY types `&` on the unshifted `1` key, so the physical code is what keeps `mod+1` bound |
| Option glyphs, dead keys, non-Latin | `event.code` | Not tokens we ship, so both checks fail and the physical code keeps the binding reachable |

The punctuation set derives from `CODE_TO_KEY` rather than being a second
hardcoded list, so the two can't drift.

`navigator.keyboard.getLayoutMap()` would be the direct way to ask for a
layout-aware unshifted character, but Chromium doesn't implement it on macOS —
`navigator.keyboard` is `undefined` in our Electron 40 (Chrome 144), i.e.
unavailable on exactly the platform this was reported from.

## Behavior delta

Verified against every shipped default. Only non-QWERTY layouts change:

| Case | Before | After |
|---|---|---|
| Dvorak ⌘V (the report) | `mod+.` | `mod+v` |
| Dvorak ⌘. command center | `mod+v` | `mod+.` |
| Dvorak ⌘, / ⌘/ | `mod+w` / `mod+[` | `mod+,` / `mod+/` |
| AZERTY ⌘, | `mod+m` | `mod+,` |
| QWERTY, all bindings | unchanged | unchanged |

## Upgrade note

Custom rebinds persist to `hermes.desktop.keybinds` as a diff from defaults. A
non-QWERTY user who recorded a custom chord under the old physical scheme has
e.g. `mod+i` stored where they now press `mod+c`, and re-records it once. That
only affects non-QWERTY users who also customized a binding, who are the broken
cohort today. Capture and dispatch share `comboFromEvent`, so after this what
they press is what gets stored.

## Testing

- `npx vitest run src/lib/keybinds/combo.test.ts --environment jsdom` — 13 passed
- Reverted the punctuation half and confirmed the new punctuation test fails
  (`expected 'mod+v' to be 'mod+.'`) while the digit and fallback guards stay
  green, so they assert invariants rather than snapshot current behavior
- `npx tsc --noEmit -p .` — clean
- `npx eslint src/lib/keybinds/combo.ts src/lib/keybinds/combo.test.ts` — clean

## Credit

Letter fix and its regression coverage by @LeonSGP43, cherry-picked with
authorship intact (#46374).
