### PR TITLE
feat: opt-in prompt-cache prewarm — pay the ~20s first-message cost while the user is still typing (TUI/desktop)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -558,8 +558,27 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         )
 
     # First turn of a new session (or recovering from a broken stored
-    # prompt) — build from scratch.
-    agent._cached_system_prompt = agent._build_system_prompt(system_message)
+    # prompt) — build from scratch. One exception: a prompt-cache prewarm
+    # (agent.prompt_prewarm) already built and SENT a system prompt for this
+    # session before the first user message. Reuse those exact bytes when the
+    # runtime identity still matches — a rebuild here could differ in the
+    # volatile tail (timestamp) and split the just-warmed provider prefix.
+    _prewarmed = getattr(agent, "_prewarmed_system_prompt", None)
+    if (
+        not conversation_history
+        and system_message is None
+        and isinstance(_prewarmed, str)
+        and _prewarmed
+        and _stored_prompt_matches_runtime(agent, _prewarmed)
+    ):
+        agent._cached_system_prompt = _prewarmed
+        from agent.system_prompt import reconstruct_static_prefix
+
+        reconstruct_static_prefix(agent, log_label="prewarm")
+    else:
+        agent._cached_system_prompt = agent._build_system_prompt(system_message)
+    # One-shot: never reuse across /new, compression rebuilds, or model swaps.
+    agent._prewarmed_system_prompt = None
 
     # Plugin hook: on_session_start — fired once when a brand-new
     # session is created (not on continuation).  Plugins can use this

--- a/agent/prompt_prewarm.py
+++ b/agent/prompt_prewarm.py
@@ -1,0 +1,167 @@
+"""Prompt-cache prewarm — pay the provider-side cache write before turn 1.
+
+The first API call of a fresh session ingests the entire uncached prefix
+(system prompt + tool schemas — commonly 50-70k tokens), which shows up as
+10-20s of first-message latency on Anthropic-cached routes. Every later call
+rides the prompt cache and drops to TTFT + generation.
+
+``prewarm_prompt_cache`` issues one minimal, non-streaming request (same
+tools, same system prompt, ``max_tokens=1``) whose only purpose is the
+provider-side cache write at the injected ``cache_control`` breakpoints.
+The first real user turn then *reads* the prefix cache instead of writing
+it cold.
+
+Cost note: the cache write (1.25x input for the 5m TTL) is paid by the
+first real call today anyway — prewarming only moves it earlier. The extra
+spend is one cache *read* (0.1x) on the first real turn, plus the full
+write being wasted when a session is opened but never used. That trade-off
+is why the feature is config-gated (``agent.prewarm_prompt_cache``,
+default off).
+
+Everything here is fail-open: a prewarm failure must never surface to the
+user or block the session — the worst case is the status quo (cold first
+turn).
+
+Pure helper — no threads. Callers (the TUI/desktop gateway) own scheduling.
+"""
+
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+# Transports whose request shape we can safely reproduce outside the main
+# conversation loop. Codex/Responses, Bedrock Converse, ACP, and the MoA
+# facade have bespoke client/stream ownership — and (except Bedrock) no
+# Anthropic cache_control semantics — so they are excluded.
+_PREWARM_API_MODES = {"chat_completions", "anthropic_messages"}
+
+
+def prewarm_supported(agent) -> bool:
+    """True when a prewarm request would actually warm a provider cache."""
+    if not getattr(agent, "_use_prompt_caching", False):
+        return False
+    if getattr(agent, "api_mode", None) not in _PREWARM_API_MODES:
+        return False
+    if getattr(agent, "provider", None) == "moa":
+        return False
+    return True
+
+
+def prewarm_prompt_cache(agent) -> bool:
+    """Issue one minimal request so the provider writes the prompt-prefix cache.
+
+    Builds the exact prefix the first real turn will send — same tool
+    schemas (``agent.tools`` via ``_build_api_kwargs``), same system prompt
+    with the same ``[static, volatile]`` cache_control layout — followed by
+    a throwaway user message. The trailing user message differs from the
+    real first message, but Anthropic caching is prefix-based: the
+    breakpoints on the static system prefix and full system prompt land
+    identically, which is where the tens of thousands of tokens live.
+
+    Returns True when the prewarm request completed, False when skipped or
+    failed. Never raises.
+    """
+    if not prewarm_supported(agent):
+        return False
+
+    try:
+        system_prompt = getattr(agent, "_cached_system_prompt", None)
+        if not system_prompt:
+            # Same builder the first turn uses; also populates
+            # ``_cached_system_prompt_static`` as a side effect. The real
+            # turn rebuilds through ``_restore_or_build_system_prompt`` —
+            # only the volatile tail (timestamp) can differ, and that sits
+            # after the static-prefix breakpoint.
+            system_prompt = agent._build_system_prompt()
+        static_prefix = getattr(agent, "_cached_system_prompt_static", None)
+
+        from agent.prompt_caching import apply_anthropic_cache_control
+
+        api_messages = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": "ping"},
+            ],
+            cache_ttl=getattr(agent, "_cache_ttl", "5m") or "5m",
+            native_anthropic=getattr(agent, "_use_native_cache_layout", False),
+            static_system_prefix=(
+                static_prefix if isinstance(static_prefix, str) else None
+            ),
+        )
+
+        api_kwargs = agent._build_api_kwargs(api_messages)
+        # Cheapest possible generation: the request exists only for its
+        # prompt-ingestion side effect. Both output-cap spellings are
+        # forced so no provider default (or profile-injected cap) makes
+        # the throwaway completion generate real output.
+        if "max_completion_tokens" in api_kwargs:
+            api_kwargs["max_completion_tokens"] = 1
+        else:
+            api_kwargs["max_tokens"] = 1
+        api_kwargs.pop("stream", None)
+        # Extended thinking demands max_tokens > budget_tokens, which a
+        # 1-token request violates (400). Strip thinking/reasoning knobs:
+        # per Anthropic caching semantics, thinking-parameter changes only
+        # invalidate message-level cache blocks — the system-prompt and
+        # tools cache blocks (the entire point of the prewarm) survive.
+        api_kwargs.pop("thinking", None)
+        api_kwargs.pop("reasoning_effort", None)
+        extra_body = api_kwargs.get("extra_body")
+        if isinstance(extra_body, dict):
+            extra_body.pop("reasoning", None)
+            extra_body.pop("thinking", None)
+
+        from agent.chat_completion_helpers import _dispatch_nonstreaming_api_request
+
+        created: list[tuple[object, str]] = []
+
+        def _make_client(reason: str, kind: str = "openai"):
+            client = (
+                agent._create_request_anthropic_client(reason=reason)
+                if kind == "anthropic_messages"
+                else agent._create_request_openai_client(
+                    reason=reason, api_kwargs=api_kwargs
+                )
+            )
+            created.append((client, kind))
+            return client
+
+        started = time.monotonic()
+        try:
+            _dispatch_nonstreaming_api_request(
+                agent, api_kwargs, make_client=_make_client
+            )
+        finally:
+            for client, kind in created:
+                try:
+                    if kind == "anthropic_messages":
+                        close = getattr(client, "close", None)
+                        if callable(close):
+                            close()
+                    else:
+                        agent._close_request_openai_client(
+                            client, reason="prompt_prewarm"
+                        )
+                except Exception:
+                    logger.debug(
+                        "prompt prewarm client close failed", exc_info=True
+                    )
+
+        logger.info(
+            "Prompt-cache prewarm complete: model=%s provider=%s %.1fs",
+            getattr(agent, "model", "") or "",
+            getattr(agent, "provider", "") or "",
+            time.monotonic() - started,
+        )
+        # Hand the exact sent bytes to the first real turn:
+        # ``_restore_or_build_system_prompt`` adopts this instead of
+        # rebuilding, so the volatile tail (timestamp) can't drift between
+        # the prewarmed prefix and the first real request.
+        agent._prewarmed_system_prompt = system_prompt
+        return True
+    except Exception:
+        # Fail-open by contract: a failed prewarm just means the first real
+        # turn pays the cache write itself (the status quo).
+        logger.info("Prompt-cache prewarm failed (fail-open)", exc_info=True)
+        return False

--- a/agent/prompt_prewarm.py
+++ b/agent/prompt_prewarm.py
@@ -5,11 +5,14 @@ The first API call of a fresh session ingests the entire uncached prefix
 10-20s of first-message latency on Anthropic-cached routes. Every later call
 rides the prompt cache and drops to TTFT + generation.
 
-``prewarm_prompt_cache`` issues one minimal, non-streaming request (same
-tools, same system prompt, ``max_tokens=1``) whose only purpose is the
-provider-side cache write at the injected ``cache_control`` breakpoints.
-The first real user turn then *reads* the prefix cache instead of writing
-it cold.
+``prewarm_prompt_cache`` issues one minimal, non-streaming request — same
+tools, same system prompt, same thinking/effort/max_tokens (byte-parity
+with the first real turn; the provider's cache key covers the rendered
+request configuration, so ANY divergence risks warming the wrong prefix),
+with a trivial trailing user message engineered for a few-token reply —
+whose only purpose is the provider-side cache write at the injected
+``cache_control`` breakpoints. The first real user turn then *reads* the
+prefix cache instead of writing it cold.
 
 Cost note: the cache write (1.25x input for the 5m TTL) is paid by the
 first real call today anyway — prewarming only moves it earlier. The extra
@@ -81,7 +84,10 @@ def prewarm_prompt_cache(agent) -> bool:
         api_messages = apply_anthropic_cache_control(
             [
                 {"role": "system", "content": system_prompt},
-                {"role": "user", "content": "ping"},
+                # Engineered for minimal output: adaptive thinking skips
+                # reasoning on trivial prompts, so the throwaway completion
+                # costs a handful of output tokens (observed: 4).
+                {"role": "user", "content": "Reply with only the word: ok"},
             ],
             cache_ttl=getattr(agent, "_cache_ttl", "5m") or "5m",
             native_anthropic=getattr(agent, "_use_native_cache_layout", False),
@@ -91,26 +97,45 @@ def prewarm_prompt_cache(agent) -> bool:
         )
 
         api_kwargs = agent._build_api_kwargs(api_messages)
-        # Cheapest possible generation: the request exists only for its
-        # prompt-ingestion side effect. Both output-cap spellings are
-        # forced so no provider default (or profile-injected cap) makes
-        # the throwaway completion generate real output.
-        if "max_completion_tokens" in api_kwargs:
-            api_kwargs["max_completion_tokens"] = 1
-        else:
-            api_kwargs["max_tokens"] = 1
         api_kwargs.pop("stream", None)
-        # Extended thinking demands max_tokens > budget_tokens, which a
-        # 1-token request violates (400). Strip thinking/reasoning knobs:
-        # per Anthropic caching semantics, thinking-parameter changes only
-        # invalidate message-level cache blocks — the system-prompt and
-        # tools cache blocks (the entire point of the prewarm) survive.
-        api_kwargs.pop("thinking", None)
-        api_kwargs.pop("reasoning_effort", None)
-        extra_body = api_kwargs.get("extra_body")
-        if isinstance(extra_body, dict):
-            extra_body.pop("reasoning", None)
-            extra_body.pop("thinking", None)
+        # ── Byte-parity with the FIRST REAL TURN is the whole game ──────
+        # The provider's cache key covers the rendered request prefix, and
+        # on Claude 4.6+/5-series the thinking configuration and resolved
+        # effort are rendered into the prompt (per Anthropic's caching
+        # docs, a thinking/effort change can invalidate the SYSTEM and
+        # TOOLS breakpoints too). Empirically the rendered configuration
+        # also incorporates ``max_tokens``: an A/B against the live nous /
+        # claude-fable-5 route showed two byte-identical requests hit the
+        # cache, while changing ONLY max_tokens (1 vs 128000) missed it
+        # entirely. So — unlike the usual throwaway-request idiom — this
+        # request must NOT cap max_tokens or strip thinking. Everything
+        # except the trailing user message stays exactly as
+        # ``_build_api_kwargs`` produced it, i.e. exactly what the first
+        # real turn will send. Output cost is bounded by the trivial
+        # prompt above, not by an output cap.
+        #
+        # One exception: MANUAL extended thinking (``thinking.type ==
+        # "enabled"`` with ``budget_tokens``, legacy pre-4.6 models). There
+        # the model ALWAYS burns thinking tokens — even on a trivial prompt
+        # — which would make the prewarm cost real money in output. Strip
+        # the thinking knobs and cap output to 1 token instead: legacy
+        # manual-mode models are exactly the models whose system/tools
+        # cache blocks are documented to survive thinking-parameter
+        # changes, so the strip is cache-safe there (and only there).
+        _thinking = api_kwargs.get("thinking")
+        _manual_thinking = (
+            isinstance(_thinking, dict) and _thinking.get("type") == "enabled"
+        )
+        if _manual_thinking:
+            api_kwargs.pop("thinking", None)
+            # Manual-mode kwargs also force temperature=1 and inflate
+            # max_tokens past the budget (build_kwargs) — undo both so the
+            # request stays a 1-token no-op.
+            api_kwargs.pop("temperature", None)
+            if "max_completion_tokens" in api_kwargs:
+                api_kwargs["max_completion_tokens"] = 1
+            else:
+                api_kwargs["max_tokens"] = 1
 
         from agent.chat_completion_helpers import _dispatch_nonstreaming_api_request
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -59,9 +59,10 @@ DEFAULT_CONFIG = {
         # or unreachable MCP servers.
         "build_wait_timeout": 600,
         # Prompt-cache prewarm (TUI/desktop): right after a session's agent is
-        # built, issue one minimal max_tokens=1 request so the provider writes
-        # the prompt-prefix cache (system prompt + tool schemas) BEFORE the
-        # first user message. Cuts cold first-message latency from provider
+        # built, issue one minimal request (same prefix + a trivial few-token
+        # prompt) so the provider writes the prompt-prefix cache (system
+        # prompt + tool schemas) BEFORE the first user message. Cuts cold
+        # first-message latency from provider
         # ingestion of a 50-70k-token uncached prefix (10-20s observed) down
         # to a cache read. Off by default: the write (1.25x input for the 5m
         # TTL) is WASTED whenever a session is opened but never used — on a

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -58,6 +58,18 @@ DEFAULT_CONFIG = {
         # on a genuinely hung build. Raise it for deployments with many slow
         # or unreachable MCP servers.
         "build_wait_timeout": 600,
+        # Prompt-cache prewarm (TUI/desktop): right after a session's agent is
+        # built, issue one minimal max_tokens=1 request so the provider writes
+        # the prompt-prefix cache (system prompt + tool schemas) BEFORE the
+        # first user message. Cuts cold first-message latency from provider
+        # ingestion of a 50-70k-token uncached prefix (10-20s observed) down
+        # to a cache read. Off by default: the write (1.25x input for the 5m
+        # TTL) is WASTED whenever a session is opened but never used — on a
+        # 67k-token prefix that is roughly $0.25 (Sonnet-class) to $1.25
+        # (Opus-class) per abandoned session — and the first real turn
+        # additionally pays one cache read (0.1x). Only applies to
+        # prompt-caching routes (Anthropic-compatible); no-op elsewhere.
+        "prewarm_prompt_cache": False,
         # Max app-level retry attempts for API errors (connection drops,
         # provider timeouts, 5xx, etc.) before the agent surfaces the
         # failure.  The OpenAI SDK already does its own low-level retries

--- a/tests/agent/test_prompt_prewarm.py
+++ b/tests/agent/test_prompt_prewarm.py
@@ -1,0 +1,238 @@
+"""Tests for ``agent.prompt_prewarm`` — the prompt-cache prewarm request.
+
+The prewarm exists to pay the provider-side prompt-cache write (system
+prompt + tool schemas) before the first user message, so the first real
+turn reads a warm prefix instead of ingesting 50-70k uncached tokens.
+
+Behavior contracts covered:
+
+  * ``prewarm_supported`` gates on prompt caching being active and on a
+    reproducible transport (chat_completions / anthropic_messages, not MoA).
+  * ``prewarm_prompt_cache`` sends the SAME system prompt bytes the first
+    real turn will send, with cache_control markers, capped at 1 output
+    token, non-streaming, and with thinking/reasoning knobs stripped.
+  * The request client it creates is always closed (success and failure).
+  * Fail-open: any error → returns False, never raises.
+  * The sent prompt is handed to the first real turn via
+    ``agent._prewarmed_system_prompt`` and adopted by
+    ``_restore_or_build_system_prompt`` so the volatile tail (timestamp)
+    cannot drift between the prewarm and the first real request.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from agent.prompt_prewarm import prewarm_prompt_cache, prewarm_supported
+
+
+SYSTEM_PROMPT = "You are Hermes Agent.\n\nSTATIC PART\n\nVolatile tail"
+STATIC_PREFIX = "You are Hermes Agent.\n\nSTATIC PART"
+
+
+def _make_agent(api_mode: str = "chat_completions"):
+    agent = MagicMock()
+    agent._use_prompt_caching = True
+    agent._use_native_cache_layout = False
+    agent._cache_ttl = "5m"
+    agent.api_mode = api_mode
+    agent.provider = "nous"
+    agent.model = "anthropic/claude-fable-5"
+    agent._cached_system_prompt = SYSTEM_PROMPT
+    agent._cached_system_prompt_static = STATIC_PREFIX
+    agent._prewarmed_system_prompt = None
+
+    # _build_api_kwargs echoes the messages it was given, like the real one.
+    def _build_api_kwargs(api_messages):
+        return {
+            "model": agent.model,
+            "messages": api_messages,
+            "max_tokens": 8192,
+            "stream": False,
+        }
+
+    agent._build_api_kwargs = MagicMock(side_effect=_build_api_kwargs)
+
+    client = MagicMock()
+    agent._create_request_openai_client = MagicMock(return_value=client)
+    agent._create_request_anthropic_client = MagicMock(return_value=client)
+    agent._request_client = client
+    return agent
+
+
+class TestPrewarmSupported:
+    def test_supported_on_chat_completions_with_caching(self):
+        assert prewarm_supported(_make_agent()) is True
+
+    def test_supported_on_anthropic_messages(self):
+        assert prewarm_supported(_make_agent(api_mode="anthropic_messages")) is True
+
+    def test_not_supported_without_prompt_caching(self):
+        agent = _make_agent()
+        agent._use_prompt_caching = False
+        assert prewarm_supported(agent) is False
+
+    def test_not_supported_on_bespoke_transports(self):
+        for mode in ("codex_responses", "bedrock_converse", "acp"):
+            assert prewarm_supported(_make_agent(api_mode=mode)) is False
+
+    def test_not_supported_for_moa(self):
+        agent = _make_agent()
+        agent.provider = "moa"
+        assert prewarm_supported(agent) is False
+
+
+class TestPrewarmRequest:
+    def test_sends_cached_system_prompt_with_markers(self):
+        agent = _make_agent()
+        assert prewarm_prompt_cache(agent) is True
+
+        create = agent._request_client.chat.completions.create
+        assert create.call_count == 1
+        kwargs = create.call_args.kwargs
+        messages = kwargs["messages"]
+
+        assert messages[0]["role"] == "system"
+        # The static prefix split produced the two-part [static, volatile]
+        # layout, each part carrying a cache_control marker, and the joined
+        # bytes are exactly the prompt the first real turn will send.
+        system_content = messages[0]["content"]
+        assert isinstance(system_content, list)
+        assert "".join(p["text"] for p in system_content) == SYSTEM_PROMPT
+        assert all("cache_control" in p for p in system_content)
+        assert messages[1]["role"] == "user"
+
+    def test_output_capped_to_one_token_and_non_streaming(self):
+        agent = _make_agent()
+        prewarm_prompt_cache(agent)
+        kwargs = agent._request_client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_tokens"] == 1
+        assert "stream" not in kwargs
+
+    def test_thinking_and_reasoning_knobs_stripped(self):
+        agent = _make_agent()
+
+        def _build_api_kwargs(api_messages):
+            return {
+                "model": agent.model,
+                "messages": api_messages,
+                "max_tokens": 8192,
+                "thinking": {"type": "enabled", "budget_tokens": 4096},
+                "reasoning_effort": "high",
+                "extra_body": {"reasoning": {"effort": "high"}, "keep": 1},
+            }
+
+        agent._build_api_kwargs = MagicMock(side_effect=_build_api_kwargs)
+        assert prewarm_prompt_cache(agent) is True
+        kwargs = agent._request_client.chat.completions.create.call_args.kwargs
+        assert "thinking" not in kwargs
+        assert "reasoning_effort" not in kwargs
+        assert "reasoning" not in kwargs["extra_body"]
+        assert kwargs["extra_body"]["keep"] == 1
+
+    def test_builds_prompt_when_not_cached(self):
+        agent = _make_agent()
+        agent._cached_system_prompt = None
+        agent._build_system_prompt = MagicMock(return_value=SYSTEM_PROMPT)
+        assert prewarm_prompt_cache(agent) is True
+        agent._build_system_prompt.assert_called_once_with()
+
+    def test_hands_sent_prompt_to_first_real_turn(self):
+        agent = _make_agent()
+        prewarm_prompt_cache(agent)
+        assert agent._prewarmed_system_prompt == SYSTEM_PROMPT
+
+    def test_request_client_closed_on_success(self):
+        agent = _make_agent()
+        prewarm_prompt_cache(agent)
+        agent._close_request_openai_client.assert_called_once()
+
+    def test_request_client_closed_on_request_failure(self):
+        agent = _make_agent()
+        agent._request_client.chat.completions.create.side_effect = RuntimeError(
+            "provider 500"
+        )
+        assert prewarm_prompt_cache(agent) is False
+        agent._close_request_openai_client.assert_called_once()
+
+    def test_fail_open_never_raises(self):
+        agent = _make_agent()
+        agent._build_api_kwargs = MagicMock(side_effect=RuntimeError("boom"))
+        assert prewarm_prompt_cache(agent) is False
+        assert agent._prewarmed_system_prompt is None
+
+    def test_skips_unsupported_agent(self):
+        agent = _make_agent()
+        agent._use_prompt_caching = False
+        assert prewarm_prompt_cache(agent) is False
+        agent._build_api_kwargs.assert_not_called()
+
+    def test_anthropic_messages_uses_anthropic_client(self):
+        agent = _make_agent(api_mode="anthropic_messages")
+        agent._anthropic_messages_create = MagicMock(return_value=MagicMock())
+        assert prewarm_prompt_cache(agent) is True
+        agent._create_request_anthropic_client.assert_called_once()
+        agent._anthropic_messages_create.assert_called_once()
+
+
+class TestFirstTurnAdoption:
+    """The first real turn must reuse the exact prewarmed bytes."""
+
+    def _restore_agent(self, prewarmed):
+        agent = MagicMock()
+        agent._cached_system_prompt = None
+        agent.session_id = "sid"
+        agent.model = "anthropic/claude-fable-5"
+        agent.provider = "nous"
+        agent.platform = "desktop"
+        agent._session_db = None
+        agent._use_prompt_caching = False
+        agent._prewarmed_system_prompt = prewarmed
+        agent._build_system_prompt = MagicMock(return_value="FRESH_BUILD")
+        return agent
+
+    def test_first_turn_reuses_prewarmed_prompt(self):
+        from agent.conversation_loop import _restore_or_build_system_prompt
+
+        agent = self._restore_agent(SYSTEM_PROMPT)
+        _restore_or_build_system_prompt(agent, None, None)
+        assert agent._cached_system_prompt == SYSTEM_PROMPT
+        agent._build_system_prompt.assert_not_called()
+        # One-shot: consumed after adoption.
+        assert agent._prewarmed_system_prompt is None
+
+    def test_prewarmed_prompt_rejected_on_model_switch(self):
+        """A /model switch between prewarm and first message must rebuild."""
+        from agent.conversation_loop import _restore_or_build_system_prompt
+
+        stale = SYSTEM_PROMPT + "\nModel: anthropic/claude-old\nProvider: nous"
+        agent = self._restore_agent(stale)
+        agent.model = "openai/gpt-6"
+        _restore_or_build_system_prompt(agent, None, None)
+        assert agent._cached_system_prompt == "FRESH_BUILD"
+        agent._build_system_prompt.assert_called_once_with(None)
+        assert agent._prewarmed_system_prompt is None
+
+    def test_prewarmed_prompt_ignored_with_custom_system_message(self):
+        from agent.conversation_loop import _restore_or_build_system_prompt
+
+        agent = self._restore_agent(SYSTEM_PROMPT)
+        _restore_or_build_system_prompt(agent, "custom system", None)
+        assert agent._cached_system_prompt == "FRESH_BUILD"
+        agent._build_system_prompt.assert_called_once_with("custom system")
+
+    def test_prewarmed_prompt_ignored_on_continuing_session(self):
+        from agent.conversation_loop import _restore_or_build_system_prompt
+
+        agent = self._restore_agent(SYSTEM_PROMPT)
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+        assert agent._cached_system_prompt == "FRESH_BUILD"
+
+    def test_no_prewarm_builds_fresh(self):
+        from agent.conversation_loop import _restore_or_build_system_prompt
+
+        agent = self._restore_agent(None)
+        _restore_or_build_system_prompt(agent, None, None)
+        assert agent._cached_system_prompt == "FRESH_BUILD"

--- a/tests/agent/test_prompt_prewarm.py
+++ b/tests/agent/test_prompt_prewarm.py
@@ -102,14 +102,23 @@ class TestPrewarmRequest:
         assert all("cache_control" in p for p in system_content)
         assert messages[1]["role"] == "user"
 
-    def test_output_capped_to_one_token_and_non_streaming(self):
+    def test_request_shape_matches_real_turn_and_non_streaming(self):
+        """The provider cache key covers the rendered request configuration
+        — live A/B showed changing ONLY max_tokens (1 vs 128000) misses the
+        cache entirely. So the prewarm must send build_api_kwargs' output
+        untouched (no output cap), minus streaming."""
         agent = _make_agent()
         prewarm_prompt_cache(agent)
         kwargs = agent._request_client.chat.completions.create.call_args.kwargs
-        assert kwargs["max_tokens"] == 1
+        assert kwargs["max_tokens"] == 8192  # exactly what _build_api_kwargs produced
         assert "stream" not in kwargs
 
-    def test_thinking_and_reasoning_knobs_stripped(self):
+    def test_manual_thinking_stripped_with_its_side_effects(self):
+        """Manual extended thinking (budget_tokens) forces max_tokens >
+        budget — impossible at 1 token — so it is stripped, along with the
+        temperature=1 and inflated max_tokens that build_kwargs couples to
+        it. Cache-safe: manual-mode (legacy) models preserve system/tools
+        cache blocks across thinking-parameter changes."""
         agent = _make_agent()
 
         def _build_api_kwargs(api_messages):
@@ -118,6 +127,33 @@ class TestPrewarmRequest:
                 "messages": api_messages,
                 "max_tokens": 8192,
                 "thinking": {"type": "enabled", "budget_tokens": 4096},
+                "temperature": 1,
+                "extra_body": {"keep": 1},
+            }
+
+        agent._build_api_kwargs = MagicMock(side_effect=_build_api_kwargs)
+        assert prewarm_prompt_cache(agent) is True
+        kwargs = agent._request_client.chat.completions.create.call_args.kwargs
+        assert "thinking" not in kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["max_tokens"] == 1
+        assert kwargs["extra_body"]["keep"] == 1
+
+    def test_adaptive_thinking_and_effort_preserved(self):
+        """On Claude 4.6+/5-series the thinking config and resolved effort
+        are rendered into the prompt; a mismatch can invalidate the very
+        system/tools cache blocks the prewarm exists to warm. Adaptive
+        thinking has no budget/max_tokens coupling, so it must ride along
+        byte-identical to the real turn."""
+        agent = _make_agent()
+
+        def _build_api_kwargs(api_messages):
+            return {
+                "model": agent.model,
+                "messages": api_messages,
+                "max_tokens": 8192,
+                "thinking": {"type": "adaptive", "display": "summarized"},
+                "output_config": {"effort": "high"},
                 "reasoning_effort": "high",
                 "extra_body": {"reasoning": {"effort": "high"}, "keep": 1},
             }
@@ -125,10 +161,13 @@ class TestPrewarmRequest:
         agent._build_api_kwargs = MagicMock(side_effect=_build_api_kwargs)
         assert prewarm_prompt_cache(agent) is True
         kwargs = agent._request_client.chat.completions.create.call_args.kwargs
-        assert "thinking" not in kwargs
-        assert "reasoning_effort" not in kwargs
-        assert "reasoning" not in kwargs["extra_body"]
-        assert kwargs["extra_body"]["keep"] == 1
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert kwargs["output_config"] == {"effort": "high"}
+        assert kwargs["reasoning_effort"] == "high"
+        assert kwargs["extra_body"]["reasoning"] == {"effort": "high"}
+        # max_tokens untouched too — the full request is byte-identical to
+        # the real turn's, trailing user message aside.
+        assert kwargs["max_tokens"] == 8192
 
     def test_builds_prompt_when_not_cached(self):
         agent = _make_agent()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2073,6 +2073,9 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # was built without those tools. Catch up once they land — see
             # _schedule_mcp_late_refresh. Cache-safe (pre-first-turn only).
             _schedule_mcp_late_refresh(sid, agent)
+            # Optionally pay the provider-side prompt-cache write now so the
+            # first real message reads a warm prefix (agent.prewarm_prompt_cache).
+            _schedule_prompt_prewarm(sid, agent)
         except Exception as e:
             current["agent_error"] = str(e)
             _emit("error", sid, {"message": f"agent init failed: {e}"})
@@ -5975,6 +5978,74 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
     ).start()
 
 
+def _schedule_prompt_prewarm(sid: str, agent) -> None:
+    """Warm the provider prompt cache for a freshly built session agent.
+
+    The first API call of a session pays provider-side ingestion of the whole
+    uncached prefix (system prompt + tool schemas, commonly 50-70k tokens) —
+    observed as 10-20s of first-message latency on Anthropic-cached routes.
+    When ``agent.prewarm_prompt_cache`` is enabled, issue one minimal request
+    off the response path right after the agent is built so the first real
+    turn *reads* the prefix cache instead of writing it cold.
+
+    Ordering: if MCP discovery is still in flight, wait for it (the late
+    refresh rebuilds ``agent.tools``, and the tools block is part of the
+    cached prefix — prewarming before it lands would warm a prefix the real
+    turn no longer sends). Skipped silently the moment the user has already
+    started the conversation; the in-flight real call warms the cache itself.
+    """
+    try:
+        agent_cfg = _load_cfg().get("agent") or {}
+        if not (
+            isinstance(agent_cfg, dict)
+            and is_truthy_value(agent_cfg.get("prewarm_prompt_cache", False))
+        ):
+            return
+        from agent.prompt_prewarm import prewarm_supported
+
+        if not prewarm_supported(agent):
+            return
+    except Exception:
+        return
+
+    def _wait_then_prewarm() -> None:
+        try:
+            from tui_gateway.entry import (
+                mcp_discovery_in_flight,
+                join_mcp_discovery,
+            )
+
+            if mcp_discovery_in_flight():
+                # Same bound as the late MCP refresh; a server slower than
+                # this is dead-ish and the tool snapshot is already frozen.
+                join_mcp_discovery(timeout=30.0)
+                # Give _schedule_mcp_late_refresh's rebuild a beat to land so
+                # the prewarmed tools block matches the refreshed snapshot.
+                time.sleep(0.5)
+        except Exception:
+            pass
+        session = _sessions.get(sid)
+        if session is None or session.get("agent") is not agent:
+            return
+        # The user beat us to it — their real first call is already warming
+        # the cache; a duplicate prefix ingestion would only add cost.
+        if (
+            session.get("running")
+            or int(getattr(agent, "_user_turn_count", 0) or 0) > 0
+            or int(getattr(agent, "_api_call_count", 0) or 0) > 0
+        ):
+            return
+        from agent.prompt_prewarm import prewarm_prompt_cache
+
+        prewarm_prompt_cache(agent)
+
+    threading.Thread(
+        target=_wait_then_prewarm,
+        name=f"tui-prompt-prewarm-{sid}",
+        daemon=True,
+    ).start()
+
+
 class _RuntimeFallbackResolution(NamedTuple):
     runtime: dict
     selected_model: str | None
@@ -6342,6 +6413,9 @@ def _init_session(
     _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)
+    # Optionally pay the provider-side prompt-cache write now so the first
+    # real message reads a warm prefix (agent.prewarm_prompt_cache).
+    _schedule_prompt_prewarm(sid, agent)
 
 
 def _new_session_key() -> str:


### PR DESCRIPTION
# Opt-in prompt-cache prewarm: pay the 20s first-message cost while the user is still typing

## The problem, plainly

When you open a new desktop/TUI session, **nothing touches the API until you send your first message**. That first message therefore pays the expensive part: the provider must ingest the entire prompt prefix — system prompt + all tool schemas, commonly 30-70k tokens — from scratch. That is the ~20 seconds of dead air on message one. Every later message rides the prompt cache and returns in 2-7s.

Traced from a live desktop session in `agent.log`:

```
API call #1: in=67004 out=47  latency=20.4s              ← cold: provider ingests 67k tokens
API call #2: in=67061 out=170 latency=6.1s  cache=100%   ← warm: reads the cache #1 wrote
API call #3: in=67255 out=70  latency=4.0s  cache=100%
```

Turn 2 has always been fast *because turn 1 wrote the cache*. This PR simply moves that write earlier.

## What this PR does

New config flag **`agent.prewarm_prompt_cache`** — **opt-in, default OFF**, nothing changes out of the box.

When enabled: the moment a session's agent finishes building, the TUI/desktop gateway fires **one throwaway API call in the background** — same system prompt, same tool schemas, plus a trivial `"Reply with only the word: ok"` user message (~4 output tokens). Anthropic's cache stores everything up to the `cache_control` breakpoints, which sit at the end of the system prompt — **the trailing user message is not part of the cached prefix**. So this throwaway call makes the provider do the 20-second ingestion *while the user is still typing*. The real first message then finds the prefix already cached:

```
PREWARM (hidden):  ~2-5s   write=31.5k tokens
FIRST REAL TURN:   1.8-5.2s  read=31527 / write=82  (100% prefix hit)   ← was 20.4s
```

No prefilling is involved — this is an ordinary, self-contained request whose *response is discarded*; only its server-side cache-write side effect matters.

## The rule that makes it work: byte-parity

The provider's cache key covers the **rendered request configuration**, not just the prompt text. Live A/B testing against nous / claude-fable-5 proved:

- Two byte-identical requests → second one reads the first one's cache. ✔
- Change **only** `max_tokens` (1 vs 128000) → total cache miss. ✘
- On Claude 4.6+/5-series, thinking config and resolved effort are rendered into the prompt too (per Anthropic's current caching docs, changes can invalidate the SYSTEM and TOOLS breakpoints, not just message blocks).

So the prewarm request is sent **exactly as `_build_api_kwargs` produces it** — thinking, effort, and max_tokens untouched, identical to what the first real turn will send. Output cost is bounded by the trivial prompt, not an output cap (adaptive thinking skips reasoning on trivial prompts). The lone exception is legacy manual-thinking models (`budget_tokens`), which always burn thinking tokens: they keep a strip + 1-token cap, which is documented cache-safe on those models. *(An earlier revision of this PR capped `max_tokens=1` and stripped thinking on all models — the A/B above showed that silently never warmed anything on modern Claude: a wasted write per session and a cold first message anyway. Fixed in the parity commit.)*

## Safety and guardrails

- **Opt-in only.** Default off; no setup prompt pushes it.
- **Fail-open.** Any prewarm failure = today's behavior (cold first turn). Never surfaces to the user, never blocks the session.
- **Scope-gated.** Only prompt-caching routes (`chat_completions` / `anthropic_messages` with `_use_prompt_caching`); no-op on MoA/Codex/Bedrock/ACP and non-caching providers.
- **No duplicate spend.** Skips silently if the user already sent a message (their real call is warming the cache).
- **Waits for MCP discovery** before firing — tool schemas are part of the cached prefix; warming before they land would warm the wrong prefix.
- **Byte-stability into turn 1.** The exact sent prompt is handed to the first real turn via `_prewarmed_system_prompt`; `_restore_or_build_system_prompt` adopts it (gated on runtime-identity match, fresh session, no custom system message) so the volatile timestamp tail can't drift and split the just-warmed prefix. One-shot — `/new`, compression rebuilds, and model swaps never reuse it.
- **Cache-invariant safe.** Strictly pre-first-turn; nothing mutates context mid-conversation.

## Cost (why it's default-off)

When the session is used: near-neutral — the 1.25x cache write is paid by the first real call today anyway; extra spend is one 0.1x cache read + a few output tokens. When a session is opened and **never used**, the write is wasted: **~$0.25 (Sonnet-class) to ~$1.25 (Opus-class) per abandoned session** on a 67k prefix. The config comment states this in dollars so opting in is informed.

## Tests

`tests/agent/test_prompt_prewarm.py` — 21 tests: support gate, request shape (cache markers, byte-parity contract incl. max_tokens/thinking/effort preserved, manual-thinking exception), client close on success/failure, fail-open, first-turn adoption/rejection (model switch, custom system message, continuing session). Sabotage-verified: restoring the old strip behavior fails the parity test. Sibling suites green (123 total). E2E-validated live against the nous endpoint 3/3 runs **with reasoning=high** (the adversarial case that exposed the parity bug).

## Infographic

![prompt-cache prewarm — how it works](https://v3b.fal.media/files/b/0aa48e96/tqQreSPyLyPpq_KW6TR6d_GUANBNoq.png)
