### PR TITLE
fix(install): let managed checkouts see branches other than main

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -219,7 +219,11 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     is_shallow = shallow == "true"
 
     try:
-        fetch_args = ["git", "fetch", "origin"]
+        # Name the branch. A bare `git fetch origin` walks the configured
+        # refspec; on a checkout that can see all of this repo's branches
+        # that is hundreds of MB, behind a 10s timeout, on every startup.
+        # Naming main keeps it to one ref whatever remote.origin.fetch says.
+        fetch_args = ["git", "fetch", "origin", "main"]
         if is_shallow:
             fetch_args += ["--depth", "1"]
         fetch_args.append("--quiet")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10741,6 +10741,27 @@ def _resolve_update_branch(args) -> str:
     return (getattr(args, "branch", None) or "main").strip() or "main"
 
 
+def _widen_remote_branches(git_cmd: list) -> None:
+    """Let the checkout resolve branches other than the one it was cloned on.
+
+    Installer checkouts come from ``git clone --depth 1 --branch main``, which
+    implies ``--single-branch`` and pins ``remote.origin.fetch`` to main. Our
+    scoped ``git fetch origin <branch>`` then updates FETCH_HEAD but never
+    creates ``origin/<branch>``, so ``--branch <other>`` reports the branch as
+    missing from a remote that plainly has it.
+
+    Restoring the wildcard costs no bandwidth — every fetch we issue names its
+    branch, and git only walks the full refspec on a bare ``git fetch``.
+    Best-effort: a failure here just leaves the checkout as it was.
+    """
+    subprocess.run(
+        git_cmd + ["remote", "set-branches", "origin", "*"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+
+
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     """Implement ``hermes update --check``: fetch and report without installing.
 
@@ -10797,6 +10818,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         == "true"
     )
     depth_args = ["--depth", "1"] if is_shallow else []
+    _widen_remote_branches(git_cmd)
 
     if branch == "main":
         print("→ Fetching from upstream...")
@@ -12052,6 +12074,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # minutes on a non-single-branch checkout. Fetch only what we update
         # against.
         branch = _resolve_update_branch(args)
+        _widen_remote_branches(git_cmd)
 
         print("→ Fetching updates...")
         fetch_result = subprocess.run(

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1761,6 +1761,13 @@ function Install-Repository {
     # next `hermes update` checkout aborts on a "dirty" tree the user never
     # touched (see the update path above).
     git -c windows.appendAtomically=false config core.autocrlf false 2>$null
+    # `clone --depth 1 --branch $Branch` implies --single-branch, which pins
+    # remote.origin.fetch to that one branch: `git fetch origin <other>` then
+    # updates FETCH_HEAD but never creates origin/<other>, so other branches
+    # are invisible to `git branch -r` / `gh pr checkout` and `hermes update
+    # --branch` fails. Restore the wildcard -- every fetch we issue names its
+    # branch, so nothing extra gets downloaded.
+    git -c windows.appendAtomically=false remote set-branches origin '*' 2>$null
 
     # Post-clone pin: when a clone (or ZIP-fallback init) just landed us on
     # $Branch's tip, honour the higher-precedence $Commit / $Tag by checking

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -305,6 +305,22 @@ EOF
     log_info "Discarded npm lockfile churn (${dirty_count} file(s))"
 }
 
+# `git clone --depth 1 --branch main` implies --single-branch, which pins
+# remote.origin.fetch to main alone. On such a checkout `git fetch origin <b>`
+# updates FETCH_HEAD but never creates origin/<b>, so other branches are
+# invisible to `git branch -r` and `gh pr checkout`, and `hermes update
+# --branch <b>` fails with "does not exist locally or on origin".
+#
+# Restoring the wildcard costs nothing: every fetch the installer and the CLI
+# issue names its branch, and git only walks the full refspec on a bare
+# `git fetch`. Also heals checkouts an older installer already narrowed.
+widen_remote_branches() {
+    local repo="${1:-$INSTALL_DIR}"
+    [ -n "$repo" ] && [ -d "$repo/.git" ] || return 0
+    command -v git >/dev/null 2>&1 || return 0
+    git -C "$repo" remote set-branches origin '*' 2>/dev/null || true
+}
+
 emit_manifest() {
     # Stage-Desktop is included only with --include-desktop, mirroring
     # install.ps1: the signed bootstrap installer (Hermes-Setup) passes it so
@@ -1210,11 +1226,11 @@ clone_repo() {
                 autostash_ref="stash@{0}"
             fi
 
-            # Fetch only the target branch. A bare `git fetch origin` pulls
-            # every ref, and this repo carries thousands of auto-generated
-            # branches — on a non-single-branch checkout that turns each update
-            # into a multi-minute download that can stall the installer.
-            git remote set-branches origin "$BRANCH" 2>/dev/null || true
+            widen_remote_branches "$INSTALL_DIR"
+            # Naming the branch is what keeps the fetch cheap: a bare
+            # `git fetch origin` pulls every ref, and this repo carries
+            # thousands of branches, which turns each update into a
+            # multi-minute download that can stall the installer.
             git fetch origin "$BRANCH"
             git checkout "$BRANCH"
             # Managed installs should follow origin/$BRANCH exactly. If the
@@ -1304,6 +1320,7 @@ EOF
                 exit 1
             fi
         fi
+        widen_remote_branches "$INSTALL_DIR"
     fi
 
     cd "$INSTALL_DIR"

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -852,6 +852,24 @@ def test_cmd_update_fetch_is_scoped_to_target_branch(monkeypatch, tmp_path):
     assert ["git", "fetch", "origin"] not in recorded
 
 
+def test_cmd_update_widens_remote_branches_before_fetching(monkeypatch, tmp_path):
+    """Installer checkouts are single-branch, so a scoped `git fetch origin
+    <branch>` never creates origin/<branch> and `--branch <other>` fails the
+    checkout as missing. Widen the refspec first — free, since the fetch that
+    follows still names its branch."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect()
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    widen = ["git", "remote", "set-branches", "origin", "*"]
+    assert widen in recorded
+    assert recorded.index(widen) < recorded.index(["git", "fetch", "origin", "main"])
+
+
 # ---------------------------------------------------------------------------
 # Fetch failure — friendly error messages
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -125,7 +125,7 @@ def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
         result = banner._check_via_local_git(repo_dir)
 
     assert result == 1
-    assert ["git", "fetch", "origin", "--quiet"] not in calls
+    assert not any(cmd[:2] == ["git", "fetch"] for cmd in calls)
 
 
 def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):
@@ -165,8 +165,10 @@ def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):
         result = banner._check_via_local_git(repo_dir)
 
     assert result == banner.UPDATE_AVAILABLE_NO_COUNT
-    # The shallow fetch must preserve the boundary (--depth 1), not unshallow.
-    assert ["git", "fetch", "origin", "--depth", "1", "--quiet"] in calls
+    # The shallow fetch must preserve the boundary (--depth 1), not unshallow,
+    # and must name main so a checkout that can see every branch doesn't pull
+    # them all on startup.
+    assert ["git", "fetch", "origin", "main", "--depth", "1", "--quiet"] in calls
 
 
 def test_check_via_local_git_shallow_clone_up_to_date(tmp_path):

--- a/tests/test_managed_checkout_branch_visibility.py
+++ b/tests/test_managed_checkout_branch_visibility.py
@@ -1,0 +1,154 @@
+"""Regression: managed installs must be able to see the repo's other branches.
+
+``git clone --depth 1 --branch main`` implies ``--single-branch``, which pins
+``remote.origin.fetch`` to ``+refs/heads/main:refs/remotes/origin/main``. On
+such a checkout ``git fetch origin <other>`` updates FETCH_HEAD but never
+creates ``origin/<other>``, so other branches are invisible to ``git branch
+-r`` / ``gh pr checkout`` and ``hermes update --branch <other>`` fails with
+"does not exist locally or on origin".
+
+The installer restores the wildcard refspec. That only costs bandwidth if
+something issues a bare ``git fetch``, so the startup update check has to keep
+naming its branch.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git and bash",
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _make_upstream(tmp_path: Path) -> Path:
+    """A bare remote with `main` plus a couple of side branches."""
+    upstream = tmp_path / "upstream.git"
+    seed = tmp_path / "seed"
+    _git(tmp_path, "init", "--bare", "-b", "main", str(upstream))
+    _git(tmp_path, "clone", upstream.as_uri(), str(seed))
+    (seed / "a.txt").write_text("one\n")
+    _git(seed, "add", "a.txt")
+    _git(seed, "commit", "-m", "init")
+    for branch in ("feat-1", "feat-2"):
+        _git(seed, "checkout", "-b", branch, "main")
+        (seed / f"{branch}.txt").write_text(branch)
+        _git(seed, "add", ".")
+        _git(seed, "commit", "-m", branch)
+    _git(seed, "checkout", "main")
+    _git(seed, "push", "--all", "origin")
+    return upstream
+
+
+def _narrow_clone(tmp_path: Path, upstream: Path) -> Path:
+    """Clone exactly the way the installer does: shallow and single-branch."""
+    checkout = tmp_path / "checkout"
+    _git(tmp_path, "clone", "--depth", "1", "--branch", "main",
+         upstream.as_uri(), str(checkout))
+    assert _git(checkout, "config", "--get-all", "remote.origin.fetch") == (
+        "+refs/heads/main:refs/remotes/origin/main"
+    )
+    return checkout
+
+
+def _widen(checkout: Path) -> None:
+    """Run install.sh's widen_remote_branches() against a real checkout."""
+    match = re.search(r"widen_remote_branches\(\) \{.*?\n\}", INSTALL_SH.read_text(),
+                      re.DOTALL)
+    assert match is not None, "widen_remote_branches() not found in install.sh"
+    script = f"{match.group(0)}\nwiden_remote_branches {shlex.quote(str(checkout))}\n"
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_narrow_clone_cannot_resolve_other_branches(tmp_path: Path) -> None:
+    """The premise: without the fix, fetching a branch by name is not enough."""
+    checkout = _narrow_clone(tmp_path, _make_upstream(tmp_path))
+
+    _git(checkout, "fetch", "origin", "feat-1")
+    assert _git(checkout, "branch", "-r").split() == ["origin/main"]
+
+    # This is the exact pair of commands `hermes update --branch feat-1` runs.
+    for args in (("checkout", "feat-1"), ("checkout", "-B", "feat-1", "origin/feat-1")):
+        assert subprocess.run(["git", *args], cwd=checkout,
+                              capture_output=True).returncode != 0
+
+
+def test_widening_makes_other_branches_resolvable(tmp_path: Path) -> None:
+    checkout = _narrow_clone(tmp_path, _make_upstream(tmp_path))
+    _widen(checkout)
+
+    assert _git(checkout, "config", "--get-all", "remote.origin.fetch") == (
+        "+refs/heads/*:refs/remotes/origin/*"
+    )
+    _git(checkout, "fetch", "--depth", "1", "origin", "feat-1")
+    assert _git(checkout, "branch", "-r").split() == ["origin/feat-1", "origin/main"]
+    _git(checkout, "checkout", "-B", "feat-1", "origin/feat-1")
+    assert _git(checkout, "rev-parse", "--abbrev-ref", "HEAD") == "feat-1"
+
+
+def test_widening_downloads_nothing_by_itself(tmp_path: Path) -> None:
+    """Rewriting the refspec must not pull refs the user didn't ask for."""
+    checkout = _narrow_clone(tmp_path, _make_upstream(tmp_path))
+    before = _git(checkout, "rev-list", "--all", "--objects", "--count")
+
+    _widen(checkout)
+
+    assert _git(checkout, "branch", "-r").split() == ["origin/main"]
+    assert _git(checkout, "rev-list", "--all", "--objects", "--count") == before
+
+
+def test_widening_is_idempotent(tmp_path: Path) -> None:
+    """Re-running the installer over an already-widened checkout is a no-op."""
+    checkout = _narrow_clone(tmp_path, _make_upstream(tmp_path))
+    _widen(checkout)
+    _widen(checkout)
+
+    assert _git(checkout, "config", "--get-all", "remote.origin.fetch") == (
+        "+refs/heads/*:refs/remotes/origin/*"
+    )
+
+
+def test_update_check_stays_scoped_on_a_widened_checkout(tmp_path: Path) -> None:
+    """The startup banner check must not pull every branch once it can see them.
+
+    A bare ``git fetch origin`` on a widened checkout would drag in every
+    branch — hundreds of MB on the real repo, behind a 10s timeout, on every
+    launch. Naming main keeps the transfer to one ref.
+    """
+    import hermes_cli.banner as banner
+
+    upstream = _make_upstream(tmp_path)
+    checkout = _narrow_clone(tmp_path, upstream)
+    _widen(checkout)
+
+    # Move main forward so the check has something to report.
+    seed = tmp_path / "seed"
+    (seed / "a.txt").write_text("two\n")
+    _git(seed, "commit", "-am", "advance main")
+    _git(seed, "push", "origin", "main")
+
+    assert banner._check_via_local_git(checkout) == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert _git(checkout, "branch", "-r").split() == ["origin/main"]
+    assert _git(checkout, "rev-parse", "--is-shallow-repository") == "true"


### PR DESCRIPTION
A `curl | bash` install clones with `git clone --depth 1 --branch main`, which implies `--single-branch` and pins `remote.origin.fetch` to `+refs/heads/main:refs/remotes/origin/main`. Every managed checkout therefore cannot resolve any branch but main: `git fetch origin <branch>` updates `FETCH_HEAD` but never creates `origin/<branch>`, so `git branch -r` shows nothing to work with, `gh pr checkout` has nothing to find, and `hermes update --branch <other>` exits with "Branch 'x' does not exist locally or on origin" against a remote that plainly has it. Re-running the installer made it stickier: it called `git remote set-branches origin "$BRANCH"`, re-narrowing checkouts users had widened by hand.

The narrowing was there to stop a bare `git fetch origin` from pulling ~1400 branches, but it is not what buys that. Naming the branch is. With the full wildcard restored, protocol v2 makes `git fetch origin main` advertise 2 refs instead of 1393. Every fetch Hermes issues already names its branch, with one exception — the startup update check in `banner.py` — which this fixes.

Both installers now restore `+refs/heads/*:refs/remotes/origin/*`, which also heals checkouts an older installer already narrowed. `hermes update` and `hermes update --check` do the same so existing installs self-heal without a reinstall, and the banner's fetch names main.

The bandwidth this was guarding is also smaller than assumed. Measured against this repo:

| clone | `.git` | wall time |
| --- | --- | --- |
| `--depth 1 --branch main` (today) | 61 MB | 3.1 s |
| `--filter=blob:none`, full history, all 1394 branches | 100 MB | 10.5 s |

A depth-1 snapshot of all 1393 live branch tips is 254 MB of objects against 50 MB for main alone, because branch tips share nearly everything with main and delta-compress against it. Branch count is not what costs. Nothing here changes what a normal install or update downloads; a bare `git fetch` on a widened checkout is a one-time ~200 MB and is now the user's explicit choice rather than something they cannot opt into.

## Test plan

- [x] `tests/test_managed_checkout_branch_visibility.py` (new, real git against a temp remote): proves the premise that a narrow clone cannot resolve `feat-1` even after fetching it by name, proves the widening fixes it, proves widening downloads nothing on its own and is idempotent, and proves the banner check on a widened shallow clone still leaves only `origin/main`.
- [x] `tests/hermes_cli/test_update_check.py`, `tests/hermes_cli/test_update_autostash.py`, `tests/hermes_cli/test_cmd_update_docker.py` and the six `tests/test_install_*` suites: 93 passing, no flakes.
- [ ] `scripts/install.ps1` is not syntax-checked — no `pwsh` on the machine this was written on. The change is a single line matching its neighbours in the same block.