### PR TITLE
test: isolate compaction regression session database

### DIFF
--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2004,7 +2004,7 @@ def test_mid_turn_compaction_does_not_double_persist_in_place_rows(monkeypatch, 
     agent.context_compressor.context_length = 20_000
     agent.context_compressor.threshold_tokens = 20_000
 
-    agent._session_db = SessionDB()
+    agent._session_db = SessionDB(db_path=tmp_path / "state.db")
     agent._ensure_db_session()
 
     responses = [


### PR DESCRIPTION
## Summary
- pass the pytest temporary database path directly to `SessionDB`
- prevent the mid-turn compaction regression test from writing synthetic sessions into a developer's real Hermes state database

## Test plan
- `pytest tests/run_agent/test_run_agent_codex_responses.py::test_mid_turn_compaction_does_not_double_persist_in_place_rows -o addopts= -q`
- verified the live state database session count remains unchanged before and after the focused test
