### PR TITLE
fix(cron): redact secrets from delivery content before sending

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1447,6 +1447,29 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _redact_cron_payload(text: str, what: str) -> str:
+    """Fail-closed secret redaction for anything a cron job emits outward.
+
+    Both outward paths — the chat message and the session mirror — must apply
+    the same policy, so the policy lives in one place.
+
+    ``force=True`` because this is a safety boundary, not logging: the
+    ``security.redact_secrets`` preference governs how much is scrubbed from
+    the user's own logs, and must not be able to turn off scrubbing on the way
+    out to a chat (same reasoning as ``tools/delegation_live_log.py``).
+    Empty input is returned as-is; any failure inside the redactor replaces the
+    payload entirely rather than letting an unscanned value through.
+    """
+    if not text:
+        return text
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text(text, force=True)
+    except Exception as e:
+        logger.warning("Failed to redact secrets from cron %s: %s", what, e)
+        return "[REDACTED - redaction failed]"
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -1519,13 +1542,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # (e.g. echoed a failing curl with an API key, or summarised a config file)
     # sent it verbatim to the chat. Redacting once here covers every platform
     # and both send paths.
-    if cleaned_delivery_content:
-        try:
-            from agent.redact import redact_sensitive_text
-            cleaned_delivery_content = redact_sensitive_text(cleaned_delivery_content)
-        except Exception as e:
-            logger.warning("Failed to redact secrets from cron delivery content: %s", e)
-            cleaned_delivery_content = "[REDACTED - redaction failed]"
+    cleaned_delivery_content = _redact_cron_payload(
+        cleaned_delivery_content, "delivery content",
+    )
 
     # Resolve the delivery-mirror gate ONCE (default off). When on, each
     # successful delivery is also appended to the target chat's gateway session
@@ -1539,6 +1558,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     if mirror_enabled:
         _, mirror_text = BasePlatformAdapter.extract_media(content)
         mirror_text = (mirror_text or "").strip()
+        # This payload is derived from the raw `content`, not from
+        # `cleaned_delivery_content`, so it does NOT inherit the redaction
+        # above. Without this, enabling the mirror writes an unredacted
+        # credential into the origin session transcript even though the chat
+        # message itself was clean — and a transcript outlives the message.
+        mirror_text = _redact_cron_payload(mirror_text, "mirror payload")
 
     try:
         config = load_gateway_config()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1512,6 +1512,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
+    # Redact secrets from the delivery text at this single chokepoint, BEFORE
+    # the live-adapter vs standalone send branches below. Shell-job stdout/stderr
+    # is already redacted where it is captured, but an LLM cron job's response
+    # text reaches delivery unscanned — so a job that surfaced a credential
+    # (e.g. echoed a failing curl with an API key, or summarised a config file)
+    # sent it verbatim to the chat. Redacting once here covers every platform
+    # and both send paths.
+    if cleaned_delivery_content:
+        try:
+            from agent.redact import redact_sensitive_text
+            cleaned_delivery_content = redact_sensitive_text(cleaned_delivery_content)
+        except Exception as e:
+            logger.warning("Failed to redact secrets from cron delivery content: %s", e)
+            cleaned_delivery_content = "[REDACTED - redaction failed]"
+
     # Resolve the delivery-mirror gate ONCE (default off). When on, each
     # successful delivery is also appended to the target chat's gateway session
     # transcript so a user reply in that chat sees the cron output in context.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -720,7 +720,7 @@ def _maybe_mirror_cron_delivery(
         ok = mirror_to_session(
             platform_name,
             str(chat_id),
-            f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}",
+            f"[Cron delivery: {_cron_display_name(job)}]\n{text}",
             source_label="cron",
             thread_id=thread_id,
             user_id=user_id,
@@ -761,7 +761,7 @@ def _open_continuable_cron_thread(
     create_thread = getattr(adapter, "create_handoff_thread", None)
     if not callable(create_thread) or loop is None:
         return None
-    task_name = job.get("name") or job.get("id", "cron")
+    task_name = _cron_display_name(job)
     thread_name = f"Hermes — {task_name}"
     try:
         from agent.async_utils import safe_schedule_threadsafe
@@ -841,7 +841,7 @@ def _seed_cron_thread_session(
         mirror_to_session(
             platform_name,
             str(chat_id),
-            f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}",
+            f"[Cron delivery: {_cron_display_name(job)}]\n{text}",
             source_label="cron",
             thread_id=str(thread_id),
             user_id="system:cron",
@@ -934,7 +934,7 @@ def _seed_cron_channel_session(
         ok = mirror_to_session(
             platform_name,
             str(chat_id),
-            f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}",
+            f"[Cron delivery: {_cron_display_name(job)}]\n{text}",
             source_label="cron",
             thread_id=None,
             user_id=str(user_id) if user_id else None,
@@ -1445,6 +1445,17 @@ def _is_channel_dm_topic(
             job_id, chat_id,
         )
     return is_channel
+
+
+def _cron_display_name(job: dict) -> str:
+    """Job name/id as it may appear in outward-facing text.
+
+    The session-mirror sinks and the thread title splice the job *name* around
+    the redacted payload. The name is user-controlled config, so a name that
+    embeds a credential would re-leak it right next to the scrubbed body —
+    same policy, same fail-closed helper.
+    """
+    return _redact_cron_payload(job.get("name") or job.get("id", "cron"), "job name")
 
 
 def _redact_cron_payload(text: str, what: str) -> str:

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -162,8 +162,35 @@ def _inchannel_seed_allowed(*, is_dm: bool, user_id: Optional[str]) -> bool:
     return bool(is_dm or user_id)
 
 
+def _redact_cron_payload(text: str, what: str) -> str:
+    """Fail-closed secret redaction for anything a cron job emits outward.
+
+    Every outward lane — chat message, session mirror, bot-chat turn — must apply the same policy,
+    so the policy lives in one place. ``force=True`` because this is a safety boundary, not
+    logging: the ``security.redact_secrets`` preference governs how much is scrubbed from the
+    user's own logs and must not be able to turn scrubbing off on the way out to a chat (same
+    reasoning as ``tools/delegation_live_log.py``). Empty input is returned as-is; any failure
+    inside the redactor replaces the payload entirely rather than letting an unscanned value out.
+    """
+    if not text:
+        return text
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text(text, force=True)
+    except Exception as e:
+        logger.warning("Failed to redact secrets from cron %s: %s", what, e)
+        return "[REDACTED - redaction failed]"
+
+
+def _cron_display_name(job: dict) -> str:
+    """Job name/id as it appears in outward-facing text. The mirror sinks and the thread title
+    splice the job *name* around the redacted payload, and the name is user-controlled config — a
+    name embedding a credential would re-leak it next to the scrubbed body."""
+    return _redact_cron_payload(job.get("name") or job.get("id", "cron"), "job name")
+
+
 def _cron_mirror_message(job: dict, text: str) -> str:
-    return f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}"
+    return f"[Cron delivery: {_cron_display_name(job)}]\n{text}"
 
 
 def _maybe_mirror_cron_delivery(
@@ -214,7 +241,7 @@ def _open_continuable_cron_thread(job: dict, adapter, chat_id: str, loop) -> Opt
     create_thread = getattr(adapter, "create_handoff_thread", None)
     if not callable(create_thread) or loop is None:
         return None
-    thread_name = f"Hermes — {job.get('name') or job.get('id', 'cron')}"
+    thread_name = f"Hermes — {_cron_display_name(job)}"
     try:
         from agent.async_utils import safe_schedule_threadsafe
         coro = create_thread(str(chat_id), thread_name)
@@ -660,10 +687,13 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
 
     job_id = job.get("id", "?")
     profile_label = profile or "(own)"
+    # Outward lane: this text becomes an inbound turn in another profile's Bot Chat — via the
+    # live owner or the CLI fallback — so it gets the same fail-closed scrub as the chat message
+    # and the session mirror. Redact here, above both lanes, so neither can be added back unscanned.
     message = (
-        f'[Cronjob "{job.get("name", job_id)}" output — scheduled job, not the user. '
-        f"Review it, act on anything that needs action, and summarize "
-        f"for the chat.]\n\n{content}"
+        f'[Cronjob "{_redact_cron_payload(job.get("name", job_id), "job name")}" output — '
+        f"scheduled job, not the user. Review it, act on anything that needs action, and "
+        f"summarize for the chat.]\n\n{_redact_cron_payload(content, 'bot-chat payload')}"
     )
     try:
         source_home = get_hermes_home().resolve()
@@ -1712,6 +1742,11 @@ def _deliver_result(
     from gateway.media_policy import apply_media_policy_env
     apply_media_policy_env(user_cfg)
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+    # Redact at this single chokepoint, BEFORE the live-adapter / standalone send lanes below.
+    # Shell-job stdout/stderr is already redacted where it is captured, but an LLM cron job's
+    # response text reaches delivery unscanned — so a job that surfaced a credential (echoed a
+    # failing curl with an API key, summarised a config file) sent it verbatim to the chat.
+    cleaned_delivery_content = _redact_cron_payload(cleaned_delivery_content, "delivery content")
     requested_media = len(media_files)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
     # Policy-dropped attachments will never be sent on ANY lane — record them in run status.
@@ -1731,7 +1766,10 @@ def _deliver_result(
     # Independent of the mirror knob: continuable surfaces (in_channel) must seed even when
     # attach_to_session=false and cron.mirror_delivery=false, else the seed gets "" and fails.
     _, mirror_text = BasePlatformAdapter.extract_media(content)
-    mirror_text = (mirror_text or "").strip()
+    # Derived from the raw `content`, so it does NOT inherit the redaction above. Without this,
+    # enabling the mirror writes an unredacted credential into the session transcript even though
+    # the chat message itself was clean — and a transcript outlives the message.
+    mirror_text = _redact_cron_payload((mirror_text or "").strip(), "mirror payload")
 
     try:
         config = load_gateway_config()

--- a/tests/cron/test_cron_delivery_redaction.py
+++ b/tests/cron/test_cron_delivery_redaction.py
@@ -70,6 +70,70 @@ class TestCronDeliveryRedaction:
         assert "3 tasks done" in delivered
         assert result is None
 
+    def test_session_mirror_payload_redacts_secret(self):
+        """The delivery mirror must not write an unredacted secret to the session.
+
+        ``mirror_text`` is derived from the raw ``content``, not from
+        ``cleaned_delivery_content``, so it does not inherit the delivery-path
+        redaction. With ``cron.mirror_delivery`` enabled the mirror payload is
+        appended to the origin chat's session transcript — an unscanned value
+        there is just as exposed as one sent to the chat, and survives longer.
+        """
+        from cron.scheduler import _deliver_result
+
+        send_mock = AsyncMock(return_value={"success": True})
+        mirror_mock = MagicMock()
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler._cron_mirror_delivery_enabled", return_value=True), \
+             patch("cron.scheduler._target_matches_origin", return_value=True), \
+             patch("cron.scheduler._maybe_mirror_cron_delivery", new=mirror_mock), \
+             patch("sys.is_finalizing", return_value=False):
+            _deliver_result(_job(), f"Job finished. Token was {FAKE_SECRET} (oops).")
+
+        assert mirror_mock.called, "mirror path did not run — test would vacuously pass"
+        mirrored = " ".join(str(a) for a in mirror_mock.call_args.args)
+        mirrored += " " + " ".join(str(v) for v in mirror_mock.call_args.kwargs.values())
+        # An empty mirror payload would satisfy the secret assertion for the
+        # wrong reason, so pin that the real body still went through.
+        assert "Job finished." in mirrored, "mirror payload was empty — assertion below is vacuous"
+        assert FAKE_SECRET not in mirrored, "secret reached the session mirror payload"
+
+    def test_redaction_survives_disabled_logging_preference(self, monkeypatch):
+        """``security.redact_secrets: false`` must not disable delivery redaction.
+
+        That preference governs how much is scrubbed from the user's own logs.
+        Delivery is an egress boundary, so it redacts with ``force=True`` — the
+        same rule the other safety boundaries in the tree already follow (e.g.
+        ``tools/delegation_live_log.py``, ``tools/approval.py``). Without it a
+        user who turned down log scrubbing would silently also turn off secret
+        scrubbing on the way out to the chat.
+        """
+        import importlib
+
+        import agent.redact
+
+        monkeypatch.setenv("HERMES_REDACT_SECRETS", "false")
+        importlib.reload(agent.redact)
+        try:
+            from cron.scheduler import _deliver_result
+
+            send_mock = AsyncMock(return_value={"success": True})
+            with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+                 patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+                 patch("sys.is_finalizing", return_value=False):
+                _deliver_result(_job(), f"Job finished. Token was {FAKE_SECRET} (oops).")
+
+            send_mock.assert_called_once()
+            delivered = " ".join(str(a) for a in send_mock.call_args.args)
+            delivered += " " + " ".join(str(v) for v in send_mock.call_args.kwargs.values())
+            assert FAKE_SECRET not in delivered, (
+                "logging preference disabled delivery redaction — needs force=True"
+            )
+        finally:
+            monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+            importlib.reload(agent.redact)
+
     def test_redaction_failure_does_not_leak(self):
         """If the redactor itself raises, the delivery must fail closed rather
         than send the unscanned text."""

--- a/tests/cron/test_cron_delivery_redaction.py
+++ b/tests/cron/test_cron_delivery_redaction.py
@@ -1,0 +1,88 @@
+"""Cron delivery text must be secret-redacted before it reaches any platform.
+
+Shell-job stdout/stderr is redacted where it is captured, but an LLM cron job's
+response text reached ``_deliver_result`` unscanned, so a job that surfaced a
+credential in its answer delivered it verbatim to the chat.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _telegram_cfg():
+    from gateway.config import Platform
+
+    pconfig = MagicMock()
+    pconfig.enabled = True
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+    return mock_cfg
+
+
+def _job():
+    return {
+        "id": "report-job",
+        "name": "daily-report",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "123"},
+    }
+
+
+# A synthetic OpenAI-style key: long enough to trip the redactor, and not a
+# real credential.
+FAKE_SECRET = "sk-" + "A" * 32
+
+
+class TestCronDeliveryRedaction:
+    def test_standalone_delivery_redacts_secret(self):
+        """A secret in the job's answer must not reach the platform send.
+
+        Redaction happens once on ``cleaned_delivery_content`` right after
+        media extraction — i.e. before the live-adapter / standalone branch —
+        so both delivery paths consume the same redacted string. This test
+        drives the standalone branch; the live-adapter branch reads the very
+        same variable.
+        """
+        from cron.scheduler import _deliver_result
+
+        send_mock = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("sys.is_finalizing", return_value=False):
+            _deliver_result(_job(), f"Job finished. Token was {FAKE_SECRET} (oops).")
+
+        send_mock.assert_called_once()
+        delivered = " ".join(str(a) for a in send_mock.call_args.args)
+        delivered += " " + " ".join(str(v) for v in send_mock.call_args.kwargs.values())
+        assert FAKE_SECRET not in delivered, "secret reached the platform send"
+
+    def test_clean_content_is_unchanged(self):
+        """Redaction must not mangle ordinary delivery text."""
+        from cron.scheduler import _deliver_result
+
+        body = "Daily report: 3 tasks done, 1 pending. All systems nominal."
+        send_mock = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("sys.is_finalizing", return_value=False):
+            result = _deliver_result(_job(), body)
+
+        send_mock.assert_called_once()
+        delivered = " ".join(str(a) for a in send_mock.call_args.args)
+        assert "3 tasks done" in delivered
+        assert result is None
+
+    def test_redaction_failure_does_not_leak(self):
+        """If the redactor itself raises, the delivery must fail closed rather
+        than send the unscanned text."""
+        from cron.scheduler import _deliver_result
+
+        send_mock = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("agent.redact.redact_sensitive_text", side_effect=RuntimeError("boom")), \
+             patch("sys.is_finalizing", return_value=False):
+            _deliver_result(_job(), f"Token {FAKE_SECRET}")
+
+        send_mock.assert_called_once()
+        delivered = " ".join(str(a) for a in send_mock.call_args.args)
+        assert FAKE_SECRET not in delivered
+        assert "REDACTED" in delivered

--- a/tests/cron/test_cron_delivery_redaction.py
+++ b/tests/cron/test_cron_delivery_redaction.py
@@ -70,6 +70,29 @@ class TestCronDeliveryRedaction:
         assert "3 tasks done" in delivered
         assert result is None
 
+    def _deliver_with_mirror(self, job, content):
+        """Drive a delivery with the mirror enabled, through the REAL
+        ``_maybe_mirror_cron_delivery``, capturing what reaches the
+        ``mirror_to_session`` sink. Mocking the mirror helper itself would hide
+        anything the sink splices in around the payload (e.g. the job-name
+        prefix), so only the outermost session write is stubbed."""
+        from cron.scheduler import _deliver_result
+
+        send_mock = AsyncMock(return_value={"success": True})
+        sink_mock = MagicMock(return_value=True)
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler._cron_mirror_delivery_enabled", return_value=True), \
+             patch("cron.scheduler._target_matches_origin", return_value=True), \
+             patch("gateway.mirror.mirror_to_session", new=sink_mock), \
+             patch("sys.is_finalizing", return_value=False):
+            _deliver_result(job, content)
+
+        assert sink_mock.called, "mirror sink did not run — test would vacuously pass"
+        mirrored = " ".join(str(a) for a in sink_mock.call_args.args)
+        mirrored += " " + " ".join(str(v) for v in sink_mock.call_args.kwargs.values())
+        return mirrored
+
     def test_session_mirror_payload_redacts_secret(self):
         """The delivery mirror must not write an unredacted secret to the session.
 
@@ -79,25 +102,26 @@ class TestCronDeliveryRedaction:
         appended to the origin chat's session transcript — an unscanned value
         there is just as exposed as one sent to the chat, and survives longer.
         """
-        from cron.scheduler import _deliver_result
-
-        send_mock = AsyncMock(return_value={"success": True})
-        mirror_mock = MagicMock()
-        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
-             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
-             patch("cron.scheduler._cron_mirror_delivery_enabled", return_value=True), \
-             patch("cron.scheduler._target_matches_origin", return_value=True), \
-             patch("cron.scheduler._maybe_mirror_cron_delivery", new=mirror_mock), \
-             patch("sys.is_finalizing", return_value=False):
-            _deliver_result(_job(), f"Job finished. Token was {FAKE_SECRET} (oops).")
-
-        assert mirror_mock.called, "mirror path did not run — test would vacuously pass"
-        mirrored = " ".join(str(a) for a in mirror_mock.call_args.args)
-        mirrored += " " + " ".join(str(v) for v in mirror_mock.call_args.kwargs.values())
+        mirrored = self._deliver_with_mirror(
+            _job(), f"Job finished. Token was {FAKE_SECRET} (oops).",
+        )
         # An empty mirror payload would satisfy the secret assertion for the
         # wrong reason, so pin that the real body still went through.
         assert "Job finished." in mirrored, "mirror payload was empty — assertion below is vacuous"
         assert FAKE_SECRET not in mirrored, "secret reached the session mirror payload"
+
+    def test_session_mirror_job_name_does_not_leak_secret(self):
+        """The sink splices the job NAME around the redacted payload.
+
+        The name is user-controlled config; redacting only the body would leave
+        ``[Cron delivery: <name-with-secret>]`` re-leaking a credential right
+        next to the scrubbed text.
+        """
+        job = _job()
+        job["name"] = f"rotate {FAKE_SECRET} daily"
+        mirrored = self._deliver_with_mirror(job, "Job finished. All good.")
+        assert "[Cron delivery:" in mirrored, "sink prefix missing — assembly path not exercised"
+        assert FAKE_SECRET not in mirrored, "secret in the job name reached the session mirror"
 
     def test_redaction_survives_disabled_logging_preference(self, monkeypatch):
         """``security.redact_secrets: false`` must not disable delivery redaction.

--- a/tests/cron/test_cron_delivery_redaction.py
+++ b/tests/cron/test_cron_delivery_redaction.py
@@ -1,0 +1,203 @@
+"""Cron delivery text must be secret-redacted before it reaches any platform.
+
+Shell-job stdout/stderr is redacted where it is captured, but an LLM cron job's
+response text reached ``_deliver_result`` unscanned, so a job that surfaced a
+credential in its answer delivered it verbatim to the chat.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _telegram_cfg():
+    from gateway.config import Platform
+
+    pconfig = MagicMock()
+    pconfig.enabled = True
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+    return mock_cfg
+
+
+def _job():
+    return {
+        "id": "report-job",
+        "name": "daily-report",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "123"},
+    }
+
+
+# A synthetic OpenAI-style key: long enough to trip the redactor, and not a
+# real credential.
+FAKE_SECRET = "sk-" + "A" * 32
+
+
+class TestCronDeliveryRedaction:
+    def test_standalone_delivery_redacts_secret(self):
+        """A secret in the job's answer must not reach the platform send.
+
+        Redaction happens once on ``cleaned_delivery_content`` right after
+        media extraction — i.e. before the live-adapter / standalone branch —
+        so both delivery paths consume the same redacted string. This test
+        drives the standalone branch; the live-adapter branch reads the very
+        same variable.
+        """
+        from cron.scheduler_delivery import _deliver_result
+
+        send_mock = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("sys.is_finalizing", return_value=False):
+            _deliver_result(_job(), f"Job finished. Token was {FAKE_SECRET} (oops).")
+
+        send_mock.assert_called_once()
+        delivered = " ".join(str(a) for a in send_mock.call_args.args)
+        delivered += " " + " ".join(str(v) for v in send_mock.call_args.kwargs.values())
+        assert FAKE_SECRET not in delivered, "secret reached the platform send"
+
+    def test_clean_content_is_unchanged(self):
+        """Redaction must not mangle ordinary delivery text."""
+        from cron.scheduler_delivery import _deliver_result
+
+        body = "Daily report: 3 tasks done, 1 pending. All systems nominal."
+        send_mock = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("sys.is_finalizing", return_value=False):
+            result = _deliver_result(_job(), body)
+
+        send_mock.assert_called_once()
+        delivered = " ".join(str(a) for a in send_mock.call_args.args)
+        assert "3 tasks done" in delivered
+        assert result is None
+
+    def _deliver_with_mirror(self, job, content):
+        """Drive a delivery with the mirror enabled, through the REAL
+        ``_maybe_mirror_cron_delivery``, capturing what reaches the
+        ``mirror_to_session`` sink. Mocking the mirror helper itself would hide
+        anything the sink splices in around the payload (e.g. the job-name
+        prefix), so only the outermost session write is stubbed."""
+        from cron.scheduler_delivery import _deliver_result
+
+        send_mock = AsyncMock(return_value={"success": True})
+        sink_mock = MagicMock(return_value=True)
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler_delivery._cron_mirror_delivery_enabled", return_value=True), \
+             patch("cron.scheduler_delivery._target_matches_origin", return_value=True), \
+             patch("gateway.mirror.mirror_to_session", new=sink_mock), \
+             patch("sys.is_finalizing", return_value=False):
+            _deliver_result(job, content)
+
+        assert sink_mock.called, "mirror sink did not run — test would vacuously pass"
+        mirrored = " ".join(str(a) for a in sink_mock.call_args.args)
+        mirrored += " " + " ".join(str(v) for v in sink_mock.call_args.kwargs.values())
+        return mirrored
+
+    def test_session_mirror_payload_redacts_secret(self):
+        """The delivery mirror must not write an unredacted secret to the session.
+
+        ``mirror_text`` is derived from the raw ``content``, not from
+        ``cleaned_delivery_content``, so it does not inherit the delivery-path
+        redaction. With ``cron.mirror_delivery`` enabled the mirror payload is
+        appended to the origin chat's session transcript — an unscanned value
+        there is just as exposed as one sent to the chat, and survives longer.
+        """
+        mirrored = self._deliver_with_mirror(
+            _job(), f"Job finished. Token was {FAKE_SECRET} (oops).",
+        )
+        # An empty mirror payload would satisfy the secret assertion for the
+        # wrong reason, so pin that the real body still went through.
+        assert "Job finished." in mirrored, "mirror payload was empty — assertion below is vacuous"
+        assert FAKE_SECRET not in mirrored, "secret reached the session mirror payload"
+
+    def test_session_mirror_job_name_does_not_leak_secret(self):
+        """The sink splices the job NAME around the redacted payload.
+
+        The name is user-controlled config; redacting only the body would leave
+        ``[Cron delivery: <name-with-secret>]`` re-leaking a credential right
+        next to the scrubbed text.
+        """
+        job = _job()
+        job["name"] = f"rotate {FAKE_SECRET} daily"
+        mirrored = self._deliver_with_mirror(job, "Job finished. All good.")
+        assert "[Cron delivery:" in mirrored, "sink prefix missing — assembly path not exercised"
+        assert FAKE_SECRET not in mirrored, "secret in the job name reached the session mirror"
+
+    def test_redaction_survives_disabled_logging_preference(self, monkeypatch):
+        """``security.redact_secrets: false`` must not disable delivery redaction.
+
+        That preference governs how much is scrubbed from the user's own logs.
+        Delivery is an egress boundary, so it redacts with ``force=True`` — the
+        same rule the other safety boundaries in the tree already follow (e.g.
+        ``tools/delegation_live_log.py``, ``tools/approval.py``). Without it a
+        user who turned down log scrubbing would silently also turn off secret
+        scrubbing on the way out to the chat.
+        """
+        import importlib
+
+        import agent.redact
+
+        monkeypatch.setenv("HERMES_REDACT_SECRETS", "false")
+        importlib.reload(agent.redact)
+        try:
+            from cron.scheduler_delivery import _deliver_result
+
+            send_mock = AsyncMock(return_value={"success": True})
+            with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+                 patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+                 patch("sys.is_finalizing", return_value=False):
+                _deliver_result(_job(), f"Job finished. Token was {FAKE_SECRET} (oops).")
+
+            send_mock.assert_called_once()
+            delivered = " ".join(str(a) for a in send_mock.call_args.args)
+            delivered += " " + " ".join(str(v) for v in send_mock.call_args.kwargs.values())
+            assert FAKE_SECRET not in delivered, (
+                "logging preference disabled delivery redaction — needs force=True"
+            )
+        finally:
+            monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+            importlib.reload(agent.redact)
+
+    def test_redaction_failure_does_not_leak(self):
+        """If the redactor itself raises, the delivery must fail closed rather
+        than send the unscanned text."""
+        from cron.scheduler_delivery import _deliver_result
+
+        send_mock = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=_telegram_cfg()), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("agent.redact.redact_sensitive_text", side_effect=RuntimeError("boom")), \
+             patch("sys.is_finalizing", return_value=False):
+            _deliver_result(_job(), f"Token {FAKE_SECRET}")
+
+        send_mock.assert_called_once()
+        delivered = " ".join(str(a) for a in send_mock.call_args.args)
+        assert FAKE_SECRET not in delivered
+        assert "REDACTED" in delivered
+
+    def test_bot_chat_lane_redacts_secret(self):
+        """The bot-chat lane hands the job's output to another profile as a real inbound turn.
+
+        That turn lands in a canonical session transcript, which outlives the message, so it needs
+        the same fail-closed scrub as the chat send and the mirror. Both the payload and the job
+        name are spliced into the prologue, so this drives a secret through each.
+        """
+        from cron.scheduler_delivery import _deliver_to_bot_chat
+
+        captured = {}
+
+        def _fake_run(argv, **kwargs):
+            with open(argv[argv.index("--query-file") + 1], encoding="utf-8") as fh:
+                captured["message"] = fh.read()
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("cron.scheduler_delivery.shutil.which", return_value="/usr/bin/hermes"), \
+             patch("cron.scheduler_delivery.subprocess.run", side_effect=_fake_run):
+            err = _deliver_to_bot_chat(
+                {"id": "report-job", "name": f"rotate {FAKE_SECRET} daily"},
+                f"Job finished. Token was {FAKE_SECRET} (oops).",
+                "",
+            )
+
+        assert err is None, err
+        assert FAKE_SECRET not in captured["message"], "secret reached the bot-chat turn"


### PR DESCRIPTION
## What does this PR do?

Cron shell jobs already have their `stdout`/`stderr` redacted where they are captured, but an **LLM cron job's response text** reached `_deliver_result()` unscanned. A job that surfaced a credential in its answer — echoing a failing `curl` that carried an API key, summarising a config file, quoting an error string that embeds a token — delivered it verbatim to Telegram/Discord/Slack/etc.

This adds one redaction call at the single delivery chokepoint: on `cleaned_delivery_content`, right after media extraction and **before** the live-adapter / standalone branch. Both delivery paths read that same variable, so one call covers every platform and both branches.

A redactor failure now fails closed (`[REDACTED - redaction failed]`) instead of sending the unscanned text — the same posture the existing `stdout`/`stderr` redaction already takes a few hundred lines below.

## Related Issue

No existing issue — found while auditing cron delivery paths for credential exposure. Searched open and closed PRs for `cron delivery redact` / `cron secret` and found no prior work on this path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `cron/scheduler.py`: in `_deliver_result()`, redact `cleaned_delivery_content` immediately after `extract_media()` — before the live-adapter vs standalone send branches. Fails closed on redactor error.
- `tests/cron/test_cron_delivery_redaction.py` (new): three regressions covering the fix.

## How to Test

1. `pytest tests/cron/test_cron_delivery_redaction.py -q` — 3 passed.
2. Regression proof: `git stash push -- cron/scheduler.py` and re-run — `test_standalone_delivery_redacts_secret` and `test_redaction_failure_does_not_leak` both fail (the synthetic `sk-…` key reaches the send). `git stash pop` and they pass again.
3. No regressions in the surrounding suite: `pytest tests/cron/ -q` — 770 passed.

Tests use a synthetic `sk-` + 32 chars string, never a real credential.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass (`tests/cron/` — 770 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing surface change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys; reuses the existing `agent.redact` helper)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure Python, no platform-specific calls)
- [x] I've updated tool descriptions/schemas — N/A

## Notes for review

One deliberate scope choice: the test drives the **standalone** send branch only. The live-adapter branch resolves its adapter through the internal transport lookup, and mocking that would bind the test to implementation details for no extra signal — both branches consume the same already-redacted `cleaned_delivery_content`, which is exactly why the fix sits where it does.
