### PR TITLE
fix: classify 422 through multimodal-tool-content check (#72905)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -269,6 +269,10 @@ _MULTIMODAL_TOOL_CONTENT_PATTERNS = [
     "expected string, got array",
     # Alibaba/DashScope variant
     "tool_call.content must be string",
+    # DeepInfra (pydantic v2 on ChatCompletionToolMessage.content)
+    "input should be a valid string",
+    # Morph — untagged-enum deserialize failure
+    "chatcompletionrequesttoolmessagecontent",
 ]
 
 # Context overflow patterns
@@ -1159,6 +1163,23 @@ def _classify_by_status(
     # aborts a 400 Bad Request.
     if status_code == 408:
         return result_fn(FailoverReason.timeout, retryable=True)
+
+    # 422 Unprocessable Entity — schema-validation rejection.  Providers
+    # like DeepInfra and Morph return 422 for content-type mismatches
+    # (e.g. list-type tool content on a model that requires string).
+    # Check multimodal-tool-content patterns before the generic 4xx
+    # fallthrough so the existing recovery path fires.
+    if status_code == 422:
+        if any(p in error_msg for p in _MULTIMODAL_TOOL_CONTENT_PATTERNS):
+            return result_fn(
+                FailoverReason.multimodal_tool_content_unsupported,
+                retryable=True,
+            )
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
 
     # Other 4xx — non-retryable
     if 400 <= status_code < 500:


### PR DESCRIPTION
## Summary

HTTP 422 Unprocessable Entity was never classified in `error_classifier.py`, so providers returning 422 for schema-validation rejections (e.g. list-type tool content on strict models) fell through to the generic 4xx handler as non-retryable `format_error`. This left the existing `_try_strip_image_parts_from_tool_messages` recovery path unreachable, permanently killing sessions when screenshots were sent via `browser_vision` to models served by DeepInfra or Morph.

## Changes

### `agent/error_classifier.py`

1. **Added 422 handler** before the generic 4xx fallthrough (line ~1164). Routes 422 through `_MULTIMODAL_TOOL_CONTENT_PATTERNS` check first — if matched, returns `multimodal_tool_content_unsupported` (retryable) so the existing recovery fires. Otherwise falls through to `format_error` (non-retryable).

2. **Added two missing patterns** to `_MULTIMODAL_TOOL_CONTENT_PATTERNS`:
   - `"input should be a valid string"` — DeepInfra's pydantic-v2 rejection of list-type `ChatCompletionToolMessage.content`
   - `"chatcompletionrequesttoolmessagecontent"` — Morph's serde failure on untagged enum (matched case-insensitively)

## Fixes

Fixes #72905

## Test Plan

- [x] All 205 existing `test_error_classifier.py` tests pass
- [x] `ast.parse` syntax check passes
- [ ] Manual: trigger `browser_vision` on an OpenRouter model served by DeepInfra — session should recover instead of dying permanently