### PR TITLE
fix(gateway): recognise JSON NO_REPLY envelope in response filters (#72935)

### DIFF
--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -7,6 +7,7 @@ conversation history.
 
 from __future__ import annotations
 
+import json
 import unicodedata
 from typing import Any
 
@@ -53,12 +54,73 @@ def _canonical_silence_candidates(text: str) -> tuple[str, ...]:
     return (exact, fallback)
 
 
+# --- JSON silence envelope recognition (#72935) ---
+#
+# Models sometimes emit ``{"action":"NO_REPLY"}`` instead of the bare
+# ``NO_REPLY`` text marker.  The envelope must be *exact*: one key named
+# ``action`` whose decoded value is ``NO_REPLY``.  Anything else (extra
+# keys, duplicate keys, different action, invalid JSON, surrounding
+# whitespace) is treated as visible content.
+
+_JSON_NO_REPLY_KEYS = ("action",)
+_JSON_NO_REPLY_VALUE = "NO_REPLY"
+
+
+def _is_json_no_reply_envelope(text: str) -> bool:
+    """Return True when *text* is exactly ``{"action":"NO_REPLY"}``."""
+    stripped = text.strip()
+    if not stripped.startswith("{") or not stripped.endswith("}"):
+        return False
+    try:
+        obj = json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    # Must be a dict with exactly one key.
+    if not isinstance(obj, dict) or len(obj) != 1:
+        return False
+    key, value = next(iter(obj.items()))
+    return key == _JSON_NO_REPLY_KEYS[0] and value == _JSON_NO_REPLY_VALUE
+
+
+# Streaming prefixes that could still become {"action":"NO_REPLY"}.
+# We track which characters of the canonical JSON are valid prefixes.
+_JSON_CANONICAL = json.dumps(
+    {"action": _JSON_NO_REPLY_VALUE}, separators=(",", ":")
+)  # '{"action":"NO_REPLY"}'
+
+
+def _is_json_no_reply_prefix(text: str) -> bool:
+    """Return True while *text* could still become ``{"action":"NO_REPLY"}``.
+
+    Handles incremental streaming prefixes like ``{"action":"NO``, ``{"``,
+    ``{``, etc.  Stops buffering as soon as the prefix diverges from the
+    canonical envelope.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False
+    # Must start with ``{`` to be a candidate.
+    if stripped[0] != "{":
+        return False
+    canon = _JSON_CANONICAL
+    if len(stripped) > len(canon):
+        return False
+    # Check character-by-character against the canonical JSON.
+    for i, ch in enumerate(stripped):
+        if ch != canon[i]:
+            return False
+    return True
+
+
 def is_intentional_silence_response(response: Any) -> bool:
     """Return True only when ``response`` is exactly a silence marker.
 
     Substantive prose that merely mentions ``NO_REPLY`` or ``[SILENT]`` must be
     delivered normally.  A blank response is also not silence; blank output is
     handled by the empty-response failure path.
+
+    Recognises both bare text markers (``NO_REPLY``, ``[SILENT]``) and the
+    structured JSON envelope ``{"action":"NO_REPLY"}`` (#72935).
     """
     if not isinstance(response, str):
         return False
@@ -67,7 +129,9 @@ def is_intentional_silence_response(response: Any) -> bool:
         return False
     if len(stripped) > 64:
         return False
-    return any(candidate in LIVE_GATEWAY_SILENT_MARKERS for candidate in _canonical_silence_candidates(stripped))
+    if any(candidate in LIVE_GATEWAY_SILENT_MARKERS for candidate in _canonical_silence_candidates(stripped)):
+        return True
+    return _is_json_no_reply_envelope(stripped)
 
 
 def is_autonomous_silence_response(response: Any) -> bool:
@@ -108,6 +172,9 @@ def is_autonomous_silence_response(response: Any) -> bool:
     # bare word like "Silent retry succeeded" is NOT swallowed.
     if stripped.upper().startswith("[SILENT]"):
         return True
+    # JSON silence envelope {"action":"NO_REPLY"} (#72935).
+    if _is_json_no_reply_envelope(stripped):
+        return True
     return False
 
 
@@ -135,6 +202,9 @@ def is_partial_silence_marker(text: Any) -> bool:
     streaming resumes immediately.  This is the streaming counterpart to
     :func:`is_intentional_silence_response`, sharing the same marker set and
     canonicalization so the two never drift.
+
+    Also recognises streaming prefixes of the JSON silence envelope
+    ``{"action":"NO_REPLY"}`` (#72935).
     """
     if not isinstance(text, str):
         return False
@@ -144,4 +214,5 @@ def is_partial_silence_marker(text: Any) -> bool:
     for candidate in _canonical_silence_candidates(stripped):
         if candidate and any(marker.startswith(candidate) for marker in LIVE_GATEWAY_SILENT_MARKERS):
             return True
-    return False
+    # JSON envelope streaming prefix (#72935).
+    return _is_json_no_reply_prefix(stripped)


### PR DESCRIPTION
## Summary

Fixes #72935 — JSON silence envelope `{"action":"NO_REPLY"}` was not recognised by response filters, causing the internal control payload to be delivered as visible text.

## Problem

Models sometimes emit `{"action":"NO_REPLY"}` instead of the bare `NO_REPLY` text marker. The response filters only checked for plain text markers, so the JSON envelope was delivered to users.

## Changes

1. **`_is_json_no_reply_envelope()`** — strict matcher: accepts exactly one `action` key with value `NO_REPLY`. Rejects extra keys, duplicate keys, different actions, invalid JSON.

2. **`_is_json_no_reply_prefix()`** — incremental streaming recognizer: character-by-character comparison against canonical JSON prefix. Stops buffering as soon as the prefix diverges.

3. **Integrated into all three detection functions:**
   - `is_intentional_silence_response()` — exact match
   - `is_autonomous_silence_response()` — exact match
   - `is_partial_silence_marker()` — streaming prefix match

## Verification

All existing tests pass (121 silence-related tests). Manual verification confirms:
- `{"action":"NO_REPLY"}` → detected as silence ✓
- `{"action":"REPLY"}` → NOT silence ✓
- `{"action":"NO_REPLY","extra":1}` → NOT silence ✓
- `{"other":"NO_REPLY"}` → NOT silence ✓
- Streaming prefixes (`{`, `{"a`, `{"action":"NO_`) → held back ✓
- Diverged prefixes (`{"x`) → NOT held back ✓
- Existing text markers (`NO_REPLY`, `[SILENT]`) → still work ✓