### PR TITLE
fix(compression): preserve history across bounded passes

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3128,6 +3128,119 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         tail = content[-tail_chars:].lstrip() if tail_chars else ""
         return content[:head_chars].rstrip() + marker + tail
 
+    def _split_turns_for_summary(
+        self,
+        turns: List[Dict[str, Any]],
+    ) -> List[List[Dict[str, Any]]]:
+        """Group whole turns into bounded summarizer passes.
+
+        ``_serialize_for_summary`` already applies the intentional per-message
+        content and tool-argument limits. This splitter prevents the later
+        aggregate bound from dropping the middle of that serialized source.
+        Normal turns stay intact. A pathological single turn that still
+        exceeds the aggregate limit (for example, an assistant message with
+        thousands of tool calls) is represented as ordered assistant-role
+        source fragments so it cannot be mistaken for user-authored input.
+        """
+        limit = self._SUMMARY_INPUT_MAX_CHARS
+        chunks: List[List[Dict[str, Any]]] = []
+        current: List[Dict[str, Any]] = []
+        current_chars = 0
+
+        for turn in turns:
+            rendered = self._serialize_for_summary([turn])
+            parts: List[Dict[str, Any]] = [turn]
+            if len(rendered) > limit:
+                # Keep fragment bodies below the normal per-message body cap so
+                # serializing them again cannot truncate the preserved source.
+                digits = len(str(len(rendered)))
+                header_probe = (
+                    "[Oversized historical turn, part "
+                    f"{'9' * digits}/{'9' * digits}; source material only]\n"
+                )
+                overhead = len(
+                    self._serialize_for_summary(
+                        [{"role": "assistant", "content": header_probe}]
+                    )
+                )
+                payload_chars = max(1, min(self._CONTENT_HEAD, limit - overhead))
+                total_parts = (
+                    len(rendered) + payload_chars - 1
+                ) // payload_chars
+                parts = [
+                    {
+                        "role": "assistant",
+                        "content": (
+                            "[Oversized historical turn, part "
+                            f"{part_index}/{total_parts}; source material only]\n"
+                            + rendered[offset:offset + payload_chars]
+                        ),
+                    }
+                    for part_index, offset in enumerate(
+                        range(0, len(rendered), payload_chars),
+                        start=1,
+                    )
+                ]
+
+            for part in parts:
+                part_chars = len(self._serialize_for_summary([part]))
+                separator_chars = 2 if current else 0
+                if (
+                    current
+                    and current_chars + separator_chars + part_chars > limit
+                ):
+                    chunks.append(current)
+                    current = []
+                    current_chars = 0
+                    separator_chars = 0
+                current.append(part)
+                current_chars += separator_chars + part_chars
+
+        if current:
+            chunks.append(current)
+        return chunks
+
+    def _generate_summary_in_passes(
+        self,
+        turns_to_summarize: List[Dict[str, Any]],
+        focus_topic: Optional[str] = None,
+        memory_context: str = "",
+    ) -> Optional[str]:
+        """Summarize every bounded pass, committing only the final result."""
+        chunks = self._split_turns_for_summary(turns_to_summarize)
+        telemetry = getattr(self, "_active_compression_telemetry", None)
+        if isinstance(telemetry, dict):
+            telemetry["chunking"] = len(chunks) > 1
+            telemetry["chunk_count"] = len(chunks)
+
+        # Match _generate_summary's strict iterative-input boundary before
+        # taking the rollback snapshot. A failed later pass must not restore a
+        # legacy pre-redaction summary.
+        if self._previous_summary:
+            self._previous_summary = _redact_compaction_text(
+                self._previous_summary
+            )
+        previous_summary = self._previous_summary
+        summary: Optional[str] = None
+        committed = False
+        try:
+            for chunk in chunks:
+                summary = self._generate_summary(
+                    chunk,
+                    focus_topic=focus_topic,
+                    memory_context=memory_context,
+                )
+                if not summary:
+                    return None
+            committed = True
+            return summary
+        finally:
+            if not committed:
+                # Successful earlier passes are tentative iterative state. A
+                # later failure or interruption must not commit a partial view
+                # of the source.
+                self._previous_summary = previous_summary
+
     def _fallback_to_main_for_compression(self, e: Exception, reason: str) -> None:
         """Switch from a separate ``summary_model`` back to the main model.
 
@@ -5190,7 +5303,7 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         # Phase 3: Generate structured summary
         summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages)
-        summary = self._generate_summary(
+        summary = self._generate_summary_in_passes(
             turns_to_summarize,
             focus_topic=summary_focus_topic,
             memory_context=memory_context,

--- a/tests/agent/test_compression_multipass.py
+++ b/tests/agent/test_compression_multipass.py
@@ -1,0 +1,235 @@
+"""Whole-turn, transactional context-compression pass coverage."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import agent.context_compressor as cc
+import pytest
+from agent.context_compressor import ContextCompressor
+
+
+def _make(limit: int = 1_000) -> ContextCompressor:
+    with patch.object(cc, "get_model_context_length", return_value=128_000):
+        compressor = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            quiet_mode=True,
+        )
+    compressor._SUMMARY_INPUT_MAX_CHARS = limit
+    return compressor
+
+
+def _turns(count: int = 6) -> list[dict]:
+    return [
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"turn-{index}-" + ("x" * 360),
+        }
+        for index in range(count)
+    ]
+
+
+def test_splitter_keeps_regular_turns_intact_and_in_order():
+    compressor = _make()
+    turns = _turns()
+
+    chunks = compressor._split_turns_for_summary(turns)
+
+    assert len(chunks) > 1
+    assert [turn for chunk in chunks for turn in chunk] == turns
+    assert all(
+        len(compressor._serialize_for_summary(chunk))
+        <= compressor._SUMMARY_INPUT_MAX_CHARS
+        for chunk in chunks
+    )
+
+
+def test_splitter_preserves_oversized_serialized_turn_without_user_attribution():
+    compressor = _make()
+    turn = {
+        "role": "assistant",
+        "content": "completed calls",
+        "tool_calls": [
+            {
+                "id": f"call-{index}",
+                "function": {
+                    "name": "terminal",
+                    "arguments": "x" * 900,
+                },
+            }
+            for index in range(12)
+        ],
+    }
+    rendered = compressor._serialize_for_summary([turn])
+    assert len(rendered) > compressor._SUMMARY_INPUT_MAX_CHARS
+
+    chunks = compressor._split_turns_for_summary([turn])
+    fragments = [fragment for chunk in chunks for fragment in chunk]
+
+    assert len(fragments) > 1
+    assert all(fragment["role"] == "assistant" for fragment in fragments)
+    recovered = "".join(
+        fragment["content"].split("source material only]\n", 1)[1]
+        for fragment in fragments
+    )
+    assert recovered == rendered
+    assert all(
+        len(compressor._serialize_for_summary(chunk))
+        <= compressor._SUMMARY_INPUT_MAX_CHARS
+        for chunk in chunks
+    )
+
+
+def test_multipass_commits_only_the_final_summary():
+    compressor = _make()
+    compressor._previous_summary = "seed"
+    compressor._active_compression_telemetry = {}
+    calls: list[list[dict]] = []
+
+    def generate(chunk, **_kwargs):
+        calls.append(chunk)
+        compressor._previous_summary = f"pass-{len(calls)}"
+        return f"summary-{len(calls)}"
+
+    with patch.object(
+        compressor,
+        "_generate_summary",
+        side_effect=generate,
+    ):
+        summary = compressor._generate_summary_in_passes(_turns())
+
+    assert len(calls) > 1
+    assert [turn for chunk in calls for turn in chunk] == _turns()
+    assert summary == f"summary-{len(calls)}"
+    assert compressor._previous_summary == f"pass-{len(calls)}"
+    assert compressor._active_compression_telemetry["chunking"] is True
+    assert compressor._active_compression_telemetry["chunk_count"] == len(calls)
+
+
+def test_multipass_rolls_back_partial_summary_but_keeps_failure_state():
+    compressor = _make()
+    secret = "sk-proj-" + ("a" * 40)
+    compressor._previous_summary = f"seed {secret}"
+    calls = 0
+
+    def generate(_chunk, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            compressor._previous_summary = "partial"
+            return "summary-1"
+        compressor._last_summary_error = "second pass failed"
+        return None
+
+    with patch.object(
+        compressor,
+        "_generate_summary",
+        side_effect=generate,
+    ):
+        assert compressor._generate_summary_in_passes(_turns()) is None
+    assert calls == 2
+    assert compressor._previous_summary.startswith("seed ")
+    assert secret not in compressor._previous_summary
+    assert compressor._last_summary_error == "second pass failed"
+
+
+def test_multipass_rolls_back_partial_summary_on_interruption():
+    compressor = _make()
+    compressor._previous_summary = "seed"
+    calls = 0
+
+    def generate(_chunk, **_kwargs):
+        nonlocal calls
+        calls += 1
+        compressor._previous_summary = "partial"
+        if calls == 2:
+            raise KeyboardInterrupt
+        return "summary-1"
+
+    with (
+        patch.object(
+            compressor,
+            "_generate_summary",
+            side_effect=generate,
+        ),
+        patch.object(cc, "_redact_compaction_text", side_effect=lambda text: text),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        compressor._generate_summary_in_passes(_turns())
+
+    assert calls == 2
+    assert compressor._previous_summary == "seed"
+
+
+def test_single_pass_keeps_existing_summary_path():
+    compressor = _make()
+    calls = []
+
+    def generate(chunk, **_kwargs):
+        calls.append(chunk)
+        return "summary"
+
+    turns = _turns(2)
+
+    with patch.object(
+        compressor,
+        "_generate_summary",
+        side_effect=generate,
+    ):
+        assert compressor._generate_summary_in_passes(turns) == "summary"
+    assert calls == [turns]
+
+
+def test_real_summary_path_sends_every_turn_without_aggregate_omission():
+    compressor = _make()
+    compressor._summary_has_user_turn = True
+    prompts: list[str] = []
+
+    def call_llm(**kwargs):
+        prompts.append(kwargs["messages"][0]["content"])
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=(
+                            "## Active Task\nContinue.\n\n"
+                            "## Goal\nPreserve the historical source."
+                        )
+                    )
+                )
+            ]
+        )
+
+    with (
+        patch.object(
+            ContextCompressor,
+            "_SUMMARY_INPUT_MAX_CHARS",
+            compressor._SUMMARY_INPUT_MAX_CHARS,
+        ),
+        patch.object(cc, "call_llm", side_effect=call_llm),
+    ):
+        bounded_once = compressor._bound_summary_input(
+            compressor._serialize_for_summary(_turns())
+        )
+        assert "summary input truncated" in bounded_once
+        assert compressor._generate_summary_in_passes(_turns()) is not None
+
+    assert len(prompts) > 1
+    current_source_sections: list[str] = []
+    for prompt in prompts:
+        if "NEW TURNS TO INCORPORATE:" in prompt:
+            source = prompt.split("NEW TURNS TO INCORPORATE:", 1)[1]
+            source = source.split("\n\nUpdate the summary", 1)[0]
+        else:
+            source = prompt.split("TURNS TO SUMMARIZE:", 1)[1]
+            source = source.split("\n\nUse this exact structure:", 1)[0]
+        current_source_sections.append(source)
+
+    current_source = "\n".join(current_source_sections)
+    assert "summary input truncated" not in current_source
+    for index in range(6):
+        assert current_source.count(f"turn-{index}-") == 1
+    assert all(
+        "PREVIOUS SUMMARY:" in prompt
+        for prompt in prompts[1:]
+    )


### PR DESCRIPTION
## Problem

Context compression already bounds individual message fields and caps the final serialized summary input at 160K characters. When the serialized history exceeds that aggregate cap, however, the current head/tail fallback omits the middle before the summarizer sees it.

That keeps one request bounded, but it can silently remove otherwise-preserved turns from the source used to build the continuation summary.

## Change

- Treat the existing 160K aggregate limit as a per-pass input bound.
- Greedily group ordinary turns into ordered, whole-turn passes.
- Split only a pathological single serialized turn that exceeds the bound, marking every fragment as assistant-role source material so it cannot be attributed to the user.
- Feed each pass through the existing iterative summary path.
- Roll back tentative `previous_summary` state when a later pass fails or is interrupted.
- Record pass count in the existing compression telemetry.

Single-pass behavior is unchanged. This adds no configuration, dependency, model-routing, or recovery-policy surface.

## Compatibility and security

- Additional auxiliary-model calls occur only when serialized summary source exceeds the existing 160K bound.
- Existing per-message limits, retries, provider fallback, redaction, provenance checks, and terminal auth/network failure handling remain in the established `_generate_summary` path.
- Oversized source fragments use the assistant role and are explicitly labeled as source material.
- A failed later pass cannot leave a partial summary committed as iterative state.

## Verification

- 7 focused multipass tests covering ordering, bounds, oversized-turn preservation, telemetry, single-pass compatibility, later-pass failure rollback, interruption rollback, and the real prompt path.
- 2,320 existing affected-area tests across 111 files passed on the implementation base.
- Focused tests rerun after rebasing onto current `main`: 7 passed.
- Ruff, byte compilation, `git diff --check`, and the Windows-footgun scan pass.
- Targeted type checking reports no new diagnostics in the added tests; existing diagnostics in `context_compressor.py` are unchanged.
