### PR TITLE
fix(cron): guard profile secret scope with multiplex check (#65773)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3888,13 +3888,19 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # gateway/run.py (_profile_runtime_scope).
         from agent.secret_scope import (
             build_profile_secret_scope,
+            is_multiplex_active,
             reset_secret_scope,
             set_secret_scope,
         )
 
-        _scope_token = set_secret_scope(
-            build_profile_secret_scope(_get_hermes_home())
-        )
+        # Only install a profile secret scope when multiplex is active (#65773).
+        # On single-profile deployments with env-injected credentials, the
+        # scope would shadow os.environ and cause HTTP 401 on provider calls.
+        _scope_token = None
+        if is_multiplex_active():
+            _scope_token = set_secret_scope(
+                build_profile_secret_scope(_get_hermes_home())
+            )
         # Defer the cron agent's async-resource teardown until AFTER delivery.
         # run_job normally closes the agent (and reaps stale async clients) in
         # its finally block; doing that before _deliver_result runs means the
@@ -3917,7 +3923,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 _teardown_cron_agent(_deferred_agent, job["id"])
             raise
         finally:
-            reset_secret_scope(_scope_token)
+            if _scope_token is not None:
+                reset_secret_scope(_scope_token)
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step


### PR DESCRIPTION
## Summary

Fixes #65773 — Cron scheduler unconditionally installs a profile secret scope, breaking env-injected credentials on single-profile deployments.

## Problem

Every interactive path in `gateway/run.py` guards the profile secret scope with `is_multiplex_active()`. The cron path was missing this guard. On single-profile deployments where credentials are injected via process environment (container env vars, systemd `Environment=`), the scope shadows `os.environ` and causes HTTP 401 on provider calls.

## Fix

Only install the profile secret scope when `multiplex_profiles` is active. When multiplex is off, the cron job inherits `os.environ` like interactive turns do.

## Changes

- `cron/scheduler.py`: Add `is_multiplex_active` guard around `set_secret_scope(build_profile_secret_scope(...))`.
- Guard `reset_secret_scope` with `None` check when scope was not installed.

## Verification

767 cron tests passed. No regressions.