### PR TITLE
fix(agent): persist before emitting verify-on-stop / pre_verify nudge answers

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6621,17 +6621,36 @@ def run_conversation(
                         getattr(agent, "_verification_stop_nudges", 0) + 1
                     )
                     final_msg["finish_reason"] = "verification_required"
-                    # The assistant response is real content — persist it and
-                    # emit to the UI as an interim message so the user sees the
-                    # attempted final answer before the verification loop runs.
-                    # Only the nudge is flagged synthetic so it gets stripped
-                    # from the durable transcript (#65919 §7).
-                    agent._emit_interim_assistant_message(final_msg)
+                    # A UI must never observe an assistant row that is still
+                    # only an ephemeral in-memory projection — persist first,
+                    # then emit the interim message so the user sees the
+                    # attempted final answer before the verification loop
+                    # runs. Only the nudge is flagged synthetic so it gets
+                    # stripped from the durable transcript (#65919 §7).
                     messages.append(final_msg)
+                    _verify_turn_persisted = None
                     try:
-                        agent._flush_messages_to_session_db(messages, conversation_history)
-                    except Exception:
-                        logger.debug("verify-on-stop interim flush failed", exc_info=True)
+                        _verify_turn_persisted = agent._flush_messages_to_session_db(
+                            messages, conversation_history
+                        )
+                    except Exception as exc:
+                        _verify_turn_persisted = False
+                        logger.warning(
+                            "verify-on-stop interim flush failed (session=%s): %s",
+                            agent.session_id or "none",
+                            exc,
+                        )
+
+                    if _verify_turn_persisted is False:
+                        # The canonical append failed. Do not project the row
+                        # or continue the verification loop from state that
+                        # exists only in this process.
+                        _turn_exit_reason = "session_persistence_failed"
+                        final_response = ""
+                        failed = True
+                        break
+
+                    agent._emit_interim_assistant_message(final_msg)
                     messages.append({
                         "role": "user",
                         "content": _verify_nudge,
@@ -6692,17 +6711,36 @@ def run_conversation(
                 if _verify_nudge2:
                     agent._pre_verify_nudges = _attempt + 1
                     final_msg["finish_reason"] = "verify_hook_continue"
-                    # The assistant response is real content — persist it and
-                    # emit to the UI as an interim message so the user sees the
+                    # A UI must never observe an assistant row that is still
+                    # only an ephemeral in-memory projection — persist first,
+                    # then emit the interim message so the user sees the
                     # attempted final answer before the pre_verify loop runs.
                     # Only the nudge is flagged synthetic so it gets stripped
                     # from the durable transcript (#65919 §7).
-                    agent._emit_interim_assistant_message(final_msg)
                     messages.append(final_msg)
+                    _pre_verify_turn_persisted = None
                     try:
-                        agent._flush_messages_to_session_db(messages, conversation_history)
-                    except Exception:
-                        logger.debug("pre_verify interim flush failed", exc_info=True)
+                        _pre_verify_turn_persisted = agent._flush_messages_to_session_db(
+                            messages, conversation_history
+                        )
+                    except Exception as exc:
+                        _pre_verify_turn_persisted = False
+                        logger.warning(
+                            "pre_verify interim flush failed (session=%s): %s",
+                            agent.session_id or "none",
+                            exc,
+                        )
+
+                    if _pre_verify_turn_persisted is False:
+                        # The canonical append failed. Do not project the row
+                        # or continue the pre_verify loop from state that
+                        # exists only in this process.
+                        _turn_exit_reason = "session_persistence_failed"
+                        final_response = ""
+                        failed = True
+                        break
+
+                    agent._emit_interim_assistant_message(final_msg)
                     messages.append({
                         "role": "user",
                         "content": _verify_nudge2,

--- a/tests/run_agent/test_verify_nudge_persist_before_emit.py
+++ b/tests/run_agent/test_verify_nudge_persist_before_emit.py
@@ -1,0 +1,130 @@
+"""Behavior contract: the verify-on-stop and pre_verify nudge paths in
+``run_conversation`` must persist the attempted final answer to the session
+DB BEFORE projecting it to the UI — and must not continue the
+verification/pre_verify loop on an answer that only exists in this process.
+
+``agent/conversation_loop.py`` already pins this invariant for the
+tool-call persistence path (``tests/run_agent/test_tool_call_incremental_persistence.py::
+test_failed_assistant_persist_blocks_ui_projection_and_tool_side_effects``);
+these tests pin the identical contract for its two nudge-loop siblings.
+"""
+
+from pathlib import Path
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent():
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-test-home-"))
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _mock_response(content="Hello", finish_reason="stop"):
+    from types import SimpleNamespace
+
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def test_failed_verify_on_stop_persist_blocks_ui_projection_and_loop_continuation():
+    """A verify-on-stop nudge must not surface or loop on an unpersisted answer."""
+    agent = _make_agent()
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="Here is the final answer.", finish_reason="stop"
+    )
+    agent._flush_messages_to_session_db = MagicMock(return_value=False)
+    agent.interim_assistant_callback = MagicMock()
+
+    with (
+        patch("agent.verification_stop.verify_on_stop_enabled", return_value=True),
+        patch(
+            "agent.verification_stop.build_verify_on_stop_nudge",
+            return_value="Please verify your changes before finishing.",
+        ),
+    ):
+        result = agent.run_conversation("do something")
+
+    agent.interim_assistant_callback.assert_not_called()
+    assert agent.client.chat.completions.create.call_count == 1, (
+        "the verification-stop loop must not continue on unpersisted state"
+    )
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == "session_persistence_failed"
+
+
+def test_failed_pre_verify_persist_blocks_ui_projection_and_loop_continuation():
+    """A pre_verify-hook nudge must not surface or loop on an unpersisted answer."""
+    agent = _make_agent()
+
+    def _respond(*_args, **_kwargs):
+        # turn_context resets `_turn_file_mutation_paths` to an empty set
+        # during per-turn setup, BEFORE the API call — populate it here
+        # (simulating an earlier tool call in the same turn having edited a
+        # file) so it is non-empty by the time the pre_verify gate checks it.
+        agent._turn_file_mutation_paths = {"src/example.py"}
+        return _mock_response(content="I edited the file.", finish_reason="stop")
+
+    agent.client.chat.completions.create.side_effect = _respond
+    agent._flush_messages_to_session_db = MagicMock(return_value=False)
+    agent.interim_assistant_callback = MagicMock()
+
+    with (
+        patch("agent.verification_stop.verify_on_stop_enabled", return_value=False),
+        patch("agent.verify_hooks.max_verify_nudges", return_value=3),
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch(
+            "hermes_cli.plugins.get_pre_verify_continue_message",
+            return_value="Please run the tests before finishing.",
+        ),
+    ):
+        result = agent.run_conversation("edit the file")
+
+    agent.interim_assistant_callback.assert_not_called()
+    assert agent.client.chat.completions.create.call_count == 1, (
+        "the pre_verify loop must not continue on unpersisted state"
+    )
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == "session_persistence_failed"


### PR DESCRIPTION
## Summary

`run_conversation`'s verify-on-stop and pre_verify-hook nudge paths (`agent/conversation_loop.py`) emitted the attempted final answer to the UI *before* persisting it to the session DB, and silently discarded `_flush_messages_to_session_db`'s result (a `False` return, or a raised exception swallowed by a bare `except: logger.debug(...)`).

This is the exact inversion of the invariant this same file already enforces for tool-call turns: persist first, check the return value, and only then project to the UI / continue the loop (see the `_tool_turn_persisted` handling a few hundred lines above, and its own regression test `test_failed_assistant_persist_blocks_ui_projection_and_tool_side_effects`).

## Impact

On a read-only or otherwise unwritable `state.db`:
- the user's attempted final answer was still delivered to the UI, even though it was never durably stored — lost on restart/resume;
- the verification-stop / pre_verify loop kept running on state that only existed in this process. In one reproduction this burned through the *entire* 500-call iteration budget instead of stopping.

## Fix

Both nudge sites now mirror the established `_tool_turn_persisted` contract:
1. Append the final message and attempt the flush.
2. If the flush explicitly returns `False` (or raises), do **not** emit to the UI and do **not** continue the verification/pre_verify loop — exit through the existing `session_persistence_failed` turn-exit reason, which already has a user-facing, actionable message ("session storage could not be written ... send your message again").
3. Only on a successful flush does the interim message get emitted and the loop continue as before.

No behavior changes on the success path (the common case) — this only changes what happens when persistence genuinely fails.

## Test plan

- New `tests/run_agent/test_verify_nudge_persist_before_emit.py` — two tests (verify-on-stop, pre_verify) that force `_flush_messages_to_session_db` to return `False` and assert: the UI callback is never invoked, the API is called exactly once (no loop continuation), and the turn exits with `failed=True`, `turn_exit_reason="session_persistence_failed"`.
- Mutation-verify: stashed the production fix and reran the new tests against pre-fix code — both fail for the expected reason (`interim_assistant_callback` was called despite the failed flush; the verify-on-stop case burned the full 500-call iteration budget before stopping).
- `tests/run_agent/` full suite (2384 tests): all pass, no regressions.
- `tests/agent/` full suite: ran both with and without the fix — identical failure set (187 failing, same test names, all pre-existing/unrelated to this change, e.g. `test_unsupported_temperature_retry.py`, `test_codex_app_server_session.py`) in both runs, confirming those failures are pre-existing test-order pollution independent of this change.
- `ruff check` clean on both changed files.

- [x] New regression tests pass against the fix
- [x] New regression tests fail against pre-fix code (mutation-verify)
- [x] `tests/run_agent/` full suite passes (2384 passed)
- [x] `tests/agent/` full suite shows identical results with/without the fix
- [x] `ruff check` clean