### PR TITLE
fix(gateway): normalize MSYS drive paths in MEDIA tag parsing on Windows

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1638,7 +1638,13 @@ def _normalize_media_tag_path(raw: str) -> str:
     path = str(raw or "").strip()
     if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
         path = path[1:-1].strip()
-    return path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+    path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+    # On Windows running under Git Bash / MSYS, the shell translates
+    # native drive paths like ``C:/...`` into POSIX-style ``/C:/...``.
+    # Strip the leading slash so native Windows ``Path()`` can parse it.
+    if os.name == "nt" and re.match(r"^/[A-Za-z]:[/\\]", path):
+        path = path[1:]
+    return path
 
 
 def _path_lacks_deliverable_extension(path: str) -> bool:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -496,6 +496,37 @@ class TestExtractMedia:
         )
         assert media == []
 
+    @pytest.mark.parametrize(
+        "tag,expected",
+        [
+            # MSYS / Git Bash forward-slash form
+            ("MEDIA:/C:/Users/wujunze/Desktop/report.pdf", "C:/Users/wujunze/Desktop/report.pdf"),
+            # MSYS / Git Bash backslash form (QQ Bot adapter output)
+            (r"MEDIA:/C:\Users\wujunze\Desktop\report.pdf", r"C:\Users\wujunze\Desktop\report.pdf"),
+            # Native Windows paths must remain untouched
+            ("MEDIA:C:/Users/wujunze/Desktop/report.pdf", "C:/Users/wujunze/Desktop/report.pdf"),
+            (r"MEDIA:C:\Users\wujunze\Desktop\report.pdf", r"C:\Users\wujunze\Desktop\report.pdf"),
+            # Non-Windows POSIX paths must remain untouched
+            ("MEDIA:/tmp/report.pdf", "/tmp/report.pdf"),
+        ],
+    )
+    def test_msys_drive_paths_normalized(self, tag, expected):
+        """Windows MSYS/Git Bash paths in MEDIA tags must be normalized to
+        native drive form so validate_media_delivery_path() can resolve them.
+
+        Under Git Bash / MSYS, native ``C:/...`` paths surface as
+        ``/C:/...`` (forward slashes, seen on Feishu) or ``/C:\\...``
+        (backslashes, seen on QQ Bot). Path() on native Windows cannot
+        parse the leading-slash form — is_absolute() returns False and
+        resolve() raises WinError 123 — so the MEDIA tag was previously
+        dropped and the file never delivered.
+        """
+        media, cleaned = BasePlatformAdapter.extract_media(tag)
+        assert len(media) == 1
+        assert media[0][0] == expected
+        # The tag itself is stripped from the delivered text
+        assert "MEDIA:" not in cleaned
+
     # --- Code block / inline code / blockquote false-positive guards (#35695) ---
 
     def test_media_in_fenced_code_block_ignored(self):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -496,6 +496,7 @@ class TestExtractMedia:
         )
         assert media == []
 
+    @pytest.mark.windows_only
     @pytest.mark.parametrize(
         "tag,expected",
         [


### PR DESCRIPTION
## Summary

On Windows under Git Bash / MSYS, the shell translates native Windows drive paths (e.g. `C:/Users/...`) into POSIX-style paths (e.g. `/C:/Users/...` or `/C:\Users\...`). These paths are emitted in `MEDIA:` tags by agents running under the gateway.

Native Windows Python `Path()` cannot parse `/C:/...` format:
- `Path('/C:/...').is_absolute()` returns **False**
- `Path('/C:/...').resolve(strict=True)` raises **WinError 123**

As a result, `validate_media_delivery_path()` rejects the path, causing all media attachments (images, videos, files) on Feishu, QQ Bot, and other platforms to fail silently — the `MEDIA:` tag is sent as plain text instead of a native attachment.

## Fix

Strip the leading slash from `/X:/...` and `/X:\...` paths in `_normalize_media_tag_path()` so the shared `validate_media_delivery_path()` boundary can correctly resolve them.

```diff
+    # On Windows running under Git Bash / MSYS, the shell translates
+    # native drive paths like ``C:/...`` into POSIX-style ``/C:/...``.
+    # Strip the leading slash so native Windows ``Path()`` can parse it.
+    if os.name == "nt" and re.match(r"^/[A-Za-z]:[/\\]", path):
+        path = path[1:]
```

## Verification

| Input | Normalized | validate_result |
|---|---|---|
| `/C:/Users/.../Desktop/小猪跳水.mp4` | `C:/Users/.../Desktop/小猪跳水.mp4` | ✅ OK |
| `/C:\Users\...\pig_diving.mp4` | `C:\Users\...\pig_diving.mp4` | ✅ OK |
| `C:/Users/.../pig_diving.mp4` | unchanged | ✅ OK |

## Related

Closes #47767, #31457
Related to #41596 (closed), #31472, #32735