### PR TITLE
fix(desktop): scope pluginSocket's connection to the active profile

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -19,6 +19,7 @@ import {
   listAllProfileSessions,
   listSessions,
   listSidebarSessions,
+  pluginSocket,
   resetSidebarBatchCapability,
   setApiRequestProfile,
   speakText,
@@ -463,5 +464,43 @@ describe('Hermes REST helpers', () => {
         path: '/api/model/options?refresh=1&include_unconfigured=1'
       })
     )
+  })
+})
+
+describe('pluginSocket', () => {
+  let getConnection: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    getConnection = vi.fn().mockResolvedValue(null)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api: vi.fn(), getConnection }
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Reflect.deleteProperty(window, 'hermesDesktop')
+    setApiRequestProfile(null)
+  })
+
+  it('scopes the connection to the active profile, like pluginRest', async () => {
+    setApiRequestProfile('work')
+
+    const dispose = pluginSocket('kanban', '/events', () => {})
+
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalled())
+    expect(getConnection).toHaveBeenCalledWith('work')
+
+    dispose()
+  })
+
+  it('passes null when no profile is scoped (single-profile / primary)', async () => {
+    const dispose = pluginSocket('kanban', '/events', () => {})
+
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalled())
+    expect(getConnection).toHaveBeenCalledWith(null)
+
+    dispose()
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -325,7 +325,7 @@ export function pluginSocket(pluginId: string, path: string, onMessage: (data: u
   let attempt = 0
 
   const connect = async () => {
-    const connection = await window.hermesDesktop.getConnection().catch(() => null)
+    const connection = await window.hermesDesktop.getConnection(_apiProfile).catch(() => null)
 
     // No bridge / OAuth cookie auth (WS tickets are single-use, core-managed):
     // stay on the polling fallback rather than half-working.


### PR DESCRIPTION
## Summary

`pluginSocket` (`apps/desktop/src/hermes.ts`) is documented in its own docstring as *"the live twin of `pluginRest`, scoped the same way"*. It isn't:

- `pluginRest` sends `...profileScoped()` → `window.hermesDesktop.api({..., profile})` → `hermes:api` IPC → `ensureBackend(profile)` → the profile-routing table.
- `pluginSocket` calls `window.hermesDesktop.getConnection()` with **no argument** → `hermes:connection` IPC → `ensureBackend(undefined)`.

`ensureBackend`'s own comment says *"an empty / unknown profile resolves to the primary"* — confirmed in `electron/main.ts`:

```js
async function ensureBackend(profile) {
  const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
  ...
}
```

So an unscoped `getConnection()` call always resolves to the **primary** profile's backend, regardless of which profile is actually active.

`apps/desktop/src/lib/voice-playback.ts`'s `resolveSpeakStreamUrl` has the identical gap (`desktop.getConnection()`, no profile).

## Impact

For a plugin used from a non-primary profile (e.g. `kanban`), REST calls (`pluginRest`) go to the correct pooled backend while the plugin's live WebSocket (`pluginSocket`) silently connects to the *primary* profile's backend instead. A multi-profile user opening the kanban board on a secondary profile sees that profile's board data (from `pluginRest`) but live events sourced from the wrong (primary) profile's backend — updates never arrive, and the primary profile's unrelated events may leak in.

TTS streaming (`startSpeechStream` → `resolveSpeakStreamUrl`) has the same misrouting: voice playback always uses the primary profile's TTS configuration/backend even when speaking from a secondary profile's session.

## Fix

Both call sites now pass the active profile through to `getConnection`, mirroring the sibling call sites that already do this correctly (`use-gateway-request.ts`, `use-gateway-boot.ts`, `store/gateway.ts`, `store/profile.ts`):

- `hermes.ts::pluginSocket` — passes the module-local `_apiProfile` (the same state `profileScoped()` reads for `pluginRest`, kept module-private specifically to avoid a store import cycle per its own comment).
- `voice-playback.ts::resolveSpeakStreamUrl` — imports `$activeGatewayProfile` from `@/store/profile` and passes `.get()`, matching the pattern already used in `use-gateway-request.ts`.

No behavior change for single-profile users (both resolve to `'default'`, matching `primaryProfileKey()`'s own fallback).

## Test plan

- New tests in `hermes.test.ts` (`pluginSocket` describe block): asserts `getConnection` is called with the scoped profile when one is set via `setApiRequestProfile`, and with `null` when none is scoped.
- New `voice-playback.test.ts`: asserts `getConnection` is called with `$activeGatewayProfile`'s current value.
- Mutation-verify: stashed both production fixes and reran the new tests against pre-fix code — all 4 new assertions fail as expected (`getConnection` called with no arguments instead of the profile).
- Broader regression sweep: `npx vitest run src/store src/lib src/hermes.test.ts` — 1020 tests pass, no regressions.
- `npx tsc --noEmit` clean (no circular-import issue from the new `@/store/profile` import in `voice-playback.ts`).
- `npx eslint` and `npx prettier --check` clean on all changed files.

- [x] New regression tests pass against the fix
- [x] New regression tests fail against pre-fix code (mutation-verify)
- [x] Broader `src/store` + `src/lib` suite passes (1020 passed)
- [x] `tsc --noEmit`, `eslint`, `prettier --check` all clean