### PR TITLE
fix(desktop): fire the active-work quit guard on Windows/Linux window close

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9950,6 +9950,23 @@ function createWindow() {
   mainWindow.on('unmaximize', schedulePersistWindowState)
   mainWindow.on('close', () => schedulePersistWindowState.flush())
 
+  // heldQuitForActiveWork's own `before-quit` hook only protects the macOS
+  // quit gesture (Cmd-Q fires `before-quit` while every window is still
+  // alive). On Windows/Linux the primary quit gesture is the title-bar
+  // close button: closing the last window destroys it (and its webContents,
+  // which clears its `activeWorkByWebContents` entry) BEFORE `window-all-
+  // closed` reactively calls `app.quit()` below — by the time `before-quit`
+  // runs, there is no parent window left to anchor a dialog on and no
+  // active-work report left to read, so the guard silently no-ops and a
+  // turn in flight is killed without asking. Run the same check here, while
+  // this (about to become the last) window and its active-work report are
+  // still alive, so "Quit Anyway" can re-enter `before-quit` normally.
+  mainWindow.on('close', event => {
+    if (process.platform !== 'darwin' && BrowserWindow.getAllWindows().length === 1) {
+      heldQuitForActiveWork(event)
+    }
+  })
+
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   mainWindow.on('closed', () => {
     closePetOverlay()


### PR DESCRIPTION
## Summary

`heldQuitForActiveWork()` — the guard that asks "Keep Running / Quit Anyway" before a quit kills a turn in flight — is only wired to the app-level `before-quit` event. That correctly covers the macOS quit gesture (Cmd-Q fires `before-quit` while every window is still alive), but not the primary Windows/Linux quit gesture: clicking the title-bar close button (X) on the last open window.

## Root cause

On Windows/Linux, `window-all-closed` reactively calls `app.quit()`:

```js
app.on('window-all-closed', () => {
  if (process.platform !== 'darwin' || isQuittingForHandoff) {
    app.quit()
  }
})
```

But `window-all-closed` only fires *after* every window is already destroyed — that's its definition. By the time the resulting `app.quit()` triggers `before-quit`, `heldQuitForActiveWork()` finds:

- `BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]` → `undefined` (no windows left), so `!parent` is true and it bails out;
- `activeWorkByWebContents` already missing the closed window's entry — it's cleared by a `event.sender.once('destroyed', ...)` listener that fires as part of window/webContents teardown, which happens before `window-all-closed`.

Both conditions independently make the guard a no-op. Net effect: on Windows/Linux, clicking X while a turn is mid-tool-call silently kills the backend process — no confirmation, ever.

## Fix

Also invoke `heldQuitForActiveWork` from the main window's own `'close'` event (which fires *before* the window/webContents are destroyed), gated to exactly the case that currently bypasses the guard — a non-macOS platform where this window closing would leave zero windows open:

```ts
mainWindow.on('close', event => {
  if (process.platform !== 'darwin' && BrowserWindow.getAllWindows().length === 1) {
    heldQuitForActiveWork(event)
  }
})
```

At that point the window (for the dialog's parent) and its active-work report are both still alive, so the existing dialog + "Quit Anyway" → `app.quit()` → `before-quit` re-entry flow (already used and working for the macOS path) runs unchanged.

Traced behavior for every path this touches:
- **macOS**: gated on `process.platform !== 'darwin'` — this handler never fires; zero change.
- **Win/Linux, closing the last window, nothing running**: `quitPromptFor(...)` returns `null` (as already covered by `quit-guard.test.ts`) → `heldQuitForActiveWork` returns `false` without calling `preventDefault()` → close proceeds exactly as before.
- **Win/Linux, closing the last window, a turn in flight**: dialog now shows. "Keep Running" leaves the window open (bug fixed). "Quit Anyway" sets `quitConfirmedWithActiveWork = true` and calls `app.quit()`, which re-enters `before-quit` (no-ops on the now-true latch) and, when Electron subsequently closes the window for real, re-enters this same `'close'` handler — which now short-circuits on the latch too, so the window actually closes. No double dialog, no loop.
- **Win/Linux, closing a window while others remain open**: `BrowserWindow.getAllWindows().length === 1` is false → handler doesn't fire → unchanged (correct, since the app isn't quitting).
- **Update/uninstall handoff** (`isQuittingForHandoff`): already passed through as a parameter into `quitPromptFor`, which returns `null` unconditionally during a handoff (covered by `quit-guard.test.ts`) — unaffected.

## Test plan

`electron/main.ts` has no existing test seam for its internal event wiring (confirmed against `main-window-lifecycle.test.ts` / `quit-guard.test.ts`, which only cover the small extracted, pure modules `main.ts` calls into — this is the established pattern in this codebase for this file). The decision logic this change reuses (`quitPromptFor`, `mergeActiveWork`, `normalizeActiveWork` in `quit-guard.ts`) is unmodified and already covered by `quit-guard.test.ts`; this change is pure wiring (which event triggers the existing, already-tested check) and was verified by manually tracing every path above against the actual `before-quit` / `window-all-closed` / `activeWorkByWebContents` implementation.

- [x] `npx tsc --noEmit -p tsconfig.electron.json` clean
- [x] `npx eslint electron/main.ts` clean
- [x] `npx prettier --check electron/main.ts` clean
- [x] Full `electron/` test suite (`npx vitest run electron/`) — 784 passed, 2 skipped, no regressions
- [x] Every reachable path manually traced (see above) against the real production code, not assumed