### PR TITLE
fix: replace assert with runtime guard in session recovery

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1238,7 +1238,10 @@ def recover_session_database(
         output_path=output_path,
         work_dir=work_dir,
     )
-    assert output is not None
+    if output is None:
+        raise SessionRecoverySafetyError(
+            "output_path is required for session recovery"
+        )
     disk_space = _disk_space_preflight(source, work_root, output.parent)
 
     temp_dir, snapshot_source, inspection = _snapshot_and_inspect(source, work_root)


### PR DESCRIPTION
## Summary

`assert output is not None` at `session_recovery.py:1241` is stripped by `python -O`, silently removing the invariant check before `output.parent` is accessed on the next line.

Replace with an explicit `if output is None: raise SessionRecoverySafetyError(...)` using the same error class that other validation checks in this function already use.

## Changes
- `hermes_cli/session_recovery.py:1241`: `assert output is not None` → `if output is None: raise SessionRecoverySafetyError(...)`

## Test Plan
- [x] Syntax check passes
- [x] `SessionRecoverySafetyError` is already imported in the file