### PR TITLE
fix(kanban): preserve chat_type and delivery_metadata in subscription inheritance (#73030)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3319,9 +3319,10 @@ def _inherit_notify_subs(
     conn.execute(
         f"""
         INSERT OR IGNORE INTO kanban_notify_subs
-            (task_id, platform, chat_id, thread_id, user_id,
-             notifier_profile, created_at, last_event_id)
-        SELECT ?, platform, chat_id, thread_id, user_id, notifier_profile, ?, ?
+            (task_id, platform, chat_id, chat_type, thread_id, user_id,
+             notifier_profile, delivery_metadata, created_at, last_event_id)
+        SELECT ?, platform, chat_id, chat_type, thread_id, user_id,
+               notifier_profile, delivery_metadata, ?, ?
           FROM kanban_notify_subs
          WHERE task_id IN ({placeholders})
         """,

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -26,6 +26,15 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+_INHERITED_DELIVERY_METADATA = {
+    "chat_type": "dm",
+    "direct_messages_topic_id": "20197",
+    "telegram_dm_topic_reply_fallback": True,
+    "telegram_reply_to_message_id": "462",
+    "thread_id": "20197",
+}
+
+
 def _assert_inherited_notify_sub(subs: list[dict]) -> None:
     assert len(subs) == 1
     assert subs[0]["platform"] == "telegram"
@@ -33,6 +42,125 @@ def _assert_inherited_notify_sub(subs: list[dict]) -> None:
     assert subs[0]["thread_id"] == "topic1"
     assert subs[0]["user_id"] == "user1"
     assert subs[0]["notifier_profile"] == "default"
+    assert subs[0]["chat_type"] == "dm"
+    assert subs[0]["delivery_metadata"] == _INHERITED_DELIVERY_METADATA
+
+
+def test_create_task_inherits_parent_notify_subscriptions(kanban_home):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="worker1")
+        kb.add_notify_sub(
+            conn,
+            task_id=parent,
+            platform="telegram",
+            chat_id="chat1",
+            chat_type="dm",
+            thread_id="topic1",
+            user_id="user1",
+            notifier_profile="default",
+            delivery_metadata=_INHERITED_DELIVERY_METADATA,
+        )
+        child = kb.create_task(conn, title="child", parents=[parent], assignee="worker1")
+        subs = kb.list_notify_subs(conn, child)
+    finally:
+        conn.close()
+
+    _assert_inherited_notify_sub(subs)
+
+
+def test_link_tasks_inherits_parent_notify_subscriptions_without_replaying_old_child_events(kanban_home):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="worker1")
+        child = kb.create_task(conn, title="child", assignee="worker1")
+        with kb.write_txn(conn):
+            kb._append_event(conn, child, kind="blocked", payload={"reason": "old"})
+        kb.add_notify_sub(
+            conn,
+            task_id=parent,
+            platform="telegram",
+            chat_id="chat1",
+            chat_type="dm",
+            thread_id="topic1",
+            user_id="user1",
+            notifier_profile="default",
+            delivery_metadata=_INHERITED_DELIVERY_METADATA,
+        )
+        kb.link_tasks(conn, parent, child)
+        subs = kb.list_notify_subs(conn, child)
+        _, old_events = kb.unseen_events_for_sub(
+            conn,
+            task_id=child,
+            platform="telegram",
+            chat_id="chat1",
+            thread_id="topic1",
+            kinds=["blocked"],
+        )
+    finally:
+        conn.close()
+
+    _assert_inherited_notify_sub(subs)
+    assert old_events == []
+
+
+def test_decompose_triage_task_inherits_root_notify_subscriptions(kanban_home):
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="triage root", triage=True, assignee="orchestrator")
+        kb.add_notify_sub(
+            conn,
+            task_id=root,
+            platform="telegram",
+            chat_id="chat1",
+            chat_type="dm",
+            thread_id="topic1",
+            user_id="user1",
+            notifier_profile="default",
+            delivery_metadata=_INHERITED_DELIVERY_METADATA,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "first child", "assignee": "worker1"},
+                {"title": "second child", "assignee": "worker2", "parents": [0]},
+            ],
+            author="triager",
+            auto_promote=False,
+        )
+        assert child_ids is not None
+        child_subs = [kb.list_notify_subs(conn, child_id) for child_id in child_ids]
+    finally:
+        conn.close()
+
+    assert len(child_subs) == 2
+    for subs in child_subs:
+        _assert_inherited_notify_sub(subs)
+
+
+def test_inherited_notify_sub_preserves_null_routing_fields(kanban_home):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="worker1")
+        kb.add_notify_sub(
+            conn,
+            task_id=parent,
+            platform="telegram",
+            chat_id="chat1",
+            thread_id="topic1",
+            user_id="user1",
+            notifier_profile="default",
+        )
+        child = kb.create_task(conn, title="child", parents=[parent], assignee="worker1")
+        subs = kb.list_notify_subs(conn, child)
+    finally:
+        conn.close()
+
+    assert len(subs) == 1
+    assert subs[0]["chat_type"] is None
+    assert subs[0]["delivery_metadata"] in (None, {})
 
 
 


### PR DESCRIPTION
## Problem

`_inherit_notify_subs()` in `hermes_cli/kanban_db.py` copies a parent task's notification subscription to a child via `INSERT … SELECT`, but omits the `chat_type` and `delivery_metadata` columns. Inherited child rows silently lose available routing metadata.

This affects all three call paths that route through the helper: `create_task(parents=…)`, `link_tasks()`, and `decompose_triage_task()`.

**Impact:**
- Creator-wake reconstruction falls back to `chat_type="group"`, so a DM-originated child completion wakes a fresh group-scoped session instead of the originating DM session.
- Telegram DM-topic subscriptions lose their persisted reply-fallback and topic metadata; `message_thread_id` alone can render outside the intended visible lane.

Closes #73030.

## Fix

Add `chat_type` and `delivery_metadata` to both the INSERT column list and the SELECT projection in `_inherit_notify_subs`. One logical change — the stored TEXT value is copied as-is and decoded on read by `list_notify_subs` as before. No re-encoding needed.

## Verification

- **RED:** 3 regression tests fail on `upstream/main` before the fix (`assert None == 'dm'` — `chat_type` not inherited).
- **GREEN:** All 4 targeted tests pass with the fix.
- **Nearby suite:** 246 passed (`test_kanban_notify.py` + `test_kanban_db.py`), 0 failed.

## Tests

- Extended `_assert_inherited_notify_sub()` to assert `chat_type` and `delivery_metadata` are preserved.
- Updated all 3 existing inheritance tests (create_task, link_tasks, decompose_triage_task) to supply `chat_type="dm"` and realistic `delivery_metadata`.
- Added `test_inherited_notify_sub_preserves_null_routing_fields` — a parent subscription created without routing metadata must inherit cleanly (NULL → None).

## Competitor analysis

No competing open PRs found (issue-number search, topic-overlap keyword search, same-author check — all clean).

---

Auto-published by Moonsong via Path B automated pipeline.