### PR TITLE
fix(agent): log warning when client abort shuts down 0 active sockets (#72975)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4688,13 +4688,21 @@ class AIAgent:
             return
         try:
             shutdown_count = self._force_close_tcp_sockets(client)
-            logger.info(
-                "OpenAI client aborted (%s, shared=False, tcp_force_closed=%d, "
-                "deferred_close=stranger_thread) %s",
-                reason,
-                shutdown_count,
-                self._client_log_context(),
-            )
+            if shutdown_count == 0:
+                logger.warning(
+                    "OpenAI client abort found 0 active sockets (%s, shared=False, "
+                    "tcp_force_closed=0, deferred_close=stranger_thread) %s",
+                    reason,
+                    self._client_log_context(),
+                )
+            else:
+                logger.info(
+                    "OpenAI client aborted (%s, shared=False, tcp_force_closed=%d, "
+                    "deferred_close=stranger_thread) %s",
+                    reason,
+                    shutdown_count,
+                    self._client_log_context(),
+                )
         except Exception as exc:
             logger.debug(
                 "OpenAI client abort failed (%s, shared=False) %s error=%s",
@@ -4783,14 +4791,23 @@ class AIAgent:
             return
         try:
             shutdown_count = self._force_close_tcp_sockets(client)
-            logger.info(
-                "Anthropic client aborted (%s, shared=False, tcp_force_closed=%d, "
-                "deferred_close=stranger_thread) provider=%s model=%s",
-                reason,
-                shutdown_count,
-                getattr(self, "provider", None),
-                getattr(self, "model", None),
-            )
+            if shutdown_count == 0:
+                logger.warning(
+                    "Anthropic client abort found 0 active sockets (%s, shared=False, "
+                    "tcp_force_closed=0, deferred_close=stranger_thread) provider=%s model=%s",
+                    reason,
+                    getattr(self, "provider", None),
+                    getattr(self, "model", None),
+                )
+            else:
+                logger.info(
+                    "Anthropic client aborted (%s, shared=False, tcp_force_closed=%d, "
+                    "deferred_close=stranger_thread) provider=%s model=%s",
+                    reason,
+                    shutdown_count,
+                    getattr(self, "provider", None),
+                    getattr(self, "model", None),
+                )
         except Exception as exc:
             logger.debug(
                 "Anthropic client abort failed (%s, shared=False) provider=%s model=%s error=%s",

--- a/tests/run_agent/test_abort_zero_sockets_warning.py
+++ b/tests/run_agent/test_abort_zero_sockets_warning.py
@@ -1,0 +1,46 @@
+"""Tests verifying that client aborts log warnings when 0 sockets are force-closed."""
+import logging
+from unittest.mock import patch, MagicMock
+
+
+def _make_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://custom.example.com/v1",
+        provider="custom",
+        model="deepseek-v4-pro",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    return agent
+
+
+def test_abort_request_openai_client_logs_warning_when_zero_sockets(caplog):
+    agent = _make_agent()
+    mock_client = MagicMock()
+    with patch.object(agent, "_force_close_tcp_sockets", return_value=0):
+        with caplog.at_level(logging.WARNING):
+            agent._abort_request_openai_client(mock_client, reason="test_reason")
+    assert "OpenAI client abort found 0 active sockets" in caplog.text
+
+
+def test_abort_request_anthropic_client_logs_warning_when_zero_sockets(caplog):
+    agent = _make_agent()
+    mock_client = MagicMock()
+    with patch.object(agent, "_force_close_tcp_sockets", return_value=0):
+        with caplog.at_level(logging.WARNING):
+            agent._abort_request_anthropic_client(mock_client, reason="test_reason")
+    assert "Anthropic client abort found 0 active sockets" in caplog.text
+
+
+def test_abort_request_openai_client_logs_info_when_sockets_closed(caplog):
+    agent = _make_agent()
+    mock_client = MagicMock()
+    with patch.object(agent, "_force_close_tcp_sockets", return_value=1):
+        with caplog.at_level(logging.INFO):
+            agent._abort_request_openai_client(mock_client, reason="test_reason")
+    assert "OpenAI client aborted" in caplog.text
+    assert "found 0 active sockets" not in caplog.text


### PR DESCRIPTION
Resolves #72975

### Summary
When stranger-thread aborts (`_abort_request_openai_client` / `_abort_request_anthropic_client`) run, `force_close_tcp_sockets` attempts to shut down in-flight pool sockets without releasing file descriptors. Currently, when `force_close_tcp_sockets` returns `0` (no active socket yielded or shut down), the event is logged at `INFO` with the exact same message as a successful socket shutdown (`tcp_force_closed=0`). Because an abort shutting down 0 sockets is ineffective and leaves the underlying worker request running server-side, logging it identically to a successful abort hides the silent failure.

### Changes
1. Updated `_abort_request_openai_client` and `_abort_request_anthropic_client` in `run_agent.py` to log a `WARNING` when `shutdown_count == 0`.
2. Preserved existing `INFO` logging for successful aborts (`shutdown_count > 0`).
3. Added unit tests in `tests/run_agent/test_abort_zero_sockets_warning.py` verifying warning output on zero-socket aborts and info output when sockets are closed.

### Testing
- Executed `uv run --with pytest python -m pytest tests/run_agent/test_abort_zero_sockets_warning.py tests/run_agent/test_70773_shared_client_fd_corruption.py tests/run_agent/test_tls_fd_recycle_corruption.py tests/run_agent/test_create_openai_client_reuse.py` (22/22 tests passed).