### PR TITLE
fix(desktop): anchor the inline image download button to the image, not the block

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -373,14 +373,18 @@ function MarkdownImage({ className, src, alt, ...props }: ComponentProps<'img'>)
     return <span className="my-2 block text-sm text-muted-foreground">Loading {name}...</span>
   }
 
+  // The width cap belongs on the container, not the <img>: a percentage
+  // max-width resolves to none while the container measures its fit-content
+  // width, so the box overshoots the rendered image and strands the download
+  // button — which anchors to the container — out in the margin.
   return (
     <ZoomableImage
       alt={alt}
       className={cn(
-        'm-0 block h-auto w-auto max-h-(--image-preview-height) max-w-[min(100%,var(--image-preview-max-width))] rounded-lg object-contain shadow-[0_0.0625rem_0.125rem_color-mix(in_srgb,#000_4%,transparent),0_0.625rem_1.5rem_color-mix(in_srgb,#000_5%,transparent)]',
+        'm-0 block h-auto w-auto max-h-(--image-preview-height) max-w-full rounded-lg object-contain shadow-[0_0.0625rem_0.125rem_color-mix(in_srgb,#000_4%,transparent),0_0.625rem_1.5rem_color-mix(in_srgb,#000_5%,transparent)]',
         className
       )}
-      containerClassName="my-2 block w-fit max-w-full"
+      containerClassName="my-2 block w-fit max-w-[min(100%,var(--image-preview-max-width))]"
       slot="aui_markdown-image"
       src={resolvedSrc}
       {...props}


### PR DESCRIPTION
## Summary

The download button on an inline chat image anchors to its container, but the container wasn't the image's size. The `<img>` carried `max-w-[min(100%,var(--image-preview-max-width))]` while the wrapper was `w-fit max-w-full` — and a percentage `max-width` resolves to `none` while the wrapper measures its `fit-content` width. So the wrapper claimed the full column, the image stayed capped at 34rem, and on anything wider than it is tall the button floated off into the margin beside the picture.

Moving the width cap onto the container and leaving the image at `max-w-full` makes the wrapper shrink-wrap the rendered image, so `right-2 top-2` lands on the image's own corner at every aspect ratio.

## Test plan

- [ ] Send a wide image (e.g. 1600×600) in chat and hover it — the download pill sits on the image's top-right corner, not out in the margin
- [ ] Same for portrait, square, tiny (64px), and extreme-wide (4000×300) images
- [ ] Images still cap at `--image-preview-max-width` / `--image-preview-height` and narrow the viewport without overflowing
- [ ] Lightbox, generated-image, directive-image, and artifact-card previews are unchanged
