### PR TITLE
fix(gateway): preserve unknown launchd status

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -75,6 +75,7 @@ class GatewayRuntimeSnapshot:
     manager: str
     service_installed: bool = False
     service_running: bool = False
+    service_status_known: bool = True
     gateway_pids: tuple[int, ...] = ()
     service_scope: str | None = None
 
@@ -84,7 +85,12 @@ class GatewayRuntimeSnapshot:
 
     @property
     def has_process_service_mismatch(self) -> bool:
-        return self.service_installed and self.running and not self.service_running
+        return (
+            self.service_status_known
+            and self.service_installed
+            and self.running
+            and not self.service_running
+        )
 
 
 @dataclass(frozen=True)
@@ -1274,13 +1280,24 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
     return None
 
 
-def _probe_launchd_service_running() -> bool:
-    """Return True when launchd is actively supervising the gateway process.
+def _launchctl_status_indicates_unloaded(result: subprocess.CompletedProcess) -> bool:
+    """Return True only when launchctl positively reports a missing job."""
+    stderr = (result.stderr or "").lower()
+    return (
+        result.returncode in _LAUNCHD_JOB_UNLOADED_EXIT_CODES
+        or "could not find service" in stderr
+    )
+
+
+def _probe_launchd_service_running() -> bool | None:
+    """Return whether launchd is actively supervising the gateway process.
 
     ``launchctl list <label>`` returns exit 0 whenever the service definition is
     registered with launchd — even when ``state = not running`` (macOS 26+).
     We additionally require a PID in the output to confirm launchd is actually
-    managing a live process, not just holding a static definition.
+    managing a live process, not just holding a static definition. ``None``
+    means this shell could not query launchd, so callers must not infer that the
+    service is stopped or detached.
     """
     if not get_launchd_plist_path().exists():
         return False
@@ -1291,10 +1308,12 @@ def _probe_launchd_service_running() -> bool:
             text=True, encoding='utf-8', errors='replace',
             timeout=10,
         )
-    except subprocess.TimeoutExpired:
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if _launchctl_status_indicates_unloaded(result):
         return False
     if result.returncode != 0:
-        return False
+        return None
     return _parse_launchd_pid_from_list_output(result.stdout) is not None
 
 
@@ -1358,10 +1377,12 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
         )
 
     if is_macos():
+        launchd_running = _probe_launchd_service_running()
         return GatewayRuntimeSnapshot(
             manager="launchd",
             service_installed=get_launchd_plist_path().exists(),
-            service_running=_probe_launchd_service_running(),
+            service_running=launchd_running is True,
+            service_status_known=launchd_running is not None,
             gateway_pids=gateway_pids,
             service_scope="launchd",
         )
@@ -4508,6 +4529,7 @@ def launchd_restart():
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
+    service_status_known = True
     try:
         result = subprocess.run(
             ["launchctl", "list", label],
@@ -4516,9 +4538,15 @@ def launchd_status(deep: bool = False):
             timeout=10,
         )
         service_listed = result.returncode == 0
+        if (
+            not service_listed
+            and not _launchctl_status_indicates_unloaded(result)
+        ):
+            service_status_known = False
         list_output = result.stdout
-    except subprocess.TimeoutExpired:
+    except (subprocess.TimeoutExpired, OSError):
         service_listed = False
+        service_status_known = False
         list_output = ""
 
     # Determine whether launchd is actively supervising a process.
@@ -4551,7 +4579,19 @@ def launchd_status(deep: bool = False):
         print("⚠ Service definition is stale relative to the current Hermes install")
         print("  Run: hermes gateway start")
 
-    if service_listed:
+    if not service_status_known:
+        print("⚠ Unable to verify launchd service state from this shell")
+        print(
+            "  The launchctl status query was blocked or unavailable; "
+            "this does not mean the service is unloaded."
+        )
+        if fallback_pid:
+            print(
+                f"  Gateway process is running (PID {fallback_pid}), but "
+                "launchd supervision could not be verified."
+            )
+        print("  Run from an unrestricted host shell: hermes gateway status")
+    elif service_listed:
         if launchd_pid is not None:
             print(f"✓ Gateway is supervised by launchd (PID {launchd_pid})")
             print("  Auto-start at login and auto-restart on crash are available.")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1273,6 +1273,44 @@ class TestLaunchdServiceRecovery:
         )
         assert gateway_cli._probe_launchd_service_running() is True
 
+    def test_probe_launchd_service_running_unknown_when_query_is_blocked(
+        self, tmp_path, monkeypatch
+    ):
+        """A restricted shell must not turn launchctl denial into stopped."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="",
+            ),
+        )
+
+        assert gateway_cli._probe_launchd_service_running() is None
+
+    def test_probe_launchd_service_running_false_when_missing_message_uses_other_code(
+        self, tmp_path, monkeypatch
+    ):
+        """Some launchctl versions report a missing job with a generic exit."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="Could not find service",
+            ),
+        )
+
+        assert gateway_cli._probe_launchd_service_running() is False
+
     # ── Unsupport marker lifecycle ───────────────────────────────────────
 
     def test_launchd_unsupported_marker_write_and_clear(self, tmp_path, monkeypatch):
@@ -1330,6 +1368,45 @@ class TestLaunchdServiceRecovery:
         out = capsys.readouterr().out
         assert "supervised by launchd" in out
         assert "Auto-start at login" in out
+
+    def test_launchd_status_reports_unknown_when_query_is_blocked(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Do not label a supervised gateway detached when launchctl is denied."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="",
+            ),
+        )
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda cleanup_stale=False: 24680,
+        )
+
+        gateway_cli.launchd_status()
+
+        out = capsys.readouterr().out
+        assert "Unable to verify launchd service state from this shell" in out
+        assert "Gateway process is running (PID 24680)" in out
+        assert "not loaded" not in out
+        assert "detached" not in out
+
+        snapshot = gateway_cli.GatewayRuntimeSnapshot(
+            manager="launchd",
+            service_installed=True,
+            service_running=False,
+            service_status_known=False,
+            gateway_pids=(24680,),
+        )
+        gateway_cli._print_gateway_process_mismatch(snapshot)
+        assert capsys.readouterr().out == ""
 
     def test_launchd_status_reports_fallback_when_unsupported_and_pid_running(self, tmp_path, monkeypatch, capsys):
         """When the unsupported marker exists and a fallback PID is running."""


### PR DESCRIPTION
## Summary
- distinguish a launchd job that is positively missing from a status probe that is blocked or unavailable
- carry the unknown service state through the runtime snapshot so a supervised gateway is not mislabeled as a detached/manual process
- tell operators to verify from an unrestricted host shell while still reporting the live Hermes PID

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -k 'launchd_status or probe_launchd_service_running or gateway_runtime_snapshot or process_service_mismatch' -vv` (9 passed)
- `ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- sandbox smoke against the Zheng profile: reports unknown supervision with the live PID and does not report `not loaded` or `detached`