### PR TITLE
feat(slack): add adaptive reply routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -650,6 +650,28 @@ def _resolve_progress_thread_id(
     return None
 
 
+def _slack_progress_uses_thread(
+    reply_in_thread: Any,
+    source_thread_id: Any,
+) -> bool:
+    """Match Slack progress routing to the adapter's configured reply mode.
+
+    Adaptive routing records its per-message decision in ``source.thread_id``:
+    thread-worthy and existing-thread turns carry an ID, while conversational
+    in-channel turns do not. Legacy boolean and string forms retain their
+    existing meaning.
+    """
+    if isinstance(reply_in_thread, bool):
+        return reply_in_thread
+    value = str(reply_in_thread if reply_in_thread is not None else "true")
+    value = value.strip().lower()
+    if value == "auto":
+        return source_thread_id is not None
+    if value in {"false", "off", "no", "0", "channel"}:
+        return False
+    return True
+
+
 def _has_platform_display_override(user_config: dict, platform_key: str, setting: str) -> bool:
     """Return True when display.platforms.<platform> explicitly sets setting."""
     display = user_config.get("display") if isinstance(user_config, dict) else None
@@ -20905,10 +20927,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _slack_adapter_for_progress = self._adapter_for_source(source)
             if _slack_adapter_for_progress is not None:
                 try:
-                    _progress_reply_in_thread = bool(
+                    _progress_reply_in_thread = _slack_progress_uses_thread(
                         _slack_adapter_for_progress.config.extra.get(
                             "reply_in_thread", True
-                        )
+                        ),
+                        source.thread_id,
                     )
                 except Exception:
                     _progress_reply_in_thread = True

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -111,6 +111,101 @@ _SLACK_SPECIAL_MENTION_RE = re.compile(
     r"<!(?:everyone|channel|here)(?:\|[^>\n]*)?>", re.IGNORECASE
 )
 
+_SLACK_REPLY_MODE_THREAD = "thread"
+_SLACK_REPLY_MODE_CHANNEL = "channel"
+_SLACK_REPLY_MODE_AUTO = "auto"
+
+_SLACK_CHANNEL_REPLY_DIRECTIVE_RE = re.compile(
+    r"""
+    \b(?:
+        (?:keep|stay)\s+(?:(?:this|it)\s+)?(?:in|on)\s+(?:the\s+)?channel
+        |(?:keep|stay)\s+(?:this\s+)?here
+        |(?:reply|answer|respond|post)\s+(?:to\s+)?(?:this\s+)?here
+        |(?:no|without)\s+(?:a\s+)?thread
+        |(?:do\s+not|don't)\s+(?:start|use|make|open)\s+(?:a\s+)?thread
+    )\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_SLACK_THREAD_REPLY_DIRECTIVE_RE = re.compile(
+    r"""
+    \b(?:
+        thread\s+this
+        |(?:take|move|put)\s+(?:this|it)\s+(?:to|into)\s+(?:a|the)\s+thread
+        |(?:reply|answer|respond|continue)\s+(?:to\s+)?(?:this\s+)?in\s+(?:a|the)\s+thread
+        |(?:start|open)\s+(?:a|the)\s+thread
+        |(?:do\s+not|don't)\s+(?:reply|answer|respond)\s+here
+    )\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_SLACK_INVOLVED_REQUEST_RE = re.compile(
+    r"""
+    \b(?:
+        analy[sz]e|audit|debug|diagnose|investigate|research|review
+        |compare|evaluate|assess|plan|design|implement|build
+        |walk\s+me\s+through|step[\s-]+by[\s-]+step|deep[\s-]+dive
+    )\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_SLACK_LIST_ITEM_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+", re.MULTILINE)
+
+
+def _normalize_slack_reply_mode(raw: Any) -> str:
+    """Normalize legacy booleans and the adaptive Slack reply mode.
+
+    ``True``/``"true"`` retain the historical thread-per-message behavior;
+    ``False``/``"false"`` retain channel-wide replies. ``"auto"`` opts into
+    contextual routing. Unknown values fail safe to the historical default.
+    """
+    if isinstance(raw, bool):
+        return _SLACK_REPLY_MODE_THREAD if raw else _SLACK_REPLY_MODE_CHANNEL
+    if raw is None:
+        return _SLACK_REPLY_MODE_THREAD
+    value = str(raw).strip().lower()
+    if value in {"true", "on", "yes", "1", _SLACK_REPLY_MODE_THREAD}:
+        return _SLACK_REPLY_MODE_THREAD
+    if value in {"false", "off", "no", "0", _SLACK_REPLY_MODE_CHANNEL}:
+        return _SLACK_REPLY_MODE_CHANNEL
+    if value == _SLACK_REPLY_MODE_AUTO:
+        return _SLACK_REPLY_MODE_AUTO
+    return _SLACK_REPLY_MODE_THREAD
+
+
+def _slack_auto_reply_in_thread(
+    text: str,
+    files: Optional[List[Dict[str, Any]]] = None,
+) -> bool:
+    """Choose a human-like surface for a top-level Slack message.
+
+    The policy is deliberately deterministic: explicit surface requests win,
+    then clearly involved prompts move to a thread, while ordinary short
+    conversation stays in the channel. Existing Slack threads bypass this
+    classifier and always remain threaded.
+    """
+    authored = str(text or "").strip()
+    if _SLACK_CHANNEL_REPLY_DIRECTIVE_RE.search(authored):
+        return False
+    if _SLACK_THREAD_REPLY_DIRECTIVE_RE.search(authored):
+        return True
+
+    nonempty_lines = [line for line in authored.splitlines() if line.strip()]
+    list_items = _SLACK_LIST_ITEM_RE.findall(authored)
+    has_code_block = "```" in authored
+    has_involved_intent = bool(_SLACK_INVOLVED_REQUEST_RE.search(authored))
+    has_multiple_files = len(files or []) > 1
+
+    return bool(
+        has_code_block
+        or has_multiple_files
+        or has_involved_intent
+        or len(authored) >= 320
+        or len(nonempty_lines) >= 5
+        or len(list_items) >= 2
+    )
+
+
 # Cap on how many thread-root images are downloaded and delivered when the
 # bot is mentioned mid-thread (cold-start hydrate). Prior thread messages'
 # attachments are surfaced as text markers only — the root is special
@@ -3077,8 +3172,12 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             if self._cron_continuable_surface() != "in_channel":
                 return
-            # reply_in_thread defaults True (legacy: reply in a thread).
-            if self.config.extra.get("reply_in_thread", True):
+            # Only an explicitly channel-wide mode guarantees the shared
+            # in-channel continuation surface. Auto may route an involved
+            # continuation into a thread, so retain the warning there.
+            if _normalize_slack_reply_mode(
+                self.config.extra.get("reply_in_thread", True)
+            ) != _SLACK_REPLY_MODE_CHANNEL:
                 logger.warning(
                     "[Slack] %s: cron_continuable_surface=in_channel is set "
                     "WITHOUT reply_in_thread=false. A continuable in-channel "
@@ -3130,11 +3229,15 @@ class SlackAdapter(BasePlatformAdapter):
         Prefers metadata thread_id (the thread parent's ts, set by the
         gateway) over reply_to (which may be a child message's ts).
 
-        When ``reply_in_thread`` is ``false`` in the platform extra config,
-        top-level channel messages receive direct channel replies instead of
-        thread replies.  Messages that originate inside an existing thread are
-        always replied to in-thread to preserve conversation context.
+        ``reply_in_thread`` accepts the legacy booleans plus ``"auto"``.
+        ``false`` sends top-level channel replies directly; ``auto`` uses the
+        inbound handler's contextual decision. Messages that originate inside
+        an existing thread are always replied to in-thread.
         """
+        reply_mode = _normalize_slack_reply_mode(
+            self.config.extra.get("reply_in_thread", True)
+        )
+
         # When reply_in_thread is disabled (default: True for backward compat),
         # only thread messages that are already part of an existing thread.
         # For top-level channel messages, the inbound handler sets
@@ -3144,12 +3247,28 @@ class SlackAdapter(BasePlatformAdapter):
         # top-level message. reply_to is the incoming message's own id, so
         # when thread_id == reply_to the "thread" is synthetic and we reply
         # directly in the channel instead.
-        if not self.config.extra.get("reply_in_thread", True):
+        if reply_mode == _SLACK_REPLY_MODE_CHANNEL:
             md = metadata or {}
             existing_thread = md.get("thread_id") or md.get("thread_ts")
             if existing_thread and reply_to and existing_thread == reply_to:
                 existing_thread = None
             return existing_thread or None
+
+        if reply_mode == _SLACK_REPLY_MODE_AUTO:
+            # The inbound classifier represents its decision in the durable
+            # routing state: a thread-worthy top-level turn carries its message
+            # ts as thread_id; a conversational in-channel turn carries no
+            # thread_id. Existing threads likewise carry their real root ts.
+            md = metadata or {}
+            existing_thread = md.get("thread_id") or md.get("thread_ts")
+            if existing_thread:
+                return existing_thread
+            # A metadata-bearing gateway send with no thread id is an explicit
+            # in-channel auto decision. A direct adapter caller that supplies
+            # only reply_to retains normal explicit-reply semantics.
+            if metadata is not None:
+                return None
+            return reply_to
 
         if metadata:
             if metadata.get("thread_id"):
@@ -5555,7 +5674,7 @@ class SlackAdapter(BasePlatformAdapter):
         else:
             # Channel message session scoping.
             #
-            # Three cases:
+            # Four cases:
             #   (a) genuine thread reply   → scope session per thread
             #   (b) top-level, reply_in_thread=true (the default)  →
             #       legacy behaviour: each top-level message becomes its
@@ -5564,6 +5683,9 @@ class SlackAdapter(BasePlatformAdapter):
             #   (c) top-level, reply_in_thread=false → scope one session
             #       across the whole channel so context accumulates across
             #       messages (#15421 bug 1)
+            #   (d) top-level, reply_in_thread=auto → use a deterministic
+            #       conversational-vs-involved classifier; the chosen visible
+            #       surface and session scope always agree
             event_thread_ts_raw = event.get("thread_ts")
             # Align with ``is_thread_reply`` below — a ``thread_ts ==
             # ts`` payload (some thread-root shapes) is not a real reply
@@ -5573,18 +5695,31 @@ class SlackAdapter(BasePlatformAdapter):
             # variants (Copilot on #15464).
             if event_thread_ts_raw and event_thread_ts_raw != ts:
                 thread_ts = event_thread_ts_raw
-            elif self.config.extra.get("reply_in_thread", True):
-                # Legacy default: treat ts as a synthetic thread root so
-                # this top-level message gets its own session.
-                thread_ts = ts
             else:
-                # reply_in_thread=false: no thread key → session manager
-                # groups by (platform, channel_id, None) and the channel
-                # shares one conversation.  reply_to_message_id at the
-                # outbound side is already gated on ``thread_ts != ts``
-                # so None here produces a non-threaded reply without
-                # further changes.
-                thread_ts = None
+                reply_mode = _normalize_slack_reply_mode(
+                    self.config.extra.get("reply_in_thread", True)
+                )
+                if reply_mode == _SLACK_REPLY_MODE_AUTO:
+                    thread_ts = (
+                        ts
+                        if _slack_auto_reply_in_thread(
+                            original_text,
+                            files=event.get("files") or [],
+                        )
+                        else None
+                    )
+                elif reply_mode == _SLACK_REPLY_MODE_THREAD:
+                    # Legacy default: treat ts as a synthetic thread root so
+                    # this top-level message gets its own session.
+                    thread_ts = ts
+                else:
+                    # reply_in_thread=false: no thread key → session manager
+                    # groups by (platform, channel_id, None) and the channel
+                    # shares one conversation.  reply_to_message_id at the
+                    # outbound side is already gated on ``thread_ts != ts``
+                    # so None here produces a non-threaded reply without
+                    # further changes.
+                    thread_ts = None
 
         # In channels, respond if:
         #   (unless ignore_other_user_mentions is on and the message opens by

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1960,3 +1960,21 @@ class TestSlackReplyInThreadProgressRouting:
             source_thread_id=None,
             event_message_id="1700000000.000100",
         ) == "1700000000.000100"
+
+    def test_slack_auto_uses_per_message_session_decision(self):
+        from gateway.run import _slack_progress_uses_thread
+
+        assert _slack_progress_uses_thread("auto", source_thread_id=None) is False
+        assert (
+            _slack_progress_uses_thread(
+                "auto",
+                source_thread_id="1700000000.000100",
+            )
+            is True
+        )
+
+    def test_slack_progress_normalizes_channel_aliases(self):
+        from gateway.run import _slack_progress_uses_thread
+
+        for value in (False, "false", "off", "no", "0", "channel"):
+            assert _slack_progress_uses_thread(value, "1700000000.000100") is False

--- a/tests/gateway/test_slack_adaptive_reply_routing.py
+++ b/tests/gateway/test_slack_adaptive_reply_routing.py
@@ -1,0 +1,226 @@
+"""Behavior contracts for Slack's adaptive channel/thread reply mode."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import (
+    SlackAdapter,
+    _normalize_slack_reply_mode,
+    _slack_auto_reply_in_thread,
+)
+
+
+@pytest.fixture
+def adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+    config.extra["reply_in_thread"] = "auto"
+    instance = SlackAdapter(config)
+    instance._app = MagicMock()
+    instance._app.client = AsyncMock()
+    instance._bot_user_id = "U_BOT"
+    instance._running = True
+    instance.handle_message = AsyncMock()
+    return instance
+
+
+@pytest.fixture(autouse=True)
+def _redirect_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
+    )
+
+
+def _channel_event(
+    text: str,
+    *,
+    ts: str = "1700000000.000001",
+    thread_ts: str | None = None,
+    files: list[dict] | None = None,
+) -> dict:
+    event = {
+        "channel": "C_CHAN",
+        "channel_type": "channel",
+        "user": "U_USER",
+        "text": text,
+        "ts": ts,
+    }
+    if thread_ts is not None:
+        event["thread_ts"] = thread_ts
+    if files is not None:
+        event["files"] = files
+    return event
+
+
+async def _capture_event(adapter: SlackAdapter, event: dict):
+    captured = []
+    adapter.handle_message = AsyncMock(side_effect=captured.append)
+    with patch.object(
+        adapter,
+        "_resolve_user_name",
+        new=AsyncMock(return_value="testuser"),
+    ):
+        await adapter._handle_slack_message(event)
+    assert len(captured) == 1
+    return captured[0]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (True, "thread"),
+        (False, "channel"),
+        ("true", "thread"),
+        ("false", "channel"),
+        ("thread", "thread"),
+        ("channel", "channel"),
+        ("auto", "auto"),
+        ("unexpected", "thread"),
+        (None, "thread"),
+    ],
+)
+def test_reply_mode_normalizes_legacy_and_adaptive_values(raw, expected):
+    assert _normalize_slack_reply_mode(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Thanks — that makes sense.",
+        "What do you think?",
+        "Can you give me the short version?",
+    ],
+)
+def test_auto_policy_keeps_compact_conversation_in_channel(text):
+    assert _slack_auto_reply_in_thread(text) is False
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Please investigate why the deployment is failing.",
+        "Walk me through the tradeoffs step-by-step.",
+        "Please handle these:\n- check the logs\n- compare the failures",
+        "Can you explain this code?\n```python\nraise RuntimeError('boom')\n```",
+    ],
+)
+def test_auto_policy_threads_clearly_involved_requests(text):
+    assert _slack_auto_reply_in_thread(text) is True
+
+
+def test_explicit_channel_direction_overrides_involved_request():
+    assert (
+        _slack_auto_reply_in_thread(
+            "Please investigate the failure, but keep this in the channel."
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Please keep it in the channel.",
+        "Stay here.",
+        "Don't use a thread.",
+    ],
+)
+def test_common_channel_directions_stay_in_channel(text):
+    assert _slack_auto_reply_in_thread(text) is False
+
+
+def test_explicit_thread_direction_overrides_short_message():
+    assert _slack_auto_reply_in_thread("Quick thought—thread this.") is True
+
+
+def test_gateway_config_preserves_adaptive_mode(monkeypatch, tmp_path):
+    from gateway.config import Platform, load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  reply_in_thread: auto\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.SLACK].extra["reply_in_thread"] == "auto"
+
+
+def test_short_top_level_turn_uses_channel_session(adapter):
+    message = asyncio.run(
+        _capture_event(
+            adapter,
+            _channel_event("<@U_BOT> What do you think?"),
+        )
+    )
+
+    assert message.source.thread_id is None
+    assert message.reply_to_message_id is None
+    assert (
+        adapter._resolve_thread_ts(
+            reply_to=message.message_id,
+            metadata={"slack_team_id": "T_TEAM"},
+        )
+        is None
+    )
+
+
+def test_involved_top_level_turn_uses_thread_session(adapter):
+    message = asyncio.run(
+        _capture_event(
+            adapter,
+            _channel_event("<@U_BOT> Please investigate the deployment failure."),
+        )
+    )
+
+    assert message.source.thread_id == message.message_id
+    assert (
+        adapter._resolve_thread_ts(
+            reply_to=message.message_id,
+            metadata={
+                "thread_id": message.source.thread_id,
+                "slack_team_id": "T_TEAM",
+            },
+        )
+        == message.message_id
+    )
+
+
+def test_existing_thread_always_stays_threaded(adapter):
+    message = asyncio.run(
+        _capture_event(
+            adapter,
+            _channel_event(
+                "<@U_BOT> Thanks.",
+                ts="1700000000.000002",
+                thread_ts="1700000000.000001",
+            ),
+        )
+    )
+
+    assert message.source.thread_id == "1700000000.000001"
+    assert message.reply_to_message_id == "1700000000.000001"
+
+
+def test_multiple_files_are_thread_worthy(adapter):
+    message = asyncio.run(
+        _capture_event(
+            adapter,
+            _channel_event(
+                "<@U_BOT> Thoughts?",
+                files=[
+                    {"id": "F_ONE", "name": "one.png"},
+                    {"id": "F_TWO", "name": "two.png"},
+                ],
+            ),
+        )
+    )
+
+    assert message.source.thread_id == message.message_id

--- a/tests/gateway/test_slack_cron_continuable_surface.py
+++ b/tests/gateway/test_slack_cron_continuable_surface.py
@@ -129,6 +129,19 @@ def test_warns_when_in_channel_with_reply_in_thread_true(caplog):
                for r in caplog.records)
 
 
+def test_warns_when_in_channel_with_adaptive_replies(caplog):
+    """Auto does not guarantee the flat continuation surface."""
+    adapter = _make_adapter(
+        {"cron_continuable_surface": "in_channel", "reply_in_thread": "auto"}
+    )
+    with caplog.at_level(logging.WARNING):
+        adapter._warn_if_inchannel_without_flat_reply("Acme")
+    assert any(
+        "cron_continuable_surface=in_channel" in record.message
+        for record in caplog.records
+    )
+
+
 def test_no_warning_when_properly_paired(caplog):
     """in_channel + reply_in_thread: false is the correct pairing → silent."""
     adapter = _make_adapter(

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -400,10 +400,11 @@ platforms:
     reply_to_mode: "first"
 
     extra:
-      # Whether to reply in a thread (default: true).
-      # When false, channel messages get direct channel replies instead
-      # of threads. Messages inside existing threads still reply in-thread.
-      reply_in_thread: true
+      # Where top-level channel replies appear (default: true).
+      # true: always start a thread; false: always reply in the channel;
+      # auto: keep short conversation in-channel and thread involved requests.
+      # Messages inside existing threads always remain in-thread.
+      reply_in_thread: auto
 
       # Also post thread replies to the main channel
       # (Slack's "Also send to channel" feature).
@@ -450,7 +451,7 @@ platforms:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
-| `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
+| `platforms.slack.extra.reply_in_thread` | `true` | Top-level channel reply surface. `true` always starts a thread, `false` always replies in-channel, and `"auto"` keeps compact conversation in-channel while routing explicit thread requests and clearly involved incoming prompts (analysis, debugging, planning, multi-part/code-heavy requests) into a thread. Explicit “reply here” / “thread this” directions win. Messages inside existing threads always remain in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in adaptive Slack reply mode so Hermes can answer ordinary conversation in the channel while moving involved work into a thread. Existing thread conversations remain in their thread, and explicit user cues such as "thread this" or "keep it in channel" take precedence.

This solves the rigid all-thread/all-channel behavior without changing existing installations: `reply_in_thread: true` remains the default, while `reply_in_thread: auto` enables adaptive routing.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add deterministic adaptive routing to `plugins/platforms/slack/adapter.py`.
- Keep inbound session scope aligned with the selected Slack surface.
- Make gateway progress updates follow the same per-message routing decision.
- Preserve boolean configuration and accept explicit `thread` / `channel` aliases.
- Document `slack.reply_in_thread: auto` and add focused behavior coverage.

## How to Test

1. Set `slack.reply_in_thread: auto`.
2. Send a short conversational message in a channel and confirm the response stays in the channel.
3. Send an involved request such as an audit, debugging task, multi-file request, or explicit "thread this" message and confirm the response uses a thread.
4. Reply inside an existing thread and confirm Hermes remains in that thread.
5. Run:

   `scripts/run_tests.sh tests/gateway/test_slack_adaptive_reply_routing.py tests/gateway/test_slack_channel_session_scope.py tests/gateway/test_slack_mention.py tests/gateway/test_slack_cron_continuable_surface.py tests/gateway/test_run_progress_topics.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (existing key, new accepted value)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Verification

- Focused Slack/session/progress suite: 168 passed.
- Broad Slack suite: 880 passed; one network-dependent test blocked by sandbox DNS passed when rerun with network access.
- Ruff lint: passed.
- Windows footgun diff scan: passed.
- `git diff --check`: passed.
