### PR TITLE
refactor: single owner for empty-content wire repair (salvages #71439)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2819,6 +2819,18 @@ def _msg_has_payload(msg: Dict[str, Any]) -> bool:
         return True
     if msg.get("reasoning") or msg.get("reasoning_details"):
         return True
+    # Codex Responses item carriers: a commentary-phase assistant turn
+    # persists with content:"" by DESIGN — its text lives in
+    # ``codex_message_items`` (delivered via the interim callback) and the
+    # structured items are replayed for prefix-cache hits.  Same for
+    # ``codex_reasoning_items``.  These turns are never wire-empty on any
+    # api_mode: the codex transport replays the items, and the
+    # chat-completions transport strips the carriers only after this repair
+    # pass has already run.  Treat them as payload so the repair never
+    # rewrites a designed-empty codex turn (July 2026: a write-time pad that
+    # ignored this broke codex commentary replay in CI).
+    if msg.get("codex_message_items") or msg.get("codex_reasoning_items"):
+        return True
     return False
 
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2779,6 +2779,117 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
 
 
 
+# Placeholder substituted for an empty non-final message that would otherwise
+# make the provider reject the whole request. Kept identical to the stub-
+# creation placeholder in chat_completion_helpers so a healed transcript reads
+# consistently whether the empty turn was caught at write time or send time.
+_INTERRUPTED_PLACEHOLDER = "[response interrupted]"
+
+
+def _msg_has_payload(msg: Dict[str, Any]) -> bool:
+    """True if ``msg`` carries anything the API treats as non-empty content.
+
+    Covers string content, non-empty multimodal content lists, tool_calls,
+    tool_call_id linkage (tool results), and reasoning payloads. Mirrors the
+    emptiness checks used by ``AIAgent._is_thinking_only_assistant`` but is
+    role-agnostic so it can vet user/assistant/tool turns uniformly.
+    """
+    content = msg.get("content")
+    if isinstance(content, str):
+        if content.strip():
+            return True
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                # any typed block (text/image/tool_use/document/...) counts,
+                # as long as a text block is not itself blank
+                if block.get("type") == "text":
+                    if isinstance(block.get("text"), str) and block["text"].strip():
+                        return True
+                    continue
+                return True
+            elif block:
+                return True
+    elif content not in (None, ""):
+        return True
+    # Structural payloads that make an "empty-content" message still valid.
+    if msg.get("tool_calls"):
+        return True
+    if isinstance(msg.get("reasoning_content"), str) and msg["reasoning_content"].strip():
+        return True
+    if msg.get("reasoning") or msg.get("reasoning_details"):
+        return True
+    return False
+
+
+def repair_empty_non_final_messages(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Heal empty-content non-final messages before they reach the provider.
+
+    Root-cause context: a stream that dies with 0 recovered characters (peer
+    reset, stall-kill) could persist an assistant turn with ``content=None``
+    and no tool_calls. The Anthropic message schema — and the litellm/Bedrock
+    proxies in front of it — reject ANY request whose transcript contains an
+    empty non-final message:
+
+        "all messages must have non-empty content except for the optional
+         final assistant message"  (HTTP 400 INVALID_REQUEST_BODY)
+
+    Once such a message lands mid-transcript it poisons EVERY subsequent turn
+    of that session until it scrolls out of context. The write-time guard in
+    ``chat_completion_helpers`` stops NEW stubs, but sessions already carrying
+    one (persisted before the guard, or fed in from a host history) stay stuck
+    and previously needed a manual DB edit + gateway restart to recover.
+
+    This pass is the self-healing counterpart: it runs unconditionally on the
+    per-call ``api_messages`` copy, so a poisoned transcript repairs itself
+    IN MEMORY on the very next send — no restart, no DB surgery. The final
+    message is left untouched (an empty final assistant turn is legal). The
+    stored conversation history is never mutated; only the wire copy is
+    repaired, so the UI/session trace stays faithful.
+
+    Repair strategy is substitution, not deletion: dropping a mid-transcript
+    turn can break role alternation and tool-call pairing, whereas an honest
+    minimal placeholder keeps the sequence intact and reads correctly as an
+    interrupted turn on replay.
+    """
+    if not messages or len(messages) < 2:
+        return messages
+
+    repaired: List[Dict[str, Any]] = []
+    healed = 0
+    last_idx = len(messages) - 1
+    for idx, msg in enumerate(messages):
+        if (
+            idx != last_idx
+            and isinstance(msg, dict)
+            # tool results are validated by their own orphan/pairing pass; an
+            # empty tool result is a separate (and rarer) concern.
+            and msg.get("role") in ("assistant", "user")
+            and not _msg_has_payload(msg)
+        ):
+            # Shallow-copy so stored history / prompt caching stays byte-stable.
+            fixed = dict(msg)
+            fixed["content"] = _INTERRUPTED_PLACEHOLDER
+            repaired.append(fixed)
+            healed += 1
+        else:
+            repaired.append(msg)
+
+    if healed:
+        _ra().logger.warning(
+            "Pre-call sanitizer: healed %d empty non-final message(s) by "
+            "substituting placeholder content — an empty-content turn was in "
+            "the transcript and would 400 the request ('messages must have "
+            "non-empty content' / INVALID_REQUEST_BODY). Self-recovering the "
+            "poisoned transcript in memory; no restart needed.",
+            healed,
+        )
+        return repaired
+    return messages
+
+
 def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
@@ -2798,6 +2909,15 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             continue
         filtered.append(msg)
     messages = filtered
+
+    # --- Heal empty-content non-final messages (self-recovery) ---
+    # A dead stream can leave an empty assistant stub (or an empty user turn)
+    # mid-transcript; the provider then 400s EVERY subsequent request until it
+    # scrolls out. Repair it here, on the per-call copy, so a poisoned session
+    # recovers itself in memory on the next send — no restart, no DB edit.
+    # Done first so a substituted turn participates normally in the tool-pair
+    # and dedup passes below.
+    messages = repair_empty_non_final_messages(messages)
 
     # --- Drop empty / malformed tool_calls arrays on assistant messages ---
     # An assistant message carrying ``tool_calls: []`` (an empty array) — or a

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3944,6 +3944,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     result["error"],
                 )
                 _stub_finish_reason = FINISH_REASON_LENGTH
+            # Never persist a content-less, tool-call-less assistant stub.
+            # When a stream dies before any text arrives (and no partial tool
+            # calls were captured), _partial_text is None → the stub becomes an
+            # empty assistant message.  The Anthropic message schema (and the
+            # litellm/Bedrock proxies in front of it) reject any request whose
+            # transcript contains an empty non-final message:
+            #   "all messages must have non-empty content except for the
+            #    optional final assistant message"  (400 INVALID_REQUEST_BODY)
+            # Once such a stub lands mid-transcript, EVERY subsequent turn 400s
+            # until it scrolls out of context — and the 400 gets misread as a
+            # context-overflow "Cannot compress further" loop.  Substitute a
+            # minimal, honest placeholder so the message is always API-valid
+            # and the continuation prompt still reads as an interrupted turn.
+            if not _partial_text:
+                _partial_text = "[response interrupted]"
             _stub_msg = SimpleNamespace(
                 role="assistant", content=_partial_text, tool_calls=None,
                 reasoning_content=None,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3959,6 +3959,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # and the continuation prompt still reads as an interrupted turn.
             if not _partial_text:
                 _partial_text = "[response interrupted]"
+                logger.warning(
+                    "Empty partial-stream stub (0 chars recovered, no tool "
+                    "call) — substituting placeholder content so the assistant "
+                    "message is not persisted empty (would otherwise 400 every "
+                    "later request with 'messages must have non-empty content' "
+                    "/ INVALID_REQUEST_BODY). error=%s",
+                    result["error"],
+                )
             _stub_msg = SimpleNamespace(
                 role="assistant", content=_partial_text, tool_calls=None,
                 reasoning_content=None,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1373,31 +1373,16 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         from agent.redact import redact_sensitive_text
         _san_content = redact_sensitive_text(_san_content)
 
-    # Defence-in-depth: never serialize a TEXTLESS assistant turn with an
-    # empty content string.  Providers with strict validation (Moonshot/Kimi
-    # via OpenRouter: "the message at position N with role 'assistant' must
-    # not be empty") reject the replay with HTTP 400, which permanently
-    # poisons the persisted session — every subsequent turn re-sends the
-    # offending message.  Reachable via the partial-stream-stub path when a
-    # stream drops before delivering any text (the loop now skips that case,
-    # but other callers of this builder get the same guarantee).  A single
-    # space satisfies non-empty validation without fabricating content —
-    # the same trick the reasoning_content pad uses above (#15250, #17400).
-    # Tool-call turns are exempt: ``content: ""`` alongside ``tool_calls``
-    # is accepted everywhere and normalizing it would alter cache keys.
-    # codex_responses is exempt too: empty assistant content is a designed
-    # first-class state there (commentary-phase messages persist with
-    # content:"" while their text is delivered via the interim callback),
-    # and the Responses wire has no "assistant must not be empty"
-    # validation.  A codex session later replayed through a strict
-    # chat-completions provider is still repaired by the send-time pad,
-    # which keys on the ACTIVE api_mode at replay time.
-    if (
-        not _san_content
-        and not assistant_tool_calls
-        and getattr(agent, "api_mode", None) != "codex_responses"
-    ):
-        _san_content = " "
+    # NOTE (empty-content class fix): textless assistant turns are NOT padded
+    # here.  The single owner for "never send a turn strict wire validation
+    # rejects as empty" is ``repair_empty_non_final_messages`` in
+    # agent_runtime_helpers, which runs inside ``sanitize_api_messages`` — the
+    # unconditional pre-send chokepoint for both the main loop and the summary
+    # path.  Padding at write time was tried (a single-space pad, later a
+    # placeholder) and rejected: it forked the concept across three sites,
+    # broke codex commentary turns (content:'' is a designed state there), and
+    # a DB-side pad can't survive ``_rows_to_conversation``'s whitespace strip
+    # anyway.  Repair belongs at the send boundary, once.
 
     msg = {
         "role": "assistant",
@@ -3944,29 +3929,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     result["error"],
                 )
                 _stub_finish_reason = FINISH_REASON_LENGTH
-            # Never persist a content-less, tool-call-less assistant stub.
-            # When a stream dies before any text arrives (and no partial tool
-            # calls were captured), _partial_text is None → the stub becomes an
-            # empty assistant message.  The Anthropic message schema (and the
-            # litellm/Bedrock proxies in front of it) reject any request whose
-            # transcript contains an empty non-final message:
-            #   "all messages must have non-empty content except for the
-            #    optional final assistant message"  (400 INVALID_REQUEST_BODY)
-            # Once such a stub lands mid-transcript, EVERY subsequent turn 400s
-            # until it scrolls out of context — and the 400 gets misread as a
-            # context-overflow "Cannot compress further" loop.  Substitute a
-            # minimal, honest placeholder so the message is always API-valid
-            # and the continuation prompt still reads as an interrupted turn.
-            if not _partial_text:
-                _partial_text = "[response interrupted]"
-                logger.warning(
-                    "Empty partial-stream stub (0 chars recovered, no tool "
-                    "call) — substituting placeholder content so the assistant "
-                    "message is not persisted empty (would otherwise 400 every "
-                    "later request with 'messages must have non-empty content' "
-                    "/ INVALID_REQUEST_BODY). error=%s",
-                    result["error"],
-                )
+            # NOTE (empty-content class fix): the stub is deliberately allowed
+            # to carry empty content here.  The conversation loop's truncation
+            # path detects an EMPTY partial-stream stub (PARTIAL_STREAM_STUB_ID
+            # + no content) and skips appending it to history entirely — only
+            # the continuation nudge is sent.  Substituting placeholder text at
+            # this site was tried and reverted: it defeats that guard (the stub
+            # no longer looks empty), gets appended to history, and the
+            # placeholder leaks into the stitched final response via
+            # truncated_response_parts.  Transcripts that already carry a
+            # persisted empty turn are healed at the send boundary by
+            # ``repair_empty_non_final_messages`` (the single owner).
             _stub_msg = SimpleNamespace(
                 role="assistant", content=_partial_text, tool_calls=None,
                 reasoning_content=None,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1638,37 +1638,14 @@ def run_conversation(
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
 
-        # Pad a textless assistant turn's empty content to a single space.
-        # Strict providers (Moonshot/Kimi via OpenRouter: "the message at
-        # position N with role 'assistant' must not be empty") reject the
-        # replay with HTTP 400 — and the session is poisoned for every
-        # subsequent turn.  This is the DURABLE repair for ALREADY-poisoned
-        # persisted sessions: the partial-stream-stub rows older builds
-        # wrote (content:'' finish_reason:'length') are rebuilt to '' on
-        # every reload — ``_rows_to_conversation`` strips whitespace, so a
-        # DB-side pad can't survive — and only a SEND-time pad repairs
-        # them.  It must run AFTER the whitespace-normalization pass above
-        # (which would strip the pad back to '') and after
-        # _drop_thinking_only_and_merge_users (which can leave a textless
-        # turn), but BEFORE apply_anthropic_cache_control rewrites content
-        # into list blocks.  Tool-call turns are exempt: ``content: ''``
-        # alongside ``tool_calls`` is accepted everywhere and normalizing
-        # it would alter prompt-cache keys.  codex_responses is exempt:
-        # empty assistant content is a designed first-class state there
-        # (commentary-phase turns persist with content:'') and the
-        # Responses wire has no empty-content validation.  Keying on the
-        # ACTIVE api_mode means a codex-written empty turn is still
-        # repaired the moment the session replays through a strict
-        # chat-completions provider.
-        if getattr(agent, "api_mode", None) != "codex_responses":
-            for am in api_messages:
-                if (
-                    am.get("role") == "assistant"
-                    and not am.get("tool_calls")
-                    and isinstance(am.get("content"), str)
-                    and not am["content"].strip()
-                ):
-                    am["content"] = " "
+        # NOTE (empty-content class fix): no send-time pad loop here.  The
+        # single owner for "never send a turn strict wire validation rejects
+        # as empty" is ``repair_empty_non_final_messages``, which runs inside
+        # ``_sanitize_api_messages`` above — the unconditional pre-send
+        # chokepoint shared with the summary path.  Its placeholder is
+        # non-whitespace, so it survives the whitespace-normalization pass
+        # regardless of ordering (a single-space pad here previously had to
+        # be sequenced after normalization to survive, forking the concept).
 
         # Apply Anthropic prompt caching for Claude models on native
         # Anthropic, OpenRouter, and third-party Anthropic-compatible

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1326,6 +1326,14 @@ def _classify_400(
         any(p in error_msg for p in _INVALID_MESSAGE_BODY_PATTERNS)
         or error_code_lower == "invalid_request_body"
     ):
+        logger.warning(
+            "Malformed message array 400 (invalid request body) classified as "
+            "format_error, NOT context overflow — failing fast + falling back "
+            "instead of entering the compression loop. This usually means an "
+            "empty-content assistant stub is in the transcript; num_messages=%s "
+            "approx_tokens=%s. error=%.200s",
+            num_messages, approx_tokens, error_msg,
+        )
         return result_fn(
             FailoverReason.format_error,
             retryable=False,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -339,6 +339,30 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "no endpoints found that support tool use",
 ]
 
+# Malformed-message-array 400s.  Deterministic request-shape rejections that
+# describe the *transcript* being invalid, not a parameter.  The canonical
+# case: a stream dies mid-response and Hermes persists a content-less
+# assistant stub; on the next turn the Anthropic message schema (and the
+# litellm/Bedrock proxies in front of it) reject the whole request with
+#   "all messages must have non-empty content except for the optional final
+#    assistant message"  /  errorCode INVALID_REQUEST_BODY
+# These are NOT context overflow — the input may be tiny — but a large
+# session used to mis-route them into the compression loop via the generic
+# "400 + large session" heuristic below, ending in "Cannot compress further"
+# every retry (the input is unchanged, so compression cannot help).  Match
+# the message-shape signals explicitly and fail fast as a format_error so the
+# loop stops looping.  The empty-stub creation is the root cause (fixed in
+# chat_completion_helpers); this pattern stops the misclassification symptom
+# for transcripts that already contain a poisoned stub.
+_INVALID_MESSAGE_BODY_PATTERNS = [
+    "must have non-empty content",
+    "messages must have non-empty",
+    "invalid_request_body",
+    "text content blocks must be non-empty",
+    "content field is required",
+    "messages: at least one message is required",
+]
+
 # Request-validation patterns — the request is malformed and will fail
 # identically on every retry. Some OpenAI-compatible gateways (notably
 # codex.nekos.me) return these as 5xx instead of the standard 4xx, which
@@ -1289,6 +1313,25 @@ def _classify_400(
             should_fallback=True,
         )
 
+    # Malformed message array (empty-content assistant stub, etc.). Must be
+    # checked BEFORE context_overflow: the input can be tiny, so the generic
+    # "400 + large session" heuristic would otherwise mis-route it into the
+    # compression loop and thrash until "Cannot compress further" on every
+    # retry (the request is unchanged, so compression cannot fix it). This is
+    # a deterministic request-shape rejection — fail fast as a non-retryable
+    # format_error and fall back. Checked against the message text AND the
+    # structured error code, since proxies (litellm/Bedrock) surface the
+    # signal in errorCode=INVALID_REQUEST_BODY.
+    if (
+        any(p in error_msg for p in _INVALID_MESSAGE_BODY_PATTERNS)
+        or error_code_lower == "invalid_request_body"
+    ):
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
+
     # Empty-provider-response advisories must not enter compression. They
     # often mention "max_tokens" as a possible cause and used to match the
     # bare overflow pattern, then thrash compress until "Cannot compress
@@ -1349,6 +1392,18 @@ def _classify_400(
         # Responses API (and some providers) use flat body: {"message": "..."}
         if not err_body_msg:
             err_body_msg = str(body.get("message") or "").strip().lower()
+        # litellm / Bedrock proxies use a custom shape: {"errorMessage": "...",
+        # "errorCode": "...", "errorArgs": {"reason": "..."}}.  Without these
+        # keys err_body_msg stays "" and a long, descriptive rejection is
+        # wrongly treated as a "generic" (bare) error below, which — on a
+        # large session — mis-routes into the compression loop.  Recognize
+        # them so the is_generic heuristic sees the real message length.
+        if not err_body_msg:
+            err_body_msg = str(body.get("errorMessage") or "").strip().lower()
+        if not err_body_msg:
+            _args = body.get("errorArgs")
+            if isinstance(_args, dict):
+                err_body_msg = str(_args.get("reason") or "").strip().lower()
     is_generic = len(err_body_msg) < 30 or err_body_msg in {"error", ""}
     # Absolute token/message-count thresholds are only a proxy for smaller
     # context windows.  Large-context sessions can have many messages while
@@ -1647,7 +1702,7 @@ def _extract_error_code(body: dict) -> str:
                 return nested_code
 
     # Top-level code
-    code = body.get("code") or body.get("error_code") or ""
+    code = body.get("code") or body.get("error_code") or body.get("errorCode") or ""
     if isinstance(code, (str, int)):
         text = str(code).strip()
         if text and text != "400":
@@ -1667,6 +1722,16 @@ def _extract_message(error: Exception, body: dict) -> str:
         msg = body.get("message", "")
         if isinstance(msg, str) and msg.strip():
             return msg.strip()[:500]
+        # litellm / Bedrock proxy shape: {"errorMessage": "...",
+        # "errorArgs": {"reason": "..."}}.
+        msg = body.get("errorMessage", "")
+        if isinstance(msg, str) and msg.strip():
+            return msg.strip()[:500]
+        args = body.get("errorArgs")
+        if isinstance(args, dict):
+            reason = args.get("reason", "")
+            if isinstance(reason, str) and reason.strip():
+                return reason.strip()[:500]
     # Fallback to str(error)
     return str(error)[:500]
 

--- a/contributors/emails/a.weiker@sap.com
+++ b/contributors/emails/a.weiker@sap.com
@@ -1,0 +1,1 @@
+aweiker

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1326,7 +1326,7 @@ class TestClassifyApiError:
         assert result.retryable is False
         assert result.should_compress is not True
 
-    def test_400_litellm_invalid_request_body_shape(self):
+    def test_400_litellm_invalid_request_body_shape(self, caplog):
         """litellm/Bedrock proxy shape (errorMessage/errorCode) → format_error.
 
         The proxy in front of Anthropic surfaces the empty-content rejection
@@ -1335,8 +1335,10 @@ class TestClassifyApiError:
         are not the standard error.message / message, so err_body_msg used to
         come back empty → is_generic=True → mis-routed into compression on a
         large session.  Both the message pattern and the errorCode must be
-        recognized.
+        recognized, and a distinct warning must be logged so the condition is
+        observable in the field.
         """
+        import logging
         proxy_msg = ("The provided request body is invalid: claude "
                      "messages.208: all messages must have non-empty content "
                      "except for the optional final assistant message")
@@ -1350,12 +1352,17 @@ class TestClassifyApiError:
                 "errorArgs": {"reason": "claude messages.208: ..."},
             },
         )
-        result = classify_api_error(
-            e, approx_tokens=66000, context_length=200000, num_messages=219,
-        )
+        with caplog.at_level(logging.WARNING, logger="agent.error_classifier"):
+            result = classify_api_error(
+                e, approx_tokens=66000, context_length=200000, num_messages=219,
+            )
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
         assert result.should_compress is not True
+        assert any(
+            "Malformed message array 400" in r.getMessage()
+            for r in caplog.records
+        ), "Expected a distinct warning identifying the malformed-body 400"
 
     def test_400_real_context_overflow_still_compresses(self):
         """Guard: the new empty-content guard must NOT swallow real overflows.

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1298,6 +1298,84 @@ class TestClassifyApiError:
         result = classify_api_error(e, approx_tokens=100000, context_length=200000)
         assert result.reason == FailoverReason.context_overflow
 
+    def test_400_empty_content_message_not_context_overflow(self):
+        """Anthropic 'non-empty content' 400 → format_error, NOT compression.
+
+        Regression for the empty-assistant-stub bug: a stream dies with 0
+        recovered chars, an empty assistant message is persisted, and every
+        subsequent request 400s with 'all messages must have non-empty
+        content'.  On a large session the generic '400 + large session'
+        heuristic used to mis-route this into the compression loop, ending in
+        'Cannot compress further' on every retry (compression can't fix a
+        malformed transcript).  It must classify as a non-retryable
+        format_error so the loop stops looping.
+        """
+        msg = ("all messages must have non-empty content except for the "
+               "optional final assistant message")
+        e = MockAPIError(
+            msg,
+            status_code=400,
+            body={"error": {"message": msg, "type": "invalid_request_error"}},
+        )
+        # Large session (many messages / tokens) to prove the overflow
+        # heuristic does NOT capture it.
+        result = classify_api_error(
+            e, approx_tokens=66000, context_length=200000, num_messages=219,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is not True
+
+    def test_400_litellm_invalid_request_body_shape(self):
+        """litellm/Bedrock proxy shape (errorMessage/errorCode) → format_error.
+
+        The proxy in front of Anthropic surfaces the empty-content rejection
+        as {"errorMessage": "...non-empty content...", "errorCode":
+        "INVALID_REQUEST_BODY", "errorArgs": {"reason": "..."}}.  Those keys
+        are not the standard error.message / message, so err_body_msg used to
+        come back empty → is_generic=True → mis-routed into compression on a
+        large session.  Both the message pattern and the errorCode must be
+        recognized.
+        """
+        proxy_msg = ("The provided request body is invalid: claude "
+                     "messages.208: all messages must have non-empty content "
+                     "except for the optional final assistant message")
+        e = MockAPIError(
+            proxy_msg,
+            status_code=400,
+            body={
+                "errorMessage": proxy_msg,
+                "errorCode": "INVALID_REQUEST_BODY",
+                "statusCode": 400,
+                "errorArgs": {"reason": "claude messages.208: ..."},
+            },
+        )
+        result = classify_api_error(
+            e, approx_tokens=66000, context_length=200000, num_messages=219,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is not True
+
+    def test_400_real_context_overflow_still_compresses(self):
+        """Guard: the new empty-content guard must NOT swallow real overflows.
+
+        A genuine 'maximum context length' 400 must still route into
+        compression — the fix is surgical, not a blanket 400→format_error.
+        """
+        msg = ("This model's maximum context length is 200000 tokens. "
+               "However, your messages resulted in 250000 tokens.")
+        e = MockAPIError(
+            msg,
+            status_code=400,
+            body={"error": {"message": msg, "type": "invalid_request_error"}},
+        )
+        result = classify_api_error(
+            e, approx_tokens=250000, context_length=200000, num_messages=219,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
     # ── Peer closed + large session ──
 
     def test_peer_closed_large_session(self):

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -868,3 +868,35 @@ def test_sanitize_preserves_reasoning_only_and_toolcall_turns():
     assert tc_asst.get("tool_calls") and tc_asst["tool_calls"][0]["id"] == "call_R"
     assert tc_asst["content"] != "[response interrupted]"
 
+
+
+def test_sanitize_preserves_codex_item_carrier_turns():
+    """Negative control: a codex commentary-phase assistant turn persists with
+    content:'' by DESIGN — its text lives in codex_message_items (delivered
+    via the interim callback, replayed as structured items for prefix-cache
+    hits).  The empty-content repair must treat the item carriers as payload
+    and never rewrite these turns (July 2026: a write-time pad that ignored
+    this broke codex commentary replay in CI)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "analyze repo"},
+        {"role": "assistant", "content": "", "codex_message_items": [
+            {"id": "msg_1", "phase": "commentary",
+             "content": [{"type": "output_text", "text": "I'll inspect first."}]},
+        ]},
+        {"role": "user", "content": "go on"},
+        {"role": "assistant", "content": "", "codex_reasoning_items": [
+            {"type": "reasoning", "id": "rs_1", "encrypted_content": "opaque"},
+        ]},
+        {"role": "user", "content": "final"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    commentary = out[1]
+    reasoning_carrier = out[3]
+    assert commentary["content"] == "", (
+        "codex_message_items carrier must keep its designed-empty content"
+    )
+    assert reasoning_carrier["content"] == "", (
+        "codex_reasoning_items carrier must keep its designed-empty content"
+    )

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -770,3 +770,101 @@ def test_sanitize_preserves_populated_tool_calls():
     out = sanitize_api_messages(list(messages))
     assistant = [m for m in out if m.get("role") == "assistant"][0]
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
+
+
+# ── Self-recovery: heal empty-content non-final messages ──────────────────
+# Repro of the production incident: a dead stream persisted an empty-content
+# assistant stub mid-transcript, and every later request 400'd with
+# "all messages must have non-empty content except for the optional final
+# assistant message" (INVALID_REQUEST_BODY). sanitize_api_messages now heals
+# such turns on the per-call copy so the session recovers itself in memory.
+
+def test_sanitize_heals_empty_assistant_stub_between_tool_and_user():
+    """The exact production shape: tool -> EMPTY assistant (finish=length) ->
+    user recovery. The empty assistant would 400 the whole request; it must be
+    substituted with non-empty placeholder content, not left empty."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "do a thing"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "call_A", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "result"},
+        {"role": "assistant", "content": None},  # <-- poison stub (non-final)
+        {"role": "user", "content": "[System: previous response was cut off]"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    # Every non-final message now has non-empty content.
+    for m in out[:-1]:
+        c = m.get("content")
+        assert m.get("tool_calls") or (isinstance(c, str) and c.strip()) or (
+            isinstance(c, list) and c), f"empty non-final survived: {m}"
+    # The stub specifically became the placeholder.
+    stub = out[3]
+    assert stub["role"] == "assistant"
+    assert stub["content"] == "[response interrupted]"
+
+
+def test_sanitize_heals_empty_user_message():
+    """An empty user turn mid-transcript is equally invalid and is healed."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": ""},          # <-- empty user (non-final)
+        {"role": "assistant", "content": "still here"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert out[1]["content"] == "[response interrupted]"
+
+
+def test_sanitize_allows_empty_final_assistant():
+    """Negative control: an empty FINAL assistant message is legal per the API
+    ('except for the optional final assistant message') and must NOT be
+    touched."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},  # final — allowed empty
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert out[-1]["content"] == ""  # untouched
+
+
+def test_sanitize_empty_heal_is_non_destructive():
+    """Healing must not mutate the caller's persisted dicts — only the per-call
+    copy is repaired, so the stored trajectory keeps the true empty turn."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    original_stub = {"role": "assistant", "content": None}
+    messages = [
+        {"role": "user", "content": "q"},
+        original_stub,
+        {"role": "user", "content": "recovery"},
+    ]
+    sanitize_api_messages(list(messages))
+    assert original_stub["content"] is None  # untouched in-place
+
+
+def test_sanitize_preserves_reasoning_only_and_toolcall_turns():
+    """Negative control: a non-final assistant turn that is 'empty content' but
+    carries reasoning OR tool_calls is valid payload and must NOT be rewritten
+    to the placeholder (that would clobber real model output)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "call_R", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_R", "content": "r"},
+        {"role": "user", "content": "next"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    # tool_call assistant keeps its tool_calls, content not clobbered to text
+    tc_asst = out[1]
+    assert tc_asst.get("tool_calls") and tc_asst["tool_calls"][0]["id"] == "call_R"
+    assert tc_asst["content"] != "[response interrupted]"
+

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -716,11 +716,11 @@ class TestEmptyPartialStreamStubNotPersisted:
 
 
 class TestBuildAssistantMessageEmptyContentPad:
-    """Regression layer 2 (chat_completion_helpers.build_assistant_message):
-    never serialize a textless assistant turn with ``content: ""`` — pad to
-    a single space, the same trick as the reasoning_content pad (#15250).
-    Tool-call turns are exempt (``content: ""`` + ``tool_calls`` is accepted
-    everywhere)."""
+    """Layer 2 was consolidated into the class owner: the builder stores
+    textless turns AS-IS (no write-time pad — a pad here broke codex
+    commentary turns and forked the concept).  Wire safety is owned by
+    ``repair_empty_non_final_messages`` inside ``sanitize_api_messages``.
+    These tests pin the builder's store-as-is contract."""
 
     def _agent_for_builder(self):
         from run_agent import AIAgent
@@ -738,24 +738,24 @@ class TestBuildAssistantMessageEmptyContentPad:
             )
         return a
 
-    def test_empty_content_padded_to_space(self):
+    def test_empty_content_stored_as_is(self):
         from agent.chat_completion_helpers import build_assistant_message
         from tests.run_agent.test_run_agent import _mock_assistant_msg
 
         agent = self._agent_for_builder()
         msg = build_assistant_message(agent, _mock_assistant_msg(content=""), "stop")
-        assert msg["content"] == " ", (
-            "Textless assistant turn must be padded to a single space — "
-            "Moonshot/Kimi reject empty assistant content with HTTP 400."
+        assert msg["content"] == "", (
+            "Builder must store textless turns as-is — wire repair is owned "
+            "by repair_empty_non_final_messages at the send boundary."
         )
 
-    def test_none_content_padded_to_space(self):
+    def test_none_content_stored_as_empty(self):
         from agent.chat_completion_helpers import build_assistant_message
         from tests.run_agent.test_run_agent import _mock_assistant_msg
 
         agent = self._agent_for_builder()
         msg = build_assistant_message(agent, _mock_assistant_msg(content=None), "stop")
-        assert msg["content"] == " "
+        assert msg["content"] == ""
 
     def test_tool_call_turn_content_left_empty(self):
         from agent.chat_completion_helpers import build_assistant_message
@@ -767,10 +767,7 @@ class TestBuildAssistantMessageEmptyContentPad:
             _mock_assistant_msg(content="", tool_calls=[_mock_tool_call()]),
             "tool_calls",
         )
-        assert msg["content"] == "", (
-            "Tool-call turns are exempt from the pad: content:'' alongside "
-            "tool_calls is accepted by every provider."
-        )
+        assert msg["content"] == ""
         assert msg["tool_calls"]
 
     def test_non_empty_content_unchanged(self):
@@ -787,11 +784,12 @@ class TestSendTimeEmptyAssistantPad:
     -stream-stub row written by an older build (content:'' ,
     finish_reason:'length') is rebuilt to content:'' on every reload —
     ``_rows_to_conversation`` strips whitespace, so a DB-side pad cannot
-    survive.  The send-time pad in conversation_loop's api_messages loop
-    must therefore repair the empty textless assistant turn at the
-    serialization boundary, so a RESUMED poisoned session replays
-    cleanly against strict providers (Moonshot/Kimi HTTP 400 "message ...
-    with role 'assistant' must not be empty")."""
+    survive.  The class owner ``repair_empty_non_final_messages`` (inside
+    ``sanitize_api_messages``, the pre-send chokepoint) must repair the
+    empty textless assistant turn at the serialization boundary, so a
+    RESUMED poisoned session replays cleanly against strict providers
+    (Moonshot/Kimi HTTP 400 "message ... with role 'assistant' must not
+    be empty" / Anthropic "all messages must have non-empty content")."""
 
     def _run_one_turn_with_history(self, loop_agent, history):
         from tests.run_agent.test_run_agent import _mock_response
@@ -809,7 +807,7 @@ class TestSendTimeEmptyAssistantPad:
         kwargs = loop_agent.client.chat.completions.create.call_args_list[0]
         return kwargs.kwargs.get("messages") or kwargs.args[0].get("messages")
 
-    def test_poisoned_resumed_history_padded_on_send(self, loop_agent):
+    def test_poisoned_resumed_history_repaired_on_send(self, loop_agent):
         # Byte-shape of a persisted poisoned session:
         # user -> assistant('' , finish_reason='length', NO tool_calls) -> user.
         poisoned = [
@@ -822,7 +820,7 @@ class TestSendTimeEmptyAssistantPad:
             m for m in sent
             if m.get("role") == "assistant"
             and not m.get("tool_calls")
-            and m.get("content") == ""
+            and not (m.get("content") or "").strip()
         ]
         assert empties == [], (
             "A resumed session carrying a persisted empty partial-stream "
@@ -834,7 +832,7 @@ class TestSendTimeEmptyAssistantPad:
              and not m.get("tool_calls")),
             None,
         )
-        assert stub is not None and stub["content"] == " "
+        assert stub is not None and stub["content"] == "[response interrupted]"
 
     def test_tool_call_turn_not_padded_on_send(self, loop_agent):
         history = [
@@ -864,18 +862,16 @@ class TestSendTimeEmptyAssistantPad:
 
 
 class TestSendTimePadMultimodalSafety:
-    """Regression: the send-time pad must skip non-string (list) assistant
+    """Regression: the send-time repair must skip non-string (list) assistant
     content instead of crashing — a forked session whose new user turn
     attaches an image hit AttributeError: 'list' object has no attribute
-    'strip' inside the pad loop.
+    'strip' inside an earlier pad loop.
 
-    Note: current main flattens multimodal assistant list-content to a
-    plain string upstream of the send boundary, so the list shape rarely
-    survives to the pad loop in this path — but other builders/callers can
-    still produce list content, and the ``isinstance(str)`` guard must hold
-    regardless of upstream flattening.  This test drives a multimodal
+    The repair is now owned by ``repair_empty_non_final_messages``, whose
+    ``_msg_has_payload`` treats a list with any typed block as payload —
+    multimodal turns are never rewritten.  This test drives a multimodal
     history through the loop and asserts (a) no crash, and (b) the
-    assistant turn's text is neither dropped nor replaced by the pad.
+    assistant turn's text is neither dropped nor replaced.
     """
 
     def test_multimodal_assistant_content_not_touched(self, loop_agent):
@@ -917,27 +913,23 @@ class TestSendTimePadMultimodalSafety:
             )
         else:
             assert "I see an image" in (c or ""), (
-                "Flattened multimodal assistant text must survive the pad loop."
+                "Flattened multimodal assistant text must survive the repair."
             )
-        assert c != " ", "The pad must never replace real multimodal content."
 
-    def test_pad_loop_skips_list_content_directly(self):
-        """Unit-shape check: the pad predicate itself must skip list content
-        (the exact AttributeError shape) and pad only textless str turns."""
+    def test_repair_owner_skips_list_content_directly(self):
+        """Unit-shape check against the REAL owner: multimodal list content
+        (the exact AttributeError shape) passes through untouched; a textless
+        str turn is repaired; tool-call turns are exempt."""
+        from agent.agent_runtime_helpers import repair_empty_non_final_messages
         api_messages = [
             {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
             {"role": "assistant", "content": ""},
             {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
+            {"role": "user", "content": "trailing turn keeps the above non-final"},
         ]
-        # Mirror of the send-boundary pad in conversation_loop.
-        for am in api_messages:
-            if (
-                am.get("role") == "assistant"
-                and not am.get("tool_calls")
-                and isinstance(am.get("content"), str)
-                and not am["content"].strip()
-            ):
-                am["content"] = " "
-        assert api_messages[0]["content"] == [{"type": "text", "text": "hi"}]
-        assert api_messages[1]["content"] == " "
-        assert api_messages[2]["content"] == ""
+        out = repair_empty_non_final_messages(api_messages)
+        assert out[0]["content"] == [{"type": "text", "text": "hi"}]
+        assert out[1]["content"] == "[response interrupted]"
+        assert out[2]["content"] == ""
+        # input list untouched (repair is copy-on-write)
+        assert api_messages[1]["content"] == ""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2215,13 +2215,12 @@ class TestBuildAssistantMessage:
         assert result["reasoning_details"][0]["text"] == "step1"
 
     def test_empty_content(self, agent):
-        # Textless assistant turns are padded to a single space: strict
-        # providers (Moonshot/Kimi via OpenRouter) reject empty assistant
-        # content with HTTP 400 ("message ... with role 'assistant' must
-        # not be empty") on replay, permanently poisoning the session.
+        # The builder stores textless turns as-is; wire safety for strict
+        # providers ("assistant must not be empty" 400s) is owned by
+        # repair_empty_non_final_messages at the send boundary, not here.
         msg = _mock_assistant_msg(content=None)
         result = agent._build_assistant_message(msg, "stop")
-        assert result["content"] == " "
+        assert result["content"] == ""
 
     def test_streaming_only_reasoning_promoted_to_reasoning_content(self, agent):
         """Refs #16844 / #16884. Streaming-only providers (glm, MiniMax,
@@ -2350,9 +2349,9 @@ class TestBuildAssistantMessage:
         result = agent._build_assistant_message(msg, "stop")
         assert "<think>" not in result["content"]
         assert "reasoning that never closes" not in result["content"]
-        # Stripped-to-empty textless turns are padded to a single space
-        # (Moonshot/Kimi reject empty assistant content on replay).
-        assert result["content"] == " "
+        # Stripped-to-empty content is stored as-is; wire safety for strict
+        # providers is owned by repair_empty_non_final_messages at send time.
+        assert result["content"] == ""
 
 
 class TestFormatToolsForSystemMessage:

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1585,36 +1585,29 @@ class TestPartialToolCallWarning:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
-    def test_empty_partial_stream_never_yields_empty_content(
+    def test_empty_partial_stream_stub_stays_empty_for_loop_guard(
         self, mock_close, mock_create,
     ):
-        """Stream dies with 0 recovered chars and no tool call → stub content
-        must be a non-empty placeholder, never None/''.
+        """Stream dies with 0 recovered chars and no tool call → the stub
+        keeps its empty content ON PURPOSE.
 
-        Root-cause regression for the empty-assistant-stub bug: a stream
-        delivered some deltas, then died before any text landed in
-        ``_current_streamed_assistant_text`` (and no tool call was captured).
-        The stub was built with ``content=None`` → an empty assistant message
-        got persisted mid-transcript.  The Anthropic message schema (and the
-        litellm/Bedrock proxies in front of it) then reject EVERY subsequent
-        request:
-            "all messages must have non-empty content except for the optional
-             final assistant message"  (400 INVALID_REQUEST_BODY)
-        which the loop misreads as a context-overflow "Cannot compress
-        further" spiral.  The stub must carry a minimal placeholder so the
-        message is always API-valid.
+        The conversation loop's truncation path detects an EMPTY
+        partial-stream stub (PARTIAL_STREAM_STUB_ID + no content) and skips
+        appending it to history entirely — only the continuation nudge is
+        sent (the #68041 class fix).  An earlier iteration substituted
+        '[response interrupted]' placeholder text HERE, which defeated that
+        guard: the stub no longer looked empty, entered history, and the
+        placeholder leaked into the stitched final response.  Transcripts
+        that already carry a persisted empty turn are healed at the send
+        boundary by repair_empty_non_final_messages instead.
         """
         from run_agent import AIAgent
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
 
         class _StallError(RuntimeError):
             pass
 
         def _stalling_stream():
-            # A real content delta fires (deltas_were_sent=True → the
-            # post-delivery stub path runs), but the recovered-text
-            # accumulator is empty by the time the stub is built (cleared on
-            # reset in prod), and no tool call was captured — the exact
-            # "0 chars recovered, no tool call" production condition.
             yield _make_stream_chunk(content="partial token")
             raise _StallError("simulated upstream stall after a delta")
 
@@ -1635,8 +1628,8 @@ class TestPartialToolCallWarning:
         agent.api_mode = "chat_completions"
         agent._interrupt_requested = False
         agent._fire_stream_delta = lambda text: None
-        # Empty recovered text — this is what produced the empty stub in prod
-        # even though a delta was delivered to the platform above.
+        # Empty recovered text — the exact "0 chars recovered, no tool call"
+        # production condition.
         agent._current_streamed_assistant_text = ""
 
         import os as _os
@@ -1650,14 +1643,14 @@ class TestPartialToolCallWarning:
             else:
                 _os.environ["HERMES_STREAM_RETRIES"] = _prev
 
+        # The stub must be RECOGNIZABLY empty so the loop guard can skip it.
+        assert getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
         content = response.choices[0].message.content
-        assert content, (
-            f"Empty-partial-stream stub must NOT have empty/None content "
-            f"(it poisons the transcript and 400s every later request). "
-            f"Got content={content!r}"
-        )
-        assert content.strip() != "", (
-            f"Stub content is whitespace-only, still API-invalid: {content!r}"
+        assert not content, (
+            f"Empty-partial-stream stub must keep empty content so the "
+            f"conversation loop's empty-stub guard can detect and skip it — "
+            f"substituted text defeats the guard and leaks into the final "
+            f"response. Got content={content!r}"
         )
         assert response.choices[0].message.tool_calls is None
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1583,6 +1583,84 @@ class TestPartialToolCallWarning:
             f"Unexpected warning on text-only partial stream: {content!r}"
         )
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_empty_partial_stream_never_yields_empty_content(
+        self, mock_close, mock_create,
+    ):
+        """Stream dies with 0 recovered chars and no tool call → stub content
+        must be a non-empty placeholder, never None/''.
+
+        Root-cause regression for the empty-assistant-stub bug: a stream
+        delivered some deltas, then died before any text landed in
+        ``_current_streamed_assistant_text`` (and no tool call was captured).
+        The stub was built with ``content=None`` → an empty assistant message
+        got persisted mid-transcript.  The Anthropic message schema (and the
+        litellm/Bedrock proxies in front of it) then reject EVERY subsequent
+        request:
+            "all messages must have non-empty content except for the optional
+             final assistant message"  (400 INVALID_REQUEST_BODY)
+        which the loop misreads as a context-overflow "Cannot compress
+        further" spiral.  The stub must carry a minimal placeholder so the
+        message is always API-valid.
+        """
+        from run_agent import AIAgent
+
+        class _StallError(RuntimeError):
+            pass
+
+        def _stalling_stream():
+            # A real content delta fires (deltas_were_sent=True → the
+            # post-delivery stub path runs), but the recovered-text
+            # accumulator is empty by the time the stub is built (cleared on
+            # reset in prod), and no tool call was captured — the exact
+            # "0 chars recovered, no tool call" production condition.
+            yield _make_stream_chunk(content="partial token")
+            raise _StallError("simulated upstream stall after a delta")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _stalling_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent._fire_stream_delta = lambda text: None
+        # Empty recovered text — this is what produced the empty stub in prod
+        # even though a delta was delivered to the platform above.
+        agent._current_streamed_assistant_text = ""
+
+        import os as _os
+        _prev = _os.environ.get("HERMES_STREAM_RETRIES")
+        _os.environ["HERMES_STREAM_RETRIES"] = "0"
+        try:
+            response = agent._interruptible_streaming_api_call({})
+        finally:
+            if _prev is None:
+                _os.environ.pop("HERMES_STREAM_RETRIES", None)
+            else:
+                _os.environ["HERMES_STREAM_RETRIES"] = _prev
+
+        content = response.choices[0].message.content
+        assert content, (
+            f"Empty-partial-stream stub must NOT have empty/None content "
+            f"(it poisons the transcript and 400s every later request). "
+            f"Got content={content!r}"
+        )
+        assert content.strip() != "", (
+            f"Stub content is whitespace-only, still API-invalid: {content!r}"
+        )
+        assert response.choices[0].message.tool_calls is None
+
 
 class TestSilentRetryMidToolCall:
     """Regression: when the stream dies mid tool-call JSON after text was


### PR DESCRIPTION
## Summary

One owner now exists for "never send a turn that strict wire validation rejects as empty": `repair_empty_non_final_messages`, running inside `sanitize_api_messages` (the unconditional pre-send chokepoint) — replacing four forked sites that each re-implemented the concept with their own predicate and blind spots. Salvages PR #71439 by @aweiker (authorship preserved) as the owner implementation, plus his error-classifier fix that stops these 400s being misrouted into the compression death-spiral.

Follow-up to #73028: the class-fix pass mandated by the never-patch-predicates standing order.

## The class

| Site | Predicate it used | Blind spot | Disposition |
|---|---|---|---|
| `build_assistant_message` write-time `" "` pad | `not content and not tool_calls` + codex exemption | broke codex commentary turns until special-cased; DB pad can't survive `_rows_to_conversation` strip | removed |
| `conversation_loop` send-time `" "` pad | `isinstance(str) and not strip()` + codex exemption | main loop only — summary path uncovered; ordering-fragile (must run post-normalization); assistant-only | removed |
| stream-stub `"[response interrupted]"` substitution (#71439's site 1) | `not _partial_text` | defeated the loop's empty-stub guard from #73028 — stub entered history, placeholder leaked into stitched final response | removed |
| `repair_empty_non_final_messages` (#71439's site 3) | `_msg_has_payload` — role-agnostic, payload-aware, non-final-only, copy-on-write | none after extension below | **single owner** |

## Changes

- `agent/agent_runtime_helpers.py`: @aweiker's `repair_empty_non_final_messages` + `_msg_has_payload`, wired first in `sanitize_api_messages` — covers main loop AND summary path, user AND assistant turns, heals already-poisoned resumed sessions in memory (no restart, no DB edit). Extended: `codex_message_items` / `codex_reasoning_items` count as payload, so designed-empty codex commentary turns are never rewritten on any api_mode — the failure shape that broke the write-time pad in CI is encoded in the owner itself.
- `agent/error_classifier.py` (@aweiker): `_INVALID_MESSAGE_BODY_PATTERNS` checked before the context-overflow heuristic — a malformed-transcript 400 on a large session no longer thrashes compression to "Cannot compress further"; litellm/Bedrock `errorMessage`/`errorCode`/`errorArgs` body shapes recognized.
- `agent/chat_completion_helpers.py`, `agent/conversation_loop.py`: forked pads removed, NOTE comments point at the owner.
- Tests updated to pin the new contracts (builder stores as-is; stub stays recognizably empty for the loop guard; poisoned histories repaired at send; codex carriers untouched; multimodal list content untouched).

## Validation

| | Before | After |
|---|---|---|
| Sites owning the concept | 4 (diverging predicates) | 1 |
| Summary path (`get_conversation_summary`) | uncovered | covered via chokepoint |
| Empty user turns | uncovered by pads | repaired |
| Codex designed-empty turns | per-site exemptions | payload-aware in owner |
| Malformed-transcript 400 on large session | compression spiral | fail-fast format_error |

Targeted: 906 passed, 0 failed across the six affected suites. Sabotage-verified: unwiring the owner fails 3 regression tests; each removed site's old behavior is pinned by an updated test explaining why it must NOT return.

## Infographic

![single owner consolidation](https://v3b.fal.media/files/b/0aa4029b/HBniLibDImi7V9Gn13Hh4_QHsoI5zo.png)
