### PR TITLE
fix(desktop): keep slash completion alive after a leading command

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
@@ -120,6 +120,29 @@ describe('useComposerTrigger — slash anywhere in the prompt', () => {
 
     expect(hook.result.current.trigger).toBeNull()
   })
+
+  it('opens the list for a second slash after a leading command', () => {
+    // `/work /cle`: the command regex's argument tail would otherwise swallow
+    // `/cle` as an argument to `/work`, and a no-arg command suppresses the
+    // popover — so every slash after the first went dead.
+    const editor = mountEditor('/work /cle')
+    const { hook } = mountTrigger(editor, [item('/clean')])
+
+    act(() => hook.result.current.refreshTrigger())
+
+    expect(hook.result.current.trigger).toMatchObject({ kind: '/', inline: true, query: 'cle' })
+    expect(hook.result.current.triggerItems).toHaveLength(1)
+  })
+
+  it('inserts the second command without disturbing the first', () => {
+    const editor = mountEditor('/work rewrite the composer /cle')
+    const { hook } = mountTrigger(editor, [item('/clean')])
+
+    act(() => hook.result.current.refreshTrigger())
+    act(() => hook.result.current.replaceTriggerWithChip(item('/clean')))
+
+    expect(composerPlainText(editor)).toBe('/work rewrite the composer /clean ')
+  })
 })
 
 describe('useComposerTrigger — free-text slash arguments', () => {

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -28,6 +28,11 @@ export interface TriggerState {
 //    there are no args to complete — the trigger is a single token that ends at
 //    the next space, exactly like `@`.
 //
+// Only the FIRST slash can be an invocation, so the inline shape is tested
+// first: the command regex's argument tail (`(?:\s+\S*)*`) happily swallows a
+// later `/skill` as if it were an argument, which killed completion for every
+// slash after a leading command (`/work /cle` → nothing).
+//
 // The inline shape is what makes skills reachable anywhere in a prompt. Both
 // shapes need the trailing `$`: detection runs against the text BEFORE the
 // caret, so the match must end where the user is typing.
@@ -124,20 +129,22 @@ export function textBeforeCaret(editor: HTMLDivElement): string | null {
 }
 
 export function detectTrigger(textBefore: string): TriggerState | null {
-  const command = SLASH_COMMAND_TRIGGER_RE.exec(textBefore)
-
-  if (command) {
-    return { kind: '/', query: command[2], tokenLength: 1 + command[2].length }
-  }
-
   // An inline `/skill` is a reference dropped into prose, so it carries no args
-  // and the whole match is the token the chip replaces.
+  // and the whole match is the token the chip replaces. Checked before the
+  // anchored command shape so a second slash isn't mistaken for the first
+  // command's argument.
   const inline = SLASH_INLINE_TRIGGER_RE.exec(textBefore)
 
   if (inline) {
     const query = inline[2] ?? ''
 
     return { inline: true, kind: '/', query, tokenLength: 1 + query.length }
+  }
+
+  const command = SLASH_COMMAND_TRIGGER_RE.exec(textBefore)
+
+  if (command) {
+    return { kind: '/', query: command[2], tokenLength: 1 + command[2].length }
   }
 
   const at = AT_TRIGGER_RE.exec(textBefore)


### PR DESCRIPTION
A second slash command in the desktop composer only completes when the message starts with prose. `do /work then /cle` opens the popover; `/work /cle` opens nothing. Same session, same skills — the difference is the first character of the draft, which reads as an intermittent glitch rather than a rule.

`detectTrigger` tries the `^`-anchored command shape before the inline one. Its argument tail `(?:\s+\S*)*` swallows the rest of the line, so a later `/skill` parses as an argument to the first command; `refreshTrigger` then suppresses the popover for any command whose `argumentMode` isn't `options`/`mixed`, and every slash after the first is unreachable. `/goal` and `/personality` happen to escape it by being arg-taking, which is what makes the failure look random.

Only the first slash can be an invocation, so the inline shape is detected first. It requires a whitespace-preceded slash sitting at the caret, so it can't take over ordinary argument completion — `/personality alic` has no second slash — and it fires only where completion was already dead.