### PR TITLE
refactor(desktop): drop leva from the chat backdrop

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -106,7 +106,6 @@
     "hast-util-to-text": "^4.0.2",
     "ignore": "^7.0.5",
     "katex": "^0.16.45",
-    "leva": "^0.10.1",
     "mermaid": "^11.15.0",
     "motion": "^12.38.0",
     "nanostores": "^1.3.0",

--- a/apps/desktop/src/components/Backdrop.tsx
+++ b/apps/desktop/src/components/Backdrop.tsx
@@ -1,118 +1,24 @@
 import { useStore } from '@nanostores/react'
-import { Leva, useControls } from 'leva'
-import { type CSSProperties, useEffect, useState } from 'react'
 
 import { $backdrop } from '@/store/backdrop'
 
-const BLEND_MODES = [
-  'normal',
-  'multiply',
-  'screen',
-  'overlay',
-  'darken',
-  'lighten',
-  'color-dodge',
-  'color-burn',
-  'hard-light',
-  'soft-light',
-  'difference',
-  'exclusion',
-  'hue',
-  'saturation',
-  'color',
-  'luminosity'
-] as const
-
-type BlendMode = (typeof BLEND_MODES)[number]
 const assetPath = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\/+/, '')}`
 
 export function Backdrop() {
-  const [controlsOpen, setControlsOpen] = useState(false)
   const on = useStore($backdrop)
 
-  useEffect(() => {
-    if (!import.meta.env.DEV) {
-      return
-    }
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null
-
-      const editing =
-        target?.isContentEditable ||
-        target instanceof HTMLInputElement ||
-        target instanceof HTMLTextAreaElement ||
-        target instanceof HTMLSelectElement
-
-      if (editing || event.repeat || event.altKey || event.ctrlKey || event.metaKey) {
-        return
-      }
-
-      if (event.shiftKey && event.code === 'KeyY') {
-        setControlsOpen(open => !open)
-      }
-    }
-
-    window.addEventListener('keydown', onKeyDown)
-
-    return () => window.removeEventListener('keydown', onKeyDown)
-  }, [])
-
-  const shape = useControls(
-    'UI / Shape',
-    { radiusScalar: { value: 0.2, min: 0, max: 2, step: 0.1, label: 'radius scalar' } },
-    { collapsed: true }
-  )
-
-  useEffect(() => {
-    document.documentElement.style.setProperty('--radius-scalar', String(shape.radiusScalar))
-  }, [shape.radiusScalar])
-
-  const statue = useControls(
-    'Backdrop / Statue',
-    {
-      enabled: { value: true, label: 'on' },
-      opacity: { value: 0.025, min: 0, max: 1, step: 0.005 },
-      blendMode: { value: 'difference' as BlendMode, options: BLEND_MODES, label: 'blend' },
-      invert: { value: true, label: 'invert color' },
-      saturate: { value: 1, min: 0, max: 3, step: 0.05, label: 'saturate' },
-      brightness: { value: 1, min: 0, max: 2, step: 0.05, label: 'brightness' },
-      objectPosition: {
-        value: 'top left',
-        options: ['top left', 'top right', 'bottom left', 'bottom right', 'center', 'top', 'bottom', 'left', 'right'],
-        label: 'position'
-      },
-      scale: { value: 160, min: 100, max: 300, step: 5, label: 'height (dvh)' }
-    },
-    { collapsed: true }
-  )
+  if (!on) {
+    return null
+  }
 
   return (
-    <>
-      <Leva collapsed hidden={!import.meta.env.DEV || !controlsOpen} titleBar={{ title: 'backdrop', drag: true }} />
-
-      {on && statue.enabled && (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 z-2"
-          style={{
-            mixBlendMode: statue.blendMode as CSSProperties['mixBlendMode'],
-            opacity: statue.opacity
-          }}
-        >
-          <img
-            alt=""
-            className="w-auto min-w-dvw object-cover"
-            fetchPriority="low"
-            src={assetPath('ds-assets/filler-bg0.jpg')}
-            style={{
-              height: `${statue.scale}dvh`,
-              objectPosition: statue.objectPosition,
-              filter: `invert(calc(${statue.invert ? 1 : 0} * var(--backdrop-invert-mul, 1))) saturate(${statue.saturate}) brightness(${statue.brightness})`
-            }}
-          />
-        </div>
-      )}
-    </>
+    <div aria-hidden className="pointer-events-none absolute inset-0 z-2 opacity-[0.025] mix-blend-difference">
+      <img
+        alt=""
+        className="h-[160dvh] w-auto min-w-dvw object-cover object-left-top [filter:invert(var(--backdrop-invert-mul,1))]"
+        fetchPriority="low"
+        src={assetPath('ds-assets/filler-bg0.jpg')}
+      />
+    </div>
   )
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -387,7 +387,11 @@
     --dt-spacing-mul: 1;
 
     --radius: 0.75rem;
-    --radius-scalar: 0.6;
+    /* Effective value everywhere: the chat backdrop used to force 0.2 onto the
+       root element at runtime (an ungated leva slider default), so this 0.6
+       only ever applied to the windows that don't mount the backdrop. Pinned
+       to the value the app actually renders at. */
+    --radius-scalar: 0.2;
 
     /* Space under last message vs overlay composer — driven by the measured composer height (see composer/index.tsx)
        plus the out-of-flow status stack's measured height (see status-stack/index.tsx) when one is showing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,6 @@
         "hast-util-to-text": "^4.0.2",
         "ignore": "^7.0.5",
         "katex": "^0.16.45",
-        "leva": "^0.10.1",
         "mermaid": "^11.15.0",
         "motion": "^12.38.0",
         "nanostores": "^1.3.0",


### PR DESCRIPTION
The chat backdrop shipped a [leva](https://github.com/pmndrs/leva) control panel — a Shift+Y tweak surface for opacity, blend mode, filters and a radius scalar — that has never been touched since the desktop app landed in #20059. This drops the desktop's direct dependency on it and inlines the values the backdrop was already rendering with.

The panel's *visibility* was gated on `import.meta.env.DEV`, but the two `useControls` calls and the zustand store behind them were not: they ran in every build, packaged included. The gate hid the UI, not the cost.

`Backdrop.tsx` was the only file in the tree importing leva. It stays installed in `node_modules` — `@nous-research/ui` declares it as an optional peer and `web` depends on that — but it no longer reaches the desktop renderer bundle.

### The radius bug

`--radius-scalar` is declared `0.6` in `styles.css` and feeds every `--radius-*` token. The slider's `0.2` default was written onto `document.documentElement` on mount, so any window that mounts the backdrop (chat) rendered at 0.2 while any window that doesn't (pet overlay, quick entry) kept 0.6 — two different corner radii from one token, decided by an ungated dev control.

The token now declares `0.2`, the value chat has actually rendered at all along. Corners are unchanged where you've been looking; the auxiliary windows now match instead of drifting rounder.

### Everything else is byte-equivalent

The leva defaults map 1:1 onto classes — `0.025` opacity, `difference` blend, `160dvh`, `top left`, `invert(var(--backdrop-invert-mul,1))`. `saturate(1)` and `brightness(1)` were identity functions and are dropped. The `enabled` toggle collapsed into the existing `$backdrop` store check, which already gated the same element.

`package-lock.json` is a one-line delta: the desktop workspace's `leva` entry. The hoisted `node_modules/leva` install path stays — `web` resolves through it.

### Verification

`npm ci` clean on a fresh clone of this branch. `npm run build` clean. Confirmed against `dist/`: no `LevaRoot` / `useControls` / `colord` / `react-colorful` in any chunk, `filler-bg0.jpg` still referenced, and Tailwind emitted every new class (`mix-blend-difference`, `h-[160dvh]`, `opacity-[0.025]`, `object-left-top`, `filter:invert(var(--backdrop-invert-mul,1))`). Built CSS carries `--radius-scalar:.2`. `tsc --build` and eslint clean.