### PR TITLE
fix(gateway): clear full FIFO queue on /stop (#73060)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19298,6 +19298,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if adapter and hasattr(adapter, "get_pending_message"):
             adapter.get_pending_message(session_key)  # consume and discard
         self._pending_messages.pop(session_key, None)
+        # Clear the full FIFO overflow queue so /stop cancels everything,
+        # not just the head (#73060).
+        queued_events = getattr(self, "_queued_events", None)
+        if queued_events is not None:
+            queued_events.pop(session_key, None)
         if release_running_state:
             self._release_running_agent_state(session_key)
             # Evict the cached agent: ``_interrupt_requested`` is only


### PR DESCRIPTION
Fixes #73060. /stop only cleared the adapter pending slot (1 item) but left _queued_events overflow FIFO intact, so /stop would discard the queue head and execute the rest. Added _queued_events.pop(session_key) in _interrupt_and_clear_session(). 65 queue/interrupt tests passed.