### PR TITLE
fix(lsp): use npm .cmd wrappers on Windows instead of the POSIX shim

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -133,24 +133,38 @@ def hermes_lsp_bin_dir() -> Path:
 
 
 def _native_binary_candidates(base: Path) -> list[Path]:
-    """Return platform-native executable candidates for a staged binary."""
-    candidates = [base]
-    if _is_windows():
-        existing = {str(base).lower()}
-        for suffix in _WINDOWS_WRAPPER_SUFFIXES:
-            candidate = Path(str(base) + suffix)
-            key = str(candidate).lower()
-            if key not in existing:
-                candidates.append(candidate)
-                existing.add(key)
+    """Return platform-native executable candidates for a staged binary.
+
+    On Windows the extensionless file npm writes next to its wrappers is a
+    POSIX ``sh`` script; handing it to CreateProcess fails with
+    "WinError 193: not a valid Win32 application".  Only the
+    ``.cmd``/``.exe``/``.bat`` wrappers are actually runnable, so the bare
+    path is not a candidate there at all.
+    """
+    if not _is_windows():
+        return [base]
+    candidates: list[Path] = []
+    existing: set[str] = set()
+    for suffix in _WINDOWS_WRAPPER_SUFFIXES:
+        candidate = Path(str(base) + suffix)
+        key = str(candidate).lower()
+        if key not in existing:
+            candidates.append(candidate)
+            existing.add(key)
     return candidates
 
 
+def _npm_bin_dir() -> Path:
+    """npm's own wrapper dir — where relative-path wrappers actually work."""
+    return hermes_lsp_bin_dir().parent / "node_modules" / ".bin"
+
+
 def _existing_binary(name: str) -> Optional[str]:
-    """Probe the staging dir + PATH for a binary named ``name``."""
-    for staged in _native_binary_candidates(hermes_lsp_bin_dir() / name):
-        if staged.exists() and os.access(staged, os.X_OK):
-            return str(staged)
+    """Probe the staging dir, npm's bin dir, then PATH for ``name``."""
+    for base in (hermes_lsp_bin_dir() / name, _npm_bin_dir() / name):
+        for staged in _native_binary_candidates(base):
+            if staged.exists() and os.access(staged, os.X_OK):
+                return str(staged)
     on_path = shutil.which(name)
     if on_path:
         return on_path
@@ -285,6 +299,12 @@ def _install_npm(
     nm_bin = staging / "node_modules" / ".bin" / bin_name
     for c in _native_binary_candidates(nm_bin):
         if c.exists():
+            if _is_windows():
+                # npm's Windows wrappers resolve their payload relative to
+                # their own location (``%dp0%\..\<pkg>\...``), so copying or
+                # symlinking one into ``lsp/bin/`` makes it point at a
+                # directory that does not exist.  Use it where npm put it.
+                return str(c)
             # Symlink into our `lsp/bin/` for stable PATH access.
             link = hermes_lsp_bin_dir() / c.name
             if not link.exists():

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -238,10 +238,15 @@ def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
         bin_path = try_install("pyright", ctx.install_strategy)
         if bin_path is None:
             return None
-    # If we got the cli ``pyright``, the langserver is its sibling.
+    # If we got the cli ``pyright``, the langserver is its sibling — keeping
+    # whatever suffix the resolved binary had, since on Windows the bare
+    # sibling is an unrunnable POSIX shim.
     base = os.path.basename(bin_path)
-    if base in {"pyright", "pyright.exe"}:
-        sibling = os.path.join(os.path.dirname(bin_path), "pyright-langserver")
+    stem, suffix = os.path.splitext(base)
+    if stem == "pyright":
+        sibling = os.path.join(
+            os.path.dirname(bin_path), f"pyright-langserver{suffix}"
+        )
         if os.path.exists(sibling):
             bin_path = sibling
     init: Dict[str, Any] = {}


### PR DESCRIPTION
## Problem

On Windows, **every** npm-installed language server fails to start:

```
WARNING hermes.lint.lsp: lsp[pyright] spawn/initialize failed for <project>:
OSError: [WinError 193] %1 is not a valid Win32 application
```

This affects `pyright`, `typescript-language-server` and `yaml-language-server` —
i.e. all servers using the `npm` install strategy. The result is that post-write
semantic diagnostics in `write_file`/`patch` silently never run on Windows; the
only symptom is that warning line in the gateway log.

## Root cause

npm writes **two** files into `node_modules/.bin` for each executable: an
extensionless POSIX `sh` script and a `.cmd` wrapper. `_native_binary_candidates`
put the bare path first in the candidate list:

```python
candidates = [base]
if _is_windows():
    for suffix in _WINDOWS_WRAPPER_SUFFIXES:
        ...
```

and `_existing_binary` accepts the first candidate that passes
`os.access(path, os.X_OK)`. On Windows that check is true for *any* existing
file, so the `sh` script always won and was handed to `CreateProcess`, which
rejects it with WinError 193.

The staging step in `_install_npm` shares the root cause: it walks the same
candidate list and copies the first hit into `lsp/bin/`. That is broken twice
over, because npm's wrappers resolve their payload **relative to their own
location**:

```bat
"%_prog%"  "%dp0%\..\pyright\langserver.index.js" %*
```

Copying or symlinking one up into `lsp/bin/` makes `%dp0%\..` point at
`<HERMES_HOME>/lsp/`, where no package directory exists. So even the staged
`.cmd` would not have worked.

## Changes

- On Windows, only `.cmd`/`.exe`/`.bat` are candidates — the extensionless
  POSIX shim is never runnable there, so it is not a candidate at all.
- Also probe `node_modules/.bin`, where npm's wrappers actually resolve.
- Skip the copy/symlink staging on Windows and return npm's own path.
- Preserve the resolved suffix when deriving `pyright-langserver` from
  `pyright`, so a resolved `pyright.cmd` does not fall back to the bare sibling.

No behaviour change on POSIX: `_native_binary_candidates` still returns just
`[base]` there.

## Verification

Windows 11, Python 3.11, npm 10 — before the change all three servers failed
with WinError 193. After:

```
pyright-langserver         -> ...\lsp\node_modules\.bin\pyright-langserver.cmd
typescript-language-server -> ...\lsp\node_modules\.bin\typescript-language-server.cmd
yaml-language-server       -> ...\lsp\node_modules\.bin\yaml-language-server.cmd
```

`hermes lsp status` now reports pyright and typescript as `[installed]`, and the
language server process spawns and stays alive over stdio.

Existing suite: `tests/agent/lsp` → **164 passed, 1 failed**. The single failure
is `test_workspace.py::test_normalize_path_expands_tilde`, which is unrelated and
pre-existing on Windows: it sets `HOME=/home/user`, but `os.path.expanduser`
prefers `USERPROFILE` on Windows, so it asserts a POSIX-only expansion.
