### PR TITLE
Drop the remaining session counts from the sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -8,8 +8,8 @@ import { cn } from '@/lib/utils'
 // sections and the project/workspace tree, so it lives outside either to keep
 // imports one-directional (no index <-> projects cycle).
 
-/** The muted count chip next to a section/workspace label. */
-export function SidebarCount({ children }: { children: React.ReactNode }) {
+/** The muted slot beside a section label (loading glyph, status hint). */
+export function SidebarSectionMeta({ children }: { children: React.ReactNode }) {
   return <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{children}</span>
 }
 

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -127,8 +127,6 @@ export function SidebarCronJobsSection({
   const cap = Math.min(visibleCount, max)
   const shown = sorted.slice(0, cap)
   const hiddenCount = Math.min(sorted.length, max) - shown.length
-  // When capped, signal "50+" rather than implying the list is complete.
-  const countLabel = jobs.length > max ? `${max}+` : String(jobs.length)
 
   return (
     <SidebarGroup className="shrink-0 p-0 pb-1">
@@ -139,7 +137,6 @@ export function SidebarCronJobsSection({
           type="button"
         >
           <SidebarPanelLabel>{label}</SidebarPanelLabel>
-          <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{countLabel}</span>
           <DisclosureCaret
             className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"
             open={open}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1223,7 +1223,6 @@ export function ChatSidebar({
                   )
                 }
                 label={s.results}
-                labelMeta={String(searchResults.length)}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}
                 onDeleteSession={onDeleteSession}
@@ -1458,7 +1457,6 @@ export function ChatSidebar({
                         platformName={group.label}
                       />
                     }
-                    labelMeta={String(shownSessions.length)}
                     onArchiveSession={onArchiveSession}
                     onDeleteSession={onDeleteSession}
                     onResumeSession={onResumeSession}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -14,7 +14,7 @@ import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 
-import { SidebarCount, SidebarDateDivider } from './chrome'
+import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
 import {
   EnteredProjectContent,
   ProjectOverviewRow,
@@ -56,7 +56,7 @@ function SidebarSectionHeader({
     <>
       {icon}
       <SidebarPanelLabel>{label}</SidebarPanelLabel>
-      {meta && <SidebarCount>{meta}</SidebarCount>}
+      {meta && <SidebarSectionMeta>{meta}</SidebarSectionMeta>}
     </>
   )
 


### PR DESCRIPTION
Removing the sidebar's session counts has taken three passes because each surface counted its own rows. [#72336](https://github.com/NousResearch/hermes-agent/pull/72336) got the flat list and [#72912](https://github.com/NousResearch/hermes-agent/pull/72912) the entered project; this one sweeps the rest.

Three sites were still tallying: the search-results header, every messaging group header (Telegram, Discord, and the other platform groups), and the cron jobs header — the last with its own `50+` cap label.

With those gone `SidebarCount` no longer renders a count. Its one remaining caller is the projects-loading spinner, so it's renamed `SidebarSectionMeta` to match what it actually holds.