### PR TITLE
docs(feishu): update stale feishu_comment path references after module migration

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2659,7 +2659,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def _on_drive_comment_event(self, data: Any) -> None:
         """Handle drive document comment notification (drive.notice.comment_add_v1).
 
-        Delegates to :mod:`gateway.platforms.feishu_comment` for parsing,
+        Delegates to :mod:`plugins.platforms.feishu.feishu_comment` for parsing,
         logging, and reaction.  Scheduling follows the same
         ``run_coroutine_threadsafe`` pattern used by ``_on_message_event``.
         """

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2611,7 +2611,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def _on_drive_comment_event(self, data: Any) -> None:
         """Handle drive document comment notification (drive.notice.comment_add_v1).
 
-        Delegates to :mod:`gateway.platforms.feishu_comment` for parsing,
+        Delegates to :mod:`plugins.platforms.feishu.feishu_comment` for parsing,
         logging, and reaction.  Scheduling follows the same
         ``run_coroutine_threadsafe`` pattern used by ``_on_message_event``.
         """

--- a/plugins/platforms/feishu/feishu_comment_rules.py
+++ b/plugins/platforms/feishu/feishu_comment_rules.py
@@ -357,7 +357,7 @@ def _main() -> int:
         pass
 
     usage = (
-        "Usage: python -m gateway.platforms.feishu_comment_rules <command> [args]\n"
+        "Usage: python -m plugins.platforms.feishu.feishu_comment_rules <command> [args]\n"
         "\n"
         "Commands:\n"
         "  status                              Show rules config and pairing state\n"

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -64,7 +64,7 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 
 ## `feishu_doc` toolset
 
-Scoped to the Feishu document-comment intelligent-reply handler (`gateway/platforms/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.
+Scoped to the Feishu document-comment intelligent-reply handler (`plugins/platforms/feishu/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -336,15 +336,15 @@ CLI:
 
 ```bash
 # Inspect current rules and pairing state
-python -m gateway.platforms.feishu_comment_rules status
+python -m plugins.platforms.feishu.feishu_comment_rules status
 
 # Simulate an access check for a specific doc + user
-python -m gateway.platforms.feishu_comment_rules check <fileType:fileToken> <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules check <fileType:fileToken> <user_open_id>
 
 # Manage pairing grants at runtime
-python -m gateway.platforms.feishu_comment_rules pairing list
-python -m gateway.platforms.feishu_comment_rules pairing add <user_open_id>
-python -m gateway.platforms.feishu_comment_rules pairing remove <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules pairing list
+python -m plugins.platforms.feishu.feishu_comment_rules pairing add <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules pairing remove <user_open_id>
 ```
 
 ### Required Feishu App Configuration

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
@@ -64,7 +64,7 @@ description: "Hermes 内置工具权威参考，按工具集分组"
 
 ## `feishu_doc` 工具集
 
-仅限飞书文档评论智能回复处理器（`gateway/platforms/feishu_comment.py`）使用。不在 `hermes-cli` 或常规飞书聊天适配器中暴露。
+仅限飞书文档评论智能回复处理器（`plugins/platforms/feishu/feishu_comment.py`）使用。不在 `hermes-cli` 或常规飞书聊天适配器中暴露。
 
 | 工具 | 描述 | 所需环境 |
 |------|------|----------|

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
@@ -302,15 +302,15 @@ CLI：
 
 ```bash
 # 查看当前规则和 pairing 状态
-python -m gateway.platforms.feishu_comment_rules status
+python -m plugins.platforms.feishu.feishu_comment_rules status
 
 # 模拟特定文档 + 用户的访问检查
-python -m gateway.platforms.feishu_comment_rules check <fileType:fileToken> <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules check <fileType:fileToken> <user_open_id>
 
 # 运行时管理 pairing 授权
-python -m gateway.platforms.feishu_comment_rules pairing list
-python -m gateway.platforms.feishu_comment_rules pairing add <user_open_id>
-python -m gateway.platforms.feishu_comment_rules pairing remove <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules pairing list
+python -m plugins.platforms.feishu.feishu_comment_rules pairing add <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules pairing remove <user_open_id>
 ```
 
 ### 飞书应用所需配置


### PR DESCRIPTION
## Problem

Six files still reference the old module locations for the Feishu document-comment handler:
- Docs cite `gateway/platforms/feishu_comment.py` and `gateway.platforms.feishu_comment_rules`
- These modules were migrated to `plugins/platforms/feishu/` long ago

This misleads users trying to run `python -m gateway.platforms.feishu_comment_rules status` (ModuleNotFoundError) and anyone looking for the source file at the documented path.

## Triage / Root cause

The feishu platform modules moved from `gateway/platforms/` to `plugins/platforms/feishu/` but docs and inline usage strings were not updated to match.

Affected files:
- `website/docs/reference/tools-reference.md` — EN path reference
- `website/i18n/zh-Hans/.../reference/tools-reference.md` — zh-Hans mirror
- `website/docs/user-guide/messaging/feishu.md` — CLI examples
- `website/i18n/zh-Hans/.../messaging/feishu.md` — zh-Hans mirror
- `plugins/platforms/feishu/feishu_comment_rules.py` — usage string
- `plugins/platforms/feishu/adapter.py` — docstring cross-reference

## Fix

- Updated all `gateway/platforms/feishu_comment` → `plugins/platforms/feishu/feishu_comment`
- Updated all `gateway.platforms.feishu_comment_rules` → `plugins.platforms.feishu.feishu_comment_rules`
- Covers both English docs and zh-Hans locale mirrors

Consolidates and replaces #71371, #71501, and #71551 (closed after rebase became impossible from stale branches).

## Verification

- `grep -r "gateway/platforms/feishu_comment\|gateway.platforms.feishu_comment" website/ plugins/platforms/feishu/` returns zero matches in the changed files
- New paths match actual file locations: `ls plugins/platforms/feishu/feishu_comment.py plugins/platforms/feishu/feishu_comment_rules.py` succeeds