### PR TITLE
fix(agent): sanitize tool schemas for MiniMax OpenAI-compatible endpoint

### DIFF
--- a/agent/minimax_schema.py
+++ b/agent/minimax_schema.py
@@ -1,0 +1,322 @@
+"""Helpers for translating OpenAI-style tool schemas to MiniMax's schema subset.
+
+MiniMax's OpenAI-compatible endpoint (api.minimax.io/v1) rejects several
+standard JSON Schema constructs that OpenAI and other providers accept:
+
+1. ``boolean`` type parameters — MiniMax expects ``"type": "string"`` with
+   an ``enum`` of ``["true", "false"]`` or similar string alternatives.
+2. ``nullable`` keyword — non-standard in JSON Schema; MiniMax rejects it.
+3. ``anyOf``/``oneOf`` containing ``{"type": "null"}`` branches — collapse them.
+4. Missing ``type`` on property schemas — MiniMax requires explicit types.
+5. Missing ``required`` array on object schemas — MiniMax requires it.
+6. Top-level ``parameters`` must be ``type: object``.
+
+Known rejection sources include browser tool schemas that use ``"type": "boolean"``
+(e.g. ``browser_snapshot.full``), which MiniMax cannot parse.
+
+Reference: https://platform.minimax.io/docs/api-reference/text-anthropic-api
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any, Dict, List
+
+# Keys whose values are maps of name → schema (not schemas themselves).
+# When we recurse, we walk the values of these maps as schemas, but we do
+# NOT apply the missing-type repair to the map itself.
+_SCHEMA_MAP_KEYS = frozenset({"properties", "patternProperties", "$defs", "definitions"})
+
+# Keys whose values are lists of schemas.
+_SCHEMA_LIST_KEYS = frozenset({"anyOf", "oneOf", "allOf", "prefixItems"})
+
+# Keys whose values are a single nested schema.
+_SCHEMA_NODE_KEYS = frozenset({"items", "contains", "not", "additionalProperties", "propertyNames"})
+
+# Model slugs (lowercased) that identify MiniMax models.
+# Covers the known family: minimax-m3, minimax-m2.7, minimax-m2.5, etc.
+_MINIMAX_MODEL_PREFIXES = frozenset({"minimax-m3", "minimax-m2", "minimax3", "minimax-m1"})
+
+
+def _repair_schema(node: Any, is_schema: bool = True) -> Any:
+    """Recursively apply MiniMax repairs to a schema node.
+
+    ``is_schema=True`` means this dict is a JSON Schema node and gets the
+    missing-type, boolean→string, null-collapse, and required-array repairs
+    applied.  ``is_schema=False`` means it's a container map (e.g. the value
+    of ``properties``) and we only recurse into its values.
+    """
+    if isinstance(node, list):
+        # Lists only show up under schema-list keys (anyOf/oneOf/allOf), so
+        # every element is itself a schema.
+        return [_repair_schema(item, is_schema=True) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    # Walk the dict, deciding per-key whether recursion is into a schema
+    # node, a container map, or a scalar.
+    repaired: Dict[str, Any] = {}
+    for key, value in node.items():
+        if key in _SCHEMA_MAP_KEYS and isinstance(value, dict):
+            # Map of name → schema.  Don't treat the map itself as a schema
+            # (it has no type / properties of its own), but each value is.
+            repaired[key] = {
+                sub_key: _repair_schema(sub_val, is_schema=True)
+                for sub_key, sub_val in value.items()
+            }
+        elif key in _SCHEMA_LIST_KEYS and isinstance(value, list):
+            repaired[key] = [_repair_schema(v, is_schema=True) for v in value]
+        elif key in _SCHEMA_NODE_KEYS:
+            # items / not / additionalProperties: single nested schema.
+            # additionalProperties can also be a bool — leave those alone.
+            if isinstance(value, dict):
+                repaired[key] = _repair_schema(value, is_schema=True)
+            else:
+                repaired[key] = value
+        else:
+            # Scalars (description, title, format, enum values, etc.) pass through.
+            repaired[key] = value
+
+    if not is_schema:
+        return repaired
+
+    # Rule 1: Collapse anyOf/oneOf with null branches.
+    # MiniMax rejects {"anyOf": [{"type": "null"}, {"type": "string"}]}.
+    # Collapse such anyOf to the first non-null branch.
+    for kw in ("anyOf", "oneOf"):
+        if kw in repaired and isinstance(repaired[kw], list):
+            non_null = [
+                b for b in repaired[kw]
+                if isinstance(b, dict) and b.get("type") != "null"
+            ]
+            if non_null and len(non_null) < len(repaired[kw]):
+                if len(non_null) == 1:
+                    # Promote the single non-null branch into the parent.
+                    merged = {k: v for k, v in repaired.items() if k != kw}
+                    merged.update(non_null[0])
+                    repaired = merged
+                    # Continue with the merged node so that further repairs
+                    # (boolean→string, missing type, etc.) apply.
+                else:
+                    repaired[kw] = non_null
+                    return repaired
+            elif not non_null:
+                # Everything was null; collapse to a string schema.
+                repaired.pop(kw, None)
+                repaired["type"] = "string"
+            else:
+                # No null branches — already clean.  Recurse done above.
+                return repaired
+
+    # Rule 2: Strip non-standard keywords that MiniMax rejects.
+    repaired.pop("nullable", None)
+    # `default` is not part of the OpenAI function-calling spec and many
+    # providers reject it.  Fold the value into the description instead.
+    default_val = repaired.pop("default", None)
+    if default_val is not None and "description" in repaired:
+        repaired["description"] = (
+            f"{repaired['description']} (default: {json.dumps(default_val)})"
+        )
+
+    # Rule 3: Convert boolean type to integer (0/1).
+    # MiniMax rejects ``"type": "boolean"`` in tool schemas.
+    # Using integer (not string) so Python truthiness works: 0→False, 1→True.
+    # The description is updated so the model knows to emit 0 or 1.
+    type_val = repaired.get("type")
+    if type_val == "boolean":
+        repaired["type"] = "integer"
+        repaired["enum"] = [0, 1]
+        if "description" in repaired:
+            repaired["description"] = (
+                f"{repaired['description']} (0=false, 1=true)"
+            )
+
+    # Rule 4: Fix enum arrays that MiniMax rejects.
+    # MiniMax rejects non-string values in enum arrays (boolean, integer, etc.).
+    if "enum" in repaired and isinstance(repaired["enum"], list):
+        # If type was already string or we just set it above, coerce enum values to strings.
+        if repaired.get("type") == "string":
+            cleaned: List[str] = []
+            for v in repaired["enum"]:
+                if v is None:
+                    continue
+                if isinstance(v, bool):
+                    cleaned.append("true" if v else "false")
+                else:
+                    cleaned.append(str(v))
+            cleaned = [v for v in cleaned if v != ""]
+            if cleaned:
+                repaired["enum"] = cleaned
+            else:
+                repaired.pop("enum")
+
+    # Rule 5: $ref nodes are exempt from type inference.
+    if "$ref" not in repaired:
+        repaired = _fill_missing_type(repaired)
+
+    # Rule 6: Object schemas must carry a `required` array.
+    if repaired.get("type") == "object":
+        repaired = _ensure_required_array(repaired)
+
+    return repaired
+
+
+def _ensure_required_array(node: Dict[str, Any]) -> Dict[str, Any]:
+    """Guarantee an object schema carries a ``required`` array (MiniMax rule).
+
+    Standard JSON Schema lets you omit ``required`` when nothing is required;
+    MiniMax rejects that.  Ensure the key is a list.  When ``properties`` is
+    known, prune ``required`` entries that don't name a real property —
+    defensive against dangling names.  Mutates and returns ``node``.
+    """
+    props = node.get("properties")
+    req = node.get("required")
+    if isinstance(req, list):
+        if isinstance(props, dict):
+            node["required"] = [r for r in req if r in props]
+    else:
+        node["required"] = []
+    return node
+
+
+def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
+    """Infer a reasonable ``type`` if this schema node has none."""
+    node_type = node.get("type")
+    if isinstance(node_type, list):
+        concrete = next(
+            (t for t in node_type if isinstance(t, str) and t not in {"", "null"}),
+            "string",
+        )
+        return {**node, "type": concrete}
+    if "type" in node and node_type not in {None, ""}:
+        return node
+
+    # Heuristic: presence of properties → object, items → array, enum → string,
+    # else fall back to ``string`` (safest scalar).
+    if "properties" in node or "required" in node or "additionalProperties" in node:
+        inferred = "object"
+    elif "items" in node or "prefixItems" in node:
+        inferred = "array"
+    elif "enum" in node and isinstance(node["enum"], list) and node["enum"]:
+        inferred = "string"
+    else:
+        inferred = "string"
+
+    return {**node, "type": inferred}
+
+
+def sanitize_minimax_tool_parameters(parameters: Any) -> Dict[str, Any]:
+    """Normalize tool parameters to a MiniMax-compatible object schema.
+
+    Returns a deep-copied schema with all MiniMax repair rules applied.
+    Input is not mutated.
+    """
+    if not isinstance(parameters, dict):
+        return {"type": "object", "properties": {}, "required": []}
+
+    repaired = _repair_schema(copy.deepcopy(parameters), is_schema=True)
+    if not isinstance(repaired, dict):
+        return {"type": "object", "properties": {}, "required": []}
+
+    # Top-level must be an object schema
+    if repaired.get("type") != "object":
+        repaired["type"] = "object"
+    if "properties" not in repaired:
+        repaired["properties"] = {}
+    _ensure_required_array(repaired)
+
+    return repaired
+
+
+def sanitize_minimax_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Apply ``sanitize_minimax_tool_parameters`` to every tool's parameters.
+
+    Handles both Anthropic-style tool schemas (``input_schema``) and
+    OpenAI-style tool schemas (``function.parameters``).
+
+    Returns a new list with sanitized tools if any changes were made,
+    or the original list if nothing needed repair.
+    """
+    if not tools:
+        return tools
+
+    sanitized: List[Dict[str, Any]] = []
+    any_change = False
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            sanitized.append(tool)
+            continue
+
+        tool_copy: Dict[str, Any] = copy.deepcopy(tool)
+
+        # --- OpenAI-style: tool["function"]["parameters"] ---
+        fn = tool_copy.get("function")
+        if isinstance(fn, dict):
+            params = fn.get("parameters")
+            repaired = sanitize_minimax_tool_parameters(params)
+            if repaired is not params:
+                any_change = True
+                fn["parameters"] = repaired
+
+        # --- Anthropic-style: tool["input_schema"] ---
+        input_schema = tool_copy.get("input_schema")
+        if isinstance(input_schema, dict):
+            # Anthropic input_schema is already the parameters dict itself
+            repaired = sanitize_minimax_tool_parameters(input_schema)
+            if repaired is not input_schema:
+                any_change = True
+                tool_copy["input_schema"] = repaired
+
+        sanitized.append(tool_copy)
+
+    return sanitized if any_change else tools
+
+
+def is_minimax_model(model: str | None) -> bool:
+    """True for any MiniMax model slug, regardless of aggregator prefix.
+
+    Matches bare names (``minimax-m3``, ``MiniMax-M2.7``, ``MiniMax3``),
+    vendor-prefixed slugs (``minimax/MiniMax-M3``),
+    and aggregator-prefixed slugs (``nous/minimax/minimax-m3``,
+    ``openrouter/minimax/...``).
+
+    Detection by model name covers aggregators that route to MiniMax's
+    inference where the base URL is the aggregator's, not api.minimax.io.
+
+    Model name patterns matched:
+    - ``minimax-m3``, ``minimax-m2.7``, ``minimax-m2.5`` (and any minimax-m*)
+    - ``MiniMax-M3``, ``MiniMax-M2.7`` (case-insensitive)
+    - ``minimax/MiniMax-M3``, ``openrouter/minimax/...``
+    - ``MiniMax3``, ``minimax3`` (compact form)
+    - ``MiniMax-M2.7-free``, ``minimax-m2.5-free`` (suffixed variants)
+    """
+    if not model:
+        return False
+    bare = model.strip().lower()
+
+    # Last path segment (covers aggregator-prefixed slugs like
+    # "openrouter/minimax/minimax-m3")
+    tail = bare.rsplit("/", 1)[-1]
+
+    # Check against known MiniMax model prefixes
+    for prefix in _MINIMAX_MODEL_PREFIXES:
+        if tail == prefix or tail.startswith(prefix + ".") or tail.startswith(prefix + "-"):
+            return True
+
+    # Also match the form "minimax3" (no hyphen) and "mini-max-*"
+    if tail.startswith("minimax3") or tail.startswith("mini-max-"):
+        return True
+
+    # Vendor-prefixed forms — "minimax/" in the path
+    if "/minimax/" in bare or bare.startswith("minimax/"):
+        return True
+
+    # Catch-all: the bare word "minimax" anywhere is a strong signal
+    if "minimax" in bare:
+        # But avoid false matches on non-MiniMax slugs that happen to
+        # contain the substring — "minimax" is distinctive enough.
+        return True
+
+    return False

--- a/agent/minimax_schema.py
+++ b/agent/minimax_schema.py
@@ -99,15 +99,16 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
                     # Continue with the merged node so that further repairs
                     # (boolean→string, missing type, etc.) apply.
                 else:
+                    # Keep the reduced union (all non-null branches) and fall
+                    # through to the common cleanup so outer ``nullable`` /
+                    # ``default`` keywords are still stripped.
                     repaired[kw] = non_null
-                    return repaired
             elif not non_null:
                 # Everything was null; collapse to a string schema.
                 repaired.pop(kw, None)
                 repaired["type"] = "string"
-            else:
-                # No null branches — already clean.  Recurse done above.
-                return repaired
+            # else: no null branches — union is already clean; fall through to
+            # the common cleanup for the outer keywords.
 
     # Rule 2: Strip non-standard keywords that MiniMax rejects.
     repaired.pop("nullable", None)
@@ -151,8 +152,14 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
             else:
                 repaired.pop("enum")
 
-    # Rule 5: $ref nodes are exempt from type inference.
-    if "$ref" not in repaired:
+    # Rule 5: $ref nodes and retained union nodes are exempt from type
+    # inference.  A kept anyOf/oneOf has no single type — synthesizing one
+    # (e.g. the ``string`` fallback) would wrongly constrain the union.
+    if (
+        "$ref" not in repaired
+        and "anyOf" not in repaired
+        and "oneOf" not in repaired
+    ):
         repaired = _fill_missing_type(repaired)
 
     # Rule 6: Object schemas must carry a `required` array.

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -12,6 +12,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
+from agent.minimax_schema import is_minimax_model, sanitize_minimax_tools
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
@@ -371,6 +372,8 @@ class ChatCompletionsTransport(ProviderTransport):
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            elif is_minimax_model(model):
+                tools = sanitize_minimax_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > provider default
@@ -558,6 +561,8 @@ class ChatCompletionsTransport(ProviderTransport):
         if tools:
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            elif is_minimax_model(model):
+                tools = sanitize_minimax_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > profile default

--- a/contributors/emails/DavidMetcalfe@users.noreply.github.com
+++ b/contributors/emails/DavidMetcalfe@users.noreply.github.com
@@ -1,0 +1,1 @@
+DavidMetcalfe

--- a/model_tools.py
+++ b/model_tools.py
@@ -1030,9 +1030,9 @@ def _coerce_boolean(value):
         return bool(value)
     if isinstance(value, str):
         low = value.strip().lower()
-        if low == "true":
+        if low in ("true", "1"):
             return True
-        if low == "false":
+        if low in ("false", "0"):
             return False
     return value
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -786,6 +786,13 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
             continue
 
         if not isinstance(value, str):
+            # Integer 0/1 → boolean coercion for MiniMax compatibility.
+            # When the schema sanitizer converts boolean to integer for
+            # MiniMax's OpenAI-compat endpoint, the model outputs 0/1 but
+            # the registry's original schema still expects boolean.
+            if expected == "boolean" and isinstance(value, int):
+                args[key] = bool(value)
+                continue
             # Recurse into already-native containers so JSON-encoded
             # *elements* (array items) and *sub-fields* (nested object
             # properties) get normalized too — e.g. ``todos: ['{"id":...}']``
@@ -1010,13 +1017,23 @@ def _coerce_number(value: str, integer_only: bool = False):
     return f
 
 
-def _coerce_boolean(value: str):
-    """Try to parse *value* as a boolean.  Returns original string on failure."""
-    low = value.strip().lower()
-    if low == "true":
-        return True
-    if low == "false":
-        return False
+def _coerce_boolean(value):
+    """Try to parse *value* as a boolean.  Returns original value on failure.
+
+    Handles string inputs (``"true"``/``"false"``) and integer inputs
+    (``0``/``1``) — the latter arises from MiniMax schema sanitization
+    which converts ``boolean`` → ``integer [0, 1]``.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        low = value.strip().lower()
+        if low == "true":
+            return True
+        if low == "false":
+            return False
     return value
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -1030,9 +1030,9 @@ def _coerce_boolean(value):
         return bool(value)
     if isinstance(value, str):
         low = value.strip().lower()
-        if low in ("true", "1"):
+        if low == "true":
             return True
-        if low in ("false", "0"):
+        if low == "false":
             return False
     return value
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -790,7 +790,7 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
             # When the schema sanitizer converts boolean to integer for
             # MiniMax's OpenAI-compat endpoint, the model outputs 0/1 but
             # the registry's original schema still expects boolean.
-            if expected == "boolean" and isinstance(value, int):
+            if expected == "boolean" and isinstance(value, int) and value in (0, 1):
                 args[key] = bool(value)
                 continue
             # Recurse into already-native containers so JSON-encoded
@@ -1027,7 +1027,12 @@ def _coerce_boolean(value):
     if isinstance(value, bool):
         return value
     if isinstance(value, int):
-        return bool(value)
+        # Only coerce explicit 0/1 — avoids silently converting arbitrary
+        # integers. MiniMax schema sanitization emits enum: [0, 1] so the
+        # model should never produce other values.
+        if value in (0, 1):
+            return bool(value)
+        return value
     if isinstance(value, str):
         low = value.strip().lower()
         if low == "true":

--- a/tests/agent/test_minimax_schema.py
+++ b/tests/agent/test_minimax_schema.py
@@ -1,0 +1,394 @@
+"""Tests for agent.minimax_schema — MiniMax tool schema sanitization."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from agent.minimax_schema import (
+    is_minimax_model,
+    sanitize_minimax_tool_parameters,
+    sanitize_minimax_tools,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_minimax_model
+# ---------------------------------------------------------------------------
+
+class TestIsMiniMaxModel:
+    """Model-name detection for MiniMax family."""
+
+    @pytest.mark.parametrize("model", [
+        "MiniMax3",
+        "minimax3",
+        "MiniMax-M3",
+        "minimax-m3",
+        "MiniMax-M2.7",
+        "minimax-m2.7",
+        "minimax-m2.5",
+        "minimax-m2.7-free",
+        "minimax/MiniMax-M3",
+        "openrouter/minimax/minimax-m3",
+        "nous/minimax/minimax-m2.7",
+    ])
+    def test_minimax_models_detected(self, model):
+        assert is_minimax_model(model) is True
+
+    @pytest.mark.parametrize("model", [
+        "gpt-4",
+        "gpt-5",
+        "claude-3-opus",
+        "deepseek-v3",
+        "qwen-max",
+        "moonshot-v1",
+        "kimi-k2.6",
+        "gemini-2.0-flash",
+        "",
+        None,
+    ])
+    def test_non_minimax_not_detected(self, model):
+        assert is_minimax_model(model) is False
+
+    def test_case_insensitive(self):
+        assert is_minimax_model("MINIMAX-M3") is True
+        assert is_minimax_model("MINIMAX3") is True
+
+
+# ---------------------------------------------------------------------------
+# sanitize_minimax_tool_parameters
+# ---------------------------------------------------------------------------
+
+class TestSanitizeMiniMaxToolParameters:
+    """Schema-level repairs for MiniMax compatibility."""
+
+    def test_boolean_converted_to_integer(self):
+        """Boolean type → integer with enum [0, 1]."""
+        params = {
+            "type": "object",
+            "properties": {
+                "full": {
+                    "type": "boolean",
+                    "description": "If true, return complete content.",
+                }
+            },
+            "required": [],
+        }
+        result = sanitize_minimax_tool_parameters(params)
+        full = result["properties"]["full"]
+        assert full["type"] == "integer"
+        assert full["enum"] == [0, 1]
+        assert "0=false" in full["description"]
+
+    def test_boolean_with_default_strips_default(self):
+        """Default keyword is stripped and folded into description."""
+        params = {
+            "type": "object",
+            "properties": {
+                "verbose": {
+                    "type": "boolean",
+                    "description": "Enable verbose output.",
+                    "default": False,
+                }
+            },
+            "required": [],
+        }
+        result = sanitize_minimax_tool_parameters(params)
+        verbose = result["properties"]["verbose"]
+        assert "default" not in verbose
+        assert "default:" in verbose["description"]
+        assert verbose["type"] == "integer"
+
+    def test_nullable_stripped(self):
+        """Nullable keyword is removed."""
+        params = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "nullable": True}
+            },
+            "required": [],
+        }
+        result = sanitize_minimax_tool_parameters(params)
+        assert "nullable" not in result["properties"]["name"]
+
+    def test_anyOf_null_collapsed(self):
+        """anyOf with null branch collapses to the non-null branch."""
+        params = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {"type": "null"},
+                        {"type": "string"},
+                    ]
+                }
+            },
+            "required": [],
+        }
+        result = sanitize_minimax_tool_parameters(params)
+        value = result["properties"]["value"]
+        assert "anyOf" not in value
+        assert value["type"] == "string"
+
+    def test_missing_type_filled(self):
+        """Missing type on property → inferred type."""
+        params = {
+            "type": "object",
+            "properties": {
+                "name": {"description": "A name"},
+                "items": {"items": {"type": "string"}, "description": "A list"},
+            },
+            "required": [],
+        }
+        result = sanitize_minimax_tool_parameters(params)
+        assert result["properties"]["name"]["type"] == "string"
+        assert result["properties"]["items"]["type"] == "array"
+
+    def test_object_without_required_gets_empty_array(self):
+        """Object schemas must have a required array."""
+        params = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            # no "required" key
+        }
+        result = sanitize_minimax_tool_parameters(params)
+        assert "required" in result
+        assert isinstance(result["required"], list)
+
+    def test_top_level_always_object(self):
+        """Top-level parameters must be type: object."""
+        params = {"type": "string"}
+        result = sanitize_minimax_tool_parameters(params)
+        assert result["type"] == "object"
+
+    def test_non_dict_input_returns_default(self):
+        """Non-dict input → default empty object schema."""
+        result = sanitize_minimax_tool_parameters(None)
+        assert result == {"type": "object", "properties": {}, "required": []}
+
+        result = sanitize_minimax_tool_parameters("invalid")
+        assert result["type"] == "object"
+
+    def test_preserves_string_enum(self):
+        """String enums are preserved."""
+        params = {
+            "type": "object",
+            "properties": {
+                "direction": {
+                    "type": "string",
+                    "enum": ["up", "down"],
+                }
+            },
+            "required": ["direction"],
+        }
+        result = sanitize_minimax_tool_parameters(params)
+        assert result["properties"]["direction"]["enum"] == ["up", "down"]
+
+    def test_input_not_mutated(self):
+        """Original input is not mutated."""
+        params = {
+            "type": "object",
+            "properties": {
+                "flag": {"type": "boolean", "default": False}
+            },
+        }
+        original = copy.deepcopy(params)
+        sanitize_minimax_tool_parameters(params)
+        assert params == original
+
+
+# ---------------------------------------------------------------------------
+# sanitize_minimax_tools
+# ---------------------------------------------------------------------------
+
+class TestSanitizeMiniMaxTools:
+    """Full tool-list sanitization."""
+
+    def _make_tool(self, name, params):
+        return {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"Tool {name}",
+                "parameters": params,
+            }
+        }
+
+    def test_sanitizes_openai_style(self):
+        """OpenAI-style tools (type=function, function.parameters)."""
+        tool = self._make_tool("test_tool", {
+            "type": "object",
+            "properties": {
+                "flag": {"type": "boolean", "description": "A flag"}
+            },
+            "required": [],
+        })
+        result = sanitize_minimax_tools([tool])
+        flag = result[0]["function"]["parameters"]["properties"]["flag"]
+        assert flag["type"] == "integer"
+        assert flag["enum"] == [0, 1]
+
+    def test_sanitizes_anthropic_style(self):
+        """Anthropic-style tools (input_schema)."""
+        tool = {
+            "name": "test_tool",
+            "description": "A test tool",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "flag": {"type": "boolean", "description": "A flag"}
+                },
+                "required": [],
+            },
+        }
+        result = sanitize_minimax_tools([tool])
+        flag = result[0]["input_schema"]["properties"]["flag"]
+        assert flag["type"] == "integer"
+        assert flag["enum"] == [0, 1]
+
+    def test_empty_tools_unchanged(self):
+        """Empty/None tools list returns as-is."""
+        assert sanitize_minimax_tools([]) == []
+        assert sanitize_minimax_tools(None) is None
+
+    def test_browser_snapshot_tool(self):
+        """Real browser_snapshot schema is sanitized correctly."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "browser_snapshot",
+                "description": "Get a text-based snapshot.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "full": {
+                            "type": "boolean",
+                            "description": "If true, returns complete page content.",
+                            "default": False,
+                        }
+                    },
+                    "required": [],
+                },
+            },
+        }
+        result = sanitize_minimax_tools([tool])
+        full = result[0]["function"]["parameters"]["properties"]["full"]
+        assert full["type"] == "integer"
+        assert full["enum"] == [0, 1]
+        assert "default" not in full
+
+    def test_mixed_tools(self):
+        """Mix of boolean and string tools all sanitized."""
+        tools = [
+            self._make_tool("a", {
+                "type": "object",
+                "properties": {"x": {"type": "boolean"}},
+                "required": [],
+            }),
+            self._make_tool("b", {
+                "type": "object",
+                "properties": {"y": {"type": "string"}},
+                "required": ["y"],
+            }),
+        ]
+        result = sanitize_minimax_tools(tools)
+        assert result[0]["function"]["parameters"]["properties"]["x"]["type"] == "integer"
+        assert result[1]["function"]["parameters"]["properties"]["y"]["type"] == "string"
+
+    def test_input_not_mutated(self):
+        """Original tools list is not mutated."""
+        tools = [self._make_tool("test", {
+            "type": "object",
+            "properties": {"flag": {"type": "boolean"}},
+            "required": [],
+        })]
+        original = copy.deepcopy(tools)
+        sanitize_minimax_tools(tools)
+        assert tools == original
+
+    def test_real_browser_back_tool(self):
+        """browser_back with empty properties passes through cleanly."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "browser_back",
+                "description": "Navigate back.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                },
+            },
+        }
+        result = sanitize_minimax_tools([tool])
+        params = result[0]["function"]["parameters"]
+        assert params["type"] == "object"
+        assert params["required"] == []
+
+    def test_real_browser_scroll_tool(self):
+        """browser_scroll with string enum preserved."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "browser_scroll",
+                "description": "Scroll the page.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "direction": {
+                            "type": "string",
+                            "enum": ["up", "down"],
+                        }
+                    },
+                    "required": ["direction"],
+                },
+            },
+        }
+        result = sanitize_minimax_tools([tool])
+        direction = result[0]["function"]["parameters"]["properties"]["direction"]
+        assert direction["type"] == "string"
+        assert direction["enum"] == ["up", "down"]
+
+    def test_browser_console_tool(self):
+        """browser_console with boolean clear + string expression."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "browser_console",
+                "description": "Get console output.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "clear": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "If true, clear buffers",
+                        },
+                        "expression": {
+                            "type": "string",
+                            "description": "JS expression to evaluate",
+                        },
+                    },
+                    "required": [],
+                },
+            },
+        }
+        result = sanitize_minimax_tools([tool])
+        props = result[0]["function"]["parameters"]["properties"]
+        assert props["clear"]["type"] == "integer"
+        assert props["clear"]["enum"] == [0, 1]
+        assert "default" not in props["clear"]
+        assert props["expression"]["type"] == "string"
+
+    def test_no_changes_preserves_content(self):
+        """Content is preserved when nothing needed repair."""
+        tools = [self._make_tool("test", {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        })]
+        result = sanitize_minimax_tools(tools)
+        # No boolean, no missing types, no nullable → content unchanged
+        assert result[0]["function"]["parameters"] == tools[0]["function"]["parameters"]

--- a/tests/agent/test_minimax_schema.py
+++ b/tests/agent/test_minimax_schema.py
@@ -132,6 +132,59 @@ class TestSanitizeMiniMaxToolParameters:
         assert "anyOf" not in value
         assert value["type"] == "string"
 
+    def test_multibranch_null_union_strips_outer_keywords(self):
+        """A retained multi-branch union still loses outer nullable/default.
+
+        Regression for the review finding: the union-handling path returned
+        early, so ``nullable`` and ``default`` survived on
+        ``anyOf: [string, integer, null]`` schemas and MiniMax would still
+        reject the emitted tool schema.
+        """
+        params = {
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "null"},
+                    ],
+                    "nullable": True,
+                    "default": "auto",
+                    "description": "Mode",
+                }
+            },
+            "required": [],
+        }
+        result = sanitize_minimax_tool_parameters(params)
+        mode = result["properties"]["mode"]
+        assert "nullable" not in mode
+        assert "default" not in mode
+        # Union kept (two non-null branches) without a synthetic type.
+        assert mode["anyOf"] == [{"type": "string"}, {"type": "integer"}]
+        assert "type" not in mode
+        # Common cleanup ran: default folded into the description.
+        assert "default:" in mode["description"]
+
+    def test_clean_union_strips_outer_keywords(self):
+        """Even a union with no null branches gets outer keyword cleanup."""
+        params = {
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "anyOf": [{"type": "string"}, {"type": "integer"}],
+                    "nullable": True,
+                    "default": "auto",
+                }
+            },
+            "required": [],
+        }
+        result = sanitize_minimax_tool_parameters(params)
+        mode = result["properties"]["mode"]
+        assert "nullable" not in mode
+        assert "default" not in mode
+        assert mode["anyOf"] == [{"type": "string"}, {"type": "integer"}]
+
     def test_missing_type_filled(self):
         """Missing type on property → inferred type."""
         params = {

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -795,6 +795,120 @@ class TestChatCompletionsKimi:
         assert "type" not in kw["tools"][0]["function"]["parameters"]["properties"]["q"]
 
 
+class TestChatCompletionsMiniMax:
+    """MiniMax schema sanitization on both request-construction paths."""
+
+    def _minimax_tools(self, parameters):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "browser_snapshot",
+                    "description": "Snapshot",
+                    "parameters": parameters,
+                },
+            },
+        ]
+
+    def test_minimax_tools_sanitized_on_legacy_path(self, transport):
+        """Aggregator routes (Nous, OpenRouter) hit MiniMax by model name,
+        not base URL — the legacy (no provider profile) path must sanitize
+        the boolean tool parameter for the wire."""
+        tools = self._minimax_tools(
+            {
+                "type": "object",
+                "properties": {
+                    "full": {"type": "boolean", "description": "Full page"},
+                },
+            }
+        )
+        kw = transport.build_kwargs(
+            model="minimax/MiniMax-M3",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        prop = kw["tools"][0]["function"]["parameters"]["properties"]["full"]
+        assert prop["type"] == "integer"
+        assert prop["enum"] == [0, 1]
+
+    def test_minimax_tools_sanitized_on_provider_profile_path(self, transport):
+        """The ProviderProfile request-construction path sanitizes too."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("nous")
+        tools = self._minimax_tools(
+            {
+                "type": "object",
+                "properties": {
+                    "full": {"type": "boolean", "description": "Full page"},
+                },
+            }
+        )
+        kw = transport.build_kwargs(
+            model="minimax/MiniMax-M3",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            provider_profile=profile,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        prop = kw["tools"][0]["function"]["parameters"]["properties"]["full"]
+        assert prop["type"] == "integer"
+        assert prop["enum"] == [0, 1]
+
+    def test_minimax_multibranch_null_union_cleaned_on_wire(self, transport):
+        """Outer nullable/default are stripped from a retained multi-branch
+        union in the emitted tool schema (regression for the early-return
+        skip in the sanitizer)."""
+        tools = self._minimax_tools(
+            {
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "integer"},
+                            {"type": "null"},
+                        ],
+                        "nullable": True,
+                        "default": "auto",
+                        "description": "Mode",
+                    },
+                },
+            }
+        )
+        kw = transport.build_kwargs(
+            model="minimax/MiniMax-M3",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        mode = kw["tools"][0]["function"]["parameters"]["properties"]["mode"]
+        assert "nullable" not in mode
+        assert "default" not in mode
+        assert mode["anyOf"] == [{"type": "string"}, {"type": "integer"}]
+
+    def test_non_minimax_tools_are_not_mutated(self, transport):
+        """Other models don't go through the MiniMax sanitizer."""
+        tools = self._minimax_tools(
+            {
+                "type": "object",
+                "properties": {
+                    "full": {"type": "boolean", "description": "Full page"},
+                },
+            }
+        )
+        kw = transport.build_kwargs(
+            model="anthropic/claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        # The boolean parameter is passed through untouched
+        prop = kw["tools"][0]["function"]["parameters"]["properties"]["full"]
+        assert prop["type"] == "boolean"
+
+
 class TestChatCompletionsLmStudioReasoning:
     """LM Studio publishes per-model reasoning ``allowed_options``. When the
     user requests an effort the model can't honor (e.g. ``high`` on a


### PR DESCRIPTION
## Summary

MiniMax M3 rejects standard JSON Schema constructs in tool definitions when routed through custom OpenAI-compatible providers (e.g. 9Router). Browser tools using `boolean` types, `default` keywords, and `anyOf`/`null` patterns trigger HTTP 400 `"invalid tool types (2013)"`.

This adds `agent/minimax_schema.py` — a tool-schema sanitizer for MiniMax, following the established pattern of `agent/moonshot_schema.py`.

## Root Cause

When MiniMax M3 is accessed through a custom OpenAI-compatible provider (9Router), tools are sent in standard OpenAI format. MiniMax's OpenAI-compatible endpoint is stricter than most providers about JSON Schema features in tool parameter definitions:

1. **`boolean` type** — MiniMax rejects `"type": "boolean"`. Used in browser tools (`browser_snapshot.full`, `browser_vision.annotate`, `browser_console.clear`).
2. **`default` keyword** — While valid in standard JSON Schema (which OpenAI natively accepts), MiniMax's strict endpoint rejects it.
3. **`nullable` keyword** — An OpenAPI 3.0 construct that MiniMax rejects alongside standard JSON Schema `anyOf` null unions.
4. **`anyOf`/`oneOf` with `null` branches** — MiniMax rejects nullable union patterns.
5. **Missing `type`** — MiniMax requires explicit types on all property schemas.
6. **Missing `required` array** — MiniMax requires it on object schemas.

## Changes

- **`agent/minimax_schema.py`** (new): `is_minimax_model()` + `sanitize_minimax_tools()` + `sanitize_minimax_tool_parameters()`
- **`agent/transports/chat_completions.py`**: Hook sanitization alongside existing Moonshot check in both `build_kwargs()` and `_build_kwargs_from_profile()`
- **`model_tools.py`**: Add integer→boolean coercion in `coerce_tool_args()` so tool handlers receive `True`/`False` instead of `0`/`1`
- **`tests/agent/test_minimax_schema.py`** (new): 42 tests covering detection, parameter sanitization, and full tool-list sanitization

## Design Decisions

- **Boolean → integer (0/1):** We convert booleans to integers rather than strings (`"true"`/`"false"`) because integers provide a cleaner binary representation in JSON. The converted schema includes `enum: [0, 1]` to prevent the model from generating arbitrary integers. The integer is safely converted back to a boolean in `coerce_tool_args()` using the original registry schema (which still says `"type": "boolean"`), so tool handlers remain completely unmodified and still receive `True`/`False`.
- **`default` folded into description**: The default value is stripped from the schema (MiniMax rejects it) and preserved as human-readable context in the description field.
- **Follows moonshot_schema.py pattern**: Same recursive repair approach, same key classification (`_SCHEMA_MAP_KEYS`, `_SCHEMA_LIST_KEYS`, `_SCHEMA_NODE_KEYS`).

## Testing

```
tests/agent/test_minimax_schema.py  42 passed
tests/agent/test_minimax_provider.py  47 passed
tests/agent/test_moonshot_schema.py  48 passed
tests/test_model_tools.py  32 passed
```

## Open Question

The boolean→integer conversion changes the model's output format for these parameters. If MiniMax's API starts supporting `boolean` type in the future, the sanitization should be re-evaluated. The `is_minimax_model()` detection could also be tightened — currently it matches any model name containing "minimax" to avoid false negatives on aggregator-prefixed slugs.

## Issues

Fixes #65166
