### PR TITLE
feat(agent): add cognitive rotation guardrail

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -30,6 +30,10 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse, urlunparse
 
+from agent.cognitive_rotation import (
+    CognitiveRotationConfig,
+    CognitiveRotationController,
+)
 from agent.context_compressor import ContextCompressor
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import StreamingContextScrubber
@@ -764,6 +768,7 @@ def init_agent(
     agent._executing_tools = False
     agent._tool_guardrails = ToolCallGuardrailController()
     agent._tool_guardrail_halt_decision: ToolGuardrailDecision | None = None
+    agent._cognitive_rotation = CognitiveRotationController()
 
     # Interrupt mechanism for breaking out of tool loops
     agent._interrupt_requested = False
@@ -1595,6 +1600,18 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+    try:
+        _agent_section = _agent_cfg.get("agent", {})
+        if not isinstance(_agent_section, dict):
+            _agent_section = {}
+        agent._cognitive_rotation = CognitiveRotationController(
+            CognitiveRotationConfig.from_mapping(
+                _agent_section.get("cognitive_rotation", {})
+            )
+        )
+    except Exception as _cr_err:
+        _ra().logger.warning("Cognitive rotation config ignored: %s", _cr_err)
+        agent._cognitive_rotation = CognitiveRotationController()
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/cognitive_rotation.py
+++ b/agent/cognitive_rotation.py
@@ -1,0 +1,248 @@
+"""Session-scoped controller for opt-in cognitive rotation.
+
+The controller is intentionally independent of the agent loop. Runtime callers
+feed it completed tool outcomes and ask for a decision before direct source
+mutation. It owns no I/O and keeps its small amount of session state behind a
+lock because tool batches may complete on worker threads.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+DIRECT_MUTATOR_TOOLS = frozenset({"patch", "write_file", "execute_code"})
+
+
+@dataclass(frozen=True)
+class CognitiveRotationConfig:
+    """Configuration for one session's cognitive-rotation controller."""
+
+    enabled: bool = False
+    mutation_budget: int = 20
+    rotate_after_compaction: bool = True
+    lock_after_delegation: bool = True
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: Mapping[str, Any] | None,
+    ) -> "CognitiveRotationConfig":
+        if not isinstance(data, Mapping):
+            return cls()
+        defaults = cls()
+        return cls(
+            enabled=_as_bool(data.get("enabled"), defaults.enabled),
+            mutation_budget=_as_int(
+                data.get("mutation_budget"), defaults.mutation_budget
+            ),
+            rotate_after_compaction=_as_bool(
+                data.get("rotate_after_compaction"),
+                defaults.rotate_after_compaction,
+            ),
+            lock_after_delegation=_as_bool(
+                data.get("lock_after_delegation"),
+                defaults.lock_after_delegation,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class CognitiveRotationDecision:
+    """Pre-call decision for a direct mutator."""
+
+    action: str = "allow"
+    reason: str = ""
+    message: str = ""
+    reservation_id: int | None = None
+
+    @property
+    def allows_execution(self) -> bool:
+        return self.action == "allow"
+
+
+class CognitiveRotationController:
+    """Thread-safe cognitive-rotation state for one agent session."""
+
+    def __init__(self, config: CognitiveRotationConfig | None = None):
+        self.config = config or CognitiveRotationConfig()
+        self._lock = threading.RLock()
+        self._active_reason = ""
+        self._successful_mutations = 0
+        self._pending_mutation_reservations: set[int] = set()
+        self._next_mutation_reservation_id = 1
+
+    @property
+    def active_reason(self) -> str:
+        with self._lock:
+            return self._active_reason
+
+    @property
+    def successful_mutations(self) -> int:
+        with self._lock:
+            return self._successful_mutations
+
+    @property
+    def pending_mutation_reservations(self) -> int:
+        with self._lock:
+            return len(self._pending_mutation_reservations)
+
+    def before_call(
+        self,
+        tool_name: str,
+        *,
+        batch_has_delegation: bool = False,
+    ) -> CognitiveRotationDecision:
+        """Return whether ``tool_name`` may execute in the current session."""
+        with self._lock:
+            if not self.config.enabled or tool_name not in DIRECT_MUTATOR_TOOLS:
+                return CognitiveRotationDecision()
+            if self._active_reason:
+                return CognitiveRotationDecision(
+                    action="block",
+                    reason=self._active_reason,
+                    message=_block_message(self._active_reason),
+                )
+            if batch_has_delegation:
+                return CognitiveRotationDecision(
+                    action="block",
+                    reason="mixed_delegation_batch",
+                    message=_block_message("mixed_delegation_batch"),
+                )
+            budget = self.config.mutation_budget
+            if budget > 0:
+                occupied = self._successful_mutations + len(
+                    self._pending_mutation_reservations
+                )
+                if occupied >= budget:
+                    return CognitiveRotationDecision(
+                        action="block",
+                        reason="mutation_budget",
+                        message=_block_message("mutation_budget"),
+                    )
+                reservation_id = self._next_mutation_reservation_id
+                self._next_mutation_reservation_id += 1
+                self._pending_mutation_reservations.add(reservation_id)
+                return CognitiveRotationDecision(reservation_id=reservation_id)
+            return CognitiveRotationDecision()
+
+    def observe_tool_result(
+        self,
+        tool_name: str,
+        *,
+        failed: bool,
+        reservation_id: int | None = None,
+    ) -> str | None:
+        """Observe one completed tool and return a one-time activation notice."""
+        with self._lock:
+            if not self.config.enabled:
+                return None
+            if tool_name in DIRECT_MUTATOR_TOOLS:
+                if reservation_id is not None:
+                    if reservation_id not in self._pending_mutation_reservations:
+                        return None
+                    self._pending_mutation_reservations.remove(reservation_id)
+                if failed:
+                    return None
+                self._successful_mutations += 1
+                budget = self.config.mutation_budget
+                if budget > 0 and self._successful_mutations >= budget:
+                    return self._activate("mutation_budget")
+                return None
+            if failed:
+                return None
+            if tool_name == "delegate_task":
+                if self.config.lock_after_delegation:
+                    return self._activate("delegation")
+                return None
+            return None
+
+    def cancel_mutation_reservation(self, reservation_id: int | None) -> None:
+        """Release an admitted direct mutator that will not produce a result."""
+        if reservation_id is None:
+            return
+        with self._lock:
+            self._pending_mutation_reservations.discard(reservation_id)
+
+    def observe_compaction(
+        self,
+        *,
+        made_progress: bool,
+        committed: bool,
+    ) -> str | None:
+        """Observe a completed compaction boundary."""
+        with self._lock:
+            if (
+                not self.config.enabled
+                or not self.config.rotate_after_compaction
+                or not made_progress
+                or not committed
+                or self._successful_mutations == 0
+            ):
+                return None
+            return self._activate("compaction")
+
+    def _activate(self, reason: str) -> str | None:
+        if self._active_reason:
+            return None
+        self._active_reason = reason
+        return _activation_notice(reason)
+
+
+def cognitive_rotation_block_result(
+    decision: CognitiveRotationDecision,
+) -> str:
+    """Build a synthetic tool result without requesting a tool-loop halt."""
+    return json.dumps(
+        {
+            "success": False,
+            "error": decision.message,
+            "error_type": "cognitive_rotation_required",
+            "reason": decision.reason,
+        },
+        ensure_ascii=False,
+    )
+
+
+def _activation_notice(reason: str) -> str:
+    return (
+        f"[Cognitive rotation activated: {reason}] Direct source mutation is now "
+        "reserved for a fresh builder. This session may continue reading, "
+        "verifying, testing, inspecting diffs, delegating, and performing "
+        "release operations."
+    )
+
+
+def _block_message(reason: str) -> str:
+    return (
+        f"Cognitive rotation is required ({reason}). Start or delegate to a "
+        "fresh builder for further direct source mutation. Read, verification, "
+        "test, diff, terminal, delegation, commit, and push operations remain "
+        "available in this session."
+    )
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "disabled"}:
+            return False
+    if isinstance(value, (int, float)) and value in {0, 1}:
+        return bool(value)
+    return default
+
+
+def _as_int(value: Any, default: int) -> int:
+    if value is None or isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2247,6 +2247,38 @@ def compress_context(
         )
         _boundary_parent = _old_sid or agent.session_id or ""
 
+        # Cognitive rotation is session-scoped workflow state, so observe only
+        # a real built-in compaction boundary that both made progress and landed
+        # durably. Aborted/no-op/uncommitted attempts must leave it untouched.
+        if _compression_made_progress and _context_engine_boundary_committed:
+            try:
+                _rotation_notice = agent._cognitive_rotation.observe_compaction(
+                    made_progress=True,
+                    committed=True,
+                )
+            except Exception as _rotation_err:
+                logger.debug(
+                    "cognitive rotation compaction observation failed: %s",
+                    _rotation_err,
+                )
+            else:
+                _rotation_status_callback = getattr(
+                    agent,
+                    "status_callback",
+                    None,
+                )
+                if _rotation_notice and _rotation_status_callback:
+                    try:
+                        _rotation_status_callback(
+                            "cognitive_rotation",
+                            _rotation_notice,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "status_callback error in cognitive rotation notice",
+                            exc_info=True,
+                        )
+
         # Notify the context engine that a compaction boundary occurred. Plugin
         # engines (e.g. hermes-lcm) use boundary_reason="compression" to preserve
         # DAG lineage / checkpoint per-session state across the boundary instead of

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -22,6 +22,7 @@ import threading
 import time
 from typing import Any, Optional
 
+from agent.cognitive_rotation import cognitive_rotation_block_result
 from agent.display import (
     KawaiiSpinner,
     build_tool_preview as _build_tool_preview,
@@ -214,6 +215,72 @@ def _cancelled_tool_result(reason: str = "user interrupt") -> str:
     )
 
 
+def _append_cognitive_rotation_notice(result: Any, notice: str | None) -> Any:
+    """Append an activation notice without flattening multimodal results."""
+    if not notice:
+        return result
+    suffix = f"\n\n{notice}"
+    if _is_multimodal_tool_result(result):
+        _append_subdir_hint_to_multimodal(result, suffix)
+        return result
+    if isinstance(result, str):
+        return result + suffix
+    return f"{_multimodal_text_summary(result)}{suffix}"
+
+
+def _finalize_remaining_cognitive_rotation_reservations(
+    agent,
+    parsed_calls: list,
+    results: list,
+    reservations: dict[int, int],
+    *,
+    submitted_indices: set[int] | None = None,
+) -> None:
+    """Settle admitted mutations whose ordered results will not be consumed."""
+    if submitted_indices is None:
+        submitted_indices = set()
+
+    for index, (tool_call, function_name, *_rest) in enumerate(parsed_calls):
+        reservation_key = id(tool_call)
+        reservation_id = reservations.get(reservation_key)
+        if reservation_id is None:
+            continue
+
+        result = results[index] if index < len(results) else None
+        if result is not None:
+            # Result tuple positions are intentionally explicit here: [0] is
+            # the executed tool name, [4] is failure, and [5] is pre-dispatch
+            # blocking. Completed calls settle from their actual outcome.
+            if result[5]:
+                agent._cognitive_rotation.cancel_mutation_reservation(
+                    reservation_id
+                )
+            else:
+                agent._cognitive_rotation.observe_tool_result(
+                    result[0],
+                    failed=result[4],
+                    reservation_id=reservation_id,
+                )
+        elif index in submitted_indices:
+            # submit() returned, but no worker result is available. The source
+            # effect is unknowable, so fail closed by consuming the reservation.
+            agent._cognitive_rotation.observe_tool_result(
+                function_name,
+                failed=False,
+                reservation_id=reservation_id,
+            )
+        else:
+            # The executor never accepted this call (or dispatch was blocked).
+            agent._cognitive_rotation.cancel_mutation_reservation(reservation_id)
+        reservations.pop(reservation_key, None)
+
+    # A BaseException can land after admission but before parsed_calls.append().
+    # Such reservations were never submitted and therefore only need release.
+    for reservation_id in tuple(reservations.values()):
+        agent._cognitive_rotation.cancel_mutation_reservation(reservation_id)
+    reservations.clear()
+
+
 def _emit_cancelled_terminal_post_tool_call(
     agent,
     *,
@@ -351,7 +418,69 @@ def _run_agent_tool_execution_middleware(
     return result, observed_args
 
 
-def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
+def execute_tool_calls_concurrent(
+    agent,
+    assistant_message,
+    messages: list,
+    effective_task_id: str,
+    api_call_count: int = 0,
+    *,
+    finalize: bool = True,
+    batch_has_delegation: bool | None = None,
+) -> None:
+    """Execute a concurrent batch behind an exact-once reservation boundary."""
+    parsed_calls: list = []
+    results: list = []
+    rotation_reservations: dict[int, int] = {}
+    submitted_indices: set[int] = set()
+    try:
+        return _execute_tool_calls_concurrent_impl(
+            agent,
+            assistant_message,
+            messages,
+            effective_task_id,
+            api_call_count,
+            finalize=finalize,
+            batch_has_delegation=batch_has_delegation,
+            parsed_calls=parsed_calls,
+            results=results,
+            rotation_reservations=rotation_reservations,
+            submitted_indices=submitted_indices,
+        )
+    except BaseException:
+        # This boundary spans admission through canonical post-processing
+        # without mechanically reindenting the large executor implementation.
+        # Settlement itself must never replace the original executor failure.
+        try:
+            _finalize_remaining_cognitive_rotation_reservations(
+                agent,
+                parsed_calls,
+                results,
+                rotation_reservations,
+                submitted_indices=submitted_indices,
+            )
+        except BaseException:
+            logger.exception(
+                "failed to settle cognitive-rotation reservations after "
+                "concurrent executor failure"
+            )
+        raise
+
+
+def _execute_tool_calls_concurrent_impl(
+    agent,
+    assistant_message,
+    messages: list,
+    effective_task_id: str,
+    api_call_count: int = 0,
+    *,
+    finalize: bool,
+    batch_has_delegation: bool | None,
+    parsed_calls: list,
+    results: list,
+    rotation_reservations: dict[int, int],
+    submitted_indices: set[int],
+) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
     Results are collected in the original tool-call order and appended to
@@ -363,10 +492,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     """
     tool_calls = assistant_message.tool_calls
     num_tools = len(tool_calls)
+    if batch_has_delegation is None:
+        batch_has_delegation = any(
+            tool_call.function.name == "delegate_task"
+            for tool_call in tool_calls
+        )
 
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
     # avoids rebuilding it per result inside the loop below).
     _tool_budget = _budget_for_agent(agent)
+    _rotation_reservations = rotation_reservations
 
     # ── Pre-flight: interrupt check ──────────────────────────────────
     if agent._interrupt_requested:
@@ -386,7 +521,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         return
 
     # ── Parse args + pre-execution bookkeeping ───────────────────────
-    parsed_calls = []  # list of (tool_call, function_name, function_args, middleware_trace, block_result, blocked_by_guardrail)
+    # ``parsed_calls`` is shared with the outer exceptional-settlement boundary.
     for tool_call in tool_calls:
         function_name = tool_call.function.name
 
@@ -514,10 +649,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     middleware_trace=list(middleware_trace),
                 )
             else:
-                guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
-                if not guardrail_decision.allows_execution:
-                    block_result = agent._guardrail_block_result(guardrail_decision)
-                    blocked_by_guardrail = True
+                rotation_decision = agent._cognitive_rotation.before_call(
+                    function_name,
+                    batch_has_delegation=batch_has_delegation,
+                )
+                if not rotation_decision.allows_execution:
+                    block_result = cognitive_rotation_block_result(
+                        rotation_decision
+                    )
                     _emit_terminal_post_tool_call(
                         agent,
                         function_name=function_name,
@@ -526,10 +665,34 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         effective_task_id=effective_task_id,
                         tool_call_id=getattr(tool_call, "id", "") or "",
                         status="blocked",
-                        error_type="guardrail_block",
-                        error_message=getattr(guardrail_decision, "message", None) or "Tool blocked by guardrail policy",
+                        error_type="cognitive_rotation_required",
+                        error_message=rotation_decision.message,
                         middleware_trace=list(middleware_trace),
                     )
+                else:
+                    if rotation_decision.reservation_id is not None:
+                        _rotation_reservations[id(tool_call)] = (
+                            rotation_decision.reservation_id
+                        )
+                    guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+                    if not guardrail_decision.allows_execution:
+                        agent._cognitive_rotation.cancel_mutation_reservation(
+                            _rotation_reservations.pop(id(tool_call), None)
+                        )
+                        block_result = agent._guardrail_block_result(guardrail_decision)
+                        blocked_by_guardrail = True
+                        _emit_terminal_post_tool_call(
+                            agent,
+                            function_name=function_name,
+                            function_args=function_args,
+                            result=block_result,
+                            effective_task_id=effective_task_id,
+                            tool_call_id=getattr(tool_call, "id", "") or "",
+                            status="blocked",
+                            error_type="guardrail_block",
+                            error_message=getattr(guardrail_decision, "message", None) or "Tool blocked by guardrail policy",
+                            middleware_trace=list(middleware_trace),
+                        )
 
         # ── Checkpoint preflight (only for tools that will execute) ──
         if block_result is None:
@@ -596,7 +759,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
     # ── Concurrent execution ─────────────────────────────────────────
     # Each slot holds (function_name, function_args, function_result, duration, error_flag, blocked_flag, middleware_trace)
-    results = [None] * num_tools
+    results.extend([None] * num_tools)
     for i, (tc, name, args, middleware_trace, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
         if block_result is not None:
             results[i] = (name, args, block_result, 0.0, True, True, middleware_trace)
@@ -753,6 +916,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                                     middleware_trace,
                                 )
                         break
+                    submitted_indices.add(i)
                     futures.append(f)
                     future_to_index[f] = i
 
@@ -866,6 +1030,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     for i, (tc, name, args, middleware_trace, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
         r = results[i]
         blocked = False
+        rotation_reservation_key = id(tc)
+        rotation_reservation_id = _rotation_reservations.get(
+            rotation_reservation_key
+        )
         is_error = True
         progress_function_name = name
         # A worker can finish and write results[i] in the window between the
@@ -876,6 +1044,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if i in timed_out_indices and r is None:
             suffix = f"{timeout_s:.1f}s" if timeout_s is not None else "the configured timeout"
             function_result = f"Error executing tool '{name}': timed out after {suffix}"
+            agent._cognitive_rotation.observe_tool_result(
+                name,
+                failed=True,
+                reservation_id=rotation_reservation_id,
+            )
+            _rotation_reservations.pop(rotation_reservation_key, None)
             effect_disposition = "unknown"
             _emit_terminal_post_tool_call(
                 agent,
@@ -892,6 +1066,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             tool_duration = float(timeout_s or 0.0)
         elif r is None:
             # Tool was cancelled (interrupt) or thread didn't return
+            agent._cognitive_rotation.observe_tool_result(
+                name,
+                failed=True,
+                reservation_id=rotation_reservation_id,
+            )
+            _rotation_reservations.pop(rotation_reservation_key, None)
             if agent._interrupt_requested:
                 function_result = f"[Tool execution cancelled — {name} was skipped due to user interrupt]"
                 _emit_terminal_post_tool_call(
@@ -926,8 +1106,33 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             progress_function_name = function_name
             if blocked:
                 effect_disposition = "none"
+                agent._cognitive_rotation.cancel_mutation_reservation(
+                    rotation_reservation_id
+                )
+                _rotation_reservations.pop(rotation_reservation_key, None)
 
             if not blocked:
+                # The verifier classifies the handler's JSON contract. Notice
+                # decoration deliberately makes that string non-JSON, so feed
+                # the raw result into the existing turn state first.
+                try:
+                    agent._record_file_mutation_result(
+                        function_name, function_args, function_result, is_error,
+                    )
+                except Exception as _ver_err:
+                    logging.debug(
+                        "file-mutation verifier record failed: %s", _ver_err
+                    )
+                rotation_notice = agent._cognitive_rotation.observe_tool_result(
+                    function_name,
+                    failed=is_error,
+                    reservation_id=rotation_reservation_id,
+                )
+                _rotation_reservations.pop(rotation_reservation_key, None)
+                function_result = _append_cognitive_rotation_notice(
+                    function_result,
+                    rotation_notice,
+                )
                 function_result = agent._append_guardrail_observation(
                     function_name,
                     function_args,
@@ -939,17 +1144,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _err_text = _multimodal_text_summary(function_result)
                 result_preview = _err_text[:200] if len(_err_text) > 200 else _err_text
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
-
-            # Track file-mutation outcome for the turn-end verifier.
-            # `blocked` calls never actually ran — don't let a guardrail
-            # block count as either a failure or a success.
-            if not blocked:
-                try:
-                    agent._record_file_mutation_result(
-                        function_name, function_args, function_result, is_error,
-                    )
-                except Exception as _ver_err:
-                    logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
             if agent.verbose_logging:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
@@ -999,6 +1193,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             messages,
             stage=f"tool result {name}",
         ):
+            _finalize_remaining_cognitive_rotation_reservations(
+                agent,
+                parsed_calls,
+                results,
+                _rotation_reservations,
+            )
             return
 
         # Every completion surface is downstream of the canonical append. If
@@ -1075,7 +1275,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
 
 
-def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
+def execute_tool_calls_sequential(
+    agent,
+    assistant_message,
+    messages: list,
+    effective_task_id: str,
+    api_call_count: int = 0,
+    *,
+    finalize: bool = True,
+    batch_has_delegation: bool | None = None,
+) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools.
 
     ``finalize=False`` skips the end-of-batch aggregate budget enforcement
@@ -1084,6 +1293,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+    if batch_has_delegation is None:
+        batch_has_delegation = any(
+            tool_call.function.name == "delegate_task"
+            for tool_call in assistant_message.tool_calls
+        )
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
@@ -1199,13 +1413,35 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception:
                 pass
 
-        _guardrail_block_decision: ToolGuardrailDecision | None = None
+        _cognitive_rotation_block = None
+        _cognitive_rotation_reservation_id = None
         if _block_msg is None:
+            rotation_decision = agent._cognitive_rotation.before_call(
+                function_name,
+                batch_has_delegation=batch_has_delegation,
+            )
+            if not rotation_decision.allows_execution:
+                _cognitive_rotation_block = rotation_decision
+            else:
+                _cognitive_rotation_reservation_id = (
+                    rotation_decision.reservation_id
+                )
+
+        _guardrail_block_decision: ToolGuardrailDecision | None = None
+        if _block_msg is None and _cognitive_rotation_block is None:
             guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
             if not guardrail_decision.allows_execution:
+                agent._cognitive_rotation.cancel_mutation_reservation(
+                    _cognitive_rotation_reservation_id
+                )
+                _cognitive_rotation_reservation_id = None
                 _guardrail_block_decision = guardrail_decision
 
-        _execution_blocked = _block_msg is not None or _guardrail_block_decision is not None
+        _execution_blocked = (
+            _block_msg is not None
+            or _cognitive_rotation_block is not None
+            or _guardrail_block_decision is not None
+        )
 
         if _execution_blocked:
             # Tool blocked by plugin or guardrail policy — skip counters,
@@ -1282,7 +1518,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         tool_start_time = time.time()
 
-        if _block_msg is not None:
+        if _cognitive_rotation_block is not None:
+            function_result = cognitive_rotation_block_result(
+                _cognitive_rotation_block
+            )
+            tool_duration = 0.0
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="cognitive_rotation_required",
+                error_message=_cognitive_rotation_block.message,
+                middleware_trace=list(middleware_trace),
+            )
+        elif _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.
             function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
             tool_duration = 0.0
@@ -1570,6 +1823,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
                 _spinner_result = function_result
             except KeyboardInterrupt:
+                agent._cognitive_rotation.cancel_mutation_reservation(
+                    _cognitive_rotation_reservation_id
+                )
+                _cognitive_rotation_reservation_id = None
                 function_result = _emit_cancelled_terminal_post_tool_call(
                     agent,
                     function_name=function_name,
@@ -1611,6 +1868,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     tool_request_middleware_trace=list(middleware_trace),
                 )
             except KeyboardInterrupt:
+                agent._cognitive_rotation.cancel_mutation_reservation(
+                    _cognitive_rotation_reservation_id
+                )
+                _cognitive_rotation_reservation_id = None
                 _emit_cancelled_terminal_post_tool_call(
                     agent,
                     function_name=function_name,
@@ -1666,6 +1927,25 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 middleware_trace=list(middleware_trace),
             )
         if not _execution_blocked:
+            # Preserve the raw handler JSON for the existing turn verifier;
+            # cognitive/guardrail notices are model-visible decoration only.
+            try:
+                agent._record_file_mutation_result(
+                    function_name, function_args, function_result, _is_error_result,
+                )
+            except Exception as _ver_err:
+                logging.debug(
+                    "file-mutation verifier record failed: %s", _ver_err
+                )
+            rotation_notice = agent._cognitive_rotation.observe_tool_result(
+                function_name,
+                failed=_is_error_result,
+                reservation_id=_cognitive_rotation_reservation_id,
+            )
+            function_result = _append_cognitive_rotation_notice(
+                function_result,
+                rotation_notice,
+            )
             function_result = agent._append_guardrail_observation(
                 function_name,
                 function_args,
@@ -1679,18 +1959,6 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
         else:
             logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, _result_len)
-
-        # Track file-mutation outcome for the turn-end verifier.  See
-        # the concurrent path for the rationale; both paths must feed
-        # the same state so the footer reflects every tool call in the
-        # turn, not just the parallel ones.
-        if not _execution_blocked:
-            try:
-                agent._record_file_mutation_result(
-                    function_name, function_args, function_result, _is_error_result,
-                )
-            except Exception as _ver_err:
-                logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
         agent._current_tool = None
         _status_suffix = " (error)" if _is_error_result else ""
@@ -1721,7 +1989,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
-        tool_message = make_tool_result_message(function_name, _tool_content, tool_call.id)
+        tool_message = make_tool_result_message(
+            function_name,
+            _tool_content,
+            tool_call.id,
+            effect_disposition=(
+                "none" if _cognitive_rotation_block is not None else None
+            ),
+        )
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(
@@ -1856,6 +2131,10 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
+    batch_has_delegation = any(
+        tool_call.function.name == "delegate_task"
+        for tool_call in assistant_message.tool_calls
+    )
     for kind, calls in segments:
         if getattr(agent, "_incremental_persistence_failed", False):
             return
@@ -1864,11 +2143,13 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
             execute_tool_calls_concurrent(
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
+                batch_has_delegation=batch_has_delegation,
             )
         else:
             execute_tool_calls_sequential(
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
+                batch_has_delegation=batch_has_delegation,
             )
 
         if getattr(agent, "_incremental_persistence_failed", False):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -946,6 +946,15 @@ DEFAULT_CONFIG = {
     "max_live_sessions": 16,
     "agent": {
         "max_turns": 500,
+        # Opt-in, session-scoped workflow circuit breaker for long-running
+        # implementation contexts. A non-positive mutation budget disables only
+        # the budget trigger; delegation and committed-compaction triggers remain.
+        "cognitive_rotation": {
+            "enabled": False,
+            "mutation_budget": 20,
+            "rotate_after_compaction": True,
+            "lock_after_delegation": True,
+        },
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has
@@ -6493,6 +6502,8 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         _aux_curator_defaults = (
             DEFAULT_CONFIG.get("auxiliary", {}).get("curator", {})
         )
+        if not isinstance(_aux_curator_defaults, dict):
+            _aux_curator_defaults = {}
         raw_aux = config.get("auxiliary")
         if not isinstance(raw_aux, dict):
             raw_aux = {}

--- a/tests/agent/test_cognitive_rotation.py
+++ b/tests/agent/test_cognitive_rotation.py
@@ -1,0 +1,239 @@
+"""Pure behavior tests for the session-scoped cognitive-rotation controller."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, cast
+
+import pytest
+
+from agent.cognitive_rotation import (
+    CognitiveRotationConfig,
+    CognitiveRotationController,
+)
+
+
+def test_mutation_budget_counts_only_successes_and_activates_at_exact_boundary():
+    controller = CognitiveRotationController(
+        CognitiveRotationConfig(enabled=True, mutation_budget=2)
+    )
+
+    assert controller.observe_tool_result("patch", failed=True) is None
+    assert controller.successful_mutations == 0
+    assert controller.observe_tool_result("write_file", failed=False) is None
+    assert controller.successful_mutations == 1
+    assert controller.before_call("execute_code").allows_execution
+
+    notice = controller.observe_tool_result("execute_code", failed=False)
+
+    assert controller.successful_mutations == 2
+    assert notice is not None
+    assert "mutation_budget" in notice
+    blocked = controller.before_call("patch")
+    assert not blocked.allows_execution
+    assert blocked.reason == "mutation_budget"
+    assert controller.observe_tool_result("write_file", failed=False) is None
+
+
+def test_successful_compaction_after_a_mutation_activates_rotation():
+    controller = CognitiveRotationController(
+        CognitiveRotationConfig(enabled=True, mutation_budget=0)
+    )
+    controller.observe_tool_result("write_file", failed=False)
+
+    notice = controller.observe_compaction(made_progress=True, committed=True)
+
+    assert notice is not None
+    assert "compaction" in notice
+    blocked = controller.before_call("patch")
+    assert not blocked.allows_execution
+    assert blocked.reason == "compaction"
+
+
+def test_mixed_delegation_batch_blocks_direct_mutator_without_permanent_activation():
+    controller = CognitiveRotationController(
+        CognitiveRotationConfig(enabled=True, mutation_budget=0)
+    )
+
+    blocked = controller.before_call(
+        "write_file",
+        batch_has_delegation=True,
+    )
+
+    assert not blocked.allows_execution
+    assert blocked.reason == "mixed_delegation_batch"
+    assert controller.active_reason == ""
+    assert controller.before_call("write_file").allows_execution
+
+
+def test_default_disabled_controller_is_a_complete_noop():
+    controller = CognitiveRotationController()
+
+    assert controller.before_call(
+        "write_file", batch_has_delegation=True
+    ).allows_execution
+    assert controller.observe_tool_result("write_file", failed=False) is None
+    assert controller.observe_tool_result("delegate_task", failed=False) is None
+    assert controller.observe_compaction(made_progress=True, committed=True) is None
+    assert controller.successful_mutations == 0
+    assert controller.active_reason == ""
+
+
+def test_malformed_config_values_fall_back_to_safe_defaults():
+    config = CognitiveRotationConfig.from_mapping({
+        "enabled": "sometimes",
+        "mutation_budget": object(),
+        "rotate_after_compaction": [],
+        "lock_after_delegation": {"invalid": True},
+    })
+
+    assert config == CognitiveRotationConfig()
+    malformed_mapping = cast(Any, ["not", "a", "mapping"])
+    assert CognitiveRotationConfig.from_mapping(malformed_mapping) == (
+        CognitiveRotationConfig()
+    )
+
+
+def test_failed_delegation_does_not_activate_rotation():
+    controller = CognitiveRotationController(CognitiveRotationConfig(enabled=True))
+
+    assert controller.observe_tool_result("delegate_task", failed=True) is None
+    assert controller.active_reason == ""
+    assert controller.before_call("write_file").allows_execution
+
+
+def test_successful_delegation_activates_rotation_when_enabled():
+    controller = CognitiveRotationController(CognitiveRotationConfig(enabled=True))
+
+    notice = controller.observe_tool_result("delegate_task", failed=False)
+
+    assert notice is not None
+    assert "delegation" in notice
+    assert controller.active_reason == "delegation"
+
+
+@pytest.mark.parametrize("mutation_budget", [0, -1])
+def test_non_positive_budget_does_not_activate_from_mutations(mutation_budget):
+    controller = CognitiveRotationController(
+        CognitiveRotationConfig(enabled=True, mutation_budget=mutation_budget)
+    )
+
+    for _ in range(3):
+        assert controller.observe_tool_result("patch", failed=False) is None
+
+    assert controller.successful_mutations == 3
+    assert controller.active_reason == ""
+    assert controller.before_call("write_file").allows_execution
+
+
+@pytest.mark.parametrize("mutation_budget", [0, -1])
+def test_non_positive_budget_preserves_delegation_trigger(mutation_budget):
+    controller = CognitiveRotationController(
+        CognitiveRotationConfig(enabled=True, mutation_budget=mutation_budget)
+    )
+
+    notice = controller.observe_tool_result("delegate_task", failed=False)
+
+    assert notice is not None
+    assert controller.active_reason == "delegation"
+
+
+def test_compaction_before_a_successful_mutation_does_not_activate():
+    controller = CognitiveRotationController(CognitiveRotationConfig(enabled=True))
+
+    assert controller.observe_compaction(made_progress=True, committed=True) is None
+    assert controller.active_reason == ""
+
+
+def test_no_progress_compaction_does_not_activate():
+    controller = CognitiveRotationController(
+        CognitiveRotationConfig(enabled=True, mutation_budget=0)
+    )
+    controller.observe_tool_result("write_file", failed=False)
+
+    assert controller.observe_compaction(made_progress=False, committed=True) is None
+    assert controller.active_reason == ""
+
+
+def test_uncommitted_compaction_does_not_activate():
+    controller = CognitiveRotationController(
+        CognitiveRotationConfig(enabled=True, mutation_budget=0)
+    )
+    controller.observe_tool_result("write_file", failed=False)
+
+    assert controller.observe_compaction(made_progress=True, committed=False) is None
+    assert controller.active_reason == ""
+
+
+def test_disabled_compaction_trigger_does_not_activate():
+    controller = CognitiveRotationController(
+        CognitiveRotationConfig(
+            enabled=True,
+            mutation_budget=0,
+            rotate_after_compaction=False,
+        )
+    )
+    controller.observe_tool_result("write_file", failed=False)
+
+    assert controller.observe_compaction(made_progress=True, committed=True) is None
+    assert controller.active_reason == ""
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["read_file", "search_files", "terminal", "run_tests", "delegate_task"],
+)
+def test_non_mutating_work_remains_permitted_after_activation(tool_name):
+    controller = CognitiveRotationController(CognitiveRotationConfig(enabled=True))
+    controller.observe_tool_result("delegate_task", failed=False)
+
+    assert controller.before_call(tool_name).allows_execution
+
+
+def test_activation_notice_is_returned_exactly_once():
+    controller = CognitiveRotationController(CognitiveRotationConfig(enabled=True))
+
+    first_notice = controller.observe_tool_result("delegate_task", failed=False)
+    repeated_notice = controller.observe_tool_result("delegate_task", failed=False)
+    later_compaction_notice = controller.observe_compaction(
+        made_progress=True,
+        committed=True,
+    )
+
+    assert first_notice is not None
+    assert repeated_notice is None
+    assert later_compaction_notice is None
+
+
+def test_rotation_budget_admission_is_atomic_across_threads():
+    controller = CognitiveRotationController(
+        CognitiveRotationConfig(enabled=True, mutation_budget=1)
+    )
+    start = threading.Barrier(3)
+
+    def admit():
+        start.wait()
+        return controller.before_call("write_file")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(admit) for _ in range(2)]
+        start.wait()
+        decisions = [future.result() for future in futures]
+
+    admitted = [decision for decision in decisions if decision.allows_execution]
+    blocked = [decision for decision in decisions if not decision.allows_execution]
+    assert len(admitted) == 1
+    assert len(blocked) == 1
+    assert blocked[0].reason == "mutation_budget"
+    assert controller.successful_mutations == 0
+    assert controller.pending_mutation_reservations == 1
+
+    assert admitted[0].reservation_id is not None
+    assert (
+        controller.observe_tool_result(
+            "write_file",
+            failed=True,
+            reservation_id=admitted[0].reservation_id,
+        )
+        is None
+    )
+    assert controller.pending_mutation_reservations == 0

--- a/tests/hermes_cli/test_cognitive_rotation_config.py
+++ b/tests/hermes_cli/test_cognitive_rotation_config.py
@@ -1,0 +1,36 @@
+"""Configuration contract tests for the cognitive-rotation guardrail."""
+
+from hermes_cli.config import DEFAULT_CONFIG, load_config
+
+
+EXPECTED_COGNITIVE_ROTATION_DEFAULTS = {
+    "enabled": False,
+    "mutation_budget": 20,
+    "rotate_after_compaction": True,
+    "lock_after_delegation": True,
+}
+
+
+def test_cognitive_rotation_defaults_to_opt_in_safe_values():
+    agent_defaults = DEFAULT_CONFIG["agent"]
+    assert isinstance(agent_defaults, dict)
+    assert agent_defaults["cognitive_rotation"] == (
+        EXPECTED_COGNITIVE_ROTATION_DEFAULTS
+    )
+
+
+def test_partial_cognitive_rotation_config_preserves_nested_defaults(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  cognitive_rotation:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    config = load_config()
+
+    assert config["agent"]["cognitive_rotation"] == {
+        **EXPECTED_COGNITIVE_ROTATION_DEFAULTS,
+        "enabled": True,
+    }

--- a/tests/run_agent/test_cognitive_rotation_runtime.py
+++ b/tests/run_agent/test_cognitive_rotation_runtime.py
@@ -1,0 +1,1308 @@
+"""Runtime regressions for the opt-in cognitive-rotation guardrail."""
+
+import json
+import threading
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tool_guardrails import ToolGuardrailDecision
+from run_agent import AIAgent
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _tool_call(name: str, call_id: str, arguments: dict | None = None):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(
+            name=name,
+            arguments=json.dumps(arguments or {}),
+        ),
+    )
+
+
+def _make_agent(config: dict) -> AIAgent:
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_tool_defs(
+                "delegate_task",
+                "write_file",
+                "patch",
+                "execute_code",
+                "read_file",
+            ),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    setattr(agent, "tool_delay", 0)
+    setattr(agent, "compression_enabled", False)
+    setattr(agent, "save_trajectories", False)
+    return agent
+
+
+def _rotation_config(**overrides) -> dict:
+    rotation = {
+        "enabled": True,
+        "mutation_budget": 20,
+        "rotate_after_compaction": True,
+        "lock_after_delegation": True,
+    }
+    rotation.update(overrides)
+    return {"agent": {"cognitive_rotation": rotation}}
+
+
+_RUN_SUBMITTED_CALL = object()
+_LEAVE_SUBMITTED_CALL_PENDING = object()
+
+
+class _ExecutorBoundaryFailure(BaseException):
+    """Deterministic non-Exception failure from an executor boundary."""
+
+
+class _ScriptedExecutor:
+    """Executor fake that makes submit/result availability deterministic."""
+
+    def __init__(
+        self,
+        *submit_actions: object,
+        shutdown_error: BaseException | None = None,
+    ):
+        self._submit_actions = submit_actions
+        self._shutdown_error = shutdown_error
+        self.submit_count = 0
+
+    def submit(self, function, *args, **kwargs):
+        action = self._submit_actions[self.submit_count]
+        self.submit_count += 1
+        if isinstance(action, BaseException):
+            raise action
+
+        future = Future()
+        if action is _LEAVE_SUBMITTED_CALL_PENDING:
+            return future
+        assert action is _RUN_SUBMITTED_CALL
+        try:
+            result = function(*args, **kwargs)
+        except BaseException as error:
+            future.set_exception(error)
+        else:
+            future.set_result(result)
+        return future
+
+    def shutdown(self, *_args, **_kwargs):
+        if self._shutdown_error is not None:
+            raise self._shutdown_error
+
+
+def _install_completion_callbacks(agent) -> tuple[MagicMock, MagicMock]:
+    tool_progress_callback = MagicMock()
+    tool_complete_callback = MagicMock()
+    setattr(agent, "tool_progress_callback", tool_progress_callback)
+    setattr(agent, "tool_complete_callback", tool_complete_callback)
+    return tool_progress_callback, tool_complete_callback
+
+
+def _assert_no_completion_output(
+    messages: list[dict],
+    tool_progress_callback: MagicMock,
+    tool_complete_callback: MagicMock,
+) -> None:
+    assert messages == []
+    tool_complete_callback.assert_not_called()
+    assert not any(
+        call.args and call.args[0] == "tool.completed"
+        for call in tool_progress_callback.call_args_list
+    )
+
+
+def test_successful_delegation_blocks_later_direct_mutation_without_halting_turn():
+    """Enabled Hermes must rotate rather than mutate after delegated implementation."""
+    agent = _make_agent(_rotation_config())
+    messages: list[dict] = []
+    delegation = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "delegate_task",
+                "delegate-1",
+                {"goal": "implement the change"},
+            )
+        ]
+    )
+
+    with patch.object(
+        agent,
+        "_dispatch_delegate_task",
+        return_value=json.dumps({"success": True, "delegation_id": "child-1"}),
+    ):
+        agent._execute_tool_calls_sequential(
+            delegation,
+            messages,
+            "task-1",
+        )
+
+    mutation = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-1",
+                {"path": "feature.py", "content": "changed = True\n"},
+            )
+        ]
+    )
+    with patch(
+        "run_agent.handle_function_call",
+        return_value=json.dumps({"success": True}),
+    ) as execute:
+        agent._execute_tool_calls_sequential(
+            mutation,
+            messages,
+            "task-1",
+        )
+
+    execute.assert_not_called()
+    blocked = json.loads(messages[-1]["content"])
+    assert blocked["error_type"] == "cognitive_rotation_required"
+    assert blocked["reason"] == "delegation"
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_concurrent_mixed_delegation_batch_blocks_direct_mutator_before_execution():
+    agent = _make_agent(_rotation_config(mutation_budget=0))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "delegate_task",
+                "delegate-mixed",
+                {"goal": "implement elsewhere"},
+            ),
+            _tool_call(
+                "write_file",
+                "write-mixed",
+                {"path": "feature.py", "content": "changed = True\n"},
+            ),
+        ]
+    )
+    executed: list[str] = []
+
+    def invoke(name, *_args, **_kwargs):
+        executed.append(name)
+        return json.dumps({"success": True})
+
+    with patch.object(agent, "_invoke_tool", side_effect=invoke):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert executed == ["delegate_task"]
+    assert [message["tool_call_id"] for message in messages] == [
+        "delegate-mixed",
+        "write-mixed",
+    ]
+    blocked = json.loads(messages[1]["content"])
+    assert blocked["error_type"] == "cognitive_rotation_required"
+    assert blocked["reason"] == "mixed_delegation_batch"
+
+
+def test_sequential_mixed_delegation_batch_blocks_direct_mutator():
+    agent = _make_agent(_rotation_config(mutation_budget=0))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "delegate_task",
+                "delegate-sequential",
+                {"goal": "attempt implementation elsewhere"},
+            ),
+            _tool_call(
+                "write_file",
+                "write-sequential",
+                {"path": "feature.py", "content": "changed = True\n"},
+            ),
+        ]
+    )
+
+    with (
+        patch.object(
+            agent,
+            "_dispatch_delegate_task",
+            return_value=json.dumps({"success": False, "error": "child failed"}),
+        ),
+        patch("run_agent.handle_function_call") as execute_mutation,
+    ):
+        agent._execute_tool_calls_sequential(batch, messages, "task-1")
+
+    execute_mutation.assert_not_called()
+    assert [message["tool_call_id"] for message in messages] == [
+        "delegate-sequential",
+        "write-sequential",
+    ]
+    blocked = json.loads(messages[1]["content"])
+    assert blocked["error_type"] == "cognitive_rotation_required"
+    assert blocked["reason"] == "mixed_delegation_batch"
+    assert getattr(agent, "_cognitive_rotation").active_reason == ""
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_segmented_batch_preserves_original_delegation_signal():
+    agent = _make_agent(_rotation_config(mutation_budget=0))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "delegate_task",
+                "delegate-segment",
+                {"goal": "attempt implementation elsewhere"},
+            ),
+            _tool_call(
+                "write_file",
+                "write-segment",
+                {"path": "feature.py", "content": "changed = True\n"},
+            ),
+            _tool_call(
+                "read_file",
+                "read-segment",
+                {"path": "README.md"},
+            ),
+        ]
+    )
+    executed: list[str] = []
+
+    def invoke(name, *_args, **_kwargs):
+        executed.append(name)
+        return json.dumps({"success": True})
+
+    with (
+        patch.object(
+            agent,
+            "_dispatch_delegate_task",
+            return_value=json.dumps({"success": False, "error": "child failed"}),
+        ),
+        patch.object(agent, "_invoke_tool", side_effect=invoke),
+    ):
+        agent._execute_tool_calls(batch, messages, "task-1")
+
+    assert "write_file" not in executed
+    assert executed == ["read_file"]
+    assert [message["tool_call_id"] for message in messages] == [
+        "delegate-segment",
+        "write-segment",
+        "read-segment",
+    ]
+    blocked = json.loads(messages[1]["content"])
+    assert blocked["error_type"] == "cognitive_rotation_required"
+    assert blocked["reason"] == "mixed_delegation_batch"
+    assert getattr(agent, "_cognitive_rotation").active_reason == ""
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_rotation_budget_concurrent_admission_blocks_one_mutator_but_runs_read():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-budget",
+                {"path": "one.py", "content": "one = 1\n"},
+            ),
+            _tool_call(
+                "patch",
+                "patch-budget",
+                {
+                    "mode": "replace",
+                    "path": "two.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+            ),
+            _tool_call("read_file", "read-budget", {"path": "README.md"}),
+        ]
+    )
+    executed: list[str] = []
+
+    def invoke(name, *_args, **_kwargs):
+        executed.append(name)
+        if name == "read_file":
+            return json.dumps({"success": True, "content": "read"})
+        if name == "write_file":
+            return json.dumps({
+                "success": True,
+                "bytes_written": 8,
+                "files_modified": ["/tmp/one.py"],
+            })
+        return json.dumps({
+            "success": True,
+            "diff": "--- a/two.py\n+++ b/two.py\n",
+            "files_modified": ["/tmp/two.py"],
+        })
+
+    with patch.object(agent, "_invoke_tool", side_effect=invoke):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    executed_mutators = [name for name in executed if name in {"write_file", "patch"}]
+    assert len(executed_mutators) == 1
+    assert "read_file" in executed
+    assert [message["tool_call_id"] for message in messages] == [
+        "write-budget",
+        "patch-budget",
+        "read-budget",
+    ]
+    blocked_id = (
+        "patch-budget" if executed_mutators == ["write_file"] else "write-budget"
+    )
+    blocked_message = next(
+        message for message in messages if message["tool_call_id"] == blocked_id
+    )
+    blocked = json.loads(blocked_message["content"])
+    assert blocked["error_type"] == "cognitive_rotation_required"
+    assert blocked["reason"] == "mutation_budget"
+    assert (
+        sum(
+            str(message["content"]).count(
+                "[Cognitive rotation activated: mutation_budget]"
+            )
+            for message in messages
+        )
+        == 1
+    )
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 1
+    assert controller.pending_mutation_reservations == 0
+
+
+def test_concurrent_persistence_abort_finalizes_unconsumed_mutation_reservations():
+    agent = _make_agent(_rotation_config(mutation_budget=2))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-before-persist-failure",
+                {"path": "landed.py", "content": "landed = True\n"},
+            ),
+            _tool_call(
+                "patch",
+                "patch-after-persist-failure",
+                {
+                    "mode": "replace",
+                    "path": "failed.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+            ),
+        ]
+    )
+    executed: list[str] = []
+
+    def invoke(name, *_args, **_kwargs):
+        executed.append(name)
+        if name == "write_file":
+            return json.dumps({
+                "success": True,
+                "bytes_written": 14,
+                "files_modified": ["/tmp/landed.py"],
+            })
+        return json.dumps({"success": False, "error": "patch failed"})
+
+    flush_messages_to_session_db = MagicMock(return_value=False)
+    tool_complete_callback = MagicMock()
+    tool_progress_callback = MagicMock()
+    setattr(agent, "tool_complete_callback", tool_complete_callback)
+    setattr(agent, "tool_progress_callback", tool_progress_callback)
+
+    with (
+        patch.object(
+            agent,
+            "_flush_messages_to_session_db",
+            flush_messages_to_session_db,
+        ),
+        patch.object(agent, "_invoke_tool", side_effect=invoke),
+    ):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert sorted(executed) == ["patch", "write_file"]
+    assert [message["tool_call_id"] for message in messages] == [
+        "write-before-persist-failure"
+    ]
+    flush_messages_to_session_db.assert_called_once()
+    assert getattr(agent, "_incremental_persistence_failed", False) is True
+    tool_complete_callback.assert_not_called()
+    assert not any(
+        call.args and call.args[0] == "tool.completed"
+        for call in tool_progress_callback.call_args_list
+    )
+
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 1
+    assert controller.pending_mutation_reservations == 0
+    assert controller.active_reason == ""
+
+    later_admission = controller.before_call("patch")
+    assert later_admission.allows_execution
+    assert later_admission.reservation_id is not None
+    controller.cancel_mutation_reservation(later_admission.reservation_id)
+    assert controller.pending_mutation_reservations == 0
+
+
+def test_concurrent_persistence_abort_counts_unconsumed_successful_mutation():
+    agent = _make_agent(_rotation_config(mutation_budget=2))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-before-successful-remainder",
+                {"path": "first.py", "content": "first = True\n"},
+            ),
+            _tool_call(
+                "patch",
+                "patch-successful-remainder",
+                {
+                    "mode": "replace",
+                    "path": "second.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+            ),
+        ]
+    )
+
+    def invoke(name, *_args, **_kwargs):
+        if name == "write_file":
+            return json.dumps({
+                "success": True,
+                "bytes_written": 13,
+                "files_modified": ["/tmp/first.py"],
+            })
+        return json.dumps({
+            "success": True,
+            "diff": "--- a/second.py\n+++ b/second.py\n",
+            "files_modified": ["/tmp/second.py"],
+        })
+
+    flush_messages_to_session_db = MagicMock(return_value=False)
+
+    with (
+        patch.object(
+            agent,
+            "_flush_messages_to_session_db",
+            flush_messages_to_session_db,
+        ),
+        patch.object(agent, "_invoke_tool", side_effect=invoke) as execute,
+    ):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert execute.call_count == 2
+    assert [message["tool_call_id"] for message in messages] == [
+        "write-before-successful-remainder"
+    ]
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 2
+    assert controller.pending_mutation_reservations == 0
+    assert controller.active_reason == "mutation_budget"
+
+
+def test_concurrent_submit_failure_settles_completed_and_never_submitted_reservations():
+    agent = _make_agent(_rotation_config(mutation_budget=2))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-completed-before-submit-failure",
+                {"path": "completed.py", "content": "completed = True\n"},
+            ),
+            _tool_call(
+                "patch",
+                "patch-never-submitted",
+                {
+                    "mode": "replace",
+                    "path": "never_submitted.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+            ),
+        ]
+    )
+    submission_error = RuntimeError("can't start new thread")
+    executor = _ScriptedExecutor(_RUN_SUBMITTED_CALL, submission_error)
+    tool_progress_callback, tool_complete_callback = _install_completion_callbacks(
+        agent
+    )
+    landed_result = json.dumps({
+        "success": True,
+        "bytes_written": 17,
+        "files_modified": ["/tmp/completed.py"],
+    })
+
+    with (
+        patch(
+            "tools.daemon_pool.DaemonThreadPoolExecutor",
+            return_value=executor,
+        ),
+        patch.object(agent, "_invoke_tool", return_value=landed_result) as execute,
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert exc_info.value is submission_error
+    assert executor.submit_count == 2
+    execute.assert_called_once()
+    _assert_no_completion_output(
+        messages,
+        tool_progress_callback,
+        tool_complete_callback,
+    )
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 1
+    assert controller.pending_mutation_reservations == 0
+    assert controller.active_reason == ""
+
+    later_admission = controller.before_call("patch")
+    assert later_admission.allows_execution
+    assert later_admission.reservation_id is not None
+    controller.cancel_mutation_reservation(later_admission.reservation_id)
+    assert controller.pending_mutation_reservations == 0
+
+
+def test_concurrent_submit_failure_conservatively_counts_submitted_unknown_mutation():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-submitted-unknown",
+                {"path": "unknown.py", "content": "unknown = True\n"},
+            ),
+            _tool_call(
+                "read_file",
+                "read-submit-failure",
+                {"path": "README.md"},
+            ),
+        ]
+    )
+    submission_error = RuntimeError("can't start new thread")
+    executor = _ScriptedExecutor(
+        _LEAVE_SUBMITTED_CALL_PENDING,
+        submission_error,
+    )
+    tool_progress_callback, tool_complete_callback = _install_completion_callbacks(
+        agent
+    )
+
+    with (
+        patch(
+            "tools.daemon_pool.DaemonThreadPoolExecutor",
+            return_value=executor,
+        ),
+        patch.object(agent, "_invoke_tool") as execute,
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert exc_info.value is submission_error
+    assert executor.submit_count == 2
+    execute.assert_not_called()
+    _assert_no_completion_output(
+        messages,
+        tool_progress_callback,
+        tool_complete_callback,
+    )
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 1
+    assert controller.pending_mutation_reservations == 0
+    assert controller.active_reason == "mutation_budget"
+
+    later_admission = controller.before_call("patch")
+    assert not later_admission.allows_execution
+    assert later_admission.reason == "mutation_budget"
+    assert later_admission.reservation_id is None
+
+
+def test_concurrent_first_submit_failure_releases_never_submitted_reservations():
+    agent = _make_agent(_rotation_config(mutation_budget=2))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-never-submitted",
+                {"path": "first.py", "content": "first = True\n"},
+            ),
+            _tool_call(
+                "patch",
+                "patch-never-submitted",
+                {
+                    "mode": "replace",
+                    "path": "second.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+            ),
+        ]
+    )
+    submission_error = RuntimeError("can't start new thread")
+    executor = _ScriptedExecutor(submission_error)
+    tool_progress_callback, tool_complete_callback = _install_completion_callbacks(
+        agent
+    )
+
+    with (
+        patch(
+            "tools.daemon_pool.DaemonThreadPoolExecutor",
+            return_value=executor,
+        ),
+        patch.object(agent, "_invoke_tool") as execute,
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert exc_info.value is submission_error
+    assert executor.submit_count == 1
+    execute.assert_not_called()
+    _assert_no_completion_output(
+        messages,
+        tool_progress_callback,
+        tool_complete_callback,
+    )
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 0
+    assert controller.pending_mutation_reservations == 0
+    assert controller.active_reason == ""
+
+    later_admission = controller.before_call("write_file")
+    assert later_admission.allows_execution
+    assert later_admission.reservation_id is not None
+    controller.cancel_mutation_reservation(later_admission.reservation_id)
+    assert controller.pending_mutation_reservations == 0
+
+
+def test_concurrent_executor_constructor_failure_releases_reservations():
+    agent = _make_agent(_rotation_config(mutation_budget=2))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-before-constructor-failure",
+                {"path": "first.py", "content": "first = True\n"},
+            ),
+            _tool_call(
+                "patch",
+                "patch-before-constructor-failure",
+                {
+                    "mode": "replace",
+                    "path": "second.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+            ),
+        ]
+    )
+    constructor_error = _ExecutorBoundaryFailure("constructor failed")
+    tool_progress_callback, tool_complete_callback = _install_completion_callbacks(
+        agent
+    )
+
+    with (
+        patch(
+            "tools.daemon_pool.DaemonThreadPoolExecutor",
+            side_effect=constructor_error,
+        ),
+        patch.object(agent, "_invoke_tool") as execute,
+        pytest.raises(_ExecutorBoundaryFailure) as exc_info,
+    ):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert exc_info.value is constructor_error
+    execute.assert_not_called()
+    _assert_no_completion_output(
+        messages,
+        tool_progress_callback,
+        tool_complete_callback,
+    )
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 0
+    assert controller.pending_mutation_reservations == 0
+    assert controller.active_reason == ""
+
+
+def test_concurrent_wait_base_exception_counts_submitted_unknown_mutation():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-pending-before-wait-failure",
+                {"path": "pending.py", "content": "pending = True\n"},
+            )
+        ]
+    )
+    wait_error = _ExecutorBoundaryFailure("wait failed")
+    executor = _ScriptedExecutor(_LEAVE_SUBMITTED_CALL_PENDING)
+    tool_progress_callback, tool_complete_callback = _install_completion_callbacks(
+        agent
+    )
+
+    with (
+        patch(
+            "tools.daemon_pool.DaemonThreadPoolExecutor",
+            return_value=executor,
+        ),
+        patch(
+            "agent.tool_executor.concurrent.futures.wait",
+            side_effect=wait_error,
+        ) as wait_for_futures,
+        patch.object(agent, "_invoke_tool") as execute,
+        pytest.raises(_ExecutorBoundaryFailure) as exc_info,
+    ):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert exc_info.value is wait_error
+    assert executor.submit_count == 1
+    wait_for_futures.assert_called_once()
+    execute.assert_not_called()
+    _assert_no_completion_output(
+        messages,
+        tool_progress_callback,
+        tool_complete_callback,
+    )
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 1
+    assert controller.pending_mutation_reservations == 0
+    assert controller.active_reason == "mutation_budget"
+
+
+def test_concurrent_shutdown_base_exception_settles_completed_mutation():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-completed-before-shutdown-failure",
+                {"path": "completed.py", "content": "completed = True\n"},
+            )
+        ]
+    )
+    shutdown_error = _ExecutorBoundaryFailure("shutdown failed")
+    executor = _ScriptedExecutor(
+        _RUN_SUBMITTED_CALL,
+        shutdown_error=shutdown_error,
+    )
+    tool_progress_callback, tool_complete_callback = _install_completion_callbacks(
+        agent
+    )
+    landed_result = json.dumps({
+        "success": True,
+        "bytes_written": 17,
+        "files_modified": ["/tmp/completed.py"],
+    })
+
+    with (
+        patch(
+            "tools.daemon_pool.DaemonThreadPoolExecutor",
+            return_value=executor,
+        ),
+        patch.object(agent, "_invoke_tool", return_value=landed_result) as execute,
+        pytest.raises(_ExecutorBoundaryFailure) as exc_info,
+    ):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert exc_info.value is shutdown_error
+    assert executor.submit_count == 1
+    execute.assert_called_once()
+    _assert_no_completion_output(
+        messages,
+        tool_progress_callback,
+        tool_complete_callback,
+    )
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 1
+    assert controller.pending_mutation_reservations == 0
+    assert controller.active_reason == "mutation_budget"
+
+
+def test_rotation_budget_failed_reservation_releases_capacity_for_later_pass():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    messages: list[dict] = []
+    failed_batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-failed",
+                {"path": "failed.py", "content": "broken"},
+            )
+        ]
+    )
+
+    with patch.object(
+        agent,
+        "_invoke_tool",
+        return_value=json.dumps({"success": False, "error": "write failed"}),
+    ):
+        agent._execute_tool_calls_concurrent(failed_batch, messages, "task-1")
+
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 0
+    assert controller.pending_mutation_reservations == 0
+
+    later_batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "patch",
+                "patch-later",
+                {
+                    "mode": "replace",
+                    "path": "later.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+            )
+        ]
+    )
+    with patch.object(
+        agent,
+        "_invoke_tool",
+        return_value=json.dumps({
+            "success": True,
+            "diff": "--- a/later.py\n+++ b/later.py\n",
+            "files_modified": ["/tmp/later.py"],
+        }),
+    ) as execute:
+        agent._execute_tool_calls_concurrent(later_batch, messages, "task-1")
+
+    execute.assert_called_once()
+    assert controller.successful_mutations == 1
+    assert controller.pending_mutation_reservations == 0
+    assert "[Cognitive rotation activated: mutation_budget]" in messages[-1]["content"]
+
+
+def test_rotation_budget_segmented_execution_cannot_exceed_remaining_capacity():
+    agent = _make_agent(_rotation_config(mutation_budget=2))
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.observe_tool_result("write_file", failed=False) is None
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-segment-budget",
+                {"path": "segment.py", "content": "changed = True\n"},
+            ),
+            _tool_call(
+                "read_file",
+                "read-segment-budget",
+                {"path": "README.md"},
+            ),
+            _tool_call(
+                "execute_code",
+                "execute-segment-budget",
+                {"code": "print('must not run')"},
+            ),
+        ]
+    )
+    executed: list[str] = []
+
+    def invoke(name, *_args, **_kwargs):
+        executed.append(name)
+        if name == "write_file":
+            return json.dumps({
+                "success": True,
+                "bytes_written": 15,
+                "files_modified": ["/tmp/segment.py"],
+            })
+        return json.dumps({"success": True, "content": "read"})
+
+    with (
+        patch.object(agent, "_invoke_tool", side_effect=invoke),
+        patch("run_agent.handle_function_call", side_effect=invoke),
+    ):
+        agent._execute_tool_calls(batch, messages, "task-1")
+
+    assert executed.count("write_file") == 1
+    assert executed.count("read_file") == 1
+    assert "execute_code" not in executed
+    assert [message["tool_call_id"] for message in messages] == [
+        "write-segment-budget",
+        "read-segment-budget",
+        "execute-segment-budget",
+    ]
+    blocked = json.loads(messages[-1]["content"])
+    assert blocked["error_type"] == "cognitive_rotation_required"
+    assert blocked["reason"] == "mutation_budget"
+    assert controller.successful_mutations == 2
+    assert controller.pending_mutation_reservations == 0
+
+
+def test_rotation_budget_downstream_guardrail_block_releases_reservation():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    messages: list[dict] = []
+    blocked_batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-guardrail-blocked",
+                {"path": "blocked.py", "content": "blocked = True\n"},
+            )
+        ]
+    )
+    ordinary_block = ToolGuardrailDecision(
+        action="block",
+        code="test_block",
+        message="blocked downstream",
+        tool_name="write_file",
+    )
+
+    with patch.object(
+        getattr(agent, "_tool_guardrails"),
+        "before_call",
+        return_value=ordinary_block,
+    ):
+        agent._execute_tool_calls_sequential(blocked_batch, messages, "task-1")
+
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 0
+    assert controller.pending_mutation_reservations == 0
+
+    later_batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-after-guardrail",
+                {"path": "allowed.py", "content": "allowed = True\n"},
+            )
+        ]
+    )
+    with patch(
+        "run_agent.handle_function_call",
+        return_value=json.dumps({
+            "success": True,
+            "bytes_written": 15,
+            "files_modified": ["/tmp/allowed.py"],
+        }),
+    ) as execute:
+        agent._execute_tool_calls_sequential(later_batch, messages, "task-1")
+
+    execute.assert_called_once()
+    assert controller.successful_mutations == 1
+    assert controller.pending_mutation_reservations == 0
+
+
+def test_rotation_budget_timeout_releases_reservation_for_later_pass():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    messages: list[dict] = []
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    timed_batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-timeout",
+                {"path": "timeout.py", "content": "timeout = True\n"},
+            )
+        ]
+    )
+
+    def wait_forever(*_args, **_kwargs):
+        started.set()
+        release.wait(timeout=5)
+        finished.set()
+        return json.dumps({
+            "success": True,
+            "bytes_written": 15,
+            "files_modified": ["/tmp/timeout.py"],
+        })
+
+    try:
+        with (
+            patch.object(agent, "_invoke_tool", side_effect=wait_forever),
+            patch(
+                "agent.tool_executor._resolve_concurrent_tool_timeout",
+                return_value=0.5,
+            ),
+        ):
+            agent._execute_tool_calls_concurrent(timed_batch, messages, "task-1")
+    finally:
+        release.set()
+
+    assert started.is_set()
+    assert finished.wait(timeout=2)
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 0
+    assert controller.pending_mutation_reservations == 0
+
+    later_batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "patch",
+                "patch-after-timeout",
+                {
+                    "mode": "replace",
+                    "path": "after.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+            )
+        ]
+    )
+    with patch.object(
+        agent,
+        "_invoke_tool",
+        return_value=json.dumps({
+            "success": True,
+            "diff": "--- a/after.py\n+++ b/after.py\n",
+            "files_modified": ["/tmp/after.py"],
+        }),
+    ):
+        agent._execute_tool_calls_concurrent(later_batch, messages, "task-1")
+
+    assert controller.successful_mutations == 1
+    assert controller.pending_mutation_reservations == 0
+
+
+def test_rotation_budget_keyboard_interrupt_releases_sequential_reservation():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-interrupted",
+                {"path": "interrupt.py", "content": "interrupted = True\n"},
+            )
+        ]
+    )
+
+    with (
+        patch("run_agent.handle_function_call", side_effect=KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        agent._execute_tool_calls_sequential(batch, messages, "task-1")
+
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.successful_mutations == 0
+    assert controller.pending_mutation_reservations == 0
+
+
+def test_raw_mutation_result_reaches_sequential_verifier_before_notice_decoration():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    setattr(agent, "_turn_failed_file_mutations", {})
+    setattr(agent, "_turn_file_mutation_paths", set())
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "write_file",
+                "write-verifier-sequential",
+                {"path": "sequential.py", "content": "landed = True\n"},
+            )
+        ]
+    )
+    raw_result = json.dumps({
+        "success": True,
+        "bytes_written": 14,
+        "files_modified": ["/tmp/project/sequential.py"],
+    })
+
+    with patch("run_agent.handle_function_call", return_value=raw_result):
+        agent._execute_tool_calls_sequential(batch, messages, "task-1")
+
+    assert getattr(agent, "_turn_file_mutation_paths") == {"/tmp/project/sequential.py"}
+    assert (
+        messages[0]["content"].count("[Cognitive rotation activated: mutation_budget]")
+        == 1
+    )
+
+
+def test_raw_mutation_result_reaches_concurrent_verifier_before_notice_decoration():
+    agent = _make_agent(_rotation_config(mutation_budget=1))
+    setattr(agent, "_turn_failed_file_mutations", {})
+    setattr(agent, "_turn_file_mutation_paths", set())
+    messages: list[dict] = []
+    batch = SimpleNamespace(
+        tool_calls=[
+            _tool_call(
+                "patch",
+                "patch-verifier-concurrent",
+                {
+                    "mode": "replace",
+                    "path": "concurrent.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+            )
+        ]
+    )
+    raw_result = json.dumps({
+        "success": True,
+        "diff": "--- a/concurrent.py\n+++ b/concurrent.py\n",
+        "files_modified": ["/tmp/project/concurrent.py"],
+    })
+
+    with patch.object(agent, "_invoke_tool", return_value=raw_result):
+        agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+
+    assert getattr(agent, "_turn_file_mutation_paths") == {"/tmp/project/concurrent.py"}
+    assert (
+        messages[0]["content"].count("[Cognitive rotation activated: mutation_budget]")
+        == 1
+    )
+
+
+@pytest.mark.parametrize("mode", ["sequential", "concurrent", "segmented"])
+def test_effect_disposition_is_none_for_cognitive_blocks_in_every_mode(mode):
+    agent = _make_agent(_rotation_config(mutation_budget=0))
+    controller = getattr(agent, "_cognitive_rotation")
+    assert controller.observe_tool_result("delegate_task", failed=False) is not None
+    calls = [
+        _tool_call(
+            "write_file",
+            f"write-blocked-{mode}",
+            {"path": f"{mode}.py", "content": "blocked = True\n"},
+        ),
+        _tool_call(
+            "read_file",
+            f"read-allowed-{mode}",
+            {"path": "README.md"},
+        ),
+    ]
+    if mode == "segmented":
+        calls.append(
+            _tool_call(
+                "execute_code",
+                "execute-blocked-segmented",
+                {"code": "print('must not run')"},
+            )
+        )
+    batch = SimpleNamespace(tool_calls=calls)
+    messages: list[dict] = []
+    executed: list[str] = []
+
+    def invoke(name, *_args, **_kwargs):
+        executed.append(name)
+        return json.dumps({"success": True, "content": "read"})
+
+    with (
+        patch.object(agent, "_invoke_tool", side_effect=invoke),
+        patch("run_agent.handle_function_call", side_effect=invoke),
+    ):
+        if mode == "sequential":
+            agent._execute_tool_calls_sequential(batch, messages, "task-1")
+        elif mode == "concurrent":
+            agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+        else:
+            from agent.tool_executor import execute_tool_calls_segmented
+
+            execute_tool_calls_segmented(
+                agent,
+                batch,
+                messages,
+                "task-1",
+                segments=[("parallel", calls[:2]), ("sequential", calls[2:])],
+            )
+
+    assert executed == ["read_file"]
+    assert [message["tool_call_id"] for message in messages] == [
+        call.id for call in calls
+    ]
+    for call, message in zip(calls, messages):
+        if call.function.name == "read_file":
+            continue
+        blocked = json.loads(message["content"])
+        assert blocked["error_type"] == "cognitive_rotation_required"
+        assert blocked["reason"] == "delegation"
+        assert message["effect_disposition"] == "none"
+
+
+@pytest.mark.parametrize("mode", ["sequential", "concurrent", "segmented"])
+def test_effect_disposition_remains_effect_capable_for_executed_mutators(mode):
+    agent = _make_agent(_rotation_config(mutation_budget=0))
+    calls = [
+        _tool_call(
+            "write_file",
+            f"write-executed-{mode}",
+            {"path": f"{mode}.py", "content": "executed = True\n"},
+        ),
+        _tool_call(
+            "read_file",
+            f"read-executed-{mode}",
+            {"path": "README.md"},
+        ),
+    ]
+    if mode == "segmented":
+        calls.append(
+            _tool_call(
+                "execute_code",
+                "execute-executed-segmented",
+                {"code": "print('executed')"},
+            )
+        )
+    batch = SimpleNamespace(tool_calls=calls)
+    messages: list[dict] = []
+
+    def invoke(name, *_args, **_kwargs):
+        if name == "write_file":
+            return json.dumps({
+                "success": True,
+                "bytes_written": 16,
+                "files_modified": [f"/tmp/{mode}.py"],
+            })
+        if name == "execute_code":
+            return json.dumps({"success": True, "output": "executed"})
+        return json.dumps({"success": True, "content": "read"})
+
+    with (
+        patch.object(agent, "_invoke_tool", side_effect=invoke),
+        patch("run_agent.handle_function_call", side_effect=invoke),
+    ):
+        if mode == "sequential":
+            agent._execute_tool_calls_sequential(batch, messages, "task-1")
+        elif mode == "concurrent":
+            agent._execute_tool_calls_concurrent(batch, messages, "task-1")
+        else:
+            from agent.tool_executor import execute_tool_calls_segmented
+
+            execute_tool_calls_segmented(
+                agent,
+                batch,
+                messages,
+                "task-1",
+                segments=[("parallel", calls[:2]), ("sequential", calls[2:])],
+            )
+
+    assert [message["tool_call_id"] for message in messages] == [
+        call.id for call in calls
+    ]
+    for call, message in zip(calls, messages):
+        if call.function.name in {"write_file", "execute_code"}:
+            assert message.get("effect_disposition") is None

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -18,12 +18,17 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.cognitive_rotation import (
+    CognitiveRotationConfig,
+    CognitiveRotationController,
+)
 from agent.conversation_compression import (
+    COMPACTION_DONE_STATUS,
     finalize_context_engine_compression_notification,
 )
 
 class TestCompressionBoundaryHook:
-    def _make_agent(self, session_db):
+    def _make_agent(self, session_db, *, status_callback=None):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
             from run_agent import AIAgent
             agent = AIAgent(
@@ -35,10 +40,330 @@ class TestCompressionBoundaryHook:
                 session_id="original-session",
                 skip_context_files=True,
                 skip_memory=True,
+                status_callback=status_callback,
             )
             # ROTATION fallback — pin in_place=False regardless of default (#38763).
             agent.compression_in_place = False
             return agent
+
+    @staticmethod
+    def _progress_compressor():
+        compressor = MagicMock()
+        compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "tail question"},
+        ]
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_compress_aborted = False
+        compressor._last_compression_made_progress = True
+        return compressor
+
+    def test_compaction_notice_matches_returned_notice_and_preserves_compacted_status(self):
+        from hermes_state import SessionDB
+
+        events = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(
+                db,
+                status_callback=lambda kind, text: events.append((kind, text)),
+            )
+            controller = CognitiveRotationController(
+                CognitiveRotationConfig(enabled=True, mutation_budget=0)
+            )
+            controller.observe_tool_result("write_file", failed=False)
+            setattr(agent, "_cognitive_rotation", controller)
+            setattr(agent, "context_compressor", self._progress_compressor())
+            real_observe = controller.observe_compaction
+            returned_notices = []
+
+            def observe_compaction_side_effect(**kwargs):
+                notice = real_observe(**kwargs)
+                returned_notices.append(notice)
+                return notice
+
+            with patch.object(
+                controller,
+                "observe_compaction",
+                side_effect=observe_compaction_side_effect,
+            ) as observe_compaction_mock:
+                agent._compress_context(
+                    [{"role": "user", "content": "request"}],
+                    "sys",
+                    approx_tokens=100,
+                )
+
+            observe_compaction_mock.assert_called_once_with(
+                made_progress=True,
+                committed=True,
+            )
+            assert controller.active_reason == "compaction"
+            assert returned_notices[0] is not None
+            assert [event for event in events if event[0] == "cognitive_rotation"] == [
+                ("cognitive_rotation", returned_notices[0])
+            ]
+            assert ("compacted", COMPACTION_DONE_STATUS) in events
+
+    def test_committed_progress_before_mutation_does_not_activate_rotation(self):
+        from hermes_state import SessionDB
+
+        events = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(
+                db,
+                status_callback=lambda kind, text: events.append((kind, text)),
+            )
+            controller = CognitiveRotationController(
+                CognitiveRotationConfig(enabled=True, mutation_budget=0)
+            )
+            setattr(agent, "_cognitive_rotation", controller)
+            setattr(agent, "context_compressor", self._progress_compressor())
+
+            with patch.object(
+                controller,
+                "observe_compaction",
+                wraps=controller.observe_compaction,
+            ) as observe_compaction:
+                agent._compress_context(
+                    [{"role": "user", "content": "request"}],
+                    "sys",
+                    approx_tokens=100,
+                )
+
+            observe_compaction.assert_called_once_with(
+                made_progress=True,
+                committed=True,
+            )
+            assert controller.active_reason == ""
+            assert not any(kind == "cognitive_rotation" for kind, _ in events)
+
+    def test_no_progress_does_not_notify_cognitive_rotation(self):
+        from hermes_state import SessionDB
+
+        events = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(
+                db,
+                status_callback=lambda kind, text: events.append((kind, text)),
+            )
+            controller = CognitiveRotationController(
+                CognitiveRotationConfig(enabled=True, mutation_budget=0)
+            )
+            controller.observe_tool_result("write_file", failed=False)
+            compressor = self._progress_compressor()
+            compressor.compress.side_effect = lambda messages, **_kwargs: messages
+            compressor._last_compression_made_progress = False
+            setattr(agent, "_cognitive_rotation", controller)
+            setattr(agent, "context_compressor", compressor)
+
+            with patch.object(
+                controller,
+                "observe_compaction",
+                wraps=controller.observe_compaction,
+            ) as observe_compaction:
+                agent._compress_context(
+                    [{"role": "user", "content": "request"}],
+                    "sys",
+                    approx_tokens=100,
+                )
+
+            observe_compaction.assert_not_called()
+            assert controller.active_reason == ""
+            assert not any(kind == "cognitive_rotation" for kind, _ in events)
+
+    def test_aborted_compression_does_not_notify_cognitive_rotation(self):
+        from hermes_state import SessionDB
+
+        events = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(
+                db,
+                status_callback=lambda kind, text: events.append((kind, text)),
+            )
+            controller = CognitiveRotationController(
+                CognitiveRotationConfig(enabled=True, mutation_budget=0)
+            )
+            controller.observe_tool_result("write_file", failed=False)
+            compressor = self._progress_compressor()
+            compressor.compress.side_effect = lambda messages, **_kwargs: messages
+            compressor._last_compress_aborted = True
+            compressor._last_compression_made_progress = False
+            compressor._last_summary_error = "synthetic abort"
+            setattr(agent, "_cognitive_rotation", controller)
+            setattr(agent, "context_compressor", compressor)
+
+            with patch.object(
+                controller,
+                "observe_compaction",
+                wraps=controller.observe_compaction,
+            ) as observe_compaction:
+                agent._compress_context(
+                    [{"role": "user", "content": "request"}],
+                    "sys",
+                    approx_tokens=100,
+                )
+
+            observe_compaction.assert_not_called()
+            assert controller.active_reason == ""
+            assert not any(kind == "cognitive_rotation" for kind, _ in events)
+
+    def test_uncommitted_compression_does_not_notify_cognitive_rotation(self):
+        from hermes_state import SessionDB
+
+        events = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(
+                db,
+                status_callback=lambda kind, text: events.append((kind, text)),
+            )
+            controller = CognitiveRotationController(
+                CognitiveRotationConfig(enabled=True, mutation_budget=0)
+            )
+            controller.observe_tool_result("write_file", failed=False)
+            setattr(agent, "_cognitive_rotation", controller)
+            setattr(agent, "context_compressor", self._progress_compressor())
+
+            with (
+                patch.object(
+                    controller,
+                    "observe_compaction",
+                    wraps=controller.observe_compaction,
+                ) as observe_compaction,
+                patch.object(
+                    db,
+                    "publish_compression_child",
+                    side_effect=RuntimeError("synthetic commit failure"),
+                ),
+            ):
+                agent._compress_context(
+                    [{"role": "user", "content": "request"}],
+                    "sys",
+                    approx_tokens=100,
+                )
+
+            observe_compaction.assert_not_called()
+            assert controller.active_reason == ""
+            assert not any(kind == "cognitive_rotation" for kind, _ in events)
+
+    def test_compaction_notice_is_emitted_once_across_repeated_compactions(self):
+        from hermes_state import SessionDB
+
+        events = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(
+                db,
+                status_callback=lambda kind, text: events.append((kind, text)),
+            )
+            controller = CognitiveRotationController(
+                CognitiveRotationConfig(enabled=True, mutation_budget=0)
+            )
+            controller.observe_tool_result("write_file", failed=False)
+            setattr(agent, "_cognitive_rotation", controller)
+            setattr(agent, "context_compressor", self._progress_compressor())
+
+            for request in ("first", "second"):
+                agent._compress_context(
+                    [{"role": "user", "content": request}],
+                    "sys",
+                    approx_tokens=100,
+                )
+
+            cognitive_events = [
+                event for event in events if event[0] == "cognitive_rotation"
+            ]
+            assert len(cognitive_events) == 1
+            assert "compaction" in cognitive_events[0][1]
+            assert events.count(("compacted", COMPACTION_DONE_STATUS)) == 2
+
+    @pytest.mark.parametrize(
+        "case, config",
+        [
+            (
+                "disabled",
+                CognitiveRotationConfig(enabled=False, mutation_budget=0),
+            ),
+            (
+                "trigger_disabled",
+                CognitiveRotationConfig(
+                    enabled=True,
+                    mutation_budget=0,
+                    rotate_after_compaction=False,
+                ),
+            ),
+            (
+                "already_active",
+                CognitiveRotationConfig(enabled=True, mutation_budget=0),
+            ),
+        ],
+    )
+    def test_compaction_notice_is_silent_when_controller_does_not_activate(
+        self,
+        case,
+        config,
+    ):
+        from hermes_state import SessionDB
+
+        events = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(
+                db,
+                status_callback=lambda kind, text: events.append((kind, text)),
+            )
+            controller = CognitiveRotationController(config)
+            controller.observe_tool_result("write_file", failed=False)
+            if case == "already_active":
+                controller.observe_tool_result("delegate_task", failed=False)
+            setattr(agent, "_cognitive_rotation", controller)
+            setattr(agent, "context_compressor", self._progress_compressor())
+
+            agent._compress_context(
+                [{"role": "user", "content": "request"}],
+                "sys",
+                approx_tokens=100,
+            )
+
+            assert not any(kind == "cognitive_rotation" for kind, _ in events)
+            assert ("compacted", COMPACTION_DONE_STATUS) in events
+
+    def test_compaction_notice_callback_exception_does_not_abort_compaction(self):
+        from hermes_state import SessionDB
+
+        events = []
+
+        def status_callback(kind, text):
+            events.append((kind, text))
+            if kind == "cognitive_rotation":
+                raise RuntimeError("synthetic callback failure")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db, status_callback=status_callback)
+            controller = CognitiveRotationController(
+                CognitiveRotationConfig(enabled=True, mutation_budget=0)
+            )
+            controller.observe_tool_result("write_file", failed=False)
+            setattr(agent, "_cognitive_rotation", controller)
+            setattr(agent, "context_compressor", self._progress_compressor())
+
+            compressed, _ = agent._compress_context(
+                [{"role": "user", "content": "request"}],
+                "sys",
+                approx_tokens=100,
+            )
+
+            assert compressed
+            assert controller.active_reason == "compaction"
+            assert sum(kind == "cognitive_rotation" for kind, _ in events) == 1
+            assert ("compacted", COMPACTION_DONE_STATUS) in events
 
     def test_on_session_start_called_with_compression_boundary(self):
         from hermes_state import SessionDB

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -868,6 +868,27 @@ When the iteration budget is fully exhausted, the CLI shows a notification to th
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 
+## Cognitive Rotation Guardrail
+
+`agent.cognitive_rotation` is an **opt-in, session-scoped workflow circuit breaker** for long-running implementation contexts. It is disabled by default. When enabled, it reserves further direct source mutation for a fresh builder after a successful implementation delegation, a committed built-in compaction following a successful mutation, or exhaustion of the successful-mutation budget.
+
+```yaml
+agent:
+  cognitive_rotation:
+    enabled: false                 # Opt in; default is disabled
+    mutation_budget: 20            # Successful direct mutations before rotation
+    rotate_after_compaction: true  # Rotate after a committed, progressing compaction
+    lock_after_delegation: true    # Rotate after successful delegate_task
+```
+
+The direct mutators are exactly `patch`, `write_file`, and `execute_code`. The mutation that reaches the budget is allowed to finish; the next direct mutator is blocked. Set `mutation_budget: 0` (or another non-positive value) to disable only the budget trigger while leaving the enabled delegation and compaction triggers intact.
+
+Read and verification work remains available after rotation, including `read_file`, `search_files`, tests, `delegate_task`, and `terminal`. In particular, Hermes does not classify shell commands issued through `terminal` as mutations.
+
+:::warning Workflow guardrail, not a security boundary
+Cognitive rotation is not an adversarial security sandbox and is not a durable resume policy. Phase 1 state lives only in the current in-memory agent session: it is not persisted to the session database, does not automatically create a fresh session, and does not yet cover manual CLI/gateway compression, Codex app-server compaction, or plugin context engines. Those surfaces require separate phase 2 policy and persistence work.
+:::
+
 ## Standing Goals (`/goal`)
 
 When a standing goal is active, Hermes judges whether each assistant response satisfies it. If not, it feeds a continuation prompt back into the same session and keeps working until the goal is done, the turn budget is exhausted, or the user pauses/clears it. The turn budget is the real backstop — judge failures fail **open** (continue) so a flaky judge never wedges progress.


### PR DESCRIPTION
## Summary

- add an opt-in, session-scoped cognitive-rotation guardrail for long-running agent workflows
- block further direct source mutation after successful delegation, the configured mutation budget, or a committed progress-making compaction
- preserve read, verification, testing, diff inspection, delegation, and release operations after rotation activates
- return a normal synthetic tool result instead of halting the tool loop

## Why

Long-lived implementation sessions can accumulate multiple roles: planner, builder, reviewer, and release manager. After implementation is delegated or substantial source mutation has already landed, allowing the same parent context to continue patching can defeat role separation and independent review.

This change adds a structural, opt-in circuit breaker without adding a model tool or changing the system prompt mid-conversation.

## Configuration

The feature is disabled by default:

```yaml
agent:
  cognitive_rotation:
    enabled: false
    mutation_budget: 20
    rotate_after_compaction: true
    lock_after_delegation: true
```

Direct mutators are intentionally limited to `patch`, `write_file`, and `execute_code`.

## Behavior

When enabled:

- a successful delegation can reserve later source mutation for a fresh builder
- successful source mutation counts against an atomic per-session budget
- a committed, progress-making built-in compaction after mutation can activate rotation
- mixed delegation/mutation batches block the direct mutator before dispatch
- blocked calls return `error_type=cognitive_rotation_required` with no side-effect disposition
- failed/blocked/cancelled calls do not consume mutation budget
- concurrent reservations are settled exactly once across executor construction, submission, wait, shutdown, timeout, interruption, and persistence failures
- a submitted mutation with an unobservable result is counted conservatively rather than released as harmless
- non-mutating tools and release operations remain available

## Test plan

- [x] Focused runtime, config, compression, guardrail, and persistence aggregate: 91 passed
  - cognitive-rotation runtime: 26 passed, including 6 exceptional-executor regressions
  - incremental tool-call persistence: 10 passed
- [x] Ruff comparison: 0 new issues
- [x] Ty comparison: 0 new issues; diagnostics reduced from 135 on base to 129 on candidate
- [x] Independent immutable-snapshot review: PASS, 0 blocking findings
- [x] `origin/main` compatibility snapshot `fae29c841`: canonical patch applied cleanly; 91 passed
- [x] Final broad local suite classified: 24 failures across 13 unrelated/pre-existing files; no candidate regression found
  - the newly surfaced computer-use failure reproduces identically on frozen base `71e7eb3c`
  - the base-environment failure passes in an isolated rerun (33 passed)
- [ ] Hosted CI

## Scope and limitations

This is a workflow circuit breaker, not a security sandbox. Rotation state is process/session scoped. Persisting the state across process restart, session resume, manual/provider-native compaction, and late asynchronous completion is intentionally left for a separate durable-state design.
