### PR TITLE
fix(skills): resolve audit trust from provenance for official skills (#73099)

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1122,7 +1122,18 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
             c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
             continue
 
-        result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
+        # Mirror the install-time trust-source normalization (see do_install):
+        # official optional skills carry a multi-segment lockfile identifier
+        # such as "official/software-development/subagent-driven-development",
+        # but the trust resolver only recognizes the provenance value
+        # "official". Passing the raw identifier here would misclassify an
+        # installed official skill as community and turn a permitted CAUTION
+        # into a spurious BLOCKED even though the bundle is unchanged.
+        if entry.get("source") == "official":
+            scan_source = "official"
+        else:
+            scan_source = entry.get("identifier") or entry.get("source", "community")
+        result = scan_skill(skill_path, source=scan_source)
         c.print(format_scan_report(result))
 
         if deep:

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1158,7 +1158,18 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
             c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
             continue
 
-        result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
+        # Mirror the install-time trust-source normalization (see do_install):
+        # official optional skills carry a multi-segment lockfile identifier
+        # such as "official/software-development/subagent-driven-development",
+        # but the trust resolver only recognizes the provenance value
+        # "official". Passing the raw identifier here would misclassify an
+        # installed official skill as community and turn a permitted CAUTION
+        # into a spurious BLOCKED even though the bundle is unchanged.
+        if entry.get("source") == "official":
+            scan_source = "official"
+        else:
+            scan_source = entry.get("identifier") or entry.get("source", "community")
+        result = scan_skill(skill_path, source=scan_source)
         c.print(format_scan_report(result))
 
         if deep:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -313,3 +313,58 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
 
+
+
+def test_do_audit_scans_official_skills_with_source_provenance(
+    monkeypatch, tmp_path, hub_env
+):
+    """Audit must resolve trust from provenance, not the multi-segment id.
+
+    Regression: an installed official optional skill records a multi-segment
+    lockfile identifier (``official/software-development/…``). Passing that
+    raw identifier into the trust resolver classifies it as ``community``
+    (the resolver only recognizes the provenance value ``official``), which
+    can flip a permitted CAUTION into a spurious BLOCKED. Audit must mirror
+    install and key off the ``source`` field.
+    """
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+    from hermes_cli.skills_hub import do_audit
+
+    install_path = "software-development/subagent-driven-development"
+    skill_path = hub.SKILLS_DIR / install_path
+    skill_path.mkdir(parents=True)
+    (skill_path / "SKILL.md").write_text("# Subagent Driven Development", encoding="utf-8")
+
+    entry = {
+        "name": "subagent-driven-development",
+        "source": "official",
+        "identifier": "official/software-development/subagent-driven-development",
+        "install_path": install_path,
+    }
+
+    class _Lock:
+        def list_installed(self):
+            return [entry]
+
+    scanned = {}
+
+    def _scan_skill(path, source="community"):
+        scanned["source"] = source
+        return guard.ScanResult(
+            skill_name="subagent-driven-development",
+            source=source,
+            trust_level=guard._resolve_trust_level(source),
+            verdict="caution",
+        )
+
+    monkeypatch.setattr(hub, "HubLockFile", _Lock)
+    monkeypatch.setattr(guard, "scan_skill", _scan_skill)
+    monkeypatch.setattr(guard, "format_scan_report", lambda result: "scan ok")
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_audit(name="subagent-driven-development", console=console)
+
+    assert scanned["source"] == "official"
+

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -314,7 +314,6 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert "Searching for:" not in sink.getvalue()
 
 
-
 # ---------------------------------------------------------------------------
 # Local-edit protection in do_update (ported from paperclipai/paperclip#10978)
 # ---------------------------------------------------------------------------
@@ -394,3 +393,57 @@ def test_do_update_unmodified_skill_updates_normally(monkeypatch, tmp_path):
 
     assert installs == ["someone/hub-skill"]
     assert "Updated 1 skill(s)" in sink.getvalue()
+
+
+def test_do_audit_scans_official_skills_with_source_provenance(
+    monkeypatch, tmp_path, hub_env
+):
+    """Audit must resolve trust from provenance, not the multi-segment id.
+
+    Regression: an installed official optional skill records a multi-segment
+    lockfile identifier (``official/software-development/…``). Passing that
+    raw identifier into the trust resolver classifies it as ``community``
+    (the resolver only recognizes the provenance value ``official``), which
+    can flip a permitted CAUTION into a spurious BLOCKED. Audit must mirror
+    install and key off the ``source`` field.
+    """
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+    from hermes_cli.skills_hub import do_audit
+
+    install_path = "software-development/subagent-driven-development"
+    skill_path = hub.SKILLS_DIR / install_path
+    skill_path.mkdir(parents=True)
+    (skill_path / "SKILL.md").write_text("# Subagent Driven Development", encoding="utf-8")
+
+    entry = {
+        "name": "subagent-driven-development",
+        "source": "official",
+        "identifier": "official/software-development/subagent-driven-development",
+        "install_path": install_path,
+    }
+
+    class _Lock:
+        def list_installed(self):
+            return [entry]
+
+    scanned = {}
+
+    def _scan_skill(path, source="community"):
+        scanned["source"] = source
+        return guard.ScanResult(
+            skill_name="subagent-driven-development",
+            source=source,
+            trust_level=guard._resolve_trust_level(source),
+            verdict="caution",
+        )
+
+    monkeypatch.setattr(hub, "HubLockFile", _Lock)
+    monkeypatch.setattr(guard, "scan_skill", _scan_skill)
+    monkeypatch.setattr(guard, "format_scan_report", lambda result: "scan ok")
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_audit(name="subagent-driven-development", console=console)
+
+    assert scanned["source"] == "official"


### PR DESCRIPTION

## Note

The Windows-footgun gate scans touched files whole, so it surfaced five
pre-existing bare `write_text()` calls in `test_skills_hub.py` alongside the
one my new test adds. All six now pass `encoding="utf-8"`, in line with the
`#71014` read_text/encoding campaign.
