### PR TITLE
fix(cli): keep attached images when interrupted input is re-queued

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13472,9 +13472,38 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             all_parts.append(extra)
                     except queue.Empty:
                         break
-                combined = "\n".join(all_parts)
+                # Parts are plain `str`, or `(text, [Path, ...])` tuples when
+                # the Enter handler bundled attached images. `"\n".join` raises
+                # TypeError on a tuple, and since the extras were already taken
+                # off the queue with get_nowait() — and chat()'s bare `except`
+                # swallows the error — the message and its images were silently
+                # lost. Merge type-aware instead: join the text, concatenate the
+                # image lists, and emit a plain `str` when no part carries
+                # images so the text-only path is unchanged. process_loop
+                # already unpacks the `(text, images)` form.
+                text_parts = []
+                merged_images = []
+                for part in all_parts:
+                    if isinstance(part, tuple) and len(part) == 2:
+                        part_text, part_images = part
+                    else:
+                        part_text, part_images = part, None
+                    if part_text:
+                        text_parts.append(
+                            part_text if isinstance(part_text, str) else str(part_text)
+                        )
+                    if part_images:
+                        merged_images.extend(part_images)
+                combined_text = "\n".join(text_parts)
+                combined = (combined_text, merged_images) if merged_images else combined_text
                 n = len(all_parts)
-                preview = combined[:50] + ("..." if len(combined) > 50 else "")
+                preview = combined_text[:50] + ("..." if len(combined_text) > 50 else "")
+                if merged_images:
+                    _img_note = (
+                        f"[{len(merged_images)} image"
+                        f"{'s' if len(merged_images) != 1 else ''} attached]"
+                    )
+                    preview = f"{preview} {_img_note}" if preview else _img_note
                 if n > 1:
                     print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
                 else:

--- a/tests/cli/test_cli_interrupt_ack_race.py
+++ b/tests/cli/test_cli_interrupt_ack_race.py
@@ -29,6 +29,7 @@ import sys
 import threading
 import time
 import types
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
@@ -194,6 +195,127 @@ def test_acknowledged_interrupt_still_requeues_message():
         queued.append(cli._pending_input.get_nowait())
     assert any("redirect please" in str(q) for q in queued)
     assert cli._last_turn_interrupted is True
+
+
+class _AcknowledgingStubAgent(_StubAgent):
+    """Agent whose turn result DOES acknowledge the interrupt.
+
+    Mirrors the private ``_AckAgent`` above; shared by the image-payload
+    tests so both can drive the live ``chat()`` requeue branch.
+    """
+
+    def run_conversation(self, **kwargs):
+        # Wait until the monitor loop delivers the interrupt.
+        for _ in range(100):
+            if self._interrupt_requested:
+                break
+            time.sleep(0.05)
+        return {
+            "final_response": "partial work",
+            "messages": [{"role": "assistant", "content": "partial work"}],
+            "api_calls": 1,
+            "completed": False,
+            "interrupted": True,
+            "interrupt_message": self._interrupt_message,
+            "partial": True,
+            "response_previewed": True,
+        }
+
+
+def _run_interrupted_turn(cli):
+    """Run one ``chat()`` turn with the runtime/credential plumbing stubbed."""
+    with patch.object(cli, "_ensure_runtime_credentials", return_value=True), \
+         patch.object(cli, "_resolve_turn_agent_config", return_value={
+             "signature": cli._active_agent_route_signature,
+             "model": None, "runtime": None, "request_overrides": None,
+         }), \
+         patch.object(cli, "_init_agent", return_value=True):
+        cli.chat("original")
+
+    queued = []
+    while not cli._pending_input.empty():
+        queued.append(cli._pending_input.get_nowait())
+    return queued
+
+
+def test_interrupt_with_attached_images_is_requeued_intact():
+    """A single image interrupt must survive the requeue (supersedes #5202).
+
+    The Enter handler bundles attached images as ``(text, [Path, ...])`` and
+    puts that tuple on ``_interrupt_queue``, so ``pending_message`` itself can
+    be a tuple — one interrupted image message is enough to trip the old
+    ``"\\n".join(all_parts)``. The resulting ``TypeError`` was swallowed by
+    ``chat()``'s bare ``except``, and because the parts had already been taken
+    off the queue the message and its images were gone for good.
+    """
+    cli = _make_cli()
+    cli.agent = _AcknowledgingStubAgent(cli.session_id)
+    cli._interrupt_queue = queue.Queue()
+    cli._pending_input = queue.Queue()
+
+    shot = Path("/tmp/hermes-test-shot.png")
+    cli._interrupt_queue.put(("what is in this screenshot?", [shot]))
+
+    queued = _run_interrupted_turn(cli)
+
+    assert queued, "image interrupt payload was dropped instead of re-queued"
+    payload = queued[0]
+    assert isinstance(payload, tuple), (
+        f"image payload lost its attachments; pending_input={queued!r}"
+    )
+    text, images = payload
+    assert text == "what is in this screenshot?"
+    assert images == [shot]
+
+
+def test_interrupt_merges_text_and_image_parts_without_losing_attachments():
+    """Extras drained from ``_interrupt_queue`` merge type-aware.
+
+    The monitor loop claims the first queued item as the interrupt; anything
+    typed after it stays on ``_interrupt_queue`` and is drained by the requeue
+    branch. Text joins with newlines (unchanged behaviour) and every image list
+    is concatenated in arrival order.
+    """
+    cli = _make_cli()
+    cli.agent = _AcknowledgingStubAgent(cli.session_id)
+    cli._interrupt_queue = queue.Queue()
+    cli._pending_input = queue.Queue()
+
+    first = Path("/tmp/hermes-test-first.png")
+    second = Path("/tmp/hermes-test-second.png")
+    cli._interrupt_queue.put(("look at this", [first]))
+    cli._interrupt_queue.put("wait, also stop the build")
+    cli._interrupt_queue.put(("and this one", [second]))
+
+    queued = _run_interrupted_turn(cli)
+
+    assert queued, "merged interrupt payload was dropped instead of re-queued"
+    payload = queued[0]
+    assert isinstance(payload, tuple), (
+        f"merged payload lost its attachments; pending_input={queued!r}"
+    )
+    text, images = payload
+    assert text == "look at this\nwait, also stop the build\nand this one"
+    assert images == [first, second]
+
+
+def test_text_only_interrupt_still_requeues_a_plain_string():
+    """No part carries images → the payload stays a plain ``str``.
+
+    Guards the common path: process_loop only unpacks tuples, so a text-only
+    interrupt must not start arriving as ``(text, [])``.
+    """
+    cli = _make_cli()
+    cli.agent = _AcknowledgingStubAgent(cli.session_id)
+    cli._interrupt_queue = queue.Queue()
+    cli._pending_input = queue.Queue()
+
+    cli._interrupt_queue.put("stop")
+    cli._interrupt_queue.put("show me the plan instead")
+
+    queued = _run_interrupted_turn(cli)
+
+    assert queued == ["stop\nshow me the plan instead"]
 
 
 def test_chat_persists_clean_input_when_a_queued_note_changes_api_message():


### PR DESCRIPTION
## This supersedes #5202 (@mattsegura, 2026-04-05)

- **What #5202 got right:** the diagnosis. It correctly traced image loss to the `chat()` interrupt-requeue path, and the credit for finding this belongs there.
- **What it did not do:** its `tests/test_cli_interrupt_payloads.py` exercises three extracted module-level helpers in isolation and never drives the live `HermesCLI.chat()` requeue branch — the exact deficiency named in the 2026-07-12 review on that PR. It also carries an unrelated `process_loop` display refactor, and its `cli.py` hunks are stale against a `cli.py` that has been rewritten around them in the 3.5 months since (the requeue branch moved from ~line 6666 to 13466; the tuple unpack it adds to `process_loop` is already inline on main at `cli.py:16132-16134`).
- **What this adds:** the shape requested in that review — a focused type-aware merge at the requeue site only, plus tuple/image cases added to the live-path test at `tests/cli/test_cli_interrupt_ack_race.py`, asserting the queued next-turn payload retains `(text, [Path, ...])`.

## What does this PR do?

Interrupting a running turn while images are attached silently destroys the message and the images.

The Enter handler bundles attachments as a `(text, [Path, ...])` tuple (`cli.py:14343`) and, in the default `busy_input_mode == "interrupt"`, puts that tuple on `_interrupt_queue` (`cli.py:14395`). The image path always goes there — the `agent.redirect()` fast path above it is gated on `if not images and text`. `chat()`'s requeue branch then ran:

```python
all_parts = [pending_message]
...
combined = "\n".join(all_parts)      # cli.py:13475
```

which raises `TypeError: sequence item 0: expected str instance, tuple found`.

`pending_message` is itself bound from the queue value — `result.get("interrupt_message") or interrupt_msg` (`cli.py:13298`) and `pending_message = interrupt_msg` (`cli.py:13312`), and `interrupt_msg` comes straight off `_interrupt_queue`. `turn_finalizer.py:625` returns `agent._interrupt_message` verbatim, so the tuple survives the round trip intact. **A single interrupted image message is enough to trigger the crash** — a second queued message is not required.

The failure is invisible and unrecoverable:

- `chat()`'s whole body sits under a bare `except Exception as e: print(f"Error: {e}")` (`cli.py:13492`), so the user sees one line of error text and nothing else.
- The parts were already removed from the queue with `get_nowait()` before the join, so the message and its images are gone — not requeued, not re-displayed, not recallable.

The fix merges the parts type-aware at the requeue site: join the text, concatenate the image lists, and emit a plain `str` when no part carries images so the common text-only path is unchanged. `process_loop` already unpacks the `(text, images)` form at `cli.py:16132-16134`, so the merged payload round-trips into the next turn as a real multimodal message.

### Sibling-site sweep

`grep -n '_interrupt_queue\|_pending_input' cli.py` — every producer and consumer of these two queues was enumerated. The type-blind join exists at exactly one site; the rest are already tuple-safe and are deliberately left untouched:

| Site | Role | Status |
| --- | --- | --- |
| `cli.py:13475` (`chat()` requeue) | joins drained parts | **the bug — fixed here** |
| `cli.py:14370` (queue mode) | `_pending_input.put(payload)` | safe — puts the tuple verbatim |
| `cli.py:14395` (interrupt mode) | `_interrupt_queue.put(payload)` | safe — the producer, correct as-is |
| `cli.py:14423` (agent idle) | `_pending_input.put(payload)` | safe — verbatim |
| `cli.py:13117` (clarify race) | parks `interrupt_msg` in `_pending_input` | safe — verbatim, no join |
| `cli.py:10208-10211` `_drain_interrupt_queue_to_pending_input()` | moves strays across | safe — verbatim, no join |
| `cli.py:10255-10262` goal-continuation peek | inspects queued entries | safe — already unpacks `(text, images)` |
| `cli.py:6815` alt submit path | puts plain `str` | safe — no images on that path |
| `cli.py:13488` leftover `/steer` preview | slices a `str` | out of scope — `/steer` is text-only by construction (the Enter handler falls back to queue mode when images are attached) |

No mirror of this join exists in `tui_gateway/`, `gateway/`, or `apps/desktop/` — `grep -rn "all_parts" --include='*.py' .` returns this one production site.

## Related Issue

No filed issue — this supersedes open PR #5202 and implements the review left on it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py` — replaced the type-blind `"\n".join(all_parts)` in `HermesCLI.chat()`'s interrupt-requeue branch with a type-aware merge: text joined with `\n` in arrival order, image lists concatenated in arrival order, result emitted as `(text, images)` only when at least one part carries images and as a plain `str` otherwise. `preview` now derives from the joined text (so it stays a `str`) and gains an `[N images attached]` note when attachments are present, including the text-empty case. The existing `n > 1` vs single-message print branch is unchanged.
- `tests/cli/test_cli_interrupt_ack_race.py` — added three tests on the live `HermesCLI.chat()` path: a single image interrupt, a mixed text+image merge, and a text-only guard.

## How to Test

Reproduction (before this PR): attach an image with the agent running, press Enter (default `busy_input_mode = interrupt`). The turn is interrupted, then `Error: sequence item 0: expected str instance, tuple found` prints and your message and image never come back.

Automated, on the live `chat()` requeue branch:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/cli/test_cli_interrupt_ack_race.py -v
```

Fails-before / passes-after, verified in both directions by reverting only the `cli.py` hunk:

| Test | On `main` (prod hunk reverted) | With this PR |
| --- | --- | --- |
| `test_interrupt_with_attached_images_is_requeued_intact` | **FAIL** — `_pending_input` is empty; captured stdout shows the swallowed `Error: sequence item 0: expected str instance, tuple found` | PASS — payload is `("what is in this screenshot?", [Path(...)])` |
| `test_interrupt_merges_text_and_image_parts_without_losing_attachments` | **FAIL** — same swallowed `TypeError`, all three parts lost | PASS — text joined, both image paths preserved in order |
| `test_text_only_interrupt_still_requeues_a_plain_string` | PASS | PASS — proves the text-only path is untouched |

Full results:

- `tests/cli/test_cli_interrupt_ack_race.py` — 11 passed (8 pre-existing + 3 new).
- `tests/cli/` — 1232 passed, 1 failed. The single failure, `test_resume_quiet_stderr.py::TestResumeQuietStderr::test_session_not_found_goes_to_stdout_in_full_mode`, is a pre-existing baseline: the identical `pytest tests/cli/ -q -p no:randomly -n 4` run on clean `origin/main` (`ef2670113`) fails the same test (1229 passed, 1 failed), and it passes in isolation on both. It is a parallel-ordering artifact, unrelated to this change and untouched by it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cli/ -q` and all tests pass (one pre-existing baseline failure, reproduced on clean `origin/main` — see above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure in-process payload handling, no filesystem or path-separator behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

- **#5202** (`mattsegura`, open) — same diagnosis, superseded here. See the header.
- **#12751** (`nicoechaniz`, closed unmerged 2026-04-28) — earlier attempt at the same defect.
- **#35317** (`HH1162`, open) — edits the same block but for a different concern (background-task input loss / old messages reappearing, across 5 files). Its requeue rewrite adds `isinstance(extra, str)` filters, which *drops* image payloads instead of preserving them — it converts this crash into a silent attachment loss rather than fixing it. The two changes are not substitutes.