### PR TITLE
fix(state): narrow FTS UPDATE triggers to payload-bearing columns

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -928,7 +928,11 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_delete AFTER DELETE ON messages BEGIN
     DELETE FROM messages_fts WHERE rowid = old.id;
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
+CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages
+WHEN COALESCE(new.content, '') != COALESCE(old.content, '')
+   OR COALESCE(new.tool_name, '') != COALESCE(old.tool_name, '')
+   OR COALESCE(new.tool_calls, '') != COALESCE(old.tool_calls, '')
+BEGIN
     DELETE FROM messages_fts WHERE rowid = old.id;
     INSERT INTO messages_fts(rowid, content) VALUES (
         new.id,
@@ -958,7 +962,11 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON message
     DELETE FROM messages_fts_trigram WHERE rowid = old.id;
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages BEGIN
+CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages
+WHEN COALESCE(new.content, '') != COALESCE(old.content, '')
+   OR COALESCE(new.tool_name, '') != COALESCE(old.tool_name, '')
+   OR COALESCE(new.tool_calls, '') != COALESCE(old.tool_calls, '')
+BEGIN
     DELETE FROM messages_fts_trigram WHERE rowid = old.id;
     INSERT INTO messages_fts_trigram(rowid, content) VALUES (
         new.id,
@@ -1209,6 +1217,90 @@ class SessionDB:
             "COALESCE(tool_calls, '') "
             "FROM messages"
         )
+
+    @staticmethod
+    def _is_broad_update_trigger(cursor: sqlite3.Cursor, trigger_name: str) -> bool:
+        """True when the named UPDATE trigger is broad (fires on every UPDATE).
+
+        A narrowed trigger has a WHEN clause that gates on payload columns;
+        a broad trigger has none.  We inspect sqlite_master.sql so the
+        check is a single read — no trigger execution, no FTS rebuild.
+        """
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = ?",
+            (trigger_name,),
+        ).fetchone()
+        if row is None:
+            return False  # trigger doesn't exist yet — nothing to narrow
+        sql = row[0] if not isinstance(row, sqlite3.Row) else row[0]
+        if sql is None:
+            return False
+        return "WHEN" not in sql.upper()
+
+    @classmethod
+    def _migrate_fts_update_triggers(cls, cursor: sqlite3.Cursor) -> bool:
+        """Narrow broad UPDATE triggers to payload-scoped ones.
+
+        Migration contract (per review of the FTS trigger narrowing PR):
+          1. Inspect sqlite_master.sql — only migrate when an existing
+             UPDATE trigger is broad (no WHEN clause).
+          2. Drop only the two UPDATE triggers, recreate them with
+             individual cursor.execute() calls (NOT executescript, which
+             has different transaction semantics).
+          3. Keep INSERT/DELETE triggers present throughout.
+          4. Do NOT rebuild FTS — broad triggers may have over-indexed
+             unchanged payload, but they have not missed content updates,
+             so existing index contents remain valid.
+          5. Idempotent — reopening an already-converged DB performs
+             reads only and produces zero FTS rebuild/maintenance statements.
+
+        Returns True if a migration was performed, False if already converged.
+        """
+        update_triggers = (
+            "messages_fts_update",
+            "messages_fts_trigram_update",
+        )
+        # Read-only inspection: check whether any UPDATE trigger is broad.
+        needs_migration = any(
+            cls._is_broad_update_trigger(cursor, name)
+            for name in update_triggers
+        )
+        if not needs_migration:
+            return False
+
+        # Drop only the broad UPDATE triggers — INSERT/DELETE stay live.
+        for name in update_triggers:
+            cursor.execute(f"DROP TRIGGER IF EXISTS {name}")
+
+        # Recreate as narrowed triggers with individual execute() calls.
+        # The caller (typically _init_schema) wraps this in BEGIN IMMEDIATE
+        # so the drop+recreate is atomic across concurrent writers.
+        cursor.execute(
+            "CREATE TRIGGER messages_fts_update "
+            "AFTER UPDATE ON messages "
+            "WHEN COALESCE(new.content, '') != COALESCE(old.content, '') "
+            "   OR COALESCE(new.tool_name, '') != COALESCE(old.tool_name, '') "
+            "   OR COALESCE(new.tool_calls, '') != COALESCE(old.tool_calls, '') "
+            "BEGIN "
+            "DELETE FROM messages_fts WHERE rowid = old.id; "
+            "INSERT INTO messages_fts(rowid, content) VALUES (new.id, "
+            "COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')"
+            "); END;"
+        )
+        cursor.execute(
+            "CREATE TRIGGER messages_fts_trigram_update "
+            "AFTER UPDATE ON messages "
+            "WHEN COALESCE(new.content, '') != COALESCE(old.content, '') "
+            "   OR COALESCE(new.tool_name, '') != COALESCE(old.tool_name, '') "
+            "   OR COALESCE(new.tool_calls, '') != COALESCE(old.tool_calls, '') "
+            "BEGIN "
+            "DELETE FROM messages_fts_trigram WHERE rowid = old.id; "
+            "INSERT INTO messages_fts_trigram(rowid, content) VALUES (new.id, "
+            "COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')"
+            "); END;"
+        )
+        return True
 
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
         try:
@@ -1901,6 +1993,13 @@ class SessionDB:
             # FTS5 setup. Run the DDL even when the virtual table exists so
             # CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation from
             # an earlier no-FTS5 runtime.
+            #
+            # Check trigger count BEFORE _ensure_fts_schema: if triggers were
+            # dropped (e.g. by a no-FTS5 runtime) the FTS indexes may be stale
+            # and need a one-time backfill after recreation. This is distinct
+            # from the broad->narrowed migration below, which does NOT need a
+            # rebuild (broad triggers may have over-indexed unchanged payload
+            # but have not missed content updates).
             triggers_need_repair = self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
             self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
 
@@ -1912,6 +2011,21 @@ class SessionDB:
                     cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
                 )
                 self._trigram_available = trigram_enabled
+
+                # Narrow broad UPDATE triggers to payload-scoped ones.
+                # This is a read-only inspection + targeted drop/recreate of
+                # only the two UPDATE triggers -- INSERT/DELETE stay live, and
+                # no FTS rebuild is needed because broad triggers may have
+                # over-indexed unchanged payload but have not missed content
+                # updates. See _migrate_fts_update_triggers for the full
+                # migration contract. Idempotent: already-converged DBs
+                # perform reads only.
+                self._migrate_fts_update_triggers(cursor)
+
+                # Rebuild FTS when triggers were missing (not just broad).
+                # triggers_need_repair was computed above before
+                # _ensure_fts_schema recreated them; if True, the FTS
+                # indexes may be stale and need a one-time backfill.
                 if triggers_need_repair:
                     self._rebuild_fts_indexes(
                         cursor,

--- a/tests/state/test_fts_trigger_migration.py
+++ b/tests/state/test_fts_trigger_migration.py
@@ -1,0 +1,313 @@
+"""Tests for the FTS UPDATE trigger narrowing migration.
+
+Covers the migration contract from the PR review (NousResearch/hermes-agent#68891):
+  - Broad → narrowed migration (inspects sqlite_master.sql, only migrates
+    when UPDATE trigger is broad).
+  - Idempotent reopen (already-converged DB performs reads only).
+  - INSERT/DELETE triggers stay present throughout.
+  - No FTS rebuild on migration (broad triggers may have over-indexed
+    unchanged payload, but have not missed content updates).
+  - FTS-disabled / trigram-unavailable paths.
+  - Real content updates still propagate to FTS.
+"""
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    yield d
+    try:
+        d.close()
+    except Exception:
+        pass
+
+
+def _trigger_sql(db_path, trigger_name):
+    """Read the CREATE TRIGGER statement from sqlite_master."""
+    raw = sqlite3.connect(str(db_path))
+    row = raw.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+        (trigger_name,),
+    ).fetchone()
+    raw.close()
+    return row[0] if row else None
+
+
+def _trigger_exists(db_path, trigger_name):
+    raw = sqlite3.connect(str(db_path))
+    row = raw.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+        (trigger_name,),
+    ).fetchone()
+    raw.close()
+    return row is not None
+
+
+def _fts_search(db_path, table, query):
+    raw = sqlite3.connect(str(db_path))
+    rows = raw.execute(
+        f"SELECT rowid FROM {table} WHERE {table} MATCH ?",
+        (query,),
+    ).fetchall()
+    raw.close()
+    return [r[0] for r in rows]
+
+
+def _create_broad_triggers(db_path):
+    """Install broad UPDATE triggers (no WHEN clause) to simulate a
+    pre-migration database."""
+    raw = sqlite3.connect(str(db_path))
+    # Drop existing narrowed triggers first so we can install broad ones.
+    raw.execute("DROP TRIGGER IF EXISTS messages_fts_update")
+    raw.execute("DROP TRIGGER IF EXISTS messages_fts_trigram_update")
+    raw.execute(
+        """CREATE TRIGGER messages_fts_update AFTER UPDATE ON messages BEGIN
+            DELETE FROM messages_fts WHERE rowid = old.id;
+            INSERT INTO messages_fts(rowid, content) VALUES (
+                new.id,
+                COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
+            );
+        END;"""
+    )
+    raw.execute(
+        """CREATE TRIGGER messages_fts_trigram_update AFTER UPDATE ON messages BEGIN
+            DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+            INSERT INTO messages_fts_trigram(rowid, content) VALUES (
+                new.id,
+                COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
+            );
+        END;"""
+    )
+    raw.commit()
+    raw.close()
+
+
+class TestTriggerMigration:
+    def test_broad_update_trigger_is_narrowed_on_init(self, db, tmp_path):
+        """A broad UPDATE trigger gets narrowed to payload-scoped on the
+        next SessionDB init."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello world")
+
+        # Install broad triggers (simulating a pre-migration DB).
+        db.close()
+        _create_broad_triggers(tmp_path / "state.db")
+
+        # Reopen — should narrow the triggers.
+        db2 = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            sql = _trigger_sql(tmp_path / "state.db", "messages_fts_update")
+            assert sql is not None
+            assert "WHEN" in sql.upper()
+            assert "COALESCE(new.content" in sql
+            assert "COALESCE(new.tool_name" in sql
+            assert "COALESCE(new.tool_calls" in sql
+        finally:
+            db2.close()
+
+    def test_insert_delete_triggers_preserved_during_migration(self, db, tmp_path):
+        """INSERT/DELETE triggers must remain present after narrowing
+        UPDATE triggers."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello")
+
+        db.close()
+        _create_broad_triggers(tmp_path / "state.db")
+
+        db2 = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            assert _trigger_exists(tmp_path / "state.db", "messages_fts_insert")
+            assert _trigger_exists(tmp_path / "state.db", "messages_fts_delete")
+            assert _trigger_exists(tmp_path / "state.db", "messages_fts_trigram_insert")
+            assert _trigger_exists(tmp_path / "state.db", "messages_fts_trigram_delete")
+        finally:
+            db2.close()
+
+    def test_migration_is_idempotent(self, db, tmp_path):
+        """Reopening an already-converged DB performs reads only — no
+        second migration, no FTS rebuild."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello")
+
+        # First reopen: triggers are already narrowed (from DDL).
+        db.close()
+        db2 = SessionDB(db_path=tmp_path / "state.db")
+        db2.close()
+
+        # Second reopen: still narrowed, no rebuild.
+        db3 = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            sql = _trigger_sql(tmp_path / "state.db", "messages_fts_update")
+            assert "WHEN" in sql.upper()
+            # Trigger count should be the full set — no rebuild needed.
+            cursor = db3._conn.cursor()
+            count = db3._fts_trigger_count(cursor)
+            assert count == 6
+        finally:
+            db3.close()
+
+    def test_no_fts_rebuild_on_migration(self, db, tmp_path):
+        """Migration must NOT rebuild FTS indexes — broad triggers may
+        have over-indexed unchanged payload, but have not missed content
+        updates, so existing index contents remain valid."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "searchable content here")
+
+        # Verify FTS has the content.
+        hits = _fts_search(tmp_path / "state.db", "messages_fts", "searchable")
+        assert len(hits) == 1
+
+        # Install broad triggers.
+        db.close()
+        _create_broad_triggers(tmp_path / "state.db")
+
+        # Reopen — migration narrows triggers but does NOT rebuild FTS.
+        db2 = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            # Content should still be searchable (no rebuild wiped it).
+            hits = _fts_search(tmp_path / "state.db", "messages_fts", "searchable")
+            assert len(hits) == 1
+        finally:
+            db2.close()
+
+    def test_real_content_updates_propagate_to_fts(self, db, tmp_path):
+        """After migration, real content updates still propagate to FTS."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "original content")
+
+        db.close()
+        _create_broad_triggers(tmp_path / "state.db")
+
+        db2 = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            # Update the message content.
+            db2._conn.execute(
+                "UPDATE messages SET content = 'updated content' WHERE session_id = 's1'"
+            )
+            db2._conn.commit()
+
+            # FTS should reflect the update.
+            hits = _fts_search(tmp_path / "state.db", "messages_fts", "updated")
+            assert len(hits) == 1
+            hits_old = _fts_search(tmp_path / "state.db", "messages_fts", "original")
+            assert len(hits_old) == 0
+        finally:
+            db2.close()
+
+    def test_status_only_update_does_not_trigger_fts(self, db, tmp_path):
+        """A status-only UPDATE (no payload change) should NOT fire the
+        narrowed UPDATE trigger."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        msg_id = db.append_message("s1", "user", "payload content")
+
+        # Status-only update (no content/tool_name/tool_calls change).
+        db._conn.execute(
+            "UPDATE messages SET active = 0 WHERE id = ?",
+            (msg_id,),
+        )
+        db._conn.commit()
+
+        # FTS should still have the original content (trigger didn't fire).
+        hits = _fts_search(tmp_path / "state.db", "messages_fts", "payload")
+        assert len(hits) == 1
+
+    def test_trigram_update_trigger_also_narrowed(self, db, tmp_path):
+        """The trigram UPDATE trigger is also narrowed."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello")
+
+        db.close()
+        _create_broad_triggers(tmp_path / "state.db")
+
+        db2 = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            sql = _trigger_sql(tmp_path / "state.db", "messages_fts_trigram_update")
+            assert sql is not None
+            assert "WHEN" in sql.upper()
+        finally:
+            db2.close()
+
+    def test_is_broad_update_trigger_returns_false_for_narrowed(self, db, tmp_path):
+        """_is_broad_update_trigger returns False for a narrowed trigger."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello")
+
+        cursor = db._conn.cursor()
+        # New DBs get narrowed triggers from the DDL.
+        assert not db._is_broad_update_trigger(cursor, "messages_fts_update")
+        assert not db._is_broad_update_trigger(cursor, "messages_fts_trigram_update")
+
+    def test_is_broad_update_trigger_returns_true_for_broad(self, db, tmp_path):
+        """_is_broad_update_trigger returns True for a broad trigger."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello")
+
+        db.close()
+        _create_broad_triggers(tmp_path / "state.db")
+
+        # Check on a raw connection BEFORE SessionDB init narrows them.
+        raw = sqlite3.connect(str(tmp_path / "state.db"))
+        cursor = raw.cursor()
+        assert SessionDB._is_broad_update_trigger(cursor, "messages_fts_update")
+        assert SessionDB._is_broad_update_trigger(cursor, "messages_fts_trigram_update")
+        raw.close()
+
+    def test_migration_returns_true_when_narrowing(self, db, tmp_path):
+        """_migrate_fts_update_triggers returns True when a migration
+        was performed."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello")
+
+        db.close()
+        _create_broad_triggers(tmp_path / "state.db")
+
+        # Call _migrate_fts_update_triggers on a raw connection with broad
+        # triggers — should return True and narrow them.
+        raw = sqlite3.connect(str(tmp_path / "state.db"))
+        cursor = raw.cursor()
+        result = SessionDB._migrate_fts_update_triggers(cursor)
+        assert result is True
+        raw.commit()
+        raw.close()
+
+        # Verify triggers are now narrowed.
+        sql = _trigger_sql(tmp_path / "state.db", "messages_fts_update")
+        assert "WHEN" in sql.upper()
+
+    def test_migration_returns_false_when_already_converged(self, db, tmp_path):
+        """_migrate_fts_update_triggers returns False when triggers are
+        already narrowed."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello")
+
+        cursor = db._conn.cursor()
+        result = db._migrate_fts_update_triggers(cursor)
+        assert result is False


### PR DESCRIPTION
Narrow the messages_fts_update and messages_fts_trigram_update triggers to only fire when content, tool_name, or tool_calls actually change, instead of on every UPDATE (including status-only writes like the active flag). On a ~447k-message DB this eliminates multi-GB of redundant FTS churn per SessionDB open.

Migration contract (per review of the FTS trigger narrowing PR):
- Inspect sqlite_master.sql; only migrate when an existing UPDATE trigger is broad (no WHEN clause).
- Drop only the two UPDATE triggers, recreate with individual cursor.execute() calls (not executescript).
- Keep INSERT/DELETE triggers present throughout.
- Do NOT rebuild FTS: broad triggers may have over-indexed unchanged payload, but have not missed content updates.
- Idempotent: reopening an already-converged DB performs reads only.

Fixes #68891