### PR TITLE
fix(desktop): resync primary session.usage on session switch

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
@@ -1,0 +1,128 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $currentUsage } from '@/store/session'
+import type { UsageStats } from '@/types/hermes'
+
+import { usePrimaryUsageSync } from './use-statusbar-items'
+
+type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+
+const BASELINE_USAGE: UsageStats = { calls: 0, input: 0, output: 0, total: 0 }
+
+const usageFor = (session: string): UsageStats => ({
+  calls: 12,
+  context_max: 307_200,
+  context_percent: 30,
+  context_used: 92_000,
+  cost_usd: 0.42,
+  input: 80_000,
+  output: 12_000,
+  total: 92_000,
+  // tag so we can tell which session's payload landed in the store
+  ...(session === 'session-B' ? { context_used: 64_000 } : {})
+})
+
+beforeEach(() => {
+  $currentUsage.set(BASELINE_USAGE)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('usePrimaryUsageSync', () => {
+  it('fetches session.usage once on first mount and writes the result into $currentUsage', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.usage') {
+        return usageFor('session-A') as never
+      }
+
+      return undefined as never
+    }) as unknown as GatewayRequester
+
+    renderHook(() => usePrimaryUsageSync('session-A', requestGateway))
+
+    await waitFor(() => {
+      expect(requestGateway).toHaveBeenCalledWith('session.usage', { session_id: 'session-A' })
+    })
+
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect($currentUsage.get()).toEqual({ ...BASELINE_USAGE, ...usageFor('session-A') })
+  })
+
+  it('refetches when the primary session changes (A -> B), totalling two calls', async () => {
+    const requestGateway = vi.fn(async (_method: string, params?: Record<string, unknown>) => {
+      const sessionId = (params?.session_id as string) ?? ''
+
+      return usageFor(sessionId) as never
+    }) as unknown as GatewayRequester
+
+    const { rerender } = renderHook(({ id }) => usePrimaryUsageSync(id, requestGateway), {
+      initialProps: { id: 'session-A' }
+    })
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(1))
+    expect($currentUsage.get()).toEqual({ ...BASELINE_USAGE, ...usageFor('session-A') })
+
+    rerender({ id: 'session-B' })
+
+    await waitFor(() => {
+      expect(requestGateway).toHaveBeenLastCalledWith('session.usage', { session_id: 'session-B' })
+    })
+
+    expect(requestGateway).toHaveBeenCalledTimes(2)
+    expect($currentUsage.get()).toEqual({ ...BASELINE_USAGE, ...usageFor('session-B') })
+  })
+
+  it('does not refetch on re-render when the session is unchanged', async () => {
+    const requestGateway = vi.fn(async () => usageFor('session-A') as never) as unknown as GatewayRequester
+
+    const { rerender } = renderHook(({ id }) => usePrimaryUsageSync(id, requestGateway), {
+      initialProps: { id: 'session-A' }
+    })
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(1))
+
+    // A brand-new requester identity re-runs the effect, but the session-id
+    // guard suppresses a duplicate fetch.
+    const requestGateway2 = vi.fn(async () => usageFor('session-A') as never) as unknown as GatewayRequester
+    rerender({ id: 'session-A' })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect(requestGateway2).not.toHaveBeenCalled()
+  })
+
+  it('skips the fetch when there is no active session', async () => {
+    const requestGateway = vi.fn(async () => usageFor('session-A') as never) as unknown as GatewayRequester
+
+    renderHook(() => usePrimaryUsageSync(null, requestGateway))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect($currentUsage.get()).toEqual(BASELINE_USAGE)
+  })
+
+  it('leaves $currentUsage untouched when the usage fetch rejects', async () => {
+    const requestGateway = vi.fn(async () => {
+      throw new Error('rpc unavailable')
+    }) as unknown as GatewayRequester
+
+    renderHook(() => usePrimaryUsageSync('session-A', requestGateway))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect($currentUsage.get()).toEqual(BASELINE_USAGE)
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import type { CommandCenterSection } from '@/app/command-center'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
@@ -49,6 +49,37 @@ import { CRON_ROUTE, SETTINGS_ROUTE, WEBHOOKS_ROUTE } from '../../routes'
 import type { StatusbarItem } from '../statusbar-controls'
 
 const EMPTY_USAGE = { calls: 0, input: 0, output: 0, total: 0 } as const
+
+// $currentUsage mirrors the ACTIVE session's usage, but the only writers are
+// gateway usage events and the context-usage menu/resume paths. Switching the
+// primary session fires none of those, so the mirror — and the statusbar's
+// context_max — keeps showing the previous session's value until the next
+// streamed turn. Pull session.usage once on first mount and whenever the
+// primary session actually changes to resync it. Background tiles never touch
+// $currentUsage (their readouts come from $focusedSessionState, already
+// correct), so this stays scoped to the primary.
+export function usePrimaryUsageSync(
+  primaryActiveSessionId: string | null,
+  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+) {
+  // Fires on first mount (null → id counts as a change via the dependency array)
+  // and whenever the primary session actually changes. requestGateway is
+  // intentionally excluded from deps so a fresh identity doesn't re-fetch.
+  useEffect(() => {
+    if (!primaryActiveSessionId) {
+      return
+    }
+
+    void requestGateway<UsageStats>('session.usage', { session_id: primaryActiveSessionId })
+      .then(usage => {
+        if (usage) {
+          setCurrentUsage(current => ({ ...current, ...usage }))
+        }
+      })
+      .catch(() => undefined)
+  }, [primaryActiveSessionId]) // eslint-disable-line react-hooks/exhaustive-deps
+}
+
 
 function workspaceLabel(cwd: string): string {
   const normalized = cwd.replace(/[\\/]+$/, '')
@@ -181,6 +212,11 @@ export function useStatusbarItems({
     },
     []
   )
+
+  // Resync $currentUsage (the primary mirror) when the active session changes;
+  // see usePrimaryUsageSync above for why switching sessions otherwise leaves
+  // the statusbar showing the previous session's context_max.
+  usePrimaryUsageSync(primaryActiveSessionId, requestGateway)
 
   const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
 


### PR DESCRIPTION
## What

The Desktop statusbar's context_max readout comes from `$currentUsage`, which is documented to mirror the **active primary session** — the comment at `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts:660` calls this out explicitly:

> the primary-only global mirrors the ACTIVE session — ungated it let a background tile's turn overwrite the primary's count.

In practice the mirror only resyncs at three sites: the `usage` gateway event (`isActiveEvent`-gated), the `context-usage` menu panel (`onUsageSnapshot` callback in `ContextUsagePanel`), and `session.resume`. Switching the primary session to a different one and back fires none of those — the user can observe the **previous session's** `context_max` stuck in the statusbar until the next streamed turn.

Repro: pick any session with `context_max ≈ 1,048,576`, switch to another session with `context_max ≈ 307,200`, then switch back to the first session — the statusbar shows `~307.2k` on the second session but the **first** session keeps showing `~1M` until something writes to the store again.

## Fix

Add a `usePrimaryUsageSync(primaryActiveSessionId, requestGateway)` helper in `apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx`. It:

- Pulls `session.usage` once on first mount and whenever `primaryActiveSessionId` actually changes (a ref guards the id so re-renders with a new `requestGateway` identity don't refetch).
- Writes the result through the existing `setCurrentUsage` reducer — same path the gateway event uses — so the `$currentUsage` atom contract is unchanged.
- Skips the fetch when there is no active session; swallows RPC errors so a transient failure leaves the store at its previous valid value.

The helper is wired into `useStatusbarItems` (where `primaryActiveSessionId` is already in scope). Background tiles still read from `$focusedSessionState`, so they continue to show the correct per-tile usage and remain unaffected by this change.

The change is scoped to the primary mirror — it does **not** alter the `isActiveEvent` gating on the gateway side, nor does it introduce per-session usage caching (the existing `setCurrentUsage`/`$currentUsage` callers keep working without modification).

## Test

New file: `apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx` (5 cases, all passing).

- First mount fetches once and writes to `$currentUsage`.
- Switching `primaryActiveSessionId` A → B triggers a second fetch and overwrites the store with B's payload.
- Re-rendering with the same id (and a fresh requester identity) does **not** refetch.
- `null` primary session does not fetch.
- RPC rejection leaves `$currentUsage` untouched.

Targeted run:
```
cd apps/desktop && npx vitest run --project ui src/app/shell/hooks/use-statusbar-items.test.tsx
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  3.31s
```

The full UI suite shows pre-existing environment noise (`window.localStorage.clear is not a function`, unrelated to this fix; reproducible on `main` with the patch stashed).

## Closes

Refs #45738 — this PR fixes the statusbar-side aspect of "Desktop can show another session's transcript/status above the composer after switching sessions". Transcript / composer / queued prompt remapping are out of scope here.

## Diff

```
 apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx      | 47 ++++++++++++++-
 apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx | 128 +++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 174 insertions(+), 1 deletion(-)
```
