### PR TITLE
fix(test): stub _exit_after_graceful_shutdown in systemd-refresh test

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -238,6 +238,14 @@ class TestSystemdServiceRefresh:
             return True
 
         monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
+        # ``run_gateway()`` routes every exit path through
+        # ``_exit_after_graceful_shutdown`` which hard-kills the process with
+        # ``os._exit`` (by design, see #53107). Stub it or the test runner
+        # itself dies mid-suite. Same pattern as test_gateway.py's
+        # ``_install_fake_gateway_run``.
+        monkeypatch.setattr(
+            "gateway.run._exit_after_graceful_shutdown", lambda code: None
+        )
 
         gateway_cli.run_gateway()
 


### PR DESCRIPTION
## Summary

`test_run_gateway_refreshes_outdated_unit_on_boot` stubs `start_gateway` but not `_exit_after_graceful_shutdown`. With the stubbed gateway reporting success, `run_gateway()` takes its clean-exit path and calls `_exit_after_graceful_shutdown(0)` — which terminates the process with `os._exit(0)` **by design** (#53107).

Because the exit code is 0, this kills the pytest runner **mid-suite while reporting success**. On a real Linux dev box with systemd:

```
collected 266 items
tests/hermes_cli/test_gateway_service.py ........   <- 8 tests, then runner dies, exit 0
```

189 tests collected in that file, 8 executed, suite reports green — the remaining ~180 tests are silently skipped.

## Fix

Stub `gateway.run._exit_after_graceful_shutdown` for the duration of the test — the same pattern `test_gateway.py` already established with `_install_fake_gateway_run`. The runtime `from gateway.run import ...` inside `run_gateway()` picks up the monkeypatched attribute.

## Test plan

- [x] `pytest tests/hermes_cli/test_gateway_service.py` — **189 passed** (was: 8 executed, then runner death with exit 0)
- [x] `pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_restart_loop.py tests/hermes_cli/test_systemd_optional_directives.py` — all green