### PR TITLE
fix(desktop): add homepage for electron-builder deb target

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,6 +5,7 @@
   "version": "0.17.0",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
+  "homepage": "https://github.com/NousResearch/hermes-agent",
   "type": "module",
   "main": "dist/electron-main.mjs",
   "engines": {


### PR DESCRIPTION
## Summary

`electron-builder`'s `FpmTarget` requires a project homepage for deb/rpm packaging and fails the whole build without it:

```
⨯ Please specify project homepage, see https://www.electron.build/configuration#metadata
    at FpmTarget.computeFpmMetaInfoOptions (app-builder-lib/src/targets/FpmTarget.ts:126)
```

Since `deb` is listed in `build.linux.target`, any local `npm run dist` on Linux exits 1 at the deb step — even though `linux-unpacked` (what the `.desktop` launcher actually runs) and the AppImage were already produced.

## Fix

One-line metadata addition. No behavior change; outputs are unaffected beyond the build no longer erroring out.

## Test plan

- [x] `npm run dist` on Ubuntu 26.04 — `linux-unpacked` + AppImage + deb all produced, exit 0 (was: exit 1 at deb step)