### PR TITLE
fix(desktop): resolve hermes CLI from ~/.local/bin when PATH omits it (#73014)

### DIFF
--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -1,3 +1,4 @@
+import os from 'node:os'
 import path from 'node:path'
 
 // Match the POSIX fallback surface used by the Python terminal environment.
@@ -72,7 +73,13 @@ function buildDesktopBackendPath({
   const venvBin = venvRoot ? pathModule.join(venvRoot, platform === 'win32' ? 'Scripts' : 'bin') : null
   const saneEntries = platform === 'win32' ? [] : POSIX_SANE_PATH_ENTRIES
 
-  return appendUniquePathEntries([hermesNodeBin, venvBin, currentPath, saneEntries], { delimiter })
+  // ~/.local/bin is the default target for pip install --user and
+  // scripts/install.sh. GUI-launched macOS apps miss it from process.env.PATH.
+  const userLocalBin = platform !== 'win32'
+    ? pathModule.join(os.homedir(), '.local', 'bin')
+    : null
+
+  return appendUniquePathEntries([hermesNodeBin, venvBin, currentPath, userLocalBin, saneEntries], { delimiter })
 }
 
 function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatform(process.platform) }: any = {}) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1737,7 +1737,7 @@ function unpackedPathFor(filePath) {
   return filePath.replace(/app\.asar(?=$|[\\/])/, 'app.asar.unpacked')
 }
 
-function findOnPath(command) {
+function findOnPath(command, { extraDirs = [] } = {}) {
   if (!command) {
     return null
   }
@@ -1757,6 +1757,14 @@ function findOnPath(command) {
   const pathEntries = String(process.env.PATH || '')
     .split(path.delimiter)
     .filter(Boolean)
+
+  // Append extra directories (e.g. ~/.local/bin) that GUI-launched apps may
+  // miss from process.env.PATH because launchd/snapd strip shell rc additions.
+  for (const dir of extraDirs) {
+    if (dir && !pathEntries.includes(dir)) {
+      pathEntries.push(dir)
+    }
+  }
 
   // On Windows, try PATHEXT extensions BEFORE the bare (empty-extension) name.
   // A real command must resolve via its .exe/.cmd (Windows command-resolution
@@ -3767,7 +3775,21 @@ function resolveHermesBackend(backendArgs) {
         rememberLog(`Ignoring Windows Hermes override under WSL: ${hermesOverride}`)
       }
     } else {
-      hermesCommand = findOnPath('hermes')
+      // On POSIX, also check ~/.local/bin which is the default target for
+      // pip install --user and scripts/install.sh.  GUI-launched apps on macOS
+      // inherit launchd's minimal PATH which omits shell-rc additions like
+      // ~/.local/bin — so findOnPath('hermes') would silently return null.
+      const extraDirs = !IS_WINDOWS
+        ? [path.join(os.homedir(), '.local', 'bin')]
+        : []
+      hermesCommand = findOnPath('hermes', { extraDirs })
+
+      if (!hermesCommand) {
+        rememberLog(
+          `[boot] findOnPath('hermes') returned null — searched PATH (${(process.env.PATH || '').split(path.delimiter).length} entries)` +
+          (extraDirs.length ? ` and ${extraDirs.join(', ')}` : '')
+        )
+      }
     }
 
     if (hermesCommand) {


### PR DESCRIPTION
## Summary

GUI-launched macOS apps (Finder, Dock, Spotlight) inherit launchd's minimal per-user PATH which omits shell-rc additions like `~/.local/bin`. When the `hermes` CLI is installed there via `scripts/install.sh` or `pip install --user`, `findOnPath('hermes')` returns null and the Desktop hangs forever on "Waiting for first-run setup choice".

## Root Cause

`resolveHermesBackend()` at `apps/desktop/electron/main.ts` step 4 calls `findOnPath('hermes')`, which only searches `process.env.PATH`. On macOS, GUI-launched apps get launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) — not the interactive shell PATH from `.zshrc`/`.zprofile`. So `~/.local/bin` is absent and `findOnPath` returns null.

Because this is a "not found" outcome (not a "found but probe failed"), no log line is emitted — the existing "Ignoring existing Hermes CLI" message only fires when `hermesCommand` is truthy. The resolver silently falls through to bootstrap, which also can't find hermes, and the app hangs.

## Changes

1. **`findOnPath()` accepts optional `extraDirs`** — additional directories to search after PATH entries. Backward compatible (default is `[]`). All existing call sites are unaffected.

2. **Hermes resolver passes `~/.local/bin`** — on non-Windows, `[path.join(os.homedir(), '.local', 'bin')]` is passed as `extraDirs`. This is the default target for `scripts/install.sh` and `pip install --user`.

3. **`buildDesktopBackendPath()` includes `~/.local/bin`** — so the spawned backend also has it in PATH, matching the `POSIX_SANE_PATH_ENTRIES` pattern for Homebrew/system dirs.

4. **Diagnostic log** — when `findOnPath('hermes')` returns null, a log line now records how many PATH entries were searched and which extra dirs were checked. This makes future "can't find hermes" reports diagnosable.

## Test Plan

- [ ] Desktop on macOS with hermes in `~/.local/bin` boots normally from Finder
- [ ] Desktop on macOS with hermes in `/opt/homebrew/bin` still works (existing PATH entries)
- [ ] Desktop on Windows is unaffected (`IS_WINDOWS` guard skips extra dirs)
- [ ] Existing `backend-env.test.ts` passes (tests use `includes()` assertions, unaffected by new entry)
- [ ] `findOnPath` with no `extraDirs` arg behaves identically to before

Fixes #73014