### PR TITLE
fix(slack): retry thread context fetch on timeouts and 5xx errors

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3391,6 +3391,21 @@ class SlackAdapter(BasePlatformAdapter):
             return True
         return self._is_retryable_error(body)
 
+    def _is_retryable_context_fetch_error(self, exc: Exception) -> bool:
+        """Retryable errors for the read-only conversations.replies fetch.
+
+        Extends :meth:`_is_retryable_upload_error` (429/5xx, rate-limit and
+        transient-connection text) with read/socket timeouts: the fetch is
+        idempotent, so retrying a timed-out request can't cause the duplicate
+        delivery that makes timeouts unsafe to retry for uploads and sends.
+        """
+        if self._is_retryable_upload_error(exc):
+            return True
+        if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+            return True
+        body = str(exc).lower()
+        return "timed out" in body or "timeout" in body
+
     # ----- Markdown → mrkdwn conversion -----
 
     @staticmethod
@@ -7230,7 +7245,9 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             client = self._get_client(channel_id, team_id=team_id)
 
-            # Retry with exponential backoff for Tier-3 rate limits (429).
+            # Retry with exponential backoff on transient failures: Tier-3
+            # rate limits (429), 5xx responses, and connection/socket
+            # timeouts (safe to retry — this fetch is idempotent).
             result = None
             for attempt in range(3):
                 try:
@@ -7242,17 +7259,11 @@ class SlackAdapter(BasePlatformAdapter):
                     )
                     break
                 except Exception as exc:
-                    # Check for rate-limit error from slack_sdk
-                    err_str = str(exc).lower()
-                    is_rate_limit = (
-                        "ratelimited" in err_str
-                        or "429" in err_str
-                        or "rate_limited" in err_str
-                    )
-                    if is_rate_limit and attempt < 2:
+                    if attempt < 2 and self._is_retryable_context_fetch_error(exc):
                         retry_after = 1.0 * (2**attempt)  # 1s, 2s
                         logger.warning(
-                            "[Slack] conversations.replies rate limited; retrying in %.1fs (attempt %d/3)",
+                            "[Slack] conversations.replies failed transiently (%s); retrying in %.1fs (attempt %d/3)",
+                            exc,
                             retry_after,
                             attempt + 1,
                         )

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7195,6 +7195,31 @@ class SlackAdapter(BasePlatformAdapter):
 
         return msg_text
 
+    async def _conversations_replies_with_retry(self, client: Any, **kwargs: Any) -> Any:
+        """Call ``conversations.replies`` with bounded exponential backoff.
+
+        Retries transient failures (Tier-3 rate limits, 5xx responses, and
+        connection/socket timeouts — see
+        :meth:`_is_retryable_context_fetch_error`); the fetch is idempotent,
+        so a retried timeout can't duplicate anything. Non-transient errors
+        and the final failed attempt propagate to the caller.
+        """
+        for attempt in range(3):
+            try:
+                return await client.conversations_replies(**kwargs)
+            except Exception as exc:
+                if attempt < 2 and self._is_retryable_context_fetch_error(exc):
+                    retry_after = 1.0 * (2**attempt)  # 1s, 2s
+                    logger.warning(
+                        "[Slack] conversations.replies failed transiently (%s); retrying in %.1fs (attempt %d/3)",
+                        exc,
+                        retry_after,
+                        attempt + 1,
+                    )
+                    await asyncio.sleep(retry_after)
+                    continue
+                raise
+
     async def _fetch_thread_context(
         self,
         channel_id: str,
@@ -7245,31 +7270,13 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             client = self._get_client(channel_id, team_id=team_id)
 
-            # Retry with exponential backoff on transient failures: Tier-3
-            # rate limits (429), 5xx responses, and connection/socket
-            # timeouts (safe to retry — this fetch is idempotent).
-            result = None
-            for attempt in range(3):
-                try:
-                    result = await client.conversations_replies(
-                        channel=channel_id,
-                        ts=thread_ts,
-                        limit=limit + 1,  # +1 because it includes the current message
-                        inclusive=True,
-                    )
-                    break
-                except Exception as exc:
-                    if attempt < 2 and self._is_retryable_context_fetch_error(exc):
-                        retry_after = 1.0 * (2**attempt)  # 1s, 2s
-                        logger.warning(
-                            "[Slack] conversations.replies failed transiently (%s); retrying in %.1fs (attempt %d/3)",
-                            exc,
-                            retry_after,
-                            attempt + 1,
-                        )
-                        await asyncio.sleep(retry_after)
-                        continue
-                    raise
+            result = await self._conversations_replies_with_retry(
+                client,
+                channel=channel_id,
+                ts=thread_ts,
+                limit=limit + 1,  # +1 because it includes the current message
+                inclusive=True,
+            )
 
             if result is None:
                 return ""
@@ -7524,7 +7531,8 @@ class SlackAdapter(BasePlatformAdapter):
 
         try:
             client = self._get_client(channel_id, team_id=team_id)
-            result = await client.conversations_replies(
+            result = await self._conversations_replies_with_retry(
+                client,
                 channel=channel_id,
                 ts=thread_ts,
                 limit=1,

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -7446,6 +7446,103 @@ class TestThreadContextUnverifiedTagging:
 
 
 # ---------------------------------------------------------------------------
+# TestThreadContextFetchRetry
+# ---------------------------------------------------------------------------
+
+
+class _FakeSlackApiError(Exception):
+    """Minimal stand-in for slack_sdk's SlackApiError: message + response
+    object exposing ``status_code``."""
+
+    def __init__(self, message, status_code):
+        super().__init__(message)
+        self.response = MagicMock()
+        self.response.status_code = status_code
+
+
+class TestThreadContextFetchRetry:
+    """conversations.replies is read-only, so besides Tier-3 rate limits the
+    fetch also retries connection/socket timeouts and 5xx responses —
+    transient failures where a retry can't cause duplicate delivery."""
+
+    _MESSAGES = [
+        {"ts": "100.0", "user": "U_BOB", "text": "kicking off"},
+        {"ts": "101.0", "user": "U_BOB", "text": "any updates?"},
+    ]
+
+    async def _fetch(self, adapter):
+        adapter._thread_context_cache.clear()
+        with (
+            patch.object(
+                adapter, "_resolve_user_name",
+                new=AsyncMock(side_effect=lambda uid, **_: uid),
+            ),
+            patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock,
+        ):
+            content = await adapter._fetch_thread_context(
+                channel_id="C1", thread_ts="100.0", current_ts="999.0",
+            )
+        return content, sleep_mock
+
+    @pytest.mark.asyncio
+    async def test_retries_on_socket_timeout(self, adapter):
+        adapter._app.client.conversations_replies = AsyncMock(
+            side_effect=[
+                asyncio.TimeoutError("timed out"),
+                {"messages": self._MESSAGES},
+            ]
+        )
+        content, sleep_mock = await self._fetch(adapter)
+        assert "U_BOB: kicking off" in content
+        assert adapter._app.client.conversations_replies.call_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+    @pytest.mark.asyncio
+    async def test_retries_on_5xx_status(self, adapter):
+        adapter._app.client.conversations_replies = AsyncMock(
+            side_effect=[
+                _FakeSlackApiError("server error", 503),
+                {"messages": self._MESSAGES},
+            ]
+        )
+        content, _ = await self._fetch(adapter)
+        assert "U_BOB: kicking off" in content
+        assert adapter._app.client.conversations_replies.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_rate_limit(self, adapter):
+        adapter._app.client.conversations_replies = AsyncMock(
+            side_effect=[
+                _FakeSlackApiError("ratelimited", 429),
+                {"messages": self._MESSAGES},
+            ]
+        )
+        content, _ = await self._fetch(adapter)
+        assert "U_BOB: kicking off" in content
+        assert adapter._app.client.conversations_replies.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_permanent_error(self, adapter):
+        adapter._app.client.conversations_replies = AsyncMock(
+            side_effect=Exception("channel_not_found")
+        )
+        content, sleep_mock = await self._fetch(adapter)
+        assert content == ""
+        assert adapter._app.client.conversations_replies.call_count == 1
+        sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_three_attempts(self, adapter):
+        adapter._app.client.conversations_replies = AsyncMock(
+            side_effect=asyncio.TimeoutError("timed out")
+        )
+        content, sleep_mock = await self._fetch(adapter)
+        assert content == ""
+        assert adapter._app.client.conversations_replies.call_count == 3
+        assert sleep_mock.await_count == 2  # backoff between attempts only
+
+
+# ---------------------------------------------------------------------------
 # TestThreadContextAppMessages
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -7463,7 +7463,9 @@ class _FakeSlackApiError(Exception):
 class TestThreadContextFetchRetry:
     """conversations.replies is read-only, so besides Tier-3 rate limits the
     fetch also retries connection/socket timeouts and 5xx responses —
-    transient failures where a retry can't cause duplicate delivery."""
+    transient failures where a retry can't cause duplicate delivery. Applies
+    to both _fetch_thread_context and the cold-cache fetch in
+    _fetch_thread_parent_text (shared _conversations_replies_with_retry)."""
 
     _MESSAGES = [
         {"ts": "100.0", "user": "U_BOB", "text": "kicking off"},
@@ -7540,6 +7542,39 @@ class TestThreadContextFetchRetry:
         assert content == ""
         assert adapter._app.client.conversations_replies.call_count == 3
         assert sleep_mock.await_count == 2  # backoff between attempts only
+
+    @pytest.mark.asyncio
+    async def test_parent_text_cold_fetch_retries_on_timeout(self, adapter):
+        """The cold-cache fetch in _fetch_thread_parent_text goes through the
+        same retry wrapper."""
+        adapter._thread_context_cache.clear()
+        adapter._app.client.conversations_replies = AsyncMock(
+            side_effect=[
+                asyncio.TimeoutError("timed out"),
+                {"messages": [{"ts": "100.0", "user": "U_BOB", "text": "root message"}]},
+            ]
+        )
+        with patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+            text = await adapter._fetch_thread_parent_text(
+                channel_id="C1", thread_ts="100.0",
+            )
+        assert text == "root message"
+        assert adapter._app.client.conversations_replies.call_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+    @pytest.mark.asyncio
+    async def test_parent_text_no_retry_on_permanent_error(self, adapter):
+        adapter._thread_context_cache.clear()
+        adapter._app.client.conversations_replies = AsyncMock(
+            side_effect=Exception("channel_not_found")
+        )
+        with patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+            text = await adapter._fetch_thread_parent_text(
+                channel_id="C1", thread_ts="100.0",
+            )
+        assert text == ""
+        assert adapter._app.client.conversations_replies.call_count == 1
+        sleep_mock.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
conversations.replies retries previously covered only Tier-3 rate limits, so a transient socket timeout or server-side 5xx dropped the thread context for that turn. The fetch is read-only/idempotent, so retrying timeouts is safe here — unlike uploads/sends, where a resent request risks duplicate delivery.

Adds `_is_retryable_context_fetch_error`, which extends the shared `_is_retryable_upload_error` checks (429/5xx status, rate-limit and transient-connection text) with connection/socket timeout detection, and wires it into the existing exponential-backoff loop.