### PR TITLE
fix(anthropic): trigger non-stream fallback on SSE event order errors (#72833)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2966,6 +2966,8 @@ def _is_stream_unavailable_error(exc: Exception) -> bool:
     err_lower = str(exc).lower()
     if "stream" in err_lower and "not supported" in err_lower:
         return True
+    if "unexpected event order" in err_lower:
+        return True
     if "invokemodelwithresponsestream" in err_lower:
         from agent.bedrock_adapter import is_streaming_access_denied_error
 


### PR DESCRIPTION
Fixes #72833. Custom providers with proxies emitting SSE events out of order caused hard failure instead of non-stream fallback. Added unexpected event order pattern to _is_stream_unavailable_error(). 205 tests passed.