### PR TITLE
fix(desktop): make auto-project Hide from sidebar reversible via an Undo toast (#73091)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
@@ -1,10 +1,16 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { dismissAutoProject, restoreAutoProject } from '@/store/layout'
+import { notify } from '@/store/notifications'
+
 import { ProjectMenu } from './project-menu'
 import type { SidebarProjectTree } from './workspace-groups'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
 
 // jsdom doesn't implement ResizeObserver; Radix's PopoverContent/Arrow use it
 // (via @radix-ui/react-use-size) to measure the arrow once the popover is
@@ -36,8 +42,10 @@ vi.mock('@/i18n', () => ({
           menuRename: 'Rename',
           menuSetActive: 'Set active',
           noColor: 'No color',
+          hiddenFromSidebar: 'Hidden from sidebar',
           removeFromSidebar: 'Remove from sidebar',
-          reveal: 'Reveal in file manager'
+          reveal: 'Reveal in file manager',
+          undoHide: 'Undo'
         }
       }
     }
@@ -54,7 +62,12 @@ vi.mock('@/store/layout', () => ({
       return () => {}
     }
   },
-  dismissAutoProject: vi.fn()
+  dismissAutoProject: vi.fn(),
+  restoreAutoProject: vi.fn()
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn()
 }))
 
 vi.mock('@/store/projects', () => ({
@@ -74,6 +87,15 @@ const project = {
   isAuto: false,
   label: 'Test D',
   path: '/repo'
+} as unknown as SidebarProjectTree
+
+const autoProject = {
+  color: null,
+  icon: null,
+  id: '/auto/repo',
+  isAuto: true,
+  label: 'repo',
+  path: '/auto/repo'
 } as unknown as SidebarProjectTree
 
 const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"]')
@@ -114,5 +136,28 @@ describe('ProjectMenu', () => {
     // real button through the full Tip > PopoverAnchor > DropdownMenuTrigger
     // chain rather than getting silently dropped on an intermediate wrapper.
     expect(await screen.findByRole('button', { name: 'No color' })).toBeTruthy()
+  }, 15000)
+
+  // #73091: "Hide from sidebar" on an auto project used to be one-way — the
+  // toast had no Undo and there was no restore control, so a mis-click was
+  // permanent. Hiding must now offer an Undo whose click restores the id.
+  it('hides an auto project with an Undo toast that restores it', async () => {
+    render(<ProjectMenu isActive={false} project={autoProject} />)
+
+    openTriggerMenu(screen.getByRole('button', { name: 'Actions' }))
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove from sidebar' }))
+
+    expect(dismissAutoProject).toHaveBeenCalledWith('/auto/repo')
+
+    expect(notify).toHaveBeenCalledTimes(1)
+    const input = vi.mocked(notify).mock.calls[0][0]
+    expect(input.action?.label).toBe('Undo')
+
+    // The Undo action must reach restoreAutoProject with the captured id even
+    // though the row is gone — it closes over the id, not live menu state.
+    expect(restoreAutoProject).not.toHaveBeenCalled()
+    input.action?.onClick()
+    expect(restoreAutoProject).toHaveBeenCalledWith('/auto/repo')
   }, 15000)
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
@@ -21,7 +21,8 @@ import {
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
-import { $panesFlipped, dismissAutoProject } from '@/store/layout'
+import { $panesFlipped, dismissAutoProject, restoreAutoProject } from '@/store/layout'
+import { notify } from '@/store/notifications'
 import {
   copyPath,
   deleteProject,
@@ -58,11 +59,24 @@ function useProjectActions({
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
 
   const removeAuto = () => {
-    dismissAutoProject(project.id)
+    // Capture the id now: the row unmounts (and, when scoped, the scope exits)
+    // the moment we dismiss, so Undo can't read it back off live menu state.
+    const id = project.id
+
+    dismissAutoProject(id)
 
     if (scoped) {
       onExitScope?.()
     }
+
+    // The hide is persisted and otherwise irreversible — there is no other
+    // restore control — so offer a short undo window (mirrors restoreWorktree).
+    notify({
+      action: { label: p.undoHide, onClick: () => restoreAutoProject(id) },
+      durationMs: 8_000,
+      kind: 'success',
+      message: p.hiddenFromSidebar
+    })
   }
 
   const confirmDelete = async () => {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1582,6 +1582,8 @@ export const ar = defineLocale({
       reveal: 'إظهار في المجلد',
       copyPath: 'نسخ المسار',
       removeFromSidebar: 'إخفاء من الشريط الجانبي',
+      hiddenFromSidebar: 'تم الإخفاء من الشريط الجانبي',
+      undoHide: 'تراجع',
       createFailed: 'تعذّر إنشاء المشروع',
       deleteConfirm: 'هذا يزيل المشروع المحفوظ من Hermes. تبقى الملفات ومستودعات git وأشجار العمل دون تغيير.',
       startWork: 'شجرة عمل جديدة',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1808,6 +1808,8 @@ export const ar = defineLocale({
       reveal: 'إظهار في المجلد',
       copyPath: 'نسخ المسار',
       removeFromSidebar: 'إخفاء من الشريط الجانبي',
+      hiddenFromSidebar: 'تم الإخفاء من الشريط الجانبي',
+      undoHide: 'تراجع',
       createFailed: 'تعذّر إنشاء المشروع',
       deleteConfirm: 'هذا يزيل المشروع المحفوظ من Hermes. تبقى الملفات ومستودعات git وأشجار العمل دون تغيير.',
       startWork: 'شجرة عمل جديدة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1866,6 +1866,8 @@ export const en: Translations = {
       reveal: 'Reveal in folder',
       copyPath: 'Copy path',
       removeFromSidebar: 'Hide from sidebar',
+      hiddenFromSidebar: 'Hidden from sidebar',
+      undoHide: 'Undo',
       createFailed: 'Could not create project',
       staleBackend:
         'Update the Hermes backend to create projects — your backend is older than this desktop app (Settings → Updates → Backend).',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2446,6 +2446,8 @@ export const en: Translations = {
       reveal: 'Reveal in folder',
       copyPath: 'Copy path',
       removeFromSidebar: 'Hide from sidebar',
+      hiddenFromSidebar: 'Hidden from sidebar',
+      undoHide: 'Undo',
       createFailed: 'Could not create project',
       staleBackend:
         'Update the Hermes backend to create projects — your backend is older than this desktop app (Settings → Updates → Backend).',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1707,6 +1707,8 @@ export const ja = defineLocale({
       reveal: 'フォルダで表示',
       copyPath: 'パスをコピー',
       removeFromSidebar: 'サイドバーから削除',
+      hiddenFromSidebar: 'サイドバーから非表示にしました',
+      undoHide: '元に戻す',
       createFailed: 'プロジェクトを作成できませんでした',
       staleBackend:
         'プロジェクトを作成するには Hermes バックエンドを更新してください。バックエンドがこのデスクトップアプリより古いです（設定 → 更新 → バックエンド）。',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2115,6 +2115,8 @@ export const ja = defineLocale({
       reveal: 'フォルダで表示',
       copyPath: 'パスをコピー',
       removeFromSidebar: 'サイドバーから削除',
+      hiddenFromSidebar: 'サイドバーから非表示にしました',
+      undoHide: '元に戻す',
       createFailed: 'プロジェクトを作成できませんでした',
       staleBackend:
         'プロジェクトを作成するには Hermes バックエンドを更新してください。バックエンドがこのデスクトップアプリより古いです（設定 → 更新 → バックエンド）。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1568,6 +1568,8 @@ export interface Translations {
       reveal: string
       copyPath: string
       removeFromSidebar: string
+      hiddenFromSidebar: string
+      undoHide: string
       createFailed: string
       staleBackend: string
       deleteConfirm: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2091,6 +2091,8 @@ export interface Translations {
       reveal: string
       copyPath: string
       removeFromSidebar: string
+      hiddenFromSidebar: string
+      undoHide: string
       createFailed: string
       staleBackend: string
       deleteConfirm: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1652,6 +1652,8 @@ export const zhHant = defineLocale({
       reveal: '在資料夾中顯示',
       copyPath: '複製路徑',
       removeFromSidebar: '從側邊欄移除',
+      hiddenFromSidebar: '已從側邊欄隱藏',
+      undoHide: '復原',
       createFailed: '無法建立專案',
       staleBackend: '請更新 Hermes 後端以建立專案——目前後端比桌面應用舊（設定 → 更新 → 後端）。',
       deleteConfirm: '這會從 Hermes 中移除已儲存的專案。檔案、git 儲存庫和工作樹維持不變。',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2039,6 +2039,8 @@ export const zhHant = defineLocale({
       reveal: '在資料夾中顯示',
       copyPath: '複製路徑',
       removeFromSidebar: '從側邊欄移除',
+      hiddenFromSidebar: '已從側邊欄隱藏',
+      undoHide: '復原',
       createFailed: '無法建立專案',
       staleBackend: '請更新 Hermes 後端以建立專案——目前後端比桌面應用舊（設定 → 更新 → 後端）。',
       deleteConfirm: '這會從 Hermes 中移除已儲存的專案。檔案、git 儲存庫和工作樹維持不變。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2060,6 +2060,8 @@ export const zh: Translations = {
       reveal: '在文件夹中显示',
       copyPath: '复制路径',
       removeFromSidebar: '从侧边栏移除',
+      hiddenFromSidebar: '已从侧边栏隐藏',
+      undoHide: '撤销',
       createFailed: '无法创建项目',
       staleBackend: '请更新 Hermes 后端以创建项目——当前后端比桌面应用旧（设置 → 更新 → 后端）。',
       deleteConfirm: '这会从 Hermes 中移除已保存的项目。文件、git 仓库和工作树保持不变。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2611,6 +2611,8 @@ export const zh: Translations = {
       reveal: '在文件夹中显示',
       copyPath: '复制路径',
       removeFromSidebar: '从侧边栏移除',
+      hiddenFromSidebar: '已从侧边栏隐藏',
+      undoHide: '撤销',
       createFailed: '无法创建项目',
       staleBackend: '请更新 Hermes 后端以创建项目——当前后端比桌面应用旧（设置 → 更新 → 后端）。',
       deleteConfirm: '这会从 Hermes 中移除已保存的项目。文件、git 仓库和工作树保持不变。',

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -236,6 +236,18 @@ export function filterVisibleProjects<T extends { id: string; isAuto?: boolean }
   return projects.filter(project => !(project.isAuto && dismissed.has(project.id)))
 }
 
+// Reverse a dismiss: un-hide an auto-derived project so its row returns to the
+// overview. Powers the "Undo" affordance on the hide toast (accidental hides
+// were otherwise irreversible — there is no other restore control). Idempotent
+// when the id isn't currently dismissed.
+export function restoreAutoProject(id: string): void {
+  const current = $dismissedAutoProjectIds.get()
+
+  if (current.includes(id)) {
+    $dismissedAutoProjectIds.set(current.filter(projectId => projectId !== id))
+  }
+}
+
 // Hide a worktree row after it's been removed via git.
 export function dismissWorktree(id: string): void {
   const current = $dismissedWorktreeIds.get()

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -470,6 +470,18 @@ export function filterVisibleProjects<T extends { id: string; isAuto?: boolean }
   return projects.filter(project => !(project.isAuto && dismissed.has(project.id)))
 }
 
+// Reverse a dismiss: un-hide an auto-derived project so its row returns to the
+// overview. Powers the "Undo" affordance on the hide toast (accidental hides
+// were otherwise irreversible — there is no other restore control). Idempotent
+// when the id isn't currently dismissed.
+export function restoreAutoProject(id: string): void {
+  const current = $dismissedAutoProjectIds.get()
+
+  if (current.includes(id)) {
+    $dismissedAutoProjectIds.set(current.filter(projectId => projectId !== id))
+  }
+}
+
 export function dismissWorktree(id: string, { removed = false }: { removed?: boolean } = {}): void {
   const removedIds = $removedWorktreeIds.get().filter(worktreeId => worktreeId !== id)
   $removedWorktreeIds.set(removed ? [...removedIds, id] : removedIds)


### PR DESCRIPTION
Fixes #73091

## Problem

**Hide from sidebar** on a Desktop auto-Project is one-way. `dismissAutoProject` only appends the id to the persisted `$dismissedAutoProjectIds` atom; there is no restore helper, the confirmation toast has no **Undo**, ⌘Z is unwired, and no other UI can un-hide a dismissed auto-Project. One mis-click permanently declutters the row with no recovery path.

Contrast: worktree rows already have `restoreWorktree`, and the notification store already supports undo-style actions (`notify({ action })`) — auto-Project hide wired neither.

## Fix

- **`store/layout.ts`** — add `restoreAutoProject(id)` mirroring `restoreWorktree`: filters the id out of `$dismissedAutoProjectIds` (idempotent when absent).
- **`project-menu.tsx`** — `removeAuto` now captures `project.id` *before* dismissing (the row unmounts / scope exits immediately, so Undo can't read it off live menu state) and fires a `success` toast with an 8s **Undo** action whose `onClick` calls `restoreAutoProject(id)`.
- **i18n** — add `hiddenFromSidebar` (toast message) and `undoHide` (action label) to `types.ts` and all five locales (en/ar/zh/zh-hant/ja).

Undo removes the id from the dismissed set, so the auto node returns on the next tree derive without a full reload. Dismiss stays persisted across reloads only when Undo is *not* used. The named-project delete path (confirm dialog) is untouched.

## Tests

`project-menu.test.tsx` — hiding an auto project calls `dismissAutoProject(id)`, fires exactly one `notify` with an **Undo** action, and invoking that action's `onClick` calls `restoreAutoProject(id)` (proving the captured-id closure survives the unmount). Existing kebab/appearance tests still pass — `3 passed`. ESLint clean on all changed files.

Meets the issue's acceptance criteria: accidental hide is reversible via Undo, Undo re-shows the row, dismiss persists only if Undo wasn't used, and named-Project delete is unchanged.