### PR TITLE
fix(plugins): align status with runtime activation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10388,8 +10388,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         loaded = {}
 
                     print(f"User plugins ({len(user_entries)}):")
-                    for name, version, _desc, source, _dir, key in sorted(user_entries):
-                        state = _plugin_status(name, enabled, disabled, key=key)
+                    for name, version, _desc, source, _dir, key, kind in sorted(user_entries):
+                        state = _plugin_status(
+                            name,
+                            enabled,
+                            disabled,
+                            key=key,
+                            source=source,
+                            kind=kind,
+                        )
                         glyph = {"enabled": "✓", "disabled": "✗"}.get(state, "○")
                         ver = f" v{version}" if version else ""
                         info = loaded.get(name) or {}

--- a/cli.py
+++ b/cli.py
@@ -10354,14 +10354,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # look like "nothing installed".
                 from hermes_cli.plugins_cmd import (
                     _discover_all_plugins,
-                    _get_disabled_set,
-                    _get_enabled_set,
-                    _plugin_status,
+                    _discover_plugin_display_records,
                 )
 
                 entries = _discover_all_plugins()
-                enabled = _get_enabled_set()
-                disabled = _get_disabled_set()
+                resolved_groups = {
+                    entry[5]: (entry, status)
+                    for entry, status in _discover_plugin_display_records()
+                }
 
                 # `/plugins` is a quick glance — default to user-installed
                 # plugins (what the user actually added). Bundled provider/
@@ -10388,15 +10388,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         loaded = {}
 
                     print(f"User plugins ({len(user_entries)}):")
-                    for name, version, _desc, source, _dir, key, kind in sorted(user_entries):
-                        state = _plugin_status(
-                            name,
-                            enabled,
-                            disabled,
-                            key=key,
-                            source=source,
-                            kind=kind,
+                    for entry in sorted(user_entries):
+                        name, version, _desc, _source, _dir, key, _kind = entry
+                        resolved_entry, group_status = resolved_groups.get(
+                            key,
+                            (None, "not enabled"),
                         )
+                        if group_status == "disabled":
+                            state = "disabled"
+                        elif group_status == "enabled" and entry == resolved_entry:
+                            state = "enabled"
+                        else:
+                            state = "not enabled"
                         glyph = {"enabled": "✓", "disabled": "✗"}.get(state, "○")
                         ver = f" v{version}" if version else ""
                         info = loaded.get(name) or {}

--- a/hermes_cli/agent_plugins.py
+++ b/hermes_cli/agent_plugins.py
@@ -558,14 +558,16 @@ def read_agent_plugin_manifest(plugin_root: Path) -> tuple[dict, tuple[AgentPlug
     return manifest, tuple(diagnostics)
 
 
-def has_enabled_agent_plugin_mcp(raw_config: Mapping[str, Any]) -> bool:
+def has_enabled_agent_plugin_mcp(effective_config: Mapping[str, Any]) -> bool:
     """Compatibility wrapper for the shared PluginManager MCP probe.
 
     Directory scanning belongs to :mod:`hermes_cli.plugins` so startup gating
     and full plugin discovery cannot drift apart. Keep this import-compatible
-    entry point for callers that used the original helper.
+    entry point for callers that used the original helper. ``effective_config``
+    must come from the canonical config loader so environment expansion,
+    managed policy, and last-known-good behavior match runtime discovery.
     """
 
     from hermes_cli.plugins import has_enabled_agent_plugin_mcp as _probe
 
-    return _probe(raw_config)
+    return _probe(effective_config)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -766,16 +766,22 @@ def get_known_provider_config(provider_id: str) -> ProviderConfig | None:
     return None
 
 
-def get_known_provider_configs() -> Mapping[str, ProviderConfig]:
-    """Return a read-only snapshot of built-in and currently active metadata.
+def get_known_provider_configs() -> tuple[ProviderConfig, ...]:
+    """Return an immutable snapshot of built-in and active configurations.
 
     Built-in entries remain visible to security consumers when their bundled
-    plugin is disabled. Third-party entries are included only while present
-    in the current active registry.
+    plugin is disabled. Active same-ID overrides are appended instead of
+    replacing built-in security metadata; identical objects and aliases are
+    de-duplicated by identity. Unknown inactive third-party metadata remains a
+    follow-up for a durable manifest inventory, not process-observed state.
     """
-    known = dict(_STATIC_PROVIDER_REGISTRY)
-    known.update(PROVIDER_REGISTRY.items())
-    return MappingProxyType(known)
+    known = list(_STATIC_PROVIDER_REGISTRY.values())
+    seen = {id(config) for config in known}
+    for config in PROVIDER_REGISTRY.values():
+        if id(config) not in seen:
+            known.append(config)
+            seen.add(id(config))
+    return tuple(known)
 
 
 def get_nous_service_config() -> ProviderConfig:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -607,6 +607,38 @@ _PROVIDER_REGISTRY_LKG_BY_SECURITY_IDENTITY: dict[
     tuple[tuple[str, str], object], Dict[str, ProviderConfig]
 ] = {}
 _PROVIDER_REGISTRY_CACHE_LOCK = threading.RLock()
+_PROVIDER_SECURITY_ENV_EXEMPT = frozenset({"CLAUDE_CODE_OAUTH_TOKEN"})
+
+
+def _provider_security_env_names(
+    provider_configs: Iterable[ProviderConfig],
+) -> set[str]:
+    names: set[str] = set()
+    for config in provider_configs:
+        names.update(config.api_key_env_vars)
+        if config.base_url_env_var:
+            names.add(config.base_url_env_var)
+    names.difference_update(_PROVIDER_SECURITY_ENV_EXEMPT)
+    return names
+
+
+_OBSERVED_PROVIDER_SECURITY_ENV_NAMES = _provider_security_env_names(
+    _STATIC_PROVIDER_REGISTRY.values()
+)
+
+
+def _record_observed_provider_security_env_names(
+    provider_configs: Iterable[ProviderConfig],
+) -> None:
+    names = _provider_security_env_names(provider_configs)
+    with _PROVIDER_REGISTRY_CACHE_LOCK:
+        _OBSERVED_PROVIDER_SECURITY_ENV_NAMES.update(names)
+
+
+def get_observed_provider_security_env_names() -> frozenset[str]:
+    """Return provider credential names observed during this process lifetime."""
+    with _PROVIDER_REGISTRY_CACHE_LOCK:
+        return frozenset(_OBSERVED_PROVIDER_SECURITY_ENV_NAMES)
 
 
 def _provider_config_from_profile(profile) -> ProviderConfig | None:
@@ -686,6 +718,9 @@ def _compute_provider_registry_snapshot() -> Dict[str, ProviderConfig]:
                 dynamic_keys.add(alias)
 
     with _PROVIDER_REGISTRY_CACHE_LOCK:
+        _OBSERVED_PROVIDER_SECURITY_ENV_NAMES.update(
+            _provider_security_env_names(replacement.values())
+        )
         _PROVIDER_REGISTRY_CACHE[cache_key] = (
             catalog,
             replacement,
@@ -783,8 +818,9 @@ def get_known_provider_configs() -> tuple[ProviderConfig, ...]:
     Built-in entries remain visible to security consumers when their bundled
     plugin is disabled. Active same-ID overrides are appended instead of
     replacing built-in security metadata; identical objects and aliases are
-    de-duplicated by identity. Unknown inactive third-party metadata remains a
-    follow-up for a durable manifest inventory, not process-observed state.
+    de-duplicated by identity. Successfully discovered credential names remain
+    blocked for the process lifetime; never-observed inactive third-party
+    metadata remains a follow-up for a durable manifest inventory.
     """
     known = list(get_builtin_provider_configs())
     seen = {id(config) for config in known}
@@ -792,7 +828,9 @@ def get_known_provider_configs() -> tuple[ProviderConfig, ...]:
         if id(config) not in seen:
             known.append(config)
             seen.add(id(config))
-    return tuple(known)
+    snapshot = tuple(known)
+    _record_observed_provider_security_env_names(snapshot)
+    return snapshot
 
 
 def get_nous_service_config() -> ProviderConfig:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -766,6 +766,11 @@ def get_known_provider_config(provider_id: str) -> ProviderConfig | None:
     return None
 
 
+def get_builtin_provider_configs() -> tuple[ProviderConfig, ...]:
+    """Return the immutable built-in provider configuration sequence."""
+    return tuple(_STATIC_PROVIDER_REGISTRY.values())
+
+
 def get_known_provider_configs() -> tuple[ProviderConfig, ...]:
     """Return an immutable snapshot of built-in and active configurations.
 
@@ -775,7 +780,7 @@ def get_known_provider_configs() -> tuple[ProviderConfig, ...]:
     de-duplicated by identity. Unknown inactive third-party metadata remains a
     follow-up for a durable manifest inventory, not process-observed state.
     """
-    known = list(_STATIC_PROVIDER_REGISTRY.values())
+    known = list(get_builtin_provider_configs())
     seen = {id(config) for config in known}
     for config in PROVIDER_REGISTRY.values():
         if id(config) not in seen:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -39,7 +39,18 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
+from types import MappingProxyType
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+)
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
@@ -571,7 +582,9 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
 }
-_STATIC_PROVIDER_REGISTRY = dict(PROVIDER_REGISTRY)
+_STATIC_PROVIDER_REGISTRY: Mapping[str, ProviderConfig] = MappingProxyType(
+    dict(PROVIDER_REGISTRY)
+)
 # The public registry resolves the immutable provider catalog for the caller's
 # current HERMES_HOME ContextVar.  No profile-specific endpoint is published
 # into process-global routing state.
@@ -751,6 +764,18 @@ def get_known_provider_config(provider_id: str) -> ProviderConfig | None:
     if static is not None:
         return static
     return None
+
+
+def get_known_provider_configs() -> Mapping[str, ProviderConfig]:
+    """Return a read-only snapshot of built-in and currently active metadata.
+
+    Built-in entries remain visible to security consumers when their bundled
+    plugin is disabled. Third-party entries are included only while present
+    in the current active registry.
+    """
+    known = dict(_STATIC_PROVIDER_REGISTRY)
+    known.update(PROVIDER_REGISTRY.items())
+    return MappingProxyType(known)
 
 
 def get_nous_service_config() -> ProviderConfig:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -63,7 +63,13 @@ from hermes_cli.config import (
 )
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
-from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
+from utils import (
+    atomic_replace,
+    atomic_yaml_write,
+    base_url_host_matches,
+    env_float,
+    is_truthy_value,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2396,8 +2402,23 @@ def resolve_provider(
             msg += " Check 'hermes model' for available providers, or run 'hermes doctor' to diagnose config issues."
         raise AuthError(msg, code="invalid_provider")
 
-    # Explicit one-off CLI creds always mean openrouter/custom
-    if explicit_api_key or explicit_base_url:
+    # Explicit one-off CLI creds always mean openrouter/custom. Classify an
+    # explicit endpoint before applying the plugin gate: non-OpenRouter hosts
+    # are generic OpenAI-compatible endpoints even though this legacy resolver
+    # keeps returning ``openrouter`` for downstream compatibility.
+    if explicit_base_url:
+        endpoint_provider = (
+            "openrouter"
+            if base_url_host_matches(explicit_base_url, "openrouter.ai")
+            else "custom"
+        )
+        if not _provider_plugin_is_active(endpoint_provider):
+            raise AuthError(
+                f"Provider '{endpoint_provider}' is disabled by plugin configuration.",
+                code="invalid_provider",
+            )
+        return "openrouter"
+    if explicit_api_key:
         return resolve_provider("openrouter")
 
     # Provider precedence for the auto-path (#29285): explicit user intent must

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -34,6 +34,7 @@ import time
 import uuid
 import webbrowser
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -208,53 +209,69 @@ class ProviderConfig:
     base_url_env_var: str = ""
 
 
-class _AtomicProviderRegistry(dict[str, ProviderConfig]):
-    """Dict-compatible registry with atomic replacement and snapshot views."""
+class _ContextProviderRegistry(dict[str, ProviderConfig]):
+    """Dict-compatible, context-scoped view of the active provider catalog."""
 
     def __init__(self, initial: Dict[str, ProviderConfig]):
-        super().__init__(initial)
-        self._lock = threading.RLock()
+        super().__init__()
+        self._override: ContextVar[Optional[Dict[str, ProviderConfig]]] = (
+            ContextVar("_AUTH_PROVIDER_REGISTRY_OVERRIDE", default=None)
+        )
+        if initial:
+            self._override.set(dict(initial))
+
+    def _snapshot(self) -> Dict[str, ProviderConfig]:
+        override = self._override.get()
+        if override is not None:
+            return override
+        return _provider_registry_snapshot()
 
     def replace(self, replacement: Dict[str, ProviderConfig]) -> None:
-        with self._lock:
-            super().clear()
-            super().update(replacement)
+        """Install a context-local compatibility/test override."""
+        self._override.set(dict(replacement))
+
+    def clear_override(self) -> None:
+        self._override.set(None)
 
     def __getitem__(self, key: str) -> ProviderConfig:
-        with self._lock:
-            return super().__getitem__(key)
+        return self._snapshot()[key]
 
     def __setitem__(self, key: str, value: ProviderConfig) -> None:
-        with self._lock:
-            super().__setitem__(key, value)
+        replacement = dict(self._snapshot())
+        replacement[key] = value
+        self.replace(replacement)
 
     def __contains__(self, key: object) -> bool:
-        with self._lock:
-            return super().__contains__(key)
+        return key in self._snapshot()
 
     def __iter__(self):
-        with self._lock:
-            return iter(tuple(super().keys()))
+        return iter(tuple(self._snapshot()))
 
     def __len__(self) -> int:
-        with self._lock:
-            return super().__len__()
+        return len(self._snapshot())
 
     def get(self, key: str, default=None):
-        with self._lock:
-            return super().get(key, default)
+        return self._snapshot().get(key, default)
 
     def keys(self):
-        with self._lock:
-            return tuple(super().keys())
+        return tuple(self._snapshot())
 
     def values(self):
-        with self._lock:
-            return tuple(super().values())
+        return tuple(self._snapshot().values())
 
     def items(self):
-        with self._lock:
-            return tuple(super().items())
+        return tuple(self._snapshot().items())
+
+    def copy(self):
+        return dict(self._snapshot())
+
+    def __repr__(self):
+        return repr(self._snapshot())
+
+    def __eq__(self, other):
+        if isinstance(other, _ContextProviderRegistry):
+            other = other._snapshot()
+        return self._snapshot() == other
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -555,55 +572,77 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     ),
 }
 _STATIC_PROVIDER_REGISTRY = dict(PROVIDER_REGISTRY)
-# The public registry is the live, activation-filtered view. Starting empty
-# makes an initial discovery failure fail closed; later refresh failures leave
-# the last successfully published snapshot untouched.
-PROVIDER_REGISTRY = _AtomicProviderRegistry({})
+# The public registry resolves the immutable provider catalog for the caller's
+# current HERMES_HOME ContextVar.  No profile-specific endpoint is published
+# into process-global routing state.
+PROVIDER_REGISTRY = _ContextProviderRegistry({})
 
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
 # providers/ that is not already declared above. New providers only need a
 # plugins/model-providers/<name>/ plugin — no edits to this file required.
 _DYNAMIC_PROVIDER_REGISTRY_KEYS: set[str] = set()
+_PROVIDER_REGISTRY_CACHE: dict[
+    int, tuple[object, Dict[str, ProviderConfig], frozenset[str]]
+] = {}
+_PROVIDER_REGISTRY_LKG_BY_SECURITY_IDENTITY: dict[
+    tuple[tuple[str, str], object], Dict[str, ProviderConfig]
+] = {}
+_PROVIDER_REGISTRY_CACHE_LOCK = threading.RLock()
 
 
-def _refresh_provider_registry_from_plugins() -> None:
-    """Atomically rebuild auth entries from the active provider profiles."""
-    try:
-        from providers import (
-            get_provider_profile_origin,
-            is_plugin_managed_provider_id,
-            list_providers,
-        )
+def _provider_config_from_profile(profile) -> ProviderConfig | None:
+    if profile.auth_type != "api_key" or not profile.env_vars:
+        return None
+    api_key_vars = tuple(
+        value
+        for value in profile.env_vars
+        if not value.endswith(("_BASE_URL", "_URL"))
+    )
+    base_url_var = next(
+        (
+            value
+            for value in profile.env_vars
+            if value.endswith(("_BASE_URL", "_URL"))
+        ),
+        None,
+    )
+    return ProviderConfig(
+        id=profile.name,
+        name=profile.display_name or profile.name,
+        auth_type="api_key",
+        inference_base_url=profile.base_url,
+        api_key_env_vars=api_key_vars or profile.env_vars,
+        base_url_env_var=base_url_var or "",
+    )
 
-        profiles = list_providers()
-    except Exception:
-        logger.warning(
-            "Failed to refresh the active provider registry; keeping its "
-            "last-known-good snapshot",
-            exc_info=True,
-        )
-        return
 
-    active_provider_ids = {profile.name for profile in profiles}
+def _compute_provider_registry_snapshot() -> Dict[str, ProviderConfig]:
+    from providers import get_provider_catalog_snapshot
+
+    catalog = get_provider_catalog_snapshot()
+    cache_key = id(catalog)
+    with _PROVIDER_REGISTRY_CACHE_LOCK:
+        cached = _PROVIDER_REGISTRY_CACHE.get(cache_key)
+        if cached is not None and cached[0] is catalog:
+            return cached[1]
+
     replacement = {
         provider_id: config
         for provider_id, config in _STATIC_PROVIDER_REGISTRY.items()
         if (
-            not is_plugin_managed_provider_id(provider_id)
-            or provider_id in active_provider_ids
+            provider_id not in catalog.bundled_provider_ids
+            or provider_id in catalog.active_plugin_provider_ids
         )
     }
     dynamic_keys: set[str] = set()
 
-    for profile in profiles:
+    for profile in catalog.profiles:
         existing = replacement.get(profile.name)
-        origin = get_provider_profile_origin(profile.name)
+        origin = catalog.origins.get(profile.name)
         is_external_override = bool(
             origin and origin[0] in {"user", "project", "legacy"}
         )
         if existing is not None and not is_external_override:
-            continue
-        if profile.auth_type != "api_key" or not profile.env_vars:
             continue
         if existing is not None and existing.auth_type != "api_key":
             continue
@@ -617,36 +656,79 @@ def _refresh_provider_registry_from_plugins() -> None:
             "custom",
         }:
             continue
-        api_key_vars = tuple(
-            value
-            for value in profile.env_vars
-            if not value.endswith(("_BASE_URL", "_URL"))
-        )
-        base_url_var = next(
-            (
-                value
-                for value in profile.env_vars
-                if value.endswith(("_BASE_URL", "_URL"))
-            ),
-            None,
-        )
-        replacement[profile.name] = ProviderConfig(
-            id=profile.name,
-            name=profile.display_name or profile.name,
-            auth_type="api_key",
-            inference_base_url=profile.base_url,
-            api_key_env_vars=api_key_vars or profile.env_vars,
-            base_url_env_var=base_url_var or "",
-        )
+        config = _provider_config_from_profile(profile)
+        if config is None:
+            continue
+        replacement[profile.name] = config
         dynamic_keys.add(profile.name)
         for alias in profile.aliases:
             if alias not in replacement:
-                replacement[alias] = replacement[profile.name]
+                replacement[alias] = config
                 dynamic_keys.add(alias)
 
-    PROVIDER_REGISTRY.replace(replacement)
-    _DYNAMIC_PROVIDER_REGISTRY_KEYS.clear()
-    _DYNAMIC_PROVIDER_REGISTRY_KEYS.update(dynamic_keys)
+    with _PROVIDER_REGISTRY_CACHE_LOCK:
+        _PROVIDER_REGISTRY_CACHE[cache_key] = (
+            catalog,
+            replacement,
+            frozenset(dynamic_keys),
+        )
+        _PROVIDER_REGISTRY_LKG_BY_SECURITY_IDENTITY[
+            (catalog.scope_identity, catalog.activation)
+        ] = replacement
+        # Compatibility/debug view only; runtime decisions use the immutable
+        # context-specific replacement returned above.
+        _DYNAMIC_PROVIDER_REGISTRY_KEYS.clear()
+        _DYNAMIC_PROVIDER_REGISTRY_KEYS.update(dynamic_keys)
+    return replacement
+
+
+def _provider_registry_snapshot() -> Dict[str, ProviderConfig]:
+    try:
+        return _compute_provider_registry_snapshot()
+    except Exception:
+        try:
+            from providers import get_provider_scope_identity
+            from hermes_cli.config import load_plugin_activation_state
+
+            scope = get_provider_scope_identity()
+            activation = load_plugin_activation_state()
+        except Exception:
+            scope = None
+            activation = None
+        with _PROVIDER_REGISTRY_CACHE_LOCK:
+            lkg = (
+                _PROVIDER_REGISTRY_LKG_BY_SECURITY_IDENTITY.get(
+                    (scope, activation)
+                )
+                if scope is not None and activation is not None
+                else None
+            )
+        if lkg is not None:
+            logger.warning(
+                "Failed to refresh the active provider registry; keeping the "
+                "same-profile, same-activation last-known-good snapshot",
+                exc_info=True,
+            )
+            return lkg
+        logger.warning(
+            "Failed to build the active provider registry; failing closed",
+            exc_info=True,
+        )
+        return {}
+
+
+def _refresh_provider_registry_from_plugins() -> None:
+    """Warm the current context snapshot after provider invalidation."""
+    try:
+        _compute_provider_registry_snapshot()
+    except Exception:
+        logger.warning(
+            "Failed to refresh the active provider registry; keeping its "
+            "last-known-good snapshot",
+            exc_info=True,
+        )
+        return
+    PROVIDER_REGISTRY.clear_override()
 
 
 def get_provider_implementation_config(provider_id: str) -> ProviderConfig:
@@ -657,6 +739,41 @@ def get_provider_implementation_config(provider_id: str) -> ProviderConfig:
     metadata to finish cleanup or report status after a provider is disabled.
     """
     return _STATIC_PROVIDER_REGISTRY[provider_id]
+
+
+def get_known_provider_config(provider_id: str) -> ProviderConfig | None:
+    """Return cleanup/security metadata independently of live routability."""
+    normalized = (provider_id or "").strip().lower()
+    live = PROVIDER_REGISTRY.get(normalized)
+    if live is not None:
+        return live
+    static = _STATIC_PROVIDER_REGISTRY.get(normalized)
+    if static is not None:
+        return static
+    try:
+        from providers import get_observed_provider_profiles
+
+        for profile in get_observed_provider_profiles():
+            if normalized == profile.name or normalized in profile.aliases:
+                return _provider_config_from_profile(profile)
+    except Exception:
+        pass
+    return None
+
+
+def get_all_known_provider_configs() -> tuple[ProviderConfig, ...]:
+    """Return a monotonic union for secret-name filtering, not routing."""
+    configs = list(_STATIC_PROVIDER_REGISTRY.values())
+    try:
+        from providers import get_observed_provider_profiles
+
+        for profile in get_observed_provider_profiles():
+            config = _provider_config_from_profile(profile)
+            if config is not None:
+                configs.append(config)
+    except Exception:
+        pass
+    return tuple(configs)
 
 
 def get_nous_service_config() -> ProviderConfig:
@@ -801,6 +918,20 @@ def _resolve_api_key_provider_secret(
         pass
 
     return "", ""
+
+
+def _resolve_provider_base_url_override(pconfig: ProviderConfig) -> str:
+    """Read a provider endpoint override from the current profile scope."""
+    if not pconfig.base_url_env_var:
+        return ""
+    try:
+        from hermes_cli.config import get_env_value_prefer_dotenv
+
+        return (
+            get_env_value_prefer_dotenv(pconfig.base_url_env_var) or ""
+        ).strip()
+    except Exception:
+        return os.getenv(pconfig.base_url_env_var, "").strip()
 
 
 # =============================================================================
@@ -1634,13 +1765,44 @@ def mark_provider_active_if_unset(provider_id: str) -> None:
 
 def is_known_auth_provider(provider_id: str) -> bool:
     normalized = (provider_id or "").strip().lower()
-    return normalized in PROVIDER_REGISTRY or normalized in SERVICE_PROVIDER_NAMES
+    if (
+        normalized in PROVIDER_REGISTRY
+        or normalized in _STATIC_PROVIDER_REGISTRY
+        or normalized in SERVICE_PROVIDER_NAMES
+    ):
+        return True
+    try:
+        from providers import get_known_provider_ids
+
+        if normalized in get_known_provider_ids():
+            return True
+    except Exception:
+        pass
+
+    # Logout is a cleanup operation.  A provider that was disabled or removed
+    # must remain addressable when this profile still has persisted auth for
+    # it; routability is deliberately not required here.
+    try:
+        auth_store = _load_auth_store()
+        for field in ("providers", "credential_pool"):
+            values = auth_store.get(field)
+            if isinstance(values, dict) and normalized in {
+                str(key).strip().lower() for key in values
+            }:
+                return True
+        active = auth_store.get("active_provider")
+        if isinstance(active, str) and active.strip().lower() == normalized:
+            return True
+    except Exception:
+        pass
+    return _config_provider_matches(normalized)
 
 
 def get_auth_provider_display_name(provider_id: str) -> str:
     normalized = (provider_id or "").strip().lower()
-    if normalized in PROVIDER_REGISTRY:
-        return PROVIDER_REGISTRY[normalized].name
+    config = get_known_provider_config(normalized)
+    if config is not None:
+        return config.name
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
@@ -7133,9 +7295,7 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     key_source = ""
     api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
 
-    env_url = ""
-    if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+    env_url = _resolve_provider_base_url_override(pconfig)
 
     if provider_id in {"kimi-coding", "kimi-coding-cn"}:
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -7176,7 +7336,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = _resolve_provider_base_url_override(pconfig)
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -7329,9 +7489,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
         api_key = LMSTUDIO_NOAUTH_PLACEHOLDER
         key_source = key_source or "default"
 
-    env_url = ""
-    if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+    env_url = _resolve_provider_base_url_override(pconfig)
 
     if provider_id in {"kimi-coding", "kimi-coding-cn"}:
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -7396,7 +7554,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = _resolve_provider_base_url_override(pconfig)
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -7523,7 +7681,7 @@ def _should_reset_config_provider_on_logout(provider_id: Optional[str]) -> bool:
     if not provider_id:
         return False
     normalized = provider_id.strip().lower()
-    return normalized in PROVIDER_REGISTRY and _config_provider_matches(normalized)
+    return is_known_auth_provider(normalized) and _config_provider_matches(normalized)
 
 
 def _logout_default_provider_from_config() -> Optional[str]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -742,7 +742,7 @@ def get_provider_implementation_config(provider_id: str) -> ProviderConfig:
 
 
 def get_known_provider_config(provider_id: str) -> ProviderConfig | None:
-    """Return cleanup/security metadata independently of live routability."""
+    """Return active or built-in metadata independently of live routability."""
     normalized = (provider_id or "").strip().lower()
     live = PROVIDER_REGISTRY.get(normalized)
     if live is not None:
@@ -750,30 +750,7 @@ def get_known_provider_config(provider_id: str) -> ProviderConfig | None:
     static = _STATIC_PROVIDER_REGISTRY.get(normalized)
     if static is not None:
         return static
-    try:
-        from providers import get_observed_provider_profiles
-
-        for profile in get_observed_provider_profiles():
-            if normalized == profile.name or normalized in profile.aliases:
-                return _provider_config_from_profile(profile)
-    except Exception:
-        pass
     return None
-
-
-def get_all_known_provider_configs() -> tuple[ProviderConfig, ...]:
-    """Return a monotonic union for secret-name filtering, not routing."""
-    configs = list(_STATIC_PROVIDER_REGISTRY.values())
-    try:
-        from providers import get_observed_provider_profiles
-
-        for profile in get_observed_provider_profiles():
-            config = _provider_config_from_profile(profile)
-            if config is not None:
-                configs.append(config)
-    except Exception:
-        pass
-    return tuple(configs)
 
 
 def get_nous_service_config() -> ProviderConfig:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -208,6 +208,55 @@ class ProviderConfig:
     base_url_env_var: str = ""
 
 
+class _AtomicProviderRegistry(dict[str, ProviderConfig]):
+    """Dict-compatible registry with atomic replacement and snapshot views."""
+
+    def __init__(self, initial: Dict[str, ProviderConfig]):
+        super().__init__(initial)
+        self._lock = threading.RLock()
+
+    def replace(self, replacement: Dict[str, ProviderConfig]) -> None:
+        with self._lock:
+            super().clear()
+            super().update(replacement)
+
+    def __getitem__(self, key: str) -> ProviderConfig:
+        with self._lock:
+            return super().__getitem__(key)
+
+    def __setitem__(self, key: str, value: ProviderConfig) -> None:
+        with self._lock:
+            super().__setitem__(key, value)
+
+    def __contains__(self, key: object) -> bool:
+        with self._lock:
+            return super().__contains__(key)
+
+    def __iter__(self):
+        with self._lock:
+            return iter(tuple(super().keys()))
+
+    def __len__(self) -> int:
+        with self._lock:
+            return super().__len__()
+
+    def get(self, key: str, default=None):
+        with self._lock:
+            return super().get(key, default)
+
+    def keys(self):
+        with self._lock:
+            return tuple(super().keys())
+
+    def values(self):
+        with self._lock:
+            return tuple(super().values())
+
+    def items(self):
+        with self._lock:
+            return tuple(super().items())
+
+
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     "nous": ProviderConfig(
         id="nous",
@@ -505,38 +554,121 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
 }
+_STATIC_PROVIDER_REGISTRY = dict(PROVIDER_REGISTRY)
+# The public registry is the live, activation-filtered view. Starting empty
+# makes an initial discovery failure fail closed; later refresh failures leave
+# the last successfully published snapshot untouched.
+PROVIDER_REGISTRY = _AtomicProviderRegistry({})
 
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
-# providers/ that is not already declared above.  New providers only need a
+# providers/ that is not already declared above. New providers only need a
 # plugins/model-providers/<name>/ plugin — no edits to this file required.
-try:
-    from providers import list_providers as _list_providers_for_registry
-    for _pp in _list_providers_for_registry():
-        if _pp.name in PROVIDER_REGISTRY:
-            continue
-        if _pp.auth_type != "api_key" or not _pp.env_vars:
-            continue
-        # Skip providers that need custom token resolution or are special-cased
-        # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;
-        # openrouter/custom are aggregator/user-supplied and handled outside
-        # the registry — adding them here breaks runtime_provider resolution
-        # that relies on `openrouter not in PROVIDER_REGISTRY`).
-        if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
-            continue
-        _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
-        _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
-        PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
-            id=_pp.name,
-            name=_pp.display_name or _pp.name,
-            auth_type="api_key",
-            inference_base_url=_pp.base_url,
-            api_key_env_vars=_api_key_vars or _pp.env_vars,
-            base_url_env_var=_base_url_var or "",
+_DYNAMIC_PROVIDER_REGISTRY_KEYS: set[str] = set()
+
+
+def _refresh_provider_registry_from_plugins() -> None:
+    """Atomically rebuild auth entries from the active provider profiles."""
+    try:
+        from providers import (
+            get_provider_profile_origin,
+            is_plugin_managed_provider_id,
+            list_providers,
         )
-        # Also register aliases so resolve_provider() resolves them
-        for _alias in _pp.aliases:
-            if _alias not in PROVIDER_REGISTRY:
-                PROVIDER_REGISTRY[_alias] = PROVIDER_REGISTRY[_pp.name]
+
+        profiles = list_providers()
+    except Exception:
+        logger.warning(
+            "Failed to refresh the active provider registry; keeping its "
+            "last-known-good snapshot",
+            exc_info=True,
+        )
+        return
+
+    active_provider_ids = {profile.name for profile in profiles}
+    replacement = {
+        provider_id: config
+        for provider_id, config in _STATIC_PROVIDER_REGISTRY.items()
+        if (
+            not is_plugin_managed_provider_id(provider_id)
+            or provider_id in active_provider_ids
+        )
+    }
+    dynamic_keys: set[str] = set()
+
+    for profile in profiles:
+        existing = replacement.get(profile.name)
+        origin = get_provider_profile_origin(profile.name)
+        is_external_override = bool(
+            origin and origin[0] in {"user", "project", "legacy"}
+        )
+        if existing is not None and not is_external_override:
+            continue
+        if profile.auth_type != "api_key" or not profile.env_vars:
+            continue
+        if existing is not None and existing.auth_type != "api_key":
+            continue
+        # These identities need bespoke token/runtime resolution.
+        if profile.name in {
+            "copilot",
+            "kimi-coding",
+            "kimi-coding-cn",
+            "zai",
+            "openrouter",
+            "custom",
+        }:
+            continue
+        api_key_vars = tuple(
+            value
+            for value in profile.env_vars
+            if not value.endswith(("_BASE_URL", "_URL"))
+        )
+        base_url_var = next(
+            (
+                value
+                for value in profile.env_vars
+                if value.endswith(("_BASE_URL", "_URL"))
+            ),
+            None,
+        )
+        replacement[profile.name] = ProviderConfig(
+            id=profile.name,
+            name=profile.display_name or profile.name,
+            auth_type="api_key",
+            inference_base_url=profile.base_url,
+            api_key_env_vars=api_key_vars or profile.env_vars,
+            base_url_env_var=base_url_var or "",
+        )
+        dynamic_keys.add(profile.name)
+        for alias in profile.aliases:
+            if alias not in replacement:
+                replacement[alias] = replacement[profile.name]
+                dynamic_keys.add(alias)
+
+    PROVIDER_REGISTRY.replace(replacement)
+    _DYNAMIC_PROVIDER_REGISTRY_KEYS.clear()
+    _DYNAMIC_PROVIDER_REGISTRY_KEYS.update(dynamic_keys)
+
+
+def get_provider_implementation_config(provider_id: str) -> ProviderConfig:
+    """Return built-in implementation metadata independent of routability.
+
+    ``PROVIDER_REGISTRY`` represents the currently active provider catalog.
+    Internal login/token implementations still need their immutable endpoint
+    metadata to finish cleanup or report status after a provider is disabled.
+    """
+    return _STATIC_PROVIDER_REGISTRY[provider_id]
+
+
+def get_nous_service_config() -> ProviderConfig:
+    """Return portal auth metadata independently of model-plugin activation."""
+    return get_provider_implementation_config("nous")
+
+
+_refresh_provider_registry_from_plugins()
+try:
+    from providers import register_provider_refresh_hook
+
+    register_provider_refresh_hook(_refresh_provider_registry_from_plugins)
 except Exception:
     pass
 
@@ -558,7 +690,7 @@ def get_anthropic_key() -> str:
     """
     from hermes_cli.config import get_env_value_prefer_dotenv
 
-    for var in PROVIDER_REGISTRY["anthropic"].api_key_env_vars:
+    for var in _STATIC_PROVIDER_REGISTRY["anthropic"].api_key_env_vars:
         value = get_env_value_prefer_dotenv(var) or ""
         if value:
             return value
@@ -1512,6 +1644,22 @@ def get_auth_provider_display_name(provider_id: str) -> str:
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
+def _provider_plugin_is_active(provider_id: str) -> bool:
+    """Return the live activation state for a plugin-managed provider."""
+    try:
+        from providers import (
+            is_plugin_managed_provider_id,
+            is_provider_plugin_active,
+        )
+
+        return (
+            not is_plugin_managed_provider_id(provider_id)
+            or is_provider_plugin_active(provider_id)
+        )
+    except Exception:
+        return False
+
+
 def is_runtime_provider_routable(provider_id: str) -> bool:
     """Return whether runtime resolution recognizes a provider identity.
 
@@ -1522,10 +1670,12 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
     normalized = (provider_id or "").strip().lower()
     if not normalized:
         return False
-    if normalized in {"auto", "openrouter", "custom", "moa"}:
+    if normalized in {"auto", "moa"}:
         return True
     if normalized.startswith("custom:"):
-        return True
+        return _provider_plugin_is_active("custom")
+    if normalized in {"openrouter", "custom"}:
+        return _provider_plugin_is_active(normalized)
     try:
         resolve_provider(normalized)
     except AuthError:
@@ -2049,6 +2199,12 @@ def resolve_provider(
         pass
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 
+    if normalized != "auto" and not _provider_plugin_is_active(normalized):
+        raise AuthError(
+            f"Provider '{normalized}' is disabled by plugin configuration.",
+            code="invalid_provider",
+        )
+
     if normalized == "openrouter":
         return "openrouter"
     if normalized == "custom":
@@ -2067,7 +2223,7 @@ def resolve_provider(
 
     # Explicit one-off CLI creds always mean openrouter/custom
     if explicit_api_key or explicit_base_url:
-        return "openrouter"
+        return resolve_provider("openrouter")
 
     # Provider precedence for the auto-path (#29285): explicit user intent must
     # win over a stale logged-in OAuth `active_provider`. Order matches the
@@ -2086,12 +2242,13 @@ def resolve_provider(
         if isinstance(_model_cfg, dict):
             _cfg_provider = _model_cfg.get("provider")
             if isinstance(_cfg_provider, str) and _cfg_provider.strip().lower() in PROVIDER_REGISTRY:
-                return _cfg_provider.strip().lower()
+                return resolve_provider(_cfg_provider.strip().lower())
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
 
     if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
-        return "openrouter"
+        if _provider_plugin_is_active("openrouter"):
+            return "openrouter"
 
     # Auto-detect an OpenRouter credential added via `hermes auth add openrouter`
     # (manual pool entry, no env var). Without this, a key that only lives in
@@ -2103,7 +2260,10 @@ def resolve_provider(
     try:
         from agent.credential_pool import load_pool as _load_pool
 
-        if _load_pool("openrouter").has_credentials():
+        if (
+            _provider_plugin_is_active("openrouter")
+            and _load_pool("openrouter").has_credentials()
+        ):
             return "openrouter"
     except Exception as e:
         logger.debug("Could not check OpenRouter credential pool: %s", e)
@@ -2122,6 +2282,8 @@ def resolve_provider(
 
     # Auto-detect API-key providers by checking their env vars
     for pid, pconfig in PROVIDER_REGISTRY.items():
+        if not _provider_plugin_is_active(pid):
+            continue
         if pconfig.auth_type != "api_key":
             continue
         # GitHub tokens are commonly present for repo/tool access but should not
@@ -2163,13 +2325,14 @@ def resolve_provider(
                 "different provider, set `model.provider` explicitly.",
                 _oauth_active,
             )
-        return _oauth_active
+        if _provider_plugin_is_active(_oauth_active):
+            return _oauth_active
 
     # AWS Bedrock — detect via boto3 credential chain (IAM roles, SSO, env vars).
     # This runs after API-key providers so explicit keys always win.
     try:
         from agent.bedrock_adapter import has_aws_credentials
-        if has_aws_credentials():
+        if has_aws_credentials() and _provider_plugin_is_active("bedrock"):
             return "bedrock"
     except ImportError:
         pass  # boto3 not installed — skip Bedrock auto-detection
@@ -8484,7 +8647,7 @@ def _minimax_oauth_login(
     timeout_seconds: float = 15.0,
 ) -> Dict[str, Any]:
     """Run MiniMax OAuth flow, persist tokens, return auth state dict."""
-    pconfig = PROVIDER_REGISTRY["minimax-oauth"]
+    pconfig = get_provider_implementation_config("minimax-oauth")
     if region == "cn":
         portal_base_url = pconfig.extra["cn_portal_base_url"]
         inference_base_url = pconfig.extra["cn_inference_base_url"]
@@ -8792,7 +8955,7 @@ def _nous_device_code_login(
     on_verification: Optional[Callable[[str, str], None]] = None,
 ) -> Dict[str, Any]:
     """Run the Nous device-code flow and return full OAuth state without persisting."""
-    pconfig = PROVIDER_REGISTRY["nous"]
+    pconfig = get_nous_service_config()
     portal_base_url = (
         portal_base_url
         or os.getenv("HERMES_PORTAL_BASE_URL")
@@ -8961,7 +9124,7 @@ def step_up_nous_billing_scope(
     Returns True iff the new token carries ``billing:manage``.
     """
     prior = get_provider_auth_state("nous") or {}
-    pconfig = PROVIDER_REGISTRY["nous"]
+    pconfig = get_nous_service_config()
 
     # Build the step-up scope: existing scopes (if any) + billing:manage, deduped,
     # order-stable. Fall back to the standard inference+tool+billing set.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -29,10 +29,13 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, TYPE_CHECKING
 
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
+
+if TYPE_CHECKING:
+    from hermes_cli.plugin_activation import PluginActivationState
 
 logger = logging.getLogger(__name__)
 
@@ -3195,6 +3198,28 @@ def load_config_readonly() -> Dict[str, Any]:
     return _load_config_impl(want_deepcopy=False)
 
 
+def load_plugin_activation_state() -> "PluginActivationState":
+    """Derive plugin activation from the canonical loaded configuration.
+
+    This accessor deliberately performs no parsing of its own.  Environment
+    expansion, managed-scope precedence, cache invalidation, and
+    last-known-good behavior all remain owned by :func:`load_config_readonly`.
+    An unexpected loader failure uses an empty allow-list, which keeps
+    non-bundled plugins fail-closed while bundled defaults remain available.
+    """
+    from hermes_cli.plugin_activation import PluginActivationState
+    from utils import env_var_enabled
+
+    try:
+        config = load_config_readonly()
+    except Exception:
+        config = {}
+    return PluginActivationState.from_config(
+        config,
+        safe_mode=env_var_enabled("HERMES_SAFE_MODE"),
+    )
+
+
 def write_platform_config_field(
     platform_key: str,
     field_key: str,
@@ -5368,6 +5393,7 @@ def config_command(args):
 # Runs once at import time.
 
 _profile_env_vars_injected = False
+_profile_env_var_names: set[str] = set()
 
 
 def _inject_profile_env_vars() -> None:
@@ -5396,12 +5422,29 @@ def _inject_profile_env_vars() -> None:
                     "category": "provider",
                     "advanced": True,
                 }
+                _profile_env_var_names.add(_var)
     except Exception:
         pass
 
 
+def _refresh_profile_env_vars() -> None:
+    """Rebuild provider-plugin environment metadata after activation changes."""
+    global _profile_env_vars_injected
+    for name in _profile_env_var_names:
+        OPTIONAL_ENV_VARS.pop(name, None)
+    _profile_env_var_names.clear()
+    _profile_env_vars_injected = False
+    _inject_profile_env_vars()
+
+
 # Eagerly inject so that OPTIONAL_ENV_VARS is fully populated at import time.
 _inject_profile_env_vars()
+try:
+    from providers import register_provider_refresh_hook
+
+    register_provider_refresh_hook(_refresh_profile_env_vars)
+except Exception:
+    pass
 
 
 # ── Platform-plugin env var injection ────────────────────────────────────────

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5397,31 +5397,31 @@ def config_command(args):
 # ── Profile-driven env var injection ─────────────────────────────────────────
 # Any provider registered in providers/ with auth_type="api_key" automatically
 # gets its env_vars exposed in OPTIONAL_ENV_VARS without editing this file.
-# Runs once at import time.
+# Entries are retained once observed so cached/concurrent profile switches
+# cannot overwrite this process-global compatibility inventory.
 
-_profile_env_vars_injected = False
-_profile_env_var_names: set[str] = set()
+_profile_env_vars_lock = threading.RLock()
 
 
 def _inject_profile_env_vars() -> None:
-    """Populate OPTIONAL_ENV_VARS from provider profiles not already listed.
-
-    Called once at module load time. Idempotent — repeated calls are no-ops.
-    """
-    global _profile_env_vars_injected
-    if _profile_env_vars_injected:
-        return
-    _profile_env_vars_injected = True
+    """Monotonically add metadata from provider profiles observed in-process."""
     try:
         from providers import list_providers
-        for _pp in list_providers():
+
+        profiles = tuple(list_providers())
+    except Exception:
+        return
+
+    with _profile_env_vars_lock:
+        additions: Dict[str, Dict[str, Any]] = {}
+        for _pp in profiles:
             if _pp.auth_type not in {"api_key",}:
                 continue
             for _var in _pp.env_vars:
-                if _var in OPTIONAL_ENV_VARS:
+                if _var in OPTIONAL_ENV_VARS or _var in additions:
                     continue
                 _is_key = not _var.endswith("_BASE_URL") and not _var.endswith("_URL")
-                OPTIONAL_ENV_VARS[_var] = {
+                additions[_var] = {
                     "description": f"{_pp.display_name or _pp.name} {'API key' if _is_key else 'base URL override'}",
                     "prompt": f"{_pp.display_name or _pp.name} {'API key' if _is_key else 'base URL (leave empty for default)'}",
                     "url": _pp.signup_url or None,
@@ -5429,18 +5429,11 @@ def _inject_profile_env_vars() -> None:
                     "category": "provider",
                     "advanced": True,
                 }
-                _profile_env_var_names.add(_var)
-    except Exception:
-        pass
+        OPTIONAL_ENV_VARS.update(additions)
 
 
 def _refresh_profile_env_vars() -> None:
-    """Rebuild provider-plugin environment metadata after activation changes."""
-    global _profile_env_vars_injected
-    for name in _profile_env_var_names:
-        OPTIONAL_ENV_VARS.pop(name, None)
-    _profile_env_var_names.clear()
-    _profile_env_vars_injected = False
+    """Observe provider metadata after a new catalog becomes active."""
     _inject_profile_env_vars()
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -943,7 +943,94 @@ def _ensure_hermes_home_managed(home: Path):
 # Config loading/saving
 # =============================================================================
 
-from hermes_cli.config_defaults import DEFAULT_CONFIG, OPTIONAL_ENV_VARS  # noqa: F401
+from hermes_cli.config_defaults import (  # noqa: F401
+    DEFAULT_CONFIG,
+    OPTIONAL_ENV_VARS as _BASE_OPTIONAL_ENV_VARS,
+)
+
+
+class _AtomicMetadataDict(dict):
+    """Dict-compatible metadata table with copy-on-write publication."""
+
+    _MISSING = object()
+
+    def __init__(self, initial: dict):
+        super().__init__()
+        self._data = dict(initial)
+        self._lock = threading.RLock()
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __contains__(self, key):
+        return key in self._data
+
+    def __iter__(self):
+        return iter(tuple(self._data))
+
+    def __len__(self):
+        return len(self._data)
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+    def keys(self):
+        return tuple(self._data)
+
+    def values(self):
+        return tuple(self._data.values())
+
+    def items(self):
+        return tuple(self._data.items())
+
+    def copy(self):
+        return dict(self._data)
+
+    def __repr__(self):
+        return repr(self._data)
+
+    def __eq__(self, other):
+        if isinstance(other, _AtomicMetadataDict):
+            other = other._data
+        return self._data == other
+
+    def replace(self, replacement: dict) -> None:
+        with self._lock:
+            self._data = dict(replacement)
+
+    def update(self, *args, **kwargs) -> None:
+        with self._lock:
+            replacement = dict(self._data)
+            replacement.update(*args, **kwargs)
+            self._data = replacement
+
+    def __setitem__(self, key, value) -> None:
+        self.update({key: value})
+
+    def pop(self, key, default=_MISSING):
+        with self._lock:
+            replacement = dict(self._data)
+            if default is self._MISSING:
+                value = replacement.pop(key)
+            else:
+                value = replacement.pop(key, default)
+            self._data = replacement
+            return value
+
+    def setdefault(self, key, default=None):
+        with self._lock:
+            if key in self._data:
+                return self._data[key]
+            replacement = dict(self._data)
+            replacement[key] = default
+            self._data = replacement
+            return default
+
+    def clear(self) -> None:
+        self.replace({})
+
+
+OPTIONAL_ENV_VARS = _AtomicMetadataDict(_BASE_OPTIONAL_ENV_VARS)
 
 # =============================================================================
 # Config Migration System
@@ -3210,13 +3297,20 @@ def load_plugin_activation_state() -> "PluginActivationState":
     from hermes_cli.plugin_activation import PluginActivationState
     from utils import env_var_enabled
 
+    safe_mode = env_var_enabled("HERMES_SAFE_MODE")
+    if safe_mode:
+        # Safe mode is a recovery boundary, not merely another config flag.
+        # Do not let an unreadable or user-controlled plugins section disable
+        # the bundled model providers needed to recover the installation.
+        return PluginActivationState(safe_mode=True)
+
     try:
         config = load_config_readonly()
     except Exception:
         config = {}
     return PluginActivationState.from_config(
         config,
-        safe_mode=env_var_enabled("HERMES_SAFE_MODE"),
+        safe_mode=False,
     )
 
 
@@ -5394,6 +5488,7 @@ def config_command(args):
 
 _profile_env_vars_injected = False
 _profile_env_var_names: set[str] = set()
+_profile_env_vars_lock = threading.RLock()
 
 
 def _inject_profile_env_vars() -> None:
@@ -5402,9 +5497,11 @@ def _inject_profile_env_vars() -> None:
     Called once at module load time. Idempotent — repeated calls are no-ops.
     """
     global _profile_env_vars_injected
-    if _profile_env_vars_injected:
-        return
-    _profile_env_vars_injected = True
+    with _profile_env_vars_lock:
+        if _profile_env_vars_injected:
+            return
+        _profile_env_vars_injected = True
+    additions: dict[str, dict[str, Any]] = {}
     try:
         from providers import list_providers
         for _pp in list_providers():
@@ -5414,7 +5511,7 @@ def _inject_profile_env_vars() -> None:
                 if _var in OPTIONAL_ENV_VARS:
                     continue
                 _is_key = not _var.endswith("_BASE_URL") and not _var.endswith("_URL")
-                OPTIONAL_ENV_VARS[_var] = {
+                additions[_var] = {
                     "description": f"{_pp.display_name or _pp.name} {'API key' if _is_key else 'base URL override'}",
                     "prompt": f"{_pp.display_name or _pp.name} {'API key' if _is_key else 'base URL (leave empty for default)'}",
                     "url": _pp.signup_url or None,
@@ -5423,17 +5520,23 @@ def _inject_profile_env_vars() -> None:
                     "advanced": True,
                 }
                 _profile_env_var_names.add(_var)
+        if additions:
+            OPTIONAL_ENV_VARS.update(additions)
     except Exception:
         pass
 
 
 def _refresh_profile_env_vars() -> None:
-    """Rebuild provider-plugin environment metadata after activation changes."""
+    """Monotonically extend provider metadata after activation changes.
+
+    This table also feeds subprocess secret filtering.  Removing a name when
+    one profile disables a provider would both race concurrent readers and
+    reopen that secret name for another profile, so observed names remain for
+    the process lifetime.
+    """
     global _profile_env_vars_injected
-    for name in _profile_env_var_names:
-        OPTIONAL_ENV_VARS.pop(name, None)
-    _profile_env_var_names.clear()
-    _profile_env_vars_injected = False
+    with _profile_env_vars_lock:
+        _profile_env_vars_injected = False
     _inject_profile_env_vars()
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -943,94 +943,7 @@ def _ensure_hermes_home_managed(home: Path):
 # Config loading/saving
 # =============================================================================
 
-from hermes_cli.config_defaults import (  # noqa: F401
-    DEFAULT_CONFIG,
-    OPTIONAL_ENV_VARS as _BASE_OPTIONAL_ENV_VARS,
-)
-
-
-class _AtomicMetadataDict(dict):
-    """Dict-compatible metadata table with copy-on-write publication."""
-
-    _MISSING = object()
-
-    def __init__(self, initial: dict):
-        super().__init__()
-        self._data = dict(initial)
-        self._lock = threading.RLock()
-
-    def __getitem__(self, key):
-        return self._data[key]
-
-    def __contains__(self, key):
-        return key in self._data
-
-    def __iter__(self):
-        return iter(tuple(self._data))
-
-    def __len__(self):
-        return len(self._data)
-
-    def get(self, key, default=None):
-        return self._data.get(key, default)
-
-    def keys(self):
-        return tuple(self._data)
-
-    def values(self):
-        return tuple(self._data.values())
-
-    def items(self):
-        return tuple(self._data.items())
-
-    def copy(self):
-        return dict(self._data)
-
-    def __repr__(self):
-        return repr(self._data)
-
-    def __eq__(self, other):
-        if isinstance(other, _AtomicMetadataDict):
-            other = other._data
-        return self._data == other
-
-    def replace(self, replacement: dict) -> None:
-        with self._lock:
-            self._data = dict(replacement)
-
-    def update(self, *args, **kwargs) -> None:
-        with self._lock:
-            replacement = dict(self._data)
-            replacement.update(*args, **kwargs)
-            self._data = replacement
-
-    def __setitem__(self, key, value) -> None:
-        self.update({key: value})
-
-    def pop(self, key, default=_MISSING):
-        with self._lock:
-            replacement = dict(self._data)
-            if default is self._MISSING:
-                value = replacement.pop(key)
-            else:
-                value = replacement.pop(key, default)
-            self._data = replacement
-            return value
-
-    def setdefault(self, key, default=None):
-        with self._lock:
-            if key in self._data:
-                return self._data[key]
-            replacement = dict(self._data)
-            replacement[key] = default
-            self._data = replacement
-            return default
-
-    def clear(self) -> None:
-        self.replace({})
-
-
-OPTIONAL_ENV_VARS = _AtomicMetadataDict(_BASE_OPTIONAL_ENV_VARS)
+from hermes_cli.config_defaults import DEFAULT_CONFIG, OPTIONAL_ENV_VARS  # noqa: F401
 
 # =============================================================================
 # Config Migration System
@@ -5488,7 +5401,6 @@ def config_command(args):
 
 _profile_env_vars_injected = False
 _profile_env_var_names: set[str] = set()
-_profile_env_vars_lock = threading.RLock()
 
 
 def _inject_profile_env_vars() -> None:
@@ -5497,11 +5409,9 @@ def _inject_profile_env_vars() -> None:
     Called once at module load time. Idempotent — repeated calls are no-ops.
     """
     global _profile_env_vars_injected
-    with _profile_env_vars_lock:
-        if _profile_env_vars_injected:
-            return
-        _profile_env_vars_injected = True
-    additions: dict[str, dict[str, Any]] = {}
+    if _profile_env_vars_injected:
+        return
+    _profile_env_vars_injected = True
     try:
         from providers import list_providers
         for _pp in list_providers():
@@ -5511,7 +5421,7 @@ def _inject_profile_env_vars() -> None:
                 if _var in OPTIONAL_ENV_VARS:
                     continue
                 _is_key = not _var.endswith("_BASE_URL") and not _var.endswith("_URL")
-                additions[_var] = {
+                OPTIONAL_ENV_VARS[_var] = {
                     "description": f"{_pp.display_name or _pp.name} {'API key' if _is_key else 'base URL override'}",
                     "prompt": f"{_pp.display_name or _pp.name} {'API key' if _is_key else 'base URL (leave empty for default)'}",
                     "url": _pp.signup_url or None,
@@ -5520,23 +5430,17 @@ def _inject_profile_env_vars() -> None:
                     "advanced": True,
                 }
                 _profile_env_var_names.add(_var)
-        if additions:
-            OPTIONAL_ENV_VARS.update(additions)
     except Exception:
         pass
 
 
 def _refresh_profile_env_vars() -> None:
-    """Monotonically extend provider metadata after activation changes.
-
-    This table also feeds subprocess secret filtering.  Removing a name when
-    one profile disables a provider would both race concurrent readers and
-    reopen that secret name for another profile, so observed names remain for
-    the process lifetime.
-    """
+    """Rebuild provider-plugin environment metadata after activation changes."""
     global _profile_env_vars_injected
-    with _profile_env_vars_lock:
-        _profile_env_vars_injected = False
+    for name in _profile_env_var_names:
+        OPTIONAL_ENV_VARS.pop(name, None)
+    _profile_env_var_names.clear()
+    _profile_env_vars_injected = False
     _inject_profile_env_vars()
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -73,6 +73,32 @@ suppress_platform_ver_console()
 import os
 import sys
 
+
+def _enable_safe_mode_env() -> None:
+    """Set the process-wide isolation flags implied by safe mode."""
+    os.environ["HERMES_SAFE_MODE"] = "1"
+    os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
+    os.environ["HERMES_IGNORE_RULES"] = "1"
+
+
+def _safe_mode_requested_early(argv: list[str]) -> bool:
+    """Detect the global flag before config/provider imports execute."""
+    for index, arg in enumerate(argv):
+        if arg == "--":
+            break
+        if arg == "--args":
+            prefix = argv[:index]
+            if "mcp" in prefix and "add" in prefix:
+                break
+        if arg == "--safe-mode":
+            return True
+    return False
+
+
+_EARLY_SAFE_MODE_REQUESTED = _safe_mode_requested_early(sys.argv[1:])
+if _EARLY_SAFE_MODE_REQUESTED:
+    _enable_safe_mode_env()
+
 # ── Startup fast-path bootstrap ─────────────────────────────────────────
 # Two lines of inline path math so ``python hermes_cli/main.py`` (script
 # mode — sys.path[0] is hermes_cli/, not the repo root) can import the
@@ -692,12 +718,17 @@ def _apply_profile_override() -> None:
 
 _apply_profile_override()
 
-# Load .env from ~/.hermes/.env first, then project root as dev fallback.
-# User-managed env files should override stale shell exports on restart.
-from hermes_cli.config import get_hermes_home
+# Load .env before importing config.py. Its provider metadata injection can
+# trigger provider discovery, whose activation lists may contain ${ENV}
+# references supplied by these files.
+from hermes_constants import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
 
 load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
+if _EARLY_SAFE_MODE_REQUESTED:
+    # A user .env is allowed to override stale shell exports, but never an
+    # isolation flag explicitly requested on this invocation.
+    _enable_safe_mode_env()
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at
@@ -10901,9 +10932,7 @@ def _prepare_agent_startup(args) -> None:
 def _apply_safe_mode(args) -> None:
     if not getattr(args, "safe_mode", False):
         return
-    os.environ["HERMES_SAFE_MODE"] = "1"
-    os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
-    os.environ["HERMES_IGNORE_RULES"] = "1"
+    _enable_safe_mode_env()
 
 
 def _set_chat_arg_defaults(args) -> None:

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -14,15 +14,15 @@ _mcp_discovery_thread: Optional[threading.Thread] = None
 def _has_configured_mcp_servers() -> bool:
     """Cheap config probe so non-MCP users avoid importing the MCP stack."""
     try:
-        from hermes_cli.config import read_raw_config
+        from hermes_cli.config import load_config_readonly
 
-        raw_config = read_raw_config() or {}
-        mcp_servers = raw_config.get("mcp_servers")
+        effective_config = load_config_readonly() or {}
+        mcp_servers = effective_config.get("mcp_servers")
         if isinstance(mcp_servers, dict) and len(mcp_servers) > 0:
             return True
         from hermes_cli.agent_plugins import has_enabled_agent_plugin_mcp
 
-        return has_enabled_agent_plugin_mcp(raw_config)
+        return has_enabled_agent_plugin_mcp(effective_config)
     except Exception:
         # Be conservative: if config probing fails, try discovery in the
         # background so startup still can't block.

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -261,7 +261,7 @@ def _model_flow_ai_gateway(config, current_model=""):
     from hermes_constants import AI_GATEWAY_BASE_URL
     from hermes_cli.main import _prompt_api_key
     from hermes_cli.auth import (
-        PROVIDER_REGISTRY,
+        get_provider_implementation_config,
         _prompt_model_selection,
         _save_model_choice,
         deactivate_provider,
@@ -270,7 +270,7 @@ def _model_flow_ai_gateway(config, current_model=""):
 
     # Route through _prompt_api_key so users can replace a stale/broken key
     # in-flow (K/R/C) instead of having to edit ~/.hermes/.env by hand.
-    pconfig = PROVIDER_REGISTRY["ai-gateway"]
+    pconfig = get_provider_implementation_config("ai-gateway")
     existing_key = get_env_value("AI_GATEWAY_API_KEY") or ""
     if not existing_key:
         print(
@@ -406,7 +406,7 @@ def _model_flow_nous(config, current_model="", args=None):
         AuthError,
         format_auth_error,
         _login_nous,
-        PROVIDER_REGISTRY,
+        get_nous_service_config,
     )
     from hermes_cli.config import (
         get_env_value,
@@ -431,7 +431,7 @@ def _model_flow_nous(config, current_model="", args=None):
                 ca_bundle=getattr(args, "ca_bundle", None),
                 insecure=bool(getattr(args, "insecure", False)),
             )
-            _login_nous(mock_args, PROVIDER_REGISTRY["nous"])
+            _login_nous(mock_args, get_nous_service_config())
             # Offer Tool Gateway enablement for paid subscribers
             try:
                 _refreshed = load_config() or {}
@@ -484,7 +484,7 @@ def _model_flow_nous(config, current_model="", args=None):
                     ca_bundle=None,
                     insecure=False,
                 )
-                _login_nous(mock_args, PROVIDER_REGISTRY["nous"])
+                _login_nous(mock_args, get_nous_service_config())
             except Exception as login_exc:
                 print(f"Re-login failed: {login_exc}")
             return
@@ -628,7 +628,7 @@ def _model_flow_openai_codex(config, current_model=""):
         _save_model_choice,
         _update_config_for_provider,
         _login_openai_codex,
-        PROVIDER_REGISTRY,
+        get_provider_implementation_config,
         DEFAULT_CODEX_BASE_URL,
     )
     from hermes_cli.codex_models import get_codex_model_ids
@@ -646,7 +646,7 @@ def _model_flow_openai_codex(config, current_model=""):
                 mock_args = argparse.Namespace()
                 _login_openai_codex(
                     mock_args,
-                    PROVIDER_REGISTRY["openai-codex"],
+                    get_provider_implementation_config("openai-codex"),
                     force_new_login=True,
                 )
             except SystemExit:
@@ -666,7 +666,10 @@ def _model_flow_openai_codex(config, current_model=""):
         print()
         try:
             mock_args = argparse.Namespace()
-            _login_openai_codex(mock_args, PROVIDER_REGISTRY["openai-codex"])
+            _login_openai_codex(
+                mock_args,
+                get_provider_implementation_config("openai-codex"),
+            )
         except SystemExit:
             print("Login cancelled or failed.")
             return
@@ -718,7 +721,7 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
         resolve_xai_oauth_runtime_credentials,
         _login_xai_oauth,
         DEFAULT_XAI_OAUTH_BASE_URL,
-        PROVIDER_REGISTRY,
+        get_provider_implementation_config,
     )
     from hermes_cli.models import _PROVIDER_MODELS
 
@@ -740,7 +743,7 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
                 )
                 _login_xai_oauth(
                     mock_args,
-                    PROVIDER_REGISTRY["xai-oauth"],
+                    get_provider_implementation_config("xai-oauth"),
                     force_new_login=True,
                 )
             except SystemExit:
@@ -759,7 +762,10 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
                 no_browser=bool(getattr(args, "no_browser", False)),
                 timeout=getattr(args, "timeout", None),
             )
-            _login_xai_oauth(mock_args, PROVIDER_REGISTRY["xai-oauth"])
+            _login_xai_oauth(
+                mock_args,
+                get_provider_implementation_config("xai-oauth"),
+            )
         except SystemExit:
             print("Login cancelled or failed.")
             return
@@ -848,7 +854,7 @@ def _model_flow_minimax_oauth(config, current_model="", args=None):
         AuthError,
         format_auth_error,
         _login_minimax_oauth,
-        PROVIDER_REGISTRY,
+        get_provider_implementation_config,
     )
 
     state = get_provider_auth_state("minimax-oauth")
@@ -861,7 +867,10 @@ def _model_flow_minimax_oauth(config, current_model="", args=None):
                 no_browser=bool(getattr(args, "no_browser", False)),
                 timeout=getattr(args, "timeout", None) or 15.0,
             )
-            _login_minimax_oauth(mock_args, PROVIDER_REGISTRY["minimax-oauth"])
+            _login_minimax_oauth(
+                mock_args,
+                get_provider_implementation_config("minimax-oauth"),
+            )
         except SystemExit:
             print("Login cancelled or failed.")
             return
@@ -3060,14 +3069,16 @@ def _model_flow_anthropic(config, current_model=""):
         # Show what we found
         if existing_key:
             from hermes_cli.env_loader import format_secret_source_suffix
-            from hermes_cli.auth import PROVIDER_REGISTRY
+            from hermes_cli.auth import get_provider_implementation_config
 
             # Surface which env var supplied the key so users with
             # Bitwarden see "(from Bitwarden)" — without this, a detected
             # BSM key looks identical to a key in .env and users assume
             # nothing is wired up.
             source_suffix = ""
-            for var in PROVIDER_REGISTRY["anthropic"].api_key_env_vars:
+            for var in get_provider_implementation_config(
+                "anthropic"
+            ).api_key_env_vars:
                 if os.getenv(var, "").strip() == existing_key:
                     source_suffix = format_secret_source_suffix(var)
                     if source_suffix:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2104,6 +2104,15 @@ def list_authenticated_providers(
     matches the active provider without blocking on every saved/offline custom
     endpoint.
     """
+    # One coarse freshness boundary per picker build keeps direct config edits
+    # live while metadata alias/label hot loops stay discovery-free.
+    try:
+        from providers import get_provider_catalog_snapshot
+
+        get_provider_catalog_snapshot()
+    except Exception:
+        pass
+
     import os
     from agent.models_dev import (
         PROVIDER_TO_MODELS_DEV,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2662,7 +2662,12 @@ def list_authenticated_providers(
     # produces two picker rows: one bare-slug ("openrouter") from section 3
     # and one "custom:openrouter" from section 4, both labelled identically.
     _section3_emitted_pairs: set = set()
-    if user_providers and isinstance(user_providers, dict):
+    _custom_runtime_routable = is_runtime_provider_routable("custom")
+    if (
+        _custom_runtime_routable
+        and user_providers
+        and isinstance(user_providers, dict)
+    ):
         # Group ``providers:`` entries by (api_url, key_env, api_mode) so that
         # multiple keyed providers pointing at the same endpoint with the
         # same credential and wire-protocol collapse into one picker row.
@@ -2917,7 +2922,8 @@ def list_authenticated_providers(
     # list_authenticated_providers(). Surface the active endpoint explicitly so
     # /model does not look like it ignored config.yaml.
     if (
-        _current_provider_norm == "custom"
+        _custom_runtime_routable
+        and _current_provider_norm == "custom"
         and current_base_url
         and "custom" not in seen_slugs
         and not any(
@@ -2969,7 +2975,11 @@ def list_authenticated_providers(
     # "Ollama" row with four models inside instead of four near-duplicates
     # that differ only by suffix. Same-host entries with different ``key_env``
     # or ``api_mode`` remain distinct providers.
-    if custom_providers and isinstance(custom_providers, list):
+    if (
+        _custom_runtime_routable
+        and custom_providers
+        and isinstance(custom_providers, list)
+    ):
         from collections import OrderedDict
 
         # Key by endpoint + credential identity + wire protocol + display

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2391,7 +2391,10 @@ def list_authenticated_providers(
 
     # --- 2. Check Hermes-only providers (nous, openai-codex, copilot, opencode-go) ---
     from hermes_cli.providers import HERMES_OVERLAYS
-    from hermes_cli.auth import PROVIDER_REGISTRY as _auth_registry
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY as _auth_registry,
+        is_runtime_provider_routable,
+    )
 
     # Build reverse mapping: models.dev ID → Hermes provider ID.
     # HERMES_OVERLAYS keys may be models.dev IDs (e.g. "github-copilot")
@@ -2407,6 +2410,8 @@ def list_authenticated_providers(
         if hermes_slug.lower() in seen_slugs:
             continue
         if pid.lower() in _excluded or hermes_slug.lower() in _excluded:
+            continue
+        if not is_runtime_provider_routable(hermes_slug):
             continue
 
         # Check if credentials exist

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1153,29 +1153,125 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway (Multi-model aggregator)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
 ]
+_STATIC_CANONICAL_PROVIDERS = tuple(CANONICAL_PROVIDERS)
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
 # that is not already in the list above.  Adding plugins/model-providers/<name>/
 # is sufficient to expose a new provider in the model picker, /model, and all
 # downstream consumers — no edits to this file needed.
-_canonical_slugs = {p.slug for p in CANONICAL_PROVIDERS}
-try:
-    from providers import list_providers as _list_providers_for_canonical
-    for _pp in _list_providers_for_canonical():
-        if _pp.name in _canonical_slugs:
+_canonical_slugs: set[str] = set()
+
+
+def _refresh_provider_aliases(profiles: list[Any]) -> None:
+    """Rebuild aliases from the static baseline plus active profiles."""
+    provider_aliases = globals().get("_PROVIDER_ALIASES")
+    static_aliases = globals().get("_STATIC_PROVIDER_ALIASES")
+    if not isinstance(provider_aliases, dict) or not isinstance(
+        static_aliases, dict
+    ):
+        return
+
+    provider_aliases.clear()
+    provider_aliases.update(static_aliases)
+    for profile in profiles:
+        for alias in profile.aliases:
+            # Existing Hermes aliases remain authoritative.
+            provider_aliases.setdefault(alias, profile.name)
+
+
+def _refresh_derived_provider_indexes() -> None:
+    """Refresh indexes that mirror ``CANONICAL_PROVIDERS`` in place."""
+    provider_labels = globals().get("_PROVIDER_LABELS")
+    if isinstance(provider_labels, dict):
+        provider_labels.clear()
+        provider_labels.update(
+            (entry.slug, entry.label) for entry in CANONICAL_PROVIDERS
+        )
+        try:
+            from providers import is_provider_plugin_active
+
+            if is_provider_plugin_active("custom"):
+                provider_labels["custom"] = "Custom endpoint"
+        except Exception:
+            pass
+
+    known_names = globals().get("_KNOWN_PROVIDER_NAMES")
+    if isinstance(known_names, set):
+        known_names.clear()
+        known_names.update(_canonical_slugs)
+        known_names.update(
+            alias
+            for alias, canonical in _PROVIDER_ALIASES.items()
+            if canonical in _canonical_slugs
+        )
+        if isinstance(provider_labels, dict) and "custom" in provider_labels:
+            known_names.add("custom")
+
+
+def _refresh_canonical_providers_from_plugins() -> None:
+    """Rebuild plugin-derived model picker entries after activation changes."""
+    try:
+        from providers import list_providers
+
+        profiles = list_providers()
+    except Exception:
+        profiles = []
+
+    active_provider_ids = {profile.name for profile in profiles}
+    CANONICAL_PROVIDERS[:] = [
+        entry
+        for entry in _STATIC_CANONICAL_PROVIDERS
+        if (
+            not _provider_id_is_plugin_managed(entry.slug)
+            or entry.slug in active_provider_ids
+        )
+    ]
+    _canonical_slugs.clear()
+    _canonical_slugs.update(entry.slug for entry in CANONICAL_PROVIDERS)
+
+    for profile in profiles:
+        if profile.name in _canonical_slugs:
             continue
-        if _pp.auth_type in {"oauth_device_code", "oauth_external", "external_process", "aws_sdk", "copilot", "vertex"}:
-            continue  # non-api-key flows need bespoke picker UX; skip auto-inject
-        _label = _pp.display_name or _pp.name
-        _desc = _pp.description or f"{_label} (direct API)"
-        CANONICAL_PROVIDERS.append(ProviderEntry(_pp.name, _label, _desc))
-        _canonical_slugs.add(_pp.name)
-except Exception:
-    pass
+        if profile.auth_type in {
+            "oauth_device_code",
+            "oauth_external",
+            "external_process",
+            "aws_sdk",
+            "copilot",
+            "vertex",
+        }:
+            continue
+        label = profile.display_name or profile.name
+        description = profile.description or f"{label} (direct API)"
+        CANONICAL_PROVIDERS.append(
+            ProviderEntry(profile.name, label, description)
+        )
+        _canonical_slugs.add(profile.name)
+
+    _refresh_provider_aliases(profiles)
+    _refresh_derived_provider_indexes()
+
+
+def _provider_id_is_plugin_managed(provider_id: str) -> bool:
+    try:
+        from providers import is_plugin_managed_provider_id
+
+        return is_plugin_managed_provider_id(provider_id)
+    except Exception:
+        return False
+
+
+_refresh_canonical_providers_from_plugins()
 
 # Derived dicts — used throughout the codebase
 _PROVIDER_LABELS = {p.slug: p.label for p in CANONICAL_PROVIDERS}
-_PROVIDER_LABELS["custom"] = "Custom endpoint"  # special case: not a named provider
+try:
+    from providers import is_provider_plugin_active
+
+    if is_provider_plugin_active("custom"):
+        _PROVIDER_LABELS["custom"] = "Custom endpoint"
+except Exception:
+    pass
 
 
 # ---------------------------------------------------------------------------
@@ -1370,6 +1466,7 @@ _PROVIDER_ALIASES = {
     "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
     "ollama_cloud": "ollama-cloud",
 }
+_STATIC_PROVIDER_ALIASES = dict(_PROVIDER_ALIASES)
 
 
 # In-repo fallback for the model Hermes silently lands on when the user never
@@ -2170,11 +2267,14 @@ def _fetch_novita_pricing(
 
 
 # All provider IDs and aliases that are valid for the provider:model syntax.
-_KNOWN_PROVIDER_NAMES: set[str] = (
-    set(_PROVIDER_LABELS.keys())
-    | set(_PROVIDER_ALIASES.keys())
-    | {"openrouter", "custom"}
-)
+_KNOWN_PROVIDER_NAMES: set[str] = set()
+_refresh_canonical_providers_from_plugins()
+try:
+    from providers import register_provider_refresh_hook
+
+    register_provider_refresh_hook(_refresh_canonical_providers_from_plugins)
+except Exception:
+    pass
 
 
 def list_available_providers() -> list[dict[str, str]]:
@@ -2186,8 +2286,9 @@ def list_available_providers() -> list[dict[str, str]]:
     Derives the provider list from :data:`CANONICAL_PROVIDERS` (single
     source of truth shared with ``hermes model``, ``/model``, etc.).
     """
-    # Derive display order from canonical list + custom
-    provider_order = [p.slug for p in CANONICAL_PROVIDERS] + ["custom"]
+    provider_order = [p.slug for p in CANONICAL_PROVIDERS]
+    if "custom" in _PROVIDER_LABELS and "custom" not in provider_order:
+        provider_order.append("custom")
 
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}
@@ -2366,6 +2467,15 @@ _LIVE_FIRST_PICKER_PROVIDERS: frozenset[str] = frozenset(
 )
 
 
+def _provider_is_routable(provider: str) -> bool:
+    try:
+        from hermes_cli.auth import is_runtime_provider_routable
+
+        return is_runtime_provider_routable(provider)
+    except Exception:
+        return False
+
+
 def _resolve_static_model_alias(
     name_lower: str,
     current_keys: set[str],
@@ -2384,6 +2494,8 @@ def _resolve_static_model_alias(
     family = identity.family
 
     def _match(provider: str) -> Optional[str]:
+        if not _provider_is_routable(provider):
+            return None
         models = _PROVIDER_MODELS.get(provider, [])
         if not models:
             return None
@@ -2495,6 +2607,8 @@ def detect_static_provider_for_model(
             continue
         if _is_custom_current:
             continue
+        if not _provider_is_routable(pid):
+            continue
         if any(name_lower == m.lower() for m in _provider_catalog_names(pid)):
             return (pid, name)
 
@@ -2502,6 +2616,8 @@ def detect_static_provider_for_model(
     # native-vendor catalog, and only when one is the current provider.
     for pid in _BORROWED_MODEL_PROVIDERS:
         if pid in current_keys:
+            continue
+        if not _provider_is_routable(pid):
             continue
         if any(name_lower == m.lower() for m in _provider_catalog_names(pid)):
             return (pid, name)
@@ -2866,6 +2982,11 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     on the platform appear in ``/model`` without a Hermes release.
     """
     normalized = normalize_provider(provider)
+    # Never let static fallbacks or a previous profile's cache make a disabled
+    # provider look selectable. ``openai`` is a legacy catalog alias whose
+    # runtime identity is ``openai-api`` and is not plugin-managed.
+    if normalized != "openai" and not _provider_is_routable(normalized):
+        return []
     if normalized == "openrouter":
         return model_ids(force_refresh=force_refresh)
     if normalized == "openai-codex":
@@ -3217,6 +3338,28 @@ def _credential_fingerprint(provider: str) -> str:
 
     parts: list[str] = []
 
+    # Provider roots and activation are part of discovery identity. This
+    # prevents profile/home/project switches from reusing another winner's
+    # on-disk model catalog when the canonical provider name is unchanged.
+    try:
+        from providers import (
+            get_provider_discovery_identity,
+            get_provider_profile,
+        )
+
+        parts.append(f"discovery={get_provider_discovery_identity()!r}")
+        profile = get_provider_profile(provider)
+        if profile is not None:
+            parts.append(
+                "profile="
+                f"{profile.name!r}|{profile.api_mode!r}|{profile.auth_type!r}|"
+                f"{profile.base_url!r}|{profile.models_url!r}|"
+                f"{profile.env_vars!r}|{profile.aliases!r}|"
+                f"{profile.fallback_models!r}"
+            )
+    except Exception:
+        parts.append("discovery=unavailable")
+
     # Env vars from PROVIDER_REGISTRY for this slug
     try:
         from hermes_cli.auth import PROVIDER_REGISTRY
@@ -3318,6 +3461,8 @@ def cached_provider_model_ids(
     """
     normalized = normalize_provider(provider) or (provider or "")
     if not normalized:
+        return []
+    if normalized != "openai" and not _provider_is_routable(normalized):
         return []
 
     cache = _load_provider_models_cache()

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -8,6 +8,7 @@ Add, remove, or reorder entries here — both `hermes setup` and
 from __future__ import annotations
 
 import copy
+import contextvars
 import json
 import logging
 import os
@@ -17,9 +18,20 @@ import urllib.parse
 import urllib.request
 import urllib.error
 import time
+from collections.abc import Set as AbstractSet
 from difflib import get_close_matches
 from pathlib import Path
-from typing import Any, NamedTuple, Optional, TYPE_CHECKING
+from types import MappingProxyType
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
     from typing import TypeGuard
@@ -1160,65 +1172,67 @@ _STATIC_CANONICAL_PROVIDERS = tuple(CANONICAL_PROVIDERS)
 # is sufficient to expose a new provider in the model picker, /model, and all
 # downstream consumers — no edits to this file needed.
 _canonical_slugs: set[str] = set()
+_PROVIDER_METADATA_LOCK = threading.RLock()
+_PROVIDER_METADATA_VIEWS_INSTALLED = False
 
 
-def _refresh_provider_aliases(profiles: list[Any]) -> None:
-    """Rebuild aliases from the static baseline plus active profiles."""
-    provider_aliases = globals().get("_PROVIDER_ALIASES")
-    static_aliases = globals().get("_STATIC_PROVIDER_ALIASES")
-    if not isinstance(provider_aliases, dict) or not isinstance(
-        static_aliases, dict
-    ):
-        return
+class _ProviderMetadataSnapshot(NamedTuple):
+    """One immutable, context-scoped view of provider-derived metadata."""
 
-    provider_aliases.clear()
-    provider_aliases.update(static_aliases)
-    for profile in profiles:
-        for alias in profile.aliases:
-            # Existing Hermes aliases remain authoritative.
-            provider_aliases.setdefault(alias, profile.name)
+    canonical_providers: tuple[ProviderEntry, ...]
+    canonical_slugs: frozenset[str]
+    provider_aliases: Mapping[str, str]
+    provider_labels: Mapping[str, str]
+    known_provider_names: frozenset[str]
 
 
-def _refresh_derived_provider_indexes() -> None:
-    """Refresh indexes that mirror ``CANONICAL_PROVIDERS`` in place."""
-    provider_labels = globals().get("_PROVIDER_LABELS")
-    if isinstance(provider_labels, dict):
-        provider_labels.clear()
-        provider_labels.update(
-            (entry.slug, entry.label) for entry in CANONICAL_PROVIDERS
-        )
-        try:
-            from providers import is_provider_plugin_active
-
-            if is_provider_plugin_active("custom"):
-                provider_labels["custom"] = "Custom endpoint"
-        except Exception:
-            pass
-
-    known_names = globals().get("_KNOWN_PROVIDER_NAMES")
-    if isinstance(known_names, set):
-        known_names.clear()
-        known_names.update(_canonical_slugs)
-        known_names.update(
-            alias
-            for alias, canonical in _PROVIDER_ALIASES.items()
-            if canonical in _canonical_slugs
-        )
-        if isinstance(provider_labels, dict) and "custom" in provider_labels:
-            known_names.add("custom")
+_PROVIDER_METADATA_BY_SCOPE: dict[
+    tuple[str, str], _ProviderMetadataSnapshot
+] = {}
 
 
-def _refresh_canonical_providers_from_plugins() -> None:
-    """Rebuild plugin-derived model picker entries after activation changes."""
+def _path_scope_identity(path: Path) -> str:
+    """Normalize a scope path without touching the filesystem."""
+    return os.path.normcase(
+        os.path.abspath(os.path.expanduser(str(path)))
+    )
+
+
+def _provider_metadata_scope_key() -> tuple[str, str]:
+    """Return the lightweight profile/project identity for this context.
+
+    Provider activation changes arrive through the registered refresh hook,
+    so hot readers must not call ``get_provider_discovery_identity()`` here.
+    That API performs provider discovery and config freshness checks; using it
+    for every alias lookup turned ``normalize_provider()`` into a filesystem
+    and callback-heavy operation and made compatibility-view materialization
+    repeat the same work once per item.
+    """
     try:
-        from providers import list_providers
+        from hermes_constants import get_hermes_home
 
-        profiles = list_providers()
+        home = _path_scope_identity(get_hermes_home())
     except Exception:
-        profiles = []
+        home = ""
 
+    project = ""
+    if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        try:
+            project = _path_scope_identity(Path.cwd())
+        except (OSError, RuntimeError):
+            project = ""
+    return home, project
+
+
+def _build_provider_metadata(profiles: list[Any]) -> _ProviderMetadataSnapshot:
+    """Build fresh containers without mutating any published metadata."""
     active_provider_ids = {profile.name for profile in profiles}
-    CANONICAL_PROVIDERS[:] = [
+    canonical_providers = [
         entry
         for entry in _STATIC_CANONICAL_PROVIDERS
         if (
@@ -1226,11 +1240,10 @@ def _refresh_canonical_providers_from_plugins() -> None:
             or entry.slug in active_provider_ids
         )
     ]
-    _canonical_slugs.clear()
-    _canonical_slugs.update(entry.slug for entry in CANONICAL_PROVIDERS)
+    canonical_slugs = {entry.slug for entry in canonical_providers}
 
     for profile in profiles:
-        if profile.name in _canonical_slugs:
+        if profile.name in canonical_slugs:
             continue
         if profile.auth_type in {
             "oauth_device_code",
@@ -1243,13 +1256,204 @@ def _refresh_canonical_providers_from_plugins() -> None:
             continue
         label = profile.display_name or profile.name
         description = profile.description or f"{label} (direct API)"
-        CANONICAL_PROVIDERS.append(
+        canonical_providers.append(
             ProviderEntry(profile.name, label, description)
         )
-        _canonical_slugs.add(profile.name)
+        canonical_slugs.add(profile.name)
 
-    _refresh_provider_aliases(profiles)
-    _refresh_derived_provider_indexes()
+    static_aliases = globals().get("_STATIC_PROVIDER_ALIASES", {})
+    provider_aliases = (
+        dict(static_aliases) if isinstance(static_aliases, dict) else {}
+    )
+    for profile in profiles:
+        for alias in profile.aliases:
+            # Existing Hermes aliases remain authoritative.
+            provider_aliases.setdefault(alias, profile.name)
+
+    provider_labels = {
+        entry.slug: entry.label for entry in canonical_providers
+    }
+    try:
+        from providers import is_provider_plugin_active
+
+        if is_provider_plugin_active("custom"):
+            provider_labels["custom"] = "Custom endpoint"
+    except Exception:
+        pass
+
+    known_provider_names = set(canonical_slugs)
+    known_provider_names.update(
+        alias
+        for alias, canonical in provider_aliases.items()
+        if canonical in canonical_slugs
+    )
+    if "custom" in provider_labels:
+        known_provider_names.add("custom")
+
+    return _ProviderMetadataSnapshot(
+        canonical_providers=tuple(canonical_providers),
+        canonical_slugs=frozenset(canonical_slugs),
+        provider_aliases=MappingProxyType(provider_aliases),
+        provider_labels=MappingProxyType(provider_labels),
+        known_provider_names=frozenset(known_provider_names),
+    )
+
+
+def _refresh_canonical_providers_from_plugins() -> None:
+    """Publish an immutable provider snapshot for the current scope."""
+    with _PROVIDER_METADATA_LOCK:
+        try:
+            from providers import list_providers
+
+            profiles = list_providers()
+        except Exception:
+            logger.debug(
+                "Provider metadata refresh failed; keeping last snapshot",
+                exc_info=True,
+            )
+            return
+
+        scope_key = _provider_metadata_scope_key()
+        snapshot = _build_provider_metadata(profiles)
+
+        # One dict-slot assignment publishes the complete immutable snapshot.
+        # Other profile scopes keep their own entry and therefore cannot be
+        # overwritten by this refresh.
+        _PROVIDER_METADATA_BY_SCOPE[scope_key] = snapshot
+
+        # During module initialization the legacy globals are still concrete
+        # containers. Replace them wholesale (never clear/update in place).
+        # Once compatibility views are installed below, they resolve the
+        # current scope directly and no further rebinding is needed.
+        if not _PROVIDER_METADATA_VIEWS_INSTALLED:
+            globals()["CANONICAL_PROVIDERS"] = list(
+                snapshot.canonical_providers
+            )
+            globals()["_canonical_slugs"] = set(snapshot.canonical_slugs)
+            globals()["_PROVIDER_ALIASES"] = dict(snapshot.provider_aliases)
+            globals()["_PROVIDER_LABELS"] = dict(snapshot.provider_labels)
+            globals()["_KNOWN_PROVIDER_NAMES"] = set(
+                snapshot.known_provider_names
+            )
+
+
+def _provider_metadata_snapshot() -> _ProviderMetadataSnapshot:
+    """Return the immutable metadata snapshot for the current scope."""
+    scope_key = _provider_metadata_scope_key()
+    with _PROVIDER_METADATA_LOCK:
+        snapshot = _PROVIDER_METADATA_BY_SCOPE.get(scope_key)
+    if snapshot is not None:
+        return snapshot
+
+    _refresh_canonical_providers_from_plugins()
+    scope_key = _provider_metadata_scope_key()
+    with _PROVIDER_METADATA_LOCK:
+        snapshot = _PROVIDER_METADATA_BY_SCOPE.get(scope_key)
+        if snapshot is not None:
+            return snapshot
+
+        # Discovery is best-effort. Keep callers functional even if an
+        # out-of-tree provider raised while the current scope was loading.
+        snapshot = _build_provider_metadata([])
+        _PROVIDER_METADATA_BY_SCOPE[scope_key] = snapshot
+        return snapshot
+
+
+class _ProviderSequenceView(Sequence[ProviderEntry]):
+    """Direct-import-compatible sequence bound to the current scope."""
+
+    def _values(self) -> tuple[ProviderEntry, ...]:
+        return _provider_metadata_snapshot().canonical_providers
+
+    def __getitem__(self, index: Any) -> Any:
+        return self._values()[index]
+
+    def __iter__(self) -> Iterator[ProviderEntry]:
+        return iter(self._values())
+
+    def __len__(self) -> int:
+        return len(self._values())
+
+    def __repr__(self) -> str:
+        return repr(list(self._values()))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Sequence):
+            return NotImplemented
+        return self._values() == tuple(other)
+
+    def copy(self) -> list[ProviderEntry]:
+        return list(self._values())
+
+
+class _ProviderMappingView(Mapping[str, str]):
+    """Direct-import-compatible mapping bound to the current scope."""
+
+    def __init__(self, attribute: str):
+        self._attribute = attribute
+
+    def _values(self) -> Mapping[str, str]:
+        return getattr(_provider_metadata_snapshot(), self._attribute)
+
+    def __getitem__(self, key: str) -> str:
+        return self._values()[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values())
+
+    def __len__(self) -> int:
+        return len(self._values())
+
+    def __repr__(self) -> str:
+        return repr(dict(self._values()))
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._values().get(key, default)
+
+    def items(self):
+        return self._values().items()
+
+    def keys(self):
+        return self._values().keys()
+
+    def values(self):
+        return self._values().values()
+
+    def copy(self) -> dict[str, str]:
+        return dict(self._values())
+
+
+class _ProviderSetView(AbstractSet[str]):
+    """Direct-import-compatible set bound to the current scope."""
+
+    def __init__(self, attribute: str):
+        self._attribute = attribute
+
+    def _values(self) -> frozenset[str]:
+        return getattr(_provider_metadata_snapshot(), self._attribute)
+
+    def __contains__(self, value: object) -> bool:
+        return value in self._values()
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values())
+
+    def __len__(self) -> int:
+        return len(self._values())
+
+    def __repr__(self) -> str:
+        return repr(set(self._values()))
+
+    @classmethod
+    def _from_iterable(cls, values: Iterable[str]) -> set[str]:
+        # ``collections.abc.Set`` normally constructs ``cls(values)`` for
+        # union/intersection results.  Our constructor takes a snapshot
+        # attribute name, so materialized set operations should return a
+        # normal concrete set instead.
+        return set(values)
+
+    def copy(self) -> set[str]:
+        return set(self._values())
 
 
 def _provider_id_is_plugin_managed(provider_id: str) -> bool:
@@ -2269,6 +2473,17 @@ def _fetch_novita_pricing(
 # All provider IDs and aliases that are valid for the provider:model syntax.
 _KNOWN_PROVIDER_NAMES: set[str] = set()
 _refresh_canonical_providers_from_plugins()
+
+# Keep direct imports live across ContextVar profile switches. These views
+# preserve the read operations callers historically used on list/dict/set
+# globals while resolving every operation against the current scope's single
+# immutable snapshot.
+_PROVIDER_METADATA_VIEWS_INSTALLED = True
+CANONICAL_PROVIDERS = _ProviderSequenceView()
+_canonical_slugs = _ProviderSetView("canonical_slugs")
+_PROVIDER_ALIASES = _ProviderMappingView("provider_aliases")
+_PROVIDER_LABELS = _ProviderMappingView("provider_labels")
+_KNOWN_PROVIDER_NAMES = _ProviderSetView("known_provider_names")
 try:
     from providers import register_provider_refresh_hook
 
@@ -2286,18 +2501,19 @@ def list_available_providers() -> list[dict[str, str]]:
     Derives the provider list from :data:`CANONICAL_PROVIDERS` (single
     source of truth shared with ``hermes model``, ``/model``, etc.).
     """
-    provider_order = [p.slug for p in CANONICAL_PROVIDERS]
-    if "custom" in _PROVIDER_LABELS and "custom" not in provider_order:
+    metadata = _provider_metadata_snapshot()
+    provider_order = [p.slug for p in metadata.canonical_providers]
+    if "custom" in metadata.provider_labels and "custom" not in provider_order:
         provider_order.append("custom")
 
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}
-    for alias, canonical in _PROVIDER_ALIASES.items():
+    for alias, canonical in metadata.provider_aliases.items():
         aliases_for.setdefault(canonical, []).append(alias)
 
     result = []
     for pid in provider_order:
-        label = _PROVIDER_LABELS.get(pid, pid)
+        label = metadata.provider_labels.get(pid, pid)
         alias_list = aliases_for.get(pid, [])
         # Check if this provider has credentials available
         has_creds = False
@@ -2344,7 +2560,10 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     if colon > 0:
         provider_part = stripped[:colon].strip().lower()
         model_part = stripped[colon + 1:].strip()
-        if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
+        known_provider_names = (
+            _provider_metadata_snapshot().known_provider_names
+        )
+        if provider_part and model_part and provider_part in known_provider_names:
             # Support custom:name:model triple syntax for named custom
             # providers.  ``custom:local:qwen`` → ("custom:local", "qwen").
             # Single colon ``custom:qwen`` → ("custom", "qwen") as before.
@@ -2563,11 +2782,12 @@ def detect_static_provider_for_model(
     # provider switch and pick the first model from that provider's catalog.
     # Skip "custom" and "openrouter" — custom has no model catalog, and
     # openrouter requires an explicit model name to be useful.
-    resolved_provider = _PROVIDER_ALIASES.get(name_lower, name_lower)
+    metadata = _provider_metadata_snapshot()
+    resolved_provider = metadata.provider_aliases.get(name_lower, name_lower)
     if resolved_provider not in {"custom", "openrouter"}:
         default_models = _PROVIDER_MODELS.get(resolved_provider, [])
         if (
-            resolved_provider in _PROVIDER_LABELS
+            resolved_provider in metadata.provider_labels
             and default_models
             and resolved_provider not in current_keys
         ):
@@ -2699,7 +2919,8 @@ def normalize_provider(provider: Optional[str]) -> str:
     provider based on credentials and environment.
     """
     normalized = (provider or "openrouter").strip().lower()
-    return _PROVIDER_ALIASES.get(normalized, normalized)
+    aliases = _provider_metadata_snapshot().provider_aliases
+    return aliases.get(normalized, normalized)
 
 
 def provider_label(provider: Optional[str]) -> str:
@@ -2708,8 +2929,9 @@ def provider_label(provider: Optional[str]) -> str:
     normalized = original.lower()
     if normalized == "auto":
         return "Auto"
-    normalized = normalize_provider(normalized)
-    return _PROVIDER_LABELS.get(normalized, original or "OpenRouter")
+    metadata = _provider_metadata_snapshot()
+    normalized = metadata.provider_aliases.get(normalized, normalized)
+    return metadata.provider_labels.get(normalized, original or "OpenRouter")
 
 
 # Models that support OpenAI Priority Processing (service_tier="priority").
@@ -3261,17 +3483,17 @@ _PROVIDER_MODELS_CACHE_TTL = 3600  # 1h
 # better than stalling every picker surface (CLI, TUI, dashboard, gateway).
 _PROVIDER_MODELS_STALE_SERVE_MAX = 7 * 24 * 3600  # 7d
 
-# Providers with a background SWR refresh currently in flight — dedupes
-# concurrent refreshes so repeated picker opens during one refresh don't
-# stack threads or duplicate network calls.
-_swr_refresh_inflight: set = set()
+# Provider scopes with a background SWR refresh currently in flight —
+# dedupes repeated picker opens without conflating two ContextVar profiles
+# that happen to use the same provider slug.
+_swr_refresh_inflight: set[tuple[tuple[str, str], str]] = set()
 _swr_refresh_lock = threading.Lock()
 
 
 def _spawn_swr_refresh(cache_key: str, refresh_fn=None) -> None:
     """Kick a background refresh of *cache_key*'s model-id cache entry.
 
-    Fire-and-forget daemon thread; at most one in flight per cache key.
+    Fire-and-forget daemon thread; at most one in flight per provider/scope.
     Failures are swallowed — the stale entry stays served until a later
     refresh succeeds (same degradation the blocking path already had).
 
@@ -3282,10 +3504,13 @@ def _spawn_swr_refresh(cache_key: str, refresh_fn=None) -> None:
     ``PROVIDER_REGISTRY`` slug and refreshed via :func:`provider_model_ids`
     (the original behavior).
     """
+    refresh_context = contextvars.copy_context()
+    scope_key = refresh_context.run(_provider_metadata_scope_key)
+    inflight_key = (scope_key, cache_key)
     with _swr_refresh_lock:
-        if cache_key in _swr_refresh_inflight:
+        if inflight_key in _swr_refresh_inflight:
             return
-        _swr_refresh_inflight.add(cache_key)
+        _swr_refresh_inflight.add(inflight_key)
 
     def _default_refresh():
         live = provider_model_ids(cache_key, force_refresh=True)
@@ -3308,10 +3533,15 @@ def _spawn_swr_refresh(cache_key: str, refresh_fn=None) -> None:
             logger.debug("SWR refresh failed for %s", cache_key, exc_info=True)
         finally:
             with _swr_refresh_lock:
-                _swr_refresh_inflight.discard(cache_key)
+                _swr_refresh_inflight.discard(inflight_key)
+
+    def _refresh_in_context() -> None:
+        refresh_context.run(_refresh)
 
     threading.Thread(
-        target=_refresh, daemon=True, name=f"model-cache-swr-{cache_key}"
+        target=_refresh_in_context,
+        daemon=True,
+        name=f"model-cache-swr-{cache_key}",
     ).start()
 
 
@@ -5603,7 +5833,9 @@ def validate_requested_model(
     # Without this block, validate_requested_model would reject every model
     # on such providers, switch_model() would return success=False, and
     # the gateway would never write to _session_model_overrides.
-    provider_label = _PROVIDER_LABELS.get(normalized, normalized)
+    provider_label = _provider_metadata_snapshot().provider_labels.get(
+        normalized, normalized
+    )
     try:
         catalog_models = provider_model_ids(normalized)
     except Exception:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2871,6 +2871,8 @@ def detect_provider_for_model(
         return None
 
     # --- Step 2: check OpenRouter catalog ---
+    if not _provider_is_routable("openrouter"):
+        return None
     # First try exact match (handles provider/model format)
     or_slug = _find_openrouter_slug(name)
     if or_slug:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1186,8 +1186,11 @@ class _ProviderMetadataSnapshot(NamedTuple):
     known_provider_names: frozenset[str]
 
 
+_ProviderMetadataCacheKey = tuple[
+    tuple[str, str], tuple[object, ...] | None
+]
 _PROVIDER_METADATA_BY_SCOPE: dict[
-    tuple[str, str], _ProviderMetadataSnapshot
+    _ProviderMetadataCacheKey, _ProviderMetadataSnapshot
 ] = {}
 
 
@@ -1199,34 +1202,53 @@ def _path_scope_identity(path: Path) -> str:
 
 
 def _provider_metadata_scope_key() -> tuple[str, str]:
-    """Return the lightweight profile/project identity for this context.
+    """Return the provider subsystem's profile/project identity.
 
     Provider activation changes arrive through the registered refresh hook,
     so hot readers must not call ``get_provider_discovery_identity()`` here.
-    That API performs provider discovery and config freshness checks; using it
-    for every alias lookup turned ``normalize_provider()`` into a filesystem
-    and callback-heavy operation and made compatibility-view materialization
-    repeat the same work once per item.
+    ``get_provider_scope_identity()`` caches normalized physical paths; using
+    that same authority here keeps Windows junction aliases from splitting one
+    profile into two metadata scopes without resolving paths on every read.
     """
     try:
-        from hermes_constants import get_hermes_home
+        from providers import get_provider_scope_identity
 
-        home = _path_scope_identity(get_hermes_home())
+        return get_provider_scope_identity()
     except Exception:
-        home = ""
-
-    project = ""
-    if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }:
         try:
-            project = _path_scope_identity(Path.cwd())
-        except (OSError, RuntimeError):
-            project = ""
-    return home, project
+            from hermes_constants import get_hermes_home
+
+            home = _path_scope_identity(get_hermes_home())
+        except Exception:
+            home = ""
+
+        project = ""
+        if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            try:
+                project = _path_scope_identity(Path.cwd())
+            except (OSError, RuntimeError):
+                project = ""
+        return home, project
+
+
+def _provider_metadata_cache_key() -> _ProviderMetadataCacheKey:
+    """Bind metadata to the catalog last resolved in this execution context."""
+    scope_key = _provider_metadata_scope_key()
+    try:
+        from providers import get_published_provider_catalog_snapshot
+
+        catalog = get_published_provider_catalog_snapshot()
+        if catalog is not None:
+            if catalog.scope_identity == scope_key:
+                return scope_key, catalog.fingerprint
+    except Exception:
+        pass
+    return scope_key, None
 
 
 def _build_provider_metadata(profiles: list[Any]) -> _ProviderMetadataSnapshot:
@@ -1305,6 +1327,8 @@ def _refresh_canonical_providers_from_plugins() -> None:
         try:
             from providers import list_providers
 
+            # list_providers() returns the immutable catalog selected in this
+            # ContextVar scope and publishes its fingerprint for cache_key.
             profiles = list_providers()
         except Exception:
             logger.debug(
@@ -1313,13 +1337,13 @@ def _refresh_canonical_providers_from_plugins() -> None:
             )
             return
 
-        scope_key = _provider_metadata_scope_key()
+        cache_key = _provider_metadata_cache_key()
         snapshot = _build_provider_metadata(profiles)
 
         # One dict-slot assignment publishes the complete immutable snapshot.
         # Other profile scopes keep their own entry and therefore cannot be
         # overwritten by this refresh.
-        _PROVIDER_METADATA_BY_SCOPE[scope_key] = snapshot
+        _PROVIDER_METADATA_BY_SCOPE[cache_key] = snapshot
 
         # During module initialization the legacy globals are still concrete
         # containers. Replace them wholesale (never clear/update in place).
@@ -1339,23 +1363,23 @@ def _refresh_canonical_providers_from_plugins() -> None:
 
 def _provider_metadata_snapshot() -> _ProviderMetadataSnapshot:
     """Return the immutable metadata snapshot for the current scope."""
-    scope_key = _provider_metadata_scope_key()
+    cache_key = _provider_metadata_cache_key()
     with _PROVIDER_METADATA_LOCK:
-        snapshot = _PROVIDER_METADATA_BY_SCOPE.get(scope_key)
+        snapshot = _PROVIDER_METADATA_BY_SCOPE.get(cache_key)
     if snapshot is not None:
         return snapshot
 
     _refresh_canonical_providers_from_plugins()
-    scope_key = _provider_metadata_scope_key()
+    cache_key = _provider_metadata_cache_key()
     with _PROVIDER_METADATA_LOCK:
-        snapshot = _PROVIDER_METADATA_BY_SCOPE.get(scope_key)
+        snapshot = _PROVIDER_METADATA_BY_SCOPE.get(cache_key)
         if snapshot is not None:
             return snapshot
 
         # Discovery is best-effort. Keep callers functional even if an
         # out-of-tree provider raised while the current scope was loading.
         snapshot = _build_provider_metadata([])
-        _PROVIDER_METADATA_BY_SCOPE[scope_key] = snapshot
+        _PROVIDER_METADATA_BY_SCOPE[cache_key] = snapshot
         return snapshot
 
 
@@ -2501,6 +2525,15 @@ def list_available_providers() -> list[dict[str, str]]:
     Derives the provider list from :data:`CANONICAL_PROVIDERS` (single
     source of truth shared with ``hermes model``, ``/model``, etc.).
     """
+    # This inventory is a coarse user-facing boundary. Resolve direct config
+    # edits once here; metadata aliases/labels below remain discovery-free.
+    try:
+        from providers import get_provider_catalog_snapshot
+
+        get_provider_catalog_snapshot()
+    except Exception:
+        pass
+
     metadata = _provider_metadata_snapshot()
     provider_order = [p.slug for p in metadata.canonical_providers]
     if "custom" in metadata.provider_labels and "custom" not in provider_order:

--- a/hermes_cli/plugin_activation.py
+++ b/hermes_cli/plugin_activation.py
@@ -1,0 +1,100 @@
+"""Pure plugin activation decisions.
+
+Configuration I/O belongs to :mod:`hermes_cli.config`.  This module only
+normalizes the already-loaded ``plugins`` section and applies the shared
+source/kind policy, so runtime discovery and management surfaces cannot drift
+without introducing another config reader.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+_BUNDLED_DEFAULT_KINDS = frozenset({"backend", "platform", "model-provider"})
+
+
+def _string_set(value: Any) -> frozenset[str]:
+    """Return non-empty string entries from a config list."""
+    if not isinstance(value, list):
+        return frozenset()
+    return frozenset(
+        item.strip() for item in value if isinstance(item, str) and item.strip()
+    )
+
+
+@dataclass(frozen=True)
+class PluginActivationState:
+    """Immutable activation inputs derived from canonical config."""
+
+    enabled: frozenset[str] | None = None
+    disabled: frozenset[str] = frozenset()
+    safe_mode: bool = False
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Any,
+        *,
+        safe_mode: bool = False,
+    ) -> "PluginActivationState":
+        plugins = config.get("plugins") if isinstance(config, dict) else None
+        if not isinstance(plugins, dict):
+            return cls(safe_mode=safe_mode)
+
+        raw_enabled = plugins.get("enabled")
+        enabled = _string_set(raw_enabled) if isinstance(raw_enabled, list) else None
+        return cls(
+            enabled=enabled,
+            disabled=_string_set(plugins.get("disabled")),
+            safe_mode=safe_mode,
+        )
+
+    @staticmethod
+    def identities(
+        name: str = "",
+        key: str = "",
+        aliases: Iterable[str] = (),
+    ) -> frozenset[str]:
+        """Return the canonical config identities accepted for one plugin."""
+        values = (name, key, *aliases)
+        return frozenset(
+            value.strip()
+            for value in values
+            if isinstance(value, str) and value.strip()
+        )
+
+    def status(
+        self,
+        *,
+        name: str = "",
+        key: str = "",
+        source: str,
+        kind: str,
+        aliases: Iterable[str] = (),
+    ) -> str:
+        """Return ``enabled``, ``disabled``, or ``not enabled``."""
+        identities = self.identities(name, key, aliases)
+        if identities & self.disabled:
+            return "disabled"
+
+        normalized_source = (source or "").strip().lower()
+        normalized_kind = (kind or "standalone").strip().lower()
+        if self.safe_mode:
+            # General PluginManager discovery is disabled wholesale in safe
+            # mode. Bundled model profiles remain available so Hermes can
+            # still resolve the explicitly selected inference provider.
+            if not (
+                normalized_source == "bundled" and normalized_kind == "model-provider"
+            ):
+                return "not enabled"
+        if normalized_source == "bundled" and normalized_kind in _BUNDLED_DEFAULT_KINDS:
+            return "enabled"
+        if self.enabled is not None and identities & self.enabled:
+            return "enabled"
+        return "not enabled"
+
+    def is_active(self, **plugin: Any) -> bool:
+        """Return whether a plugin may execute under this state."""
+        return self.status(**plugin) == "enabled"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1590,34 +1590,29 @@ class PluginManager:
         if _env_enabled("HERMES_SAFE_MODE"):
             return False
 
-        plugins_config = raw_config.get("plugins")
-        if not isinstance(plugins_config, dict):
-            return False
-        enabled_value = plugins_config.get("enabled")
-        if not isinstance(enabled_value, list):
-            return False
-        enabled = {value for value in enabled_value if isinstance(value, str)}
-        disabled_value = plugins_config.get("disabled", [])
-        disabled = (
-            {value for value in disabled_value if isinstance(value, str)}
-            if isinstance(disabled_value, list)
-            else set()
-        )
-        if not enabled:
-            return False
+        from hermes_cli.plugin_activation import PluginActivationState
 
-        winners: Dict[str, PluginManifest] = {}
+        activation = PluginActivationState.from_config(raw_config)
+        grouped: Dict[str, List[PluginManifest]] = {}
         for manifest in self._collect_directory_manifests():
-            winners[manifest.key or manifest.name] = manifest
+            grouped.setdefault(manifest.key or manifest.name, []).append(manifest)
 
-        for manifest in winners.values():
-            if not manifest.portable:
+        for candidates in grouped.values():
+            selection = resolve_plugin_candidate_winner(
+                candidates,
+                lambda candidate: activation.status(
+                    name=candidate.name,
+                    key=candidate.key or candidate.name,
+                    source=candidate.source,
+                    kind=candidate.kind,
+                ),
+            )
+            if selection is None:
+                continue
+            manifest, status = selection
+            if status != "enabled" or not manifest.portable:
                 continue
             lookup_key = manifest.key or manifest.name
-            if lookup_key in disabled or manifest.name in disabled:
-                continue
-            if lookup_key not in enabled and manifest.name not in enabled:
-                continue
             try:
                 from hermes_cli.agent_plugins import _discover_mcp
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -13,8 +13,9 @@ Discovers, loads, and manages plugins from four sources:
 4. **Pip plugins**     – packages that expose the ``hermes_agent.plugins``
    entry-point group.
 
-Later sources override earlier ones on name collision, so a user or project
-plugin with the same name as a bundled plugin replaces it.
+Among active candidates, later sources override earlier ones on name
+collision. An external candidate must be explicitly enabled before it can
+replace a bundled default with the same canonical key.
 
 Each directory plugin must contain a ``plugin.yaml`` manifest **and** an
 ``__init__.py`` with a ``register(ctx)`` function.
@@ -45,7 +46,18 @@ import threading
 import types
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    TypeVar,
+    Union,
+)
 
 from hermes_constants import get_hermes_home
 from utils import env_var_enabled, fast_safe_load
@@ -341,6 +353,38 @@ class LoadedPlugin:
     # imported) loader. The module loads on first real use via the
     # platform_registry; see PluginManager._register_deferred_platform.
     deferred: bool = False
+
+
+_PluginCandidate = TypeVar("_PluginCandidate")
+
+
+def resolve_plugin_candidate_winner(
+    candidates: Iterable[_PluginCandidate],
+    status_for: Callable[[_PluginCandidate], str],
+) -> Optional[tuple[_PluginCandidate, str]]:
+    """Resolve one canonical-key group using active-winner semantics.
+
+    ``candidates`` must be ordered from lowest to highest source precedence,
+    matching discovery (bundled, user, project, then entry point).  An
+    explicit disable on any candidate blocks the whole canonical key.
+    Otherwise, the highest-precedence enabled candidate wins and an inactive
+    external candidate cannot shadow an enabled bundled fallback.
+
+    When no candidate is enabled, the highest-precedence candidate is
+    returned with its inactive status so callers can retain one useful
+    introspection record without executing it.
+    """
+    ranked = list(candidates)
+    if not ranked:
+        return None
+
+    statuses = [(candidate, status_for(candidate)) for candidate in reversed(ranked)]
+    if any(status == "disabled" for _candidate, status in statuses):
+        return statuses[0][0], "disabled"
+    for candidate, status in statuses:
+        if status == "enabled":
+            return candidate, status
+    return statuses[0]
 
 
 # ---------------------------------------------------------------------------
@@ -1370,25 +1414,30 @@ class PluginManager:
         logger.debug("  entrypoints: %d manifest(s)", len(ep_manifests))
         manifests.extend(ep_manifests)
 
-        # Load each manifest (skip user-disabled plugins).
-        # Later sources override earlier ones on key collision — user
-        # plugins take precedence over bundled, project plugins take
-        # precedence over user. Dedup here so we only load the final
-        # winner. Keys are path-derived (``image_gen/openai``,
-        # ``disk-cleanup``) so ``tts/openai`` and ``image_gen/openai``
-        # don't collide even when both manifests say ``name: openai``.
+        # Load one active winner per canonical key. Source precedence is the
+        # discovery order above (later sources win), but only among active
+        # candidates: an unconfigured external plugin must not shadow a
+        # bundled default with the same key. Explicit disable remains a
+        # key-wide deny. Keys are path-derived (``image_gen/openai``,
+        # ``disk-cleanup``) so ``tts/openai`` and ``image_gen/openai`` don't
+        # collide even when both manifests say ``name: openai``.
         activation = load_plugin_activation_state()
-        winners: Dict[str, PluginManifest] = {}
+        grouped: Dict[str, List[PluginManifest]] = {}
         for manifest in manifests:
-            winners[manifest.key or manifest.name] = manifest
-        for manifest in winners.values():
-            lookup_key = manifest.key or manifest.name
-            status = activation.status(
-                name=manifest.name,
-                key=lookup_key,
-                source=manifest.source,
-                kind=manifest.kind,
+            grouped.setdefault(manifest.key or manifest.name, []).append(manifest)
+        for lookup_key, candidates in grouped.items():
+            selection = resolve_plugin_candidate_winner(
+                candidates,
+                lambda candidate: activation.status(
+                    name=candidate.name,
+                    key=candidate.key or candidate.name,
+                    source=candidate.source,
+                    kind=candidate.kind,
+                ),
             )
+            if selection is None:  # pragma: no cover - groups are never empty
+                continue
+            manifest, status = selection
 
             # Explicit disable always wins, including for bundled defaults.
             if status == "disabled":

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1580,19 +1580,23 @@ class PluginManager:
 
         return manifests
 
-    def has_enabled_portable_mcp(self, raw_config: Mapping[str, Any]) -> bool:
+    def has_enabled_portable_mcp(
+        self, effective_config: Mapping[str, Any]
+    ) -> bool:
         """Probe enabled portable MCP packages without loading plugins.
 
         The directory manifest collection is shared with full discovery, so
         native ``plugin.yaml`` precedence, source ordering, depth limits, and
         project-plugin gating cannot diverge between startup and runtime.
+        ``effective_config`` is the canonical loaded config snapshot used by
+        the startup gate, including environment expansion and managed policy.
         """
         if _env_enabled("HERMES_SAFE_MODE"):
             return False
 
         from hermes_cli.plugin_activation import PluginActivationState
 
-        activation = PluginActivationState.from_config(raw_config)
+        activation = PluginActivationState.from_config(effective_config)
         grouped: Dict[str, List[PluginManifest]] = {}
         for manifest in self._collect_directory_manifests():
             grouped.setdefault(manifest.key or manifest.name, []).append(manifest)
@@ -2303,13 +2307,13 @@ def get_plugin_manager() -> PluginManager:
     return _plugin_manager
 
 
-def has_enabled_agent_plugin_mcp(raw_config: Mapping[str, Any]) -> bool:
+def has_enabled_agent_plugin_mcp(effective_config: Mapping[str, Any]) -> bool:
     """Return whether config enables a portable package with MCP servers.
 
     A fresh manager performs manifest-only scanning, so this startup gate does
     not mutate the process-wide plugin registry or import native plugin code.
     """
-    return PluginManager().has_enabled_portable_mcp(raw_config)
+    return PluginManager().has_enabled_portable_mcp(effective_config)
 
 
 def discover_plugins(force: bool = False) -> None:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -49,7 +49,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Union
 
 from hermes_constants import get_hermes_home
 from utils import env_var_enabled, fast_safe_load
-from hermes_cli.config import cfg_get
+from hermes_cli.config import cfg_get, load_plugin_activation_state
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
 
 
@@ -235,13 +235,7 @@ def _get_disabled_plugins() -> set:
     name in this set will never load, even if it appears in
     ``plugins.enabled``.
     """
-    try:
-        from hermes_cli.config import load_config
-        config = load_config()
-        disabled = cfg_get(config, "plugins", "disabled", default=[])
-        return set(disabled) if isinstance(disabled, list) else set()
-    except Exception:
-        return set()
+    return set(load_plugin_activation_state().disabled)
 
 
 def _get_enabled_plugins() -> Optional[set]:
@@ -258,20 +252,8 @@ def _get_enabled_plugins() -> Optional[set]:
     * ``set()`` — an empty list was explicitly set; nothing loads.
     * ``set(...)`` — the concrete allow-list.
     """
-    try:
-        from hermes_cli.config import load_config
-        config = load_config()
-        plugins_cfg = config.get("plugins")
-        if not isinstance(plugins_cfg, dict):
-            return None
-        if "enabled" not in plugins_cfg:
-            return None
-        enabled = plugins_cfg.get("enabled")
-        if not isinstance(enabled, list):
-            return None
-        return set(enabled)
-    except Exception:
-        return None
+    enabled = load_plugin_activation_state().enabled
+    return set(enabled) if enabled is not None else None
 
 
 # ---------------------------------------------------------------------------
@@ -1395,17 +1377,21 @@ class PluginManager:
         # winner. Keys are path-derived (``image_gen/openai``,
         # ``disk-cleanup``) so ``tts/openai`` and ``image_gen/openai``
         # don't collide even when both manifests say ``name: openai``.
-        disabled = _get_disabled_plugins()
-        enabled = _get_enabled_plugins()  # None = opt-in default (nothing enabled)
+        activation = load_plugin_activation_state()
         winners: Dict[str, PluginManifest] = {}
         for manifest in manifests:
             winners[manifest.key or manifest.name] = manifest
         for manifest in winners.values():
             lookup_key = manifest.key or manifest.name
+            status = activation.status(
+                name=manifest.name,
+                key=lookup_key,
+                source=manifest.source,
+                kind=manifest.kind,
+            )
 
-            # Explicit disable always wins (matches on key or on legacy
-            # bare name for back-compat with existing user configs).
-            if lookup_key in disabled or manifest.name in disabled:
+            # Explicit disable always wins, including for bundled defaults.
+            if status == "disabled":
                 loaded = LoadedPlugin(manifest=manifest, enabled=False)
                 loaded.error = "disabled via config"
                 self._plugins[lookup_key] = loaded
@@ -1434,11 +1420,31 @@ class PluginManager:
             # ProviderProfile instances and break the "last writer wins"
             # override semantics between bundled and user plugins.
             if manifest.kind == "model-provider":
-                loaded = LoadedPlugin(manifest=manifest, enabled=True)
+                loaded = LoadedPlugin(
+                    manifest=manifest,
+                    enabled=status == "enabled",
+                )
+                if not loaded.enabled:
+                    loaded.error = (
+                        "not enabled in config (run `hermes plugins enable {}` "
+                        "to activate)".format(lookup_key)
+                    )
                 self._plugins[lookup_key] = loaded
                 logger.debug(
                     "Skipping '%s' (model-provider, handled by providers/ discovery)",
                     lookup_key,
+                )
+                continue
+
+            if status != "enabled":
+                loaded = LoadedPlugin(manifest=manifest, enabled=False)
+                loaded.error = (
+                    "not enabled in config (run `hermes plugins enable {}` to activate)"
+                    .format(lookup_key)
+                )
+                self._plugins[lookup_key] = loaded
+                logger.debug(
+                    "Skipping '%s' (not active under plugin policy)", lookup_key
                 )
                 continue
 
@@ -1465,25 +1471,6 @@ class PluginManager:
                 self._register_deferred_platform(manifest)
                 continue
 
-            # Everything else (standalone, user-installed backends,
-            # entry-point plugins) is opt-in via plugins.enabled.
-            # Accept both the path-derived key and the legacy bare name
-            # so existing configs keep working.
-            is_enabled = (
-                enabled is not None
-                and (lookup_key in enabled or manifest.name in enabled)
-            )
-            if not is_enabled:
-                loaded = LoadedPlugin(manifest=manifest, enabled=False)
-                loaded.error = (
-                    "not enabled in config (run `hermes plugins enable {}` to activate)"
-                    .format(lookup_key)
-                )
-                self._plugins[lookup_key] = loaded
-                logger.debug(
-                    "Skipping '%s' (not in plugins.enabled)", lookup_key
-                )
-                continue
             self._load_plugin(manifest)
 
         if manifests:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1240,8 +1240,13 @@ def _discover_plugin_candidates() -> list:
     return candidates
 
 
-def _select_active_plugin_entries(entries: list, activation: PluginActivationState) -> list:
-    """Select the highest-priority active candidate for each canonical key."""
+def _select_plugin_entries(
+    entries: list,
+    activation: PluginActivationState,
+    *,
+    active_only: bool = False,
+) -> list:
+    """Select the canonical winner for each key using runtime semantics."""
     from hermes_cli.plugins import resolve_plugin_candidate_winner
 
     grouped: dict[str, list] = {}
@@ -1259,9 +1264,30 @@ def _select_active_plugin_entries(entries: list, activation: PluginActivationSta
                 kind=entry[6],
             ),
         )
-        if selection is not None and selection[1] == "enabled":
+        if selection is not None and (
+            not active_only or selection[1] == "enabled"
+        ):
             winners.append(selection[0])
     return winners
+
+
+def _select_active_plugin_entries(
+    entries: list,
+    activation: PluginActivationState,
+) -> list:
+    """Select only executable canonical winners."""
+    return _select_plugin_entries(entries, activation, active_only=True)
+
+
+def _discover_plugin_display_entries(
+    activation: PluginActivationState | None = None,
+) -> list:
+    """Return one runtime-consistent introspection row per canonical key."""
+    if activation is None:
+        from hermes_cli.config import load_plugin_activation_state
+
+        activation = load_plugin_activation_state()
+    return _select_plugin_entries(_discover_plugin_candidates(), activation)
 
 
 def _discover_all_plugins() -> list:
@@ -1364,7 +1390,7 @@ def cmd_list(args: Any | None = None) -> None:
     from rich.table import Table
 
     console = Console()
-    entries = _discover_all_plugins()
+    entries = _discover_plugin_display_entries()
     if not entries:
         console.print("[dim]No plugins installed.[/dim]")
         console.print("[dim]Install with:[/dim] hermes plugins install owner/repo")

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1046,9 +1046,11 @@ def cmd_disable(name: str) -> None:
         key,
         enabled,
     )
+    _, preserved_denies = _plugin_runtime_identity_changes(key, disabled)
     enabled.difference_update(identities)
     enabled.update(preserved_enables)
     disabled.difference_update(identities)
+    disabled.update(preserved_denies)
     disabled.add(key)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
@@ -2250,9 +2252,11 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
         return {"ok": True, "name": name, "key": key, "unchanged": True}
 
     identities, preserved_enables = _plugin_runtime_identity_changes(key, en)
+    _, preserved_denies = _plugin_runtime_identity_changes(key, dis)
     en.difference_update(identities)
     en.update(preserved_enables)
     dis.difference_update(identities)
+    dis.update(preserved_denies)
     dis.add(key)
     _save_enabled_set(en)
     _save_disabled_set(dis)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -897,6 +897,24 @@ def _plugin_runtime_identity_changes(
     return identities, preserved_entries
 
 
+def _plugin_disable_identities_to_clear(key: str) -> set[str]:
+    """Return target identities that do not also activate another key."""
+    candidates = _discover_plugin_candidates()
+    target_identities = {key}
+    for entry in candidates:
+        if entry[5] == key:
+            target_identities.update((entry[0], entry[5]))
+
+    shared_identities = {
+        identity
+        for entry in candidates
+        if entry[5] != key
+        for identity in (entry[0], entry[5])
+        if identity in target_identities
+    }
+    return target_identities - shared_identities
+
+
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
     """Write ``plugins.entries.<plugin_id>.<key> = value`` into config.yaml."""
     from hermes_cli.config import load_config, save_config
@@ -1042,15 +1060,9 @@ def cmd_disable(name: str) -> None:
         console.print(f"[dim]Plugin '{key}' is already disabled.[/dim]")
         return
 
-    identities, preserved_enables = _plugin_runtime_identity_changes(
-        key,
-        enabled,
-    )
-    _, preserved_denies = _plugin_runtime_identity_changes(key, disabled)
+    identities = _plugin_disable_identities_to_clear(key)
     enabled.difference_update(identities)
-    enabled.update(preserved_enables)
     disabled.difference_update(identities)
-    disabled.update(preserved_denies)
     disabled.add(key)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
@@ -1745,12 +1757,6 @@ def _persist_composite_plugin_selection(
 
     for i in sorted(chosen - initial_selected):
         key = plugin_keys[i]
-        enabled_ids, preserved_allows = _plugin_runtime_identity_changes(
-            key,
-            new_enabled,
-        )
-        new_enabled.difference_update(enabled_ids)
-        new_enabled.update(preserved_allows)
         new_enabled.add(key)
 
         disabled_ids, preserved_denies = _plugin_runtime_identity_changes(
@@ -1762,12 +1768,9 @@ def _persist_composite_plugin_selection(
 
     for i in sorted(initial_selected - chosen):
         key = plugin_keys[i]
-        enabled_ids, preserved_allows = _plugin_runtime_identity_changes(
-            key,
-            new_enabled,
-        )
+        enabled_ids = _plugin_disable_identities_to_clear(key)
         new_enabled.difference_update(enabled_ids)
-        new_enabled.update(preserved_allows)
+        new_disabled.difference_update(enabled_ids)
         new_disabled.add(key)
 
     changed = new_enabled != previous_enabled or new_disabled != disabled
@@ -2254,12 +2257,9 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     if status == "disabled":
         return {"ok": True, "name": name, "key": key, "unchanged": True}
 
-    identities, preserved_enables = _plugin_runtime_identity_changes(key, en)
-    _, preserved_denies = _plugin_runtime_identity_changes(key, dis)
+    identities = _plugin_disable_identities_to_clear(key)
     en.difference_update(identities)
-    en.update(preserved_enables)
     dis.difference_update(identities)
-    dis.update(preserved_denies)
     dis.add(key)
     _save_enabled_set(en)
     _save_disabled_set(dis)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1267,13 +1267,30 @@ def _select_plugin_entries(
     active_only: bool = False,
 ) -> list:
     """Select the canonical winner for each key using runtime semantics."""
+    return [
+        entry
+        for entry, _status in _select_plugin_display_records(
+            entries,
+            activation,
+            active_only=active_only,
+        )
+    ]
+
+
+def _select_plugin_display_records(
+    entries: list,
+    activation: PluginActivationState,
+    *,
+    active_only: bool = False,
+) -> list:
+    """Return canonical winners paired with their resolved group status."""
     from hermes_cli.plugins import resolve_plugin_candidate_winner
 
     grouped: dict[str, list] = {}
     for entry in entries:
         grouped.setdefault(entry[5], []).append(entry)
 
-    winners: list = []
+    records: list = []
     for candidates in grouped.values():
         selection = resolve_plugin_candidate_winner(
             candidates,
@@ -1287,8 +1304,8 @@ def _select_plugin_entries(
         if selection is not None and (
             not active_only or selection[1] == "enabled"
         ):
-            winners.append(selection[0])
-    return winners
+            records.append(selection)
+    return records
 
 
 def _select_active_plugin_entries(
@@ -1302,12 +1319,25 @@ def _select_active_plugin_entries(
 def _discover_plugin_display_entries(
     activation: PluginActivationState | None = None,
 ) -> list:
-    """Return one runtime-consistent introspection row per canonical key."""
+    """Compatibility wrapper returning display entries without status."""
+    return [
+        entry
+        for entry, _status in _discover_plugin_display_records(activation)
+    ]
+
+
+def _discover_plugin_display_records(
+    activation: PluginActivationState | None = None,
+) -> list:
+    """Return each display winner with its canonical group's status."""
     if activation is None:
         from hermes_cli.config import load_plugin_activation_state
 
         activation = load_plugin_activation_state()
-    return _select_plugin_entries(_discover_plugin_candidates(), activation)
+    return _select_plugin_display_records(
+        _discover_plugin_candidates(),
+        activation,
+    )
 
 
 def _discover_all_plugins() -> list:
@@ -1384,23 +1414,13 @@ def _plugin_status(
     )
 
 
-def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set) -> list:
-    """Apply ``hermes plugins list`` CLI filters."""
-    filtered = entries
+def _filter_plugin_entries(records: list, args: Any) -> list:
+    """Apply list filters without recomputing a winner's group status."""
+    filtered = records
     if getattr(args, "no_bundled", False) or getattr(args, "user", False):
-        filtered = [entry for entry in filtered if entry[3] != "bundled"]
+        filtered = [record for record in filtered if record[0][3] != "bundled"]
     if getattr(args, "enabled", False):
-        filtered = [
-            entry for entry in filtered
-            if _plugin_status(
-                entry[0],
-                enabled,
-                disabled,
-                key=entry[5],
-                source=entry[3],
-                kind=entry[6],
-            ) == "enabled"
-        ]
+        filtered = [record for record in filtered if record[1] == "enabled"]
     return filtered
 
 
@@ -1410,17 +1430,15 @@ def cmd_list(args: Any | None = None) -> None:
     from rich.table import Table
 
     console = Console()
-    entries = _discover_plugin_display_entries()
-    if not entries:
+    records = _discover_plugin_display_records()
+    if not records:
         console.print("[dim]No plugins installed.[/dim]")
         console.print("[dim]Install with:[/dim] hermes plugins install owner/repo")
         return
 
-    enabled = _get_enabled_set()
-    disabled = _get_disabled_set()
-    entries = _filter_plugin_entries(entries, args, enabled, disabled)
+    records = _filter_plugin_entries(records, args)
     manifest_name_counts: dict[str, int] = {}
-    for entry in entries:
+    for entry, _status in records:
         manifest_name_counts[entry[0]] = manifest_name_counts.get(entry[0], 0) + 1
 
     def _display_name(name: str, key: str) -> str:
@@ -1429,44 +1447,30 @@ def cmd_list(args: Any | None = None) -> None:
         return name
 
     if getattr(args, "json", False):
-        payload = [
-            {
+        payload = []
+        for entry, status in records:
+            name, version, description, source, _dir, key, _kind = entry
+            payload.append({
                 "name": name,
                 "key": key,
-                "status": _plugin_status(
-                    name,
-                    enabled,
-                    disabled,
-                    key=key,
-                    source=source,
-                    kind=kind,
-                ),
+                "status": status,
                 "version": str(version),
                 "description": description,
                 "source": source,
-            }
-            for name, version, description, source, _dir, key, kind in entries
-        ]
+            })
         print(json.dumps(payload, indent=2))
         return
 
     if getattr(args, "plain", False):
-        for name, version, _description, source, _dir, key, kind in entries:
-            status = _plugin_status(
-                name,
-                enabled,
-                disabled,
-                key=key,
-                source=source,
-                kind=kind,
-            )
+        for entry, status in records:
+            name, version, _description, source, _dir, key, _kind = entry
             print(
                 f"{status:12} {source:8} {str(version):8} "
                 f"{_display_name(name, key)}"
             )
         return
 
-    if not entries:
+    if not records:
         console.print("[dim]No plugins matched the selected filters.[/dim]")
         return
 
@@ -1477,15 +1481,8 @@ def cmd_list(args: Any | None = None) -> None:
     table.add_column("Description")
     table.add_column("Source", style="dim")
 
-    for name, version, description, source, _dir, key, kind in entries:
-        status_name = _plugin_status(
-            name,
-            enabled,
-            disabled,
-            key=key,
-            source=source,
-            kind=kind,
-        )
+    for entry, status_name in records:
+        name, version, description, source, _dir, key, _kind = entry
         if status_name == "disabled":
             status = "[red]disabled[/red]"
         elif status_name == "enabled":
@@ -1677,8 +1674,7 @@ def cmd_toggle() -> None:
     console = Console()
 
     # -- General plugins discovery (bundled + user) --
-    entries = _discover_all_plugins()
-    enabled_set = _get_enabled_set()
+    records = _discover_plugin_display_records()
     disabled_set = _get_disabled_set()
 
     # Track by CANONICAL KEY (``key``), not the manifest name. The loader
@@ -1693,24 +1689,16 @@ def cmd_toggle() -> None:
     plugin_labels = []
     plugin_selected = set()
 
-    for i, (name, _version, description, source, _d, key, kind) in enumerate(entries):
+    for i, (entry, status) in enumerate(records):
+        name, _version, description, source, _d, key, _kind = entry
         label = f"{name} \u2014 {description}" if description else name
         if source == "bundled":
             label = f"{label} [bundled]"
         plugin_keys.append(key)
         plugin_labels.append(label)
-        # Use the same source/kind policy as runtime discovery. Bundled
-        # backends, platforms, and model profiles are on by default; every
-        # non-bundled plugin remains opt-in and explicit disable always wins.
-        is_on = _plugin_status(
-            name,
-            enabled_set,
-            disabled_set,
-            key=key,
-            source=source,
-            kind=kind,
-        ) == "enabled"
-        if is_on:
+        # Preserve the canonical group's resolved status. Recomputing from
+        # only the display winner can lose an explicit deny on another copy.
+        if status == "enabled":
             plugin_selected.add(i)
 
     # -- Provider categories --
@@ -1744,6 +1732,51 @@ def cmd_toggle() -> None:
                                 disabled_set, categories, console)
 
 
+def _persist_composite_plugin_selection(
+    plugin_keys,
+    initial_selected,
+    chosen,
+    disabled,
+):
+    """Persist checkbox deltas while preserving untouched activation aliases."""
+    previous_enabled = _get_enabled_set()
+    new_enabled = set(previous_enabled)
+    new_disabled = set(disabled)
+
+    for i in sorted(chosen - initial_selected):
+        key = plugin_keys[i]
+        enabled_ids, preserved_allows = _plugin_runtime_identity_changes(
+            key,
+            new_enabled,
+        )
+        new_enabled.difference_update(enabled_ids)
+        new_enabled.update(preserved_allows)
+        new_enabled.add(key)
+
+        disabled_ids, preserved_denies = _plugin_runtime_identity_changes(
+            key,
+            new_disabled,
+        )
+        new_disabled.difference_update(disabled_ids)
+        new_disabled.update(preserved_denies)
+
+    for i in sorted(initial_selected - chosen):
+        key = plugin_keys[i]
+        enabled_ids, preserved_allows = _plugin_runtime_identity_changes(
+            key,
+            new_enabled,
+        )
+        new_enabled.difference_update(enabled_ids)
+        new_enabled.update(preserved_allows)
+        new_disabled.add(key)
+
+    changed = new_enabled != previous_enabled or new_disabled != disabled
+    if changed:
+        _save_enabled_set(new_enabled)
+        _save_disabled_set(new_disabled)
+    return changed
+
+
 def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
                       disabled, categories, console):
     """Custom curses screen with checkboxes + category action rows."""
@@ -1756,7 +1789,7 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
     n_categories = len(categories)
     total_items = n_plugins + n_categories  # navigable items
 
-    result_holder = {"plugins_changed": False, "providers_changed": False}
+    result_holder = {"providers_changed": False}
 
     def _draw(stdscr):
         curses.curs_set(0)
@@ -1928,7 +1961,6 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
             elif key in {curses.KEY_ENTER, 10, 13}:
                 if cursor < n_plugins:
                     # ENTER on a plugin checkbox — confirm and exit
-                    result_holder["plugins_changed"] = True
                     return
                 else:
                     # ENTER on a category — same as SPACE, launch sub-screen
@@ -1959,41 +1991,23 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
                         curses.curs_set(0)
             elif key in {27, ord("q")}:
                 # Save plugin changes on exit
-                result_holder["plugins_changed"] = True
                 return
 
     curses.wrapper(_draw)
     flush_stdin()
 
-    # Persist by canonical key. Unchecked plugins are written to the
-    # disabled-list so they stay off even if a future plugin auto-enables
-    # itself — but we ONLY ever write the canonical key (never the bare
-    # manifest name), so the disabled-list can't drift out of sync with
-    # what ``cmd_enable`` clears or what PluginManager gates on (#40190).
-    new_enabled: set = set()
-    new_disabled: set = set(disabled)  # preserve existing disabled state for unseen plugins
-    for i, key in enumerate(plugin_keys):
-        bare = key.split("/")[-1]
-        if i in chosen:
-            new_enabled.add(key)
-            new_disabled.discard(key)
-            # Drop any stale legacy bare-leaf disable so re-enabling here
-            # fully clears the plugin from the disabled-list.
-            if bare != key:
-                new_disabled.discard(bare)
-        else:
-            new_disabled.add(key)
-
-    prev_enabled = _get_enabled_set()
-    enabled_changed = new_enabled != prev_enabled
-    disabled_changed = new_disabled != disabled
-
-    if enabled_changed or disabled_changed:
-        _save_enabled_set(new_enabled)
-        _save_disabled_set(new_disabled)
+    # Apply only explicit checkbox changes. Merely opening the menu must not
+    # canonicalize aliases or change which same-key candidate wins.
+    plugins_changed = _persist_composite_plugin_selection(
+        plugin_keys,
+        plugin_selected,
+        chosen,
+        disabled,
+    )
+    if plugins_changed:
         console.print(
-            f"\n[green]\u2713[/green] General plugins: {len(new_enabled)} enabled, "
-            f"{len(plugin_keys) - len(new_enabled)} disabled."
+            f"\n[green]\u2713[/green] General plugins: {len(chosen)} enabled, "
+            f"{len(plugin_keys) - len(chosen)} disabled."
         )
     elif n_plugins > 0:
         console.print("\n[dim]General plugins unchanged.[/dim]")
@@ -2040,24 +2054,13 @@ def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
                 return
             print()
 
-        # Persist by canonical key only — never the bare manifest name — so
-        # the disabled-list stays aligned with cmd_enable / PluginManager
-        # (#40190).
-        new_enabled: set = set()
-        new_disabled: set = set(disabled)
-        for i, key in enumerate(plugin_keys):
-            bare = key.split("/")[-1]
-            if i in chosen:
-                new_enabled.add(key)
-                new_disabled.discard(key)
-                if bare != key:
-                    new_disabled.discard(bare)
-            else:
-                new_disabled.add(key)
-        prev_enabled = _get_enabled_set()
-        if new_enabled != prev_enabled or new_disabled != disabled:
-            _save_enabled_set(new_enabled)
-            _save_disabled_set(new_disabled)
+        # Share the same delta semantics as the curses UI.
+        _persist_composite_plugin_selection(
+            plugin_keys,
+            plugin_selected,
+            chosen,
+            disabled,
+        )
 
     # Provider categories
     if categories:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -23,7 +23,9 @@ from typing import Any, Optional
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import noninteractive_git_env
 from hermes_cli.config import cfg_get
+from hermes_cli.plugin_activation import PluginActivationState
 from hermes_cli.secret_prompt import masked_secret_prompt
+from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -662,6 +664,8 @@ def cmd_install(
             f"Run `hermes plugins enable {installed_name}` to activate.[/dim]",
         )
 
+    _invalidate_provider_discovery()
+
     console.print("[dim]Restart the gateway for the plugin to take effect:[/dim]")
     console.print("[dim]  hermes gateway restart[/dim]")
     console.print()
@@ -701,6 +705,7 @@ def cmd_update(name: str) -> None:
 
     # Copy any new .example files
     _copy_example_files(target, console)
+    _invalidate_provider_discovery()
 
     out = output.strip()
     if "Already up to date" in out:
@@ -726,7 +731,18 @@ def cmd_remove(name: str) -> None:
         sys.exit(1)
 
     shutil.rmtree(target)
+    _invalidate_provider_discovery()
     _display_removed(name, plugins_dir)
+
+
+def _invalidate_provider_discovery() -> None:
+    """Refresh provider-derived surfaces after plugin files or policy change."""
+    try:
+        from providers import invalidate_provider_discovery
+
+        invalidate_provider_discovery()
+    except Exception:
+        logger.debug("Provider discovery refresh failed", exc_info=True)
 
 
 def _get_disabled_set() -> set:
@@ -735,13 +751,9 @@ def _get_disabled_set() -> set:
     An explicit deny-list. A plugin name here never loads, even if also
     listed in ``plugins.enabled``.
     """
-    try:
-        from hermes_cli.config import load_config
-        config = load_config()
-        disabled = cfg_get(config, "plugins", "disabled", default=[])
-        return set(disabled) if isinstance(disabled, list) else set()
-    except Exception:
-        return set()
+    from hermes_cli.config import load_plugin_activation_state
+
+    return set(load_plugin_activation_state().disabled)
 
 
 def _save_disabled_set(disabled: set) -> None:
@@ -752,6 +764,7 @@ def _save_disabled_set(disabled: set) -> None:
         config["plugins"] = {}
     config["plugins"]["disabled"] = sorted(disabled)
     save_config(config)
+    _invalidate_provider_discovery()
 
 
 _BASIC_AUTH_PLUGIN_KEYS = frozenset({"basic", "dashboard_auth/basic"})
@@ -787,16 +800,10 @@ def _get_enabled_set() -> set:
     Plugins are opt-in: only names here are loaded. Returns ``set()`` if
     the key is missing (same behaviour as "nothing enabled yet").
     """
-    try:
-        from hermes_cli.config import load_config
-        config = load_config()
-        plugins_cfg = config.get("plugins", {})
-        if not isinstance(plugins_cfg, dict):
-            return set()
-        enabled = plugins_cfg.get("enabled", [])
-        return set(enabled) if isinstance(enabled, list) else set()
-    except Exception:
-        return set()
+    from hermes_cli.config import load_plugin_activation_state
+
+    enabled = load_plugin_activation_state().enabled
+    return set(enabled or ())
 
 
 def _save_enabled_set(enabled: set) -> None:
@@ -822,12 +829,15 @@ def _resolve_plugin_key(name: str) -> Optional[str]:
     nested category plugins (e.g. ``observability/nemo_relay``) included.
     """
     entries = _discover_all_plugins()
-    # 1. Exact match on canonical key or manifest name — always unambiguous.
-    for entry in entries:
-        # entry = (name, version, description, source, dir_path, key)
-        if name == entry[5] or name == entry[0]:
-            return entry[5]
-    # 2. Fall back to a bare leaf-name match (e.g. "nemo_relay" ->
+    # 1. Canonical keys are exact and authoritative.
+    key_matches = [entry[5] for entry in entries if name == entry[5]]
+    if len(key_matches) == 1:
+        return key_matches[0]
+    # 2. Manifest names are accepted only when globally unambiguous.
+    manifest_matches = [entry[5] for entry in entries if name == entry[0]]
+    if len(manifest_matches) == 1:
+        return manifest_matches[0]
+    # 3. Fall back to a bare leaf-name match (e.g. "nemo_relay" ->
     #    "observability/nemo_relay"), but only when it resolves to exactly one
     #    plugin so we never silently pick the wrong same-named nested plugin.
     leaf_matches = [entry[5] for entry in entries if name == entry[5].split("/")[-1]]
@@ -837,19 +847,27 @@ def _resolve_plugin_key(name: str) -> Optional[str]:
 
 
 def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
-    """Resolve *name* to ``(canonical_key, source)`` or ``None`` if no match.
+    """Resolve *name* to ``(key, source, manifest_name, kind)`` or ``None``.
 
     Mirrors :func:`_resolve_plugin_key`'s normalization but also returns the
     plugin's source (``"bundled"``, ``"user"``, ``"project"``, ...) so the
     enable path can tell whether a built-in-override consent prompt is needed.
     """
     entries = _discover_all_plugins()
-    for entry in entries:
-        # entry = (name, version, description, source, dir_path, key)
-        if name == entry[5] or name == entry[0]:
-            return (entry[5], entry[3])
+    key_matches = [
+        (entry[5], entry[3], entry[0], entry[6])
+        for entry in entries if name == entry[5]
+    ]
+    if len(key_matches) == 1:
+        return key_matches[0]
+    manifest_matches = [
+        (entry[5], entry[3], entry[0], entry[6])
+        for entry in entries if name == entry[0]
+    ]
+    if len(manifest_matches) == 1:
+        return manifest_matches[0]
     leaf_matches = [
-        (entry[5], entry[3]) for entry in entries
+        (entry[5], entry[3], entry[0], entry[6]) for entry in entries
         if name == entry[5].split("/")[-1]
     ]
     if len(leaf_matches) == 1:
@@ -896,12 +914,19 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
     if resolved is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
-    key, source = resolved
+    key, source, manifest_name, kind = resolved
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
 
-    already_enabled = key in enabled and key not in disabled
+    already_enabled = _plugin_status(
+        manifest_name,
+        enabled,
+        disabled,
+        key=key,
+        source=source,
+        kind=kind,
+    ) == "enabled"
 
     if not already_enabled:
         enabled.add(key)
@@ -917,7 +942,7 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         if bare != key:
             disabled.discard(bare)
         for entry in _discover_all_plugins():
-            # entry = (name, version, description, source, dir_path, key)
+            # entry = (name, version, description, source, dir_path, key, kind)
             if entry[5] == key:
                 disabled.discard(entry[0])
                 break
@@ -983,24 +1008,29 @@ def cmd_disable(name: str) -> None:
     from rich.console import Console
 
     console = Console()
-    key = _resolve_plugin_key(name)
-    if key is None:
+    resolved = _resolve_plugin_key_and_source(name)
+    if resolved is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
+    key, source, manifest_name, kind = resolved
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
 
-    if key not in enabled and key in disabled:
+    if _plugin_status(
+        manifest_name,
+        enabled,
+        disabled,
+        key=key,
+        source=source,
+        kind=kind,
+    ) == "disabled":
         console.print(f"[dim]Plugin '{key}' is already disabled.[/dim]")
         return
 
-    enabled.discard(key)
-    # Drop any legacy bare-name entry from the allow-list too, so a stale
-    # bare name can't keep a nested plugin loading after an explicit disable.
-    bare = key.split("/")[-1]
-    if bare != key:
-        enabled.discard(bare)
+    aliases = {name, manifest_name, key, key.split("/")[-1]}
+    enabled.difference_update(aliases)
+    disabled.difference_update(aliases)
     disabled.add(key)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
@@ -1016,7 +1046,7 @@ def _plugin_exists(name: str) -> bool:
 
 
 def _read_manifest_info(d: Path, prefix: str):
-    """Read a native or portable manifest and return display metadata.
+    """Read native or portable metadata used by side-effect-free listing.
 
     Returns None if no manifest file exists.
     """
@@ -1048,6 +1078,7 @@ def _read_manifest_info(d: Path, prefix: str):
     name = d.name
     version = ""
     description = ""
+    kind = "standalone"
     if yaml:
         try:
             with open(manifest_file, encoding="utf-8") as f:
@@ -1055,10 +1086,13 @@ def _read_manifest_info(d: Path, prefix: str):
             name = manifest.get("name", d.name)
             version = manifest.get("version", "")
             description = manifest.get("description", "")
+            raw_kind = manifest.get("kind", "standalone")
+            if isinstance(raw_kind, str) and raw_kind.strip():
+                kind = raw_kind.strip().lower()
         except Exception:
             pass
     key = f"{prefix}/{d.name}" if prefix else name
-    return name, version, description, key
+    return name, version, description, key, kind
 
 
 def _is_portable_plugin_dir(dir_path) -> bool:
@@ -1112,7 +1146,8 @@ def _scan_level(
 ) -> None:
     """Recursive directory scan matching PluginManager._scan_directory_level.
 
-    Populates *seen* with key -> (name, version, description, source, dir, key).
+    Populates *seen* with key ->
+    (name, version, description, source, dir, key, kind).
     """
     if not base.is_dir():
         return
@@ -1123,13 +1158,17 @@ def _scan_level(
             continue
         info = _read_manifest_info(d, prefix)
         if info is not None:
-            name, version, description, key = info
+            if len(info) == 4:
+                name, version, description, key = info
+                kind = "standalone"
+            else:
+                name, version, description, key, kind = info
             if key in seen and source == "bundled":
                 continue
             src_label = source
             if source == "user" and (d / ".git").exists():
                 src_label = "git"
-            seen[key] = (name, version, description, src_label, d, key)
+            seen[key] = (name, version, description, src_label, d, key, kind)
             continue
         if depth >= 1:
             continue
@@ -1138,27 +1177,52 @@ def _scan_level(
 
 
 def _discover_all_plugins() -> list:
-    """Return a list of (name, version, description, source, dir_path, key) for
-    every plugin the loader can see — user + bundled + project + entry point.
+    """Return side-effect-free metadata for every discoverable plugin.
 
     Matches the ordering/dedup of ``PluginManager.discover_and_load``:
     bundled first, then user, then project, then entry points. Later sources
     override earlier ones on key collision.
     """
-    seen: dict = {}  # key -> (name, version, description, source, path, key)
+    seen: dict = {}
 
     # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
     from hermes_cli.plugins import get_bundled_plugins_dir
     repo_plugins = get_bundled_plugins_dir()
-    for base, source, skip in (
-        (repo_plugins, "bundled", {"memory", "context_engine"}),
-        (_plugins_dir(), "user", set()),
-    ):
-        _scan_level(base, source, skip, "", 0, seen)
+    _scan_level(
+        repo_plugins,
+        "bundled",
+        {"memory", "context_engine", "platforms"},
+        "",
+        0,
+        seen,
+    )
+    # Runtime discovery scans bundled platforms from this category root, so
+    # their canonical key is the manifest name (for example
+    # ``buzz-platform``), not ``platforms/buzz``.
+    _scan_level(repo_plugins / "platforms", "bundled", set(), "", 0, seen)
+    _scan_level(_plugins_dir(), "user", set(), "", 0, seen)
+
+    if env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
+        _scan_level(
+            Path.cwd() / ".hermes" / "plugins",
+            "project",
+            set(),
+            "",
+            0,
+            seen,
+        )
 
     # Entry-point plugins (installed as Python packages; no plugin directory).
     for name, version, description, path in _discover_entrypoint_plugins():
-        seen[name] = (name, version, description, "entrypoint", path, name)
+        seen[name] = (
+            name,
+            version,
+            description,
+            "entrypoint",
+            path,
+            name,
+            "standalone",
+        )
     return list(seen.values())
 
 
@@ -1196,13 +1260,27 @@ def _discover_entrypoint_plugins() -> list[tuple[str, str, str, str]]:
     return entries
 
 
-def _plugin_status(name: str, enabled: set, disabled: set, key: str = "") -> str:
-    """Return the user-facing activation state for a plugin name or key."""
-    if name in disabled or key in disabled:
-        return "disabled"
-    if name in enabled or key in enabled:
-        return "enabled"
-    return "not enabled"
+def _plugin_status(
+    name: str,
+    enabled: set,
+    disabled: set,
+    key: str = "",
+    *,
+    source: str = "",
+    kind: str = "standalone",
+) -> str:
+    """Return the shared runtime activation state for one plugin."""
+    state = PluginActivationState(
+        enabled=frozenset(enabled),
+        disabled=frozenset(disabled),
+        safe_mode=env_var_enabled("HERMES_SAFE_MODE"),
+    )
+    return state.status(
+        name=name,
+        key=key,
+        source=source,
+        kind=kind,
+    )
 
 
 def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set) -> list:
@@ -1213,7 +1291,14 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     if getattr(args, "enabled", False):
         filtered = [
             entry for entry in filtered
-            if _plugin_status(entry[0], enabled, disabled, key=entry[5]) == "enabled"
+            if _plugin_status(
+                entry[0],
+                enabled,
+                disabled,
+                key=entry[5],
+                source=entry[3],
+                kind=entry[6],
+            ) == "enabled"
         ]
     return filtered
 
@@ -1238,19 +1323,33 @@ def cmd_list(args: Any | None = None) -> None:
         payload = [
             {
                 "name": name,
-                "status": _plugin_status(name, enabled, disabled, key=key),
+                "status": _plugin_status(
+                    name,
+                    enabled,
+                    disabled,
+                    key=key,
+                    source=source,
+                    kind=kind,
+                ),
                 "version": str(version),
                 "description": description,
                 "source": source,
             }
-            for name, version, description, source, _dir, key in entries
+            for name, version, description, source, _dir, key, kind in entries
         ]
         print(json.dumps(payload, indent=2))
         return
 
     if getattr(args, "plain", False):
-        for name, version, _description, source, _dir, key in entries:
-            status = _plugin_status(name, enabled, disabled, key=key)
+        for name, version, _description, source, _dir, key, kind in entries:
+            status = _plugin_status(
+                name,
+                enabled,
+                disabled,
+                key=key,
+                source=source,
+                kind=kind,
+            )
             print(f"{status:12} {source:8} {str(version):8} {name}")
         return
 
@@ -1265,8 +1364,15 @@ def cmd_list(args: Any | None = None) -> None:
     table.add_column("Description")
     table.add_column("Source", style="dim")
 
-    for name, version, description, source, _dir, key in entries:
-        status_name = _plugin_status(name, enabled, disabled, key=key)
+    for name, version, description, source, _dir, key, kind in entries:
+        status_name = _plugin_status(
+            name,
+            enabled,
+            disabled,
+            key=key,
+            source=source,
+            kind=kind,
+        )
         if status_name == "disabled":
             status = "[red]disabled[/red]"
         elif status_name == "enabled":
@@ -1474,20 +1580,23 @@ def cmd_toggle() -> None:
     plugin_labels = []
     plugin_selected = set()
 
-    for i, (name, _version, description, source, _d, key) in enumerate(entries):
+    for i, (name, _version, description, source, _d, key, kind) in enumerate(entries):
         label = f"{name} \u2014 {description}" if description else name
         if source == "bundled":
             label = f"{label} [bundled]"
         plugin_keys.append(key)
         plugin_labels.append(label)
-        # Selected (enabled) when in enabled-set AND not in disabled-set.
-        # Accept the legacy bare name on either side for back-compat with
-        # existing configs written before this normalization.
-        is_on = (
-            (key in enabled_set or name in enabled_set)
-            and key not in disabled_set
-            and name not in disabled_set
-        )
+        # Use the same source/kind policy as runtime discovery. Bundled
+        # backends, platforms, and model profiles are on by default; every
+        # non-bundled plugin remains opt-in and explicit disable always wins.
+        is_on = _plugin_status(
+            name,
+            enabled_set,
+            disabled_set,
+            key=key,
+            source=source,
+            kind=kind,
+        ) == "enabled"
         if is_on:
             plugin_selected.add(i)
 
@@ -1888,6 +1997,8 @@ def dashboard_install_plugin(
         dis.discard(installed_name)
         _save_enabled_set(en)
         _save_disabled_set(dis)
+    else:
+        _invalidate_provider_discovery()
 
     hint: str | None = None
     ap = target / "after-install.md"
@@ -1994,31 +2105,44 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     For plugins that provide tools (toolsets), also toggles the toolset in
     ``platform_toolsets`` so the agent actually sees the tools in sessions.
     """
-    if not _plugin_exists(name):
+    resolved = _resolve_plugin_key_and_source(name)
+    if resolved is None:
         return {"ok": False, "error": f"Plugin '{name}' is not installed or bundled."}
+    key, source, manifest_name, kind = resolved
 
     en = _get_enabled_set()
     dis = _get_disabled_set()
+    status = _plugin_status(
+        manifest_name,
+        en,
+        dis,
+        key=key,
+        source=source,
+        kind=kind,
+    )
+    aliases = {name, manifest_name, key, key.split("/")[-1]}
 
     if enabled:
-        if name in en and name not in dis:
-            return {"ok": True, "name": name, "unchanged": True}
-        en.add(name)
-        dis.discard(name)
+        if status == "enabled":
+            return {"ok": True, "name": key, "unchanged": True}
+        en.difference_update(aliases)
+        en.add(key)
+        dis.difference_update(aliases)
         _save_enabled_set(en)
         _save_disabled_set(dis)
-        _toggle_plugin_toolset(name, enable=True)
-        return {"ok": True, "name": name, "unchanged": False}
+        _toggle_plugin_toolset(key, enable=True)
+        return {"ok": True, "name": key, "unchanged": False}
 
-    if name not in en and name in dis:
-        return {"ok": True, "name": name, "unchanged": True}
+    if status == "disabled":
+        return {"ok": True, "name": key, "unchanged": True}
 
-    en.discard(name)
-    dis.add(name)
+    en.difference_update(aliases)
+    dis.difference_update(aliases)
+    dis.add(key)
     _save_enabled_set(en)
     _save_disabled_set(dis)
-    _toggle_plugin_toolset(name, enable=False)
-    return {"ok": True, "name": name, "unchanged": False}
+    _toggle_plugin_toolset(key, enable=False)
+    return {"ok": True, "name": key, "unchanged": False}
 
 
 def _user_installed_plugin_dir(name: str) -> Optional[Path]:
@@ -2057,6 +2181,7 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
     from rich.console import Console
 
     _copy_example_files(target, Console())
+    _invalidate_provider_discovery()
     unchanged = "Already up to date" in msg
     return {"ok": True, "name": name, "output": msg, "unchanged": unchanged}
 
@@ -2113,7 +2238,7 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
     """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
     plugins_dir = _plugins_dir()
-    for n, _ver, _d, src, _path, _key in _discover_all_plugins():
+    for n, _ver, _d, src, _path, _key, _kind in _discover_all_plugins():
         if n == name and src == "bundled":
             return {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
 
@@ -2125,6 +2250,7 @@ def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
         }
 
     shutil.rmtree(target)
+    _invalidate_provider_discovery()
     return {"ok": True, "name": name}
 
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1394,6 +1394,60 @@ def _discover_plugin_display_records(
     )
 
 
+def _select_plugin_management_entries(entries: list) -> list:
+    """Select the highest-precedence installed target for each key."""
+    management_by_key: dict[str, tuple] = {}
+    for entry in entries:
+        source = entry[3]
+        key = entry[5]
+        if key in management_by_key and source == "bundled":
+            continue
+        management_by_key[key] = entry
+    return list(management_by_key.values())
+
+
+def _select_plugin_management_records(
+    entries: list,
+    activation: PluginActivationState,
+) -> list:
+    """Keep the installed management target while reporting runtime truth."""
+    management_entries = _select_plugin_management_entries(entries)
+
+    runtime_by_key = {
+        entry[5]: (entry, status)
+        for entry, status in _select_plugin_display_records(entries, activation)
+    }
+    records = []
+    for entry in management_entries:
+        key = entry[5]
+        runtime_entry, group_status = runtime_by_key.get(
+            key,
+            (None, "not enabled"),
+        )
+        if group_status == "disabled":
+            status = "disabled"
+        elif group_status == "enabled" and entry == runtime_entry:
+            status = "enabled"
+        else:
+            status = "not enabled"
+        records.append((entry, status))
+    return records
+
+
+def _discover_plugin_management_records(
+    activation: PluginActivationState | None = None,
+) -> list:
+    """Return actionable installed rows with their effective runtime status."""
+    if activation is None:
+        from hermes_cli.config import load_plugin_activation_state
+
+        activation = load_plugin_activation_state()
+    return _select_plugin_management_records(
+        _discover_plugin_candidates(),
+        activation,
+    )
+
+
 def _discover_all_plugins() -> list:
     """Return side-effect-free metadata for every effective raw plugin.
 
@@ -1401,14 +1455,7 @@ def _discover_all_plugins() -> list:
     bundled first, then user, then project, then entry points. Later sources
     override earlier ones on key collision.
     """
-    seen: dict = {}
-    for entry in _discover_plugin_candidates():
-        source = entry[3]
-        key = entry[5]
-        if key in seen and source == "bundled":
-            continue
-        seen[key] = entry
-    return list(seen.values())
+    return _select_plugin_management_entries(_discover_plugin_candidates())
 
 
 def _discover_entrypoint_plugins() -> list[tuple[str, str, str, str]]:
@@ -1484,7 +1531,7 @@ def cmd_list(args: Any | None = None) -> None:
     from rich.table import Table
 
     console = Console()
-    records = _discover_plugin_display_records()
+    records = _discover_plugin_management_records()
     if not records:
         console.print("[dim]No plugins installed.[/dim]")
         console.print("[dim]Install with:[/dim] hermes plugins install owner/repo")
@@ -1728,7 +1775,7 @@ def cmd_toggle() -> None:
     console = Console()
 
     # -- General plugins discovery (bundled + user) --
-    records = _discover_plugin_display_records()
+    records = _discover_plugin_management_records()
     disabled_set = _get_disabled_set()
 
     # Track by CANONICAL KEY (``key``), not the manifest name. The loader

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -897,8 +897,18 @@ def _plugin_runtime_identity_changes(
     return identities, preserved_entries
 
 
-def _plugin_disable_identities_to_clear(key: str) -> set[str]:
-    """Return target identities that do not also activate another key."""
+def _plugin_disable_identity_changes(
+    key: str,
+    enabled: set[str],
+    disabled: set[str],
+) -> tuple[set[str], set[str]]:
+    """Return safe allow/deny identities to clear while disabling *key*.
+
+    A manifest-name allow can cover several canonical groups. Keep such an
+    alias only when removing it would change another group's resolved winner
+    or status after the target deny takes effect. Shared denies are never
+    rewritten here.
+    """
     candidates = _discover_plugin_candidates()
     target_identities = {key}
     for entry in candidates:
@@ -912,7 +922,35 @@ def _plugin_disable_identities_to_clear(key: str) -> set[str]:
         for identity in (entry[0], entry[5])
         if identity in target_identities
     }
-    return target_identities - shared_identities
+    exclusive_identities = target_identities - shared_identities
+    enabled_to_clear = set(exclusive_identities)
+
+    proposed_disabled = set(disabled)
+    proposed_disabled.add(key)
+
+    def _other_group_records(configured_enabled: set[str]) -> list:
+        activation = PluginActivationState(
+            enabled=frozenset(configured_enabled),
+            disabled=frozenset(proposed_disabled),
+        )
+        return [
+            (entry, status)
+            for entry, status in _select_plugin_display_records(
+                candidates,
+                activation,
+            )
+            if entry[5] != key
+        ]
+
+    working_enabled = set(enabled)
+    baseline = _other_group_records(working_enabled)
+    for identity in sorted(shared_identities & working_enabled):
+        without_identity = working_enabled - {identity}
+        if _other_group_records(without_identity) == baseline:
+            enabled_to_clear.add(identity)
+            working_enabled = without_identity
+
+    return enabled_to_clear, exclusive_identities
 
 
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
@@ -1060,9 +1098,13 @@ def cmd_disable(name: str) -> None:
         console.print(f"[dim]Plugin '{key}' is already disabled.[/dim]")
         return
 
-    identities = _plugin_disable_identities_to_clear(key)
-    enabled.difference_update(identities)
-    disabled.difference_update(identities)
+    enabled_ids, disabled_ids = _plugin_disable_identity_changes(
+        key,
+        enabled,
+        disabled,
+    )
+    enabled.difference_update(enabled_ids)
+    disabled.difference_update(disabled_ids)
     disabled.add(key)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
@@ -1768,9 +1810,13 @@ def _persist_composite_plugin_selection(
 
     for i in sorted(initial_selected - chosen):
         key = plugin_keys[i]
-        enabled_ids = _plugin_disable_identities_to_clear(key)
+        enabled_ids, disabled_ids = _plugin_disable_identity_changes(
+            key,
+            new_enabled,
+            new_disabled,
+        )
         new_enabled.difference_update(enabled_ids)
-        new_disabled.difference_update(enabled_ids)
+        new_disabled.difference_update(disabled_ids)
         new_disabled.add(key)
 
     changed = new_enabled != previous_enabled or new_disabled != disabled
@@ -2257,9 +2303,9 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     if status == "disabled":
         return {"ok": True, "name": name, "key": key, "unchanged": True}
 
-    identities = _plugin_disable_identities_to_clear(key)
-    en.difference_update(identities)
-    dis.difference_update(identities)
+    enabled_ids, disabled_ids = _plugin_disable_identity_changes(key, en, dis)
+    en.difference_update(enabled_ids)
+    dis.difference_update(disabled_ids)
     dis.add(key)
     _save_enabled_set(en)
     _save_disabled_set(dis)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -875,13 +875,26 @@ def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
     return None
 
 
-def _plugin_candidate_identities(key: str) -> set[str]:
-    """Return every config identity used by candidates for a canonical key."""
-    identities = {key, key.split("/")[-1]}
-    for entry in _discover_plugin_candidates():
+def _plugin_enable_identity_changes(
+    key: str,
+    disabled: set[str],
+) -> tuple[set[str], set[str]]:
+    """Return target identities to clear and shared other-key denies to keep."""
+    candidates = _discover_plugin_candidates()
+    identities = {key}
+    for entry in candidates:
         if entry[5] == key:
             identities.update((entry[0], entry[5]))
-    return identities
+    cleared_denies = disabled & identities
+    # A legacy manifest-name deny can cover several canonical groups. Replace
+    # it with canonical denies for every non-target group before removing it.
+    preserved_denies = {
+        entry[5]
+        for entry in candidates
+        if entry[5] != key
+        and cleared_denies & {entry[0], entry[5]}
+    }
+    return identities, preserved_denies
 
 
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
@@ -936,14 +949,17 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         source=source,
         kind=kind,
     ) == "enabled"
-    identities = _plugin_candidate_identities(key)
-    identities.update((name, manifest_name))
+    identities, preserved_denies = _plugin_enable_identity_changes(
+        key,
+        disabled,
+    )
 
     if not already_enabled or bool(disabled & identities):
         enabled.add(key)
         # An explicit disable on any candidate blocks the whole canonical
         # group, so enabling must clear every bundled/user/project identity.
         disabled.difference_update(identities)
+        disabled.update(preserved_denies)
         _save_enabled_set(enabled)
         _save_disabled_set(disabled)
         console.print(
@@ -2211,20 +2227,22 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
         source=source,
         kind=kind,
     )
-    aliases = {name, manifest_name, key, key.split("/")[-1]}
-
     if enabled:
-        aliases.update(_plugin_candidate_identities(key))
-        if status == "enabled" and not bool(dis & aliases):
+        identities, preserved_denies = _plugin_enable_identity_changes(
+            key,
+            dis,
+        )
+        if status == "enabled" and not bool(dis & identities):
             return {"ok": True, "name": name, "key": key, "unchanged": True}
-        en.difference_update(aliases)
         en.add(key)
-        dis.difference_update(aliases)
+        dis.difference_update(identities)
+        dis.update(preserved_denies)
         _save_enabled_set(en)
         _save_disabled_set(dis)
         _toggle_plugin_toolset(key, enable=True)
         return {"ok": True, "name": name, "key": key, "unchanged": False}
 
+    aliases = {name, manifest_name, key, key.split("/")[-1]}
     if status == "disabled":
         return {"ok": True, "name": name, "key": key, "unchanged": True}
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -875,6 +875,15 @@ def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
     return None
 
 
+def _plugin_candidate_identities(key: str) -> set[str]:
+    """Return every config identity used by candidates for a canonical key."""
+    identities = {key, key.split("/")[-1]}
+    for entry in _discover_plugin_candidates():
+        if entry[5] == key:
+            identities.update((entry[0], entry[5]))
+    return identities
+
+
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
     """Write ``plugins.entries.<plugin_id>.<key> = value`` into config.yaml."""
     from hermes_cli.config import load_config, save_config
@@ -927,25 +936,14 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         source=source,
         kind=kind,
     ) == "enabled"
+    identities = _plugin_candidate_identities(key)
+    identities.update((name, manifest_name))
 
-    if not already_enabled:
+    if not already_enabled or bool(disabled & identities):
         enabled.add(key)
-        disabled.discard(key)
-        # Drop every alias of this plugin from the disabled list so an
-        # explicit disable under a different form can't keep it off. The
-        # loader's disable check matches on BOTH the canonical key
-        # (``web/firecrawl``) AND the manifest name (``web-firecrawl``);
-        # a stale entry under either form makes "explicit disable wins"
-        # (plugins.py) silently veto this enable. Discard the key, its
-        # bare leaf, and the manifest name. (#40190 follow-up.)
-        bare = key.split("/")[-1]
-        if bare != key:
-            disabled.discard(bare)
-        for entry in _discover_all_plugins():
-            # entry = (name, version, description, source, dir_path, key, kind)
-            if entry[5] == key:
-                disabled.discard(entry[0])
-                break
+        # An explicit disable on any candidate blocks the whole canonical
+        # group, so enabling must clear every bundled/user/project identity.
+        disabled.difference_update(identities)
         _save_enabled_set(enabled)
         _save_disabled_set(disabled)
         console.print(
@@ -2216,7 +2214,8 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     aliases = {name, manifest_name, key, key.split("/")[-1]}
 
     if enabled:
-        if status == "enabled":
+        aliases.update(_plugin_candidate_identities(key))
+        if status == "enabled" and not bool(dis & aliases):
             return {"ok": True, "name": name, "key": key, "unchanged": True}
         en.difference_update(aliases)
         en.add(key)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -875,26 +875,26 @@ def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
     return None
 
 
-def _plugin_enable_identity_changes(
+def _plugin_runtime_identity_changes(
     key: str,
-    disabled: set[str],
+    configured: set[str],
 ) -> tuple[set[str], set[str]]:
-    """Return target identities to clear and shared other-key denies to keep."""
+    """Return target identities to clear and shared other-key entries to keep."""
     candidates = _discover_plugin_candidates()
     identities = {key}
     for entry in candidates:
         if entry[5] == key:
             identities.update((entry[0], entry[5]))
-    cleared_denies = disabled & identities
-    # A legacy manifest-name deny can cover several canonical groups. Replace
-    # it with canonical denies for every non-target group before removing it.
-    preserved_denies = {
+    cleared_entries = configured & identities
+    # A legacy manifest-name entry can cover several canonical groups. Replace
+    # it with canonical entries for every non-target group before removing it.
+    preserved_entries = {
         entry[5]
         for entry in candidates
         if entry[5] != key
-        and cleared_denies & {entry[0], entry[5]}
+        and cleared_entries & {entry[0], entry[5]}
     }
-    return identities, preserved_denies
+    return identities, preserved_entries
 
 
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
@@ -949,7 +949,7 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         source=source,
         kind=kind,
     ) == "enabled"
-    identities, preserved_denies = _plugin_enable_identity_changes(
+    identities, preserved_denies = _plugin_runtime_identity_changes(
         key,
         disabled,
     )
@@ -1042,9 +1042,13 @@ def cmd_disable(name: str) -> None:
         console.print(f"[dim]Plugin '{key}' is already disabled.[/dim]")
         return
 
-    aliases = {name, manifest_name, key, key.split("/")[-1]}
-    enabled.difference_update(aliases)
-    disabled.difference_update(aliases)
+    identities, preserved_enables = _plugin_runtime_identity_changes(
+        key,
+        enabled,
+    )
+    enabled.difference_update(identities)
+    enabled.update(preserved_enables)
+    disabled.difference_update(identities)
     disabled.add(key)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
@@ -2228,7 +2232,7 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
         kind=kind,
     )
     if enabled:
-        identities, preserved_denies = _plugin_enable_identity_changes(
+        identities, preserved_denies = _plugin_runtime_identity_changes(
             key,
             dis,
         )
@@ -2242,12 +2246,13 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
         _toggle_plugin_toolset(key, enable=True)
         return {"ok": True, "name": name, "key": key, "unchanged": False}
 
-    aliases = {name, manifest_name, key, key.split("/")[-1]}
     if status == "disabled":
         return {"ok": True, "name": name, "key": key, "unchanged": True}
 
-    en.difference_update(aliases)
-    dis.difference_update(aliases)
+    identities, preserved_enables = _plugin_runtime_identity_changes(key, en)
+    en.difference_update(identities)
+    en.update(preserved_enables)
+    dis.difference_update(identities)
     dis.add(key)
     _save_enabled_set(en)
     _save_disabled_set(dis)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1143,6 +1143,7 @@ def _scan_level(
     prefix: str,
     depth: int,
     seen: dict,
+    candidates: Optional[list] = None,
 ) -> None:
     """Recursive directory scan matching PluginManager._scan_directory_level.
 
@@ -1163,30 +1164,35 @@ def _scan_level(
                 kind = "standalone"
             else:
                 name, version, description, key, kind = info
-            if key in seen and source == "bundled":
-                continue
             src_label = source
             if source == "user" and (d / ".git").exists():
                 src_label = "git"
-            seen[key] = (name, version, description, src_label, d, key, kind)
+            entry = (name, version, description, src_label, d, key, kind)
+            if candidates is not None:
+                candidates.append(entry)
+            if key in seen and source == "bundled":
+                continue
+            seen[key] = entry
             continue
         if depth >= 1:
             continue
         sub_prefix = f"{prefix}/{d.name}" if prefix else d.name
-        _scan_level(d, source, set(), sub_prefix, depth + 1, seen)
+        _scan_level(d, source, set(), sub_prefix, depth + 1, seen, candidates)
 
 
-def _discover_all_plugins() -> list:
-    """Return side-effect-free metadata for every discoverable plugin.
+def _discover_plugin_candidates() -> list:
+    """Return every discoverable plugin candidate in runtime priority order.
 
-    Matches the ordering/dedup of ``PluginManager.discover_and_load``:
-    bundled first, then user, then project, then entry points. Later sources
-    override earlier ones on key collision.
+    Unlike :func:`_discover_all_plugins`, this retains lower-priority copies
+    that share a canonical key. Runtime-adjacent consumers use it to select
+    the highest-priority *active* copy instead of letting an installed but
+    inactive user/project copy suppress an active bundled fallback.
     """
     seen: dict = {}
+    candidates: list = []
 
-    # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
     from hermes_cli.plugins import get_bundled_plugins_dir
+
     repo_plugins = get_bundled_plugins_dir()
     _scan_level(
         repo_plugins,
@@ -1195,12 +1201,18 @@ def _discover_all_plugins() -> list:
         "",
         0,
         seen,
+        candidates,
     )
-    # Runtime discovery scans bundled platforms from this category root, so
-    # their canonical key is the manifest name (for example
-    # ``buzz-platform``), not ``platforms/buzz``.
-    _scan_level(repo_plugins / "platforms", "bundled", set(), "", 0, seen)
-    _scan_level(_plugins_dir(), "user", set(), "", 0, seen)
+    _scan_level(
+        repo_plugins / "platforms",
+        "bundled",
+        set(),
+        "",
+        0,
+        seen,
+        candidates,
+    )
+    _scan_level(_plugins_dir(), "user", set(), "", 0, seen, candidates)
 
     if env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
         _scan_level(
@@ -1210,19 +1222,62 @@ def _discover_all_plugins() -> list:
             "",
             0,
             seen,
+            candidates,
         )
 
-    # Entry-point plugins (installed as Python packages; no plugin directory).
     for name, version, description, path in _discover_entrypoint_plugins():
-        seen[name] = (
-            name,
-            version,
-            description,
-            "entrypoint",
-            path,
-            name,
-            "standalone",
+        candidates.append(
+            (
+                name,
+                version,
+                description,
+                "entrypoint",
+                path,
+                name,
+                "standalone",
+            )
         )
+    return candidates
+
+
+def _select_active_plugin_entries(entries: list, activation: PluginActivationState) -> list:
+    """Select the highest-priority active candidate for each canonical key."""
+    from hermes_cli.plugins import resolve_plugin_candidate_winner
+
+    grouped: dict[str, list] = {}
+    for entry in entries:
+        grouped.setdefault(entry[5], []).append(entry)
+
+    winners: list = []
+    for candidates in grouped.values():
+        selection = resolve_plugin_candidate_winner(
+            candidates,
+            lambda entry: activation.status(
+                name=entry[0],
+                key=entry[5],
+                source=entry[3],
+                kind=entry[6],
+            ),
+        )
+        if selection is not None and selection[1] == "enabled":
+            winners.append(selection[0])
+    return winners
+
+
+def _discover_all_plugins() -> list:
+    """Return side-effect-free metadata for every effective raw plugin.
+
+    Matches the ordering/dedup of ``PluginManager.discover_and_load``:
+    bundled first, then user, then project, then entry points. Later sources
+    override earlier ones on key collision.
+    """
+    seen: dict = {}
+    for entry in _discover_plugin_candidates():
+        source = entry[3]
+        key = entry[5]
+        if key in seen and source == "bundled":
+            continue
+        seen[key] = entry
     return list(seen.values())
 
 
@@ -1318,11 +1373,20 @@ def cmd_list(args: Any | None = None) -> None:
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
     entries = _filter_plugin_entries(entries, args, enabled, disabled)
+    manifest_name_counts: dict[str, int] = {}
+    for entry in entries:
+        manifest_name_counts[entry[0]] = manifest_name_counts.get(entry[0], 0) + 1
+
+    def _display_name(name: str, key: str) -> str:
+        if manifest_name_counts.get(name, 0) > 1:
+            return f"{name} [{key}]"
+        return name
 
     if getattr(args, "json", False):
         payload = [
             {
                 "name": name,
+                "key": key,
                 "status": _plugin_status(
                     name,
                     enabled,
@@ -1350,7 +1414,10 @@ def cmd_list(args: Any | None = None) -> None:
                 source=source,
                 kind=kind,
             )
-            print(f"{status:12} {source:8} {str(version):8} {name}")
+            print(
+                f"{status:12} {source:8} {str(version):8} "
+                f"{_display_name(name, key)}"
+            )
         return
 
     if not entries:
@@ -1379,7 +1446,7 @@ def cmd_list(args: Any | None = None) -> None:
             status = "[green]enabled[/green]"
         else:
             status = "[yellow]not enabled[/yellow]"
-        table.add_row(name, status, str(version), description, source)
+        table.add_row(_display_name(name, key), status, str(version), description, source)
 
     console.print()
     console.print(table)
@@ -2124,17 +2191,17 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
 
     if enabled:
         if status == "enabled":
-            return {"ok": True, "name": key, "unchanged": True}
+            return {"ok": True, "name": name, "key": key, "unchanged": True}
         en.difference_update(aliases)
         en.add(key)
         dis.difference_update(aliases)
         _save_enabled_set(en)
         _save_disabled_set(dis)
         _toggle_plugin_toolset(key, enable=True)
-        return {"ok": True, "name": key, "unchanged": False}
+        return {"ok": True, "name": name, "key": key, "unchanged": False}
 
     if status == "disabled":
-        return {"ok": True, "name": key, "unchanged": True}
+        return {"ok": True, "name": name, "key": key, "unchanged": True}
 
     en.difference_update(aliases)
     dis.difference_update(aliases)
@@ -2142,12 +2209,31 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     _save_enabled_set(en)
     _save_disabled_set(dis)
     _toggle_plugin_toolset(key, enable=False)
-    return {"ok": True, "name": key, "unchanged": False}
+    return {"ok": True, "name": name, "key": key, "unchanged": False}
 
 
 def _user_installed_plugin_dir(name: str) -> Optional[Path]:
-    """Resolved path under ``~/.hermes/plugins/<name>`` if it exists."""
+    """Resolve a plugin identifier to its installed user-tree directory."""
     plugins_dir = _plugins_dir()
+    try:
+        plugins_root = plugins_dir.resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    key = _resolve_plugin_key(name)
+    if key is not None:
+        for entry in _discover_all_plugins():
+            if entry[5] != key or entry[3] not in {"user", "git"}:
+                continue
+            try:
+                target = Path(entry[4]).resolve()
+                target.relative_to(plugins_root)
+            except (OSError, RuntimeError, TypeError, ValueError):
+                return None
+            return target if target.is_dir() else None
+
+    # Compatibility for old clients that send a directory name rather than a
+    # canonical key (including an ambiguous manifest-name collision).
     try:
         target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
     except ValueError:
@@ -2238,9 +2324,12 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
     """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
     plugins_dir = _plugins_dir()
-    for n, _ver, _d, src, _path, _key, _kind in _discover_all_plugins():
-        if n == name and src == "bundled":
-            return {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
+    resolved = _resolve_plugin_key_and_source(name)
+    if resolved is not None and resolved[1] == "bundled":
+        return {
+            "ok": False,
+            "error": "Bundled plugins cannot be removed from the dashboard.",
+        }
 
     target = _user_installed_plugin_dir(name)
     if target is None:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2332,6 +2332,14 @@ def resolve_runtime_provider(
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
     )
+    if requested_provider == "auto":
+        runtime_base_url = str(runtime.get("base_url") or "").strip()
+        endpoint_provider = (
+            "openrouter"
+            if base_url_host_matches(runtime_base_url, "openrouter.ai")
+            else "custom"
+        )
+        require_plugin_provider(endpoint_provider)
     runtime["requested_provider"] = requested_provider
     return runtime
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -26,6 +26,7 @@ from hermes_cli.auth import (
     DEFAULT_QWEN_BASE_URL,
     DEFAULT_XAI_OAUTH_BASE_URL,
     PROVIDER_REGISTRY,
+    get_provider_implementation_config,
     _agent_key_is_usable,
     _nous_inference_env_override,
     format_auth_error,
@@ -503,7 +504,10 @@ def _resolve_runtime_from_pool_entry(
             getattr(entry, "runtime_api_key", ""),
             target_model=effective_model,
         )
-        base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
+        base_url = (
+            base_url
+            or get_provider_implementation_config("copilot").inference_base_url
+        )
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
@@ -1681,6 +1685,44 @@ def resolve_runtime_provider(
     """
     requested_provider = resolve_requested_provider(requested)
 
+    def require_plugin_provider(provider_id: str) -> None:
+        from providers import is_provider_plugin_active
+
+        if not is_provider_plugin_active(provider_id):
+            raise AuthError(
+                f"Provider '{provider_id}' is disabled by plugin configuration.",
+                code="invalid_provider",
+            )
+
+    shortcut_provider = requested_provider
+    if requested_provider.startswith("custom:") or requested_provider in {
+        "custom",
+        "local",
+        "ollama",
+        "vllm",
+        "llamacpp",
+        "llama.cpp",
+        "llama-cpp",
+    }:
+        shortcut_provider = "custom"
+    elif requested_provider in {
+        "vertex",
+        "google-vertex",
+        "vertex-ai",
+        "gcp-vertex",
+        "vertexai",
+    }:
+        shortcut_provider = "vertex"
+    elif requested_provider in {
+        "azure-foundry",
+        "azure",
+        "azure-ai-foundry",
+        "azure-ai",
+    }:
+        shortcut_provider = "azure-foundry"
+    if shortcut_provider not in {"auto", "moa"}:
+        require_plugin_provider(shortcut_provider)
+
     # Honour ``providers.<name>.enabled: false`` for BOTH user-defined
     # custom providers and the built-in ones (openai / anthropic /
     # openrouter / gemini / ...). The earlier ``_get_named_custom_provider``
@@ -1786,6 +1828,7 @@ def resolve_runtime_provider(
         explicit_base_url=explicit_base_url,
     )
     if custom_runtime:
+        require_plugin_provider("custom")
         custom_runtime["requested_provider"] = requested_provider
         return custom_runtime
 
@@ -1818,6 +1861,7 @@ def resolve_runtime_provider(
                 base_url_host_matches(cfg_base_url, host)
                 for host in _known_cloud_hosts
             ):
+                require_plugin_provider("custom")
                 runtime = _resolve_openrouter_runtime(
                     requested_provider=requested_provider,
                     explicit_api_key=explicit_api_key,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1927,13 +1927,17 @@ def _run_post_setup(post_setup_key: str):
         # The plugin ships in the repo but doesn't load until the user enables
         # it (standalone plugins are opt-in).
         try:
-            from hermes_cli.plugins_cmd import _get_enabled_set, _save_enabled_set
-            enabled = _get_enabled_set()
-            if "observability/langfuse" in enabled or "langfuse" in enabled:
+            from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
+
+            result = dashboard_set_agent_plugin_enabled(
+                "observability/langfuse",
+                enabled=True,
+            )
+            if not result.get("ok"):
+                raise RuntimeError(result.get("error") or "plugin enable failed")
+            if result.get("unchanged"):
                 _print_success("    Plugin observability/langfuse already enabled")
             else:
-                enabled.add("observability/langfuse")
-                _save_enabled_set(enabled)
                 _print_success("    Plugin observability/langfuse enabled")
         except Exception as exc:
             _print_warning(f"    Could not enable plugin automatically: {exc}")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16809,17 +16809,19 @@ def _discover_dashboard_runtime_entries() -> list:
 
 
 def _discover_dashboard_plugin_records() -> list:
-    """Discover display winners and resolved status in process-home scope."""
+    """Discover actionable installed rows and status in process-home scope."""
     from hermes_constants import (
         reset_hermes_home_override,
         set_hermes_home_override,
     )
     from hermes_cli.config import load_plugin_activation_state
-    from hermes_cli.plugins_cmd import _discover_plugin_display_records
+    from hermes_cli.plugins_cmd import _discover_plugin_management_records
 
     token = set_hermes_home_override(get_process_hermes_home())
     try:
-        return _discover_plugin_display_records(load_plugin_activation_state())
+        return _discover_plugin_management_records(
+            load_plugin_activation_state()
+        )
     finally:
         reset_hermes_home_override(token)
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -599,16 +599,6 @@ async def _plugin_api_runtime_gate(request: Request, call_next):
             if len(parts) >= 4:
                 plugin_name = parts[3]
                 if plugin_name:
-                    try:
-                        from hermes_cli.plugins_cmd import (
-                            _get_enabled_set,
-                            _get_disabled_set,
-                        )
-                        enabled_set = _get_enabled_set()
-                        disabled_set = _get_disabled_set()
-                    except Exception:
-                        enabled_set = set()
-                        disabled_set = set()
                     # Determine plugin source.  Check the cached plugin list;
                     # if not found, assume user plugin (safe default — blocks).
                     plugins = _get_dashboard_plugins()
@@ -616,19 +606,15 @@ async def _plugin_api_runtime_gate(request: Request, call_next):
                         (p for p in plugins if p.get("name") == plugin_name),
                         None,
                     )
-                    source = plugin.get("source") if plugin else "user"
-                    if source == "user":
-                        if plugin_name in disabled_set or plugin_name not in enabled_set:
-                            return JSONResponse(
-                                status_code=404,
-                                content={"detail": "Plugin not found"},
-                            )
-                    elif source == "bundled":
-                        if plugin_name in disabled_set:
-                            return JSONResponse(
-                                status_code=404,
-                                content={"detail": "Plugin not found"},
-                            )
+                    candidate = plugin or {
+                        "name": plugin_name,
+                        "source": "user",
+                    }
+                    if not _dashboard_plugin_is_active(candidate):
+                        return JSONResponse(
+                            status_code=404,
+                            content={"detail": "Plugin not found"},
+                        )
     return await call_next(request)
 
 
@@ -9666,8 +9652,11 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
     # environment first (where Bitwarden-sourced secrets land) then .env.
     env_var_order: tuple = ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
     try:
-        from hermes_cli.auth import PROVIDER_REGISTRY
-        env_var_order = PROVIDER_REGISTRY["anthropic"].api_key_env_vars
+        from hermes_cli.auth import get_provider_implementation_config
+
+        env_var_order = get_provider_implementation_config(
+            "anthropic"
+        ).api_key_env_vars
     except (ImportError, KeyError):
         pass
     try:
@@ -10419,10 +10408,10 @@ async def _start_device_code_flow(
     if provider_id == "nous":
         from hermes_cli.auth import (
             _request_device_code,
-            PROVIDER_REGISTRY,
+            get_nous_service_config,
         )
         import httpx
-        pconfig = PROVIDER_REGISTRY["nous"]
+        pconfig = get_nous_service_config()
         portal_base_url = (
             os.getenv("HERMES_PORTAL_BASE_URL")
             or os.getenv("NOUS_PORTAL_BASE_URL")
@@ -16799,27 +16788,65 @@ def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional
     return api_field
 
 
+def _discover_dashboard_runtime_entries() -> list:
+    """Discover runtime winners in the dashboard's process-home scope."""
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from hermes_cli.plugins_cmd import _discover_all_plugins
+
+    token = set_hermes_home_override(get_process_hermes_home())
+    try:
+        return _discover_all_plugins()
+    finally:
+        reset_hermes_home_override(token)
+
+
 def _discover_dashboard_plugins() -> list:
     """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
 
-    Checks three plugin sources (same as hermes_cli.plugins):
-    1. User plugins:    ~/.hermes/plugins/<name>/dashboard/manifest.json
-    2. Bundled plugins: <repo>/plugins/<name>/dashboard/manifest.json  (memory/, etc.)
+    Checks three plugin sources in runtime precedence order:
+    1. Bundled plugins: <repo>/plugins/<name>/dashboard/manifest.json  (memory/, etc.)
+    2. User plugins:    ~/.hermes/plugins/<name>/dashboard/manifest.json
     3. Project plugins: ./.hermes/plugins/  (only if HERMES_ENABLE_PROJECT_PLUGINS)
     """
-    plugins = []
-    seen_names: set = set()
-
     from hermes_cli.plugins import get_bundled_plugins_dir
     bundled_root = get_bundled_plugins_dir()
+    try:
+        runtime_entries = _discover_dashboard_runtime_entries()
+        runtime_discovery_ok = True
+    except Exception:
+        # A dashboard extension backed by a runtime plugin must never become
+        # executable merely because canonical runtime discovery failed. Pure
+        # dashboard-only extensions still use the activation policy below.
+        runtime_entries = []
+        runtime_discovery_ok = False
+
+    runtime_by_root: Dict[Path, tuple] = {}
+    runtime_by_key: Dict[str, tuple] = {}
+    for entry in runtime_entries:
+        try:
+            root = Path(entry[4]).resolve()
+        except (OSError, RuntimeError, TypeError, ValueError):
+            continue
+        runtime_by_root[root] = entry
+        runtime_by_key[str(entry[5])] = entry
+
+    # Use the same source precedence as PluginManager/_discover_all_plugins:
+    # bundled first, then user, then project. Later non-bundled candidates
+    # replace earlier candidates on canonical-key collision. A higher-priority
+    # plugin therefore suppresses a lower-priority dashboard even when the
+    # winner is inactive (there is no fallback to executable bundled UI/code).
+    winners: Dict[str, dict] = {}
     # User dashboard plugins are a dashboard-owned asset (same category as
     # theme YAML): resolve them from the process launch home so they don't
     # vanish when a request is scoped to another profile via a context-local
     # HERMES_HOME override (e.g. embedded /chat under --open-profile).
     search_dirs = [
-        (get_process_hermes_home() / "plugins", "user"),
         (bundled_root / "memory", "bundled"),
         (bundled_root, "bundled"),
+        (get_process_hermes_home() / "plugins", "user"),
     ]
     # GHSA-5qr3-c538-wm9j (#29156): the previous ``os.environ.get(...)``
     # check treated *any* non-empty string as truthy, so ``=0``, ``=false``,
@@ -16845,9 +16872,79 @@ def _discover_dashboard_plugins() -> list:
             try:
                 data = json.loads(manifest_file.read_text(encoding="utf-8"))
                 name = data.get("name", child.name)
-                if name in seen_names:
-                    continue
-                seen_names.add(name)
+                if not isinstance(name, str) or not name.strip():
+                    name = child.name
+                name = name.strip()
+
+                try:
+                    plugin_root = child.resolve()
+                except (OSError, RuntimeError):
+                    plugin_root = child.absolute()
+
+                runtime_entry = runtime_by_root.get(plugin_root)
+                runtime_manifest = child / "plugin.yaml"
+                if not runtime_manifest.exists():
+                    runtime_manifest = child / "plugin.yml"
+                # Memory providers have an exclusive selector and are not
+                # candidates in general runtime winner discovery. Preserve
+                # their dashboard-only treatment instead of misclassifying
+                # them as a missing (therefore inactive) runtime winner.
+                runtime_managed = runtime_manifest.exists() and (
+                    plugins_root != bundled_root / "memory"
+                )
+
+                if runtime_entry is not None:
+                    runtime_name = str(runtime_entry[0])
+                    runtime_source = str(runtime_entry[3])
+                    runtime_key = str(runtime_entry[5])
+                    runtime_kind = str(runtime_entry[6])
+                    runtime_winner = True
+                elif runtime_managed:
+                    # Flat dashboard plugins use the manifest name as their
+                    # canonical runtime key, matching _read_manifest_info(...,
+                    # prefix=""). This also lets us identify a losing bundled
+                    # dashboard whose user/project winner has no dashboard.
+                    runtime_name = child.name
+                    runtime_kind = "standalone"
+                    try:
+                        manifest_data = yaml.safe_load(
+                            runtime_manifest.read_text(encoding="utf-8")
+                        ) or {}
+                        if isinstance(manifest_data, dict):
+                            manifest_name = manifest_data.get("name")
+                            if isinstance(manifest_name, str) and manifest_name.strip():
+                                runtime_name = manifest_name.strip()
+                            manifest_kind = manifest_data.get("kind")
+                            if isinstance(manifest_kind, str) and manifest_kind.strip():
+                                runtime_kind = manifest_kind.strip().lower()
+                    except Exception:
+                        # Malformed runtime identity is not a dashboard-only
+                        # escape hatch. Keep it runtime-managed and fail closed.
+                        pass
+                    runtime_key = runtime_name
+                    runtime_source = (
+                        "git" if source == "user" and (child / ".git").exists()
+                        else source
+                    )
+                    winning_entry = runtime_by_key.get(runtime_key)
+                    if winning_entry is None:
+                        runtime_winner = False
+                    else:
+                        try:
+                            winning_root = Path(winning_entry[4]).resolve()
+                        except (OSError, RuntimeError, TypeError, ValueError):
+                            runtime_winner = False
+                        else:
+                            runtime_winner = winning_root == plugin_root
+                else:
+                    # Dashboard-only extensions have no Python runtime
+                    # manifest. They still follow source activation policy and
+                    # canonical source precedence using their dashboard name.
+                    runtime_name = name
+                    runtime_key = name
+                    runtime_source = source
+                    runtime_kind = "backend" if source == "bundled" else "standalone"
+                    runtime_winner = True
                 # Tab options: ``path`` + ``position`` for a new tab, optional
                 # ``override`` to replace a built-in route, and ``hidden`` to
                 # register the plugin component/slots without adding a tab
@@ -16886,7 +16983,7 @@ def _discover_dashboard_plugins() -> list:
                         "not be mounted",
                         name, raw_api,
                     )
-                plugins.append({
+                candidate = {
                     "name": name,
                     "label": data.get("label", name),
                     "description": data.get("description", ""),
@@ -16900,25 +16997,216 @@ def _discover_dashboard_plugins() -> list:
                     "source": source,
                     "_dir": str(dashboard_dir),
                     "_api_file": safe_api,
-                })
+                    "_runtime_name": runtime_name,
+                    "_runtime_key": runtime_key,
+                    "_runtime_source": runtime_source,
+                    "_runtime_kind": runtime_kind,
+                    "_runtime_managed": runtime_managed,
+                    "_runtime_winner": runtime_winner and runtime_discovery_ok
+                    if runtime_managed else runtime_winner,
+                }
+
+                # _discover_all_plugins keeps the first bundled candidate for
+                # a duplicate key, while later user/project sources override.
+                if runtime_key in winners and source == "bundled":
+                    continue
+                winners[runtime_key] = candidate
             except Exception as exc:
                 _log.warning("Bad dashboard plugin manifest %s: %s", manifest_file, exc)
                 continue
-    return plugins
+    return list(winners.values())
 
 
-# Cache discovered plugins per-process (refresh on explicit re-scan).
+# Cache discovered plugins per process and discovery scope. Dashboard manifests
+# can include project-controlled JavaScript, so a cache populated in one cwd or
+# with the project gate enabled must not survive a scope switch.
 _dashboard_plugins_cache: Optional[list] = None
+_dashboard_plugins_cache_fingerprint: Optional[tuple[str, str, str, bool]] = None
+_dashboard_plugins_cache_lock = threading.RLock()
+
+
+def _dashboard_path_identity(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except (OSError, RuntimeError):
+        return str(path.absolute())
+
+
+def _dashboard_plugins_discovery_fingerprint() -> tuple[str, str, str, bool]:
+    """Return every process value that changes dashboard plugin scope."""
+    from hermes_cli.plugins import get_bundled_plugins_dir
+
+    return (
+        _dashboard_path_identity(get_process_hermes_home() / "plugins"),
+        _dashboard_path_identity(get_bundled_plugins_dir()),
+        _dashboard_path_identity(Path.cwd()),
+        env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"),
+    )
 
 
 def _get_dashboard_plugins(force_rescan: bool = False) -> list:
-    global _dashboard_plugins_cache
-    if _dashboard_plugins_cache is None or force_rescan:
-        _dashboard_plugins_cache = _discover_dashboard_plugins()
-    elif _dashboard_plugins_cache:
-        if any(not Path(p["_dir"]).is_dir() for p in _dashboard_plugins_cache):
+    global _dashboard_plugins_cache, _dashboard_plugins_cache_fingerprint
+    fingerprint = _dashboard_plugins_discovery_fingerprint()
+    with _dashboard_plugins_cache_lock:
+        if (
+            _dashboard_plugins_cache is None
+            or force_rescan
+            or _dashboard_plugins_cache_fingerprint != fingerprint
+        ):
             _dashboard_plugins_cache = _discover_dashboard_plugins()
-    return _dashboard_plugins_cache
+            _dashboard_plugins_cache_fingerprint = fingerprint
+        elif _dashboard_plugins_cache:
+            if any(not Path(p["_dir"]).is_dir() for p in _dashboard_plugins_cache):
+                _dashboard_plugins_cache = _discover_dashboard_plugins()
+                _dashboard_plugins_cache_fingerprint = fingerprint
+        return _dashboard_plugins_cache
+
+
+def _dashboard_plugin_root(plugin: dict) -> Optional[Path]:
+    """Return the runtime plugin root represented by a dashboard manifest."""
+    raw_dashboard_dir = plugin.get("_dir")
+    raw_plugin_dir = plugin.get("_plugin_dir")
+    try:
+        if raw_dashboard_dir:
+            return Path(raw_dashboard_dir).resolve().parent
+        if raw_plugin_dir:
+            return Path(raw_plugin_dir).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return None
+
+
+def _dashboard_plugin_identity(
+    plugin: dict,
+    runtime_entries: Optional[list] = None,
+) -> tuple[str, str, str, str, bool]:
+    """Map dashboard metadata to the runtime plugin by resolved root path.
+
+    Dashboard and runtime manifests may intentionally use different display
+    names.  Path identity keeps API, asset, list, and management decisions on
+    the same canonical key without guessing from a potentially ambiguous name.
+    """
+    if runtime_entries is None:
+        try:
+            runtime_entries = _discover_dashboard_runtime_entries()
+        except Exception:
+            runtime_entries = []
+
+    plugin_root = _dashboard_plugin_root(plugin)
+    if plugin_root is not None:
+        for name, _version, _description, source, path, key, kind in runtime_entries:
+            try:
+                if Path(path).resolve() == plugin_root:
+                    return name, key, source, kind, True
+            except (OSError, RuntimeError, TypeError, ValueError):
+                continue
+
+    runtime_name = plugin.get("_runtime_name")
+    runtime_key = plugin.get("_runtime_key")
+    runtime_source = plugin.get("_runtime_source")
+    runtime_kind = plugin.get("_runtime_kind")
+    runtime_managed = bool(plugin.get("_runtime_managed"))
+    if all(
+        isinstance(value, str) and value
+        for value in (runtime_name, runtime_key, runtime_source, runtime_kind)
+    ):
+        if runtime_managed:
+            # A runtime-backed dashboard is active only for the current
+            # canonical winner. This recomputation deliberately ignores the
+            # cached _runtime_winner marker so cwd/profile/source changes are
+            # fail-closed even when a stale plugin dict reaches this helper.
+            for entry in runtime_entries:
+                if str(entry[5]) != runtime_key:
+                    continue
+                try:
+                    winner_root = Path(entry[4]).resolve()
+                except (OSError, RuntimeError, TypeError, ValueError):
+                    return (
+                        runtime_name,
+                        runtime_key,
+                        runtime_source,
+                        runtime_kind,
+                        False,
+                    )
+                return (
+                    runtime_name,
+                    runtime_key,
+                    runtime_source,
+                    runtime_kind,
+                    plugin_root is not None and winner_root == plugin_root,
+                )
+            return (
+                runtime_name,
+                runtime_key,
+                runtime_source,
+                runtime_kind,
+                False,
+            )
+        return runtime_name, runtime_key, runtime_source, runtime_kind, True
+
+    # Dashboard-only bundled extensions retain their existing default-on
+    # behavior. Unknown/user/project extensions are fail-closed and opt-in.
+    name = str(plugin.get("name") or "")
+    source = str(plugin.get("source") or "user")
+    kind = "backend" if source == "bundled" else "standalone"
+    return name, name, source, kind, True
+
+
+def _dashboard_plugin_source_scope_active(plugin: dict, source: str) -> bool:
+    """Reject cached project extensions outside the current opt-in scope."""
+    if source != "project":
+        return True
+    if not env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
+        return False
+
+    plugin_root = _dashboard_plugin_root(plugin)
+    if plugin_root is None:
+        return False
+    try:
+        project_root = (Path.cwd() / ".hermes" / "plugins").resolve()
+        plugin_root.relative_to(project_root)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def _dashboard_plugin_status(
+    plugin: dict,
+    runtime_entries: Optional[list] = None,
+    activation=None,
+) -> str:
+    """Return the canonical activation status for a dashboard extension."""
+    if activation is None:
+        try:
+            from hermes_cli.config import load_plugin_activation_state
+
+            activation = load_plugin_activation_state()
+        except Exception:
+            return "not enabled"
+
+    name, key, source, kind, is_winner = _dashboard_plugin_identity(
+        plugin,
+        runtime_entries,
+    )
+    if not is_winner or not _dashboard_plugin_source_scope_active(plugin, source):
+        return "not enabled"
+    return activation.status(
+        name=name,
+        key=key,
+        source=source,
+        kind=kind,
+    )
+
+
+def _dashboard_plugin_is_active(
+    plugin: dict,
+    runtime_entries: Optional[list] = None,
+    activation=None,
+) -> bool:
+    return (
+        _dashboard_plugin_status(plugin, runtime_entries, activation)
+        == "enabled"
+    )
 
 
 @app.get("/api/dashboard/plugins")
@@ -16928,34 +17216,32 @@ async def get_dashboard_plugins():
         plugins = _get_dashboard_plugins()
         # Read user's hidden plugins list from config.
         config = load_config()
-        hidden: list = cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
-        # Gate: only serve user plugins that are in plugins.enabled and not
-        # in plugins.disabled.  This prevents the frontend from loading JS/CSS
-        # from plugins the user has not explicitly activated.  (#46435)
+        hidden_values = cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
+        hidden = {
+            value for value in hidden_values
+            if isinstance(value, str) and value
+        }
         try:
-            from hermes_cli.plugins_cmd import _get_enabled_set, _get_disabled_set
-            enabled_set = _get_enabled_set()
-            disabled_set = _get_disabled_set()
-        except Exception:
-            enabled_set = set()
-            disabled_set = set()
-        return plugins, hidden, enabled_set, disabled_set
+            from hermes_cli.plugins_cmd import _discover_all_plugins
+            from hermes_cli.config import load_plugin_activation_state
 
-    plugins, hidden, enabled_set, disabled_set = await asyncio.to_thread(_run)
+            runtime_entries = _discover_all_plugins()
+            activation = load_plugin_activation_state()
+        except Exception:
+            runtime_entries = []
+            activation = None
+        return plugins, hidden, runtime_entries, activation
+
+    plugins, hidden, runtime_entries, activation = await asyncio.to_thread(_run)
 
     def _is_active(p: dict) -> bool:
-        name = p.get("name", "")
-        if name in hidden:
+        name, key, _source, _kind, _is_winner = _dashboard_plugin_identity(
+            p,
+            runtime_entries,
+        )
+        if {name, key, str(p.get("name") or "")} & hidden:
             return False
-        if p.get("source") == "user":
-            if name in disabled_set:
-                return False
-            if name not in enabled_set:
-                return False
-        elif p.get("source") == "bundled":
-            if name in disabled_set:
-                return False
-        return True
+        return _dashboard_plugin_is_active(p, runtime_entries, activation)
 
     # Strip internal fields before sending to frontend.
     return [
@@ -17050,16 +17336,19 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
         _get_current_context_engine,
         _get_current_memory_provider,
         _discover_context_engines,
-        _get_disabled_set,
-        _get_enabled_set,
         _read_manifest as _read_plugin_manifest_at,
     )
 
     dashboard_list = _get_dashboard_plugins()
-    dash_by_name = {str(p["name"]): p for p in dashboard_list}
+    dash_by_root = {
+        root: plugin
+        for plugin in dashboard_list
+        if (root := _dashboard_plugin_root(plugin)) is not None
+    }
+    runtime_entries = _discover_all_plugins()
+    from hermes_cli.config import load_plugin_activation_state
 
-    disabled_set = _get_disabled_set()
-    enabled_set = _get_enabled_set()
+    activation = load_plugin_activation_state()
 
     # Read user-hidden plugins from config for the user_hidden field.
     config = load_config()
@@ -17068,23 +17357,28 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
     plugins_root_resolved = (get_hermes_home() / "plugins").resolve()
     rows: List[Dict[str, Any]] = []
 
-    for name, version, description, source, dir_str, key in _discover_all_plugins():
-        # Both the path-derived key (nested category plugins) and the bare
-        # manifest name count for enabled/disabled state, matching the runtime
-        # loader's back-compat lookup.
-        aliases = {name}
-        if key:
-            aliases.add(key)
-        if aliases & disabled_set:
-            runtime_status = "disabled"
-        elif aliases & enabled_set:
-            runtime_status = "enabled"
-        else:
-            runtime_status = "inactive"
-
+    matched_dashboard_roots: set[Path] = set()
+    for name, version, description, source, dir_str, key, kind in runtime_entries:
         dir_path = Path(dir_str)
-        dm = dash_by_name.get(name)
+        try:
+            runtime_root = dir_path.resolve()
+        except (OSError, RuntimeError, ValueError):
+            runtime_root = dir_path
+        dm = dash_by_root.get(runtime_root)
+        if dm is not None:
+            matched_dashboard_roots.add(runtime_root)
         has_dash_manifest = dm is not None or (dir_path / "dashboard" / "manifest.json").exists()
+        runtime_status = _dashboard_plugin_status(
+            dm or {
+                "name": name,
+                "source": source,
+                "_plugin_dir": str(dir_path),
+            },
+            runtime_entries,
+            activation,
+        )
+        if runtime_status == "not enabled":
+            runtime_status = "inactive"
 
         under_user_tree = False
         try:
@@ -17143,11 +17437,10 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
             "user_hidden": name in hidden_plugins,
         })
 
-    agent_names = {r["name"] for r in rows}
     orphan_dashboard = [
         _strip_dashboard_manifest(p)
         for p in dashboard_list
-        if str(p["name"]) not in agent_names
+        if _dashboard_plugin_root(p) not in matched_dashboard_roots
     ]
 
     memory_providers = _discover_memory_provider_statuses()
@@ -17355,21 +17648,8 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
     if not plugin:
         raise HTTPException(status_code=404, detail="Plugin not found")
 
-    # Gate: user plugins must be enabled to serve assets;
-    # bundled plugins must not be explicitly disabled.
-    try:
-        from hermes_cli.plugins_cmd import _get_enabled_set, _get_disabled_set
-        enabled_set = _get_enabled_set()
-        disabled_set = _get_disabled_set()
-    except Exception:
-        enabled_set = set()
-        disabled_set = set()
-    if plugin.get("source") == "user":
-        if plugin_name in disabled_set or plugin_name not in enabled_set:
-            raise HTTPException(status_code=404, detail="Plugin not found")
-    elif plugin.get("source") == "bundled":
-        if plugin_name in disabled_set:
-            raise HTTPException(status_code=404, detail="Plugin not found")
+    if not _dashboard_plugin_is_active(plugin):
+        raise HTTPException(status_code=404, detail="Plugin not found")
 
     base = Path(plugin["_dir"])
     target = (base / file_path).resolve()
@@ -17438,44 +17718,31 @@ def _mount_plugin_api_routes():
     execution vector that bypasses the user's intent. (#46435,
     GHSA-mcfc-hp25-cjv7)
     """
-    # Load the enabled/disabled sets once for the loop.
     try:
-        from hermes_cli.plugins_cmd import _get_enabled_set, _get_disabled_set
-        enabled_set = _get_enabled_set()
-        disabled_set = _get_disabled_set()
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+        from hermes_cli.config import load_plugin_activation_state
+
+        runtime_entries = _discover_all_plugins()
+        activation = load_plugin_activation_state()
     except Exception:
-        enabled_set = set()
-        disabled_set = set()
+        runtime_entries = []
+        activation = None
 
     for plugin in _get_dashboard_plugins():
         api_file_name = plugin.get("_api_file")
         if not api_file_name:
             continue
         plugin_name = plugin.get("name", "")
-        # Gate: user plugins must be in plugins.enabled and not in
-        # plugins.disabled before we import their Python code.
-        # Bundled plugins are trusted (they ship with the release) but
-        # still respect an explicit disable.
-        if plugin.get("source") == "user":
-            if plugin_name in disabled_set:
-                _log.debug(
-                    "Plugin %s: skipping API mount (explicitly disabled)",
-                    plugin_name,
-                )
-                continue
-            if plugin_name not in enabled_set:
-                _log.debug(
-                    "Plugin %s: skipping API mount (not in plugins.enabled)",
-                    plugin_name,
-                )
-                continue
-        elif plugin.get("source") == "bundled":
-            if plugin_name in disabled_set:
-                _log.debug(
-                    "Plugin %s: skipping API mount (explicitly disabled)",
-                    plugin_name,
-                )
-                continue
+        if not _dashboard_plugin_is_active(
+            plugin,
+            runtime_entries,
+            activation,
+        ):
+            _log.debug(
+                "Plugin %s: skipping API mount (inactive by plugin policy)",
+                plugin_name,
+            )
+            continue
         if plugin.get("source") == "project":
             _log.warning(
                 "Plugin %s: ignoring backend api=%s (project plugins may "

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16810,6 +16810,22 @@ def _discover_dashboard_runtime_entries() -> list:
         reset_hermes_home_override(token)
 
 
+def _discover_dashboard_plugin_entries() -> list:
+    """Discover display winners in the dashboard process-home scope."""
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from hermes_cli.config import load_plugin_activation_state
+    from hermes_cli.plugins_cmd import _discover_plugin_display_entries
+
+    token = set_hermes_home_override(get_process_hermes_home())
+    try:
+        return _discover_plugin_display_entries(load_plugin_activation_state())
+    finally:
+        reset_hermes_home_override(token)
+
+
 def _load_dashboard_plugin_activation_state():
     """Load activation config in the same process-home scope as discovery."""
     from hermes_constants import (
@@ -17394,7 +17410,6 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
 
     started_at = time.monotonic()
     from hermes_cli.plugins_cmd import (
-        _discover_all_plugins,
         _get_current_context_engine,
         _get_current_memory_provider,
         _discover_context_engines,
@@ -17407,7 +17422,7 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
         for plugin in dashboard_list
         if (root := _dashboard_plugin_root(plugin)) is not None
     }
-    runtime_entries = _discover_all_plugins()
+    runtime_entries = _discover_dashboard_plugin_entries()
     try:
         active_runtime_entries = _discover_dashboard_runtime_entries()
         activation = _load_dashboard_plugin_activation_state()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16810,18 +16810,18 @@ def _discover_dashboard_runtime_entries() -> list:
         reset_hermes_home_override(token)
 
 
-def _discover_dashboard_plugin_entries() -> list:
-    """Discover display winners in the dashboard process-home scope."""
+def _discover_dashboard_plugin_records() -> list:
+    """Discover display winners and resolved status in process-home scope."""
     from hermes_constants import (
         reset_hermes_home_override,
         set_hermes_home_override,
     )
     from hermes_cli.config import load_plugin_activation_state
-    from hermes_cli.plugins_cmd import _discover_plugin_display_entries
+    from hermes_cli.plugins_cmd import _discover_plugin_display_records
 
     token = set_hermes_home_override(get_process_hermes_home())
     try:
-        return _discover_plugin_display_entries(load_plugin_activation_state())
+        return _discover_plugin_display_records(load_plugin_activation_state())
     finally:
         reset_hermes_home_override(token)
 
@@ -17422,7 +17422,7 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
         for plugin in dashboard_list
         if (root := _dashboard_plugin_root(plugin)) is not None
     }
-    runtime_entries = _discover_dashboard_plugin_entries()
+    runtime_records = _discover_dashboard_plugin_records()
     try:
         active_runtime_entries = _discover_dashboard_runtime_entries()
         activation = _load_dashboard_plugin_activation_state()
@@ -17441,7 +17441,8 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
     rows: List[Dict[str, Any]] = []
 
     matched_dashboard_roots: set[Path] = set()
-    for name, version, description, source, dir_str, key, kind in runtime_entries:
+    for entry, resolved_status in runtime_records:
+        name, version, description, source, dir_str, key, kind = entry
         dir_path = Path(dir_str)
         try:
             runtime_root = dir_path.resolve()
@@ -17451,20 +17452,23 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
         if dm is not None:
             matched_dashboard_roots.add(runtime_root)
         has_dash_manifest = dm is not None or (dir_path / "dashboard" / "manifest.json").exists()
-        runtime_status = _dashboard_plugin_status(
-            dm or {
-                "name": name,
-                "source": source,
-                "_plugin_dir": str(dir_path),
-                "_runtime_name": name,
-                "_runtime_key": key,
-                "_runtime_source": source,
-                "_runtime_kind": kind,
-                "_runtime_managed": True,
-            },
-            active_runtime_entries,
-            activation,
-        )
+        if resolved_status == "disabled":
+            runtime_status = "disabled"
+        else:
+            runtime_status = _dashboard_plugin_status(
+                dm or {
+                    "name": name,
+                    "source": source,
+                    "_plugin_dir": str(dir_path),
+                    "_runtime_name": name,
+                    "_runtime_key": key,
+                    "_runtime_source": source,
+                    "_runtime_kind": kind,
+                    "_runtime_managed": True,
+                },
+                active_runtime_entries,
+                activation,
+            )
         if runtime_status == "not enabled":
             runtime_status = "inactive"
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16850,6 +16850,7 @@ def _discover_dashboard_plugins() -> list:
     3. Project plugins: ./.hermes/plugins/  (only if HERMES_ENABLE_PROJECT_PLUGINS)
     """
     from hermes_cli.plugins import get_bundled_plugins_dir
+    from hermes_cli.plugins_cmd import _read_manifest_info
     bundled_root = get_bundled_plugins_dir()
     try:
         runtime_entries = _discover_dashboard_runtime_entries()
@@ -16924,11 +16925,20 @@ def _discover_dashboard_plugins() -> list:
                 runtime_manifest = child / "plugin.yaml"
                 if not runtime_manifest.exists():
                     runtime_manifest = child / "plugin.yml"
+                portable_manifest = child / "plugin.json"
                 # Memory providers have an exclusive selector and are not
                 # candidates in general runtime winner discovery. Preserve
                 # their dashboard-only treatment instead of misclassifying
                 # them as a missing (therefore inactive) runtime winner.
-                runtime_managed = runtime_manifest.exists() and (
+                # A portable manifest remains runtime-managed even when it is
+                # disabled (and therefore absent from ``runtime_entries``) or
+                # malformed. In either case it must not fall back to the
+                # dashboard-only identity and bypass its canonical gate.
+                runtime_managed = (
+                    runtime_manifest.exists()
+                    or portable_manifest.exists()
+                    or portable_manifest.is_symlink()
+                ) and (
                     plugins_root != bundled_root / "memory"
                 )
 
@@ -16943,23 +16953,14 @@ def _discover_dashboard_plugins() -> list:
                     # prefix=""). This also lets us identify a losing bundled
                     # dashboard whose user/project winner has no dashboard.
                     runtime_name = child.name
-                    runtime_kind = "standalone"
-                    try:
-                        manifest_data = yaml.safe_load(
-                            runtime_manifest.read_text(encoding="utf-8")
-                        ) or {}
-                        if isinstance(manifest_data, dict):
-                            manifest_name = manifest_data.get("name")
-                            if isinstance(manifest_name, str) and manifest_name.strip():
-                                runtime_name = manifest_name.strip()
-                            manifest_kind = manifest_data.get("kind")
-                            if isinstance(manifest_kind, str) and manifest_kind.strip():
-                                runtime_kind = manifest_kind.strip().lower()
-                    except Exception:
-                        # Malformed runtime identity is not a dashboard-only
-                        # escape hatch. Keep it runtime-managed and fail closed.
-                        pass
                     runtime_key = runtime_name
+                    runtime_kind = "standalone"
+                    manifest_info = _read_manifest_info(child, "")
+                    if manifest_info is not None:
+                        runtime_name = str(manifest_info[0])
+                        runtime_key = str(manifest_info[3])
+                        if len(manifest_info) > 4:
+                            runtime_kind = str(manifest_info[4])
                     runtime_source = (
                         "git" if source == "user" and (child / ".git").exists()
                         else source

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16789,16 +16789,38 @@ def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional
 
 
 def _discover_dashboard_runtime_entries() -> list:
-    """Discover runtime winners in the dashboard's process-home scope."""
+    """Discover active runtime winners in the dashboard process-home scope."""
     from hermes_constants import (
         reset_hermes_home_override,
         set_hermes_home_override,
     )
-    from hermes_cli.plugins_cmd import _discover_all_plugins
+    from hermes_cli.config import load_plugin_activation_state
+    from hermes_cli.plugins_cmd import (
+        _discover_plugin_candidates,
+        _select_active_plugin_entries,
+    )
 
     token = set_hermes_home_override(get_process_hermes_home())
     try:
-        return _discover_all_plugins()
+        return _select_active_plugin_entries(
+            _discover_plugin_candidates(),
+            load_plugin_activation_state(),
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _load_dashboard_plugin_activation_state():
+    """Load activation config in the same process-home scope as discovery."""
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from hermes_cli.config import load_plugin_activation_state
+
+    token = set_hermes_home_override(get_process_hermes_home())
+    try:
+        return load_plugin_activation_state()
     finally:
         reset_hermes_home_override(token)
 
@@ -16815,13 +16837,16 @@ def _discover_dashboard_plugins() -> list:
     bundled_root = get_bundled_plugins_dir()
     try:
         runtime_entries = _discover_dashboard_runtime_entries()
-        runtime_discovery_ok = True
     except Exception:
         # A dashboard extension backed by a runtime plugin must never become
         # executable merely because canonical runtime discovery failed. Pure
         # dashboard-only extensions still use the activation policy below.
         runtime_entries = []
-        runtime_discovery_ok = False
+
+    try:
+        activation = _load_dashboard_plugin_activation_state()
+    except Exception:
+        activation = None
 
     runtime_by_root: Dict[Path, tuple] = {}
     runtime_by_key: Dict[str, tuple] = {}
@@ -16833,12 +16858,10 @@ def _discover_dashboard_plugins() -> list:
         runtime_by_root[root] = entry
         runtime_by_key[str(entry[5])] = entry
 
-    # Use the same source precedence as PluginManager/_discover_all_plugins:
-    # bundled first, then user, then project. Later non-bundled candidates
-    # replace earlier candidates on canonical-key collision. A higher-priority
-    # plugin therefore suppresses a lower-priority dashboard even when the
-    # winner is inactive (there is no fallback to executable bundled UI/code).
-    winners: Dict[str, dict] = {}
+    # Retain all dashboard candidates until their canonical-key group can be
+    # resolved against the active runtime winner. This permits a bundled
+    # fallback when a higher-priority copy is installed but inactive.
+    candidates_by_key: Dict[str, List[dict]] = {}
     # User dashboard plugins are a dashboard-owned asset (same category as
     # theme YAML): resolve them from the process launch home so they don't
     # vanish when a request is scoped to another profile via a context-local
@@ -16898,7 +16921,6 @@ def _discover_dashboard_plugins() -> list:
                     runtime_source = str(runtime_entry[3])
                     runtime_key = str(runtime_entry[5])
                     runtime_kind = str(runtime_entry[6])
-                    runtime_winner = True
                 elif runtime_managed:
                     # Flat dashboard plugins use the manifest name as their
                     # canonical runtime key, matching _read_manifest_info(...,
@@ -16926,16 +16948,6 @@ def _discover_dashboard_plugins() -> list:
                         "git" if source == "user" and (child / ".git").exists()
                         else source
                     )
-                    winning_entry = runtime_by_key.get(runtime_key)
-                    if winning_entry is None:
-                        runtime_winner = False
-                    else:
-                        try:
-                            winning_root = Path(winning_entry[4]).resolve()
-                        except (OSError, RuntimeError, TypeError, ValueError):
-                            runtime_winner = False
-                        else:
-                            runtime_winner = winning_root == plugin_root
                 else:
                     # Dashboard-only extensions have no Python runtime
                     # manifest. They still follow source activation policy and
@@ -16944,7 +16956,6 @@ def _discover_dashboard_plugins() -> list:
                     runtime_key = name
                     runtime_source = source
                     runtime_kind = "backend" if source == "bundled" else "standalone"
-                    runtime_winner = True
                 # Tab options: ``path`` + ``position`` for a new tab, optional
                 # ``override`` to replace a built-in route, and ``hidden`` to
                 # register the plugin component/slots without adding a tab
@@ -17002,26 +17013,62 @@ def _discover_dashboard_plugins() -> list:
                     "_runtime_source": runtime_source,
                     "_runtime_kind": runtime_kind,
                     "_runtime_managed": runtime_managed,
-                    "_runtime_winner": runtime_winner and runtime_discovery_ok
-                    if runtime_managed else runtime_winner,
                 }
 
-                # _discover_all_plugins keeps the first bundled candidate for
-                # a duplicate key, while later user/project sources override.
-                if runtime_key in winners and source == "bundled":
-                    continue
-                winners[runtime_key] = candidate
+                candidates_by_key.setdefault(runtime_key, []).append(candidate)
             except Exception as exc:
                 _log.warning("Bad dashboard plugin manifest %s: %s", manifest_file, exc)
                 continue
-    return list(winners.values())
+
+    from hermes_cli.plugins import resolve_plugin_candidate_winner
+
+    def _candidate_status(candidate: dict) -> str:
+        if activation is None:
+            return "not enabled"
+        status = activation.status(
+            name=str(candidate.get("_runtime_name") or ""),
+            key=str(candidate.get("_runtime_key") or ""),
+            source=str(candidate.get("_runtime_source") or "user"),
+            kind=str(candidate.get("_runtime_kind") or "standalone"),
+        )
+        if status == "disabled" or not candidate.get("_runtime_managed"):
+            return status
+
+        active_entry = runtime_by_key.get(str(candidate.get("_runtime_key") or ""))
+        candidate_root = _dashboard_plugin_root(candidate)
+        if active_entry is None or candidate_root is None:
+            return "not enabled"
+        try:
+            active_root = Path(active_entry[4]).resolve()
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return "not enabled"
+        return status if active_root == candidate_root else "not enabled"
+
+    selected: List[dict] = []
+    for candidates in candidates_by_key.values():
+        selection = resolve_plugin_candidate_winner(candidates, _candidate_status)
+        if selection is not None:
+            selected.append(selection[0])
+
+    # Route names are the public asset/API namespace. Two canonical plugins
+    # claiming one name are ambiguous, so every claimant is marked fail-closed
+    # rather than letting discovery order choose whose gate protects the route.
+    route_name_counts: Dict[str, int] = {}
+    for candidate in selected:
+        route_name = str(candidate.get("name") or "")
+        route_name_counts[route_name] = route_name_counts.get(route_name, 0) + 1
+    for candidate in selected:
+        if route_name_counts.get(str(candidate.get("name") or ""), 0) > 1:
+            candidate["_route_name_collision"] = True
+
+    return selected
 
 
 # Cache discovered plugins per process and discovery scope. Dashboard manifests
 # can include project-controlled JavaScript, so a cache populated in one cwd or
 # with the project gate enabled must not survive a scope switch.
 _dashboard_plugins_cache: Optional[list] = None
-_dashboard_plugins_cache_fingerprint: Optional[tuple[str, str, str, bool]] = None
+_dashboard_plugins_cache_fingerprint: Optional[tuple] = None
 _dashboard_plugins_cache_lock = threading.RLock()
 
 
@@ -17032,15 +17079,31 @@ def _dashboard_path_identity(path: Path) -> str:
         return str(path.absolute())
 
 
-def _dashboard_plugins_discovery_fingerprint() -> tuple[str, str, str, bool]:
+def _dashboard_plugins_discovery_fingerprint() -> tuple:
     """Return every process value that changes dashboard plugin scope."""
     from hermes_cli.plugins import get_bundled_plugins_dir
+
+    try:
+        activation = _load_dashboard_plugin_activation_state()
+        enabled_identity = (
+            None
+            if activation.enabled is None
+            else tuple(sorted(activation.enabled))
+        )
+        activation_identity = (
+            enabled_identity,
+            tuple(sorted(activation.disabled)),
+            bool(activation.safe_mode),
+        )
+    except Exception:
+        activation_identity = ("unavailable",)
 
     return (
         _dashboard_path_identity(get_process_hermes_home() / "plugins"),
         _dashboard_path_identity(get_bundled_plugins_dir()),
         _dashboard_path_identity(Path.cwd()),
         env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"),
+        activation_identity,
     )
 
 
@@ -17112,9 +17175,8 @@ def _dashboard_plugin_identity(
     ):
         if runtime_managed:
             # A runtime-backed dashboard is active only for the current
-            # canonical winner. This recomputation deliberately ignores the
-            # cached _runtime_winner marker so cwd/profile/source changes are
-            # fail-closed even when a stale plugin dict reaches this helper.
+            # canonical active winner. Recompute from root identity so
+            # cwd/profile/source changes fail closed for stale plugin dicts.
             for entry in runtime_entries:
                 if str(entry[5]) != runtime_key:
                     continue
@@ -17176,11 +17238,11 @@ def _dashboard_plugin_status(
     activation=None,
 ) -> str:
     """Return the canonical activation status for a dashboard extension."""
+    if plugin.get("_route_name_collision"):
+        return "not enabled"
     if activation is None:
         try:
-            from hermes_cli.config import load_plugin_activation_state
-
-            activation = load_plugin_activation_state()
+            activation = _load_dashboard_plugin_activation_state()
         except Exception:
             return "not enabled"
 
@@ -17188,14 +17250,17 @@ def _dashboard_plugin_status(
         plugin,
         runtime_entries,
     )
-    if not is_winner or not _dashboard_plugin_source_scope_active(plugin, source):
-        return "not enabled"
-    return activation.status(
+    status = activation.status(
         name=name,
         key=key,
         source=source,
         kind=kind,
     )
+    if status == "disabled":
+        return status
+    if not is_winner or not _dashboard_plugin_source_scope_active(plugin, source):
+        return "not enabled"
+    return status
 
 
 def _dashboard_plugin_is_active(
@@ -17222,11 +17287,8 @@ async def get_dashboard_plugins():
             if isinstance(value, str) and value
         }
         try:
-            from hermes_cli.plugins_cmd import _discover_all_plugins
-            from hermes_cli.config import load_plugin_activation_state
-
-            runtime_entries = _discover_all_plugins()
-            activation = load_plugin_activation_state()
+            runtime_entries = _discover_dashboard_runtime_entries()
+            activation = _load_dashboard_plugin_activation_state()
         except Exception:
             runtime_entries = []
             activation = None
@@ -17346,13 +17408,19 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
         if (root := _dashboard_plugin_root(plugin)) is not None
     }
     runtime_entries = _discover_all_plugins()
-    from hermes_cli.config import load_plugin_activation_state
-
-    activation = load_plugin_activation_state()
+    try:
+        active_runtime_entries = _discover_dashboard_runtime_entries()
+        activation = _load_dashboard_plugin_activation_state()
+    except Exception:
+        active_runtime_entries = []
+        activation = None
 
     # Read user-hidden plugins from config for the user_hidden field.
     config = load_config()
-    hidden_plugins: list = cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
+    hidden_values = cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
+    hidden_plugins = {
+        value for value in hidden_values if isinstance(value, str) and value
+    }
 
     plugins_root_resolved = (get_hermes_home() / "plugins").resolve()
     rows: List[Dict[str, Any]] = []
@@ -17373,8 +17441,13 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
                 "name": name,
                 "source": source,
                 "_plugin_dir": str(dir_path),
+                "_runtime_name": name,
+                "_runtime_key": key,
+                "_runtime_source": source,
+                "_runtime_kind": kind,
+                "_runtime_managed": True,
             },
-            runtime_entries,
+            active_runtime_entries,
             activation,
         )
         if runtime_status == "not enabled":
@@ -17423,6 +17496,7 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
 
         rows.append({
             "name": name,
+            "key": key,
             "version": version or "",
             "description": description or "",
             "source": source,
@@ -17434,7 +17508,10 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
             "can_update_git": can_remove_update and (Path(dir_str) / ".git").exists(),
             "auth_required": auth_required,
             "auth_command": auth_command,
-            "user_hidden": name in hidden_plugins,
+            "user_hidden": bool(
+                {name, key, str(dm.get("name") or "") if dm else ""}
+                & hidden_plugins
+            ),
         })
 
     orphan_dashboard = [
@@ -17719,11 +17796,8 @@ def _mount_plugin_api_routes():
     GHSA-mcfc-hp25-cjv7)
     """
     try:
-        from hermes_cli.plugins_cmd import _discover_all_plugins
-        from hermes_cli.config import load_plugin_activation_state
-
-        runtime_entries = _discover_all_plugins()
-        activation = load_plugin_activation_state()
+        runtime_entries = _discover_dashboard_runtime_entries()
+        activation = _load_dashboard_plugin_activation_state()
     except Exception:
         runtime_entries = []
         activation = None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -565,6 +565,12 @@ async def host_header_middleware(request: Request, call_next):
     return await call_next(request)
 
 
+# FastAPI routers stay mounted for the lifetime of the process.  Keep the
+# exact dashboard record whose router was mounted so request-time policy never
+# authorizes a different same-name winner discovered after a config refresh.
+_mounted_plugin_api_owners: dict[str, dict] = {}
+
+
 @app.middleware("http")
 async def _plugin_api_runtime_gate(request: Request, call_next):
     """Block requests to disabled plugin API routes at request time.
@@ -599,18 +605,10 @@ async def _plugin_api_runtime_gate(request: Request, call_next):
             if len(parts) >= 4:
                 plugin_name = parts[3]
                 if plugin_name:
-                    # Determine plugin source.  Check the cached plugin list;
-                    # if not found, assume user plugin (safe default — blocks).
-                    plugins = _get_dashboard_plugins()
-                    plugin = next(
-                        (p for p in plugins if p.get("name") == plugin_name),
-                        None,
-                    )
-                    candidate = plugin or {
-                        "name": plugin_name,
-                        "source": "user",
-                    }
-                    if not _dashboard_plugin_is_active(candidate):
+                    mounted_owner = _mounted_plugin_api_owners.get(plugin_name)
+                    if mounted_owner is None or not _dashboard_plugin_is_active(
+                        mounted_owner
+                    ):
                         return JSONResponse(
                             status_code=404,
                             content={"detail": "Plugin not found"},
@@ -17827,6 +17825,12 @@ def _mount_plugin_api_routes():
         if not api_file_name:
             continue
         plugin_name = plugin.get("name", "")
+        if plugin_name in _mounted_plugin_api_owners:
+            _log.debug(
+                "Plugin %s: skipping API mount (namespace already mounted)",
+                plugin_name,
+            )
+            continue
         if not _dashboard_plugin_is_active(
             plugin,
             runtime_entries,
@@ -17887,6 +17891,10 @@ def _mount_plugin_api_routes():
                 _log.warning("Plugin %s api file has no 'router' attribute", plugin["name"])
                 continue
             app.include_router(router, prefix=f"/api/plugins/{plugin['name']}")
+            # Route matching is first-wins.  Preserve the first successful
+            # mount for this public namespace even if a later manual rescan
+            # attempts to add another same-name router.
+            _mounted_plugin_api_owners[plugin_name] = dict(plugin)
             _log.info("Mounted plugin API routes: /api/plugins/%s/", plugin["name"])
         except Exception as exc:
             _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)

--- a/plugins/model-providers/README.md
+++ b/plugins/model-providers/README.md
@@ -16,14 +16,16 @@ plugins/model-providers/
 
 ## How discovery works
 
-`providers/__init__.py._discover_providers()` scans this directory (and
-`$HERMES_HOME/plugins/model-providers/`) the first time anything calls
-`get_provider_profile()` or `list_providers()`. Each `__init__.py` is
-imported and expected to call `providers.register_provider(profile)`.
+`providers/__init__.py._discover_providers()` scans this directory,
+`$HERMES_HOME/plugins/model-providers/`, and (when explicitly enabled)
+`./.hermes/plugins/model-providers/` the first time anything calls
+`get_provider_profile()` or `list_providers()`. It reads each manifest and
+checks the canonical plugin activation policy before importing `__init__.py`.
+User and project providers are opt-in through `plugins.enabled`; bundled
+providers are enabled by default and still respect `plugins.disabled`.
 
-User plugins at `$HERMES_HOME/plugins/model-providers/<name>/` override
-bundled plugins of the same name — last-writer-wins in
-`register_provider()`. Drop a file there to replace a built-in.
+An active user/project plugin with the same canonical key overrides the
+bundled plugin. Merely installing third-party code does not import it.
 
 ## Adding a new provider
 
@@ -55,6 +57,13 @@ bundled plugins of the same name — last-writer-wins in
    version: 1.0.0
    description: Short sentence about the provider
    author: Your Name
+   ```
+
+   If one manifest registers multiple provider IDs, declare them so disabling
+   the plugin removes every derived identity:
+
+   ```yaml
+   provider_ids: [your-provider, your-provider-cn]
    ```
 
 Nothing else needs to change. `auth.py`, `config.py`, `models.py`,

--- a/plugins/model-providers/kimi-coding/plugin.yaml
+++ b/plugins/model-providers/kimi-coding/plugin.yaml
@@ -1,5 +1,6 @@
 name: kimi-coding-provider
 kind: model-provider
+provider_ids: [kimi-coding, kimi-coding-cn]
 version: 1.0.0
 description: Moonshot Kimi Coding (global + China)
 author: Nous Research

--- a/plugins/model-providers/minimax/plugin.yaml
+++ b/plugins/model-providers/minimax/plugin.yaml
@@ -1,5 +1,6 @@
 name: minimax-provider
 kind: model-provider
+provider_ids: [minimax, minimax-cn, minimax-oauth]
 version: 1.0.0
 description: MiniMax M-series (global + China + OAuth)
 author: Nous Research

--- a/plugins/model-providers/opencode-zen/plugin.yaml
+++ b/plugins/model-providers/opencode-zen/plugin.yaml
@@ -1,5 +1,6 @@
 name: opencode-zen-provider
 kind: model-provider
+provider_ids: [opencode-zen, opencode-go]
 version: 1.0.0
 description: OpenCode (Zen + Go)
 author: Nous Research

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,25 +1,26 @@
 """Provider module registry.
 
-Provider profiles can live in two places:
+Provider profiles can live in three places:
 
 1. Bundled plugins: ``plugins/model-providers/<name>/`` (shipped with hermes-agent)
 2. User plugins: ``$HERMES_HOME/plugins/model-providers/<name>/``
+3. Opt-in project plugins: ``./.hermes/plugins/model-providers/<name>/``
 
 Each plugin directory contains:
   - ``__init__.py`` — calls ``register_provider(profile)`` at import
   - ``plugin.yaml`` — manifest (name, kind: model-provider, version, description)
 
-Discovery is lazy: the first call to ``get_provider_profile()`` or
-``list_providers()`` scans both locations and imports every plugin. User
-plugins override bundled plugins on name collision (last-writer-wins), so
-third parties can monkey-patch or replace any built-in profile without
-editing the repo.
+Discovery is lazy. Manifest identity and activation are evaluated before any
+plugin code is imported. Bundled profiles are on by default; user and project
+profiles must be listed in ``plugins.enabled``. Explicit disable always wins,
+and safe mode imports bundled profiles only. Active user/project plugins
+override bundled plugins on canonical-key collision.
 
-For backward compatibility, ``providers/*.py`` files (other than ``base.py``
-and ``__init__.py``) are still discovered via ``pkgutil.iter_modules``.
-This lets out-of-tree users drop a single-file profile into an editable
-install without the plugin dir structure. New profiles should prefer the
-plugin layout.
+For backward compatibility, explicitly enabled ``providers/*.py`` files
+(other than ``base.py`` and ``__init__.py``) are still discovered via
+``pkgutil.iter_modules``. This lets out-of-tree users keep a single-file
+profile in an editable install without making it execute by default. New
+profiles should prefer the plugin layout.
 
 Usage::
 
@@ -34,9 +35,14 @@ import importlib
 import importlib.util
 import logging
 import sys
+import threading
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
+from hermes_cli.plugin_activation import PluginActivationState
 from providers.base import OMIT_TEMPERATURE, ProviderProfile  # noqa: F401
+from utils import env_var_enabled, fast_safe_load
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +50,14 @@ _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
 _PROVIDER_LIST_CACHE: list[ProviderProfile] | None = None
 _discovered = False
+_discovering = False
+_ACTIVATION_STATE: PluginActivationState | None = None
+_DISCOVERY_FINGERPRINT: tuple[object, ...] | None = None
+_DISCOVERY_LOCK = threading.RLock()
+_IMPORTED_PROVIDER_MODULES: set[str] = set()
+_PROVIDER_REFRESH_HOOKS: list[Callable[[], None]] = []
+_PLUGIN_MANAGED_PROVIDER_IDS: set[str] = set()
+_PROVIDER_PROFILE_ORIGINS: dict[str, tuple[str, str]] = {}
 
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
 _BUNDLED_PLUGINS_DIR = (
@@ -59,10 +73,11 @@ def register_provider(profile: ProviderProfile) -> None:
     bundled profiles without editing repo code.
     """
     global _PROVIDER_LIST_CACHE
-    _REGISTRY[profile.name] = profile
-    for alias in profile.aliases:
-        _ALIASES[alias] = profile.name
-    _PROVIDER_LIST_CACHE = None
+    with _DISCOVERY_LOCK:
+        _REGISTRY[profile.name] = profile
+        for alias in profile.aliases:
+            _ALIASES[alias] = profile.name
+        _PROVIDER_LIST_CACHE = None
 
 
 def get_provider_profile(name: str) -> ProviderProfile | None:
@@ -70,29 +85,143 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
 
     Returns None if the provider has no profile (falls back to generic).
     """
-    if not _discovered:
-        _discover_providers()
-    canonical = _ALIASES.get(name, name)
-    return _REGISTRY.get(canonical)
+    _ensure_providers_discovered()
+    with _DISCOVERY_LOCK:
+        canonical = _ALIASES.get(name, name)
+        return _REGISTRY.get(canonical)
 
 
 def list_providers() -> list[ProviderProfile]:
     """Return all registered provider profiles (one per canonical name)."""
     global _PROVIDER_LIST_CACHE
-    if not _discovered:
-        _discover_providers()
-    if _PROVIDER_LIST_CACHE is not None:
-        return list(_PROVIDER_LIST_CACHE)
-    # Deduplicate: _REGISTRY has canonical names; _ALIASES points to same objects
-    seen: set[int] = set()
-    result: list[ProviderProfile] = []
-    for profile in _REGISTRY.values():
-        pid = id(profile)
-        if pid not in seen:
-            seen.add(pid)
-            result.append(profile)
-    _PROVIDER_LIST_CACHE = result
-    return list(result)
+    _ensure_providers_discovered()
+    with _DISCOVERY_LOCK:
+        if _PROVIDER_LIST_CACHE is not None:
+            return list(_PROVIDER_LIST_CACHE)
+        # Deduplicate: _REGISTRY has canonical names; _ALIASES points to same objects
+        seen: set[int] = set()
+        result: list[ProviderProfile] = []
+        for profile in _REGISTRY.values():
+            pid = id(profile)
+            if pid not in seen:
+                seen.add(pid)
+                result.append(profile)
+        _PROVIDER_LIST_CACHE = result
+        return list(result)
+
+
+def register_provider_refresh_hook(callback: Callable[[], None]) -> None:
+    """Register an in-process index derived from provider discovery."""
+    with _DISCOVERY_LOCK:
+        if callback not in _PROVIDER_REFRESH_HOOKS:
+            _PROVIDER_REFRESH_HOOKS.append(callback)
+
+
+def get_provider_discovery_identity() -> tuple[object, ...]:
+    """Return the active discovery identity for downstream cache keys."""
+    _ensure_providers_discovered()
+    with _DISCOVERY_LOCK:
+        fingerprint = _DISCOVERY_FINGERPRINT or ()
+        if not fingerprint or not isinstance(
+            fingerprint[0], PluginActivationState
+        ):
+            return fingerprint
+        state = fingerprint[0]
+        return (
+            state.safe_mode,
+            None if state.enabled is None else tuple(sorted(state.enabled)),
+            tuple(sorted(state.disabled)),
+            *fingerprint[1:],
+            tuple(sorted(_PROVIDER_PROFILE_ORIGINS.items())),
+        )
+
+
+def get_provider_profile_origin(name: str) -> tuple[str, str] | None:
+    """Return ``(source, path)`` for the active provider profile."""
+    _ensure_providers_discovered()
+    with _DISCOVERY_LOCK:
+        canonical = _ALIASES.get(name, name)
+        return _PROVIDER_PROFILE_ORIGINS.get(canonical)
+
+
+def invalidate_provider_discovery() -> None:
+    """Rebuild providers and notify indexes after activation changes."""
+    global _discovered, _ACTIVATION_STATE, _DISCOVERY_FINGERPRINT
+    with _DISCOVERY_LOCK:
+        _discovered = False
+        _ACTIVATION_STATE = None
+        _DISCOVERY_FINGERPRINT = None
+    _ensure_providers_discovered()
+
+
+def is_plugin_managed_provider_id(provider_id: str) -> bool:
+    """Return whether any model-provider plugin declares *provider_id*."""
+    _ensure_providers_discovered()
+    with _DISCOVERY_LOCK:
+        return provider_id in _PLUGIN_MANAGED_PROVIDER_IDS
+
+
+def is_provider_plugin_active(provider_id: str) -> bool:
+    """Return whether a plugin-managed provider is active and registered."""
+    _ensure_providers_discovered()
+    with _DISCOVERY_LOCK:
+        if provider_id not in _PLUGIN_MANAGED_PROVIDER_IDS:
+            return True
+        return provider_id in _REGISTRY
+
+
+def _current_activation_state() -> PluginActivationState:
+    """Late-bind config.py to avoid its eager provider-injection cycle."""
+    try:
+        from hermes_cli.config import load_plugin_activation_state
+
+        return load_plugin_activation_state()
+    except Exception:
+        return PluginActivationState(
+            safe_mode=env_var_enabled("HERMES_SAFE_MODE"),
+        )
+
+
+def _ensure_providers_discovered() -> None:
+    """Refresh when activation or any discovery root changes."""
+    state = _current_activation_state()
+    user_dir = _user_plugins_dir()
+    project_dir = _project_plugins_dir()
+    fingerprint = (
+        state,
+        _path_identity(_BUNDLED_PLUGINS_DIR),
+        _path_identity(user_dir),
+        _path_identity(project_dir),
+    )
+    callbacks: tuple[Callable[[], None], ...] = ()
+    with _DISCOVERY_LOCK:
+        if _discovered and _DISCOVERY_FINGERPRINT == fingerprint:
+            return
+        _discover_providers(
+            state,
+            user_dir=user_dir,
+            project_dir=project_dir,
+            fingerprint=fingerprint,
+        )
+        callbacks = tuple(_PROVIDER_REFRESH_HOOKS)
+
+    for callback in callbacks:
+        try:
+            callback()
+        except Exception:
+            logger.warning(
+                "Failed to refresh a provider-derived registry",
+                exc_info=True,
+            )
+
+
+def _path_identity(path: Path | None) -> str:
+    if path is None:
+        return ""
+    try:
+        return str(path.resolve())
+    except (OSError, RuntimeError):
+        return str(path.absolute())
 
 
 def _user_plugins_dir() -> Path | None:
@@ -106,11 +235,69 @@ def _user_plugins_dir() -> Path | None:
         return None
 
 
+def _project_plugins_dir() -> Path | None:
+    """Return the opt-in project model-provider directory when present."""
+    if not env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
+        return None
+    directory = Path.cwd() / ".hermes" / "plugins" / "model-providers"
+    return directory if directory.is_dir() else None
+
+
+@dataclass(frozen=True)
+class _ProviderPlugin:
+    path: Path
+    source: str
+    key: str
+    name: str
+    provider_ids: frozenset[str]
+
+
+def _provider_plugin(plugin_dir: Path, source: str) -> _ProviderPlugin:
+    """Read provider identities without importing executable plugin code."""
+    key = f"model-providers/{plugin_dir.name}"
+    name = key
+    provider_ids = {plugin_dir.name}
+    manifest_file = plugin_dir / "plugin.yaml"
+    if not manifest_file.exists():
+        manifest_file = plugin_dir / "plugin.yml"
+    if manifest_file.exists():
+        try:
+            data = fast_safe_load(manifest_file.read_text(encoding="utf-8")) or {}
+            if isinstance(data, dict):
+                manifest_name = data.get("name")
+                if isinstance(manifest_name, str) and manifest_name.strip():
+                    name = manifest_name.strip()
+                declared_ids = data.get("provider_ids")
+                if isinstance(declared_ids, list):
+                    normalized_ids = {
+                        value.strip()
+                        for value in declared_ids
+                        if isinstance(value, str) and value.strip()
+                    }
+                    if normalized_ids:
+                        provider_ids = normalized_ids
+        except Exception:
+            logger.debug(
+                "Could not parse provider plugin manifest identity: %s",
+                plugin_dir,
+                exc_info=True,
+            )
+    return _ProviderPlugin(
+        path=plugin_dir,
+        source=source,
+        key=key,
+        name=name,
+        provider_ids=frozenset(provider_ids),
+    )
+
+
 def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
     """Import a single plugin directory so it self-registers.
 
-    ``source`` is "bundled" or "user", used only for log messages.
+    ``source`` is "bundled", "user", or "project".
     """
+    global _PROVIDER_LIST_CACHE
+
     init_file = plugin_dir / "__init__.py"
     if not init_file.exists():
         return
@@ -123,11 +310,18 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
     if source == "bundled":
         module_name = f"plugins.model_providers.{safe_name}"
     else:
-        module_name = f"_hermes_user_provider_{safe_name}"
+        module_name = f"_hermes_{source}_provider_{safe_name}"
 
     if module_name in sys.modules:
+        _IMPORTED_PROVIDER_MODULES.add(module_name)
         return  # already imported
 
+    registry_snapshot = dict(_REGISTRY)
+    aliases_snapshot = dict(_ALIASES)
+    origins_snapshot = dict(_PROVIDER_PROFILE_ORIGINS)
+    cache_snapshot = (
+        None if _PROVIDER_LIST_CACHE is None else list(_PROVIDER_LIST_CACHE)
+    )
     try:
         spec = importlib.util.spec_from_file_location(
             module_name, init_file, submodule_search_locations=[str(plugin_dir)]
@@ -137,62 +331,173 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
         spec.loader.exec_module(module)
+        origin = (source, _path_identity(plugin_dir))
+        for provider_id, profile in _REGISTRY.items():
+            if registry_snapshot.get(provider_id) is not profile:
+                _PROVIDER_PROFILE_ORIGINS[provider_id] = origin
+        _IMPORTED_PROVIDER_MODULES.add(module_name)
     except Exception as exc:
         logger.warning(
             "Failed to load %s provider plugin %s: %s", source, plugin_dir.name, exc
         )
-        sys.modules.pop(module_name, None)
+        _REGISTRY.clear()
+        _REGISTRY.update(registry_snapshot)
+        _ALIASES.clear()
+        _ALIASES.update(aliases_snapshot)
+        _PROVIDER_PROFILE_ORIGINS.clear()
+        _PROVIDER_PROFILE_ORIGINS.update(origins_snapshot)
+        _PROVIDER_LIST_CACHE = cache_snapshot
+        for imported_name in tuple(sys.modules):
+            if imported_name == module_name or imported_name.startswith(
+                f"{module_name}."
+            ):
+                sys.modules.pop(imported_name, None)
 
 
-def _discover_providers() -> None:
-    """Populate the registry by importing every provider plugin.
-
-    Order:
-      1. Bundled plugins at ``<repo>/plugins/model-providers/<name>/``
-      2. User plugins at ``$HERMES_HOME/plugins/model-providers/<name>/``
-      3. Legacy per-file modules at ``providers/<name>.py`` (back-compat)
-
-    Each step imports its plugins, which call ``register_provider()`` at
-    module-level. Later steps win on name collision.
-    """
-    global _discovered
-    if _discovered:
+def _discover_providers(
+    state: PluginActivationState,
+    *,
+    user_dir: Path | None,
+    project_dir: Path | None,
+    fingerprint: tuple[object, ...],
+) -> None:
+    """Rebuild provider discovery from one canonical activation snapshot."""
+    global _discovered, _discovering, _ACTIVATION_STATE
+    global _DISCOVERY_FINGERPRINT, _PROVIDER_LIST_CACHE
+    if _discovering:
         return
-    _discovered = True
 
-    # 1. Bundled plugins — shipped with hermes-agent.
-    if _BUNDLED_PLUGINS_DIR.is_dir():
-        for child in sorted(_BUNDLED_PLUGINS_DIR.iterdir()):
-            if not child.is_dir() or child.name.startswith(("_", ".")):
-                continue
-            _import_plugin_dir(child, "bundled")
-
-    # 2. User plugins — under $HERMES_HOME/plugins/model-providers/<name>/.
-    #    These can override any bundled profile of the same name (last-writer-wins
-    #    in register_provider()).
-    user_dir = _user_plugins_dir()
-    if user_dir is not None:
-        for child in sorted(user_dir.iterdir()):
-            if not child.is_dir() or child.name.startswith(("_", ".")):
-                continue
-            _import_plugin_dir(child, "user")
-
-    # 3. Legacy single-file profiles at providers/<name>.py. Kept for
-    #    back-compat — if someone drops a ``providers/foo.py`` into an
-    #    editable install, it still works without the plugin layout.
+    _discovering = True
     try:
-        import pkgutil
+        for prefix in tuple(_IMPORTED_PROVIDER_MODULES):
+            for module_name in tuple(sys.modules):
+                if module_name == prefix or module_name.startswith(f"{prefix}."):
+                    sys.modules.pop(module_name, None)
+        _IMPORTED_PROVIDER_MODULES.clear()
+        _REGISTRY.clear()
+        _ALIASES.clear()
+        _PROVIDER_LIST_CACHE = None
+        _PLUGIN_MANAGED_PROVIDER_IDS.clear()
+        _PROVIDER_PROFILE_ORIGINS.clear()
 
-        import providers as _pkg
-
-        for _importer, modname, _ispkg in pkgutil.iter_modules(_pkg.__path__):
-            if modname.startswith("_") or modname == "base":
+        candidates: list[_ProviderPlugin] = []
+        for directory, source in (
+            (_BUNDLED_PLUGINS_DIR, "bundled"),
+            (user_dir, "user"),
+            (project_dir, "project"),
+        ):
+            if state.safe_mode and source != "bundled":
                 continue
-            try:
-                importlib.import_module(f"providers.{modname}")
-            except ImportError as exc:
-                logger.warning(
-                    "Failed to import legacy provider module %s: %s", modname, exc
+            if directory is None or not directory.is_dir():
+                continue
+            for child in sorted(directory.iterdir()):
+                if not child.is_dir() or child.name.startswith(("_", ".")):
+                    continue
+                candidates.append(_provider_plugin(child, source))
+
+        winners: dict[str, _ProviderPlugin] = {}
+        grouped: dict[str, list[_ProviderPlugin]] = {}
+        for plugin in candidates:
+            winners[plugin.key] = plugin
+            grouped.setdefault(plugin.key, []).append(plugin)
+            _PLUGIN_MANAGED_PROVIDER_IDS.update(plugin.provider_ids)
+
+        for key, winner in winners.items():
+            if not state.is_active(
+                name=winner.name,
+                key=winner.key,
+                source=winner.source,
+                kind="model-provider",
+            ):
+                logger.debug(
+                    "Skipping inactive provider plugin winner '%s' (%s)",
+                    key,
+                    winner.source,
                 )
-    except Exception:
-        pass
+                continue
+
+            # Load active sources in precedence order. Bundled profiles load
+            # first so an enabled user/project override can replace selected
+            # IDs without deleting sibling profiles from a multi-ID bundle.
+            for plugin in grouped[key]:
+                if not state.is_active(
+                    name=plugin.name,
+                    key=plugin.key,
+                    source=plugin.source,
+                    kind="model-provider",
+                ):
+                    continue
+                _import_plugin_dir(plugin.path, plugin.source)
+
+        # Legacy single-file profiles are a compatibility extension path. Safe
+        # mode must not execute them because their provenance is unknowable.
+        if not state.safe_mode:
+            try:
+                import pkgutil
+
+                import providers as _pkg
+
+                for _importer, modname, _ispkg in pkgutil.iter_modules(_pkg.__path__):
+                    if modname.startswith("_") or modname == "base":
+                        continue
+                    _PLUGIN_MANAGED_PROVIDER_IDS.add(modname)
+                    if not state.is_active(
+                        name=modname,
+                        key=f"model-providers/{modname}",
+                        source="legacy",
+                        kind="model-provider",
+                    ):
+                        continue
+                    registry_snapshot = dict(_REGISTRY)
+                    aliases_snapshot = dict(_ALIASES)
+                    origins_snapshot = dict(_PROVIDER_PROFILE_ORIGINS)
+                    cache_snapshot = (
+                        None
+                        if _PROVIDER_LIST_CACHE is None
+                        else list(_PROVIDER_LIST_CACHE)
+                    )
+                    module_name = f"providers.{modname}"
+                    try:
+                        module = importlib.import_module(module_name)
+                        origin = (
+                            "legacy",
+                            _path_identity(
+                                Path(getattr(module, "__file__", None) or modname)
+                            ),
+                        )
+                        for provider_id, profile in _REGISTRY.items():
+                            if registry_snapshot.get(provider_id) is not profile:
+                                _PROVIDER_PROFILE_ORIGINS[provider_id] = origin
+                                _PLUGIN_MANAGED_PROVIDER_IDS.add(provider_id)
+                        _IMPORTED_PROVIDER_MODULES.add(module_name)
+                    except Exception as exc:
+                        _REGISTRY.clear()
+                        _REGISTRY.update(registry_snapshot)
+                        _ALIASES.clear()
+                        _ALIASES.update(aliases_snapshot)
+                        _PROVIDER_PROFILE_ORIGINS.clear()
+                        _PROVIDER_PROFILE_ORIGINS.update(origins_snapshot)
+                        _PROVIDER_LIST_CACHE = cache_snapshot
+                        for imported_name in tuple(sys.modules):
+                            if imported_name == module_name or imported_name.startswith(
+                                f"{module_name}."
+                            ):
+                                sys.modules.pop(imported_name, None)
+                        logger.warning(
+                            "Failed to import legacy provider module %s: %s",
+                            modname,
+                            exc,
+                        )
+            except Exception:
+                pass
+
+        _ACTIVATION_STATE = state
+        _DISCOVERY_FINGERPRINT = fingerprint
+        _discovered = True
+    except BaseException:
+        _ACTIVATION_STATE = None
+        _DISCOVERY_FINGERPRINT = None
+        _discovered = False
+        raise
+    finally:
+        _discovering = False

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -33,11 +33,13 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import hashlib
 import logging
 import sys
 import threading
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Callable
 
 from hermes_cli.plugin_activation import PluginActivationState
@@ -59,10 +61,67 @@ _PROVIDER_REFRESH_HOOKS: list[Callable[[], None]] = []
 _PLUGIN_MANAGED_PROVIDER_IDS: set[str] = set()
 _PROVIDER_PROFILE_ORIGINS: dict[str, tuple[str, str]] = {}
 
+
+@dataclass(frozen=True)
+class ProviderCatalogSnapshot:
+    """One immutable provider catalog for one profile/project scope.
+
+    Provider discovery used to publish into the module globals above.  That is
+    unsafe in the TUI gateway, where concurrent turns bind different
+    ``HERMES_HOME`` values with a ContextVar: one turn could read another
+    profile's endpoint after the second turn refreshed the process-global
+    registry.  Runtime readers now resolve this snapshot from their current
+    scope.  The old globals remain only as a compatibility mirror for tests
+    and third-party code that inspected private attributes.
+    """
+
+    scope_identity: tuple[str, str]
+    fingerprint: tuple[object, ...]
+    activation: PluginActivationState
+    registry: MappingProxyType
+    aliases: MappingProxyType
+    origins: MappingProxyType
+    profiles: tuple[ProviderProfile, ...]
+    plugin_managed_provider_ids: frozenset[str]
+    active_plugin_provider_ids: frozenset[str]
+    bundled_provider_ids: frozenset[str]
+    known_provider_ids: frozenset[str]
+
+
+@dataclass
+class _ProviderBuildState:
+    registry: dict[str, ProviderProfile]
+    aliases: dict[str, str]
+    origins: dict[str, tuple[str, str]]
+
+
+_BUILD_LOCAL = threading.local()
+_SNAPSHOT_CACHE: dict[tuple[object, ...], ProviderCatalogSnapshot] = {}
+_LAST_SNAPSHOT_FINGERPRINT: tuple[object, ...] | None = None
+_NOTIFIED_SNAPSHOT_FINGERPRINTS: set[tuple[object, ...]] = set()
+_MODULE_REGISTRATIONS: dict[str, tuple[ProviderProfile, ...]] = {}
+_MODULE_PATHS: dict[str, str] = {}
+_OBSERVED_PROFILES: dict[tuple[str, str, str], ProviderProfile] = {}
+_OBSERVED_PROVIDER_ENV_VARS: set[str] = set()
+_OBSERVED_PROVIDER_IDS_BY_SCOPE: dict[tuple[str, str], set[str]] = {}
+_RUNTIME_REGISTRY: dict[str, ProviderProfile] = {}
+_RUNTIME_ALIASES: dict[str, str] = {}
+_RUNTIME_REGISTRATION_GENERATION = 0
+
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
 _BUNDLED_PLUGINS_DIR = (
     Path(__file__).resolve().parent.parent / "plugins" / "model-providers"
 )
+
+
+def _record_observed_profile_locked(
+    source: str,
+    path: str,
+    profile: ProviderProfile,
+) -> None:
+    """Record monotonic non-executable security metadata under discovery lock."""
+    _OBSERVED_PROFILES[(source, path, profile.name)] = profile
+    _OBSERVED_PROVIDER_ENV_VARS.update(profile.env_vars)
 
 
 def register_provider(profile: ProviderProfile) -> None:
@@ -72,11 +131,23 @@ def register_provider(profile: ProviderProfile) -> None:
     plugins under ``$HERMES_HOME/plugins/model-providers/`` can override
     bundled profiles without editing repo code.
     """
-    global _PROVIDER_LIST_CACHE
+    global _PROVIDER_LIST_CACHE, _RUNTIME_REGISTRATION_GENERATION
+    build_state = getattr(_BUILD_LOCAL, "state", None)
+    if isinstance(build_state, _ProviderBuildState):
+        build_state.registry[profile.name] = profile
+        for alias in profile.aliases:
+            build_state.aliases[alias] = profile.name
+        return
+
     with _DISCOVERY_LOCK:
+        _RUNTIME_REGISTRY[profile.name] = profile
+        for alias in profile.aliases:
+            _RUNTIME_ALIASES[alias] = profile.name
+        _RUNTIME_REGISTRATION_GENERATION += 1
         _REGISTRY[profile.name] = profile
         for alias in profile.aliases:
             _ALIASES[alias] = profile.name
+        _record_observed_profile_locked("runtime", "", profile)
         _PROVIDER_LIST_CACHE = None
 
 
@@ -85,29 +156,79 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
 
     Returns None if the provider has no profile (falls back to generic).
     """
-    _ensure_providers_discovered()
-    with _DISCOVERY_LOCK:
-        canonical = _ALIASES.get(name, name)
-        return _REGISTRY.get(canonical)
+    snapshot = _ensure_providers_discovered()
+    if snapshot is None:
+        with _DISCOVERY_LOCK:
+            canonical = _ALIASES.get(name, name)
+            return _REGISTRY.get(canonical)
+    canonical = snapshot.aliases.get(name, name)
+    return snapshot.registry.get(canonical)
 
 
 def list_providers() -> list[ProviderProfile]:
     """Return all registered provider profiles (one per canonical name)."""
     global _PROVIDER_LIST_CACHE
-    _ensure_providers_discovered()
+    snapshot = _ensure_providers_discovered()
+    if snapshot is not None:
+        return list(snapshot.profiles)
+
+    # Private-registry compatibility for tests that deliberately install a
+    # hand-built registry and mark it discovered without a fingerprint.
     with _DISCOVERY_LOCK:
         if _PROVIDER_LIST_CACHE is not None:
             return list(_PROVIDER_LIST_CACHE)
-        # Deduplicate: _REGISTRY has canonical names; _ALIASES points to same objects
-        seen: set[int] = set()
-        result: list[ProviderProfile] = []
-        for profile in _REGISTRY.values():
-            pid = id(profile)
-            if pid not in seen:
-                seen.add(pid)
-                result.append(profile)
-        _PROVIDER_LIST_CACHE = result
-        return list(result)
+        result = _dedupe_profiles(_REGISTRY.values())
+        _PROVIDER_LIST_CACHE = list(result)
+        return result
+
+
+def _dedupe_profiles(profiles) -> list[ProviderProfile]:
+    seen: set[int] = set()
+    result: list[ProviderProfile] = []
+    for profile in profiles:
+        profile_identity = id(profile)
+        if profile_identity not in seen:
+            seen.add(profile_identity)
+            result.append(profile)
+    return result
+
+
+def get_provider_catalog_snapshot() -> ProviderCatalogSnapshot:
+    """Return the immutable provider catalog for the current ContextVar scope."""
+    snapshot = _ensure_providers_discovered()
+    if snapshot is None:
+        with _DISCOVERY_LOCK:
+            profiles = tuple(_dedupe_profiles(_REGISTRY.values()))
+            return ProviderCatalogSnapshot(
+                scope_identity=("compat", ""),
+                fingerprint=("compat",),
+                activation=PluginActivationState(),
+                registry=MappingProxyType(dict(_REGISTRY)),
+                aliases=MappingProxyType(dict(_ALIASES)),
+                origins=MappingProxyType(dict(_PROVIDER_PROFILE_ORIGINS)),
+                profiles=profiles,
+                plugin_managed_provider_ids=frozenset(
+                    _PLUGIN_MANAGED_PROVIDER_IDS
+                ),
+                active_plugin_provider_ids=frozenset(_REGISTRY),
+                bundled_provider_ids=frozenset(),
+                known_provider_ids=frozenset(_REGISTRY),
+            )
+    return snapshot
+
+
+def get_provider_scope_identity() -> tuple[str, str]:
+    """Return the profile/project identity without importing plugin code."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = _path_identity(get_hermes_home())
+    except Exception:
+        home = ""
+    project = _path_identity(Path.cwd()) if env_var_enabled(
+        "HERMES_ENABLE_PROJECT_PLUGINS"
+    ) else ""
+    return home, project
 
 
 def register_provider_refresh_hook(callback: Callable[[], None]) -> None:
@@ -119,55 +240,127 @@ def register_provider_refresh_hook(callback: Callable[[], None]) -> None:
 
 def get_provider_discovery_identity() -> tuple[object, ...]:
     """Return the active discovery identity for downstream cache keys."""
-    _ensure_providers_discovered()
-    with _DISCOVERY_LOCK:
-        fingerprint = _DISCOVERY_FINGERPRINT or ()
-        if not fingerprint or not isinstance(
-            fingerprint[0], PluginActivationState
-        ):
-            return fingerprint
-        state = fingerprint[0]
-        return (
-            state.safe_mode,
-            None if state.enabled is None else tuple(sorted(state.enabled)),
-            tuple(sorted(state.disabled)),
-            *fingerprint[1:],
-            tuple(sorted(_PROVIDER_PROFILE_ORIGINS.items())),
-        )
+    snapshot = _ensure_providers_discovered()
+    if snapshot is None:
+        with _DISCOVERY_LOCK:
+            return _DISCOVERY_FINGERPRINT or ()
+    state = snapshot.activation
+    return (
+        *snapshot.scope_identity,
+        state.safe_mode,
+        None if state.enabled is None else tuple(sorted(state.enabled)),
+        tuple(sorted(state.disabled)),
+        *snapshot.fingerprint[3:],
+        tuple(sorted(snapshot.origins.items())),
+    )
 
 
 def get_provider_profile_origin(name: str) -> tuple[str, str] | None:
     """Return ``(source, path)`` for the active provider profile."""
-    _ensure_providers_discovered()
-    with _DISCOVERY_LOCK:
-        canonical = _ALIASES.get(name, name)
-        return _PROVIDER_PROFILE_ORIGINS.get(canonical)
+    snapshot = _ensure_providers_discovered()
+    if snapshot is None:
+        with _DISCOVERY_LOCK:
+            canonical = _ALIASES.get(name, name)
+            return _PROVIDER_PROFILE_ORIGINS.get(canonical)
+    canonical = snapshot.aliases.get(name, name)
+    return snapshot.origins.get(canonical)
 
 
 def invalidate_provider_discovery() -> None:
     """Rebuild providers and notify indexes after activation changes."""
     global _discovered, _ACTIVATION_STATE, _DISCOVERY_FINGERPRINT
+    global _LAST_SNAPSHOT_FINGERPRINT
+    scope_identity = get_provider_scope_identity()
     with _DISCOVERY_LOCK:
+        stale = [
+            fingerprint
+            for fingerprint, snapshot in _SNAPSHOT_CACHE.items()
+            if snapshot.scope_identity == scope_identity
+        ]
+        for fingerprint in stale:
+            _SNAPSHOT_CACHE.pop(fingerprint, None)
+            _NOTIFIED_SNAPSHOT_FINGERPRINTS.discard(fingerprint)
+
+        # Explicit invalidation also means plugin code may have changed on
+        # disk.  Existing snapshots retain their already-created objects, so
+        # it is safe to evict module/cache entries before the next build.
+        for prefix in tuple(_IMPORTED_PROVIDER_MODULES):
+            for module_name in tuple(sys.modules):
+                if module_name == prefix or module_name.startswith(f"{prefix}."):
+                    sys.modules.pop(module_name, None)
+        _IMPORTED_PROVIDER_MODULES.clear()
+        _MODULE_REGISTRATIONS.clear()
+        _MODULE_PATHS.clear()
         _discovered = False
         _ACTIVATION_STATE = None
         _DISCOVERY_FINGERPRINT = None
+        _LAST_SNAPSHOT_FINGERPRINT = None
     _ensure_providers_discovered()
 
 
 def is_plugin_managed_provider_id(provider_id: str) -> bool:
     """Return whether any model-provider plugin declares *provider_id*."""
-    _ensure_providers_discovered()
-    with _DISCOVERY_LOCK:
-        return provider_id in _PLUGIN_MANAGED_PROVIDER_IDS
+    snapshot = _ensure_providers_discovered()
+    if snapshot is None:
+        with _DISCOVERY_LOCK:
+            return provider_id in _PLUGIN_MANAGED_PROVIDER_IDS
+    return provider_id in snapshot.plugin_managed_provider_ids
 
 
 def is_provider_plugin_active(provider_id: str) -> bool:
     """Return whether a plugin-managed provider is active and registered."""
-    _ensure_providers_discovered()
+    snapshot = _ensure_providers_discovered()
+    if snapshot is None:
+        with _DISCOVERY_LOCK:
+            if provider_id not in _PLUGIN_MANAGED_PROVIDER_IDS:
+                return True
+            return provider_id in _REGISTRY
+    if provider_id not in snapshot.plugin_managed_provider_ids:
+        return True
+    return provider_id in snapshot.active_plugin_provider_ids
+
+
+def is_bundled_provider_id(provider_id: str) -> bool:
+    """Return whether the trusted bundled catalog owns *provider_id*."""
+    snapshot = _ensure_providers_discovered()
+    if snapshot is None:
+        return False
+    return provider_id in snapshot.bundled_provider_ids
+
+
+def get_known_provider_ids() -> frozenset[str]:
+    """Return non-executable identities suitable for cleanup validation."""
+    snapshot = _ensure_providers_discovered()
+    if snapshot is None:
+        with _DISCOVERY_LOCK:
+            return frozenset(_REGISTRY)
+    return snapshot.known_provider_ids
+
+
+def get_observed_provider_profiles() -> tuple[ProviderProfile, ...]:
+    """Return a process-lifetime union used only for secret-name hardening."""
     with _DISCOVERY_LOCK:
-        if provider_id not in _PLUGIN_MANAGED_PROVIDER_IDS:
-            return True
-        return provider_id in _REGISTRY
+        return tuple(_OBSERVED_PROFILES.values())
+
+
+def get_observed_provider_env_vars() -> frozenset[str]:
+    """Return provider env names observed before catalog publication.
+
+    Provider refresh hooks run after a newly built catalog is placed in the
+    snapshot cache.  A concurrent subprocess launch must not depend on those
+    callbacks having completed: otherwise a newly discovered provider key can
+    briefly escape the child-env scrubber.  ``_OBSERVED_PROFILES`` is updated
+    synchronously while discovery still holds ``_DISCOVERY_LOCK``, so this
+    monotonic view is the security publication barrier for spawn-time checks.
+    """
+    with _DISCOVERY_LOCK:
+        return frozenset(_OBSERVED_PROVIDER_ENV_VARS)
+
+
+def is_observed_provider_env_var(name: str) -> bool:
+    """Check the provider-owned spawn-security index without hook latency."""
+    with _DISCOVERY_LOCK:
+        return name in _OBSERVED_PROVIDER_ENV_VARS
 
 
 def _current_activation_state() -> PluginActivationState:
@@ -182,37 +375,87 @@ def _current_activation_state() -> PluginActivationState:
         )
 
 
-def _ensure_providers_discovered() -> None:
-    """Refresh when activation or any discovery root changes."""
+def _ensure_providers_discovered() -> ProviderCatalogSnapshot | None:
+    """Resolve the immutable catalog for the caller's current scope."""
+    global _LAST_SNAPSHOT_FINGERPRINT
+
+    # A small private compatibility seam used by provider-registry unit tests.
+    if _discovered and _DISCOVERY_FINGERPRINT is None:
+        return None
+
     state = _current_activation_state()
+    scope_identity = get_provider_scope_identity()
     user_dir = _user_plugins_dir()
     project_dir = _project_plugins_dir()
     fingerprint = (
+        *scope_identity,
         state,
+        _RUNTIME_REGISTRATION_GENERATION,
         _path_identity(_BUNDLED_PLUGINS_DIR),
         _path_identity(user_dir),
         _path_identity(project_dir),
     )
     callbacks: tuple[Callable[[], None], ...] = ()
     with _DISCOVERY_LOCK:
-        if _discovered and _DISCOVERY_FINGERPRINT == fingerprint:
-            return
-        _discover_providers(
-            state,
-            user_dir=user_dir,
-            project_dir=project_dir,
-            fingerprint=fingerprint,
-        )
-        callbacks = tuple(_PROVIDER_REFRESH_HOOKS)
+        snapshot = _SNAPSHOT_CACHE.get(fingerprint)
+        if snapshot is None:
+            snapshot = _discover_providers(
+                state,
+                scope_identity=scope_identity,
+                user_dir=user_dir,
+                project_dir=project_dir,
+                fingerprint=fingerprint,
+            )
+            _SNAPSHOT_CACHE[fingerprint] = snapshot
 
+        if _LAST_SNAPSHOT_FINGERPRINT != fingerprint:
+            _publish_compatibility_mirror(snapshot)
+            _LAST_SNAPSHOT_FINGERPRINT = fingerprint
+
+        # Derived registries are context-scoped/lazy, while the remaining
+        # hooks only warm or monotonically harden metadata. Notify once per
+        # immutable snapshot rather than every A/B profile switch; otherwise
+        # concurrent multiplex traffic turns a compatibility-mirror change
+        # into a refresh storm.
+        if fingerprint not in _NOTIFIED_SNAPSHOT_FINGERPRINTS:
+            _NOTIFIED_SNAPSHOT_FINGERPRINTS.add(fingerprint)
+            callbacks = tuple(_PROVIDER_REFRESH_HOOKS)
+
+    callback_failed = False
     for callback in callbacks:
         try:
             callback()
         except Exception:
+            callback_failed = True
             logger.warning(
                 "Failed to refresh a provider-derived registry",
                 exc_info=True,
             )
+    if callback_failed:
+        # Best-effort hooks may be retried by the next reader. Runtime routing
+        # and subprocess security do not depend on hook completion.
+        with _DISCOVERY_LOCK:
+            _NOTIFIED_SNAPSHOT_FINGERPRINTS.discard(fingerprint)
+    return snapshot
+
+
+def _publish_compatibility_mirror(snapshot: ProviderCatalogSnapshot) -> None:
+    """Publish a non-authoritative mirror for legacy private-attribute users."""
+    global _discovered, _ACTIVATION_STATE, _DISCOVERY_FINGERPRINT
+    global _PROVIDER_LIST_CACHE
+
+    _REGISTRY.clear()
+    _REGISTRY.update(snapshot.registry)
+    _ALIASES.clear()
+    _ALIASES.update(snapshot.aliases)
+    _PROVIDER_PROFILE_ORIGINS.clear()
+    _PROVIDER_PROFILE_ORIGINS.update(snapshot.origins)
+    _PLUGIN_MANAGED_PROVIDER_IDS.clear()
+    _PLUGIN_MANAGED_PROVIDER_IDS.update(snapshot.plugin_managed_provider_ids)
+    _PROVIDER_LIST_CACHE = list(snapshot.profiles)
+    _ACTIVATION_STATE = snapshot.activation
+    _DISCOVERY_FINGERPRINT = snapshot.fingerprint
+    _discovered = True
 
 
 def _path_identity(path: Path | None) -> str:
@@ -291,95 +534,136 @@ def _provider_plugin(plugin_dir: Path, source: str) -> _ProviderPlugin:
     )
 
 
-def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
+def _provider_module_name(plugin_dir: Path, source: str) -> str:
+    safe_name = plugin_dir.name.replace("-", "_")
+    if source == "bundled":
+        return f"plugins.model_providers.{safe_name}"
+    path_digest = hashlib.sha256(
+        _path_identity(plugin_dir).encode("utf-8", errors="surrogatepass")
+    ).hexdigest()[:16]
+    return f"_hermes_{source}_provider_{safe_name}_{path_digest}"
+
+
+def _module_provider_profiles(module) -> tuple[ProviderProfile, ...]:
+    """Best-effort replay for a provider module imported before discovery."""
+    profiles: list[ProviderProfile] = []
+    seen: set[int] = set()
+    for value in vars(module).values():
+        if isinstance(value, ProviderProfile) and id(value) not in seen:
+            seen.add(id(value))
+            profiles.append(value)
+    return tuple(profiles)
+
+
+def _record_plugin_profiles(
+    profiles: tuple[ProviderProfile, ...],
+    *,
+    source: str,
+    plugin_dir: Path,
+) -> None:
+    build_state = getattr(_BUILD_LOCAL, "state", None)
+    if not isinstance(build_state, _ProviderBuildState):
+        raise RuntimeError("provider plugin imported outside discovery build")
+    origin = (source, _path_identity(plugin_dir))
+    for profile in profiles:
+        register_provider(profile)
+        build_state.origins[profile.name] = origin
+        _record_observed_profile_locked(source, origin[1], profile)
+
+
+def _import_plugin_dir(plugin_dir: Path, source: str) -> tuple[ProviderProfile, ...]:
     """Import a single plugin directory so it self-registers.
 
     ``source`` is "bundled", "user", or "project".
     """
-    global _PROVIDER_LIST_CACHE
-
     init_file = plugin_dir / "__init__.py"
     if not init_file.exists():
-        return
+        return ()
 
     # Give bundled plugins a stable import path (``plugins.model_providers.<name>``)
     # so relative imports within the plugin work. User plugins load via
     # ``importlib.util.spec_from_file_location`` with a unique module name so
     # multiple HERMES_HOME profiles don't alias each other.
-    safe_name = plugin_dir.name.replace("-", "_")
-    if source == "bundled":
-        module_name = f"plugins.model_providers.{safe_name}"
-    else:
-        module_name = f"_hermes_{source}_provider_{safe_name}"
+    module_name = _provider_module_name(plugin_dir, source)
 
     if module_name in sys.modules:
+        profiles = _MODULE_REGISTRATIONS.get(module_name)
+        if profiles is None:
+            profiles = _module_provider_profiles(sys.modules[module_name])
+            _MODULE_REGISTRATIONS[module_name] = profiles
+        _record_plugin_profiles(profiles, source=source, plugin_dir=plugin_dir)
         _IMPORTED_PROVIDER_MODULES.add(module_name)
-        return  # already imported
+        return profiles
 
-    registry_snapshot = dict(_REGISTRY)
-    aliases_snapshot = dict(_ALIASES)
-    origins_snapshot = dict(_PROVIDER_PROFILE_ORIGINS)
-    cache_snapshot = (
-        None if _PROVIDER_LIST_CACHE is None else list(_PROVIDER_LIST_CACHE)
-    )
+    build_state = getattr(_BUILD_LOCAL, "state", None)
+    if not isinstance(build_state, _ProviderBuildState):
+        raise RuntimeError("provider discovery build state is unavailable")
+    registry_snapshot = dict(build_state.registry)
+    aliases_snapshot = dict(build_state.aliases)
+    origins_snapshot = dict(build_state.origins)
     try:
         spec = importlib.util.spec_from_file_location(
             module_name, init_file, submodule_search_locations=[str(plugin_dir)]
         )
         if spec is None or spec.loader is None:
-            return
+            return ()
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
         spec.loader.exec_module(module)
+        profiles = tuple(
+            profile
+            for provider_id, profile in build_state.registry.items()
+            if registry_snapshot.get(provider_id) is not profile
+        )
         origin = (source, _path_identity(plugin_dir))
-        for provider_id, profile in _REGISTRY.items():
-            if registry_snapshot.get(provider_id) is not profile:
-                _PROVIDER_PROFILE_ORIGINS[provider_id] = origin
+        for profile in profiles:
+            build_state.origins[profile.name] = origin
+            _record_observed_profile_locked(source, origin[1], profile)
+        _MODULE_REGISTRATIONS[module_name] = profiles
+        _MODULE_PATHS[module_name] = origin[1]
         _IMPORTED_PROVIDER_MODULES.add(module_name)
+        return profiles
     except Exception as exc:
         logger.warning(
             "Failed to load %s provider plugin %s: %s", source, plugin_dir.name, exc
         )
-        _REGISTRY.clear()
-        _REGISTRY.update(registry_snapshot)
-        _ALIASES.clear()
-        _ALIASES.update(aliases_snapshot)
-        _PROVIDER_PROFILE_ORIGINS.clear()
-        _PROVIDER_PROFILE_ORIGINS.update(origins_snapshot)
-        _PROVIDER_LIST_CACHE = cache_snapshot
+        build_state.registry.clear()
+        build_state.registry.update(registry_snapshot)
+        build_state.aliases.clear()
+        build_state.aliases.update(aliases_snapshot)
+        build_state.origins.clear()
+        build_state.origins.update(origins_snapshot)
+        _MODULE_REGISTRATIONS.pop(module_name, None)
+        _MODULE_PATHS.pop(module_name, None)
         for imported_name in tuple(sys.modules):
             if imported_name == module_name or imported_name.startswith(
                 f"{module_name}."
             ):
                 sys.modules.pop(imported_name, None)
+        return ()
 
 
 def _discover_providers(
     state: PluginActivationState,
     *,
+    scope_identity: tuple[str, str],
     user_dir: Path | None,
     project_dir: Path | None,
     fingerprint: tuple[object, ...],
-) -> None:
-    """Rebuild provider discovery from one canonical activation snapshot."""
-    global _discovered, _discovering, _ACTIVATION_STATE
-    global _DISCOVERY_FINGERPRINT, _PROVIDER_LIST_CACHE
+) -> ProviderCatalogSnapshot:
+    """Build one provider snapshot without publishing process-global state."""
+    global _discovering
     if _discovering:
-        return
+        raise RuntimeError("recursive provider discovery")
 
     _discovering = True
+    build_state = _ProviderBuildState(
+        registry=dict(_RUNTIME_REGISTRY),
+        aliases=dict(_RUNTIME_ALIASES),
+        origins={},
+    )
+    _BUILD_LOCAL.state = build_state
     try:
-        for prefix in tuple(_IMPORTED_PROVIDER_MODULES):
-            for module_name in tuple(sys.modules):
-                if module_name == prefix or module_name.startswith(f"{prefix}."):
-                    sys.modules.pop(module_name, None)
-        _IMPORTED_PROVIDER_MODULES.clear()
-        _REGISTRY.clear()
-        _ALIASES.clear()
-        _PROVIDER_LIST_CACHE = None
-        _PLUGIN_MANAGED_PROVIDER_IDS.clear()
-        _PROVIDER_PROFILE_ORIGINS.clear()
-
         candidates: list[_ProviderPlugin] = []
         for directory, source in (
             (_BUNDLED_PLUGINS_DIR, "bundled"),
@@ -395,39 +679,69 @@ def _discover_providers(
                     continue
                 candidates.append(_provider_plugin(child, source))
 
-        winners: dict[str, _ProviderPlugin] = {}
         grouped: dict[str, list[_ProviderPlugin]] = {}
+        managed_provider_ids: set[str] = set(
+            _OBSERVED_PROVIDER_IDS_BY_SCOPE.get(scope_identity, ())
+        )
+        known_provider_ids: set[str] = set(managed_provider_ids)
+        bundled_provider_ids: set[str] = set()
+        active_provider_ids: set[str] = set()
         for plugin in candidates:
-            winners[plugin.key] = plugin
             grouped.setdefault(plugin.key, []).append(plugin)
-            _PLUGIN_MANAGED_PROVIDER_IDS.update(plugin.provider_ids)
+            known_provider_ids.update(plugin.provider_ids)
+            known_provider_ids.update((plugin.path.name, plugin.name))
+            if plugin.source == "bundled":
+                managed_provider_ids.update(plugin.provider_ids)
+                bundled_provider_ids.update(plugin.provider_ids)
 
-        for key, winner in winners.items():
-            if not state.is_active(
-                name=winner.name,
-                key=winner.key,
-                source=winner.source,
-                kind="model-provider",
-            ):
+        for key, plugins in grouped.items():
+            statuses = [
+                (
+                    plugin,
+                    state.status(
+                        name=plugin.name,
+                        key=plugin.key,
+                        source=plugin.source,
+                        kind="model-provider",
+                    ),
+                )
+                for plugin in plugins
+            ]
+            # A deny on any identity in a canonical-key collision is a
+            # fail-closed deny for the whole key.  Otherwise inactive external
+            # candidates simply fall back to active bundled candidates.
+            if any(status == "disabled" for _plugin, status in statuses):
                 logger.debug(
-                    "Skipping inactive provider plugin winner '%s' (%s)",
+                    "Skipping explicitly disabled provider plugin group '%s'",
                     key,
-                    winner.source,
+                )
+                continue
+            active_plugins = [
+                plugin for plugin, status in statuses if status == "enabled"
+            ]
+            if not active_plugins:
+                logger.debug(
+                    "Skipping inactive provider plugin group '%s' (%s)",
+                    key,
+                    ", ".join(plugin.source for plugin in plugins),
                 )
                 continue
 
             # Load active sources in precedence order. Bundled profiles load
             # first so an enabled user/project override can replace selected
             # IDs without deleting sibling profiles from a multi-ID bundle.
-            for plugin in grouped[key]:
-                if not state.is_active(
-                    name=plugin.name,
-                    key=plugin.key,
-                    source=plugin.source,
-                    kind="model-provider",
-                ):
-                    continue
-                _import_plugin_dir(plugin.path, plugin.source)
+            for plugin in active_plugins:
+                profiles = _import_plugin_dir(plugin.path, plugin.source)
+                for profile in profiles:
+                    active_provider_ids.add(profile.name)
+                    active_provider_ids.update(profile.aliases)
+                    managed_provider_ids.add(profile.name)
+                    managed_provider_ids.update(profile.aliases)
+                    known_provider_ids.add(profile.name)
+                    known_provider_ids.update(profile.aliases)
+                    if plugin.source == "bundled":
+                        bundled_provider_ids.add(profile.name)
+                        bundled_provider_ids.update(profile.aliases)
 
         # Legacy single-file profiles are a compatibility extension path. Safe
         # mode must not execute them because their provenance is unknowable.
@@ -440,7 +754,7 @@ def _discover_providers(
                 for _importer, modname, _ispkg in pkgutil.iter_modules(_pkg.__path__):
                     if modname.startswith("_") or modname == "base":
                         continue
-                    _PLUGIN_MANAGED_PROVIDER_IDS.add(modname)
+                    known_provider_ids.add(modname)
                     if not state.is_active(
                         name=modname,
                         key=f"model-providers/{modname}",
@@ -448,36 +762,53 @@ def _discover_providers(
                         kind="model-provider",
                     ):
                         continue
-                    registry_snapshot = dict(_REGISTRY)
-                    aliases_snapshot = dict(_ALIASES)
-                    origins_snapshot = dict(_PROVIDER_PROFILE_ORIGINS)
-                    cache_snapshot = (
-                        None
-                        if _PROVIDER_LIST_CACHE is None
-                        else list(_PROVIDER_LIST_CACHE)
-                    )
                     module_name = f"providers.{modname}"
+                    registry_snapshot = dict(build_state.registry)
+                    aliases_snapshot = dict(build_state.aliases)
+                    origins_snapshot = dict(build_state.origins)
                     try:
-                        module = importlib.import_module(module_name)
+                        if module_name in sys.modules:
+                            module = sys.modules[module_name]
+                            profiles = _MODULE_REGISTRATIONS.get(module_name)
+                            if profiles is None:
+                                profiles = _module_provider_profiles(module)
+                        else:
+                            module = importlib.import_module(module_name)
+                            profiles = tuple(
+                                profile
+                                for provider_id, profile in build_state.registry.items()
+                                if registry_snapshot.get(provider_id) is not profile
+                            )
+                        _MODULE_REGISTRATIONS[module_name] = profiles
                         origin = (
                             "legacy",
                             _path_identity(
                                 Path(getattr(module, "__file__", None) or modname)
                             ),
                         )
-                        for provider_id, profile in _REGISTRY.items():
-                            if registry_snapshot.get(provider_id) is not profile:
-                                _PROVIDER_PROFILE_ORIGINS[provider_id] = origin
-                                _PLUGIN_MANAGED_PROVIDER_IDS.add(provider_id)
+                        _MODULE_PATHS[module_name] = origin[1]
+                        for profile in profiles:
+                            register_provider(profile)
+                            build_state.origins[profile.name] = origin
+                            _record_observed_profile_locked(
+                                "legacy", origin[1], profile
+                            )
+                            active_provider_ids.add(profile.name)
+                            active_provider_ids.update(profile.aliases)
+                            managed_provider_ids.add(profile.name)
+                            managed_provider_ids.update(profile.aliases)
+                            known_provider_ids.add(profile.name)
+                            known_provider_ids.update(profile.aliases)
                         _IMPORTED_PROVIDER_MODULES.add(module_name)
                     except Exception as exc:
-                        _REGISTRY.clear()
-                        _REGISTRY.update(registry_snapshot)
-                        _ALIASES.clear()
-                        _ALIASES.update(aliases_snapshot)
-                        _PROVIDER_PROFILE_ORIGINS.clear()
-                        _PROVIDER_PROFILE_ORIGINS.update(origins_snapshot)
-                        _PROVIDER_LIST_CACHE = cache_snapshot
+                        build_state.registry.clear()
+                        build_state.registry.update(registry_snapshot)
+                        build_state.aliases.clear()
+                        build_state.aliases.update(aliases_snapshot)
+                        build_state.origins.clear()
+                        build_state.origins.update(origins_snapshot)
+                        _MODULE_REGISTRATIONS.pop(module_name, None)
+                        _MODULE_PATHS.pop(module_name, None)
                         for imported_name in tuple(sys.modules):
                             if imported_name == module_name or imported_name.startswith(
                                 f"{module_name}."
@@ -491,13 +822,31 @@ def _discover_providers(
             except Exception:
                 pass
 
-        _ACTIVATION_STATE = state
-        _DISCOVERY_FINGERPRINT = fingerprint
-        _discovered = True
-    except BaseException:
-        _ACTIVATION_STATE = None
-        _DISCOVERY_FINGERPRINT = None
-        _discovered = False
-        raise
+        observed_ids = _OBSERVED_PROVIDER_IDS_BY_SCOPE.setdefault(
+            scope_identity, set()
+        )
+        observed_ids.update(managed_provider_ids)
+        observed_ids.update(active_provider_ids)
+        managed_provider_ids.update(observed_ids)
+        known_provider_ids.update(observed_ids)
+
+        profiles = tuple(_dedupe_profiles(build_state.registry.values()))
+        return ProviderCatalogSnapshot(
+            scope_identity=scope_identity,
+            fingerprint=fingerprint,
+            activation=state,
+            registry=MappingProxyType(dict(build_state.registry)),
+            aliases=MappingProxyType(dict(build_state.aliases)),
+            origins=MappingProxyType(dict(build_state.origins)),
+            profiles=profiles,
+            plugin_managed_provider_ids=frozenset(managed_provider_ids),
+            active_plugin_provider_ids=frozenset(active_provider_ids),
+            bundled_provider_ids=frozenset(bundled_provider_ids),
+            known_provider_ids=frozenset(known_provider_ids),
+        )
     finally:
+        try:
+            del _BUILD_LOCAL.state
+        except AttributeError:
+            pass
         _discovering = False

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -35,8 +35,10 @@ import importlib
 import importlib.util
 import hashlib
 import logging
+import os
 import sys
 import threading
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -88,6 +90,11 @@ class ProviderCatalogSnapshot:
     known_provider_ids: frozenset[str]
 
 
+_PUBLISHED_PROVIDER_CATALOG: ContextVar[ProviderCatalogSnapshot | None] = (
+    ContextVar("published_provider_catalog", default=None)
+)
+
+
 @dataclass
 class _ProviderBuildState:
     registry: dict[str, ProviderProfile]
@@ -101,6 +108,9 @@ _LAST_SNAPSHOT_FINGERPRINT: tuple[object, ...] | None = None
 _NOTIFIED_SNAPSHOT_FINGERPRINTS: set[tuple[object, ...]] = set()
 _MODULE_REGISTRATIONS: dict[str, tuple[ProviderProfile, ...]] = {}
 _OBSERVED_PROVIDER_IDS_BY_SCOPE: dict[tuple[str, str], set[str]] = {}
+_PROVIDER_SCOPE_IDENTITY_CACHE: dict[
+    tuple[str, str], tuple[str, str]
+] = {}
 _RUNTIME_REGISTRY: dict[str, ProviderProfile] = {}
 _RUNTIME_ALIASES: dict[str, str] = {}
 _RUNTIME_REGISTRATION_GENERATION = 0
@@ -203,18 +213,44 @@ def get_provider_catalog_snapshot() -> ProviderCatalogSnapshot:
     return snapshot
 
 
-def get_provider_scope_identity() -> tuple[str, str]:
-    """Return the profile/project identity without importing plugin code."""
+def get_published_provider_catalog_snapshot() -> ProviderCatalogSnapshot | None:
+    """Return this context's last resolved catalog without running discovery."""
+    return _PUBLISHED_PROVIDER_CATALOG.get()
+
+
+def _provider_scope_marker() -> tuple[str, str]:
+    """Return a cheap logical scope marker for the current context."""
     try:
         from hermes_constants import get_hermes_home
 
-        home = _path_identity(get_hermes_home())
+        home = os.path.normcase(
+            os.path.abspath(os.path.expanduser(str(get_hermes_home())))
+        )
     except Exception:
         home = ""
-    project = _path_identity(Path.cwd()) if env_var_enabled(
-        "HERMES_ENABLE_PROJECT_PLUGINS"
-    ) else ""
+    project = ""
+    if env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
+        try:
+            project = os.path.normcase(os.path.abspath(str(Path.cwd())))
+        except (OSError, RuntimeError):
+            project = ""
     return home, project
+
+
+def get_provider_scope_identity() -> tuple[str, str]:
+    """Return the physical profile/project identity without importing plugins."""
+    marker = _provider_scope_marker()
+    with _DISCOVERY_LOCK:
+        cached = _PROVIDER_SCOPE_IDENTITY_CACHE.get(marker)
+    if cached is not None:
+        return cached
+
+    resolved = tuple(
+        _path_identity(Path(value)) if value else ""
+        for value in marker
+    )
+    with _DISCOVERY_LOCK:
+        return _PROVIDER_SCOPE_IDENTITY_CACHE.setdefault(marker, resolved)
 
 
 def register_provider_refresh_hook(callback: Callable[[], None]) -> None:
@@ -256,12 +292,22 @@ def invalidate_provider_discovery() -> None:
     """Rebuild providers and notify indexes after activation changes."""
     global _discovered, _ACTIVATION_STATE, _DISCOVERY_FINGERPRINT
     global _LAST_SNAPSHOT_FINGERPRINT
-    scope_identity = get_provider_scope_identity()
+    scope_marker = _provider_scope_marker()
     with _DISCOVERY_LOCK:
+        previous_scope_identity = _PROVIDER_SCOPE_IDENTITY_CACHE.pop(
+            scope_marker,
+            None,
+        )
+    scope_identity = get_provider_scope_identity()
+    _PUBLISHED_PROVIDER_CATALOG.set(None)
+    with _DISCOVERY_LOCK:
+        stale_scope_identities = {scope_identity}
+        if previous_scope_identity is not None:
+            stale_scope_identities.add(previous_scope_identity)
         stale = [
             fingerprint
             for fingerprint, snapshot in _SNAPSHOT_CACHE.items()
-            if snapshot.scope_identity == scope_identity
+            if snapshot.scope_identity in stale_scope_identities
         ]
         for fingerprint in stale:
             _SNAPSHOT_CACHE.pop(fingerprint, None)
@@ -371,6 +417,12 @@ def _ensure_providers_discovered() -> ProviderCatalogSnapshot | None:
         if fingerprint not in _NOTIFIED_SNAPSHOT_FINGERPRINTS:
             _NOTIFIED_SNAPSHOT_FINGERPRINTS.add(fingerprint)
             callbacks = tuple(_PROVIDER_REFRESH_HOOKS)
+
+    # Publish on every selection, including a cached A -> B -> A revisit whose
+    # once-per-fingerprint hooks do not run again. Downstream hot paths can
+    # select matching immutable metadata without re-entering discovery for
+    # every alias lookup.
+    _PUBLISHED_PROVIDER_CATALOG.set(snapshot)
 
     callback_failed = False
     for callback in callbacks:

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -100,9 +100,6 @@ _SNAPSHOT_CACHE: dict[tuple[object, ...], ProviderCatalogSnapshot] = {}
 _LAST_SNAPSHOT_FINGERPRINT: tuple[object, ...] | None = None
 _NOTIFIED_SNAPSHOT_FINGERPRINTS: set[tuple[object, ...]] = set()
 _MODULE_REGISTRATIONS: dict[str, tuple[ProviderProfile, ...]] = {}
-_MODULE_PATHS: dict[str, str] = {}
-_OBSERVED_PROFILES: dict[tuple[str, str, str], ProviderProfile] = {}
-_OBSERVED_PROVIDER_ENV_VARS: set[str] = set()
 _OBSERVED_PROVIDER_IDS_BY_SCOPE: dict[tuple[str, str], set[str]] = {}
 _RUNTIME_REGISTRY: dict[str, ProviderProfile] = {}
 _RUNTIME_ALIASES: dict[str, str] = {}
@@ -112,16 +109,6 @@ _RUNTIME_REGISTRATION_GENERATION = 0
 _BUNDLED_PLUGINS_DIR = (
     Path(__file__).resolve().parent.parent / "plugins" / "model-providers"
 )
-
-
-def _record_observed_profile_locked(
-    source: str,
-    path: str,
-    profile: ProviderProfile,
-) -> None:
-    """Record monotonic non-executable security metadata under discovery lock."""
-    _OBSERVED_PROFILES[(source, path, profile.name)] = profile
-    _OBSERVED_PROVIDER_ENV_VARS.update(profile.env_vars)
 
 
 def register_provider(profile: ProviderProfile) -> None:
@@ -147,7 +134,6 @@ def register_provider(profile: ProviderProfile) -> None:
         _REGISTRY[profile.name] = profile
         for alias in profile.aliases:
             _ALIASES[alias] = profile.name
-        _record_observed_profile_locked("runtime", "", profile)
         _PROVIDER_LIST_CACHE = None
 
 
@@ -290,7 +276,6 @@ def invalidate_provider_discovery() -> None:
                     sys.modules.pop(module_name, None)
         _IMPORTED_PROVIDER_MODULES.clear()
         _MODULE_REGISTRATIONS.clear()
-        _MODULE_PATHS.clear()
         _discovered = False
         _ACTIVATION_STATE = None
         _DISCOVERY_FINGERPRINT = None
@@ -320,14 +305,6 @@ def is_provider_plugin_active(provider_id: str) -> bool:
     return provider_id in snapshot.active_plugin_provider_ids
 
 
-def is_bundled_provider_id(provider_id: str) -> bool:
-    """Return whether the trusted bundled catalog owns *provider_id*."""
-    snapshot = _ensure_providers_discovered()
-    if snapshot is None:
-        return False
-    return provider_id in snapshot.bundled_provider_ids
-
-
 def get_known_provider_ids() -> frozenset[str]:
     """Return non-executable identities suitable for cleanup validation."""
     snapshot = _ensure_providers_discovered()
@@ -335,32 +312,6 @@ def get_known_provider_ids() -> frozenset[str]:
         with _DISCOVERY_LOCK:
             return frozenset(_REGISTRY)
     return snapshot.known_provider_ids
-
-
-def get_observed_provider_profiles() -> tuple[ProviderProfile, ...]:
-    """Return a process-lifetime union used only for secret-name hardening."""
-    with _DISCOVERY_LOCK:
-        return tuple(_OBSERVED_PROFILES.values())
-
-
-def get_observed_provider_env_vars() -> frozenset[str]:
-    """Return provider env names observed before catalog publication.
-
-    Provider refresh hooks run after a newly built catalog is placed in the
-    snapshot cache.  A concurrent subprocess launch must not depend on those
-    callbacks having completed: otherwise a newly discovered provider key can
-    briefly escape the child-env scrubber.  ``_OBSERVED_PROFILES`` is updated
-    synchronously while discovery still holds ``_DISCOVERY_LOCK``, so this
-    monotonic view is the security publication barrier for spawn-time checks.
-    """
-    with _DISCOVERY_LOCK:
-        return frozenset(_OBSERVED_PROVIDER_ENV_VARS)
-
-
-def is_observed_provider_env_var(name: str) -> bool:
-    """Check the provider-owned spawn-security index without hook latency."""
-    with _DISCOVERY_LOCK:
-        return name in _OBSERVED_PROVIDER_ENV_VARS
 
 
 def _current_activation_state() -> PluginActivationState:
@@ -568,7 +519,6 @@ def _record_plugin_profiles(
     for profile in profiles:
         register_provider(profile)
         build_state.origins[profile.name] = origin
-        _record_observed_profile_locked(source, origin[1], profile)
 
 
 def _import_plugin_dir(plugin_dir: Path, source: str) -> tuple[ProviderProfile, ...]:
@@ -618,9 +568,7 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> tuple[ProviderProfile, 
         origin = (source, _path_identity(plugin_dir))
         for profile in profiles:
             build_state.origins[profile.name] = origin
-            _record_observed_profile_locked(source, origin[1], profile)
         _MODULE_REGISTRATIONS[module_name] = profiles
-        _MODULE_PATHS[module_name] = origin[1]
         _IMPORTED_PROVIDER_MODULES.add(module_name)
         return profiles
     except Exception as exc:
@@ -634,7 +582,6 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> tuple[ProviderProfile, 
         build_state.origins.clear()
         build_state.origins.update(origins_snapshot)
         _MODULE_REGISTRATIONS.pop(module_name, None)
-        _MODULE_PATHS.pop(module_name, None)
         for imported_name in tuple(sys.modules):
             if imported_name == module_name or imported_name.startswith(
                 f"{module_name}."
@@ -786,13 +733,9 @@ def _discover_providers(
                                 Path(getattr(module, "__file__", None) or modname)
                             ),
                         )
-                        _MODULE_PATHS[module_name] = origin[1]
                         for profile in profiles:
                             register_provider(profile)
                             build_state.origins[profile.name] = origin
-                            _record_observed_profile_locked(
-                                "legacy", origin[1], profile
-                            )
                             active_provider_ids.add(profile.name)
                             active_provider_ids.update(profile.aliases)
                             managed_provider_ids.add(profile.name)
@@ -808,7 +751,6 @@ def _discover_providers(
                         build_state.origins.clear()
                         build_state.origins.update(origins_snapshot)
                         _MODULE_REGISTRATIONS.pop(module_name, None)
-                        _MODULE_PATHS.pop(module_name, None)
                         for imported_name in tuple(sys.modules):
                             if imported_name == module_name or imported_name.startswith(
                                 f"{module_name}."

--- a/tests/cli/test_plugins_command.py
+++ b/tests/cli/test_plugins_command.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from hermes_cli.plugin_activation import PluginActivationState
+
+
+def _make_cli():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pending_resume_sessions = None
+    return cli
+
+
+def _without_loaded_plugins(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager",
+        lambda: SimpleNamespace(list_plugins=lambda: []),
+    )
+
+
+def test_plugins_quick_view_uses_resolved_group_deny(monkeypatch, capsys):
+    from hermes_cli import plugins_cmd
+
+    candidates = [
+        ("legacy-copy", "1.0", "Bundled", "bundled", None, "shared", "backend"),
+        ("new-copy", "2.0", "User", "user", None, "shared", "standalone"),
+    ]
+    activation = PluginActivationState(
+        enabled=frozenset({"new-copy"}),
+        disabled=frozenset({"legacy-copy"}),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_plugin_activation_state",
+        lambda: activation,
+    )
+    _without_loaded_plugins(monkeypatch)
+
+    assert _make_cli().process_command("/plugins") is True
+
+    out = capsys.readouterr().out
+    assert "new-copy v2.0 [disabled]" in out
+
+
+def test_plugins_quick_view_does_not_enable_inactive_user_shadow(
+    monkeypatch,
+    capsys,
+):
+    from hermes_cli import plugins_cmd
+
+    candidates = [
+        ("bundled", "1.0", "Bundled", "bundled", None, "shared", "backend"),
+        ("user-shadow", "2.0", "User", "user", None, "shared", "standalone"),
+    ]
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_plugin_activation_state",
+        PluginActivationState,
+    )
+    _without_loaded_plugins(monkeypatch)
+
+    assert _make_cli().process_command("/plugins") is True
+
+    out = capsys.readouterr().out
+    assert "user-shadow v2.0 [not enabled]" in out

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -567,6 +567,49 @@ def test_clear_provider_auth_removes_provider_pool_entries(tmp_path, monkeypatch
     assert "openrouter" in payload.get("credential_pool", {})
 
 
+def test_logout_allows_persisted_provider_after_plugin_is_removed(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """Cleanup identity is broader than the currently routable catalog."""
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "active_provider": "retired-provider",
+            "providers": {},
+            "credential_pool": {
+                "retired-provider": [
+                    {
+                        "id": "retired-1",
+                        "source": "manual",
+                        "access_token": "retired-secret",
+                    }
+                ]
+            },
+        },
+    )
+    (hermes_home / "config.yaml").write_text(
+        "model:\n  provider: retired-provider\n",
+        encoding="utf-8",
+    )
+
+    from types import SimpleNamespace
+
+    from hermes_cli.auth import logout_command
+
+    logout_command(SimpleNamespace(provider="retired-provider"))
+
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    assert "retired-provider" not in payload.get("credential_pool", {})
+    assert payload.get("active_provider") is None
+    assert "provider: auto" in (hermes_home / "config.yaml").read_text()
+    assert "Logged out of retired-provider." in capsys.readouterr().out
+
+
 def test_logout_resets_codex_config_when_auth_state_already_cleared(tmp_path, monkeypatch, capsys):
     """`hermes logout --provider openai-codex` must still clear model.provider.
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -567,49 +567,6 @@ def test_clear_provider_auth_removes_provider_pool_entries(tmp_path, monkeypatch
     assert "openrouter" in payload.get("credential_pool", {})
 
 
-def test_logout_allows_persisted_provider_after_plugin_is_removed(
-    tmp_path,
-    monkeypatch,
-    capsys,
-):
-    """Cleanup identity is broader than the currently routable catalog."""
-    hermes_home = tmp_path / "hermes"
-    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-    _write_auth_store(
-        tmp_path,
-        {
-            "version": 1,
-            "active_provider": "retired-provider",
-            "providers": {},
-            "credential_pool": {
-                "retired-provider": [
-                    {
-                        "id": "retired-1",
-                        "source": "manual",
-                        "access_token": "retired-secret",
-                    }
-                ]
-            },
-        },
-    )
-    (hermes_home / "config.yaml").write_text(
-        "model:\n  provider: retired-provider\n",
-        encoding="utf-8",
-    )
-
-    from types import SimpleNamespace
-
-    from hermes_cli.auth import logout_command
-
-    logout_command(SimpleNamespace(provider="retired-provider"))
-
-    payload = json.loads((hermes_home / "auth.json").read_text())
-    assert "retired-provider" not in payload.get("credential_pool", {})
-    assert payload.get("active_provider") is None
-    assert "provider: auto" in (hermes_home / "config.yaml").read_text()
-    assert "Logged out of retired-provider." in capsys.readouterr().out
-
-
 def test_logout_resets_codex_config_when_auth_state_already_cleared(tmp_path, monkeypatch, capsys):
     """`hermes logout --provider openai-codex` must still clear model.provider.
 

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from argparse import Namespace
 from contextlib import nullcontext
+import json
+from pathlib import Path
 import sys
 import threading
 import time
@@ -62,7 +64,9 @@ def test_prepare_agent_startup_backgrounds_blocking_mcp_for_chat(monkeypatch):
         sys.modules,
         "hermes_cli.config",
         types.SimpleNamespace(
-            read_raw_config=lambda: {"mcp_servers": {"demo": {"transport": "stdio"}}},
+            load_config_readonly=lambda: {
+                "mcp_servers": {"demo": {"transport": "stdio"}}
+            },
             load_config=lambda: {},
         ),
     )
@@ -119,7 +123,11 @@ def test_background_mcp_discovery_suppresses_interactive_oauth(monkeypatch):
         sys.modules,
         "hermes_cli.config",
         types.SimpleNamespace(
-            read_raw_config=lambda: {"mcp_servers": {"demo": {"url": "https://mcp.example.test/mcp"}}},
+            load_config_readonly=lambda: {
+                "mcp_servers": {
+                    "demo": {"url": "https://mcp.example.test/mcp"}
+                }
+            },
         ),
     )
     monkeypatch.setitem(
@@ -150,7 +158,7 @@ def test_portable_only_mcp_configuration_opens_startup_gate(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        types.SimpleNamespace(read_raw_config=lambda: {}),
+        types.SimpleNamespace(load_config_readonly=lambda: {}),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -161,6 +169,54 @@ def test_portable_only_mcp_configuration_opens_startup_gate(monkeypatch):
     )
 
     assert mcp_startup._has_configured_mcp_servers() is True
+
+
+def test_portable_mcp_startup_gate_uses_effective_env_expansion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hermes_cli.agent_plugins import MCP_SCHEMA_V1, PLUGIN_SCHEMA_V1
+    from hermes_cli.plugins import PluginManager
+
+    home = tmp_path / "home"
+    plugin = home / "plugins" / "portable.test"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.json").write_text(
+        json.dumps({"$schema": PLUGIN_SCHEMA_V1, "name": "portable.test"}),
+        encoding="utf-8",
+    )
+    (plugin / "mcp.json").write_text(
+        json.dumps(
+            {
+                "$schema": MCP_SCHEMA_V1,
+                "mcpServers": {
+                    "worker": {
+                        "type": "streamable-http",
+                        "url": "https://example.test/mcp",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "plugins:\n  enabled:\n    - ${PORTABLE_ID}\n",
+        encoding="utf-8",
+    )
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    monkeypatch.setenv("PORTABLE_ID", "portable.test")
+
+    assert mcp_startup._has_configured_mcp_servers() is True
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    winner = manager._plugins["portable.test"]
+    assert winner.enabled is True
+    assert winner.manifest.name == "portable.test"
+    assert len(manager.get_portable_mcp_servers()) == 1
 
 
 
@@ -181,7 +237,9 @@ def _install_retry_stubs(monkeypatch, *, connected: bool, calls: dict):
         sys.modules,
         "hermes_cli.config",
         types.SimpleNamespace(
-            read_raw_config=lambda: {"mcp_servers": {"demo": {"transport": "stdio"}}},
+            load_config_readonly=lambda: {
+                "mcp_servers": {"demo": {"transport": "stdio"}}
+            },
         ),
     )
     monkeypatch.setitem(

--- a/tests/hermes_cli/test_model_cache_swr.py
+++ b/tests/hermes_cli/test_model_cache_swr.py
@@ -145,7 +145,58 @@ class TestProviderModelsSWR:
             mod._spawn_swr_refresh("openrouter")
 
         assert saved["openrouter"]["models"] == ["fresh1", "fresh2"]
-        assert "openrouter" not in mod._swr_refresh_inflight  # cleared on completion
+        assert not mod._swr_refresh_inflight  # cleared on completion
+
+    def test_swr_refresh_inherits_context_and_dedupes_per_profile(self, tmp_path):
+        import hermes_cli.models as mod
+        from hermes_constants import (
+            get_hermes_home,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        targets = []
+        observed_homes = []
+
+        class DeferredThread:
+            def __init__(self, target=None, daemon=None, name=None):
+                targets.append(target)
+
+            def start(self):
+                pass
+
+        def scope_key():
+            return (str(get_hermes_home()), "")
+
+        def live_models(provider, *, force_refresh=False):
+            observed_homes.append(get_hermes_home())
+            return [f"{get_hermes_home().name}-model"]
+
+        def spawn_from(home):
+            token = set_hermes_home_override(home)
+            try:
+                mod._spawn_swr_refresh("openrouter")
+            finally:
+                reset_hermes_home_override(token)
+
+        with patch.object(mod.threading, "Thread", DeferredThread), \
+             patch.object(mod, "_provider_metadata_scope_key", side_effect=scope_key), \
+             patch.object(mod, "provider_model_ids", side_effect=live_models), \
+             patch.object(mod, "_credential_fingerprint", return_value="fp"), \
+             patch.object(mod, "_load_provider_models_cache", return_value={}), \
+             patch.object(mod, "_save_provider_models_cache"):
+            spawn_from(home_a)
+            spawn_from(home_a)  # same provider + same profile is deduped
+            spawn_from(home_b)  # same provider + different profile is not
+
+            assert len(targets) == 2
+            for target in targets:
+                target()
+
+        assert observed_homes == [home_a, home_b]
+        assert not mod._swr_refresh_inflight
 
 
 class TestCatalogSWR:

--- a/tests/hermes_cli/test_model_provider_metadata_scope.py
+++ b/tests/hermes_cli/test_model_provider_metadata_scope.py
@@ -1,0 +1,305 @@
+"""Context-scoped provider metadata regression tests."""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+
+@contextmanager
+def _hermes_home(path):
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    token = set_hermes_home_override(path)
+    try:
+        yield
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _profile_for_current_home():
+    from hermes_constants import get_hermes_home
+
+    suffix = get_hermes_home().name
+    return SimpleNamespace(
+        name=f"scoped-provider-{suffix}",
+        aliases=("scoped-provider",),
+        auth_type="api_key",
+        display_name=f"Scoped Provider {suffix}",
+        description=f"Provider for {suffix}",
+    )
+
+
+@pytest.fixture
+def scoped_provider_discovery(monkeypatch):
+    import providers
+    monkeypatch.setattr(
+        providers,
+        "list_providers",
+        lambda: [_profile_for_current_home()],
+    )
+    monkeypatch.setattr(
+        providers,
+        "is_plugin_managed_provider_id",
+        lambda provider_id: False,
+    )
+    monkeypatch.setattr(
+        providers,
+        "is_provider_plugin_active",
+        lambda provider_id: False,
+    )
+
+
+def test_provider_metadata_snapshots_stay_bound_to_their_profile(
+    tmp_path,
+    scoped_provider_discovery,
+):
+    import hermes_cli.models as models
+
+    home_a = tmp_path / "a"
+    home_b = tmp_path / "b"
+    compatibility_views = (
+        models.CANONICAL_PROVIDERS,
+        models._PROVIDER_ALIASES,
+        models._PROVIDER_LABELS,
+        models._KNOWN_PROVIDER_NAMES,
+    )
+
+    with _hermes_home(home_a):
+        models._refresh_canonical_providers_from_plugins()
+        snapshot_a = models._provider_metadata_snapshot()
+        assert models.normalize_provider("scoped-provider") == "scoped-provider-a"
+        assert "scoped-provider-a" in {
+            entry.slug for entry in models.CANONICAL_PROVIDERS
+        }
+        assert "scoped-provider-b" not in {
+            entry.slug for entry in models.CANONICAL_PROVIDERS
+        }
+
+    with _hermes_home(home_b):
+        models._refresh_canonical_providers_from_plugins()
+        snapshot_b = models._provider_metadata_snapshot()
+        assert models.normalize_provider("scoped-provider") == "scoped-provider-b"
+        assert "scoped-provider-b" in models._KNOWN_PROVIDER_NAMES
+
+    assert snapshot_a is not snapshot_b
+    with pytest.raises(TypeError):
+        snapshot_a.provider_aliases["new-alias"] = "scoped-provider-a"
+
+    # A refresh in profile B must not mutate or replace profile A's snapshot.
+    with _hermes_home(home_a):
+        assert models._provider_metadata_snapshot() is snapshot_a
+        assert models.normalize_provider("scoped-provider") == "scoped-provider-a"
+        assert "scoped-provider-b" not in models._KNOWN_PROVIDER_NAMES
+        canonical_view, aliases_view, labels_view, known_names_view = (
+            compatibility_views
+        )
+        assert aliases_view.get("scoped-provider") == "scoped-provider-a"
+        assert labels_view.get("scoped-provider-a") == "Scoped Provider a"
+        assert "scoped-provider-a" in known_names_view
+        assert "scoped-provider-a" in {
+            entry.slug for entry in canonical_view
+        }
+
+    # Existing ``from hermes_cli.models import ...`` references stay live.
+    current_views = (
+        models.CANONICAL_PROVIDERS,
+        models._PROVIDER_ALIASES,
+        models._PROVIDER_LABELS,
+        models._KNOWN_PROVIDER_NAMES,
+    )
+    assert all(
+        original is current
+        for original, current in zip(compatibility_views, current_views)
+    )
+
+
+def test_provider_metadata_compatibility_views_preserve_collection_reads(
+    tmp_path,
+    scoped_provider_discovery,
+):
+    import hermes_cli.models as models
+
+    with _hermes_home(tmp_path / "collection-profile"):
+        models._refresh_canonical_providers_from_plugins()
+        snapshot = models._provider_metadata_snapshot()
+
+        expected_names = set(snapshot.known_provider_names)
+        assert set(models._KNOWN_PROVIDER_NAMES) == expected_names
+        assert models._KNOWN_PROVIDER_NAMES == expected_names
+        assert expected_names == models._KNOWN_PROVIDER_NAMES
+        assert models._KNOWN_PROVIDER_NAMES | {"sentinel"} == (
+            expected_names | {"sentinel"}
+        )
+        assert {"sentinel"} | models._KNOWN_PROVIDER_NAMES == (
+            expected_names | {"sentinel"}
+        )
+        assert set(models._canonical_slugs) == set(snapshot.canonical_slugs)
+
+        expected_canonical = list(snapshot.canonical_providers)
+        assert models.CANONICAL_PROVIDERS == expected_canonical
+        assert expected_canonical == models.CANONICAL_PROVIDERS
+
+
+def test_cached_profile_views_do_not_reenter_provider_discovery(
+    tmp_path,
+    scoped_provider_discovery,
+    monkeypatch,
+):
+    import hermes_cli.models as models
+    import providers
+
+    home_a = tmp_path / "hot-a"
+    home_b = tmp_path / "hot-b"
+    for home in (home_a, home_b):
+        with _hermes_home(home):
+            models._refresh_canonical_providers_from_plugins()
+
+    identity_calls = 0
+    refresh_calls = 0
+
+    def discovery_identity():
+        nonlocal identity_calls
+        identity_calls += 1
+        raise AssertionError("hot metadata read re-entered provider discovery")
+
+    original_hook = models._refresh_canonical_providers_from_plugins
+
+    def counted_refresh():
+        nonlocal refresh_calls
+        refresh_calls += 1
+        original_hook()
+
+    hooks = list(providers._PROVIDER_REFRESH_HOOKS)
+    hooks = [
+        counted_refresh if hook is original_hook else hook
+        for hook in hooks
+    ]
+    monkeypatch.setattr(providers, "_PROVIDER_REFRESH_HOOKS", hooks)
+    monkeypatch.setattr(
+        providers,
+        "get_provider_discovery_identity",
+        discovery_identity,
+    )
+
+    for _ in range(20):
+        with _hermes_home(home_a):
+            assert models.normalize_provider("scoped-provider") == (
+                "scoped-provider-hot-a"
+            )
+            assert dict(models._PROVIDER_LABELS)
+            assert set(models._KNOWN_PROVIDER_NAMES)
+        with _hermes_home(home_b):
+            assert models.normalize_provider("scoped-provider") == (
+                "scoped-provider-hot-b"
+            )
+            assert dict(models._PROVIDER_LABELS)
+            assert set(models._KNOWN_PROVIDER_NAMES)
+
+    assert identity_calls == 0
+    assert refresh_calls == 0
+
+
+def test_provider_activation_invalidation_refreshes_same_scope_snapshot(
+    tmp_path,
+    scoped_provider_discovery,
+    monkeypatch,
+):
+    import hermes_cli.models as models
+    import providers
+
+    home = tmp_path / "activation-profile"
+    home.mkdir()
+    active_name = "activation-provider-a"
+
+    def active_profiles():
+        return [
+            SimpleNamespace(
+                name=active_name,
+                aliases=("activation-provider",),
+                auth_type="api_key",
+                display_name=active_name,
+                description=f"Provider {active_name}",
+            )
+        ]
+
+    monkeypatch.setattr(providers, "list_providers", active_profiles)
+    original_hook = models._refresh_canonical_providers_from_plugins
+    hook_calls = 0
+
+    def counted_refresh():
+        nonlocal hook_calls
+        hook_calls += 1
+        original_hook()
+
+    hooks = list(providers._PROVIDER_REFRESH_HOOKS)
+    hooks = [
+        counted_refresh if hook is original_hook else hook
+        for hook in hooks
+    ]
+    monkeypatch.setattr(providers, "_PROVIDER_REFRESH_HOOKS", hooks)
+
+    with _hermes_home(home):
+        original_hook()
+        snapshot_a = models._provider_metadata_snapshot()
+        assert models.normalize_provider("activation-provider") == active_name
+
+        active_name = "activation-provider-b"
+        hook_calls = 0
+        providers.invalidate_provider_discovery()
+
+        snapshot_b = models._provider_metadata_snapshot()
+        assert hook_calls == 1
+        assert snapshot_b is not snapshot_a
+        assert models.normalize_provider("activation-provider") == active_name
+
+
+def test_concurrent_profile_refreshes_do_not_cross_contaminate(
+    tmp_path,
+    scoped_provider_discovery,
+):
+    import hermes_cli.models as models
+
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def worker(home, expected_provider):
+        try:
+            with _hermes_home(home):
+                barrier.wait(timeout=5)
+                for _ in range(25):
+                    models._refresh_canonical_providers_from_plugins()
+                    assert (
+                        models.normalize_provider("scoped-provider")
+                        == expected_provider
+                    )
+                    assert expected_provider in models._KNOWN_PROVIDER_NAMES
+                    assert expected_provider in {
+                        entry.slug for entry in models.CANONICAL_PROVIDERS
+                    }
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(
+            target=worker,
+            args=(tmp_path / "a", "scoped-provider-a"),
+        ),
+        threading.Thread(
+            target=worker,
+            args=(tmp_path / "b", "scoped-provider-b"),
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []

--- a/tests/hermes_cli/test_model_provider_metadata_scope.py
+++ b/tests/hermes_cli/test_model_provider_metadata_scope.py
@@ -9,6 +9,69 @@ from types import SimpleNamespace
 import pytest
 
 
+def test_provider_metadata_cache_uses_catalog_scope_authority(monkeypatch):
+    import hermes_cli.models as models
+    import providers
+
+    physical_scope = (r"f:\profiles\primary", r"f:\repos\hermes")
+    catalog = SimpleNamespace(
+        scope_identity=physical_scope,
+        fingerprint=("catalog", "primary"),
+    )
+    monkeypatch.setattr(
+        providers,
+        "get_provider_scope_identity",
+        lambda: physical_scope,
+    )
+    monkeypatch.setattr(
+        providers,
+        "get_published_provider_catalog_snapshot",
+        lambda: catalog,
+    )
+
+    assert models._provider_metadata_scope_key() == physical_scope
+    assert models._provider_metadata_cache_key() == (
+        physical_scope,
+        catalog.fingerprint,
+    )
+
+
+def test_warm_provider_metadata_reads_do_not_resolve_scope_paths(monkeypatch):
+    import hermes_cli.models as models
+    import providers
+
+    logical_scope = (r"c:\profiles\primary", r"c:\repos\hermes")
+    physical_scope = (r"f:\profiles\primary", r"f:\repos\hermes")
+    resolved = iter(physical_scope)
+    resolve_calls = 0
+    metadata = models._build_provider_metadata([])
+
+    def resolve_path(_path):
+        nonlocal resolve_calls
+        resolve_calls += 1
+        return next(resolved)
+
+    monkeypatch.setattr(providers, "_provider_scope_marker", lambda: logical_scope)
+    monkeypatch.setattr(providers, "_path_identity", resolve_path)
+    monkeypatch.setattr(providers, "_PROVIDER_SCOPE_IDENTITY_CACHE", {})
+    monkeypatch.setattr(
+        providers,
+        "get_published_provider_catalog_snapshot",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        models,
+        "_PROVIDER_METADATA_BY_SCOPE",
+        {(physical_scope, None): metadata},
+    )
+
+    assert providers.get_provider_scope_identity() == physical_scope
+    assert resolve_calls == 2
+    for _ in range(20):
+        models.normalize_provider("openrouter")
+    assert resolve_calls == 2
+
+
 @contextmanager
 def _hermes_home(path):
     from hermes_constants import (

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -66,6 +66,59 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
     )
 
 
+@pytest.mark.parametrize("custom_routable", [False, True])
+def test_custom_picker_rows_follow_runtime_activation(
+    monkeypatch,
+    custom_routable,
+):
+    """Every custom picker shape must share the runtime activation gate."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.auth.is_runtime_provider_routable",
+        lambda provider: custom_routable if provider == "custom" else True,
+    )
+    probes = []
+
+    def _probe(*args, **kwargs):
+        probes.append((args, kwargs))
+        return []
+
+    monkeypatch.setattr("hermes_cli.models.cached_fetch_api_models", _probe)
+
+    rows = list_authenticated_providers(
+        current_provider="custom",
+        current_model="bare-model",
+        current_base_url="https://bare.invalid/v1",
+        user_providers={
+            "named": {
+                "name": "Named Provider",
+                "base_url": "https://named.invalid/v1",
+                "models": ["named-model"],
+            }
+        },
+        custom_providers=[
+            {
+                "name": "Legacy Provider",
+                "base_url": "https://legacy.invalid/v1",
+                "models": ["legacy-model"],
+            }
+        ],
+        probe_custom_providers=True,
+        probe_current_custom_provider=True,
+        max_models=50,
+    )
+
+    custom_rows = {
+        row["slug"]
+        for row in rows
+        if row.get("source") in {"model-config", "user-config"}
+    }
+    expected = {"custom", "named", "custom:legacy-provider"}
+    assert custom_rows == (expected if custom_routable else set())
+    assert bool(probes) is custom_routable
+
+
 
 
 

--- a/tests/hermes_cli/test_plugin_activation.py
+++ b/tests/hermes_cli/test_plugin_activation.py
@@ -165,6 +165,32 @@ def test_fresh_corrupt_config_fails_closed_for_nonbundled(
     )
 
 
+def test_safe_mode_does_not_read_user_plugin_configuration(
+    monkeypatch,
+):
+    from hermes_cli import config
+
+    monkeypatch.setenv("HERMES_SAFE_MODE", "1")
+
+    def user_config_must_not_be_read():
+        raise AssertionError("safe mode read user config")
+
+    monkeypatch.setattr(
+        config,
+        "load_config_readonly",
+        user_config_must_not_be_read,
+    )
+    state = config.load_plugin_activation_state()
+
+    assert state == PluginActivationState(safe_mode=True)
+    assert state.is_active(
+        name="openrouter",
+        key="model-providers/openrouter",
+        source="bundled",
+        kind="model-provider",
+    )
+
+
 def test_static_model_alias_cannot_revive_disabled_provider(monkeypatch):
     from hermes_cli import models
 

--- a/tests/hermes_cli/test_plugin_activation.py
+++ b/tests/hermes_cli/test_plugin_activation.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.plugin_activation import PluginActivationState
+
+
+@pytest.mark.parametrize(
+    ("state", "plugin", "expected"),
+    [
+        (
+            PluginActivationState(),
+            {"name": "web", "key": "web", "source": "bundled", "kind": "backend"},
+            "enabled",
+        ),
+        (
+            PluginActivationState(),
+            {"name": "buzz", "key": "buzz", "source": "bundled", "kind": "platform"},
+            "enabled",
+        ),
+        (
+            PluginActivationState(),
+            {
+                "name": "openrouter",
+                "key": "model-providers/openrouter",
+                "source": "bundled",
+                "kind": "model-provider",
+            },
+            "enabled",
+        ),
+        (
+            PluginActivationState(),
+            {
+                "name": "cleanup",
+                "key": "cleanup",
+                "source": "bundled",
+                "kind": "standalone",
+            },
+            "not enabled",
+        ),
+        (
+            PluginActivationState(),
+            {
+                "name": "third-party",
+                "key": "third-party",
+                "source": "user",
+                "kind": "backend",
+            },
+            "not enabled",
+        ),
+        (
+            PluginActivationState(enabled=frozenset({"third-party"})),
+            {
+                "name": "third-party",
+                "key": "third-party",
+                "source": "user",
+                "kind": "backend",
+            },
+            "enabled",
+        ),
+        (
+            PluginActivationState(
+                enabled=frozenset({"third-party"}),
+                disabled=frozenset({"third-party"}),
+            ),
+            {
+                "name": "third-party",
+                "key": "third-party",
+                "source": "user",
+                "kind": "backend",
+            },
+            "disabled",
+        ),
+        (
+            PluginActivationState(safe_mode=True),
+            {"name": "web", "key": "web", "source": "bundled", "kind": "backend"},
+            "not enabled",
+        ),
+        (
+            PluginActivationState(safe_mode=True),
+            {
+                "name": "openrouter",
+                "key": "model-providers/openrouter",
+                "source": "bundled",
+                "kind": "model-provider",
+            },
+            "enabled",
+        ),
+    ],
+)
+def test_activation_policy_matrix(state, plugin, expected):
+    assert state.status(**plugin) == expected
+
+
+def _reset_config_state(config_module) -> None:
+    config_module._LOAD_CONFIG_CACHE.clear()
+    config_module._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+
+
+def test_activation_accessor_uses_canonical_env_expansion(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TEST_PLUGIN_KEY", "expanded-plugin")
+    (tmp_path / "config.yaml").write_text(
+        'plugins:\n  enabled: ["${TEST_PLUGIN_KEY}"]\n',
+        encoding="utf-8",
+    )
+
+    from hermes_cli import config
+
+    _reset_config_state(config)
+    state = config.load_plugin_activation_state()
+
+    assert state.enabled == frozenset({"expanded-plugin"})
+
+
+def test_activation_accessor_preserves_canonical_last_known_good(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "plugins:\n  enabled: [user-plugin]\n  disabled: [model-providers/gmi]\n",
+        encoding="utf-8",
+    )
+
+    from hermes_cli import config
+
+    _reset_config_state(config)
+    good = config.load_plugin_activation_state()
+    config_path.write_text("plugins: [\n", encoding="utf-8")
+    retained = config.load_plugin_activation_state()
+
+    assert retained == good
+    assert retained.enabled == frozenset({"user-plugin"})
+    assert retained.disabled == frozenset({"model-providers/gmi"})
+
+
+def test_fresh_corrupt_config_fails_closed_for_nonbundled(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("plugins: [\n", encoding="utf-8")
+
+    from hermes_cli import config
+
+    _reset_config_state(config)
+    state = config.load_plugin_activation_state()
+
+    assert not state.is_active(
+        name="third-party",
+        key="third-party",
+        source="user",
+        kind="backend",
+    )
+    assert state.is_active(
+        name="bundled-backend",
+        key="bundled-backend",
+        source="bundled",
+        kind="backend",
+    )
+
+
+def test_static_model_alias_cannot_revive_disabled_provider(monkeypatch):
+    from hermes_cli import models
+
+    monkeypatch.setattr(
+        models,
+        "_PROVIDER_MODELS",
+        {"anthropic": ["claude-sonnet-4"]},
+    )
+    monkeypatch.setattr(
+        models,
+        "_provider_is_routable",
+        lambda provider: provider != "anthropic",
+    )
+
+    assert models._resolve_static_model_alias("sonnet", set()) is None
+
+
+def test_disabled_provider_catalogs_do_not_leak_static_or_disk_cache(monkeypatch):
+    from hermes_cli import models
+
+    provider = "disabled-cache-provider"
+    fingerprint = "disabled-cache-fingerprint"
+    monkeypatch.setattr(models, "_provider_is_routable", lambda _provider: False)
+    monkeypatch.setattr(
+        models,
+        "_PROVIDER_MODELS",
+        {provider: ["static-model-must-not-leak"]},
+    )
+    monkeypatch.setattr(
+        models,
+        "_load_provider_models_cache",
+        lambda: {
+            provider: {
+                "fp": fingerprint,
+                "at": models.time.time(),
+                "models": ["cached-model-must-not-leak"],
+            }
+        },
+    )
+    monkeypatch.setattr(
+        models,
+        "_credential_fingerprint",
+        lambda _provider: fingerprint,
+    )
+
+    assert models.provider_model_ids(provider) == []
+    assert models.cached_provider_model_ids(provider) == []

--- a/tests/hermes_cli/test_plugin_activation.py
+++ b/tests/hermes_cli/test_plugin_activation.py
@@ -208,6 +208,42 @@ def test_static_model_alias_cannot_revive_disabled_provider(monkeypatch):
     assert models._resolve_static_model_alias("sonnet", set()) is None
 
 
+def test_openrouter_fallback_cannot_revive_disabled_provider(monkeypatch):
+    from hermes_cli import models
+
+    monkeypatch.setattr(
+        models,
+        "_provider_is_routable",
+        lambda provider: provider != "openrouter",
+    )
+    monkeypatch.setattr(
+        models,
+        "_find_openrouter_slug",
+        lambda _name: pytest.fail("disabled OpenRouter catalog was queried"),
+    )
+
+    assert (
+        models.detect_provider_for_model(
+            "openrouter-only-model",
+            "openai-api",
+        )
+        is None
+    )
+
+
+def test_openrouter_fallback_still_routes_when_enabled(monkeypatch):
+    from hermes_cli import models
+
+    slug = "poolside/laguna-m.1:free"
+    monkeypatch.setattr(models, "_provider_is_routable", lambda _provider: True)
+    monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: slug)
+
+    assert models.detect_provider_for_model(
+        "laguna-m.1:free",
+        "openai-api",
+    ) == ("openrouter", slug)
+
+
 def test_disabled_provider_catalogs_do_not_leak_static_or_disk_cache(monkeypatch):
     from hermes_cli import models
 

--- a/tests/hermes_cli/test_plugin_runtime_disable_gate.py
+++ b/tests/hermes_cli/test_plugin_runtime_disable_gate.py
@@ -20,14 +20,25 @@ from unittest.mock import patch, AsyncMock
 import pytest
 
 from hermes_cli import web_server
+from hermes_cli.plugin_activation import PluginActivationState
+
+
+def _activation(*, enabled=(), disabled=(), safe_mode=False):
+    return PluginActivationState(
+        enabled=frozenset(enabled),
+        disabled=frozenset(disabled),
+        safe_mode=safe_mode,
+    )
 
 
 @pytest.fixture(autouse=True)
 def _reset_plugin_cache():
     """Bust the plugin cache before and after each test."""
     web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache_fingerprint = None
     yield
     web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache_fingerprint = None
 
 
 @pytest.fixture
@@ -83,6 +94,21 @@ def _make_bundled_plugin(tmp_path, name="bundledx"):
     return dashboard_dir
 
 
+def _make_project_plugin(project_root, name="project-extension"):
+    """Create a dashboard-only project extension with a browser asset."""
+    dashboard_dir = project_root / ".hermes" / "plugins" / name / "dashboard"
+    dashboard_dir.mkdir(parents=True)
+    dist_dir = dashboard_dir / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "index.js").write_text("console.log('project');")
+    (dashboard_dir / "manifest.json").write_text(json.dumps({
+        "name": name,
+        "label": "Project Extension",
+        "entry": "dist/index.js",
+    }))
+    return dashboard_dir
+
+
 # ---------------------------------------------------------------------------
 # Test 1: Runtime-disabled user plugin API routes return 404
 # ---------------------------------------------------------------------------
@@ -119,8 +145,10 @@ class TestPluginApiRuntimeGate:
         call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
 
         with patch.object(web_server, "_get_dashboard_plugins", return_value=[fake_plugin]), \
-             patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"hot"}), \
-             patch("hermes_cli.plugins_cmd._get_disabled_set", return_value={"hot"}):
+             patch(
+                 "hermes_cli.config.load_plugin_activation_state",
+                 return_value=_activation(enabled={"hot"}, disabled={"hot"}),
+             ):
             response = await web_server._plugin_api_runtime_gate(request, call_next)
 
         assert response.status_code == 404
@@ -171,8 +199,10 @@ class TestPluginApiRuntimeGate:
         call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
 
         with patch.object(web_server, "_get_dashboard_plugins", return_value=[]), \
-             patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set()), \
-             patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set()):
+             patch(
+                 "hermes_cli.config.load_plugin_activation_state",
+                 return_value=_activation(),
+             ):
             response = await web_server._plugin_api_runtime_gate(request, call_next)
 
         assert response.status_code == 404
@@ -203,9 +233,8 @@ class TestBundledPluginAssetGate:
         with patch.object(web_server, "_get_dashboard_plugins", return_value=[fake_plugin]):
             # Sanity: asset is served when not disabled.
             with patch(
-                "hermes_cli.plugins_cmd._get_enabled_set", return_value=set()
-            ), patch(
-                "hermes_cli.plugins_cmd._get_disabled_set", return_value=set()
+                "hermes_cli.config.load_plugin_activation_state",
+                return_value=_activation(),
             ):
                 resp = test_client.get("/dashboard-plugins/bundledx/dist/index.js")
                 assert resp.status_code == 200, (
@@ -214,9 +243,8 @@ class TestBundledPluginAssetGate:
 
             # Disable it.
             with patch(
-                "hermes_cli.plugins_cmd._get_enabled_set", return_value=set()
-            ), patch(
-                "hermes_cli.plugins_cmd._get_disabled_set", return_value={"bundledx"}
+                "hermes_cli.config.load_plugin_activation_state",
+                return_value=_activation(disabled={"bundledx"}),
             ):
                 resp = test_client.get("/dashboard-plugins/bundledx/dist/index.js")
                 assert resp.status_code == 404, (
@@ -237,10 +265,160 @@ class TestBundledPluginAssetGate:
 
         with patch.object(web_server, "_get_dashboard_plugins", return_value=[fake_plugin]):
             with patch(
-                "hermes_cli.plugins_cmd._get_enabled_set", return_value=set()
-            ), patch(
-                "hermes_cli.plugins_cmd._get_disabled_set", return_value=set()
+                "hermes_cli.config.load_plugin_activation_state",
+                return_value=_activation(),
             ):
                 resp = test_client.get("/dashboard-plugins/goodbundled/dist/index.js")
                 assert resp.status_code == 200
+
+
+def test_dashboard_display_name_cannot_replace_canonical_runtime_key(tmp_path):
+    plugin_root = tmp_path / "plugins" / "web" / "runtime-key"
+    dashboard_dir = plugin_root / "dashboard"
+    dashboard_dir.mkdir(parents=True)
+    plugin = {
+        "name": "dashboard-label",
+        "source": "user",
+        "_dir": str(dashboard_dir),
+    }
+    runtime_entries = [
+        (
+            "runtime-name",
+            "1.0.0",
+            "",
+            "user",
+            plugin_root,
+            "web/runtime-key",
+            "standalone",
+        )
+    ]
+
+    display_only = _activation(enabled={"dashboard-label"})
+    canonical = _activation(enabled={"web/runtime-key"})
+
+    assert (
+        web_server._dashboard_plugin_status(
+            plugin,
+            runtime_entries,
+            display_only,
+        )
+        == "not enabled"
+    )
+    assert (
+        web_server._dashboard_plugin_status(
+            plugin,
+            runtime_entries,
+            canonical,
+        )
+        == "enabled"
+    )
+
+
+def test_dashboard_only_fallback_honors_safe_mode():
+    plugin = {
+        "name": "project-extension",
+        "source": "project",
+    }
+    state = _activation(
+        enabled={"project-extension"},
+        safe_mode=True,
+    )
+
+    assert (
+        web_server._dashboard_plugin_status(plugin, [], state)
+        == "not enabled"
+    )
+
+
+class TestProjectDashboardScopeInvalidation:
+    """Cached project JavaScript must not outlive its cwd/env opt-in scope."""
+
+    def test_gate_disable_blocks_asset_and_list_from_populated_cache(
+        self,
+        test_client,
+        tmp_path,
+        monkeypatch,
+    ):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        monkeypatch.chdir(project_root)
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+        _make_project_plugin(project_root)
+        activation = _activation(enabled={"project-extension"})
+
+        with patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            return_value=activation,
+        ):
+            cached = web_server._get_dashboard_plugins(force_rescan=True)
+            stale_plugin = next(
+                p for p in cached if p["name"] == "project-extension"
+            )
+            assert test_client.get(
+                "/dashboard-plugins/project-extension/dist/index.js"
+            ).status_code == 200
+            listed = test_client.get("/api/dashboard/plugins")
+            assert listed.status_code == 200
+            assert "project-extension" in {
+                item["name"] for item in listed.json()
+            }
+
+            # Keep the old directory in place: invalidation must be driven by
+            # scope identity, not by the legacy "directory disappeared" check.
+            monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "0")
+            assert test_client.get(
+                "/dashboard-plugins/project-extension/dist/index.js"
+            ).status_code == 404
+            listed = test_client.get("/api/dashboard/plugins")
+            assert listed.status_code == 200
+            assert "project-extension" not in {
+                item["name"] for item in listed.json()
+            }
+            assert stale_plugin["source"] == "project"
+
+    @pytest.mark.asyncio
+    async def test_runtime_api_gate_rejects_stale_project_entry_when_gate_turns_off(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from starlette.requests import Request
+        from starlette.responses import JSONResponse
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        monkeypatch.chdir(project_root)
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+        _make_project_plugin(project_root)
+        stale_plugin = next(
+            p
+            for p in web_server._get_dashboard_plugins(force_rescan=True)
+            if p["name"] == "project-extension"
+        )
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "0")
+
+        request = Request({
+            "type": "http",
+            "method": "GET",
+            "path": "/api/plugins/project-extension/probe",
+            "query_string": b"",
+            "headers": [],
+            "state": {"token_authenticated": True},
+        })
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+        with patch.object(
+            web_server,
+            "_get_dashboard_plugins",
+            return_value=[stale_plugin],
+        ), patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            return_value=_activation(enabled={"project-extension"}),
+        ):
+            response = await web_server._plugin_api_runtime_gate(
+                request,
+                call_next,
+            )
+
+        assert response.status_code == 404
+        call_next.assert_not_called()
 

--- a/tests/hermes_cli/test_plugin_runtime_disable_gate.py
+++ b/tests/hermes_cli/test_plugin_runtime_disable_gate.py
@@ -94,6 +94,22 @@ def _make_bundled_plugin(tmp_path, name="bundledx"):
     return dashboard_dir
 
 
+def _make_bundled_runtime_plugin(root, directory, *, key, dashboard_name):
+    """Create a bundled runtime plugin claiming a dashboard route name."""
+    plugin_root = root / directory
+    dashboard_dir = plugin_root / "dashboard"
+    dashboard_dir.mkdir(parents=True)
+    (plugin_root / "plugin.yaml").write_text(
+        f"name: {key}\nkind: backend\nversion: 1.0.0\n"
+    )
+    (dashboard_dir / "manifest.json").write_text(json.dumps({
+        "name": dashboard_name,
+        "label": dashboard_name,
+        "entry": "dist/index.js",
+    }))
+    return dashboard_dir
+
+
 def _make_project_plugin(project_root, name="project-extension"):
     """Create a dashboard-only project extension with a browser asset."""
     dashboard_dir = project_root / ".hermes" / "plugins" / name / "dashboard"
@@ -203,6 +219,83 @@ class TestPluginApiRuntimeGate:
                  "hermes_cli.config.load_plugin_activation_state",
                  return_value=_activation(),
              ):
+            response = await web_server._plugin_api_runtime_gate(request, call_next)
+
+        assert response.status_code == 404
+        call_next.assert_not_called()
+
+
+class TestDashboardRouteNameCollision:
+    def test_distinct_canonical_plugins_sharing_route_fail_closed(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        bundled = tmp_path / "bundled"
+        home = tmp_path / "home"
+        bundled.mkdir()
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _make_bundled_runtime_plugin(
+            bundled,
+            "one",
+            key="runtime-one",
+            dashboard_name="shared-route",
+        )
+        _make_bundled_runtime_plugin(
+            bundled,
+            "two",
+            key="runtime-two",
+            dashboard_name="shared-route",
+        )
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled,
+        ):
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            claimants = [p for p in plugins if p["name"] == "shared-route"]
+            assert len(claimants) == 2
+            assert all(p.get("_route_name_collision") for p in claimants)
+            assert all(
+                web_server._dashboard_plugin_status(p) == "not enabled"
+                for p in claimants
+            )
+
+    @pytest.mark.asyncio
+    async def test_collision_cannot_borrow_another_plugins_runtime_gate(self):
+        from starlette.requests import Request
+        from starlette.responses import JSONResponse
+
+        claimants = [
+            {
+                "name": "shared-route",
+                "source": "bundled",
+                "_runtime_key": "runtime-one",
+                "_route_name_collision": True,
+            },
+            {
+                "name": "shared-route",
+                "source": "bundled",
+                "_runtime_key": "runtime-two",
+                "_route_name_collision": True,
+            },
+        ]
+        request = Request({
+            "type": "http",
+            "method": "GET",
+            "path": "/api/plugins/shared-route/probe",
+            "query_string": b"",
+            "headers": [],
+            "state": {"token_authenticated": True},
+        })
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        with patch.object(
+            web_server,
+            "_get_dashboard_plugins",
+            return_value=claimants,
+        ):
             response = await web_server._plugin_api_runtime_gate(request, call_next)
 
         assert response.status_code == 404

--- a/tests/hermes_cli/test_plugin_runtime_disable_gate.py
+++ b/tests/hermes_cli/test_plugin_runtime_disable_gate.py
@@ -34,11 +34,15 @@ def _activation(*, enabled=(), disabled=(), safe_mode=False):
 @pytest.fixture(autouse=True)
 def _reset_plugin_cache():
     """Bust the plugin cache before and after each test."""
+    mounted_owners = dict(web_server._mounted_plugin_api_owners)
     web_server._dashboard_plugins_cache = None
     web_server._dashboard_plugins_cache_fingerprint = None
+    web_server._mounted_plugin_api_owners.clear()
     yield
     web_server._dashboard_plugins_cache = None
     web_server._dashboard_plugins_cache_fingerprint = None
+    web_server._mounted_plugin_api_owners.clear()
+    web_server._mounted_plugin_api_owners.update(mounted_owners)
 
 
 @pytest.fixture
@@ -160,11 +164,14 @@ class TestPluginApiRuntimeGate:
 
         call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
 
-        with patch.object(web_server, "_get_dashboard_plugins", return_value=[fake_plugin]), \
-             patch(
-                 "hermes_cli.config.load_plugin_activation_state",
-                 return_value=_activation(enabled={"hot"}, disabled={"hot"}),
-             ):
+        with patch.dict(
+            web_server._mounted_plugin_api_owners,
+            {"hot": fake_plugin},
+            clear=True,
+        ), patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            return_value=_activation(enabled={"hot"}, disabled={"hot"}),
+        ):
             response = await web_server._plugin_api_runtime_gate(request, call_next)
 
         assert response.status_code == 404
@@ -223,6 +230,113 @@ class TestPluginApiRuntimeGate:
 
         assert response.status_code == 404
         call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_middleware_gates_the_mounted_owner_after_winner_changes(
+        self,
+        tmp_path,
+    ):
+        """A new same-name winner cannot authorize the old mounted router."""
+        from starlette.requests import Request
+        from starlette.responses import JSONResponse
+
+        user_root = tmp_path / "user" / "shared-runtime"
+        bundled_root = tmp_path / "bundled" / "shared-runtime"
+        (user_root / "dashboard").mkdir(parents=True)
+        (bundled_root / "dashboard").mkdir(parents=True)
+
+        mounted_user = {
+            "name": "shared-api",
+            "source": "user",
+            "_dir": str(user_root / "dashboard"),
+            "_runtime_name": "shared-runtime",
+            "_runtime_key": "backend/shared-runtime",
+            "_runtime_source": "user",
+            "_runtime_kind": "backend",
+            "_runtime_managed": True,
+        }
+        current_bundled = {
+            **mounted_user,
+            "source": "bundled",
+            "_dir": str(bundled_root / "dashboard"),
+            "_runtime_source": "bundled",
+        }
+        runtime_entries = [
+            (
+                "shared-runtime",
+                "1.0.0",
+                "",
+                "bundled",
+                bundled_root,
+                "backend/shared-runtime",
+                "backend",
+            )
+        ]
+        request = Request({
+            "type": "http",
+            "method": "GET",
+            "path": "/api/plugins/shared-api/probe",
+            "query_string": b"",
+            "headers": [],
+            "state": {"token_authenticated": True},
+        })
+        call_next = AsyncMock(return_value=JSONResponse({"owner": "user"}))
+
+        with patch.dict(
+            web_server._mounted_plugin_api_owners,
+            {"shared-api": mounted_user},
+            clear=True,
+        ), patch.object(
+            web_server,
+            "_get_dashboard_plugins",
+            return_value=[current_bundled],
+        ), patch.object(
+            web_server,
+            "_discover_dashboard_runtime_entries",
+            return_value=runtime_entries,
+        ), patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            return_value=_activation(enabled={"backend/shared-runtime"}),
+        ):
+            response = await web_server._plugin_api_runtime_gate(
+                request,
+                call_next,
+            )
+
+        assert response.status_code == 404
+        call_next.assert_not_called()
+
+    def test_mount_skips_an_already_owned_public_namespace(self, tmp_path):
+        """A second same-name router cannot add differently gated subpaths."""
+        dashboard_dir = tmp_path / "second" / "dashboard"
+        dashboard_dir.mkdir(parents=True)
+        (dashboard_dir / "api.py").write_text("# import sentinel\n")
+        second_owner = {
+            "name": "shared-api",
+            "source": "user",
+            "_dir": str(dashboard_dir),
+            "_api_file": "api.py",
+        }
+
+        with patch.dict(
+            web_server._mounted_plugin_api_owners,
+            {"shared-api": {"name": "shared-api", "source": "bundled"}},
+            clear=True,
+        ), patch.object(
+            web_server,
+            "_get_dashboard_plugins",
+            return_value=[second_owner],
+        ), patch.object(
+            web_server,
+            "_dashboard_plugin_is_active",
+            return_value=True,
+        ) as active, patch(
+            "importlib.util.spec_from_file_location",
+        ) as spec:
+            web_server._mount_plugin_api_routes()
+
+        active.assert_not_called()
+        spec.assert_not_called()
 
 
 class TestDashboardRouteNameCollision:
@@ -291,10 +405,10 @@ class TestDashboardRouteNameCollision:
         })
         call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
 
-        with patch.object(
-            web_server,
-            "_get_dashboard_plugins",
-            return_value=claimants,
+        with patch.dict(
+            web_server._mounted_plugin_api_owners,
+            {"shared-route": claimants[0]},
+            clear=True,
         ):
             response = await web_server._plugin_api_runtime_gate(request, call_next)
 
@@ -499,10 +613,10 @@ class TestProjectDashboardScopeInvalidation:
             "state": {"token_authenticated": True},
         })
         call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
-        with patch.object(
-            web_server,
-            "_get_dashboard_plugins",
-            return_value=[stale_plugin],
+        with patch.dict(
+            web_server._mounted_plugin_api_owners,
+            {"project-extension": stale_plugin},
+            clear=True,
         ), patch(
             "hermes_cli.config.load_plugin_activation_state",
             return_value=_activation(enabled={"project-extension"}),

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -159,6 +159,64 @@ class TestPluginDiscovery:
         assert manager._plugins["native"].enabled is True
         assert manager._plugins["native"].module is not None
 
+    def test_portable_mcp_probe_uses_active_source_winner(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli.agent_plugins import MCP_SCHEMA_V1, PLUGIN_SCHEMA_V1
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / "home"
+        portable = home / "plugins" / "cat" / "plug"
+        portable.mkdir(parents=True)
+        (portable / "plugin.json").write_text(
+            json.dumps({"$schema": PLUGIN_SCHEMA_V1, "name": "portable.test"})
+        )
+        (portable / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "$schema": MCP_SCHEMA_V1,
+                    "mcpServers": {
+                        "remote": {
+                            "type": "streamable-http",
+                            "url": "https://example.test/mcp",
+                        }
+                    },
+                }
+            )
+        )
+        home.mkdir(exist_ok=True)
+        config = {"plugins": {"enabled": ["portable.test"]}}
+        (home / "config.yaml").write_text(yaml.safe_dump(config))
+
+        project = tmp_path / "project"
+        shadow = project / ".hermes" / "plugins" / "cat" / "plug"
+        shadow.mkdir(parents=True)
+        (shadow / "plugin.yaml").write_text(
+            yaml.safe_dump({"name": "native-shadow", "version": "1.0.0"})
+        )
+        (shadow / "__init__.py").write_text("def register(ctx):\n    pass\n")
+
+        bundled = tmp_path / "bundled"
+        bundled.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(plugins_mod, "get_bundled_plugins_dir", lambda: bundled)
+
+        manager = PluginManager()
+        assert manager.has_enabled_portable_mcp(config)
+
+        manager.discover_and_load()
+
+        winner = manager._plugins["cat/plug"]
+        assert winner.enabled is True
+        assert winner.manifest.name == "portable.test"
+        [server] = manager.get_portable_mcp_servers().values()
+        assert server == {
+            "url": "https://example.test/mcp",
+            "strict_redirect_headers": True,
+        }
+
     def test_disabled_portable_plugin_registers_nothing(self, tmp_path, monkeypatch):
         from hermes_cli.agent_plugins import PLUGIN_SCHEMA_V1
         from hermes_cli import plugins as plugins_mod

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from hermes_cli.plugin_activation import PluginActivationState
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
     VALID_HOOKS,
@@ -21,6 +22,7 @@ from hermes_cli.plugins import (
     get_pre_tool_call_block_message,
     get_pre_verify_continue_message,
     has_middleware,
+    resolve_plugin_candidate_winner,
     resolve_plugin_command_result,
     _portable_skill_namespace,
 )
@@ -382,6 +384,111 @@ class TestPluginDiscovery:
         assert mgr._plugin_skills == {}
         assert mgr._aux_tasks == {}
         assert mgr._slack_action_handlers == []
+
+
+class TestActivePluginWinnerResolution:
+    """Canonical-key collisions choose among active candidates only."""
+
+    @staticmethod
+    def _candidate(source: str, *, name: str = "shared", kind: str = "backend"):
+        return PluginManifest(
+            name=name,
+            key="shared",
+            source=source,
+            kind=kind,
+        )
+
+    @staticmethod
+    def _resolve(state: PluginActivationState, *candidates: PluginManifest):
+        return resolve_plugin_candidate_winner(
+            candidates,
+            lambda candidate: state.status(
+                name=candidate.name,
+                key=candidate.key,
+                source=candidate.source,
+                kind=candidate.kind,
+            ),
+        )
+
+    def test_manager_loads_bundled_fallback_for_inactive_user_collision(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        plugin_name = "active-winner-fallback"
+        bundled_root = tmp_path / "bundled"
+        hermes_home = tmp_path / "home"
+        manifest_extra = {"kind": "backend"}
+        _make_plugin_dir(
+            bundled_root,
+            plugin_name,
+            manifest_extra=manifest_extra,
+            auto_enable=False,
+        )
+        _make_plugin_dir(
+            hermes_home / "plugins",
+            plugin_name,
+            manifest_extra=manifest_extra,
+            auto_enable=False,
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            lambda: bundled_root,
+        )
+        monkeypatch.setattr(PluginManager, "_scan_entry_points", lambda _self: [])
+
+        manager = PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins[plugin_name]
+        assert loaded.enabled is True
+        assert loaded.manifest.source == "bundled"
+
+    def test_inactive_user_candidate_falls_back_to_bundled(self):
+        bundled = self._candidate("bundled")
+        user = self._candidate("user")
+
+        winner, status = self._resolve(PluginActivationState(), bundled, user)
+
+        assert winner is bundled
+        assert status == "enabled"
+
+    def test_enabled_user_candidate_overrides_bundled(self):
+        bundled = self._candidate("bundled")
+        user = self._candidate("user")
+        state = PluginActivationState(enabled=frozenset({"shared"}))
+
+        winner, status = self._resolve(state, bundled, user)
+
+        assert winner is user
+        assert status == "enabled"
+
+    def test_explicit_disable_on_any_candidate_blocks_whole_key(self):
+        bundled = self._candidate("bundled", name="bundled-name")
+        user = self._candidate("user", name="user-name")
+        state = PluginActivationState(
+            enabled=frozenset({"user-name"}),
+            disabled=frozenset({"bundled-name"}),
+        )
+
+        winner, status = self._resolve(state, bundled, user)
+
+        assert winner is user
+        assert status == "disabled"
+
+    def test_safe_mode_keeps_bundled_provider_over_enabled_user_override(self):
+        bundled = self._candidate("bundled", kind="model-provider")
+        user = self._candidate("user", kind="model-provider")
+        state = PluginActivationState(
+            enabled=frozenset({"shared"}),
+            safe_mode=True,
+        )
+
+        winner, status = self._resolve(state, bundled, user)
+
+        assert winner is bundled
+        assert status == "enabled"
 
 
 # ── TestPluginLoading ──────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_plugins_cmd_category_discovery.py
+++ b/tests/hermes_cli/test_plugins_cmd_category_discovery.py
@@ -261,6 +261,8 @@ class TestCmdListJson:
         names = [p["name"] for p in payload]
         assert "web-tavily" in names
         assert "disk-cleanup" in names
+        by_name = {p["name"]: p for p in payload}
+        assert by_name["web-tavily"]["key"] == "web/tavily"
 
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")

--- a/tests/hermes_cli/test_plugins_cmd_category_discovery.py
+++ b/tests/hermes_cli/test_plugins_cmd_category_discovery.py
@@ -49,11 +49,12 @@ class TestReadManifestInfo:
         })
         result = _read_manifest_info(d, "")
         assert result is not None
-        name, version, description, key = result
+        name, version, description, key, kind = result
         assert name == "my-plugin"
         assert version == "1.0.0"
         assert description == "test"
         assert key == "my-plugin"  # flat: key == name
+        assert kind == "standalone"
 
 
     def test_no_manifest(self, tmp_path):
@@ -146,6 +147,38 @@ class TestDiscoverAllPlugins:
         assert "web/tavily" in keys
         assert "a/b/c" not in keys
 
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_bundled_platform_key_matches_runtime_loader(
+        self,
+        mock_user_dir,
+        mock_bundled_dir,
+        tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+
+        bundled = tmp_path / "bundled"
+        user = tmp_path / "user"
+        user.mkdir()
+        _make_category_plugin(
+            bundled,
+            "platforms",
+            "buzz",
+            {
+                "name": "buzz-platform",
+                "kind": "platform",
+                "version": "1.0.0",
+            },
+        )
+        mock_bundled_dir.return_value = bundled
+        mock_user_dir.return_value = user
+
+        entries = _discover_all_plugins()
+        buzz = next(entry for entry in entries if entry[0] == "buzz-platform")
+
+        assert buzz[5] == "buzz-platform"
+        assert buzz[6] == "platform"
+
 
 # ---------------------------------------------------------------------------
 # _plugin_status — key-aware status
@@ -174,8 +207,16 @@ class TestFilterPluginEntries:
         from hermes_cli.plugins_cmd import _filter_plugin_entries
 
         entries = [
-            ("web-tavily", "1.0.0", "search", "user", Path("/tmp"), "web/tavily"),
-            ("disk-cleanup", "1.0.0", "cleanup", "bundled", Path("/tmp"), "disk-cleanup"),
+            ("web-tavily", "1.0.0", "search", "user", Path("/tmp"), "web/tavily", "standalone"),
+            (
+                "disk-cleanup",
+                "1.0.0",
+                "cleanup",
+                "bundled",
+                Path("/tmp"),
+                "disk-cleanup",
+                "standalone",
+            ),
         ]
         args = MagicMock()
         args.no_bundled = False

--- a/tests/hermes_cli/test_plugins_cmd_category_discovery.py
+++ b/tests/hermes_cli/test_plugins_cmd_category_discovery.py
@@ -223,9 +223,10 @@ class TestFilterPluginEntries:
         args.user = False
         args.enabled = True
 
-        result = _filter_plugin_entries(entries, args, {"web/tavily"}, set())
+        records = [(entries[0], "enabled"), (entries[1], "not enabled")]
+        result = _filter_plugin_entries(records, args)
         assert len(result) == 1
-        assert result[0][5] == "web/tavily"
+        assert result[0][0][5] == "web/tavily"
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +268,7 @@ class TestCmdListJson:
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     def test_json_status_uses_key(self, mock_user_dir, mock_bundled_dir, tmp_path, capsys):
+        from hermes_cli.plugin_activation import PluginActivationState
         from hermes_cli.plugins_cmd import cmd_list
 
         _make_category_plugin(tmp_path, "web", "tavily", {
@@ -276,7 +278,11 @@ class TestCmdListJson:
         mock_bundled_dir.return_value = tmp_path / "nonexistent"
 
         # Patch config to return web/tavily as enabled
-        with patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"web/tavily"}):
+        activation = PluginActivationState(enabled=frozenset({"web/tavily"}))
+        with patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            return_value=activation,
+        ):
             args = MagicMock()
             args.json = True
             args.plain = False

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -77,6 +77,23 @@ class TestResolvePluginKey:
         assert _resolve_plugin_key("openai") is None
         assert _resolve_plugin_key("image_gen/openai") == "image_gen/openai"
 
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_dashboard_file_actions_resolve_key_to_real_user_directory(
+        self,
+        mock_user,
+        mock_bundled,
+        nested_plugin_env,
+    ):
+        from hermes_cli.plugins_cmd import _user_installed_plugin_dir
+
+        mock_user.return_value = nested_plugin_env
+        mock_bundled.return_value = nested_plugin_env / "nonexistent"
+
+        assert _user_installed_plugin_dir("observability/nemo_relay") == (
+            nested_plugin_env / "observability" / "nemo_relay"
+        ).resolve()
+
 
 # ---------------------------------------------------------------------------
 # cmd_enable / cmd_disable — write the canonical key

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -293,6 +293,52 @@ class TestEnableDisableNested:
             candidates[1]
         ]
 
+    def test_disable_user_override_preserves_sibling_canonical_deny(
+        self,
+        monkeypatch,
+    ):
+        from hermes_cli import plugins_cmd
+        from hermes_cli.plugin_activation import PluginActivationState
+
+        candidates = [
+            ("shared", "1", "Target", "bundled", None, "target/key", "backend"),
+            ("shared", "1", "Sibling", "bundled", None, "sibling/key", "backend"),
+            ("target-user", "2", "Target", "user", None, "target/key", "backend"),
+        ]
+        saved = {}
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_resolve_plugin_key_and_source",
+            lambda _name: ("target/key", "user", "target-user", "backend"),
+        )
+        monkeypatch.setattr(
+            plugins_cmd, "_discover_plugin_candidates", lambda: candidates
+        )
+        monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"target/key"})
+        monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: {"shared"})
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_save_enabled_set",
+            lambda value: saved.update(enabled=set(value)),
+        )
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_save_disabled_set",
+            lambda value: saved.update(disabled=set(value)),
+        )
+
+        plugins_cmd.cmd_disable("target/key")
+
+        assert saved == {
+            "enabled": set(),
+            "disabled": {"target/key", "sibling/key"},
+        }
+        activation = PluginActivationState(
+            enabled=frozenset(saved["enabled"]),
+            disabled=frozenset(saved["disabled"]),
+        )
+        assert plugins_cmd._select_active_plugin_entries(candidates, activation) == []
+
 
 # ---------------------------------------------------------------------------
 # cmd_enable — built-in tool override consent (issue #29249)

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -246,7 +246,7 @@ class TestEnableDisableNested:
             candidates[0]
         ]
 
-    def test_disable_shared_manifest_preserves_other_canonical_allow(
+    def test_disable_shared_manifest_drops_redundant_bundled_allow(
         self,
         monkeypatch,
     ):
@@ -282,7 +282,7 @@ class TestEnableDisableNested:
         plugins_cmd.cmd_disable("image_gen/xai")
 
         assert saved == {
-            "enabled": {"xai"},
+            "enabled": set(),
             "disabled": {"image_gen/xai"},
         }
         activation = PluginActivationState(

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -421,11 +421,10 @@ class TestCompositeMenuWritesCanonicalKey:
         # key differs from the manifest name, mirroring web/firecrawl.
         plugin_keys = ["web/firecrawl"]
         plugin_labels = ["web-firecrawl — firecrawl [bundled]"]
-        plugin_selected = set()  # unchecked → should be disabled
+        plugin_selected = {0}  # active initially, then explicitly unchecked
 
-        # First input() toggles nothing (blank Enter confirms immediately),
-        # second (category prompt) is skipped with blank Enter.
-        with patch("builtins.input", return_value=""):
+        answers = iter(["1", ""])
+        with patch("builtins.input", side_effect=lambda _prompt: next(answers)):
             _run_composite_fallback(
                 plugin_keys, plugin_labels, plugin_selected,
                 set(), [], Console(),

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -282,7 +282,7 @@ class TestEnableDisableNested:
         plugins_cmd.cmd_disable("image_gen/xai")
 
         assert saved == {
-            "enabled": {"video_gen/xai"},
+            "enabled": {"xai"},
             "disabled": {"image_gen/xai"},
         }
         activation = PluginActivationState(
@@ -293,7 +293,7 @@ class TestEnableDisableNested:
             candidates[1]
         ]
 
-    def test_disable_user_override_preserves_sibling_canonical_deny(
+    def test_disable_user_override_preserves_shared_deny(
         self,
         monkeypatch,
     ):
@@ -331,7 +331,7 @@ class TestEnableDisableNested:
 
         assert saved == {
             "enabled": set(),
-            "disabled": {"target/key", "sibling/key"},
+            "disabled": {"shared", "target/key"},
         }
         activation = PluginActivationState(
             enabled=frozenset(saved["enabled"]),

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -246,6 +246,53 @@ class TestEnableDisableNested:
             candidates[0]
         ]
 
+    def test_disable_shared_manifest_preserves_other_canonical_allow(
+        self,
+        monkeypatch,
+    ):
+        from hermes_cli import plugins_cmd
+        from hermes_cli.plugin_activation import PluginActivationState
+
+        candidates = [
+            ("xai", "1", "Images", "bundled", None, "image_gen/xai", "backend"),
+            ("xai", "1", "Video", "bundled", None, "video_gen/xai", "backend"),
+        ]
+        saved = {}
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_resolve_plugin_key_and_source",
+            lambda _name: ("image_gen/xai", "bundled", "xai", "backend"),
+        )
+        monkeypatch.setattr(
+            plugins_cmd, "_discover_plugin_candidates", lambda: candidates
+        )
+        monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"xai"})
+        monkeypatch.setattr(plugins_cmd, "_get_disabled_set", set)
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_save_enabled_set",
+            lambda value: saved.update(enabled=set(value)),
+        )
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_save_disabled_set",
+            lambda value: saved.update(disabled=set(value)),
+        )
+
+        plugins_cmd.cmd_disable("image_gen/xai")
+
+        assert saved == {
+            "enabled": {"video_gen/xai"},
+            "disabled": {"image_gen/xai"},
+        }
+        activation = PluginActivationState(
+            enabled=frozenset(saved["enabled"]),
+            disabled=frozenset(saved["disabled"]),
+        )
+        assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+            candidates[1]
+        ]
+
 
 # ---------------------------------------------------------------------------
 # cmd_enable — built-in tool override consent (issue #29249)

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -199,6 +199,53 @@ class TestEnableDisableNested:
             candidates[1]
         ]
 
+    def test_enable_shared_manifest_preserves_other_canonical_deny(
+        self,
+        monkeypatch,
+    ):
+        from hermes_cli import plugins_cmd
+        from hermes_cli.plugin_activation import PluginActivationState
+
+        candidates = [
+            ("xai", "1", "Images", "bundled", None, "image_gen/xai", "backend"),
+            ("xai", "1", "Video", "bundled", None, "video_gen/xai", "backend"),
+        ]
+        saved = {}
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_resolve_plugin_key_and_source",
+            lambda _name: ("image_gen/xai", "bundled", "xai", "backend"),
+        )
+        monkeypatch.setattr(
+            plugins_cmd, "_discover_plugin_candidates", lambda: candidates
+        )
+        monkeypatch.setattr(plugins_cmd, "_get_enabled_set", set)
+        monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: {"xai"})
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_save_enabled_set",
+            lambda value: saved.update(enabled=set(value)),
+        )
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_save_disabled_set",
+            lambda value: saved.update(disabled=set(value)),
+        )
+
+        plugins_cmd.cmd_enable("image_gen/xai")
+
+        assert saved == {
+            "enabled": {"image_gen/xai"},
+            "disabled": {"video_gen/xai"},
+        }
+        activation = PluginActivationState(
+            enabled=frozenset(saved["enabled"]),
+            disabled=frozenset(saved["disabled"]),
+        )
+        assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+            candidates[0]
+        ]
+
 
 # ---------------------------------------------------------------------------
 # cmd_enable — built-in tool override consent (issue #29249)

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -152,6 +152,53 @@ class TestEnableDisableNested:
         saved = mock_save_en.call_args[0][0]
         assert "disk-cleanup" in saved
 
+    def test_enable_clears_legacy_denies_for_every_same_key_candidate(
+        self,
+        monkeypatch,
+    ):
+        from hermes_cli import plugins_cmd
+        from hermes_cli.plugin_activation import PluginActivationState
+
+        candidates = [
+            ("bundled-shared", "1", "", "bundled", None, "shared", "backend"),
+            ("user-shared", "2", "", "user", None, "shared", "backend"),
+        ]
+        saved = {}
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_resolve_plugin_key_and_source",
+            lambda _name: ("shared", "user", "user-shared", "backend"),
+        )
+        monkeypatch.setattr(
+            plugins_cmd, "_discover_plugin_candidates", lambda: candidates
+        )
+        monkeypatch.setattr(plugins_cmd, "_get_enabled_set", set)
+        monkeypatch.setattr(
+            plugins_cmd, "_get_disabled_set", lambda: {"bundled-shared"}
+        )
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_save_enabled_set",
+            lambda value: saved.update(enabled=set(value)),
+        )
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_save_disabled_set",
+            lambda value: saved.update(disabled=set(value)),
+        )
+        monkeypatch.setattr(plugins_cmd, "_set_plugin_entry_flag", lambda *args: None)
+
+        plugins_cmd.cmd_enable("shared", allow_tool_override=False)
+
+        assert saved == {"enabled": {"shared"}, "disabled": set()}
+        activation = PluginActivationState(
+            enabled=frozenset(saved["enabled"]),
+            disabled=frozenset(saved["disabled"]),
+        )
+        assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+            candidates[1]
+        ]
+
 
 # ---------------------------------------------------------------------------
 # cmd_enable — built-in tool override consent (issue #29249)

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -52,6 +52,55 @@ def test_cmd_list_plain_compact_output(monkeypatch, capsys):
     assert "Search" not in out  # plain mode stays compact, no descriptions
 
 
+def test_cmd_list_json_preserves_name_and_adds_canonical_key(monkeypatch, capsys):
+    entries = [
+        ("xai", "1.0.0", "Images", "bundled", None, "image_gen/xai", "backend"),
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    plugins_cmd.cmd_list(_args(json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["name"] == "xai"
+    assert payload[0]["key"] == "image_gen/xai"
+
+
+def test_cmd_list_plain_disambiguates_duplicate_manifest_names(monkeypatch, capsys):
+    entries = [
+        ("xai", "1.0.0", "Images", "bundled", None, "image_gen/xai", "backend"),
+        ("xai", "1.0.0", "Video", "bundled", None, "video_gen/xai", "backend"),
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    plugins_cmd.cmd_list(_args(plain=True))
+
+    out = capsys.readouterr().out
+    assert "xai [image_gen/xai]" in out
+    assert "xai [video_gen/xai]" in out
+
+
+def test_dashboard_toggle_response_keeps_input_name_and_adds_key(monkeypatch):
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_resolve_plugin_key_and_source",
+        lambda _name: ("image_gen/xai", "user", "xai", "standalone"),
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda _value: None)
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda _value: None)
+    monkeypatch.setattr(plugins_cmd, "_toggle_plugin_toolset", lambda *args, **kwargs: None)
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled("xai", enabled=True)
+
+    assert result["name"] == "xai"
+    assert result["key"] == "image_gen/xai"
+
+
 def test_discover_all_plugins_includes_entrypoint_plugins(monkeypatch, tmp_path):
     bundled_dir = tmp_path / "bundled"
     user_dir = tmp_path / "user"

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -19,9 +19,9 @@ def _args(**kwargs):
 
 def test_filter_plugin_entries_enabled_only():
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None, "disk-cleanup"),
-        ("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus"),
-        ("old-plugin", "1.0.0", "Old", "user", None, "old-plugin"),
+        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None, "disk-cleanup", "backend"),
+        ("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus", "standalone"),
+        ("old-plugin", "1.0.0", "Old", "user", None, "old-plugin", "standalone"),
     ]
 
     filtered = plugins_cmd._filter_plugin_entries(
@@ -36,8 +36,8 @@ def test_filter_plugin_entries_enabled_only():
 
 def test_cmd_list_plain_compact_output(monkeypatch, capsys):
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None, "disk-cleanup"),
-        ("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus"),
+        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None, "disk-cleanup", "backend"),
+        ("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus", "standalone"),
     ]
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
@@ -90,6 +90,7 @@ def test_discover_all_plugins_includes_entrypoint_plugins(monkeypatch, tmp_path)
             "entrypoint",
             "adapters.hermes.cli_plugin",
             "wiki",
+            "standalone",
         )
     ]
 

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -203,6 +203,82 @@ def test_dashboard_enable_clears_every_same_key_candidate_deny(monkeypatch):
     ]
 
 
+def test_dashboard_enable_preserves_other_shared_manifest_key_deny(monkeypatch):
+    candidates = [
+        ("xai", "1", "Images", "bundled", None, "image_gen/xai", "backend"),
+        ("xai", "1", "Video", "bundled", None, "video_gen/xai", "backend"),
+    ]
+    saved = {}
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_resolve_plugin_key_and_source",
+        lambda _name: ("image_gen/xai", "bundled", "xai", "backend"),
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_discover_plugin_candidates", lambda: candidates
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", set)
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: {"xai"})
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saved.update(enabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saved.update(disabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_toggle_plugin_toolset", lambda *args, **kwargs: None
+    )
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled(
+        "image_gen/xai",
+        enabled=True,
+    )
+
+    assert result["unchanged"] is False
+    assert saved == {
+        "enabled": {"image_gen/xai"},
+        "disabled": {"video_gen/xai"},
+    }
+    activation = PluginActivationState(
+        enabled=frozenset(saved["enabled"]),
+        disabled=frozenset(saved["disabled"]),
+    )
+    assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+        candidates[0]
+    ]
+
+
+def test_enable_identities_do_not_treat_key_leaf_as_runtime_identity(monkeypatch):
+    candidates = [
+        (
+            "xai-provider",
+            "1",
+            "Models",
+            "bundled",
+            None,
+            "model-providers/xai",
+            "model-provider",
+        ),
+        ("xai", "1", "Images", "bundled", None, "image_gen/xai", "backend"),
+        ("xai", "1", "Video", "bundled", None, "video_gen/xai", "backend"),
+    ]
+    monkeypatch.setattr(
+        plugins_cmd, "_discover_plugin_candidates", lambda: candidates
+    )
+
+    identities, preserved = plugins_cmd._plugin_enable_identity_changes(
+        "model-providers/xai",
+        {"xai"},
+    )
+
+    assert identities == {"model-providers/xai", "xai-provider"}
+    assert preserved == set()
+
+
 def test_discover_all_plugins_includes_entrypoint_plugins(monkeypatch, tmp_path):
     bundled_dir = tmp_path / "bundled"
     user_dir = tmp_path / "user"

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -3,6 +3,7 @@ import json
 from types import SimpleNamespace
 
 from hermes_cli import plugins_cmd
+from hermes_cli.plugin_activation import PluginActivationState
 
 
 def _args(**kwargs):
@@ -39,7 +40,11 @@ def test_cmd_list_plain_compact_output(monkeypatch, capsys):
         ("disk-cleanup", "2.0.0", "Bundled", "bundled", None, "disk-cleanup", "backend"),
         ("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus", "standalone"),
     ]
-    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_display_entries",
+        lambda: entries,
+    )
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
 
@@ -56,7 +61,11 @@ def test_cmd_list_json_preserves_name_and_adds_canonical_key(monkeypatch, capsys
     entries = [
         ("xai", "1.0.0", "Images", "bundled", None, "image_gen/xai", "backend"),
     ]
-    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_display_entries",
+        lambda: entries,
+    )
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
 
@@ -72,7 +81,11 @@ def test_cmd_list_plain_disambiguates_duplicate_manifest_names(monkeypatch, caps
         ("xai", "1.0.0", "Images", "bundled", None, "image_gen/xai", "backend"),
         ("xai", "1.0.0", "Video", "bundled", None, "video_gen/xai", "backend"),
     ]
-    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_display_entries",
+        lambda: entries,
+    )
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
 
@@ -81,6 +94,50 @@ def test_cmd_list_plain_disambiguates_duplicate_manifest_names(monkeypatch, caps
     out = capsys.readouterr().out
     assert "xai [image_gen/xai]" in out
     assert "xai [video_gen/xai]" in out
+
+
+def test_cmd_list_uses_active_bundled_winner_over_inactive_user_copy(
+    monkeypatch,
+    capsys,
+):
+    candidates = [
+        (
+            "bundled-shared",
+            "1.0.0",
+            "Bundled",
+            "bundled",
+            None,
+            "shared",
+            "backend",
+        ),
+        (
+            "user-shared",
+            "2.0.0",
+            "User",
+            "user",
+            None,
+            "shared",
+            "backend",
+        ),
+    ]
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_plugin_activation_state",
+        lambda: PluginActivationState(),
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    plugins_cmd.cmd_list(_args(json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [(row["name"], row["source"]) for row in payload] == [
+        ("bundled-shared", "bundled")
+    ]
 
 
 def test_dashboard_toggle_response_keeps_input_name_and_adds_key(monkeypatch):

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -6,6 +6,24 @@ from hermes_cli import plugins_cmd
 from hermes_cli.plugin_activation import PluginActivationState
 
 
+_GROUP_DENY_CANDIDATES = [
+    ("legacy-copy", "1.0", "Bundled", "bundled", None, "shared", "backend"),
+    ("new-copy", "2.0", "User", "user", None, "shared", "standalone"),
+]
+_PORTABLE_SHADOW_CANDIDATES = [
+    ("portable-user", "1.0", "Portable", "user", None, "shared", "standalone"),
+    (
+        "project-shadow",
+        "2.0",
+        "Project",
+        "project",
+        None,
+        "shared",
+        "standalone",
+    ),
+]
+
+
 def _args(**kwargs):
     defaults = {
         "enabled": False,
@@ -25,14 +43,17 @@ def test_filter_plugin_entries_enabled_only():
         ("old-plugin", "1.0.0", "Old", "user", None, "old-plugin", "standalone"),
     ]
 
-    filtered = plugins_cmd._filter_plugin_entries(
-        entries,
-        _args(enabled=True),
-        enabled={"disk-cleanup", "web-search-plus"},
-        disabled={"old-plugin"},
-    )
+    records = [
+        (entries[0], "enabled"),
+        (entries[1], "enabled"),
+        (entries[2], "disabled"),
+    ]
+    filtered = plugins_cmd._filter_plugin_entries(records, _args(enabled=True))
 
-    assert [entry[0] for entry in filtered] == ["disk-cleanup", "web-search-plus"]
+    assert [entry[0][0] for entry in filtered] == [
+        "disk-cleanup",
+        "web-search-plus",
+    ]
 
 
 def test_cmd_list_plain_compact_output(monkeypatch, capsys):
@@ -42,12 +63,9 @@ def test_cmd_list_plain_compact_output(monkeypatch, capsys):
     ]
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_entries",
-        lambda: entries,
+        "_discover_plugin_display_records",
+        lambda: [(entry, "enabled") for entry in entries],
     )
-    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
-    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
-
     plugins_cmd.cmd_list(_args(plain=True, no_bundled=True))
 
     out = capsys.readouterr().out
@@ -63,12 +81,9 @@ def test_cmd_list_json_preserves_name_and_adds_canonical_key(monkeypatch, capsys
     ]
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_entries",
-        lambda: entries,
+        "_discover_plugin_display_records",
+        lambda: [(entry, "enabled") for entry in entries],
     )
-    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
-    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
-
     plugins_cmd.cmd_list(_args(json=True))
 
     payload = json.loads(capsys.readouterr().out)
@@ -83,12 +98,9 @@ def test_cmd_list_plain_disambiguates_duplicate_manifest_names(monkeypatch, caps
     ]
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_entries",
-        lambda: entries,
+        "_discover_plugin_display_records",
+        lambda: [(entry, "enabled") for entry in entries],
     )
-    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
-    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
-
     plugins_cmd.cmd_list(_args(plain=True))
 
     out = capsys.readouterr().out
@@ -129,14 +141,177 @@ def test_cmd_list_uses_active_bundled_winner_over_inactive_user_copy(
         "hermes_cli.config.load_plugin_activation_state",
         lambda: PluginActivationState(),
     )
-    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
-    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
-
     plugins_cmd.cmd_list(_args(json=True))
 
     payload = json.loads(capsys.readouterr().out)
     assert [(row["name"], row["source"]) for row in payload] == [
         ("bundled-shared", "bundled")
+    ]
+
+
+def test_display_records_preserve_group_deny_and_list_uses_it(
+    monkeypatch,
+    capsys,
+):
+    candidates = _GROUP_DENY_CANDIDATES
+    activation = PluginActivationState(
+        enabled=frozenset({"new-copy"}),
+        disabled=frozenset({"legacy-copy"}),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_plugin_activation_state",
+        lambda: activation,
+    )
+
+    assert plugins_cmd._select_active_plugin_entries(candidates, activation) == []
+    assert plugins_cmd._discover_plugin_display_records() == [
+        (candidates[1], "disabled")
+    ]
+    assert plugins_cmd._discover_plugin_display_entries() == [candidates[1]]
+
+    plugins_cmd.cmd_list(_args(json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["name"] == "new-copy"
+    assert payload[0]["status"] == "disabled"
+
+    plugins_cmd.cmd_list(_args(plain=True))
+    assert "disabled" in capsys.readouterr().out
+
+    plugins_cmd.cmd_list(_args())
+    assert "disabled" in capsys.readouterr().out
+
+    plugins_cmd.cmd_list(_args(json=True, enabled=True))
+    assert json.loads(capsys.readouterr().out) == []
+
+
+def test_cmd_toggle_uses_enabled_winner_not_inactive_project_shadow(
+    monkeypatch,
+):
+    candidates = _PORTABLE_SHADOW_CANDIDATES
+    activation = PluginActivationState(
+        enabled=frozenset({"portable-user"}),
+    )
+    captured = {}
+
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_plugin_activation_state",
+        lambda: activation,
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", set)
+    monkeypatch.setattr(plugins_cmd, "_get_current_memory_provider", lambda: "")
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_get_current_context_engine",
+        lambda: "compressor",
+    )
+    monkeypatch.setattr(plugins_cmd.sys.stdin, "isatty", lambda: True)
+
+    def _capture(_curses, keys, labels, selected, *_args):
+        captured.update(keys=keys, labels=labels, selected=selected)
+
+    monkeypatch.setattr(plugins_cmd, "_run_composite_ui", _capture)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_run_composite_fallback",
+        lambda keys, labels, selected, *_args: captured.update(
+            keys=keys,
+            labels=labels,
+            selected=selected,
+        ),
+    )
+
+    plugins_cmd.cmd_toggle()
+
+    assert captured["keys"] == ["shared"]
+    assert captured["selected"] == {0}
+    assert "portable-user" in captured["labels"][0]
+    assert "project-shadow" not in captured["labels"][0]
+
+
+def test_composite_toggle_enable_clears_same_key_legacy_deny(monkeypatch):
+    candidates = _GROUP_DENY_CANDIDATES
+    saved = {}
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", set)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saved.update(enabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saved.update(disabled=set(value)),
+    )
+    changed = plugins_cmd._persist_composite_plugin_selection(
+        ["shared"],
+        set(),
+        {0},
+        {"legacy-copy"},
+    )
+
+    assert changed is True
+    assert saved == {"enabled": {"shared"}, "disabled": set()}
+    activation = PluginActivationState(
+        enabled=frozenset(saved["enabled"]),
+        disabled=frozenset(saved["disabled"]),
+    )
+    assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+        candidates[1]
+    ]
+
+
+def test_composite_confirm_preserves_user_alias_and_active_winner(monkeypatch):
+    candidates = _PORTABLE_SHADOW_CANDIDATES
+    saves = []
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_get_enabled_set",
+        lambda: {"portable-user"},
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saves.append(("enabled", set(value))),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saves.append(("disabled", set(value))),
+    )
+    changed = plugins_cmd._persist_composite_plugin_selection(
+        ["shared"],
+        {0},
+        {0},
+        set(),
+    )
+
+    assert changed is False
+    assert saves == []
+    activation = PluginActivationState(
+        enabled=frozenset({"portable-user"}),
+    )
+    assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+        candidates[0]
     ]
 
 

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -2,6 +2,8 @@ import argparse
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from hermes_cli import plugins_cmd
 from hermes_cli.plugin_activation import PluginActivationState
 
@@ -19,6 +21,19 @@ _PORTABLE_SHADOW_CANDIDATES = [
         "project",
         None,
         "shared",
+        "standalone",
+    ),
+]
+_SHARED_ALLOW_SOURCE_CANDIDATES = [
+    ("shared", "1.0", "Target", "user", None, "target", "standalone"),
+    ("shared", "1.0", "Sibling", "user", None, "sibling", "standalone"),
+    (
+        "project-shadow",
+        "2.0",
+        "Project",
+        "project",
+        None,
+        "sibling",
         "standalone",
     ),
 ]
@@ -315,6 +330,115 @@ def test_composite_confirm_preserves_user_alias_and_active_winner(monkeypatch):
     ]
 
 
+@pytest.mark.parametrize("surface", ["cli", "dashboard", "delta"])
+def test_disable_shared_allow_preserves_sibling_source_winner(
+    monkeypatch,
+    surface,
+):
+    candidates = _SHARED_ALLOW_SOURCE_CANDIDATES
+    saved = {}
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"shared"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", set)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saved.update(enabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saved.update(disabled=set(value)),
+    )
+
+    if surface == "cli":
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_resolve_plugin_key_and_source",
+            lambda _name: ("target", "user", "shared", "standalone"),
+        )
+        plugins_cmd.cmd_disable("target")
+    elif surface == "dashboard":
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_resolve_plugin_key_and_source",
+            lambda _name: ("target", "user", "shared", "standalone"),
+        )
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_toggle_plugin_toolset",
+            lambda *args, **kwargs: None,
+        )
+        result = plugins_cmd.dashboard_set_agent_plugin_enabled(
+            "target",
+            enabled=False,
+        )
+        assert result["unchanged"] is False
+    else:
+        changed = plugins_cmd._persist_composite_plugin_selection(
+            ["target"],
+            {0},
+            set(),
+            set(),
+        )
+        assert changed is True
+
+    assert saved == {"enabled": {"shared"}, "disabled": {"target"}}
+    activation = PluginActivationState(
+        enabled=frozenset(saved["enabled"]),
+        disabled=frozenset(saved["disabled"]),
+    )
+    assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+        candidates[1]
+    ]
+
+
+def test_composite_enable_keeps_shared_allow_and_sibling_source_winner(monkeypatch):
+    candidates = _SHARED_ALLOW_SOURCE_CANDIDATES
+    saved = {}
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"shared"})
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saved.update(enabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saved.update(disabled=set(value)),
+    )
+
+    changed = plugins_cmd._persist_composite_plugin_selection(
+        ["target"],
+        set(),
+        {0},
+        {"target"},
+    )
+
+    assert changed is True
+    assert saved == {
+        "enabled": {"shared", "target"},
+        "disabled": set(),
+    }
+    activation = PluginActivationState(
+        enabled=frozenset(saved["enabled"]),
+        disabled=frozenset(saved["disabled"]),
+    )
+    assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+        candidates[0],
+        candidates[1],
+    ]
+
+
 def test_dashboard_toggle_response_keeps_input_name_and_adds_key(monkeypatch):
     monkeypatch.setattr(
         plugins_cmd,
@@ -464,7 +588,7 @@ def test_dashboard_disable_preserves_other_shared_manifest_key_allow(monkeypatch
 
     assert result["unchanged"] is False
     assert saved == {
-        "enabled": {"video_gen/xai"},
+        "enabled": {"xai"},
         "disabled": {"image_gen/xai"},
     }
     activation = PluginActivationState(
@@ -476,7 +600,7 @@ def test_dashboard_disable_preserves_other_shared_manifest_key_allow(monkeypatch
     ]
 
 
-def test_dashboard_disable_user_override_preserves_sibling_key_deny(monkeypatch):
+def test_dashboard_disable_user_override_preserves_shared_deny(monkeypatch):
     candidates = [
         ("shared", "1", "Target", "bundled", None, "target/key", "backend"),
         ("shared", "1", "Sibling", "bundled", None, "sibling/key", "backend"),
@@ -515,7 +639,7 @@ def test_dashboard_disable_user_override_preserves_sibling_key_deny(monkeypatch)
     assert result["unchanged"] is False
     assert saved == {
         "enabled": set(),
-        "disabled": {"target/key", "sibling/key"},
+        "disabled": {"shared", "target/key"},
     }
     activation = PluginActivationState(
         enabled=frozenset(saved["enabled"]),

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -91,7 +91,7 @@ def test_cmd_list_plain_compact_output(monkeypatch, capsys):
     ]
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_records",
+        "_discover_plugin_management_records",
         lambda: [(entry, "enabled") for entry in entries],
     )
     plugins_cmd.cmd_list(_args(plain=True, no_bundled=True))
@@ -109,7 +109,7 @@ def test_cmd_list_json_preserves_name_and_adds_canonical_key(monkeypatch, capsys
     ]
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_records",
+        "_discover_plugin_management_records",
         lambda: [(entry, "enabled") for entry in entries],
     )
     plugins_cmd.cmd_list(_args(json=True))
@@ -126,7 +126,7 @@ def test_cmd_list_plain_disambiguates_duplicate_manifest_names(monkeypatch, caps
     ]
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_records",
+        "_discover_plugin_management_records",
         lambda: [(entry, "enabled") for entry in entries],
     )
     plugins_cmd.cmd_list(_args(plain=True))
@@ -136,7 +136,7 @@ def test_cmd_list_plain_disambiguates_duplicate_manifest_names(monkeypatch, caps
     assert "xai [video_gen/xai]" in out
 
 
-def test_cmd_list_uses_active_bundled_winner_over_inactive_user_copy(
+def test_cmd_list_keeps_inactive_user_override_actionable(
     monkeypatch,
     capsys,
 ):
@@ -172,8 +172,8 @@ def test_cmd_list_uses_active_bundled_winner_over_inactive_user_copy(
     plugins_cmd.cmd_list(_args(json=True))
 
     payload = json.loads(capsys.readouterr().out)
-    assert [(row["name"], row["source"]) for row in payload] == [
-        ("bundled-shared", "bundled")
+    assert [(row["name"], row["source"], row["status"]) for row in payload] == [
+        ("user-shared", "user", "not enabled")
     ]
 
 
@@ -201,6 +201,9 @@ def test_display_records_preserve_group_deny_and_list_uses_it(
         (candidates[1], "disabled")
     ]
     assert plugins_cmd._discover_plugin_display_entries() == [candidates[1]]
+    assert plugins_cmd._discover_plugin_management_records() == [
+        (candidates[1], "disabled")
+    ]
 
     plugins_cmd.cmd_list(_args(json=True))
     payload = json.loads(capsys.readouterr().out)
@@ -217,7 +220,7 @@ def test_display_records_preserve_group_deny_and_list_uses_it(
     assert json.loads(capsys.readouterr().out) == []
 
 
-def test_cmd_toggle_uses_enabled_winner_not_inactive_project_shadow(
+def test_cmd_toggle_keeps_inactive_project_override_actionable(
     monkeypatch,
 ):
     candidates = _PORTABLE_SHADOW_CANDIDATES
@@ -261,9 +264,9 @@ def test_cmd_toggle_uses_enabled_winner_not_inactive_project_shadow(
     plugins_cmd.cmd_toggle()
 
     assert captured["keys"] == ["shared"]
-    assert captured["selected"] == {0}
-    assert "portable-user" in captured["labels"][0]
-    assert "project-shadow" not in captured["labels"][0]
+    assert captured["selected"] == set()
+    assert "project-shadow" in captured["labels"][0]
+    assert "portable-user" not in captured["labels"][0]
 
 
 def test_composite_toggle_enable_clears_same_key_legacy_deny(monkeypatch):

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -301,6 +301,54 @@ def test_dashboard_disable_preserves_other_shared_manifest_key_allow(monkeypatch
     ]
 
 
+def test_dashboard_disable_user_override_preserves_sibling_key_deny(monkeypatch):
+    candidates = [
+        ("shared", "1", "Target", "bundled", None, "target/key", "backend"),
+        ("shared", "1", "Sibling", "bundled", None, "sibling/key", "backend"),
+        ("target-user", "2", "Target", "user", None, "target/key", "backend"),
+    ]
+    saved = {}
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_resolve_plugin_key_and_source",
+        lambda _name: ("target/key", "user", "target-user", "backend"),
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_discover_plugin_candidates", lambda: candidates
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"target/key"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: {"shared"})
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saved.update(enabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saved.update(disabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_toggle_plugin_toolset", lambda *args, **kwargs: None
+    )
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled(
+        "target/key",
+        enabled=False,
+    )
+
+    assert result["unchanged"] is False
+    assert saved == {
+        "enabled": set(),
+        "disabled": {"target/key", "sibling/key"},
+    }
+    activation = PluginActivationState(
+        enabled=frozenset(saved["enabled"]),
+        disabled=frozenset(saved["disabled"]),
+    )
+    assert plugins_cmd._select_active_plugin_entries(candidates, activation) == []
+
+
 def test_runtime_identities_do_not_treat_key_leaf_as_identity(monkeypatch):
     candidates = [
         (

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -37,6 +37,19 @@ _SHARED_ALLOW_SOURCE_CANDIDATES = [
         "standalone",
     ),
 ]
+_XAI_DEPENDENT_SOURCE_CANDIDATES = [
+    ("xai", "1.0", "Images", "user", None, "image_gen/xai", "standalone"),
+    ("xai", "1.0", "Video", "user", None, "video_gen/xai", "standalone"),
+    (
+        "project-shadow",
+        "2.0",
+        "Project",
+        "project",
+        None,
+        "video_gen/xai",
+        "standalone",
+    ),
+]
 
 
 def _args(**kwargs):
@@ -439,6 +452,148 @@ def test_composite_enable_keeps_shared_allow_and_sibling_source_winner(monkeypat
     ]
 
 
+@pytest.mark.parametrize("surface", ["cli", "dashboard"])
+def test_sequential_disable_clears_last_shared_allow(
+    monkeypatch,
+    surface,
+):
+    candidates = _XAI_DEPENDENT_SOURCE_CANDIDATES
+    state = {"enabled": {"xai"}, "disabled": set()}
+    resolutions = {
+        "image_gen/xai": (
+            "image_gen/xai",
+            "user",
+            "xai",
+            "standalone",
+        ),
+        "video_gen/xai": (
+            "video_gen/xai",
+            "user",
+            "xai",
+            "standalone",
+        ),
+    }
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_resolve_plugin_key_and_source",
+        resolutions.__getitem__,
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_get_enabled_set",
+        lambda: set(state["enabled"]),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_get_disabled_set",
+        lambda: set(state["disabled"]),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: state.update(enabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: state.update(disabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_toggle_plugin_toolset",
+        lambda *args, **kwargs: None,
+    )
+
+    def _disable(key):
+        if surface == "cli":
+            plugins_cmd.cmd_disable(key)
+        else:
+            result = plugins_cmd.dashboard_set_agent_plugin_enabled(
+                key,
+                enabled=False,
+            )
+            assert result["unchanged"] is False
+
+    _disable("image_gen/xai")
+    assert state == {
+        "enabled": {"xai"},
+        "disabled": {"image_gen/xai"},
+    }
+    first_activation = PluginActivationState(
+        enabled=frozenset(state["enabled"]),
+        disabled=frozenset(state["disabled"]),
+    )
+    assert plugins_cmd._select_active_plugin_entries(
+        candidates,
+        first_activation,
+    ) == [candidates[1]]
+
+    _disable("video_gen/xai")
+    assert state == {
+        "enabled": set(),
+        "disabled": {"image_gen/xai", "video_gen/xai"},
+    }
+    final_activation = PluginActivationState(
+        enabled=frozenset(state["enabled"]),
+        disabled=frozenset(state["disabled"]),
+    )
+    assert final_activation.status(
+        name="xai",
+        key="xai",
+        source="user",
+        kind="standalone",
+    ) == "not enabled"
+
+
+def test_composite_disable_two_groups_clears_last_shared_allow(monkeypatch):
+    candidates = _XAI_DEPENDENT_SOURCE_CANDIDATES
+    saved = {}
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_candidates",
+        lambda: candidates,
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"xai"})
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saved.update(enabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saved.update(disabled=set(value)),
+    )
+
+    changed = plugins_cmd._persist_composite_plugin_selection(
+        ["image_gen/xai", "video_gen/xai"],
+        {0, 1},
+        set(),
+        set(),
+    )
+
+    assert changed is True
+    assert saved == {
+        "enabled": set(),
+        "disabled": {"image_gen/xai", "video_gen/xai"},
+    }
+    activation = PluginActivationState(
+        enabled=frozenset(saved["enabled"]),
+        disabled=frozenset(saved["disabled"]),
+    )
+    assert activation.status(
+        name="xai",
+        key="xai",
+        source="user",
+        kind="standalone",
+    ) == "not enabled"
+
+
 def test_dashboard_toggle_response_keeps_input_name_and_adds_key(monkeypatch):
     monkeypatch.setattr(
         plugins_cmd,
@@ -551,7 +706,7 @@ def test_dashboard_enable_preserves_other_shared_manifest_key_deny(monkeypatch):
     ]
 
 
-def test_dashboard_disable_preserves_other_shared_manifest_key_allow(monkeypatch):
+def test_dashboard_disable_drops_redundant_bundled_allow(monkeypatch):
     candidates = [
         ("xai", "1", "Images", "bundled", None, "image_gen/xai", "backend"),
         ("xai", "1", "Video", "bundled", None, "video_gen/xai", "backend"),
@@ -588,7 +743,7 @@ def test_dashboard_disable_preserves_other_shared_manifest_key_allow(monkeypatch
 
     assert result["unchanged"] is False
     assert saved == {
-        "enabled": {"xai"},
+        "enabled": set(),
         "disabled": {"image_gen/xai"},
     }
     activation = PluginActivationState(

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -252,7 +252,56 @@ def test_dashboard_enable_preserves_other_shared_manifest_key_deny(monkeypatch):
     ]
 
 
-def test_enable_identities_do_not_treat_key_leaf_as_runtime_identity(monkeypatch):
+def test_dashboard_disable_preserves_other_shared_manifest_key_allow(monkeypatch):
+    candidates = [
+        ("xai", "1", "Images", "bundled", None, "image_gen/xai", "backend"),
+        ("xai", "1", "Video", "bundled", None, "video_gen/xai", "backend"),
+    ]
+    saved = {}
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_resolve_plugin_key_and_source",
+        lambda _name: ("image_gen/xai", "bundled", "xai", "backend"),
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_discover_plugin_candidates", lambda: candidates
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"xai"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", set)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saved.update(enabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saved.update(disabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_toggle_plugin_toolset", lambda *args, **kwargs: None
+    )
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled(
+        "image_gen/xai",
+        enabled=False,
+    )
+
+    assert result["unchanged"] is False
+    assert saved == {
+        "enabled": {"video_gen/xai"},
+        "disabled": {"image_gen/xai"},
+    }
+    activation = PluginActivationState(
+        enabled=frozenset(saved["enabled"]),
+        disabled=frozenset(saved["disabled"]),
+    )
+    assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+        candidates[1]
+    ]
+
+
+def test_runtime_identities_do_not_treat_key_leaf_as_identity(monkeypatch):
     candidates = [
         (
             "xai-provider",
@@ -270,7 +319,7 @@ def test_enable_identities_do_not_treat_key_leaf_as_runtime_identity(monkeypatch
         plugins_cmd, "_discover_plugin_candidates", lambda: candidates
     )
 
-    identities, preserved = plugins_cmd._plugin_enable_identity_changes(
+    identities, preserved = plugins_cmd._plugin_runtime_identity_changes(
         "model-providers/xai",
         {"xai"},
     )

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -158,6 +158,51 @@ def test_dashboard_toggle_response_keeps_input_name_and_adds_key(monkeypatch):
     assert result["key"] == "image_gen/xai"
 
 
+def test_dashboard_enable_clears_every_same_key_candidate_deny(monkeypatch):
+    candidates = [
+        ("bundled-shared", "1", "", "bundled", None, "shared", "backend"),
+        ("user-shared", "2", "", "user", None, "shared", "backend"),
+    ]
+    saved = {}
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_resolve_plugin_key_and_source",
+        lambda _name: ("shared", "user", "user-shared", "backend"),
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_discover_plugin_candidates", lambda: candidates
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", set)
+    monkeypatch.setattr(
+        plugins_cmd, "_get_disabled_set", lambda: {"bundled-shared"}
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saved.update(enabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saved.update(disabled=set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_toggle_plugin_toolset", lambda *args, **kwargs: None
+    )
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled("shared", enabled=True)
+
+    assert result["unchanged"] is False
+    assert saved == {"enabled": {"shared"}, "disabled": set()}
+    activation = PluginActivationState(
+        enabled=frozenset(saved["enabled"]),
+        disabled=frozenset(saved["disabled"]),
+    )
+    assert plugins_cmd._select_active_plugin_entries(candidates, activation) == [
+        candidates[1]
+    ]
+
+
 def test_discover_all_plugins_includes_entrypoint_plugins(monkeypatch, tmp_path):
     bundled_dir = tmp_path / "bundled"
     user_dir = tmp_path / "user"

--- a/tests/hermes_cli/test_plugins_hub_perf_guard.py
+++ b/tests/hermes_cli/test_plugins_hub_perf_guard.py
@@ -6,14 +6,37 @@ from types import SimpleNamespace
 
 from hermes_cli import web_server
 from hermes_cli import plugins_cmd
+from hermes_cli.plugin_activation import PluginActivationState
 from tools import registry as tools_registry
 
 
-_PLUGIN_ROW = [("demo", "1.0.0", "demo plugin", "user", "/tmp/demo-plugin", "demo")]
+_PLUGIN_ROW = [
+    (
+        "demo",
+        "1.0.0",
+        "demo plugin",
+        "user",
+        "/tmp/demo-plugin",
+        "category/demo",
+        "standalone",
+    )
+]
 
 
 def _patch_minimal_hub_dependencies(monkeypatch, *, check_fn, discover_all_plugins=None):
     monkeypatch.setattr(web_server, "_get_dashboard_plugins", lambda force_rescan=False: [])
+    monkeypatch.setattr(
+        web_server,
+        "_discover_dashboard_runtime_entries",
+        lambda: list(_PLUGIN_ROW),
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_load_dashboard_plugin_activation_state",
+        lambda: PluginActivationState(
+            enabled=frozenset({"category/demo"})
+        ),
+    )
     monkeypatch.setattr(web_server, "_discover_memory_provider_statuses", lambda: [])
     monkeypatch.setattr(web_server, "get_hermes_home", lambda: Path("/tmp/hermes-home"))
     monkeypatch.setattr(web_server, "load_config", lambda: {"dashboard": {"hidden_plugins": []}})
@@ -58,6 +81,8 @@ def test_plugins_hub_does_not_probe_cold_check_fns(monkeypatch):
     # happens on a background warmer thread, never inline.
     assert payload["plugins"][0]["auth_required"] is False
     assert payload["plugins"][0]["auth_command"] == ""
+    assert payload["plugins"][0]["name"] == "demo"
+    assert payload["plugins"][0]["key"] == "category/demo"
     assert threading.current_thread() not in calls["threads"]
 
 

--- a/tests/hermes_cli/test_plugins_hub_perf_guard.py
+++ b/tests/hermes_cli/test_plugins_hub_perf_guard.py
@@ -24,6 +24,7 @@ _PLUGIN_ROW = [
 
 
 def _patch_minimal_hub_dependencies(monkeypatch, *, check_fn, discover_all_plugins=None):
+    discover_entries = discover_all_plugins or (lambda: list(_PLUGIN_ROW))
     monkeypatch.setattr(web_server, "_get_dashboard_plugins", lambda force_rescan=False: [])
     monkeypatch.setattr(
         web_server,
@@ -32,8 +33,8 @@ def _patch_minimal_hub_dependencies(monkeypatch, *, check_fn, discover_all_plugi
     )
     monkeypatch.setattr(
         web_server,
-        "_discover_dashboard_plugin_entries",
-        discover_all_plugins or (lambda: list(_PLUGIN_ROW)),
+        "_discover_dashboard_plugin_records",
+        lambda: [(entry, "enabled") for entry in discover_entries()],
     )
     monkeypatch.setattr(
         web_server,
@@ -84,6 +85,25 @@ def test_plugins_hub_does_not_probe_cold_check_fns(monkeypatch):
     assert payload["plugins"][0]["name"] == "demo"
     assert payload["plugins"][0]["key"] == "category/demo"
     assert threading.current_thread() not in calls["threads"]
+
+
+def test_plugins_hub_preserves_resolved_group_deny_label(monkeypatch):
+    web_server._invalidate_plugins_hub_cache()
+    _patch_minimal_hub_dependencies(monkeypatch, check_fn=lambda: True)
+    monkeypatch.setattr(
+        web_server,
+        "_discover_dashboard_plugin_records",
+        lambda: [(_PLUGIN_ROW[0], "disabled")],
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_discover_dashboard_runtime_entries",
+        list,
+    )
+
+    payload = web_server._merged_plugins_hub(force_refresh=True)
+
+    assert payload["plugins"][0]["runtime_status"] == "disabled"
 
 
 def test_plugins_hub_cold_cache_schedules_background_probe(monkeypatch):

--- a/tests/hermes_cli/test_plugins_hub_perf_guard.py
+++ b/tests/hermes_cli/test_plugins_hub_perf_guard.py
@@ -32,6 +32,11 @@ def _patch_minimal_hub_dependencies(monkeypatch, *, check_fn, discover_all_plugi
     )
     monkeypatch.setattr(
         web_server,
+        "_discover_dashboard_plugin_entries",
+        discover_all_plugins or (lambda: list(_PLUGIN_ROW)),
+    )
+    monkeypatch.setattr(
+        web_server,
         "_load_dashboard_plugin_activation_state",
         lambda: PluginActivationState(
             enabled=frozenset({"category/demo"})
@@ -41,11 +46,6 @@ def _patch_minimal_hub_dependencies(monkeypatch, *, check_fn, discover_all_plugi
     monkeypatch.setattr(web_server, "get_hermes_home", lambda: Path("/tmp/hermes-home"))
     monkeypatch.setattr(web_server, "load_config", lambda: {"dashboard": {"hidden_plugins": []}})
 
-    monkeypatch.setattr(
-        plugins_cmd,
-        "_discover_all_plugins",
-        discover_all_plugins or (lambda: list(_PLUGIN_ROW)),
-    )
     monkeypatch.setattr(plugins_cmd, "_get_current_context_engine", lambda: "compressor")
     monkeypatch.setattr(plugins_cmd, "_get_current_memory_provider", lambda: "")
     monkeypatch.setattr(plugins_cmd, "_discover_context_engines", lambda: [])

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -265,6 +265,11 @@ class TestDashboardDiscoveryScopeAndWinners:
         with patch(
             "hermes_cli.plugins.get_bundled_plugins_dir",
             return_value=bundled,
+        ), patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            return_value=PluginActivationState(
+                enabled=frozenset({"shared-runtime"})
+            ),
         ):
             plugins = web_server._get_dashboard_plugins(force_rescan=True)
             shared = [p for p in plugins if p.get("_runtime_key") == "shared-runtime"]
@@ -278,7 +283,7 @@ class TestDashboardDiscoveryScopeAndWinners:
                 ),
             ) == "enabled"
 
-    def test_inactive_user_winner_suppresses_bundled_dashboard_and_api(
+    def test_inactive_user_candidate_falls_back_to_bundled_dashboard(
         self,
         tmp_path,
         monkeypatch,
@@ -294,8 +299,8 @@ class TestDashboardDiscoveryScopeAndWinners:
             dashboard_name="bundled-ui",
             with_api=True,
         )
-        # The higher-precedence winner intentionally has no dashboard. The
-        # losing bundled UI/API must not become an executable fallback.
+        # The higher-precedence copy is installed but not enabled and has no
+        # dashboard. It must not suppress the active bundled fallback.
         _write_runtime_plugin(
             user_home / "plugins",
             "user-copy",
@@ -309,22 +314,135 @@ class TestDashboardDiscoveryScopeAndWinners:
             return_value=bundled,
         ):
             plugins = web_server._get_dashboard_plugins(force_rescan=True)
-            loser = next(p for p in plugins if p["name"] == "bundled-ui")
-            assert loser["_runtime_winner"] is False
+            bundled_dashboard = next(p for p in plugins if p["name"] == "bundled-ui")
+            assert bundled_dashboard["source"] == "bundled"
             assert web_server._dashboard_plugin_status(
-                loser,
+                bundled_dashboard,
                 activation=PluginActivationState(),
+            ) == "enabled"
+
+    def test_activation_change_reselects_cached_dashboard_candidate(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        bundled = tmp_path / "bundled"
+        user_home = tmp_path / "home"
+        bundled.mkdir()
+        user_home.mkdir()
+        _write_runtime_plugin(
+            bundled,
+            "bundled-copy",
+            runtime_name="shared-runtime",
+            dashboard_name="bundled-ui",
+        )
+        _write_runtime_plugin(
+            user_home / "plugins",
+            "user-copy",
+            runtime_name="shared-runtime",
+            dashboard_name="user-ui",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(user_home))
+        state = {"activation": PluginActivationState()}
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled,
+        ), patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            side_effect=lambda: state["activation"],
+        ):
+            first = web_server._get_dashboard_plugins(force_rescan=True)
+            assert "bundled-ui" in {p["name"] for p in first}
+
+            state["activation"] = PluginActivationState(
+                enabled=frozenset({"shared-runtime"})
+            )
+            second = web_server._get_dashboard_plugins()
+            assert "user-ui" in {p["name"] for p in second}
+
+            state["activation"] = PluginActivationState()
+            third = web_server._get_dashboard_plugins()
+            assert "bundled-ui" in {p["name"] for p in third}
+
+    def test_enabled_user_without_dashboard_suppresses_bundled_dashboard(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        bundled = tmp_path / "bundled"
+        user_home = tmp_path / "home"
+        bundled.mkdir()
+        user_home.mkdir()
+        _write_runtime_plugin(
+            bundled,
+            "bundled-copy",
+            runtime_name="shared-runtime",
+            dashboard_name="bundled-ui",
+        )
+        _write_runtime_plugin(
+            user_home / "plugins",
+            "user-copy",
+            runtime_name="shared-runtime",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(user_home))
+
+        enabled = PluginActivationState(enabled=frozenset({"shared-runtime"}))
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled,
+        ), patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            return_value=enabled,
+        ):
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            bundled_dashboard = next(p for p in plugins if p["name"] == "bundled-ui")
+            assert web_server._dashboard_plugin_status(
+                bundled_dashboard,
+                activation=enabled,
             ) == "not enabled"
-            with patch.object(
-                web_server,
-                "_get_dashboard_plugins",
-                return_value=[loser],
-            ), patch(
-                "hermes_cli.config.load_plugin_activation_state",
-                return_value=PluginActivationState(),
-            ), patch("importlib.util.spec_from_file_location") as spec:
-                web_server._mount_plugin_api_routes()
-            spec.assert_not_called()
+
+    def test_explicit_disable_closes_every_candidate_for_canonical_key(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        bundled = tmp_path / "bundled"
+        user_home = tmp_path / "home"
+        bundled.mkdir()
+        user_home.mkdir()
+        _write_runtime_plugin(
+            bundled,
+            "bundled-copy",
+            runtime_name="shared-runtime",
+            dashboard_name="bundled-ui",
+        )
+        _write_runtime_plugin(
+            user_home / "plugins",
+            "user-copy",
+            runtime_name="shared-runtime",
+            dashboard_name="user-ui",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(user_home))
+
+        disabled = PluginActivationState(
+            enabled=frozenset({"shared-runtime"}),
+            disabled=frozenset({"shared-runtime"}),
+        )
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled,
+        ), patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            return_value=disabled,
+        ):
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            shared = [p for p in plugins if p.get("_runtime_key") == "shared-runtime"]
+            assert len(shared) == 1
+            assert web_server._dashboard_plugin_status(
+                shared[0],
+                activation=disabled,
+            ) == "disabled"
 
 
 # ---------------------------------------------------------------------------
@@ -443,6 +561,10 @@ class TestMountApiRoutesRefusesUntrusted:
             web_server,
             "_get_dashboard_plugins",
             return_value=[plugin],
+        ), patch.object(
+            web_server,
+            "_dashboard_plugin_is_active",
+            return_value=True,
         ), patch("importlib.util.spec_from_file_location") as spec:
             web_server._mount_plugin_api_routes()
         assert spec.call_count == 0, (
@@ -461,6 +583,10 @@ class TestMountApiRoutesRefusesUntrusted:
             web_server,
             "_get_dashboard_plugins",
             return_value=[plugin],
+        ), patch.object(
+            web_server,
+            "_dashboard_plugin_is_active",
+            return_value=True,
         ), patch("importlib.util.spec_from_file_location") as spec:
             web_server._mount_plugin_api_routes()
         assert spec.call_count == 0

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -38,6 +38,7 @@ from unittest.mock import patch
 import pytest
 
 from hermes_cli import web_server
+from hermes_cli.plugin_activation import PluginActivationState
 
 
 @pytest.fixture(autouse=True)
@@ -47,8 +48,10 @@ def _reset_plugin_cache(monkeypatch):
     mask a regression — and so the production cache the import-time
     ``_mount_plugin_api_routes()`` populated doesn't bleed in."""
     web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache_fingerprint = None
     yield
     web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache_fingerprint = None
 
 
 def _write_plugin_manifest(root: Path, name: str, manifest: dict) -> Path:
@@ -58,6 +61,39 @@ def _write_plugin_manifest(root: Path, name: str, manifest: dict) -> Path:
     dashboard_dir.mkdir(parents=True)
     (dashboard_dir / "manifest.json").write_text(json.dumps(manifest))
     return dashboard_dir
+
+
+def _write_runtime_plugin(
+    root: Path,
+    directory: str,
+    *,
+    runtime_name: str,
+    dashboard_name: str | None = None,
+    with_api: bool = False,
+) -> Path:
+    """Create a flat runtime plugin, optionally with a dashboard extension."""
+    plugin_root = root / directory
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "plugin.yaml").write_text(
+        f"name: {runtime_name}\nkind: backend\nversion: 1.0.0\n"
+    )
+    if dashboard_name is not None:
+        dashboard_dir = plugin_root / "dashboard"
+        dashboard_dir.mkdir()
+        dist_dir = dashboard_dir / "dist"
+        dist_dir.mkdir()
+        (dist_dir / "index.js").write_text("console.log('winner');")
+        manifest = {
+            "name": dashboard_name,
+            "entry": "dist/index.js",
+        }
+        if with_api:
+            (dashboard_dir / "api.py").write_text(
+                "from fastapi import APIRouter\nrouter = APIRouter()\n"
+            )
+            manifest["api"] = "api.py"
+        (dashboard_dir / "manifest.json").write_text(json.dumps(manifest))
+    return plugin_root
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +151,180 @@ class TestProjectPluginsEnvGate:
         evil = next((p for p in plugins if p["name"] == "evil"), None)
         assert evil is not None
         assert evil["source"] == "project"
+
+
+class TestDashboardDiscoveryScopeAndWinners:
+    def test_populated_project_cache_is_invalidated_on_cwd_change(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+        old_cwd = tmp_path / "old-project"
+        new_cwd = tmp_path / "new-project"
+        old_cwd.mkdir()
+        new_cwd.mkdir()
+        _write_plugin_manifest(
+            old_cwd / ".hermes" / "plugins",
+            "old-extension",
+            {"name": "old-extension", "entry": "dist/index.js"},
+        )
+
+        monkeypatch.chdir(old_cwd)
+        cached = web_server._get_dashboard_plugins(force_rescan=True)
+        stale = next(p for p in cached if p["name"] == "old-extension")
+        assert Path(stale["_dir"]).is_dir()
+
+        monkeypatch.chdir(new_cwd)
+        refreshed = web_server._get_dashboard_plugins()
+        assert "old-extension" not in {p["name"] for p in refreshed}
+        assert web_server._dashboard_plugin_status(
+            stale,
+            [],
+            PluginActivationState(enabled=frozenset({"old-extension"})),
+        ) == "not enabled"
+
+    def test_user_home_and_bundled_root_are_cache_identities(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        home_one = tmp_path / "home-one"
+        home_two = tmp_path / "home-two"
+        home_one.mkdir()
+        home_two.mkdir()
+        _write_plugin_manifest(
+            home_one / "plugins",
+            "old-user",
+            {"name": "old-user", "entry": "dist/index.js"},
+        )
+        bundled_one = tmp_path / "bundled-one"
+        bundled_two = tmp_path / "bundled-two"
+        bundled_one.mkdir()
+        bundled_two.mkdir()
+        _write_plugin_manifest(
+            bundled_one,
+            "old-bundled",
+            {"name": "old-bundled", "entry": "dist/index.js"},
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(home_one))
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled_one,
+        ):
+            first = web_server._get_dashboard_plugins(force_rescan=True)
+        assert {"old-user", "old-bundled"} <= {p["name"] for p in first}
+
+        monkeypatch.setenv("HERMES_HOME", str(home_two))
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled_two,
+        ):
+            second = web_server._get_dashboard_plugins()
+        assert "old-user" not in {p["name"] for p in second}
+        assert "old-bundled" not in {p["name"] for p in second}
+
+    def test_project_dashboard_is_last_winner_by_runtime_key(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        bundled = tmp_path / "bundled"
+        user_home = tmp_path / "home"
+        project = tmp_path / "project"
+        bundled.mkdir()
+        user_home.mkdir()
+        project.mkdir()
+        _write_runtime_plugin(
+            bundled,
+            "bundled-copy",
+            runtime_name="shared-runtime",
+            dashboard_name="bundled-ui",
+        )
+        _write_runtime_plugin(
+            user_home / "plugins",
+            "user-copy",
+            runtime_name="shared-runtime",
+            dashboard_name="user-ui",
+        )
+        project_root = project / ".hermes" / "plugins"
+        _write_runtime_plugin(
+            project_root,
+            "project-copy",
+            runtime_name="shared-runtime",
+            dashboard_name="project-ui",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(user_home))
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+        monkeypatch.chdir(project)
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled,
+        ):
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            shared = [p for p in plugins if p.get("_runtime_key") == "shared-runtime"]
+            assert len(shared) == 1
+            assert shared[0]["name"] == "project-ui"
+            assert shared[0]["source"] == "project"
+            assert web_server._dashboard_plugin_status(
+                shared[0],
+                activation=PluginActivationState(
+                    enabled=frozenset({"shared-runtime"})
+                ),
+            ) == "enabled"
+
+    def test_inactive_user_winner_suppresses_bundled_dashboard_and_api(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        bundled = tmp_path / "bundled"
+        user_home = tmp_path / "home"
+        bundled.mkdir()
+        user_home.mkdir()
+        _write_runtime_plugin(
+            bundled,
+            "bundled-copy",
+            runtime_name="shared-runtime",
+            dashboard_name="bundled-ui",
+            with_api=True,
+        )
+        # The higher-precedence winner intentionally has no dashboard. The
+        # losing bundled UI/API must not become an executable fallback.
+        _write_runtime_plugin(
+            user_home / "plugins",
+            "user-copy",
+            runtime_name="shared-runtime",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(user_home))
+        monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled,
+        ):
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            loser = next(p for p in plugins if p["name"] == "bundled-ui")
+            assert loser["_runtime_winner"] is False
+            assert web_server._dashboard_plugin_status(
+                loser,
+                activation=PluginActivationState(),
+            ) == "not enabled"
+            with patch.object(
+                web_server,
+                "_get_dashboard_plugins",
+                return_value=[loser],
+            ), patch(
+                "hermes_cli.config.load_plugin_activation_state",
+                return_value=PluginActivationState(),
+            ), patch("importlib.util.spec_from_file_location") as spec:
+                web_server._mount_plugin_api_routes()
+            spec.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -229,8 +439,11 @@ class TestMountApiRoutesRefusesUntrusted:
 
     def test_project_source_api_is_not_imported(self, tmp_path):
         plugin = self._payload_plugin(tmp_path, source="project")
-        web_server._dashboard_plugins_cache = [plugin]
-        with patch("importlib.util.spec_from_file_location") as spec:
+        with patch.object(
+            web_server,
+            "_get_dashboard_plugins",
+            return_value=[plugin],
+        ), patch("importlib.util.spec_from_file_location") as spec:
             web_server._mount_plugin_api_routes()
         assert spec.call_count == 0, (
             "project-source plugin's api file was imported — "
@@ -244,8 +457,11 @@ class TestMountApiRoutesRefusesUntrusted:
         file outside the dashboard dir."""
         plugin = self._payload_plugin(tmp_path, source="user",
                                        api_file="../../../tmp/evil.py")
-        web_server._dashboard_plugins_cache = [plugin]
-        with patch("importlib.util.spec_from_file_location") as spec:
+        with patch.object(
+            web_server,
+            "_get_dashboard_plugins",
+            return_value=[plugin],
+        ), patch("importlib.util.spec_from_file_location") as spec:
             web_server._mount_plugin_api_routes()
         assert spec.call_count == 0
 

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -48,11 +48,15 @@ def _reset_plugin_cache(monkeypatch):
     cache before *and* after each test so leakage between tests can't
     mask a regression — and so the production cache the import-time
     ``_mount_plugin_api_routes()`` populated doesn't bleed in."""
+    mounted_owners = dict(web_server._mounted_plugin_api_owners)
     web_server._dashboard_plugins_cache = None
     web_server._dashboard_plugins_cache_fingerprint = None
+    web_server._mounted_plugin_api_owners.clear()
     yield
     web_server._dashboard_plugins_cache = None
     web_server._dashboard_plugins_cache_fingerprint = None
+    web_server._mounted_plugin_api_owners.clear()
+    web_server._mounted_plugin_api_owners.update(mounted_owners)
 
 
 def _write_plugin_manifest(root: Path, name: str, manifest: dict) -> Path:

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -38,6 +38,7 @@ from unittest.mock import patch
 import pytest
 
 from hermes_cli import web_server
+from hermes_cli.agent_plugins import PLUGIN_SCHEMA_V1
 from hermes_cli.plugin_activation import PluginActivationState
 
 
@@ -93,6 +94,35 @@ def _write_runtime_plugin(
             )
             manifest["api"] = "api.py"
         (dashboard_dir / "manifest.json").write_text(json.dumps(manifest))
+    return plugin_root
+
+
+def _write_portable_runtime_plugin(
+    root: Path,
+    directory: str,
+    *,
+    runtime_name: str,
+    dashboard_name: str,
+    valid_manifest: bool = True,
+) -> Path:
+    """Create an Agent Plugins v1 package with a dashboard API."""
+    plugin_root = root / directory
+    dashboard_dir = plugin_root / "dashboard"
+    dashboard_dir.mkdir(parents=True)
+    if valid_manifest:
+        portable_manifest = {
+            "$schema": PLUGIN_SCHEMA_V1,
+            "name": runtime_name,
+        }
+        (plugin_root / "plugin.json").write_text(json.dumps(portable_manifest))
+    else:
+        (plugin_root / "plugin.json").write_text("{not-json")
+    (dashboard_dir / "api.py").write_text(
+        "from fastapi import APIRouter\nrouter = APIRouter()\n"
+    )
+    (dashboard_dir / "manifest.json").write_text(
+        json.dumps({"name": dashboard_name, "api": "api.py"})
+    )
     return plugin_root
 
 
@@ -154,6 +184,97 @@ class TestProjectPluginsEnvGate:
 
 
 class TestDashboardDiscoveryScopeAndWinners:
+    @pytest.mark.parametrize(
+        (
+            "valid_manifest",
+            "activation",
+            "expected_name",
+            "expected_status",
+            "should_import",
+        ),
+        [
+            (
+                True,
+                PluginActivationState(
+                    enabled=frozenset({"ui.foo"}),
+                    disabled=frozenset({"portable.test"}),
+                ),
+                "portable.test",
+                "disabled",
+                False,
+            ),
+            (
+                True,
+                PluginActivationState(enabled=frozenset({"portable.test"})),
+                "portable.test",
+                "enabled",
+                True,
+            ),
+            (
+                False,
+                PluginActivationState(
+                    enabled=frozenset({"portable-dir", "ui.foo"})
+                ),
+                "portable-dir",
+                "not enabled",
+                False,
+            ),
+        ],
+    )
+    def test_portable_dashboard_uses_canonical_runtime_gate(
+        self,
+        tmp_path,
+        monkeypatch,
+        valid_manifest,
+        activation,
+        expected_name,
+        expected_status,
+        should_import,
+    ):
+        bundled = tmp_path / "bundled"
+        user_home = tmp_path / "home"
+        bundled.mkdir()
+        user_home.mkdir()
+        plugin_root = _write_portable_runtime_plugin(
+            user_home / "plugins",
+            "portable-dir",
+            runtime_name="portable.test",
+            dashboard_name="ui.foo",
+            valid_manifest=valid_manifest,
+        )
+        monkeypatch.setenv("HERMES_HOME", str(user_home))
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled,
+        ), patch(
+            "hermes_cli.config.load_plugin_activation_state",
+            return_value=activation,
+        ):
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            portable = next(p for p in plugins if p["name"] == "ui.foo")
+            assert portable["_runtime_managed"] is True
+            assert portable["_runtime_name"] == expected_name
+            assert portable["_runtime_key"] == expected_name
+            assert web_server._dashboard_plugin_status(
+                portable,
+                activation=activation,
+            ) == expected_status
+
+            with patch(
+                "importlib.util.spec_from_file_location",
+                side_effect=RuntimeError("portable API import probe"),
+            ) as spec:
+                web_server._mount_plugin_api_routes()
+
+        if should_import:
+            spec.assert_called_once_with(
+                "hermes_dashboard_plugin_ui.foo",
+                plugin_root / "dashboard" / "api.py",
+            )
+        else:
+            spec.assert_not_called()
+
     def test_populated_project_cache_is_invalidated_on_cwd_change(
         self,
         tmp_path,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1553,3 +1553,27 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     assert resolved["source"] == "pool:lmstudio-pool"
     assert resolved["provider"] == "custom"
     assert resolved["requested_provider"] == "custom:lmstudio"
+
+
+@pytest.mark.parametrize(
+    ("requested", "blocked_provider"),
+    [
+        ("anthropic", "anthropic"),
+        ("azure-foundry", "azure-foundry"),
+        ("vertex", "vertex"),
+        ("custom:local", "custom"),
+        ("ollama", "custom"),
+    ],
+)
+def test_shortcut_paths_cannot_bypass_disabled_provider_plugin(
+    monkeypatch,
+    requested,
+    blocked_provider,
+):
+    monkeypatch.setattr(
+        "providers.is_provider_plugin_active",
+        lambda provider_id: provider_id != blocked_provider,
+    )
+
+    with pytest.raises(rp.AuthError, match="disabled by plugin configuration"):
+        rp.resolve_runtime_provider(requested=requested)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1577,3 +1577,93 @@ def test_shortcut_paths_cannot_bypass_disabled_provider_plugin(
 
     with pytest.raises(rp.AuthError, match="disabled by plugin configuration"):
         rp.resolve_runtime_provider(requested=requested)
+
+
+@pytest.mark.parametrize(
+    ("base_url", "active_provider", "blocked_provider"),
+    [
+        ("http://127.0.0.1:11434/v1", "custom", "openrouter"),
+        ("https://openrouter.ai/api/v1", "openrouter", "custom"),
+        ("https://openrouter.ai.attacker.test/v1", "custom", "openrouter"),
+    ],
+)
+def test_auto_explicit_endpoint_uses_matching_provider_plugin(
+    monkeypatch,
+    base_url,
+    active_provider,
+    blocked_provider,
+):
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        "providers.is_provider_plugin_active",
+        lambda provider_id: provider_id == active_provider,
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="auto",
+        explicit_api_key="explicit-key",
+        explicit_base_url=base_url,
+    )
+
+    assert resolved["base_url"] == base_url
+    assert resolved["api_key"] == "explicit-key"
+
+    monkeypatch.setattr(
+        "providers.is_provider_plugin_active",
+        lambda provider_id: provider_id == blocked_provider,
+    )
+    with pytest.raises(
+        rp.AuthError,
+        match=rf"Provider '{active_provider}' is disabled by plugin configuration",
+    ):
+        rp.resolve_runtime_provider(
+            requested="auto",
+            explicit_api_key="explicit-key",
+            explicit_base_url=base_url,
+        )
+
+
+def test_auto_explicit_key_without_url_still_uses_openrouter_plugin(monkeypatch):
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        "providers.is_provider_plugin_active",
+        lambda provider_id: provider_id == "openrouter",
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="auto",
+        explicit_api_key="explicit-key",
+    )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "explicit-key"
+
+    monkeypatch.setattr(
+        "providers.is_provider_plugin_active",
+        lambda _provider_id: False,
+    )
+    with pytest.raises(
+        rp.AuthError,
+        match="Provider 'openrouter' is disabled by plugin configuration",
+    ):
+        rp.resolve_runtime_provider(
+            requested="auto",
+            explicit_api_key="explicit-key",
+        )
+
+
+def test_explicit_openrouter_mirror_still_uses_openrouter_plugin(monkeypatch):
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        "providers.is_provider_plugin_active",
+        lambda provider_id: provider_id == "openrouter",
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="openrouter",
+        explicit_api_key="explicit-key",
+        explicit_base_url="https://openrouter-proxy.example/v1",
+    )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["base_url"] == "https://openrouter-proxy.example/v1"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1667,3 +1667,42 @@ def test_explicit_openrouter_mirror_still_uses_openrouter_plugin(monkeypatch):
 
     assert resolved["provider"] == "openrouter"
     assert resolved["base_url"] == "https://openrouter-proxy.example/v1"
+
+
+@pytest.mark.parametrize(
+    ("base_url", "endpoint_provider"),
+    [
+        ("https://custom.invalid/v1", "custom"),
+        ("https://openrouter.ai/api/v1", "openrouter"),
+        ("https://openrouter.ai.attacker.test/v1", "custom"),
+    ],
+)
+def test_auto_env_endpoint_uses_effective_provider_plugin(
+    monkeypatch,
+    base_url,
+    endpoint_provider,
+):
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(rp, "resolve_provider", lambda *args, **kwargs: "openrouter")
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: None)
+    monkeypatch.setenv("CUSTOM_BASE_URL", base_url)
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        "providers.is_provider_plugin_active",
+        lambda _provider_id: True,
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="auto")
+
+    assert resolved["base_url"] == base_url
+
+    monkeypatch.setattr(
+        "providers.is_provider_plugin_active",
+        lambda provider_id: provider_id != endpoint_provider,
+    )
+    with pytest.raises(
+        rp.AuthError,
+        match=rf"Provider '{endpoint_provider}' is disabled by plugin configuration",
+    ):
+        rp.resolve_runtime_provider(requested="auto")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -93,6 +93,7 @@ def _install_example_plugin(_isolate_hermes_home):
     #      and start serving requests against a torn-down HERMES_HOME.
     app = web_server.app
     original_routes = list(app.router.routes)
+    original_mounted_owners = dict(web_server._mounted_plugin_api_owners)
 
     # Bust the module-level cache and re-discover so the example plugin
     # shows up in `_get_dashboard_plugins()`. `_mount_plugin_api_routes`
@@ -129,6 +130,8 @@ def _install_example_plugin(_isolate_hermes_home):
         # cache for the same reason.
         app.router.routes[:] = original_routes
         web_server._dashboard_plugins_cache = None
+        web_server._mounted_plugin_api_owners.clear()
+        web_server._mounted_plugin_api_owners.update(original_mounted_owners)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -162,11 +162,13 @@ class TestModelPickerBaseUrlIntegration:
 
         with (
             patch("providers.get_provider_profile", return_value=mock_profile),
+            patch("hermes_cli.models._provider_is_routable", return_value=True),
             patch("hermes_cli.auth.resolve_api_key_provider_credentials",
                   return_value={"api_key": "sk-test", "base_url": "https://custom.proxy.com"}),
         ):
             from hermes_cli.models import provider_model_ids
             result = provider_model_ids("test-provider")
+            assert result == ["model-a"]
             # Verify fetch_models was called with base_url
             mock_profile.fetch_models.assert_called_once()
             call_kwargs = mock_profile.fetch_models.call_args

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -23,11 +25,15 @@ def _clear_provider_caches():
     _pkg._ALIASES.clear()
     _pkg._PROVIDER_LIST_CACHE = None
     _pkg._discovered = False
+    _pkg._ACTIVATION_STATE = None
+    _pkg._DISCOVERY_FINGERPRINT = None
+    _pkg._IMPORTED_PROVIDER_MODULES.clear()
     # Evict any cached plugin modules so the next import re-executes.
     for mod in list(sys.modules.keys()):
         if (
             mod.startswith("plugins.model_providers")
             or mod.startswith("_hermes_user_provider")
+            or mod.startswith("_hermes_project_provider")
         ):
             del sys.modules[mod]
 
@@ -105,6 +111,10 @@ def test_user_plugin_overrides_bundled(tmp_path, monkeypatch):
         "version: 0.0.1\n"
         "description: Test user override\n"
     )
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n  enabled:\n    - model-providers/gmi\n",
+        encoding="utf-8",
+    )
 
     _clear_provider_caches()
     from providers import get_provider_profile
@@ -123,3 +133,422 @@ def test_user_plugin_overrides_bundled(tmp_path, monkeypatch):
     # No import means the module must NOT be in the plugins list as a loaded one.
     # We check that the general loader didn't crash and didn't raise from the
     # broken __init__.py.
+
+
+def _write_user_provider(
+    home: Path,
+    name: str,
+    *,
+    base_url: str,
+    env_var: str = "TEST_PROVIDER_API_KEY",
+    env_vars: tuple[str, ...] | None = None,
+    aliases: tuple[str, ...] = (),
+    marker: Path | None = None,
+    fail_after_register: bool = False,
+) -> None:
+    plugin_dir = home / "plugins" / "model-providers" / name
+    plugin_dir.mkdir(parents=True)
+    marker_write = ""
+    if marker is not None:
+        marker_write = (
+            "from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('imported', encoding='utf-8')\n"
+        )
+    registered_env_vars = env_vars or (env_var,)
+    failure = "raise RuntimeError('provider import failed')\n" if fail_after_register else ""
+    (plugin_dir / "__init__.py").write_text(
+        marker_write
+        + "from providers import register_provider\n"
+        + "from providers.base import ProviderProfile\n"
+        + "register_provider(ProviderProfile(\n"
+        + f"    name={name!r},\n"
+        + f"    display_name={name!r},\n"
+        + f"    aliases={aliases!r},\n"
+        + f"    env_vars={registered_env_vars!r},\n"
+        + f"    base_url={base_url!r},\n"
+        + "    auth_type='api_key',\n"
+        + "))\n"
+        + failure,
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.yaml").write_text(
+        f"name: {name}\n"
+        "kind: model-provider\n"
+        f"provider_ids: [{name}]\n",
+        encoding="utf-8",
+    )
+
+
+def _write_activation(home: Path, *, enabled=(), disabled=()) -> None:
+    enabled_lines = "".join(f"    - {value}\n" for value in enabled)
+    disabled_lines = "".join(f"    - {value}\n" for value in disabled)
+    (home / "config.yaml").write_text(
+        "plugins:\n"
+        "  enabled:\n"
+        f"{enabled_lines}"
+        "  disabled:\n"
+        f"{disabled_lines}",
+        encoding="utf-8",
+    )
+
+
+def test_user_provider_is_not_imported_until_explicitly_enabled(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    marker = tmp_path / "provider-imported.txt"
+    _write_user_provider(
+        home,
+        "opt-in-provider",
+        base_url="https://opt-in.example/v1",
+        marker=marker,
+    )
+    _write_activation(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import providers
+
+    _clear_provider_caches()
+    assert providers.get_provider_profile("opt-in-provider") is None
+    assert not marker.exists()
+
+    _write_activation(
+        home,
+        enabled=("model-providers/opt-in-provider",),
+    )
+    providers.invalidate_provider_discovery()
+
+    assert providers.get_provider_profile("opt-in-provider") is not None
+    assert marker.read_text(encoding="utf-8") == "imported"
+
+
+def test_provider_discovery_refreshes_when_profile_home_changes(
+    tmp_path,
+    monkeypatch,
+):
+    first_home = tmp_path / "first"
+    second_home = tmp_path / "second"
+    first_home.mkdir()
+    second_home.mkdir()
+    _write_user_provider(
+        first_home,
+        "profile-provider",
+        base_url="https://first.example/v1",
+    )
+    _write_user_provider(
+        second_home,
+        "profile-provider",
+        base_url="https://second.example/v1",
+    )
+    for home in (first_home, second_home):
+        _write_activation(
+            home,
+            enabled=("model-providers/profile-provider",),
+        )
+
+    import providers
+
+    monkeypatch.setenv("HERMES_HOME", str(first_home))
+    providers.invalidate_provider_discovery()
+    assert (
+        providers.get_provider_profile("profile-provider").base_url
+        == "https://first.example/v1"
+    )
+
+    # Activation lists are identical; the discovery-root fingerprint must
+    # still force a rebuild for the new profile.
+    monkeypatch.setenv("HERMES_HOME", str(second_home))
+    assert (
+        providers.get_provider_profile("profile-provider").base_url
+        == "https://second.example/v1"
+    )
+
+
+def test_disabling_provider_refreshes_all_derived_surfaces(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    _write_user_provider(
+        home,
+        "refresh-provider",
+        base_url="https://refresh.example/v1",
+        env_var="REFRESH_PROVIDER_API_KEY",
+    )
+    _write_activation(
+        home,
+        enabled=("model-providers/refresh-provider",),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import providers
+    from hermes_cli import auth, config, models
+
+    providers.invalidate_provider_discovery()
+    assert "refresh-provider" in auth.PROVIDER_REGISTRY
+    assert any(
+        entry.slug == "refresh-provider"
+        for entry in models.CANONICAL_PROVIDERS
+    )
+    assert "refresh-provider" in models._KNOWN_PROVIDER_NAMES
+    assert "REFRESH_PROVIDER_API_KEY" in config.OPTIONAL_ENV_VARS
+
+    _write_activation(
+        home,
+        disabled=("model-providers/refresh-provider",),
+    )
+    providers.invalidate_provider_discovery()
+
+    assert providers.get_provider_profile("refresh-provider") is None
+    assert "refresh-provider" not in auth.PROVIDER_REGISTRY
+    assert all(
+        entry.slug != "refresh-provider"
+        for entry in models.CANONICAL_PROVIDERS
+    )
+    assert "refresh-provider" not in models._KNOWN_PROVIDER_NAMES
+    assert "REFRESH_PROVIDER_API_KEY" not in config.OPTIONAL_ENV_VARS
+
+
+def test_failed_provider_import_rolls_back_registry_aliases_and_modules(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    plugin_name = "broken-provider"
+    plugin_alias = "broken-provider-alias"
+    _write_user_provider(
+        home,
+        plugin_name,
+        base_url="https://broken.example/v1",
+        aliases=(plugin_alias,),
+        fail_after_register=True,
+    )
+    plugin_dir = home / "plugins" / "model-providers" / plugin_name
+    (plugin_dir / "helper.py").write_text("LOADED = True\n", encoding="utf-8")
+    init_path = plugin_dir / "__init__.py"
+    init_path.write_text(
+        "from . import helper\n" + init_path.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    _write_activation(
+        home,
+        enabled=(f"model-providers/{plugin_name}",),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import providers
+
+    _clear_provider_caches()
+    assert providers.get_provider_profile(plugin_name) is None
+    assert providers.get_provider_profile(plugin_alias) is None
+    assert plugin_name not in providers._REGISTRY
+    assert plugin_alias not in providers._ALIASES
+    module_prefix = "_hermes_user_provider_broken_provider"
+    assert not any(
+        module_name == module_prefix or module_name.startswith(f"{module_prefix}.")
+        for module_name in sys.modules
+    )
+
+
+@pytest.mark.parametrize("source", ["user", "project"])
+def test_provider_override_drives_auth_and_runtime_metadata(
+    source,
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    _write_activation(home, enabled=("model-providers/gmi",))
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+
+    if source == "user":
+        plugin_home = home
+    else:
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        monkeypatch.chdir(project_root)
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+        plugin_home = project_root / ".hermes"
+
+    key_var = f"{source.upper()}_GMI_API_KEY"
+    base_url_var = f"{source.upper()}_GMI_BASE_URL"
+    profile_base_url = f"https://{source}-profile.example/v1"
+    runtime_base_url = f"https://{source}-runtime.example/v1"
+    _write_user_provider(
+        plugin_home,
+        "gmi",
+        base_url=profile_base_url,
+        env_vars=(key_var, base_url_var),
+    )
+    monkeypatch.setenv(key_var, f"{source}-secret")
+    monkeypatch.setenv(base_url_var, runtime_base_url)
+
+    import providers
+    from hermes_cli import auth, runtime_provider
+
+    providers.invalidate_provider_discovery()
+
+    assert providers.get_provider_profile("gmi").base_url == profile_base_url
+    provider_config = auth.PROVIDER_REGISTRY["gmi"]
+    assert provider_config.inference_base_url == profile_base_url
+    assert provider_config.api_key_env_vars == (key_var,)
+    assert provider_config.base_url_env_var == base_url_var
+
+    credentials = auth.resolve_api_key_provider_credentials("gmi")
+    assert credentials["api_key"] == f"{source}-secret"
+    assert credentials["base_url"] == runtime_base_url
+
+    runtime = runtime_provider.resolve_runtime_provider(requested="gmi")
+    assert runtime["provider"] == "gmi"
+    assert runtime["api_key"] == f"{source}-secret"
+    assert runtime["base_url"] == runtime_base_url
+
+
+def test_third_party_provider_alias_follows_activation_refresh(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    provider_name = "alias-lifecycle-provider"
+    provider_alias = "alias-lifecycle-shortcut"
+    _write_user_provider(
+        home,
+        provider_name,
+        base_url="https://alias-lifecycle.example/v1",
+        aliases=(provider_alias,),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import providers
+    from hermes_cli import auth, models
+
+    def assert_active() -> None:
+        assert providers.get_provider_profile(provider_alias).name == provider_name
+        assert models.normalize_provider(provider_alias) == provider_name
+        assert provider_alias in models._KNOWN_PROVIDER_NAMES
+        assert auth.resolve_provider(provider_alias) == provider_name
+
+    _write_activation(
+        home,
+        enabled=(f"model-providers/{provider_name}",),
+    )
+    providers.invalidate_provider_discovery()
+    assert_active()
+
+    _write_activation(
+        home,
+        disabled=(f"model-providers/{provider_name}",),
+    )
+    providers.invalidate_provider_discovery()
+
+    assert providers.get_provider_profile(provider_alias) is None
+    assert models.normalize_provider(provider_alias) == provider_alias
+    assert provider_alias not in models._KNOWN_PROVIDER_NAMES
+    with pytest.raises(auth.AuthError):
+        auth.resolve_provider(provider_alias)
+
+    _write_activation(
+        home,
+        enabled=(f"model-providers/{provider_name}",),
+    )
+    providers.invalidate_provider_discovery()
+    assert_active()
+
+
+def test_auth_refresh_exception_preserves_lkg_and_empty_initial_state(monkeypatch):
+    import providers
+    from hermes_cli import auth
+
+    original_registry = dict(auth.PROVIDER_REGISTRY)
+    original_dynamic_keys = set(auth._DYNAMIC_PROVIDER_REGISTRY_KEYS)
+
+    def fail_discovery():
+        raise RuntimeError("activation refresh failed")
+
+    monkeypatch.setattr(providers, "list_providers", fail_discovery)
+    try:
+        auth.PROVIDER_REGISTRY.replace({})
+        auth._DYNAMIC_PROVIDER_REGISTRY_KEYS.clear()
+        auth._refresh_provider_registry_from_plugins()
+        assert dict(auth.PROVIDER_REGISTRY) == {}
+        assert auth._DYNAMIC_PROVIDER_REGISTRY_KEYS == set()
+
+        lkg_config = auth.ProviderConfig(
+            id="last-known-good",
+            name="Last Known Good",
+            auth_type="api_key",
+            inference_base_url="https://lkg.example/v1",
+            api_key_env_vars=("LKG_API_KEY",),
+        )
+        auth.PROVIDER_REGISTRY.replace({"last-known-good": lkg_config})
+        auth._DYNAMIC_PROVIDER_REGISTRY_KEYS.clear()
+        auth._DYNAMIC_PROVIDER_REGISTRY_KEYS.add("last-known-good")
+
+        auth._refresh_provider_registry_from_plugins()
+
+        assert dict(auth.PROVIDER_REGISTRY) == {"last-known-good": lkg_config}
+        assert auth._DYNAMIC_PROVIDER_REGISTRY_KEYS == {"last-known-good"}
+    finally:
+        auth.PROVIDER_REGISTRY.replace(original_registry)
+        auth._DYNAMIC_PROVIDER_REGISTRY_KEYS.clear()
+        auth._DYNAMIC_PROVIDER_REGISTRY_KEYS.update(original_dynamic_keys)
+
+
+def test_auth_activation_check_fails_closed_on_discovery_error(monkeypatch):
+    import providers
+    from hermes_cli import auth
+
+    def fail_discovery(_provider_id):
+        raise RuntimeError("activation state unavailable")
+
+    monkeypatch.setattr(providers, "is_plugin_managed_provider_id", fail_discovery)
+
+    assert auth._provider_plugin_is_active("uncertain-provider") is False
+
+
+def test_legacy_single_file_provider_requires_explicit_opt_in(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    legacy_root = tmp_path / "legacy-providers"
+    legacy_root.mkdir()
+    marker = tmp_path / "legacy-imported.txt"
+    module_name = "legacy_opt_in_provider"
+    (legacy_root / f"{module_name}.py").write_text(
+        "from pathlib import Path\n"
+        "from providers import register_provider\n"
+        "from providers.base import ProviderProfile\n"
+        f"Path({str(marker)!r}).write_text('imported', encoding='utf-8')\n"
+        "register_provider(ProviderProfile(\n"
+        "    name='legacy-opt-in-provider',\n"
+        "    env_vars=('LEGACY_OPT_IN_API_KEY',),\n"
+        "    base_url='https://legacy.example/v1',\n"
+        "))\n",
+        encoding="utf-8",
+    )
+    _write_activation(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import providers
+
+    monkeypatch.setattr(providers, "__path__", [str(legacy_root)])
+    _clear_provider_caches()
+    assert providers.get_provider_profile("legacy-opt-in-provider") is None
+    assert not marker.exists()
+
+    _write_activation(home, enabled=(f"model-providers/{module_name}",))
+    providers.invalidate_provider_discovery()
+    assert providers.get_provider_profile("legacy-opt-in-provider") is not None
+    assert marker.read_text(encoding="utf-8") == "imported"
+
+    _write_activation(home)
+    providers.invalidate_provider_discovery()
+    assert providers.get_provider_profile("legacy-opt-in-provider") is None

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -460,6 +460,10 @@ def test_disabling_provider_refreshes_all_derived_surfaces(
     )
     assert "refresh-provider" in models._KNOWN_PROVIDER_NAMES
     assert "REFRESH_PROVIDER_API_KEY" in config.OPTIONAL_ENV_VARS
+    assert (
+        "REFRESH_PROVIDER_API_KEY"
+        in auth.get_observed_provider_security_env_names()
+    )
 
     _write_activation(
         home,
@@ -475,6 +479,10 @@ def test_disabling_provider_refreshes_all_derived_surfaces(
     )
     assert "refresh-provider" not in models._KNOWN_PROVIDER_NAMES
     assert "REFRESH_PROVIDER_API_KEY" not in config.OPTIONAL_ENV_VARS
+    assert (
+        "REFRESH_PROVIDER_API_KEY"
+        in auth.get_observed_provider_security_env_names()
+    )
 
 
 def test_failed_provider_import_rolls_back_registry_aliases_and_modules(

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -431,40 +431,6 @@ def test_inactive_external_manifest_cannot_suppress_static_provider(
     )
 
 
-def test_observed_provider_secret_names_remain_blocked_after_disable(
-    tmp_path,
-    monkeypatch,
-):
-    home = tmp_path / "home"
-    home.mkdir()
-    _write_user_provider(
-        home,
-        "secret-provider",
-        base_url="https://secret.example/v1",
-        env_vars=("SECRET_PROVIDER_API_KEY", "SECRET_PROVIDER_BASE_URL"),
-    )
-    _write_activation(
-        home,
-        enabled=("model-providers/secret-provider",),
-    )
-    monkeypatch.setenv("HERMES_HOME", str(home))
-
-    import providers
-    from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
-
-    providers.invalidate_provider_discovery()
-    assert "SECRET_PROVIDER_API_KEY" in _HERMES_PROVIDER_ENV_BLOCKLIST
-    assert "SECRET_PROVIDER_BASE_URL" in _HERMES_PROVIDER_ENV_BLOCKLIST
-
-    _write_activation(
-        home,
-        disabled=("model-providers/secret-provider",),
-    )
-    providers.invalidate_provider_discovery()
-    assert "SECRET_PROVIDER_API_KEY" in _HERMES_PROVIDER_ENV_BLOCKLIST
-    assert "SECRET_PROVIDER_BASE_URL" in _HERMES_PROVIDER_ENV_BLOCKLIST
-
-
 def test_disabling_provider_refreshes_all_derived_surfaces(
     tmp_path,
     monkeypatch,
@@ -508,11 +474,7 @@ def test_disabling_provider_refreshes_all_derived_surfaces(
         for entry in models.CANONICAL_PROVIDERS
     )
     assert "refresh-provider" not in models._KNOWN_PROVIDER_NAMES
-    # Observed secret names remain in the process-wide metadata/blocklist even
-    # after this profile disables the plugin.  Routability is removed above;
-    # retaining the name prevents a concurrent profile's key from becoming
-    # inheritable by terminal subprocesses.
-    assert "REFRESH_PROVIDER_API_KEY" in config.OPTIONAL_ENV_VARS
+    assert "REFRESH_PROVIDER_API_KEY" not in config.OPTIONAL_ENV_VARS
 
 
 def test_failed_provider_import_rolls_back_registry_aliases_and_modules(

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -396,6 +396,81 @@ def test_cached_profile_switch_does_not_repeat_refresh_hooks(
     ]
 
 
+def test_profile_env_metadata_is_monotonic_across_cached_scopes(
+    tmp_path,
+    monkeypatch,
+):
+    home_a = tmp_path / "profile-a-env"
+    home_b = tmp_path / "profile-b-env"
+    for home, provider, env_var in (
+        (home_a, "profile-a-provider", "PROFILE_A_ONLY_API_KEY"),
+        (home_b, "profile-b-provider", "PROFILE_B_ONLY_API_KEY"),
+    ):
+        home.mkdir()
+        _write_user_provider(
+            home,
+            provider,
+            base_url=f"https://{provider}.example/v1",
+            env_var=env_var,
+        )
+        _write_activation(home, enabled=(f"model-providers/{provider}",))
+
+    import providers
+    from hermes_cli import config
+
+    for home in (home_a, home_b, home_a):
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        providers.get_provider_catalog_snapshot()
+
+    assert {
+        "PROFILE_A_ONLY_API_KEY",
+        "PROFILE_B_ONLY_API_KEY",
+    }.issubset(config.OPTIONAL_ENV_VARS)
+
+
+def test_profile_env_metadata_concurrent_observation_keeps_union(tmp_path):
+    home_c = tmp_path / "profile-c-env"
+    home_d = tmp_path / "profile-d-env"
+    for home, provider, env_var in (
+        (home_c, "profile-c-provider", "PROFILE_C_ONLY_API_KEY"),
+        (home_d, "profile-d-provider", "PROFILE_D_ONLY_API_KEY"),
+    ):
+        home.mkdir()
+        _write_user_provider(
+            home,
+            provider,
+            base_url=f"https://{provider}.example/v1",
+            env_var=env_var,
+        )
+        _write_activation(home, enabled=(f"model-providers/{provider}",))
+
+    import providers
+    from hermes_cli import config
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    def discover(home):
+        token = set_hermes_home_override(home)
+        try:
+            return providers.get_provider_catalog_snapshot().scope_identity
+        finally:
+            reset_hermes_home_override(token)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        scopes = list(executor.map(discover, (home_c, home_d)))
+
+    assert set(scopes) == {
+        (str(home_c.resolve()), ""),
+        (str(home_d.resolve()), ""),
+    }
+    assert {
+        "PROFILE_C_ONLY_API_KEY",
+        "PROFILE_D_ONLY_API_KEY",
+    }.issubset(config.OPTIONAL_ENV_VARS)
+
+
 def test_inactive_external_manifest_cannot_suppress_static_provider(
     tmp_path,
     monkeypatch,
@@ -478,7 +553,10 @@ def test_disabling_provider_refreshes_all_derived_surfaces(
         for entry in models.CANONICAL_PROVIDERS
     )
     assert "refresh-provider" not in models._KNOWN_PROVIDER_NAMES
-    assert "REFRESH_PROVIDER_API_KEY" not in config.OPTIONAL_ENV_VARS
+    # OPTIONAL_ENV_VARS is a process-wide compatibility inventory. Routing and
+    # picker surfaces drop the disabled provider, while observed metadata stays
+    # available without being overwritten by another profile's refresh.
+    assert "REFRESH_PROVIDER_API_KEY" in config.OPTIONAL_ENV_VARS
     assert (
         "REFRESH_PROVIDER_API_KEY"
         in auth.get_observed_provider_security_env_names()

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -29,6 +29,8 @@ def _clear_provider_caches():
     _pkg._discovered = False
     _pkg._ACTIVATION_STATE = None
     _pkg._DISCOVERY_FINGERPRINT = None
+    _pkg._PUBLISHED_PROVIDER_CATALOG.set(None)
+    _pkg._PROVIDER_SCOPE_IDENTITY_CACHE.clear()
     _pkg._IMPORTED_PROVIDER_MODULES.clear()
     # Evict any cached plugin modules so the next import re-executes.
     for mod in list(sys.modules.keys()):
@@ -394,6 +396,47 @@ def test_cached_profile_switch_does_not_repeat_refresh_hooks(
         (str(home_a.resolve()), ""),
         (str(home_b.resolve()), ""),
     ]
+
+
+def test_cached_activation_revisit_restores_model_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "activation-metadata-home"
+    home.mkdir()
+    provider_name = "activation-metadata-provider"
+    provider_key = f"model-providers/{provider_name}"
+    _write_user_provider(
+        home,
+        provider_name,
+        base_url="https://activation-metadata.example/v1",
+        aliases=("activation-metadata-alias",),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_cli.models as models
+    import providers
+
+    _write_activation(home, enabled=(provider_key,))
+    assert providers.get_provider_profile(provider_name) is not None
+    enabled_snapshot = models._provider_metadata_snapshot()
+    assert models.normalize_provider("activation-metadata-alias") == provider_name
+
+    _write_activation(home, disabled=(provider_key,))
+    assert providers.get_provider_profile(provider_name) is None
+    disabled_snapshot = models._provider_metadata_snapshot()
+    assert disabled_snapshot is not enabled_snapshot
+    assert provider_name not in models._KNOWN_PROVIDER_NAMES
+
+    # The enabled catalog is cached and its once-per-fingerprint refresh hook
+    # has already fired. Each user-facing inventory is a freshness boundary
+    # for direct config edits and must select matching cached metadata.
+    _write_activation(home, enabled=(provider_key,))
+    available_ids = {row["id"] for row in models.list_available_providers()}
+    assert provider_name in available_ids
+    assert providers.get_provider_profile(provider_name) is not None
+    assert models._provider_metadata_snapshot() is enabled_snapshot
+    assert models.normalize_provider("activation-metadata-alias") == provider_name
 
 
 def test_profile_env_metadata_is_monotonic_across_cached_scopes(

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -9,6 +9,8 @@ Verifies that:
 from __future__ import annotations
 
 import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -266,6 +268,203 @@ def test_provider_discovery_refreshes_when_profile_home_changes(
     )
 
 
+def test_concurrent_profile_catalogs_do_not_mix_key_and_endpoint(
+    tmp_path,
+    monkeypatch,
+):
+    """A profile key must never be paired with another profile's endpoint."""
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+    for home, endpoint, override, secret in (
+        (
+            home_a,
+            "https://a.example/v1",
+            "https://a-override.example/v1",
+            "secret-a",
+        ),
+        (
+            home_b,
+            "https://b.example/v1",
+            "https://b-override.example/v1",
+            "secret-b",
+        ),
+    ):
+        _write_user_provider(
+            home,
+            "profile-provider",
+            base_url=endpoint,
+            env_vars=(
+                "PROFILE_PROVIDER_API_KEY",
+                "PROFILE_PROVIDER_BASE_URL",
+            ),
+        )
+        _write_activation(
+            home,
+            enabled=("model-providers/profile-provider",),
+        )
+        (home / ".env").write_text(
+            f"PROFILE_PROVIDER_API_KEY={secret}\n"
+            f"PROFILE_PROVIDER_BASE_URL={override}\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "process-home"))
+    import providers
+    from hermes_cli import auth
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    a_discovered = threading.Event()
+    b_published = threading.Event()
+
+    def run_a():
+        token = set_hermes_home_override(home_a)
+        try:
+            assert (
+                providers.get_provider_profile("profile-provider").base_url
+                == "https://a.example/v1"
+            )
+            a_discovered.set()
+            assert b_published.wait(timeout=10)
+            config = auth.PROVIDER_REGISTRY["profile-provider"]
+            credentials = auth.resolve_api_key_provider_credentials(
+                "profile-provider"
+            )
+            return config.inference_base_url, credentials
+        finally:
+            reset_hermes_home_override(token)
+
+    def run_b():
+        assert a_discovered.wait(timeout=10)
+        token = set_hermes_home_override(home_b)
+        try:
+            config = auth.PROVIDER_REGISTRY["profile-provider"]
+            credentials = auth.resolve_api_key_provider_credentials(
+                "profile-provider"
+            )
+            return config.inference_base_url, credentials
+        finally:
+            b_published.set()
+            reset_hermes_home_override(token)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_a = executor.submit(run_a)
+        future_b = executor.submit(run_b)
+        endpoint_a, credentials_a = future_a.result(timeout=15)
+        endpoint_b, credentials_b = future_b.result(timeout=15)
+
+    assert endpoint_a == "https://a.example/v1"
+    assert credentials_a["api_key"] == "secret-a"
+    assert credentials_a["base_url"] == "https://a-override.example/v1"
+    assert endpoint_b == "https://b.example/v1"
+    assert credentials_b["api_key"] == "secret-b"
+    assert credentials_b["base_url"] == "https://b-override.example/v1"
+
+
+def test_cached_profile_switch_does_not_repeat_refresh_hooks(
+    tmp_path,
+    monkeypatch,
+):
+    """A/B multiplex reads notify once per immutable catalog, not per switch."""
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    for home in (home_a, home_b):
+        home.mkdir()
+        _write_activation(home)
+
+    import providers
+
+    notifications: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        providers,
+        "_PROVIDER_REFRESH_HOOKS",
+        [lambda: notifications.append(providers.get_provider_scope_identity())],
+    )
+
+    for home in (home_a, home_b, home_a, home_b):
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        snapshot = providers.get_provider_catalog_snapshot()
+        assert snapshot.scope_identity == (str(home.resolve()), "")
+
+    assert notifications == [
+        (str(home_a.resolve()), ""),
+        (str(home_b.resolve()), ""),
+    ]
+
+
+def test_inactive_external_manifest_cannot_suppress_static_provider(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    marker = tmp_path / "takeover-imported.txt"
+    _write_user_provider(
+        home,
+        "takeover-openai",
+        base_url="https://takeover.invalid/v1",
+        marker=marker,
+    )
+    manifest = home / "plugins" / "model-providers" / "takeover-openai" / "plugin.yaml"
+    manifest.write_text(
+        "name: takeover-openai\n"
+        "kind: model-provider\n"
+        "provider_ids: [openai-api]\n",
+        encoding="utf-8",
+    )
+    _write_activation(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import providers
+    from hermes_cli import auth
+
+    providers.invalidate_provider_discovery()
+    assert not marker.exists()
+    assert "openai-api" in auth.PROVIDER_REGISTRY
+    assert (
+        auth.PROVIDER_REGISTRY["openai-api"].inference_base_url
+        == "https://api.openai.com/v1"
+    )
+
+
+def test_observed_provider_secret_names_remain_blocked_after_disable(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    _write_user_provider(
+        home,
+        "secret-provider",
+        base_url="https://secret.example/v1",
+        env_vars=("SECRET_PROVIDER_API_KEY", "SECRET_PROVIDER_BASE_URL"),
+    )
+    _write_activation(
+        home,
+        enabled=("model-providers/secret-provider",),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import providers
+    from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+    providers.invalidate_provider_discovery()
+    assert "SECRET_PROVIDER_API_KEY" in _HERMES_PROVIDER_ENV_BLOCKLIST
+    assert "SECRET_PROVIDER_BASE_URL" in _HERMES_PROVIDER_ENV_BLOCKLIST
+
+    _write_activation(
+        home,
+        disabled=("model-providers/secret-provider",),
+    )
+    providers.invalidate_provider_discovery()
+    assert "SECRET_PROVIDER_API_KEY" in _HERMES_PROVIDER_ENV_BLOCKLIST
+    assert "SECRET_PROVIDER_BASE_URL" in _HERMES_PROVIDER_ENV_BLOCKLIST
+
+
 def test_disabling_provider_refreshes_all_derived_surfaces(
     tmp_path,
     monkeypatch,
@@ -309,7 +508,11 @@ def test_disabling_provider_refreshes_all_derived_surfaces(
         for entry in models.CANONICAL_PROVIDERS
     )
     assert "refresh-provider" not in models._KNOWN_PROVIDER_NAMES
-    assert "REFRESH_PROVIDER_API_KEY" not in config.OPTIONAL_ENV_VARS
+    # Observed secret names remain in the process-wide metadata/blocklist even
+    # after this profile disables the plugin.  Routability is removed above;
+    # retaining the name prevents a concurrent profile's key from becoming
+    # inheritable by terminal subprocesses.
+    assert "REFRESH_PROVIDER_API_KEY" in config.OPTIONAL_ENV_VARS
 
 
 def test_failed_provider_import_rolls_back_registry_aliases_and_modules(
@@ -471,7 +674,11 @@ def test_auth_refresh_exception_preserves_lkg_and_empty_initial_state(monkeypatc
     def fail_discovery():
         raise RuntimeError("activation refresh failed")
 
-    monkeypatch.setattr(providers, "list_providers", fail_discovery)
+    monkeypatch.setattr(
+        providers,
+        "get_provider_catalog_snapshot",
+        fail_discovery,
+    )
     try:
         auth.PROVIDER_REGISTRY.replace({})
         auth._DYNAMIC_PROVIDER_REGISTRY_KEYS.clear()
@@ -510,6 +717,58 @@ def test_auth_activation_check_fails_closed_on_discovery_error(monkeypatch):
     monkeypatch.setattr(providers, "is_plugin_managed_provider_id", fail_discovery)
 
     assert auth._provider_plugin_is_active("uncertain-provider") is False
+
+
+def test_auth_lkg_never_crosses_activation_security_state(monkeypatch):
+    """A refresh failure after disable/safe-mode must not revive old routes."""
+    import providers
+    from hermes_cli import auth, config
+    from hermes_cli.plugin_activation import PluginActivationState
+
+    scope = ("profile-home", "")
+    enabled = PluginActivationState(
+        enabled=frozenset({"model-providers/external"})
+    )
+    disabled = PluginActivationState(
+        disabled=frozenset({"model-providers/external"})
+    )
+    external = auth.ProviderConfig(
+        id="external",
+        name="External",
+        auth_type="api_key",
+        inference_base_url="https://external.example/v1",
+        api_key_env_vars=("EXTERNAL_API_KEY",),
+    )
+
+    original_lkg = dict(auth._PROVIDER_REGISTRY_LKG_BY_SECURITY_IDENTITY)
+    auth._PROVIDER_REGISTRY_LKG_BY_SECURITY_IDENTITY.clear()
+    auth._PROVIDER_REGISTRY_LKG_BY_SECURITY_IDENTITY[(scope, enabled)] = {
+        "external": external
+    }
+    monkeypatch.setattr(
+        auth,
+        "_compute_provider_registry_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("discovery failed")),
+    )
+    monkeypatch.setattr(providers, "get_provider_scope_identity", lambda: scope)
+
+    try:
+        monkeypatch.setattr(
+            config,
+            "load_plugin_activation_state",
+            lambda: disabled,
+        )
+        assert auth._provider_registry_snapshot() == {}
+
+        monkeypatch.setattr(
+            config,
+            "load_plugin_activation_state",
+            lambda: enabled,
+        )
+        assert auth._provider_registry_snapshot() == {"external": external}
+    finally:
+        auth._PROVIDER_REGISTRY_LKG_BY_SECURITY_IDENTITY.clear()
+        auth._PROVIDER_REGISTRY_LKG_BY_SECURITY_IDENTITY.update(original_lkg)
 
 
 def test_legacy_single_file_provider_requires_explicit_opt_in(

--- a/tests/providers/test_provider_registry.py
+++ b/tests/providers/test_provider_registry.py
@@ -14,6 +14,10 @@ def isolate_provider_registry():
         else list(providers._PROVIDER_LIST_CACHE)
     )
     discovered = providers._discovered
+    fingerprint = providers._DISCOVERY_FINGERPRINT
+    runtime_registry = providers._RUNTIME_REGISTRY.copy()
+    runtime_aliases = providers._RUNTIME_ALIASES.copy()
+    runtime_generation = providers._RUNTIME_REGISTRATION_GENERATION
 
     yield
 
@@ -23,6 +27,12 @@ def isolate_provider_registry():
     providers._ALIASES.update(aliases)
     providers._PROVIDER_LIST_CACHE = provider_list_cache
     providers._discovered = discovered
+    providers._DISCOVERY_FINGERPRINT = fingerprint
+    providers._RUNTIME_REGISTRY.clear()
+    providers._RUNTIME_REGISTRY.update(runtime_registry)
+    providers._RUNTIME_ALIASES.clear()
+    providers._RUNTIME_ALIASES.update(runtime_aliases)
+    providers._RUNTIME_REGISTRATION_GENERATION = runtime_generation
 
 
 def _profile(name: str, *aliases: str) -> ProviderProfile:
@@ -32,8 +42,11 @@ def _profile(name: str, *aliases: str) -> ProviderProfile:
 def _reset_registry() -> None:
     providers._REGISTRY.clear()
     providers._ALIASES.clear()
+    providers._RUNTIME_REGISTRY.clear()
+    providers._RUNTIME_ALIASES.clear()
     providers._PROVIDER_LIST_CACHE = None
     providers._discovered = True
+    providers._DISCOVERY_FINGERPRINT = None
 
 
 def test_list_providers_reuses_cached_snapshot_until_registration_changes():

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -174,6 +174,28 @@ def _make_execute_only_env(forward_env=None):
     return env
 
 
+def test_implicit_forward_filters_late_active_provider_key(monkeypatch):
+    from hermes_cli import auth
+
+    active = auth.ProviderConfig(
+        id="late-active",
+        name="Late active",
+        auth_type="api_key",
+        api_key_env_vars=("LATE_ACTIVE_API_KEY",),
+    )
+    monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {active.id: active})
+    monkeypatch.setattr(
+        "tools.env_passthrough.get_all_passthrough",
+        lambda: frozenset({"LATE_ACTIVE_API_KEY"}),
+    )
+    monkeypatch.setenv("LATE_ACTIVE_API_KEY", "secret")
+    monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {})
+
+    env = _make_execute_only_env()
+
+    assert "LATE_ACTIVE_API_KEY" not in env._build_passthrough_env()
+
+
 def test_init_env_args_uses_hermes_dotenv_for_allowlisted_env(monkeypatch):
     """_build_init_env_args picks up forwarded env vars from .env file at init time."""
     # Use a var that is NOT in _HERMES_PROVIDER_ENV_BLOCKLIST (GITHUB_TOKEN

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -178,22 +178,26 @@ def test_implicit_forward_filters_late_active_provider_key(monkeypatch):
     from hermes_cli import auth
 
     active = auth.ProviderConfig(
-        id="late-active",
+        id="late-docker",
         name="Late active",
         auth_type="api_key",
-        api_key_env_vars=("LATE_ACTIVE_API_KEY",),
+        api_key_env_vars=("LATE_DOCKER_API_KEY",),
     )
     monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {active.id: active})
     monkeypatch.setattr(
         "tools.env_passthrough.get_all_passthrough",
-        lambda: frozenset({"LATE_ACTIVE_API_KEY"}),
+        lambda: frozenset({"LATE_DOCKER_API_KEY"}),
     )
-    monkeypatch.setenv("LATE_ACTIVE_API_KEY", "secret")
+    monkeypatch.setenv("LATE_DOCKER_API_KEY", "secret")
     monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {})
 
     env = _make_execute_only_env()
 
-    assert "LATE_ACTIVE_API_KEY" not in env._build_passthrough_env()
+    assert "LATE_DOCKER_API_KEY" not in env._build_passthrough_env()
+
+    monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {})
+
+    assert "LATE_DOCKER_API_KEY" not in env._build_passthrough_env()
 
 
 def test_init_env_args_uses_hermes_dotenv_for_allowlisted_env(monkeypatch):

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -302,19 +302,24 @@ class TestTerminalIntegration:
         from hermes_cli import auth
 
         active = auth.ProviderConfig(
-            id="late-active",
+            id="late-passthrough",
             name="Late active",
             auth_type="api_key",
-            api_key_env_vars=("LATE_ACTIVE_API_KEY",),
+            api_key_env_vars=("LATE_PASSTHROUGH_API_KEY",),
         )
         monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {})
-        register_env_passthrough(["LATE_ACTIVE_API_KEY"])
-        assert is_env_passthrough("LATE_ACTIVE_API_KEY")
+        register_env_passthrough(["LATE_PASSTHROUGH_API_KEY"])
+        assert is_env_passthrough("LATE_PASSTHROUGH_API_KEY")
 
         monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {active.id: active})
 
-        assert not is_env_passthrough("LATE_ACTIVE_API_KEY")
-        assert "LATE_ACTIVE_API_KEY" not in get_all_passthrough()
+        assert not is_env_passthrough("LATE_PASSTHROUGH_API_KEY")
+        assert "LATE_PASSTHROUGH_API_KEY" not in get_all_passthrough()
+
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {})
+
+        assert not is_env_passthrough("LATE_PASSTHROUGH_API_KEY")
+        assert "LATE_PASSTHROUGH_API_KEY" not in get_all_passthrough()
 
     def test_passthrough_cannot_override_internal_dynamic_secret(self):
         """A skill must NOT be able to register dynamically-named Hermes

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -295,6 +295,27 @@ class TestTerminalIntegration:
         assert blocked_var not in result
         assert "PATH" in result
 
+    def test_registered_key_is_reclassified_when_provider_becomes_active(
+        self,
+        monkeypatch,
+    ):
+        from hermes_cli import auth
+
+        active = auth.ProviderConfig(
+            id="late-active",
+            name="Late active",
+            auth_type="api_key",
+            api_key_env_vars=("LATE_ACTIVE_API_KEY",),
+        )
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {})
+        register_env_passthrough(["LATE_ACTIVE_API_KEY"])
+        assert is_env_passthrough("LATE_ACTIVE_API_KEY")
+
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {active.id: active})
+
+        assert not is_env_passthrough("LATE_ACTIVE_API_KEY")
+        assert "LATE_ACTIVE_API_KEY" not in get_all_passthrough()
+
     def test_passthrough_cannot_override_internal_dynamic_secret(self):
         """A skill must NOT be able to register dynamically-named Hermes
         secrets (AUXILIARY_*_API_KEY / _BASE_URL, GATEWAY_RELAY_* auth) as

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -392,23 +392,47 @@ class TestBlocklistCoverage:
                     f"(provider={pconfig.id}) missing from blocklist"
                 )
 
-    def test_disabled_bundled_provider_stays_blocked_after_restart(self, monkeypatch):
-        """Static bundled keys survive an empty/rebuilt active registry."""
+    def test_same_id_override_keeps_static_and_active_keys_blocked(self, monkeypatch):
+        """An active same-ID override cannot replace static security metadata."""
         from hermes_cli import auth
         from tools.environments.local import _build_provider_env_blocklist
 
         active = auth.ProviderConfig(
-            id="active-plugin",
-            name="Active plugin",
+            id="gmi",
+            name="GMI override",
             auth_type="api_key",
-            api_key_env_vars=("ACTIVE_PLUGIN_API_KEY",),
+            api_key_env_vars=("GMI_OVERRIDE_API_KEY",),
+            base_url_env_var="GMI_OVERRIDE_BASE_URL",
         )
         monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {active.id: active})
 
         blocklist = _build_provider_env_blocklist()
 
         assert {"GMI_API_KEY", "GMI_BASE_URL"}.issubset(blocklist)
-        assert "ACTIVE_PLUGIN_API_KEY" in blocklist
+        assert {"GMI_OVERRIDE_API_KEY", "GMI_OVERRIDE_BASE_URL"}.issubset(blocklist)
+
+    def test_late_active_provider_is_filtered_by_all_local_paths(self, monkeypatch):
+        """Each real sanitizer snapshots active provider metadata per call."""
+        from hermes_cli import auth
+        from tools.environments.local import (
+            _make_run_env,
+            _sanitize_subprocess_env,
+            hermes_subprocess_env,
+        )
+
+        active = auth.ProviderConfig(
+            id="late-active",
+            name="Late active",
+            auth_type="api_key",
+            api_key_env_vars=("LATE_ACTIVE_API_KEY",),
+        )
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {active.id: active})
+        source = {"LATE_ACTIVE_API_KEY": "secret", "PATH": os.defpath}
+
+        assert "LATE_ACTIVE_API_KEY" not in _sanitize_subprocess_env(source)
+        with patch.dict(os.environ, source, clear=True):
+            assert "LATE_ACTIVE_API_KEY" not in hermes_subprocess_env()
+            assert "LATE_ACTIVE_API_KEY" not in _make_run_env({})
 
     def test_bedrock_bearer_token_is_in_blocklist(self):
         """auth_type='aws_sdk' providers contribute their Hermes-managed

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -392,6 +392,24 @@ class TestBlocklistCoverage:
                     f"(provider={pconfig.id}) missing from blocklist"
                 )
 
+    def test_disabled_bundled_provider_stays_blocked_after_restart(self, monkeypatch):
+        """Static bundled keys survive an empty/rebuilt active registry."""
+        from hermes_cli import auth
+        from tools.environments.local import _build_provider_env_blocklist
+
+        active = auth.ProviderConfig(
+            id="active-plugin",
+            name="Active plugin",
+            auth_type="api_key",
+            api_key_env_vars=("ACTIVE_PLUGIN_API_KEY",),
+        )
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {active.id: active})
+
+        blocklist = _build_provider_env_blocklist()
+
+        assert {"GMI_API_KEY", "GMI_BASE_URL"}.issubset(blocklist)
+        assert "ACTIVE_PLUGIN_API_KEY" in blocklist
+
     def test_bedrock_bearer_token_is_in_blocklist(self):
         """auth_type='aws_sdk' providers contribute their Hermes-managed
         inference token (the Bedrock bearer) to the blocklist, keyed off

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -413,8 +413,8 @@ class TestBlocklistCoverage:
         assert {"GMI_API_KEY", "GMI_BASE_URL"}.issubset(blocklist)
         assert {"GMI_OVERRIDE_API_KEY", "GMI_OVERRIDE_BASE_URL"}.issubset(blocklist)
 
-    def test_late_active_provider_is_filtered_by_all_local_paths(self, monkeypatch):
-        """Each real sanitizer snapshots active provider metadata per call."""
+    def test_late_active_provider_remains_filtered_after_disable(self, monkeypatch):
+        """Observed provider names remain blocked for the process lifetime."""
         from hermes_cli import auth
         from tools.environments.local import (
             _make_run_env,
@@ -423,20 +423,44 @@ class TestBlocklistCoverage:
         )
 
         active = auth.ProviderConfig(
-            id="late-active",
+            id="late-local",
             name="Late active",
             auth_type="api_key",
-            api_key_env_vars=("LATE_ACTIVE_API_KEY",),
+            api_key_env_vars=("LATE_LOCAL_API_KEY",),
+            base_url_env_var="LATE_LOCAL_BASE_URL",
         )
         monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {active.id: active})
-        source = {"LATE_ACTIVE_API_KEY": "secret", "PATH": os.defpath}
+        source = {
+            "LATE_LOCAL_API_KEY": "secret",
+            "LATE_LOCAL_BASE_URL": "https://provider.invalid/v1",
+            "PATH": os.defpath,
+        }
 
-        assert "LATE_ACTIVE_API_KEY" not in _sanitize_subprocess_env(source)
+        assert not {"LATE_LOCAL_API_KEY", "LATE_LOCAL_BASE_URL"} & set(
+            _sanitize_subprocess_env(source)
+        )
         with patch.dict(os.environ, source, clear=True):
-            assert "LATE_ACTIVE_API_KEY" not in hermes_subprocess_env()
-            assert "LATE_ACTIVE_API_KEY" not in _make_run_env({})
+            assert not {"LATE_LOCAL_API_KEY", "LATE_LOCAL_BASE_URL"} & set(
+                hermes_subprocess_env()
+            )
+            assert not {"LATE_LOCAL_API_KEY", "LATE_LOCAL_BASE_URL"} & set(
+                _make_run_env({})
+            )
 
-    def test_current_blocklist_does_not_retain_previous_profile_key(self, monkeypatch):
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {})
+
+        assert not {"LATE_LOCAL_API_KEY", "LATE_LOCAL_BASE_URL"} & set(
+            _sanitize_subprocess_env(source)
+        )
+        with patch.dict(os.environ, source, clear=True):
+            assert not {"LATE_LOCAL_API_KEY", "LATE_LOCAL_BASE_URL"} & set(
+                hermes_subprocess_env()
+            )
+            assert not {"LATE_LOCAL_API_KEY", "LATE_LOCAL_BASE_URL"} & set(
+                _make_run_env({})
+            )
+
+    def test_current_blocklist_retains_previous_profile_key(self, monkeypatch):
         from hermes_cli import auth
         from tools.environments.local import (
             _HERMES_PROVIDER_ENV_BLOCKLIST,
@@ -456,7 +480,7 @@ class TestBlocklistCoverage:
 
         monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {})
 
-        assert "PROFILE_ONLY_API_KEY_73132" not in _get_current_provider_env_blocklist()
+        assert "PROFILE_ONLY_API_KEY_73132" in _get_current_provider_env_blocklist()
 
     def test_bedrock_bearer_token_is_in_blocklist(self):
         """auth_type='aws_sdk' providers contribute their Hermes-managed

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -377,17 +377,19 @@ class TestBlocklistCoverage:
         by the user's Claude Code install, not Hermes (#55878).
         """
         from hermes_cli.auth import PROVIDER_REGISTRY
+        from tools.environments.local import _get_current_provider_env_blocklist
 
         exempt = {"CLAUDE_CODE_OAUTH_TOKEN"}
+        current_blocklist = _get_current_provider_env_blocklist()
         for pconfig in PROVIDER_REGISTRY.values():
             for var in pconfig.api_key_env_vars:
                 if var in exempt:
                     continue
-                assert var in _HERMES_PROVIDER_ENV_BLOCKLIST, (
+                assert var in current_blocklist, (
                     f"Registry var {var} (provider={pconfig.id}) missing from blocklist"
                 )
             if pconfig.base_url_env_var:
-                assert pconfig.base_url_env_var in _HERMES_PROVIDER_ENV_BLOCKLIST, (
+                assert pconfig.base_url_env_var in current_blocklist, (
                     f"Registry base_url_env_var {pconfig.base_url_env_var} "
                     f"(provider={pconfig.id}) missing from blocklist"
                 )
@@ -433,6 +435,28 @@ class TestBlocklistCoverage:
         with patch.dict(os.environ, source, clear=True):
             assert "LATE_ACTIVE_API_KEY" not in hermes_subprocess_env()
             assert "LATE_ACTIVE_API_KEY" not in _make_run_env({})
+
+    def test_current_blocklist_does_not_retain_previous_profile_key(self, monkeypatch):
+        from hermes_cli import auth
+        from tools.environments.local import (
+            _HERMES_PROVIDER_ENV_BLOCKLIST,
+            _get_current_provider_env_blocklist,
+        )
+
+        active = auth.ProviderConfig(
+            id="profile-only",
+            name="Profile only",
+            auth_type="api_key",
+            api_key_env_vars=("PROFILE_ONLY_API_KEY_73132",),
+        )
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {active.id: active})
+
+        assert "PROFILE_ONLY_API_KEY_73132" not in _HERMES_PROVIDER_ENV_BLOCKLIST
+        assert "PROFILE_ONLY_API_KEY_73132" in _get_current_provider_env_blocklist()
+
+        monkeypatch.setattr(auth, "PROVIDER_REGISTRY", {})
+
+        assert "PROFILE_ONLY_API_KEY_73132" not in _get_current_provider_env_blocklist()
 
     def test_bedrock_bearer_token_is_in_blocklist(self):
         """auth_type='aws_sdk' providers contribute their Hermes-managed

--- a/tests/tui_gateway/test_plugins_manage.py
+++ b/tests/tui_gateway/test_plugins_manage.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from hermes_cli import plugins_cmd
+import tui_gateway.server as server
+
+
+_ENTRIES = [
+    ("xai", "1.0", "images", "bundled", "/plugins/image", "image_gen/xai", "backend"),
+    ("xai", "1.0", "video", "bundled", "/plugins/video", "video_gen/xai", "backend"),
+]
+
+
+def _call(params):
+    response = server._methods["plugins.manage"]("rid", params)
+    assert "error" not in response, response.get("error")
+    return response["result"]
+
+
+def test_plugins_manage_rows_add_key_without_replacing_name(monkeypatch):
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: list(_ENTRIES))
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    rows = _call({"action": "list"})["plugins"]
+
+    assert [row["name"] for row in rows] == ["xai", "xai"]
+    assert {row["key"] for row in rows} == {"image_gen/xai", "video_gen/xai"}
+
+
+def test_plugins_manage_toggle_targets_key_and_returns_matching_row(monkeypatch):
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: list(_ENTRIES))
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"video_gen/xai"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    calls = []
+
+    def _toggle(identifier, *, enabled):
+        calls.append((identifier, enabled))
+        return {
+            "ok": True,
+            "name": identifier,
+            "key": "video_gen/xai",
+            "unchanged": False,
+        }
+
+    monkeypatch.setattr(plugins_cmd, "dashboard_set_agent_plugin_enabled", _toggle)
+
+    result = _call({
+        "action": "toggle",
+        "enable": False,
+        "key": "video_gen/xai",
+        "name": "xai",
+    })
+
+    assert calls == [("video_gen/xai", False)]
+    assert result["name"] == "xai"
+    assert result["key"] == "video_gen/xai"
+    assert result["plugin"]["key"] == "video_gen/xai"

--- a/tests/tui_gateway/test_plugins_manage.py
+++ b/tests/tui_gateway/test_plugins_manage.py
@@ -19,12 +19,9 @@ def _call(params):
 def test_plugins_manage_rows_add_key_without_replacing_name(monkeypatch):
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_entries",
-        lambda: list(_ENTRIES),
+        "_discover_plugin_display_records",
+        lambda: [(entry, "enabled") for entry in _ENTRIES],
     )
-    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
-    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
-
     rows = _call({"action": "list"})["plugins"]
 
     assert [row["name"] for row in rows] == ["xai", "xai"]
@@ -34,11 +31,9 @@ def test_plugins_manage_rows_add_key_without_replacing_name(monkeypatch):
 def test_plugins_manage_toggle_targets_key_and_returns_matching_row(monkeypatch):
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_entries",
-        lambda: list(_ENTRIES),
+        "_discover_plugin_display_records",
+        lambda: [(entry, "enabled") for entry in _ENTRIES],
     )
-    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"video_gen/xai"})
-    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
     calls = []
 
     def _toggle(identifier, *, enabled):
@@ -63,3 +58,26 @@ def test_plugins_manage_toggle_targets_key_and_returns_matching_row(monkeypatch)
     assert result["name"] == "xai"
     assert result["key"] == "video_gen/xai"
     assert result["plugin"]["key"] == "video_gen/xai"
+
+
+def test_plugins_manage_preserves_resolved_group_deny(monkeypatch):
+    entry = (
+        "new-copy",
+        "2.0",
+        "",
+        "user",
+        "/plugins/new",
+        "shared",
+        "standalone",
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_display_records",
+        lambda: [(entry, "disabled")],
+    )
+
+    rows = _call({"action": "list"})["plugins"]
+
+    assert [(row["name"], row["status"]) for row in rows] == [
+        ("new-copy", "disabled")
+    ]

--- a/tests/tui_gateway/test_plugins_manage.py
+++ b/tests/tui_gateway/test_plugins_manage.py
@@ -17,7 +17,11 @@ def _call(params):
 
 
 def test_plugins_manage_rows_add_key_without_replacing_name(monkeypatch):
-    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: list(_ENTRIES))
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_display_entries",
+        lambda: list(_ENTRIES),
+    )
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
 
@@ -28,7 +32,11 @@ def test_plugins_manage_rows_add_key_without_replacing_name(monkeypatch):
 
 
 def test_plugins_manage_toggle_targets_key_and_returns_matching_row(monkeypatch):
-    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: list(_ENTRIES))
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_plugin_display_entries",
+        lambda: list(_ENTRIES),
+    )
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"video_gen/xai"})
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
     calls = []

--- a/tests/tui_gateway/test_plugins_manage.py
+++ b/tests/tui_gateway/test_plugins_manage.py
@@ -19,7 +19,7 @@ def _call(params):
 def test_plugins_manage_rows_add_key_without_replacing_name(monkeypatch):
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_records",
+        "_discover_plugin_management_records",
         lambda: [(entry, "enabled") for entry in _ENTRIES],
     )
     rows = _call({"action": "list"})["plugins"]
@@ -31,7 +31,7 @@ def test_plugins_manage_rows_add_key_without_replacing_name(monkeypatch):
 def test_plugins_manage_toggle_targets_key_and_returns_matching_row(monkeypatch):
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_records",
+        "_discover_plugin_management_records",
         lambda: [(entry, "enabled") for entry in _ENTRIES],
     )
     calls = []
@@ -72,7 +72,7 @@ def test_plugins_manage_preserves_resolved_group_deny(monkeypatch):
     )
     monkeypatch.setattr(
         plugins_cmd,
-        "_discover_plugin_display_records",
+        "_discover_plugin_management_records",
         lambda: [(entry, "disabled")],
     )
 

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -69,7 +69,7 @@ def _is_hermes_provider_credential(name: str) -> bool:
     """
     try:
         from tools.environments.local import (
-            _HERMES_PROVIDER_ENV_BLOCKLIST,
+            _get_current_provider_env_blocklist,
             _is_hermes_internal_secret,
         )
     except Exception as e:
@@ -87,7 +87,7 @@ def _is_hermes_provider_credential(name: str) -> bool:
     # as passthrough and tunnel them into an execute_code / terminal child.
     if _is_hermes_internal_secret(name):
         return True
-    return name in _HERMES_PROVIDER_ENV_BLOCKLIST
+    return name in _get_current_provider_env_blocklist()
 
 
 def register_env_passthrough(var_names: Iterable[str]) -> None:
@@ -169,14 +169,19 @@ def is_env_passthrough(var_name: str) -> bool:
     Returns ``True`` if the variable was registered by a skill or listed in
     the user's ``tools.env_passthrough`` config.
     """
-    if var_name in _get_allowed():
-        return True
-    return var_name in _load_config_passthrough()
+    allowed = (
+        var_name in _get_allowed()
+        or var_name in _load_config_passthrough()
+    )
+    return allowed and not _is_hermes_provider_credential(var_name)
 
 
 def get_all_passthrough() -> frozenset[str]:
     """Return the union of skill-registered and config-based passthrough vars."""
-    return frozenset(_get_allowed()) | _load_config_passthrough()
+    candidates = frozenset(_get_allowed()) | _load_config_passthrough()
+    return frozenset(
+        name for name in candidates if not _is_hermes_provider_credential(name)
+    )
 
 
 def resolve_passthrough_value(

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -24,7 +24,7 @@ from tools.environments.base import (
     _popen_bash,
 )
 from tools.environments.local import (
-    _HERMES_PROVIDER_ENV_BLOCKLIST,
+    _get_current_provider_env_blocklist,
     _is_hermes_internal_secret,
 )
 
@@ -1568,7 +1568,8 @@ class DockerEnvironment(BaseEnvironment):
         _implicit_forward = {
             k for k in passthrough_keys if not _is_hermes_internal_secret(k)
         }
-        forward_keys = explicit_forward_keys | (_implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST)
+        provider_env_blocklist = _get_current_provider_env_blocklist()
+        forward_keys = explicit_forward_keys | (_implicit_forward - provider_env_blocklist)
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         unset_names: set[str] = set()
         for key in sorted(forward_keys):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -349,9 +349,13 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist(
 
 
 def _get_current_provider_env_blocklist() -> frozenset[str]:
-    """Return static compatibility keys plus the current active-profile keys."""
-    return _HERMES_PROVIDER_ENV_BLOCKLIST | _build_provider_env_blocklist(
-        include_active=True,
+    """Return static, active, and process-observed provider credential names."""
+    from hermes_cli.auth import get_observed_provider_security_env_names
+
+    return (
+        _HERMES_PROVIDER_ENV_BLOCKLIST
+        | _build_provider_env_blocklist(include_active=True)
+        | get_observed_provider_security_env_names()
     )
 
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -227,8 +227,8 @@ def _build_provider_env_blocklist() -> frozenset:
     blocked: set[str] = set()
 
     try:
-        from hermes_cli.auth import PROVIDER_REGISTRY
-        for pconfig in PROVIDER_REGISTRY.values():
+        from hermes_cli.auth import get_known_provider_configs
+        for pconfig in get_known_provider_configs().values():
             blocked.update(pconfig.api_key_env_vars)
             if pconfig.auth_type == "aws_sdk":
                 blocked.update(_AWS_SDK_CREDENTIAL_ENV_VARS)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -222,13 +222,22 @@ _AWS_SDK_CREDENTIAL_ENV_VARS = frozenset({
 })
 
 
-def _build_provider_env_blocklist() -> frozenset:
+def _build_provider_env_blocklist(*, include_active: bool = True) -> frozenset:
     """Derive the blocklist from provider, tool, and gateway config."""
     blocked: set[str] = set()
 
     try:
-        from hermes_cli.auth import get_known_provider_configs
-        for pconfig in get_known_provider_configs():
+        from hermes_cli.auth import (
+            get_builtin_provider_configs,
+            get_known_provider_configs,
+        )
+
+        provider_configs = (
+            get_known_provider_configs()
+            if include_active
+            else get_builtin_provider_configs()
+        )
+        for pconfig in provider_configs:
             blocked.update(pconfig.api_key_env_vars)
             if pconfig.auth_type == "aws_sdk":
                 blocked.update(_AWS_SDK_CREDENTIAL_ENV_VARS)
@@ -334,12 +343,16 @@ def _build_provider_env_blocklist() -> frozenset:
     return frozenset(blocked)
 
 
-_HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
+_HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist(
+    include_active=False,
+)
 
 
 def _get_current_provider_env_blocklist() -> frozenset[str]:
     """Return static compatibility keys plus the current active-profile keys."""
-    return _HERMES_PROVIDER_ENV_BLOCKLIST | _build_provider_env_blocklist()
+    return _HERMES_PROVIDER_ENV_BLOCKLIST | _build_provider_env_blocklist(
+        include_active=True,
+    )
 
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.
 # The gateway runs inside its own venv, so its process environment carries

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -228,7 +228,7 @@ def _build_provider_env_blocklist() -> frozenset:
 
     try:
         from hermes_cli.auth import get_known_provider_configs
-        for pconfig in get_known_provider_configs().values():
+        for pconfig in get_known_provider_configs():
             blocked.update(pconfig.api_key_env_vars)
             if pconfig.auth_type == "aws_sdk":
                 blocked.update(_AWS_SDK_CREDENTIAL_ENV_VARS)
@@ -335,6 +335,11 @@ def _build_provider_env_blocklist() -> frozenset:
 
 
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
+
+
+def _get_current_provider_env_blocklist() -> frozenset[str]:
+    """Return static compatibility keys plus the current active-profile keys."""
+    return _HERMES_PROVIDER_ENV_BLOCKLIST | _build_provider_env_blocklist()
 
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.
 # The gateway runs inside its own venv, so its process environment carries
@@ -455,6 +460,7 @@ def _inject_session_context_env(env: dict) -> None:
 
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
+    provider_env_blocklist = _get_current_provider_env_blocklist()
     try:
         from tools.env_passthrough import (
             is_env_passthrough as _is_passthrough,
@@ -472,7 +478,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         if _is_hermes_internal_secret(key):
             continue
         passthrough = _is_passthrough(key)
-        if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+        if key in provider_env_blocklist and not passthrough:
             continue
         resolved = _resolve_passthrough_value(key, value) if passthrough else value
         if resolved is not None:
@@ -488,7 +494,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             continue
         else:
             passthrough = _is_passthrough(key)
-            if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+            if key in provider_env_blocklist and not passthrough:
                 continue
             resolved = _resolve_passthrough_value(key, value) if passthrough else value
             if resolved is not None:
@@ -621,7 +627,8 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
 
     if not inherit_credentials:
         # Tier 2 — strip provider/tool credentials unless explicitly inherited.
-        for key in _HERMES_PROVIDER_ENV_BLOCKLIST:
+        provider_env_blocklist = _get_current_provider_env_blocklist()
+        for key in provider_env_blocklist:
             env.pop(key, None)
 
     # Windows UTF-8 safety for spawned processes (#31420).
@@ -1267,6 +1274,7 @@ def _path_env_key(run_env: dict) -> str | None:
 
 def _make_run_env(env: dict) -> dict:
     """Build a run environment with a sane PATH and provider-var stripping."""
+    provider_env_blocklist = _get_current_provider_env_blocklist()
     try:
         from tools.env_passthrough import (
             is_env_passthrough as _is_passthrough,
@@ -1288,7 +1296,7 @@ def _make_run_env(env: dict) -> dict:
             continue
         else:
             passthrough = _is_passthrough(k)
-            if k in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+            if k in provider_env_blocklist and not passthrough:
                 continue
             value = _resolve_passthrough_value(k, v) if passthrough else v
             if value is not None:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1811,20 +1811,21 @@ def _(rid, params: dict) -> dict:
     action = params.get("action", "list")
     try:
         from hermes_cli.plugins_cmd import (
-            _discover_plugin_display_entries,
-            _get_disabled_set,
-            _get_enabled_set,
+            _discover_plugin_display_records,
             _is_portable_plugin_dir,
-            _plugin_status,
         )
 
         def _rows():
-            enabled = _get_enabled_set()
-            disabled = _get_disabled_set()
             out = []
-            for name, version, desc, source, _dir, key, kind in sorted(
-                _discover_plugin_display_entries()
+            for entry, status in sorted(
+                _discover_plugin_display_records(),
+                key=lambda record: (
+                    record[0][0],
+                    record[0][5],
+                    record[0][3],
+                ),
             ):
+                name, version, desc, source, _dir, key, _kind = entry
                 out.append(
                     {
                         "name": name,
@@ -1835,14 +1836,7 @@ def _(rid, params: dict) -> dict:
                         "version": str(version or ""),
                         "description": desc or "",
                         "source": source,
-                        "status": _plugin_status(
-                            name,
-                            enabled,
-                            disabled,
-                            key=key,
-                            source=source,
-                            kind=kind,
-                        ),
+                        "status": status,
                         # Agent Plugins v1 package (plugin.json — the portable
                         # skills/MCP format) vs a native Hermes plugin.
                         "portable": _is_portable_plugin_dir(_dir),

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1867,22 +1867,26 @@ def _(rid, params: dict) -> dict:
 
             # Prefer the canonical key — bare names are ambiguous when two
             # category plugins share one (image_gen/fal vs video_gen/fal).
-            ident = (params.get("key") or params.get("name") or "").strip()
-            if not ident:
+            input_name = (params.get("name") or "").strip()
+            identifier = (params.get("key") or input_name).strip()
+            if not identifier:
                 return _err(rid, 4019, "plugins.toggle requires a 'key' or 'name'")
             enable = bool(params.get("enable"))
-            result = dashboard_set_agent_plugin_enabled(ident, enabled=enable)
+            result = dashboard_set_agent_plugin_enabled(identifier, enabled=enable)
             if not result.get("ok"):
                 return _err(rid, 5026, result.get("error") or "toggle failed")
-            row = next(
-                (r for r in _rows() if ident in (r["key"], r["name"])), None
-            )
+            resolved_key = result.get("key") or identifier
+            rows = _rows()
+            row = next((r for r in rows if r["key"] == resolved_key), None)
+            if row is None:
+                row = next((r for r in rows if r["name"] == input_name), None)
             return _ok(
                 rid,
                 {
                     "ok": True,
                     "unchanged": bool(result.get("unchanged")),
-                    "name": ident,
+                    "name": input_name or identifier,
+                    "key": resolved_key,
                     "plugin": row,
                 },
             )

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1811,14 +1811,14 @@ def _(rid, params: dict) -> dict:
     action = params.get("action", "list")
     try:
         from hermes_cli.plugins_cmd import (
-            _discover_plugin_display_records,
+            _discover_plugin_management_records,
             _is_portable_plugin_dir,
         )
 
         def _rows():
             out = []
             for entry, status in sorted(
-                _discover_plugin_display_records(),
+                _discover_plugin_management_records(),
                 key=lambda record: (
                     record[0][0],
                     record[0][5],

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1811,7 +1811,7 @@ def _(rid, params: dict) -> dict:
     action = params.get("action", "list")
     try:
         from hermes_cli.plugins_cmd import (
-            _discover_all_plugins,
+            _discover_plugin_display_entries,
             _get_disabled_set,
             _get_enabled_set,
             _is_portable_plugin_dir,
@@ -1823,7 +1823,7 @@ def _(rid, params: dict) -> dict:
             disabled = _get_disabled_set()
             out = []
             for name, version, desc, source, _dir, key, kind in sorted(
-                _discover_all_plugins()
+                _discover_plugin_display_entries()
             ):
                 out.append(
                     {

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1811,7 +1811,6 @@ def _(rid, params: dict) -> dict:
     action = params.get("action", "list")
     try:
         from hermes_cli.plugins_cmd import (
-            _bundled_default_on,
             _discover_all_plugins,
             _get_disabled_set,
             _get_enabled_set,
@@ -1823,20 +1822,9 @@ def _(rid, params: dict) -> dict:
             enabled = _get_enabled_set()
             disabled = _get_disabled_set()
             out = []
-            for name, version, desc, source, _dir, key in sorted(
+            for name, version, desc, source, _dir, key, kind in sorted(
                 _discover_all_plugins()
             ):
-                status = _plugin_status(name, enabled, disabled, key=key)
-                # Bundled backends/platforms/providers are active without an
-                # explicit enable (they "just work" — plugins.py). Reporting
-                # them "not enabled" reads as OFF in clients when they are in
-                # fact running; surface the truthful default instead.
-                if (
-                    status == "not enabled"
-                    and source == "bundled"
-                    and _bundled_default_on(_dir)
-                ):
-                    status = "enabled"
                 out.append(
                     {
                         "name": name,
@@ -1847,7 +1835,14 @@ def _(rid, params: dict) -> dict:
                         "version": str(version or ""),
                         "description": desc or "",
                         "source": source,
-                        "status": status,
+                        "status": _plugin_status(
+                            name,
+                            enabled,
+                            disabled,
+                            key=key,
+                            source=source,
+                            kind=kind,
+                        ),
                         # Agent Plugins v1 package (plugin.json — the portable
                         # skills/MCP format) vs a native Hermes plugin.
                         "portable": _is_portable_plugin_dir(_dir),

--- a/ui-tui/src/components/pluginsHub.tsx
+++ b/ui-tui/src/components/pluginsHub.tsx
@@ -14,6 +14,7 @@ const MAX_WIDTH = 96
 
 interface PluginRow {
   description?: string
+  key?: string
   name: string
   source?: string
   status?: string
@@ -27,6 +28,7 @@ interface PluginsListResponse {
 }
 
 interface PluginsToggleResponse {
+  key?: string
   name?: string
   ok?: boolean
   plugin?: PluginRow
@@ -34,6 +36,8 @@ interface PluginsToggleResponse {
 }
 
 type Scope = 'all' | 'user'
+
+const pluginIdentity = (row: PluginRow) => row.key ?? row.name
 
 const GLYPH: Record<string, string> = {
   disabled: '✗',
@@ -90,10 +94,21 @@ export function PluginsHub({ gw, maxWidth, onClose, t }: PluginsHubProps) {
     setBusy(true)
     setErr('')
 
-    gw.request<PluginsToggleResponse>('plugins.manage', { action: 'toggle', enable, name: row.name })
+    const key = pluginIdentity(row)
+
+    gw.request<PluginsToggleResponse>('plugins.manage', {
+      action: 'toggle',
+      enable,
+      key,
+      name: row.name
+    })
       .then(r => {
         if (r?.plugin) {
-          setRows(prev => prev.map(p => (p.name === r.plugin!.name ? r.plugin! : p)))
+          setRows(prev =>
+            prev.map(p =>
+              pluginIdentity(p) === pluginIdentity(r.plugin!) ? r.plugin! : p
+            )
+          )
         } else {
           load()
         }
@@ -178,6 +193,12 @@ export function PluginsHub({ gw, maxWidth, onClose, t }: PluginsHubProps) {
     )
   }
 
+  const manifestNameCounts = new Map<string, number>()
+
+  for (const row of effectiveRows) {
+    manifestNameCounts.set(row.name, (manifestNameCounts.get(row.name) ?? 0) + 1)
+  }
+
   const labels = effectiveRows.map(r => {
     const status = r.status ?? 'not enabled'
     const glyph = GLYPH[status] ?? '○'
@@ -185,7 +206,10 @@ export function PluginsHub({ gw, maxWidth, onClose, t }: PluginsHubProps) {
     const src = effectiveScope === 'all' && r.source === 'bundled' ? ' [bundled]' : ''
     const state = status === 'enabled' ? '' : ` (${status})`
 
-    return `${glyph} ${r.name}${ver}${src}${state}`
+    const name =
+      (manifestNameCounts.get(r.name) ?? 0) > 1 ? `${r.name} [${pluginIdentity(r)}]` : r.name
+
+    return `${glyph} ${name}${ver}${src}${state}`
   })
 
   const { items, offset } = windowItems(labels, clampedIdx, VISIBLE)
@@ -212,7 +236,7 @@ export function PluginsHub({ gw, maxWidth, onClose, t }: PluginsHubProps) {
           <Text
             color={t.color.muted}
             {...chipRowProps(t, active)}
-            key={effectiveRows[lineIdx]?.name ?? row}
+            key={effectiveRows[lineIdx] ? pluginIdentity(effectiveRows[lineIdx]) : row}
             wrap="truncate-end"
           >
             {active ? '▸ ' : '  '}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -972,13 +972,13 @@ export const api = {
     }),
 
   enableAgentPlugin: (name: string) =>
-    fetchJSON<{ ok: boolean; name: string; unchanged?: boolean }>(
+    fetchJSON<{ ok: boolean; name: string; key?: string; unchanged?: boolean }>(
       `/api/dashboard/agent-plugins/${pluginPath(name)}/enable`,
       { method: "POST" },
     ),
 
   disableAgentPlugin: (name: string) =>
-    fetchJSON<{ ok: boolean; name: string; unchanged?: boolean }>(
+    fetchJSON<{ ok: boolean; name: string; key?: string; unchanged?: boolean }>(
       `/api/dashboard/agent-plugins/${pluginPath(name)}/disable`,
       { method: "POST" },
     ),
@@ -2561,6 +2561,7 @@ export interface PluginManifestResponse {
 
 export interface HubAgentPluginRow {
   name: string;
+  key?: string;
   version: string;
   description: string;
   source: string;

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -855,7 +855,7 @@ export default function PluginsPage() {
 
               {rows.map((row: HubAgentPluginRow) => (
 
-                <li key={row.name}>
+                <li key={row.key ?? row.name}>
 
 
                   <PluginRowCard
@@ -934,10 +934,11 @@ function PluginRowCard(props: PluginRowCardProps) {
   } = props;
 
   const dm = row.dashboard_manifest;
+  const pluginId = row.key ?? row.name;
 
   const tabPath = dm?.tab && !dm.tab.hidden ? dm.tab.override ?? dm.tab.path : null;
 
-  const busy = rowBusy === row.name;
+  const busy = rowBusy === pluginId;
   const [confirmRemove, setConfirmRemove] = useState(false);
 
   const badgeTone =
@@ -981,8 +982,8 @@ function PluginRowCard(props: PluginRowCardProps) {
                 ghost
                 size="sm"
                 onClick={() => {
-                  void setRuntimeLoading(row.name, async () => {
-                    await api.disableAgentPlugin(row.name);
+                  void setRuntimeLoading(pluginId, async () => {
+                    await api.disableAgentPlugin(pluginId);
                     showToast(t.pluginsPage.disableRuntime, "success");
                   });
                 }}
@@ -995,8 +996,8 @@ function PluginRowCard(props: PluginRowCardProps) {
                 ghost
                 size="sm"
                 onClick={() => {
-                  void setRuntimeLoading(row.name, async () => {
-                    await api.enableAgentPlugin(row.name);
+                  void setRuntimeLoading(pluginId, async () => {
+                    await api.enableAgentPlugin(pluginId);
                     showToast(t.pluginsPage.enableRuntime, "success");
                   });
                 }}
@@ -1026,8 +1027,8 @@ function PluginRowCard(props: PluginRowCardProps) {
                 ghost
                 size="sm"
                 onClick={() => {
-                  void setRuntimeLoading(row.name, async () => {
-                    await api.updateAgentPlugin(row.name);
+                  void setRuntimeLoading(pluginId, async () => {
+                    await api.updateAgentPlugin(pluginId);
                     showToast(t.pluginsPage.updateGit, "success");
                   });
                 }}
@@ -1044,7 +1045,7 @@ function PluginRowCard(props: PluginRowCardProps) {
                 size="sm"
                 title={row.user_hidden ? t.pluginsPage.showInSidebar : t.pluginsPage.hideFromSidebar}
                 onClick={() => {
-                  void setRuntimeLoading(row.name, async () => {
+                  void setRuntimeLoading(pluginId, async () => {
                     await api.setPluginVisibility(row.name, !row.user_hidden);
                   });
                 }}
@@ -1109,8 +1110,8 @@ function PluginRowCard(props: PluginRowCardProps) {
         onCancel={() => setConfirmRemove(false)}
         onConfirm={() => {
           setConfirmRemove(false);
-          void setRuntimeLoading(row.name, async () => {
-            await api.removeAgentPlugin(row.name);
+          void setRuntimeLoading(pluginId, async () => {
+            await api.removeAgentPlugin(pluginId);
             showToast(`${row.name} removed`, "success");
           });
         }}

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -1046,7 +1046,7 @@ function PluginRowCard(props: PluginRowCardProps) {
                 title={row.user_hidden ? t.pluginsPage.showInSidebar : t.pluginsPage.hideFromSidebar}
                 onClick={() => {
                   void setRuntimeLoading(pluginId, async () => {
-                    await api.setPluginVisibility(row.name, !row.user_hidden);
+                    await api.setPluginVisibility(pluginId, !row.user_hidden);
                   });
                 }}
               >


### PR DESCRIPTION
## What does this PR do?

Makes plugin activation consistent across runtime discovery, model-provider catalogs, CLI/TUI management, MCP startup, and the Dashboard.

This revision is rebased on current `main`. It removes the old parallel policy parser, reads activation through the canonical config-loader seam, and keeps non-bundled provider code opt-in before import.

## Related Issue

Fixes #73131

## Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Tests
- [x] Refactor
- [ ] New feature

## Changes Made

- Added a narrow `load_plugin_activation_state()` seam over canonical readonly config loading, retaining managed precedence, expansion, cache/LKG behavior, and fail-closed handling.
- Applied canonical-key, alias, explicit-deny, safe-mode, and source/kind defaults consistently across runtime discovery and CLI/TUI/Dashboard surfaces.
- Made user, project, entry-point, and legacy model-provider candidates opt-in before import.
- Bound provider registries and derived model metadata to immutable profile/project catalog snapshots, including cached A -> B -> A activation revisits and Windows junction paths without adding filesystem work to hot alias reads.
- Preserved observed provider credential metadata while filtering inactive auto-endpoint fallbacks and Basic Auth activation side effects.
- Aligned MCP startup, portable plugin API/static gates, custom model picker rows, and mounted Dashboard API ownership with the effective runtime winner.
- Kept the highest-precedence installed override actionable in management surfaces while reporting that target as inactive when a bundled fallback currently owns runtime.
- Persisted Dashboard visibility with the canonical plugin key rather than a potentially shared manifest name.
- Left revision/tombstone ledgers, install/remove transactions, bytecode mutation hardening, legacy hidden-name migration, and dual-row winner/override UX out of this scoped PR.

## How to Test

1. Run the 22 changed-area Python test files through `scripts/run_tests.sh`.
2. Run Ruff on every changed Python file.
3. Run `git diff --check origin/main...HEAD`.

Latest local result on Windows 11:

- Changed-area matrix: **598 passed, 0 failed** across 22 files.
- Four pre-existing platform-specific PATH assertions were excluded (`test_make_run_env_appends_homebrew_on_minimal_path`, `test_make_run_env_real_launchd_path_gains_homebrew`, `test_make_run_env_preserves_windows_mixed_case_path_key`, and `test_make_run_env_injects_hermes_bin_dir`).
- Ruff: clean.
- Diff check: clean.
- Structured Codex AutoReview: clean, no accepted/actionable findings. The subsequent rebase was patch-identical for all 23 commits (`git range-diff`: every commit `=`), followed by the 598-test rerun above.
- Two independent focused reviews found no remaining P1/P2 issue in the provider metadata and management-target fixes.

## Checklist

### Code

- [x] Commit messages follow Conventional Commits.
- [x] This PR contains only activation-policy and directly dependent consistency fixes.
- [x] Regression tests cover the changed behavior.
- [x] Tested on Windows 11.
- [x] Rebased on current `main`.
- [x] Non-bundled providers remain explicit opt-in.
- [x] No workflow files, dependencies, credentials, or external-service configuration changed.

### Documentation & Housekeeping

- [x] Provider plugin documentation was updated where behavior changed.
- [x] No new config keys require `cli-config.yaml.example` changes.
- [x] Cross-platform profile and path behavior was considered and tested.
- [x] Tool schemas are unchanged.

## Screenshots / Logs

Not applicable; this is activation/runtime consistency and safety behavior covered by regression tests.