### PR TITLE
fix(line): avoid duplicate loading animation

### DIFF
--- a/contributors/emails/jun.r.r.valley.314@gmail.com
+++ b/contributors/emails/jun.r.r.valley.314@gmail.com
@@ -1,0 +1,1 @@
+tetz-akaneya

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -971,10 +971,6 @@ class LineAdapter(BasePlatformAdapter):
         else:
             text = f"[unsupported message type: {msg_type}]"
 
-        # Best-effort typing indicator (DM only).
-        if chat_type == "dm" and self._client:
-            asyncio.create_task(self._client.loading(chat_id))
-
         source_obj = self.build_source(
             chat_id=chat_id,
             chat_type=chat_type,

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -114,6 +114,61 @@ class TestSourceResolution:
         assert ctype == "dm"
 
 
+class TestInboundDispatch:
+
+    def test_dm_defers_loading_indicator_to_shared_typing_lifecycle(self, monkeypatch):
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        from gateway.config import PlatformConfig
+
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={
+            "channel_access_token": "tok",
+            "channel_secret": "sec",
+        }))
+        adapter._client = MagicMock()
+        adapter._client.loading = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        event = {
+            "type": "message",
+            "replyToken": "reply-token",
+            "source": {"type": "user", "userId": "U1"},
+            "message": {"id": "m1", "type": "text", "text": "hello"},
+        }
+
+        asyncio.run(adapter._handle_message_event(event))
+
+        adapter.handle_message.assert_awaited_once()
+        adapter._client.loading.assert_not_awaited()
+
+    def test_shared_typing_lifecycle_starts_loading_indicator(self, monkeypatch):
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        from gateway.config import PlatformConfig
+
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={
+            "channel_access_token": "tok",
+            "channel_secret": "sec",
+            "slow_response_threshold": 0,
+        }))
+        adapter._client = MagicMock()
+        stop_event = asyncio.Event()
+
+        async def loading(chat_id):
+            stop_event.set()
+
+        adapter._client.loading = AsyncMock(side_effect=loading)
+
+        async def run_typing_lifecycle():
+            await asyncio.wait_for(
+                adapter._keep_typing("U1", interval=0.1, stop_event=stop_event),
+                timeout=1,
+            )
+
+        asyncio.run(run_typing_lifecycle())
+
+        adapter._client.loading.assert_awaited_once_with("U1")
+
+
 # ---------------------------------------------------------------------------
 # 3. Three-allowlist gating
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Removes a redundant LINE loading-animation request started directly by the inbound DM handler.

`BasePlatformAdapter` already owns the typing lifecycle through `_keep_typing()` and `LineAdapter.send_typing()`. Starting an additional fire-and-forget request before dispatch creates a race when a `pre_gateway_dispatch` hook sends its own reply and returns `{"action": "skip"}`: the untracked loading request can arrive after the reply and leave LINE's loading animation visible for its full duration.

This change keeps the shared typing lifecycle intact for normal agent responses while ensuring inbound dispatch does not start an independent loading request.

## Related Issue

N/A — reproduced on current `main`; no matching issue or pull request was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`plugins/platforms/line/adapter.py`** — remove the untracked, pre-dispatch `loading()` task from inbound DM handling.
- **`tests/gateway/test_line_plugin.py`** — add regression coverage proving inbound DM dispatch does not call the LINE loading API directly while the shared typing lifecycle still does.
- **`contributors/emails/jun.r.r.valley.314@gmail.com`** — map the commit-author email to `tetz-akaneya` as required by the contributor-attribution check.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_line_plugin.py -q` on the parent commit and observe the regression test fail because `loading()` is awaited once.
2. Run the same command with this change and observe all 78 LINE tests pass.
3. Run `scripts/run_tests.sh tests/gateway/test_line_plugin.py tests/gateway/test_keep_typing_timeout.py tests/gateway/test_typing_indicator_toggle.py tests/gateway/test_platform_base.py -q` and observe all 278 related tests pass.
4. Run `uv run ruff check .` and observe that all enforced checks pass.
5. Run `scripts/run_tests.sh tests/scripts/test_contributor_map.py -q` and observe all 13 contributor-mapping tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — verified by the complete GitHub Actions test matrix (8/8 slices plus e2e)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public API or configuration changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific filesystem or process behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
Before fix:
1 failed, 76 passed
AssertionError: Expected loading to not have been awaited. Awaited 1 times.

After fix:
78 passed, 0 failed

Related gateway suites:
278 passed, 0 failed

Ruff:
All checks passed!

Contributor mapping:
13 passed, 0 failed
```