### PR TITLE
fix(gateway): suppress Codex autoresolution notice

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2590,11 +2590,9 @@ def init_agent(
             agent._ollama_num_ctx,
         )
 
-    # Codex gpt-5.x autoraise notice: show at most once per profile/config
-    # state. Without the persisted marker the notice re-fires on every agent
-    # init — and the gateway rebuilds the agent per inbound message, so Discord
-    # etc. saw it repeatedly (#54432). A change in the raised threshold (or the
-    # autoraised model) updates the marker state and re-notifies once. The
+    # Codex gpt-5.x autoraise notice: CLI-only and shown at most once per
+    # profile/config state. Gateway agents are rebuilt per inbound message and
+    # must not replay this internal lifecycle hint into a user's chat (#54432).
     # config display gate (compression.codex_gpt55_autoraise_notice) still
     # suppresses the banner entirely without disabling the threshold autoraise.
     _autoraise = getattr(agent, "_compression_threshold_autoraised", None) or {}
@@ -2602,6 +2600,7 @@ def init_agent(
         bool(_autoraise)
         and compression_enabled
         and _codex_gpt55_autoraise_notice
+        and (agent.platform or "cli") == "cli"
         and not _codex_gpt55_autoraise_notice_seen(_autoraise)
     )
 
@@ -2620,22 +2619,18 @@ def init_agent(
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(_active_threshold_pct*100)}% = {agent.context_compressor.threshold_tokens:,}{_cap_note})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # Notice with the exact opt-back-out command. Printed inline at startup
-        # for CLI users; gateway users get the same text replayed via
-        # _compression_warning on turn 1 (set below).
+        # Notice with the exact opt-back-out command. Printed inline for CLI
+        # users only; gateway conversations intentionally receive no auto-raise
+        # lifecycle notice.
         if _show_autoraise_notice:
             print(_build_codex_gpt5_autoraise_notice(
                 _autoraise,
                 context_length=getattr(agent.context_compressor, "context_length", None),
             ))
 
-    # Check immediately so CLI users see the warning at startup.
-    # Gateway status_callback is not yet wired, so any warning is stored
-    # in _compression_warning and replayed in the first run_conversation().
+    # Check immediately so CLI users see the warning at startup. Gateway status
+    # callbacks are wired later, but gateway agents keep this slot empty.
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.x autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
     if _show_autoraise_notice:
         agent._compression_warning = _build_codex_gpt5_autoraise_notice(
             _autoraise,

--- a/tests/agent/test_codex_gpt55_gateway_notice.py
+++ b/tests/agent/test_codex_gpt55_gateway_notice.py
@@ -1,0 +1,40 @@
+"""Codex GPT-5.x compression autoresolution gateway-notice behavior."""
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def test_codex_gpt55_autoraise_does_not_create_gateway_warning():
+    """Gateway users must not receive an internal startup lifecycle notice."""
+    cfg = {
+        "compression": {
+            "enabled": True,
+            "threshold": 0.50,
+            "codex_gpt55_autoraise": True,
+        },
+        "memory": {"memory_enabled": False, "user_profile_enabled": False},
+        "tools": {},
+    }
+
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        agent = AIAgent(
+            model="gpt-5.5",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="test-token",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            enabled_toolsets=[],
+            platform="telegram",
+        )
+
+    autoraise = agent._compression_threshold_autoraised
+    assert autoraise["from"] == 0.50
+    assert autoraise["to"] == 0.85
+    assert agent.context_compressor.threshold_tokens == int(
+        agent.context_compressor.context_length * 0.85
+    )
+    assert agent._compression_warning is None


### PR DESCRIPTION
## Summary
- keeps the Codex GPT-5.x compression autoresolution notice on the CLI surface
- prevents gateway-created agents from replaying that internal lifecycle hint into Telegram/Discord/Slack chats
- adds a regression test while preserving the autoresolution itself

## Verification
- `uv run --extra dev python -m pytest -q tests/agent/test_codex_gpt55_gateway_notice.py tests/agent/test_codex_gpt55_autoraise_notice.py` (16 passed)
- `git diff --check`