### PR TITLE
feat(cron): enforce trusted final-result provenance

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1918,7 +1918,22 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
                         return False  # someone holds a fresh claim
                 except Exception:
                     pass  # malformed claim → overwrite
-            job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
+            # A stale-lease takeover must retain the original firing identity:
+            # the next worker may retry work, but must not turn an already
+            # dispatched external fire into a new provenance occurrence.
+            prior_occurrence = (
+                str(existing.get("occurrence_id") or "")
+                if isinstance(existing, dict)
+                else ""
+            )
+            if not prior_occurrence:
+                prior_at = str(existing.get("at") or "") if isinstance(existing, dict) else ""
+                prior_occurrence = f"external:{prior_at}" if prior_at else f"external:{now.isoformat()}"
+            job["fire_claim"] = {
+                "at": now.isoformat(),
+                "by": _machine_id(),
+                "occurrence_id": prior_occurrence,
+            }
             kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())

--- a/cron/output_provenance.py
+++ b/cron/output_provenance.py
@@ -1,0 +1,554 @@
+"""Strict local provenance claims for Cron final-result delivery.
+
+This module is deliberately independent from the scheduler transport loop.  It
+owns the durable, per-profile state machine that a scheduler must complete
+before passing a final result to an installed Kit boundary.
+"""
+from __future__ import annotations
+
+import base64
+import contextlib
+import fcntl
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import stat
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+
+SCHEMA_VERSION = "cron-output-provenance/v1"
+LOCK_NAME = ".output-provenance.lock"
+ANCHOR_NAME = "output-provenance-anchor.json"
+LEDGER_NAME = "output-provenance-ledger.json"
+KEY_NAME = "output-provenance.key"
+BOOTSTRAP_LOCK_NAME = ".output-provenance-bootstrap.lock"
+TTL_SECONDS = 300
+REPAIR_LEASE_SECONDS = 60
+SEND_RECOVERY_SECONDS = 60
+MAX_BODY_BYTES = 8_000
+TERMINAL = {"sent", "indeterminate", "blocked"}
+
+
+class ProvenanceError(RuntimeError):
+    """A provenance invariant failed closed."""
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _canonical(value: dict[str, Any]) -> bytes:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _require_private_regular(path: Path, *, expected_inode: tuple[int, int] | None = None) -> os.stat_result:
+    try:
+        info = os.lstat(path)
+    except OSError as exc:
+        raise ProvenanceError(f"missing provenance path: {path.name}") from exc
+    if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode):
+        raise ProvenanceError(f"provenance path is not a regular file: {path.name}")
+    if info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) != 0o600 or info.st_nlink != 1:
+        raise ProvenanceError(f"provenance file permissions invalid: {path.name}")
+    if expected_inode is not None and (info.st_dev, info.st_ino) != expected_inode:
+        raise ProvenanceError(f"provenance lock identity changed: {path.name}")
+    return info
+
+
+def _require_private_dir(path: Path) -> None:
+    try:
+        info = os.lstat(path)
+    except OSError as exc:
+        raise ProvenanceError("missing provenance directory") from exc
+    if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
+        raise ProvenanceError("provenance directory is invalid")
+    if info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) != 0o700:
+        raise ProvenanceError("provenance directory permissions invalid")
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb", closefd=False) as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.close(fd)
+        os.replace(temporary, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+class ProvenanceStore:
+    """Descriptor-checked, flock-serialized profile-local provenance storage."""
+
+    def __init__(self, home: str | Path):
+        self.home = Path(home)
+        # Cron already owns jobs.json and .jobs.lock. Provenance must neither
+        # require that shared directory to be empty nor change its permissions.
+        self.root = self.home / "cron" / "output-provenance"
+
+    @property
+    def lock_path(self) -> Path:
+        return self.root / LOCK_NAME
+
+    @property
+    def anchor_path(self) -> Path:
+        return self.root / ANCHOR_NAME
+
+    @property
+    def ledger_path(self) -> Path:
+        return self.root / LEDGER_NAME
+
+    @property
+    def key_path(self) -> Path:
+        return self.root / KEY_NAME
+
+    def bootstrap(self) -> dict[str, Any]:
+        """Provision the strict store; normal issue/claim never creates it."""
+        cron_dir = self.root.parent
+        cron_dir.mkdir(parents=True, exist_ok=True)
+        bootstrap_fd = os.open(cron_dir / BOOTSTRAP_LOCK_NAME, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            os.fchmod(bootstrap_fd, 0o600)
+            fcntl.flock(bootstrap_fd, fcntl.LOCK_EX)
+            return self._bootstrap_locked()
+        finally:
+            fcntl.flock(bootstrap_fd, fcntl.LOCK_UN)
+            os.close(bootstrap_fd)
+
+    def _bootstrap_locked(self) -> dict[str, Any]:
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.root, 0o700)
+        _require_private_dir(self.root)
+        existing = list(self.root.iterdir())
+        if existing:
+            all_files = {LOCK_NAME, LEDGER_NAME, KEY_NAME, ANCHOR_NAME}
+            recoverable = all_files - {ANCHOR_NAME}
+            names = {path.name for path in existing}
+            if names == all_files:
+                for path in existing:
+                    _require_private_regular(path)
+                lock_dev, lock_ino = self._anchor()
+                return {"schema_version": SCHEMA_VERSION, "lock_dev": lock_dev, "lock_ino": lock_ino}
+            if ANCHOR_NAME in names or not names <= recoverable:
+                raise ProvenanceError("provenance bootstrap requires an empty store")
+            for path in existing:
+                _require_private_regular(path)
+                path.unlink()
+            directory_fd = os.open(self.root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        for path, payload in (
+            (self.lock_path, b"lock\n"),
+            (self.ledger_path, _canonical({"schema_version": SCHEMA_VERSION, "occurrences": {}})),
+            (self.key_path, secrets.token_bytes(32)),
+        ):
+            _atomic_write(path, payload)
+        lock = _require_private_regular(self.lock_path)
+        anchor = {
+            "schema_version": SCHEMA_VERSION,
+            "lock_dev": lock.st_dev,
+            "lock_ino": lock.st_ino,
+        }
+        _atomic_write(self.anchor_path, _canonical(anchor))
+        _require_private_regular(self.anchor_path)
+        return anchor
+
+    def _anchor(self) -> tuple[int, int]:
+        _require_private_dir(self.root)
+        _require_private_regular(self.anchor_path)
+        try:
+            anchor = json.loads(self.anchor_path.read_text(encoding="utf-8"))
+            return int(anchor["lock_dev"]), int(anchor["lock_ino"])
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            raise ProvenanceError("malformed provenance anchor") from exc
+
+    @contextlib.contextmanager
+    def _locked(self, *, writeback: bool = True) -> Iterator[dict[str, Any]]:
+        expected = self._anchor()
+        _require_private_regular(self.lock_path, expected_inode=expected)
+        flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+        if not getattr(os, "O_NOFOLLOW", 0):
+            raise ProvenanceError("O_NOFOLLOW is required for provenance locking")
+        descriptor = os.open(self.lock_path, flags)
+        try:
+            locked = os.fstat(descriptor)
+            if (locked.st_dev, locked.st_ino) != expected or not stat.S_ISREG(locked.st_mode):
+                raise ProvenanceError("provenance lock changed while opening")
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            _require_private_regular(self.lock_path, expected_inode=expected)
+            _require_private_regular(self.ledger_path)
+            try:
+                ledger = json.loads(self.ledger_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                raise ProvenanceError("malformed provenance ledger") from exc
+            if ledger.get("schema_version") != SCHEMA_VERSION or not isinstance(ledger.get("occurrences"), dict):
+                raise ProvenanceError("unexpected provenance ledger schema")
+            yield ledger
+            if writeback:
+                _atomic_write(self.ledger_path, _canonical(ledger))
+        finally:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+
+    def health_check(self) -> None:
+        """Verify the provisioned store is readable without mutating its ledger."""
+        with self._locked(writeback=False):
+            key = _require_private_regular(self.key_path)
+            del key
+            if len(self.key_path.read_bytes()) != 32:
+                raise ProvenanceError("invalid provenance key")
+
+    def issue(
+        self,
+        *,
+        profile_id: str,
+        job_id: str,
+        occurrence_id: str,
+        target_id: str,
+        route_digest: str,
+        raw_body: bytes,
+        template_digest: str,
+        producer_class: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Create one occurrence/target proof without exposing a signing key."""
+        moment = now or _now()
+        if not all(isinstance(value, str) and value for value in (profile_id, job_id, occurrence_id, target_id, route_digest, template_digest, producer_class)):
+            raise ProvenanceError("proof identity is incomplete")
+        if len(raw_body) > MAX_BODY_BYTES:
+            raise ProvenanceError("raw final result exceeds provenance limit")
+        occurrence_key = _sha256(
+            _canonical({"profile_id": profile_id, "job_id": job_id, "occurrence_id": occurrence_id})
+        )
+        with self._locked() as ledger:
+            occurrences = ledger["occurrences"]
+            occurrence = occurrences.setdefault(occurrence_key, {"targets": {}})
+            targets = occurrence["targets"]
+            prior = targets.get(target_id)
+            if prior is not None:
+                if prior.get("route_digest") != route_digest:
+                    raise ProvenanceError("occurrence target route changed")
+                raise ProvenanceError("occurrence target already issued")
+            capability_id = "cop-" + secrets.token_hex(16)
+            body = {
+                "schema_version": SCHEMA_VERSION,
+                "capability_id": capability_id,
+                "profile_id": profile_id,
+                "job_id": job_id,
+                "occurrence_id": occurrence_id,
+                "target_id": target_id,
+                "route_digest": route_digest,
+                "raw_sha256": _sha256(raw_body),
+                "template_digest": template_digest,
+                "producer_class": producer_class,
+                "issued_at": moment.isoformat(),
+                "expires_at": (moment + timedelta(seconds=TTL_SECONDS)).isoformat(),
+            }
+            key = _require_private_regular(self.key_path)
+            del key
+            secret = self.key_path.read_bytes()
+            body["mac"] = hmac.new(secret, _canonical(body), hashlib.sha256).hexdigest()
+            targets[target_id] = {"route_digest": route_digest, "state": "prepared", "proof": body}
+            return {"proof": body, "raw_body_b64": base64.b64encode(raw_body).decode("ascii")}
+
+    @staticmethod
+    def _proof_mac_body(proof: dict[str, Any]) -> dict[str, Any]:
+        body = dict(proof)
+        body.pop("mac", None)
+        return body
+
+    @staticmethod
+    def _claim(ledger: dict[str, Any], capability_id: str) -> dict[str, Any]:
+        for occurrence in ledger["occurrences"].values():
+            for target in occurrence.get("targets", {}).values():
+                proof = target.get("proof")
+                if isinstance(proof, dict) and proof.get("capability_id") == capability_id:
+                    return target
+        raise ProvenanceError("unknown provenance capability")
+
+    def verify_and_claim(
+        self,
+        *,
+        proof: dict[str, Any],
+        raw_body_b64: str,
+        decision: str,
+        replacement_body_b64: str | None = None,
+    ) -> dict[str, Any]:
+        """Validate a proof and durably bind one allow/rewrite/deny decision."""
+        # Verification owns its security clock.  A caller-provided timestamp
+        # would let a stale bearer proof select its own pre-expiry instant.
+        moment = _now()
+        if decision not in {"allow", "rewrite", "deny"}:
+            raise ProvenanceError("invalid provenance decision")
+        try:
+            raw_body = base64.b64decode(raw_body_b64.encode("ascii"), validate=True)
+        except (ValueError, UnicodeError) as exc:
+            raise ProvenanceError("invalid raw proof body encoding") from exc
+        if len(raw_body) > MAX_BODY_BYTES:
+            raise ProvenanceError("raw proof body exceeds limit")
+        with self._locked() as ledger:
+            target = self._claim(ledger, str(proof.get("capability_id") or ""))
+            canonical_proof = target.get("proof")
+            if canonical_proof != proof:
+                raise ProvenanceError("proof does not match durable capability")
+            secret = self.key_path.read_bytes()
+            expected_mac = hmac.new(secret, _canonical(self._proof_mac_body(proof)), hashlib.sha256).hexdigest()
+            if not hmac.compare_digest(str(proof.get("mac") or ""), expected_mac):
+                raise ProvenanceError("invalid proof MAC")
+            try:
+                expiry = datetime.fromisoformat(str(proof["expires_at"]))
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ProvenanceError("invalid proof expiry") from exc
+            if expiry <= moment:
+                target["state"] = "blocked"
+                # The exception skips the context manager's normal writeback;
+                # persist this terminal state while the strict lock is held.
+                _atomic_write(self.ledger_path, _canonical(ledger))
+                raise ProvenanceError("expired provenance proof")
+            if _sha256(raw_body) != proof.get("raw_sha256"):
+                raise ProvenanceError("raw proof body hash mismatch")
+            if target.get("state") != "prepared":
+                raise ProvenanceError("provenance capability is not prepared")
+            if decision == "allow":
+                if replacement_body_b64 not in (None, ""):
+                    raise ProvenanceError("allow must not supply replacement body")
+                body = raw_body
+            elif decision == "deny":
+                if replacement_body_b64 not in (None, ""):
+                    raise ProvenanceError("deny must not supply replacement body")
+                target["state"] = "blocked"
+                return {"decision": "deny", "capability_id": proof["capability_id"]}
+            else:
+                if not isinstance(replacement_body_b64, str):
+                    raise ProvenanceError("rewrite requires replacement body")
+                try:
+                    body = base64.b64decode(replacement_body_b64.encode("ascii"), validate=True)
+                except (ValueError, UnicodeError) as exc:
+                    raise ProvenanceError("invalid replacement body encoding") from exc
+                if not body or len(body) > MAX_BODY_BYTES:
+                    raise ProvenanceError("replacement body violates limit")
+            claim_id = "coc-" + secrets.token_hex(16)
+            target.update({
+                "state": "claimed",
+                "claim_id": claim_id,
+                "body_sha256": _sha256(body),
+                "claimed_at": moment.isoformat(),
+            })
+            return {
+                "decision": decision,
+                "capability_id": proof["capability_id"],
+                "claim_id": claim_id,
+                "body_b64": base64.b64encode(body).decode("ascii"),
+            }
+
+    def begin_send(
+        self,
+        *,
+        capability_id: str,
+        claim_id: str,
+        body: bytes,
+        rendered_body: bytes,
+        route_digest: str,
+        post_send_repair_context: dict[str, Any] | None = None,
+    ) -> None:
+        """Fence a claimed delivery immediately before the adapter is invoked."""
+        with self._locked() as ledger:
+            target = self._claim(ledger, capability_id)
+            if target.get("state") != "claimed" or target.get("claim_id") != claim_id:
+                raise ProvenanceError("provenance claim is not sendable")
+            if target.get("route_digest") != route_digest:
+                raise ProvenanceError("provenance route changed before send")
+            if target.get("body_sha256") != _sha256(body):
+                raise ProvenanceError("provenance body changed before send")
+            try:
+                expiry = datetime.fromisoformat(str(target["proof"]["expires_at"]))
+            except (KeyError, TypeError, ValueError) as exc:
+                target["state"] = "blocked"
+                _atomic_write(self.ledger_path, _canonical(ledger))
+                raise ProvenanceError("invalid provenance expiry") from exc
+            if expiry <= _now():
+                target["state"] = "blocked"
+                _atomic_write(self.ledger_path, _canonical(ledger))
+                raise ProvenanceError("provenance proof expired before send")
+            if not rendered_body or len(rendered_body) > MAX_BODY_BYTES * 2:
+                raise ProvenanceError("rendered provenance body violates limit")
+            target["state"] = "send_started"
+            target["rendered_sha256"] = _sha256(rendered_body)
+            target["send_started_at"] = _now().isoformat().replace("+00:00", "Z")
+            target["post_send_recovery_context"] = dict(post_send_repair_context or {})
+
+    def _recover_stale_send_started(self, target: dict[str, Any], *, capability_id: str) -> bool:
+        """Converge an ambiguous dispatch without reopening transport delivery."""
+        if target.get("state") != "send_started":
+            return False
+        try:
+            started = datetime.fromisoformat(str(target["send_started_at"]).replace("Z", "+00:00"))
+        except (KeyError, TypeError, ValueError):
+            started = None
+        if started is not None and started.tzinfo is not None and started + timedelta(seconds=SEND_RECOVERY_SECONDS) > _now():
+            return False
+        claim_id = str(target.get("claim_id") or "")
+        if not claim_id or not isinstance(target.get("post_send_recovery_context"), dict):
+            raise ProvenanceError("provenance send recovery context is missing")
+        event_id = f"after-send:{capability_id}:{claim_id}:indeterminate"
+        target["state"] = "indeterminate"
+        target["post_send_repair"] = {
+            "state": "pending",
+            "error": "send_started_recovered",
+            "context": {
+                **target["post_send_recovery_context"],
+                "success": False,
+                "send_result": {"error": "send_started_recovered"},
+                "observer_event_id": event_id,
+            },
+            "event_id": event_id,
+            "attempts": 0,
+        }
+        return True
+
+    def block_claim(self, *, capability_id: str, claim_id: str) -> None:
+        """Terminally reject a claimed result before crossing transport."""
+        with self._locked() as ledger:
+            target = self._claim(ledger, capability_id)
+            if target.get("state") != "claimed" or target.get("claim_id") != claim_id:
+                raise ProvenanceError("provenance claim is not blockable")
+            target["state"] = "blocked"
+
+    def complete_claim(
+        self, *, capability_id: str, claim_id: str, result: str, post_send_error: str = "",
+        post_send_repair_context: dict[str, Any] | None = None,
+    ) -> None:
+        """Complete a started claim after the transport reports its disposition."""
+        if result not in TERMINAL:
+            raise ProvenanceError("invalid provenance completion")
+        with self._locked() as ledger:
+            target = self._claim(ledger, capability_id)
+            if target.get("state") != "send_started" or target.get("claim_id") != claim_id:
+                raise ProvenanceError("provenance claim is not in send_started")
+            target["state"] = result
+            if post_send_error and not isinstance(post_send_repair_context, dict):
+                raise ProvenanceError("post-send repair context is required")
+            if isinstance(post_send_repair_context, dict):
+                # Persist the terminal disposition before running an observer.
+                # A crash or observer failure can only leave this durable work
+                # item pending; recovery never re-enters the transport path.
+                target["post_send_repair"] = {
+                    "state": "pending",
+                    "error": post_send_error,
+                    "context": {
+                        **post_send_repair_context,
+                        "observer_event_id": f"after-send:{capability_id}:{claim_id}:{result}",
+                    },
+                    "event_id": f"after-send:{capability_id}:{claim_id}:{result}",
+                    "attempts": 0,
+                }
+            if post_send_error:
+                target["post_send_error"] = post_send_error
+
+    def claim_post_send_repair(self, *, capability_id: str) -> dict[str, Any]:
+        """Lease one durable after-send repair without reopening transport send."""
+        with self._locked() as ledger:
+            target = self._claim(ledger, capability_id)
+            self._recover_stale_send_started(target, capability_id=capability_id)
+            repair = target.get("post_send_repair")
+            if target.get("state") not in TERMINAL or not isinstance(repair, dict):
+                raise ProvenanceError("provenance post-send repair is not pending")
+            if repair.get("state") == "claimed":
+                try:
+                    claimed_at = datetime.fromisoformat(str(repair["claimed_at"]).replace("Z", "+00:00"))
+                except (KeyError, TypeError, ValueError):
+                    claimed_at = None
+                if claimed_at is not None and claimed_at.tzinfo is not None and claimed_at + timedelta(seconds=REPAIR_LEASE_SECONDS) > _now():
+                    raise ProvenanceError("provenance post-send repair is not pending")
+                repair["state"] = "pending"
+                repair.pop("repair_id", None)
+                repair.pop("claimed_at", None)
+            if repair.get("state") != "pending":
+                raise ProvenanceError("provenance post-send repair is not pending")
+            repair_id = "cor-" + secrets.token_hex(16)
+            repair["state"] = "claimed"
+            repair["repair_id"] = repair_id
+            repair["claimed_at"] = _now().isoformat().replace("+00:00", "Z")
+            repair["attempts"] = int(repair.get("attempts") or 0) + 1
+            return {
+                "capability_id": capability_id,
+                "repair_id": repair_id,
+                "event_id": str(repair.get("event_id") or ""),
+                "context": dict(repair["context"]),
+            }
+
+    def complete_post_send_repair(self, *, capability_id: str, repair_id: str, success: bool, error: str = "") -> None:
+        """Persist repair disposition; no branch here can resend the message."""
+        with self._locked() as ledger:
+            target = self._claim(ledger, capability_id)
+            repair = target.get("post_send_repair")
+            if target.get("state") not in TERMINAL or not isinstance(repair, dict) or repair.get("state") != "claimed" or repair.get("repair_id") != repair_id:
+                raise ProvenanceError("provenance post-send repair is not claimed")
+            repair["state"] = "repaired" if success else "pending"
+            repair["error"] = "" if success else error
+            repair.pop("repair_id", None)
+            repair.pop("claimed_at", None)
+
+    def pending_post_send_repairs(self) -> list[dict[str, Any]]:
+        """List durable after-send repairs without reopening a sent delivery."""
+        with self._locked(writeback=False) as ledger:
+            repairs: list[dict[str, str]] = []
+            current = _now()
+            for occurrence in ledger["occurrences"].values():
+                for target in occurrence.get("targets", {}).values():
+                    proof = target.get("proof") if isinstance(target.get("proof"), dict) else {}
+                    if target.get("state") == "send_started":
+                        # Any persisted send_started is an ambiguous transport
+                        # outcome. It must hard-gate new protected deliveries
+                        # immediately, even though its observer repair cannot be
+                        # claimed until the send lease becomes stale.
+                        repairs.append({
+                            "capability_id": str(proof.get("capability_id") or ""),
+                            "error": "send_started_recovery_pending",
+                            "context": dict(target.get("post_send_recovery_context") or {}),
+                        })
+                        continue
+                    repair = target.get("post_send_repair")
+                    expired_lease = False
+                    if isinstance(repair, dict) and repair.get("state") == "claimed":
+                        try:
+                            claimed_at = datetime.fromisoformat(str(repair["claimed_at"]).replace("Z", "+00:00"))
+                            expired_lease = claimed_at.tzinfo is not None and claimed_at + timedelta(seconds=REPAIR_LEASE_SECONDS) <= current
+                        except (KeyError, TypeError, ValueError):
+                            expired_lease = True
+                    if target.get("state") in TERMINAL and isinstance(repair, dict) and (repair.get("state") == "pending" or expired_lease):
+                        repairs.append({
+                            "capability_id": str(proof.get("capability_id") or ""),
+                            "error": str(repair.get("error") or ""),
+                            "context": dict(repair.get("context") or {}),
+                        })
+            return repairs

--- a/cron/output_provenance.py
+++ b/cron/output_provenance.py
@@ -148,16 +148,35 @@ class ProvenanceStore:
         if existing:
             all_files = {LOCK_NAME, LEDGER_NAME, KEY_NAME, ANCHOR_NAME}
             recoverable = all_files - {ANCHOR_NAME}
-            names = {path.name for path in existing}
+            temporary_prefixes = tuple(f".{name}." for name in all_files)
+            managed = []
+            temporary = []
+            for path in existing:
+                if path.name in all_files:
+                    managed.append(path)
+                elif any(
+                    path.name.startswith(prefix) and len(path.name) > len(prefix)
+                    for prefix in temporary_prefixes
+                ):
+                    temporary.append(path)
+                else:
+                    raise ProvenanceError("provenance bootstrap requires an empty store")
+                _require_private_regular(path)
+            names = {path.name for path in managed}
             if names == all_files:
-                for path in existing:
-                    _require_private_regular(path)
+                for path in temporary:
+                    path.unlink()
+                if temporary:
+                    directory_fd = os.open(self.root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+                    try:
+                        os.fsync(directory_fd)
+                    finally:
+                        os.close(directory_fd)
                 lock_dev, lock_ino = self._anchor()
                 return {"schema_version": SCHEMA_VERSION, "lock_dev": lock_dev, "lock_ino": lock_ino}
             if ANCHOR_NAME in names or not names <= recoverable:
                 raise ProvenanceError("provenance bootstrap requires an empty store")
-            for path in existing:
-                _require_private_regular(path)
+            for path in managed + temporary:
                 path.unlink()
             directory_fd = os.open(self.root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
             try:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1594,6 +1594,7 @@ def _deliver_protected_final_result(
     provenance_store: Any,
     wrap_response: bool,
     occurrence_id: str,
+    gate_mode: str,
 ) -> str | None:
     """Deliver one claimed final result without a post-claim route fallback."""
     from cron.output_provenance import ProvenanceError
@@ -1647,6 +1648,8 @@ def _deliver_protected_final_result(
             looks_actionable=False,
             output_screening_required=True,
             provenance_proof=issued["proof"],
+            boundary_enabled=True,
+            gate_mode=gate_mode,
         )
         decision = outbound_before_send_sync(
             hooks,
@@ -1733,9 +1736,7 @@ def _deliver_protected_final_result(
             try:
                 result = future.result(timeout=60)
             except TimeoutError:
-                if future.cancel():
-                    complete("blocked", success=False, send_result={"error": "pre_dispatch_timeout"})
-                    return f"protected final-result delivery timed out before dispatch {platform_name}:{chat_id}"
+                future.cancel()
                 complete("indeterminate", success=False, send_result={"error": "in_flight_timeout"})
                 return f"protected final-result delivery is indeterminate {platform_name}:{chat_id}"
             if isinstance(result, dict):
@@ -1811,6 +1812,29 @@ def sweep_protected_final_result_repairs() -> list[str]:
     return recover_protected_final_result_repairs_for_home()
 
 
+_FINAL_RESULT_GATE_MODES = {"enforce", "observe", "warn", "downgrade", "off"}
+
+
+def _cron_final_result_boundary_policy() -> tuple[bool, str]:
+    """Read the Profile-owned Cron boundary policy, defaulting closed."""
+    try:
+        config = load_config() or {}
+    except Exception:
+        return True, "enforce"
+    cron_config = config.get("cron", {}) if isinstance(config, dict) else {}
+    if not isinstance(cron_config, dict):
+        return True, "enforce"
+    enabled = cron_config.get("final_result_boundary_enabled", True)
+    gate_mode = cron_config.get("final_result_gate_mode", "enforce")
+    if (
+        not isinstance(enabled, bool)
+        or not isinstance(gate_mode, str)
+        or gate_mode not in _FINAL_RESULT_GATE_MODES
+    ):
+        return True, "enforce"
+    return enabled, gate_mode
+
+
 def _deliver_result(
     job: dict,
     content: str,
@@ -1818,6 +1842,7 @@ def _deliver_result(
     loop=None,
     *,
     protect_final_result: bool = False,
+    final_result_gate_mode: str = "enforce",
     outbound_hooks: Any = None,
     provenance_store: Any = None,
 ) -> Optional[str]:
@@ -2131,6 +2156,11 @@ def _deliver_result(
                 provenance_store=active_provenance_store,
                 wrap_response=wrap_response,
                 occurrence_id=provenance_occurrence_id,
+                gate_mode=(
+                    final_result_gate_mode
+                    if final_result_gate_mode in _FINAL_RESULT_GATE_MODES
+                    else "enforce"
+                ),
             )
             if protected_error:
                 logger.warning("Job '%s': %s", job["id"], protected_error)
@@ -4438,12 +4468,16 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
 
             if should_deliver:
                 try:
+                    boundary_enabled, gate_mode = _cron_final_result_boundary_policy()
                     delivery_error = _deliver_result(
                         job,
                         deliver_content,
                         adapters=adapters,
                         loop=loop,
-                        protect_final_result=success,
+                        protect_final_result=(
+                            success and boundary_enabled and gate_mode != "off"
+                        ),
+                        final_result_gate_mode=gate_mode,
                     )
                 except Exception as de:
                     delivery_error = str(de)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -10,8 +10,10 @@ runs at a time if multiple processes overlap.
 
 import asyncio
 import atexit
+import base64
 import concurrent.futures
 import contextvars
+import hashlib
 import json
 import logging
 import os
@@ -21,6 +23,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -1443,7 +1446,381 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _canonical_digest(value: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(
+        json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+def _provenance_occurrence_id(job: dict) -> str:
+    """Return the scheduler identity that distinguishes one firing occurrence."""
+    external_claim = job.get("fire_claim")
+    if isinstance(external_claim, dict):
+        occurrence_id = external_claim.get("occurrence_id")
+        if isinstance(occurrence_id, str) and occurrence_id:
+            return occurrence_id
+        if isinstance(external_claim.get("at"), str):
+            return "external:" + external_claim["at"]
+    scheduled_at = job.get("next_run_at")
+    if isinstance(scheduled_at, str) and scheduled_at:
+        return "scheduled:" + scheduled_at
+    # Manual/legacy runs have no persisted schedule occurrence. They are still
+    # independent firings, so retain a per-invocation opaque identity rather
+    # than coalescing unrelated manual sends.
+    return "manual:" + uuid.uuid4().hex
+
+
+def _render_cron_delivery_content(job: dict, content: str, *, wrap_response: bool) -> str:
+    if not wrap_response:
+        return content
+    task_name = job.get("name", job["id"])
+    job_id = job.get("id", "")
+    return (
+        f"Cronjob Response: {task_name}\n"
+        f"(job_id: {job_id})\n"
+        f"-------------\n\n"
+        f"{content}\n\n"
+        f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+    )
+
+
+_FINAL_DELIVERY_PRIVATE_BYTES = re.compile(
+    r"(?:BEGIN [A-Z0-9 ]*PRIVATE KEY|\b(?:access[_-]?token|api[_-]?key|auth[_-]?token|"
+    r"private[_-]?key|password|cookie|session(?:[_-]?(?:token|credential|id))?)\s*[:=]\s*\S+|"
+    r"\bBearer\s+\S+|"
+    r"/Users/[^\s`\"'<>]+|~/.hermes/[^\s`\"'<>]+)",
+    re.IGNORECASE,
+)
+
+
+def _final_delivery_bytes_safe(rendered: bytes) -> bool:
+    """Reject disclosure-shaped bytes after Core has rendered the final wrapper."""
+    try:
+        return _FINAL_DELIVERY_PRIVATE_BYTES.search(rendered.decode("utf-8")) is None
+    except UnicodeDecodeError:
+        return False
+
+
+def _protected_live_route(
+    *,
+    job: dict,
+    platform: Any,
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None,
+    adapter: Any,
+    loop: Any,
+) -> tuple[dict[str, str], Any, dict[str, Any]]:
+    """Reuse Cron's Telegram DM-topic route resolution for claimed sends."""
+    from gateway.delivery import DeliveryTarget, _looks_like_int, looks_like_telegram_private_chat_id
+    from gateway.config import Platform
+
+    route_thread_id = str(thread_id) if thread_id is not None else None
+    metadata: dict[str, Any] = {"job_id": job["id"]}
+    if route_thread_id:
+        metadata["thread_id"] = route_thread_id
+    if (
+        adapter is not None
+        and loop is not None
+        and getattr(loop, "is_running", lambda: False)()
+        and platform == Platform.TELEGRAM
+        and thread_id is not None
+        and looks_like_telegram_private_chat_id(str(chat_id))
+        and _looks_like_int(str(thread_id))
+        and _is_channel_dm_topic(adapter, chat_id, loop, job["id"])
+    ):
+        route_thread_id = None
+        metadata = {"job_id": job["id"], "direct_messages_topic_id": str(thread_id)}
+    route = {
+        "platform": platform_name,
+        "chat_id": str(chat_id),
+        "thread_id": route_thread_id or "",
+        "direct_messages_topic_id": str(metadata.get("direct_messages_topic_id") or ""),
+    }
+    target = DeliveryTarget(
+        platform=platform,
+        chat_id=str(chat_id),
+        thread_id=route_thread_id,
+        is_explicit=True,
+    )
+    return route, target, metadata
+
+
+def _protected_transport_metadata(
+    *,
+    route_metadata: dict[str, Any],
+    route: dict[str, str],
+    runtime_transport: Any,
+    gateway_config: Any = None,
+    platform: Any,
+    chat_id: str,
+) -> dict[str, Any]:
+    """Bind the exact Relay logical target before issuing provenance proof."""
+    metadata = dict(route_metadata)
+    transport_platform = getattr(getattr(runtime_transport, "transport_platform", None), "value", "")
+    route["transport_platform"] = str(transport_platform)
+    if str(transport_platform) != "relay":
+        return metadata
+    metadata["_relay_logical_platform"] = str(getattr(platform, "value", platform))
+    home = getattr(gateway_config, "get_home_channel", lambda _platform: None)(platform)
+    if home is not None and str(getattr(home, "chat_id", "")) == str(chat_id):
+        if getattr(home, "user_id", None):
+            metadata["user_id"] = str(home.user_id)
+        if getattr(home, "scope_id", None):
+            metadata["scope_id"] = str(home.scope_id)
+    binder = getattr(getattr(runtime_transport, "adapter", None), "bound_outbound_metadata", None)
+    if binder is None:
+        raise ValueError("relay transport cannot bind tenant metadata")
+    metadata = binder(str(chat_id), metadata)
+    route["transport_metadata"] = json.dumps(metadata, sort_keys=True, separators=(",", ":"))
+    return metadata
+
+
+def _deliver_protected_final_result(
+    *,
+    job: dict,
+    content: str,
+    platform: Any,
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None,
+    pconfig: Any,
+    gateway_config: Any = None,
+    adapters: Any,
+    runtime_adapter: Any,
+    runtime_transport: Any = None,
+    loop: Any,
+    hooks: Any,
+    provenance_store: Any,
+    wrap_response: bool,
+    occurrence_id: str,
+) -> str | None:
+    """Deliver one claimed final result without a post-claim route fallback."""
+    from cron.output_provenance import ProvenanceError
+    from gateway.outbound_boundary import (
+        build_outbound_context,
+        outbound_after_send_sync,
+        outbound_before_send_sync,
+    )
+
+    home = _get_hermes_home()
+    route, route_target, route_metadata = _protected_live_route(
+        job=job,
+        platform=platform,
+        platform_name=platform_name,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        adapter=runtime_adapter,
+        loop=loop,
+    )
+    route_metadata = _protected_transport_metadata(
+        route_metadata=route_metadata,
+        route=route,
+        runtime_transport=runtime_transport,
+        gateway_config=gateway_config,
+        platform=platform,
+        chat_id=chat_id,
+    )
+    route_digest = _canonical_digest(route)
+    target_id = _canonical_digest(route)
+    profile_id = home.name
+    declared_profile_id = str(job.get("profile_id") or "")
+    if declared_profile_id and declared_profile_id != profile_id:
+        return f"protected final-result boundary denied {platform_name}:{chat_id}: profile identity mismatch"
+    try:
+        issued = provenance_store.issue(
+            profile_id=profile_id,
+            job_id=str(job["id"]),
+            occurrence_id=occurrence_id,
+            target_id=target_id,
+            route_digest=route_digest,
+            raw_body=content.encode("utf-8"),
+            template_digest=_canonical_digest({"wrap_response": wrap_response, "job_id": str(job["id"])}),
+            producer_class="no_agent_final" if job.get("no_agent") else "llm_final",
+        )
+        boundary_context = build_outbound_context(
+            source_kind="gateway_reply",
+            profile_path=str(home),
+            profile_id=profile_id,
+            route=route,
+            content=content,
+            looks_actionable=False,
+            output_screening_required=True,
+            provenance_proof=issued["proof"],
+        )
+        decision = outbound_before_send_sync(
+            hooks,
+            boundary_context,
+        )
+        claim = provenance_store.verify_and_claim(
+            proof=issued["proof"],
+            raw_body_b64=issued["raw_body_b64"],
+            decision=decision.decision,
+            replacement_body_b64=(
+                base64.b64encode(decision.content.encode("utf-8")).decode("ascii")
+                if decision.decision == "rewrite"
+                else None
+            ),
+        )
+    except (ProvenanceError, ValueError, UnicodeError) as exc:
+        return f"protected final-result boundary denied {platform_name}:{chat_id}: {exc}"
+    if claim["decision"] == "deny":
+        return f"protected final-result boundary denied {platform_name}:{chat_id}: {decision.reason}"
+
+    body = base64.b64decode(claim["body_b64"].encode("ascii"), validate=True)
+    rendered = _render_cron_delivery_content(job, body.decode("utf-8"), wrap_response=wrap_response)
+
+    def complete(result: str, *, success: bool, send_result: Any = None) -> None:
+        payload = send_result if isinstance(send_result, dict) else {"success": success}
+        observer_context = {
+            **boundary_context,
+            "before_send_decision": decision.raw,
+            "content": body.decode("utf-8"),
+            "success": success,
+            "send_result": payload,
+        }
+        provenance_store.complete_claim(
+            capability_id=claim["capability_id"], claim_id=claim["claim_id"], result=result,
+            post_send_repair_context=observer_context,
+        )
+        # Only a persisted terminal claim is eligible to invoke the observer.
+        # The store owns its lease, so a retry/crash cannot resend transport.
+        if callable(getattr(provenance_store, "claim_post_send_repair", None)):
+            try:
+                repair_protected_final_result_after_send(
+                    provenance_store=provenance_store,
+                    hooks=hooks,
+                    capability_id=claim["capability_id"],
+                )
+            except Exception:
+                logger.warning("Job '%s': protected final-result after-send observer remains pending", job["id"], exc_info=True)
+
+    try:
+        from gateway.delivery import MAX_PLATFORM_OUTPUT
+
+        if not _final_delivery_bytes_safe(rendered.encode("utf-8")):
+            provenance_store.block_claim(
+                capability_id=claim["capability_id"], claim_id=claim["claim_id"]
+            )
+            return f"protected final-result delivery blocked private rendered bytes {platform_name}:{chat_id}"
+        if len(rendered) > MAX_PLATFORM_OUTPUT:
+            provenance_store.block_claim(
+                capability_id=claim["capability_id"], claim_id=claim["claim_id"]
+            )
+            return f"protected final-result delivery blocked oversized rendered bytes {platform_name}:{chat_id}"
+        provenance_store.begin_send(
+            capability_id=claim["capability_id"],
+            claim_id=claim["claim_id"],
+            body=body,
+            rendered_body=rendered.encode("utf-8"),
+            route_digest=route_digest,
+            post_send_repair_context={
+                **boundary_context,
+                "before_send_decision": decision.raw,
+                "content": body.decode("utf-8"),
+            },
+        )
+        if runtime_transport is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
+            from agent.async_utils import safe_schedule_threadsafe
+
+            future = safe_schedule_threadsafe(
+                runtime_transport.send(platform, route_target.chat_id, rendered, route_metadata),
+                loop,
+            )
+            if future is None:
+                complete("blocked", success=False, send_result={"error": "event_loop_schedule_failed"})
+                return f"protected final-result delivery could not schedule {platform_name}:{chat_id}"
+            try:
+                result = future.result(timeout=60)
+            except TimeoutError:
+                if future.cancel():
+                    complete("blocked", success=False, send_result={"error": "pre_dispatch_timeout"})
+                    return f"protected final-result delivery timed out before dispatch {platform_name}:{chat_id}"
+                complete("indeterminate", success=False, send_result={"error": "in_flight_timeout"})
+                return f"protected final-result delivery is indeterminate {platform_name}:{chat_id}"
+            if isinstance(result, dict):
+                delivered = result.get("success") is True and result.get("delivered") is not False
+            else:
+                delivered = _confirm_adapter_delivery(result)
+            complete("sent" if delivered else "indeterminate", success=delivered, send_result=result)
+            return None if delivered else f"protected final-result delivery unconfirmed {platform_name}:{chat_id}"
+
+        complete("blocked", success=False, send_result={"error": "protected_live_transport_required"})
+        return f"protected final-result delivery requires a live pinned transport {platform_name}:{chat_id}"
+    except Exception as exc:  # A send may have crossed the transport boundary.
+        try:
+            complete("indeterminate", success=False, send_result={"error": str(exc)})
+        except Exception:
+            pass
+        return f"protected final-result delivery indeterminate {platform_name}:{chat_id}: {exc}"
+
+
+def repair_protected_final_result_after_send(*, provenance_store: Any, hooks: Any, capability_id: str) -> str | None:
+    """Replay only a durable after-send observer; it never re-enters transport."""
+    from gateway.outbound_boundary import outbound_after_send_sync
+
+    repair = provenance_store.claim_post_send_repair(capability_id=capability_id)
+    try:
+        outbound_after_send_sync(hooks, repair["context"])
+    except Exception as exc:
+        provenance_store.complete_post_send_repair(
+            capability_id=capability_id, repair_id=repair["repair_id"], success=False, error=str(exc),
+        )
+        return f"protected final-result after-send repair failed: {exc}"
+    provenance_store.complete_post_send_repair(
+        capability_id=capability_id, repair_id=repair["repair_id"], success=True,
+    )
+    return None
+
+
+def recover_protected_final_result_repairs(*, provenance_store: Any, hooks: Any) -> list[str]:
+    """Drain due durable observer work before another protected delivery starts."""
+    pending = getattr(provenance_store, "pending_post_send_repairs", None)
+    if not callable(pending):
+        return []
+    errors: list[str] = []
+    for repair in pending():
+        capability_id = str(repair.get("capability_id") or "") if isinstance(repair, dict) else ""
+        if not capability_id:
+            errors.append("protected final-result repair has no capability id")
+            continue
+        error = repair_protected_final_result_after_send(
+            provenance_store=provenance_store, hooks=hooks, capability_id=capability_id,
+        )
+        if error:
+            errors.append(error)
+    return errors
+
+
+def recover_protected_final_result_repairs_for_home(home: str | os.PathLike[str] | None = None) -> list[str]:
+    """Recover one Profile's durable observer work without taking cron's job lock."""
+    from cron.output_provenance import ProvenanceStore
+    from gateway.outbound_boundary import load_installed_outbound_hooks
+
+    profile_home = _get_hermes_home() if home is None else home
+    hooks = load_installed_outbound_hooks(profile_home)
+    if hooks is None:
+        return []
+    return recover_protected_final_result_repairs(
+        provenance_store=ProvenanceStore(profile_home), hooks=hooks,
+    )
+
+
+def sweep_protected_final_result_repairs() -> list[str]:
+    """Run recovery from every scheduler tick, even when no job is due."""
+    return recover_protected_final_result_repairs_for_home()
+
+
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    *,
+    protect_final_result: bool = False,
+    outbound_hooks: Any = None,
+    provenance_store: Any = None,
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1490,23 +1867,36 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     except Exception:
         pass
 
-    if wrap_response:
-        task_name = job.get("name", job["id"])
-        job_id = job.get("id", "")
-        delivery_content = (
-            f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
-            f"-------------\n\n"
-            f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
-        )
-    else:
-        delivery_content = content
+    active_outbound_hooks = outbound_hooks
+    active_provenance_store = provenance_store
+    provenance_occurrence_id = ""
+    if protect_final_result:
+        try:
+            from cron.output_provenance import ProvenanceStore
+            from gateway.outbound_boundary import load_installed_outbound_hooks
+
+            if active_outbound_hooks is None:
+                active_outbound_hooks = load_installed_outbound_hooks(_get_hermes_home())
+            if active_outbound_hooks is None:
+                return "protected final-result boundary unavailable: required outbound hook is not installed"
+            active_provenance_store = active_provenance_store or ProvenanceStore(_get_hermes_home())
+            provenance_occurrence_id = _provenance_occurrence_id(job)
+            recovery_errors = recover_protected_final_result_repairs(
+                provenance_store=active_provenance_store, hooks=active_outbound_hooks,
+            )
+            if recovery_errors:
+                return f"protected final-result recovery pending: {recovery_errors[0]}"
+        except Exception as exc:
+            return f"protected final-result boundary unavailable: {exc}"
 
     # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    declared_media_files, clean_final_content = BasePlatformAdapter.extract_media(content)
+    delivery_content = _render_cron_delivery_content(
+        job, clean_final_content, wrap_response=wrap_response
+    )
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(declared_media_files)
+    cleaned_delivery_content = delivery_content
 
     # Resolve the delivery-mirror gate ONCE (default off). When on, each
     # successful delivery is also appended to the target chat's gateway session
@@ -1714,6 +2104,77 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # and (worse) suppresses the DM-fallback mirror via thread_seeded.
                 thread_id = new_thread_id
                 opened_thread_id = new_thread_id
+
+        if active_outbound_hooks is not None:
+            if declared_media_files:
+                msg = (
+                    f"protected final-result delivery rejected {platform_name}:{chat_id}: "
+                    "MEDIA attachments are outside the final-result contract"
+                )
+                logger.warning("Job '%s': %s", job["id"], msg)
+                delivery_errors.append(msg)
+                continue
+            protected_error = _deliver_protected_final_result(
+                job=job,
+                content=clean_final_content,
+                platform=platform,
+                platform_name=platform_name,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                pconfig=pconfig,
+                gateway_config=config,
+                adapters=adapters,
+                runtime_adapter=runtime_adapter,
+                runtime_transport=transport,
+                loop=loop,
+                hooks=active_outbound_hooks,
+                provenance_store=active_provenance_store,
+                wrap_response=wrap_response,
+                occurrence_id=provenance_occurrence_id,
+            )
+            if protected_error:
+                logger.warning("Job '%s': %s", job["id"], protected_error)
+                delivery_errors.append(protected_error)
+            else:
+                logger.info(
+                    "Job '%s': protected final result delivered to %s:%s",
+                    job["id"], platform_name, chat_id,
+                )
+                if live_adapter_ready:
+                    if opened_thread_id and not thread_seeded:
+                        _seed_cron_thread_session(
+                            job,
+                            runtime_adapter,
+                            platform_name,
+                            chat_id,
+                            opened_thread_id,
+                            mirror_text,
+                            chat_name=origin.get("chat_name"),
+                        )
+                        thread_seeded = True
+                    if in_channel_surface and mirror_this_target and not thread_seeded:
+                        inchannel_seeded = _seed_cron_channel_session(
+                            job,
+                            runtime_adapter,
+                            platform_name,
+                            chat_id,
+                            mirror_text,
+                            is_dm=is_dm_target,
+                            user_id=origin_user_id,
+                            chat_name=origin.get("chat_name"),
+                        )
+                _maybe_mirror_cron_delivery(
+                    job,
+                    platform_name,
+                    chat_id,
+                    mirror_text,
+                    thread_id=thread_id,
+                    user_id=origin_user_id,
+                    enabled=mirror_this_target and not thread_seeded and not inchannel_seeded,
+                )
+            # A claimed result may never take the historical route fallback,
+            # media branch, or raw session mirror.
+            continue
 
         if live_adapter_ready:
             # Telegram topic routing (#22773, regression fixed #52060): a
@@ -2045,7 +2506,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        def _run_fallback_send():
+                            return asyncio.run(
+                                _send_to_platform(
+                                    platform,
+                                    pconfig,
+                                    chat_id,
+                                    cleaned_delivery_content,
+                                    thread_id=thread_id,
+                                    media_files=media_files,
+                                )
+                            )
+
+                        future = pool.submit(_run_fallback_send)
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)
@@ -3965,7 +4438,13 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
 
             if should_deliver:
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_result(
+                        job,
+                        deliver_content,
+                        adapters=adapters,
+                        loop=loop,
+                        protect_final_result=success,
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
@@ -4056,6 +4535,17 @@ def tick(
         return 0
 
     try:
+        try:
+            recovery_errors = sweep_protected_final_result_repairs()
+            for recovery_error in recovery_errors:
+                logger.warning("Protected final-result recovery pending: %s", recovery_error)
+        except Exception as exc:
+            logger.warning("Protected final-result recovery sweep failed: %s", exc)
+            return 0
+        if recovery_errors:
+            # Do not advance occurrences or claim work while a prior protected
+            # result still needs its durable observer repaired.
+            return 0
         if can_dispatch is not None and not can_dispatch():
             logger.debug("Cron dispatch paused while gateway drains existing work")
             return 0

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1595,6 +1595,7 @@ def _deliver_protected_final_result(
     wrap_response: bool,
     occurrence_id: str,
     gate_mode: str,
+    declared_target_id: str | None = None,
 ) -> str | None:
     """Deliver one claimed final result without a post-claim route fallback."""
     from cron.output_provenance import ProvenanceError
@@ -1623,8 +1624,17 @@ def _deliver_protected_final_result(
         chat_id=chat_id,
     )
     route_digest = _canonical_digest(route)
-    target_id = _canonical_digest(route)
-    profile_id = home.name
+    target_id = declared_target_id or _canonical_digest({
+        "platform": platform_name,
+        "chat_id": str(chat_id),
+        "thread_id": str(thread_id) if thread_id is not None else "",
+    })
+    profile_id = str(getattr(hooks, "outbound_profile_id", "") or "").strip()
+    if not profile_id:
+        return (
+            f"protected final-result boundary denied {platform_name}:{chat_id}: "
+            "activated profile identity unavailable"
+        )
     declared_profile_id = str(job.get("profile_id") or "")
     if declared_profile_id and declared_profile_id != profile_id:
         return f"protected final-result boundary denied {platform_name}:{chat_id}: profile identity mismatch"
@@ -1795,15 +1805,30 @@ def recover_protected_final_result_repairs(*, provenance_store: Any, hooks: Any)
 
 def recover_protected_final_result_repairs_for_home(home: str | os.PathLike[str] | None = None) -> list[str]:
     """Recover one Profile's durable observer work without taking cron's job lock."""
-    from cron.output_provenance import ProvenanceStore
+    from cron.output_provenance import ProvenanceError, ProvenanceStore
     from gateway.outbound_boundary import load_installed_outbound_hooks
 
     profile_home = _get_hermes_home() if home is None else home
+    provenance_store = ProvenanceStore(profile_home)
+    # A newly prepared release intentionally has no active hook until its first
+    # Gateway process records loader attestation. Do not make that bootstrap
+    # impossible when there is no durable observer work to recover. If work is
+    # pending, the active hook is still mandatory and startup remains closed.
+    pending = getattr(provenance_store, "pending_post_send_repairs", None)
+    if callable(pending):
+        try:
+            if not pending():
+                return []
+        except ProvenanceError:
+            root = getattr(provenance_store, "root", None)
+            if isinstance(root, Path) and not root.exists():
+                return []
+            raise
     hooks = load_installed_outbound_hooks(profile_home)
     if hooks is None:
         return []
     return recover_protected_final_result_repairs(
-        provenance_store=ProvenanceStore(profile_home), hooks=hooks,
+        provenance_store=provenance_store, hooks=hooks,
     )
 
 
@@ -1949,6 +1974,11 @@ def _deliver_result(
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+        declared_target_id = _canonical_digest({
+            "platform": platform_name,
+            "chat_id": str(chat_id),
+            "thread_id": str(thread_id) if thread_id is not None else "",
+        })
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
@@ -2161,6 +2191,7 @@ def _deliver_result(
                     if final_result_gate_mode in _FINAL_RESULT_GATE_MODES
                     else "enforce"
                 ),
+                declared_target_id=declared_target_id,
             )
             if protected_error:
                 logger.warning("Job '%s': %s", job["id"], protected_error)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1737,7 +1737,13 @@ def _deliver_protected_final_result(
             from agent.async_utils import safe_schedule_threadsafe
 
             future = safe_schedule_threadsafe(
-                runtime_transport.send(platform, route_target.chat_id, rendered, route_metadata),
+                runtime_transport.send(
+                    platform,
+                    route_target.chat_id,
+                    rendered,
+                    route_metadata,
+                    strict_route=True,
+                ),
                 loop,
             )
             if future is None:
@@ -1826,7 +1832,7 @@ def recover_protected_final_result_repairs_for_home(home: str | os.PathLike[str]
             raise
     hooks = load_installed_outbound_hooks(profile_home)
     if hooks is None:
-        return []
+        return ["protected_final_result_recovery_blocked:active_hook_unavailable"]
     return recover_protected_final_result_repairs(
         provenance_store=provenance_store, hooks=hooks,
     )

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -19,9 +19,13 @@ selected via the `cron.provider` config key (empty = built-in).
 """
 from __future__ import annotations
 
+import logging
 import threading
 from abc import ABC, abstractmethod
 from typing import Any
+
+
+logger = logging.getLogger("cron.scheduler_provider")
 
 
 class CronScheduler(ABC):
@@ -102,7 +106,21 @@ class CronScheduler(ABC):
         """
         from cron.jobs import claim_job_for_fire, get_job
         from cron.executions import create_execution
-        from cron.scheduler import run_one_job
+        from cron.scheduler import recover_protected_final_result_repairs_for_home, run_one_job
+
+        try:
+            recovery_errors = recover_protected_final_result_repairs_for_home()
+            for error in recovery_errors:
+                logger.warning(
+                    "Protected final-result recovery pending: %s", error,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Protected final-result recovery sweep failed: %s", exc,
+            )
+            return False
+        if recovery_errors:
+            return False
 
         if not claim_job_for_fire(job_id):
             return False  # another machine already claimed this fire

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -461,7 +461,9 @@ class DeliveryRouter:
         self,
         target: DeliveryTarget,
         content: str,
-        metadata: Optional[Dict[str, Any]]
+        metadata: Optional[Dict[str, Any]],
+        *,
+        preserve_exact_content: bool = False,
     ) -> Dict[str, Any]:
         """Deliver content to a messaging platform."""
         transport = resolve_delivery_transport(target.platform, self.config, self.adapters)
@@ -485,7 +487,7 @@ class DeliveryRouter:
         job_id = (metadata or {}).get("job_id", "unknown")
         saved_path: Optional[Path] = None
 
-        if len(content) > MAX_PLATFORM_OUTPUT:
+        if not preserve_exact_content and len(content) > MAX_PLATFORM_OUTPUT:
             # Step 1 — audit save (best-effort).  The save is a side-effect
             # audit trail, not essential to delivery.  If it fails (full disk,
             # permissions), delivery proceeds — the content reaches the adapter
@@ -530,7 +532,7 @@ class DeliveryRouter:
         # platform adapter regardless of which persona's prompt failed.
         # Local/file delivery (_deliver_local) is a separate path and is never
         # filtered — saved silence has no loop risk.
-        if self._filter_silence_narration_enabled() and _is_silence_narration(content):
+        if not preserve_exact_content and self._filter_silence_narration_enabled() and _is_silence_narration(content):
             logger.warning(
                 "Dropped silence-narration outbound to %s (chat=%s): %r",
                 target.platform.value,
@@ -640,7 +642,6 @@ class DeliveryRouter:
             if _send_result_failed(result):
                 raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
         return result
-
 
 
 

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 # entirely — the adapter chunks in its own send() and the full output is
 # preserved.
 MAX_PLATFORM_OUTPUT = 4000
+_STRICT_ROUTE_METADATA_KEY = "_hermes_strict_route"
 
 # Matches strings that are *only* a "silence" narration with optional markdown
 # wrappers. Covers: *(silent)*, _silent_, `silent`, ~silent~, (silent), silent,
@@ -77,16 +78,22 @@ class DeliveryTransport:
         chat_id: str,
         content: str,
         metadata: Optional[Dict[str, Any]],
+        *,
+        strict_route: bool = False,
     ) -> Any:
         """Send through this transport while preserving the logical platform."""
+        send_metadata = metadata
+        if strict_route:
+            send_metadata = dict(metadata or {})
+            send_metadata[_STRICT_ROUTE_METADATA_KEY] = True
         if self.is_relay:
             return await self.adapter.send_for_platform(
                 logical_platform,
                 chat_id,
                 content,
-                metadata=metadata,
+                metadata=send_metadata,
             )
-        return await self.adapter.send(chat_id, content, metadata=metadata)
+        return await self.adapter.send(chat_id, content, metadata=send_metadata)
 
 
 def resolve_delivery_transport(
@@ -642,6 +649,5 @@ class DeliveryRouter:
             if _send_result_failed(result):
                 raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
         return result
-
 
 

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -59,10 +59,14 @@ class HookRegistry:
         await registry.emit("agent:start", {"platform": "telegram", ...})
     """
 
-    def __init__(self):
+    def __init__(self, hooks_dir=None):
         # event_type -> [handler_fn, ...]
         self._handlers: Dict[str, List[Callable]] = {}
+        # event_type -> hook name -> [handler_fn, ...].  Kept separately so
+        # a security boundary can target one installed consumer by name.
+        self._named_handlers: Dict[str, Dict[str, List[Callable]]] = {}
         self._loaded_hooks: List[dict] = []  # metadata for listing
+        self._hooks_dir = hooks_dir
 
     @property
     def loaded_hooks(self) -> List[dict]:
@@ -90,10 +94,11 @@ class HookRegistry:
         """
         self._register_builtin_hooks()
 
-        if not HOOKS_DIR.exists():
+        hooks_dir = self._hooks_dir if self._hooks_dir is not None else HOOKS_DIR
+        if not hooks_dir.exists():
             return
 
-        for hook_dir in sorted(HOOKS_DIR.iterdir()):
+        for hook_dir in sorted(hooks_dir.iterdir()):
             if not hook_dir.is_dir():
                 continue
 
@@ -102,6 +107,22 @@ class HookRegistry:
 
             if not manifest_path.exists() or not handler_path.exists():
                 continue
+
+            if hook_dir.name == "outbound-actionable":
+                try:
+                    from gateway.outbound_boundary import (
+                        capture_pending_outbound_attestation,
+                        load_activated_outbound_handler,
+                        outbound_activation_is_ready,
+                    )
+
+                    if not outbound_activation_is_ready(hook_dir):
+                        capture_pending_outbound_attestation(hook_dir)
+                        print("[hooks] Skipping outbound-actionable: release is not globally activated", flush=True)
+                        continue
+                except Exception:
+                    print("[hooks] Skipping outbound-actionable: activation verification failed", flush=True)
+                    continue
 
             try:
                 manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
@@ -123,20 +144,20 @@ class HookRegistry:
                 # Pydantic BaseModel for webhook/event payloads fails at first
                 # dispatch with "TypeAdapter ... is not fully defined".
                 module_name = f"hermes_hook_{hook_name}"
-                spec = importlib.util.spec_from_file_location(
-                    module_name, handler_path
-                )
-                if spec is None or spec.loader is None:
-                    print(f"[hooks] Skipping {hook_name}: could not load handler.py", flush=True)
-                    continue
-
-                module = importlib.util.module_from_spec(spec)
-                sys.modules[module_name] = module
-                try:
-                    spec.loader.exec_module(module)
-                except Exception:
-                    sys.modules.pop(module_name, None)
-                    raise
+                if hook_dir.name == "outbound-actionable":
+                    module = load_activated_outbound_handler(hook_dir, module_name)
+                else:
+                    spec = importlib.util.spec_from_file_location(module_name, handler_path)
+                    if spec is None or spec.loader is None:
+                        print(f"[hooks] Skipping {hook_name}: could not load handler.py", flush=True)
+                        continue
+                    module = importlib.util.module_from_spec(spec)
+                    sys.modules[module_name] = module
+                    try:
+                        spec.loader.exec_module(module)
+                    except Exception:
+                        sys.modules.pop(module_name, None)
+                        raise
 
                 handle_fn = getattr(module, "handle", None)
                 if handle_fn is None:
@@ -146,6 +167,7 @@ class HookRegistry:
                 # Register the handler for each declared event
                 for event in events:
                     self._handlers.setdefault(event, []).append(handle_fn)
+                    self._named_handlers.setdefault(event, {}).setdefault(hook_name, []).append(handle_fn)
 
                 self._loaded_hooks.append({
                     "name": hook_name,
@@ -224,4 +246,48 @@ class HookRegistry:
                     results.append(result)
             except Exception as e:
                 print(f"[hooks] Error in handler for '{event_type}': {e}", flush=True)
+        return results
+
+    async def emit_collect_strict(
+        self,
+        event_type: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> List[Any]:
+        """Collect decision-hook results without converting handler faults to allows.
+
+        Ordinary lifecycle hooks intentionally isolate a handler failure.  A
+        pre-send policy boundary has the opposite contract: its caller must be
+        able to deny before transport when any participating handler faults.
+        """
+        if context is None:
+            context = {}
+
+        results: List[Any] = []
+        for fn in self._resolve_handlers(event_type):
+            result = fn(event_type, context)
+            if asyncio.iscoroutine(result):
+                result = await result
+            if result is not None:
+                results.append(result)
+        return results
+
+    async def emit_collect_strict_named(
+        self,
+        event_type: str,
+        hook_name: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> List[Any]:
+        """Run one explicitly named installed hook or fail the caller closed."""
+        if context is None:
+            context = {}
+        handlers = list(self._named_handlers.get(event_type, {}).get(hook_name, []))
+        if not handlers:
+            raise RuntimeError(f"required hook is not registered: {hook_name}")
+        results: List[Any] = []
+        for fn in handlers:
+            result = fn(event_type, context)
+            if asyncio.iscoroutine(result):
+                result = await result
+            if result is not None:
+                results.append(result)
         return results

--- a/gateway/outbound_boundary.py
+++ b/gateway/outbound_boundary.py
@@ -1,0 +1,617 @@
+"""Fail-closed synchronous adapter for outbound decision hooks.
+
+Cron runs outside the Gateway request loop, while output handlers are exposed
+through :class:`gateway.hooks.HookRegistry`.  This adapter is the small bridge
+between those worlds; it never sends, retries, or resolves a route itself.
+"""
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+import hashlib
+import json
+from dataclasses import dataclass
+import os
+import stat
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+
+BEFORE_SEND = "outbound:before_send"
+AFTER_SEND = "outbound:after_send"
+OUTBOUND_ACTIONABLE_HOOK = "outbound-actionable"
+DECISIONS = {"allow", "rewrite", "deny"}
+RELEASE_TUPLE_FIELDS = (
+    "hak_commit", "hak_tag", "hak_source_path", "hak_archive_path", "hak_archive_sha256",
+    "homebrew_keg_path", "homebrew_keg_sha256", "core_commit",
+    "core_runtime_path", "core_patch_path", "core_patch_sha256",
+)
+BUNDLE_MANIFEST_NAME = "kit-bundle-manifest.json"
+_ACTIVATION_FINGERPRINT_FILES = (
+    "HOOK.yaml",
+    "handler.py",
+    BUNDLE_MANIFEST_NAME,
+    "kit-root.txt",
+    "kit_root_paths.py",
+    "runtime_loader_attestation.py",
+    "release-tuple.json",
+)
+_ACTIVATION_RUNTIME_FIELDS = (
+    "kit_root_paths",
+    "runtime_loader_identity",
+    "runtime_loader_generation",
+)
+
+
+class BoundaryLoadError(RuntimeError):
+    """An installed outbound boundary could not be loaded safely."""
+
+
+@dataclass(frozen=True)
+class OutboundDecision:
+    decision: str
+    reason: str
+    content: str
+    raw: dict[str, Any]
+
+    @property
+    def transmit(self) -> bool:
+        return self.decision in {"allow", "rewrite"}
+
+
+def build_outbound_context(**values: Any) -> dict[str, Any]:
+    """Return a detached event context without deriving authority from fields."""
+    return dict(values)
+
+
+def _private_regular(path: Path) -> bool:
+    try:
+        info = os.lstat(path)
+    except OSError:
+        return False
+    return (
+        stat.S_ISREG(info.st_mode)
+        and not stat.S_ISLNK(info.st_mode)
+        and info.st_uid == os.getuid()
+        and stat.S_IMODE(info.st_mode) == 0o600
+        and info.st_nlink == 1
+    )
+
+
+def _read_regular_bytes(path: Path) -> bytes | None:
+    """Read one non-symlink file through the descriptor that was checked."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_nlink != 1:
+            return None
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            return handle.read()
+    except OSError:
+        return None
+    finally:
+        os.close(descriptor)
+
+
+def _read_private_bytes(path: Path) -> bytes | None:
+    """Read a 0600 control through the descriptor whose metadata was checked."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        info = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_uid != os.getuid()
+            or stat.S_IMODE(info.st_mode) != 0o600
+            or info.st_nlink != 1
+        ):
+            return None
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            return handle.read()
+    except OSError:
+        return None
+    finally:
+        os.close(descriptor)
+
+
+def _sha256(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _release_tuple_digest(version_tuple: dict[str, Any]) -> str:
+    if set(version_tuple) != set(RELEASE_TUPLE_FIELDS) or any(
+        not isinstance(version_tuple.get(name), str) or not version_tuple[name].strip()
+        for name in RELEASE_TUPLE_FIELDS
+    ):
+        raise BoundaryLoadError("installed outbound boundary release tuple is incomplete")
+    canonical = json.dumps(
+        {name: version_tuple[name].strip() for name in RELEASE_TUPLE_FIELDS},
+        sort_keys=True, separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def outbound_activation_is_ready(hook_dir: Path) -> bool:
+    """Verify the release controls shared by generic Gateway and Cron loaders."""
+    release = hook_dir / "release-tuple.json"
+    activation = hook_dir / "release-activation.json"
+    if not _private_regular(release) or not _private_regular(activation):
+        return False
+    try:
+        release_payload = json.loads(release.read_text(encoding="utf-8"))
+        activation_payload = json.loads(activation.read_text(encoding="utf-8"))
+        version_tuple = release_payload["version_tuple"]
+        if (
+            release_payload.get("schema_version") != "outbound-actionable-release/v1"
+            or not isinstance(version_tuple, dict)
+            or _release_tuple_digest(version_tuple) != release_payload.get("tuple_digest")
+            or activation_payload.get("schema_version") != "outbound-actionable-dual-activation/v1"
+            or activation_payload.get("tuple_digest") != release_payload.get("tuple_digest")
+        ):
+            return False
+        activation_path = Path(str(activation_payload["activation_path"]))
+        if not activation_path.is_absolute() or not _private_regular(activation_path):
+            return False
+        payload = activation_path.read_bytes()
+        shared = json.loads(payload.decode("utf-8"))
+        if "sha256:" + hashlib.sha256(payload).hexdigest() != activation_payload.get("activation_sha256"):
+            return False
+        profiles = shared.get("profiles") if isinstance(shared, dict) else None
+        profile_id = activation_payload.get("profile_id")
+        own_entry = next(
+            (
+                item for item in profiles or []
+                if isinstance(item, dict)
+                and item.get("profile_id") == profile_id
+                and item.get("hook_dir") == str(hook_dir.absolute())
+            ),
+            None,
+        )
+        fingerprint = own_entry.get("fingerprint") if isinstance(own_entry, dict) else None
+        if (
+            not isinstance(fingerprint, dict)
+            or set(fingerprint) != set(_ACTIVATION_FINGERPRINT_FILES + _ACTIVATION_RUNTIME_FIELDS)
+            or any(not isinstance(fingerprint.get(name), str) for name in _ACTIVATION_RUNTIME_FIELDS)
+            or any(
+                (contents := _read_regular_bytes(hook_dir / name)) is None
+                or fingerprint.get(name) != _sha256(contents)
+                for name in _ACTIVATION_FINGERPRINT_FILES
+            )
+            or not isinstance(release_payload.get("bundle_manifest_sha256"), str)
+            or not _bundle_manifest_is_valid(
+                hook_dir,
+                hook_dir / BUNDLE_MANIFEST_NAME,
+                release_payload["bundle_manifest_sha256"],
+            )
+        ):
+            return False
+        return bool(
+            isinstance(shared, dict)
+            and shared.get("schema_version") == "outbound-actionable-dual-activation/v1"
+            and shared.get("tuple_digest") == release_payload.get("tuple_digest")
+            and shared.get("version_tuple") == version_tuple
+            and isinstance(profiles, list)
+            and len(profiles) == 2
+            and {item.get("profile_id") for item in profiles if isinstance(item, dict)} == {"atlas", "yuange"}
+            and profile_id in {"atlas", "yuange"}
+            and isinstance(own_entry, dict)
+            and isinstance(own_entry.get("runtime_identity"), dict)
+        )
+    except (KeyError, OSError, TypeError, ValueError, UnicodeError, BoundaryLoadError):
+        return False
+
+
+def _prepared_release_for_hook(hook_dir: Path) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Read the Keg-external authority that permits inert capture once."""
+    release = hook_dir / "release-tuple.json"
+    if not _private_regular(release):
+        return None
+    try:
+        release_payload = json.loads(release.read_text(encoding="utf-8"))
+        version_tuple = release_payload["version_tuple"]
+        tuple_digest = _release_tuple_digest(version_tuple)
+        if (
+            release_payload.get("schema_version") != "outbound-actionable-release/v1"
+            or release_payload.get("tuple_digest") != tuple_digest
+            or not isinstance(release_payload.get("bundle_manifest_sha256"), str)
+        ):
+            return None
+        keg = Path(version_tuple["homebrew_keg_path"]).expanduser()
+        prepared = keg.parent / ".outbound-actionable-activations" / f"{tuple_digest.removeprefix('sha256:')}.prepared.json"
+        if not _private_regular(prepared):
+            return None
+        prepared_payload = json.loads(prepared.read_text(encoding="utf-8"))
+        profiles = prepared_payload.get("profiles") if isinstance(prepared_payload, dict) else None
+        own_entry = next(
+            (
+                entry for entry in profiles or []
+                if isinstance(entry, dict) and entry.get("hook_dir") == str(hook_dir.absolute())
+            ),
+            None,
+        )
+        fingerprint = own_entry.get("fingerprint") if isinstance(own_entry, dict) else None
+        runtime_identity = own_entry.get("runtime_identity") if isinstance(own_entry, dict) else None
+        if (
+            prepared_payload.get("schema_version") != "outbound-actionable-dual-prepared/v1"
+            or prepared_payload.get("tuple_digest") != tuple_digest
+            or prepared_payload.get("version_tuple") != version_tuple
+            or not isinstance(profiles, list)
+            or len(profiles) != 2
+            or {entry.get("profile_id") for entry in profiles if isinstance(entry, dict)} != {"atlas", "yuange"}
+            or not isinstance(own_entry, dict)
+            or not isinstance(fingerprint, dict)
+            or not isinstance(runtime_identity, dict)
+            or fingerprint.get(BUNDLE_MANIFEST_NAME) != release_payload["bundle_manifest_sha256"]
+        ):
+            return None
+        return release_payload, own_entry
+    except (KeyError, OSError, TypeError, ValueError, UnicodeError, BoundaryLoadError):
+        return None
+
+
+def _prepared_runtime_root(entry: dict[str, Any]) -> Path | None:
+    """Verify the already prepared seam bundle before its handler can import it."""
+    identity = entry.get("runtime_identity")
+    if not isinstance(identity, dict):
+        return None
+    raw_root = identity.get("raw_root")
+    module_hashes = identity.get("module_hashes")
+    if not isinstance(raw_root, str) or not raw_root or not isinstance(module_hashes, dict) or not module_hashes:
+        return None
+    root = Path(raw_root)
+    try:
+        if not root.is_dir() or root.is_symlink():
+            return None
+        for name, expected in module_hashes.items():
+            relative = Path(str(name))
+            if (
+                not isinstance(name, str)
+                or not isinstance(expected, str)
+                or relative.is_absolute()
+                or ".." in relative.parts
+                or str(relative) in {"", "."}
+            ):
+                return None
+            contents = _read_regular_bytes(root / "scripts" / relative)
+            if contents is None or hashlib.sha256(contents).hexdigest() != expected:
+                return None
+    except OSError:
+        return None
+    return root
+
+
+@contextmanager
+def _pinned_prepared_runtime(root: Path):
+    """Prevent environment precedence from redirecting inert capture imports."""
+    keys = ("HERMES_AGENT_KIT_SCRIPTS", "HERMES_AGENT_KIT_HOME", "HERMES_AGENT_KIT_ROOT")
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        os.environ.pop("HERMES_AGENT_KIT_SCRIPTS", None)
+        os.environ.pop("HERMES_AGENT_KIT_ROOT", None)
+        os.environ["HERMES_AGENT_KIT_HOME"] = str(root)
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def capture_pending_outbound_attestation(hook_dir: Path) -> None:
+    """Let a restarted Gateway attest copied bytes while the hook remains inert."""
+    handler = hook_dir / "handler.py"
+    manifest = hook_dir / BUNDLE_MANIFEST_NAME
+    prepared = _prepared_release_for_hook(hook_dir)
+    if prepared is None:
+        return
+    release_payload, own_entry = prepared
+    runtime_root = _prepared_runtime_root(own_entry)
+    if runtime_root is None:
+        return
+    expected_manifest = release_payload["bundle_manifest_sha256"]
+    entries = _validated_bundle_manifest(hook_dir, manifest, expected_manifest)
+    expected_handler = entries.get("handler.py") if entries else None
+    handler_bytes = _read_regular_bytes(handler) if isinstance(expected_handler, str) else None
+    if handler_bytes is None or _sha256(handler_bytes) != expected_handler:
+        return
+    try:
+        with _pinned_prepared_runtime(runtime_root):
+            module = _exec_pinned_handler(
+                "hermes_pending_outbound_attestation", handler, handler_bytes,
+            )
+            capture = getattr(module, "capture_runtime_attestation", None)
+            if callable(capture):
+                capture(hook_dir.parent.parent)
+    except Exception:
+        return
+
+
+def _exec_pinned_handler(module_name: str, handler: Path, source: bytes) -> types.ModuleType:
+    """Execute exactly the handler bytes that manifest verification consumed."""
+    module = types.ModuleType(module_name)
+    module.__file__ = str(handler)
+    module.__package__ = ""
+    sys.modules[module_name] = module
+    try:
+        exec(compile(source, str(handler), "exec", dont_inherit=True), module.__dict__)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _validated_bundle_manifest(
+    root: Path, path: Path, expected_sha256: str | None = None,
+) -> dict[str, str] | None:
+    """Return the fully verified bundle file digest map, or ``None``."""
+    try:
+        manifest_bytes = _read_regular_bytes(path)
+        if manifest_bytes is None or (expected_sha256 is not None and expected_sha256 != _sha256(manifest_bytes)):
+            return None
+        payload = json.loads(manifest_bytes.decode("utf-8"))
+        files = payload.get("files") if isinstance(payload, dict) else None
+        if payload.get("schema_version") != 1 or not isinstance(files, list) or not files:
+            return None
+        canonical = json.dumps({"schema_version": 1, "files": files}, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        if payload.get("bundle_sha256") != hashlib.sha256(canonical).hexdigest():
+            return None
+        verified: dict[str, str] = {}
+        for entry in files:
+            name = entry.get("path") if isinstance(entry, dict) else None
+            digest = entry.get("sha256") if isinstance(entry, dict) else None
+            relative = Path(str(name or ""))
+            if not isinstance(name, str) or not isinstance(digest, str) or relative.is_absolute() or ".." in relative.parts or str(relative) in {"", "."} or name in verified:
+                return None
+            contents = _read_regular_bytes(root / relative)
+            if contents is None or hashlib.sha256(contents).hexdigest() != digest:
+                return None
+            verified[name] = _sha256(contents)
+        return verified if "handler.py" in verified else None
+    except (OSError, TypeError, ValueError, UnicodeError):
+        return None
+
+
+def _bundle_manifest_is_valid(root: Path, path: Path, expected_sha256: str | None = None) -> bool:
+    """Admit only a self-consistent, path-safe managed bundle before capture."""
+    return _validated_bundle_manifest(root, path, expected_sha256) is not None
+
+
+def _activated_handler_snapshot(hook_dir: Path) -> tuple[Path, bytes] | None:
+    """Pin all active controls and handler bytes to one self-consistent snapshot."""
+    release_bytes = _read_private_bytes(hook_dir / "release-tuple.json")
+    activation_bytes = _read_private_bytes(hook_dir / "release-activation.json")
+    if release_bytes is None or activation_bytes is None:
+        return None
+    try:
+        release_payload = json.loads(release_bytes.decode("utf-8"))
+        activation_payload = json.loads(activation_bytes.decode("utf-8"))
+        version_tuple = release_payload["version_tuple"]
+        if (
+            release_payload.get("schema_version") != "outbound-actionable-release/v1"
+            or not isinstance(version_tuple, dict)
+            or _release_tuple_digest(version_tuple) != release_payload.get("tuple_digest")
+            or activation_payload.get("schema_version") != "outbound-actionable-dual-activation/v1"
+            or activation_payload.get("tuple_digest") != release_payload.get("tuple_digest")
+        ):
+            return None
+        activation_path = Path(str(activation_payload["activation_path"]))
+        shared_bytes = _read_private_bytes(activation_path) if activation_path.is_absolute() else None
+        if shared_bytes is None or _sha256(shared_bytes) != activation_payload.get("activation_sha256"):
+            return None
+        shared = json.loads(shared_bytes.decode("utf-8"))
+        profiles = shared.get("profiles") if isinstance(shared, dict) else None
+        profile_id = activation_payload.get("profile_id")
+        own_entry = next(
+            item for item in profiles or []
+            if isinstance(item, dict)
+            and item.get("profile_id") == profile_id
+            and item.get("hook_dir") == str(hook_dir.absolute())
+        )
+        fingerprint = own_entry.get("fingerprint") if isinstance(own_entry, dict) else None
+        if (
+            not isinstance(fingerprint, dict)
+            or set(fingerprint) != set(_ACTIVATION_FINGERPRINT_FILES + _ACTIVATION_RUNTIME_FIELDS)
+            or any(not isinstance(fingerprint.get(name), str) for name in _ACTIVATION_RUNTIME_FIELDS)
+            or any(
+                (contents := _read_regular_bytes(hook_dir / name)) is None
+                or fingerprint.get(name) != _sha256(contents)
+                for name in _ACTIVATION_FINGERPRINT_FILES
+            )
+            or not isinstance(release_payload.get("bundle_manifest_sha256"), str)
+            or not _bundle_manifest_is_valid(hook_dir, hook_dir / BUNDLE_MANIFEST_NAME, release_payload["bundle_manifest_sha256"])
+            or not isinstance(shared, dict)
+            or shared.get("schema_version") != "outbound-actionable-dual-activation/v1"
+            or shared.get("tuple_digest") != release_payload.get("tuple_digest")
+            or shared.get("version_tuple") != version_tuple
+            or not isinstance(profiles, list)
+            or len(profiles) != 2
+            or {item.get("profile_id") for item in profiles if isinstance(item, dict)} != {"atlas", "yuange"}
+            or profile_id not in {"atlas", "yuange"}
+            or not isinstance(own_entry.get("runtime_identity"), dict)
+        ):
+            return None
+        handler = hook_dir / "handler.py"
+        source = _read_regular_bytes(handler)
+        if source is None or fingerprint.get("handler.py") != _sha256(source):
+            return None
+        return handler, source
+    except (KeyError, OSError, StopIteration, TypeError, ValueError, UnicodeError, BoundaryLoadError):
+        return None
+
+
+def load_activated_outbound_handler(hook_dir: Path, module_name: str) -> types.ModuleType:
+    """Load the active boundary from bytes pinned to its immutable activation."""
+    snapshot = _activated_handler_snapshot(hook_dir)
+    if snapshot is None:
+        if not _private_regular(hook_dir / "release-tuple.json") or not _private_regular(hook_dir / "release-activation.json"):
+            raise BoundaryLoadError("installed outbound boundary is not release-activated")
+        raise BoundaryLoadError("installed outbound boundary activation changed")
+    handler, source = snapshot
+    return _exec_pinned_handler(module_name, handler, source)
+
+
+def load_installed_outbound_hooks(home: str | Path) -> Any | None:
+    """Load the active outbound hook for one Profile, if it is installed.
+
+    No manifest means the existing Core delivery behavior remains in force.
+    Once a manifest declares the before-send boundary, a failed or incomplete
+    load is an explicit error for the scheduler to fail closed on.
+    """
+    home_path = Path(home)
+    hooks_root = home_path / "hooks"
+    hook_dir = hooks_root / "outbound-actionable"
+    manifest = hook_dir / "HOOK.yaml"
+    if not manifest.exists():
+        return None
+    for path in (hooks_root, hook_dir, manifest, hook_dir / "handler.py"):
+        try:
+            info = os.lstat(path)
+        except OSError as exc:
+            raise BoundaryLoadError("installed outbound boundary is incomplete") from exc
+        if stat.S_ISLNK(info.st_mode):
+            raise BoundaryLoadError("installed outbound boundary must not cross a symlink")
+    if hook_dir.parent != hooks_root or not manifest.is_file() or not (hook_dir / "handler.py").is_file():
+        raise BoundaryLoadError("installed outbound boundary is incomplete")
+    if not outbound_activation_is_ready(hook_dir):
+        raise BoundaryLoadError("installed outbound boundary is not release-activated")
+    release = hook_dir / "release-tuple.json"
+    activation = hook_dir / "release-activation.json"
+    if not _private_regular(release) or not _private_regular(activation):
+        raise BoundaryLoadError("installed outbound boundary release controls are invalid")
+    try:
+        release_payload = json.loads(release.read_text(encoding="utf-8"))
+        activation_payload = json.loads(activation.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise BoundaryLoadError("installed outbound boundary is not release-activated") from exc
+    if not isinstance(release_payload, dict) or activation_payload.get("tuple_digest") != release_payload.get("tuple_digest"):
+        raise BoundaryLoadError("installed outbound boundary activation does not match release tuple")
+    activation_path_value = activation_payload.get("activation_path")
+    activation_sha256 = activation_payload.get("activation_sha256")
+    profile_id = activation_payload.get("profile_id")
+    if not isinstance(activation_path_value, str) or not isinstance(activation_sha256, str) or not isinstance(profile_id, str):
+        raise BoundaryLoadError("installed outbound boundary has no shared activation record")
+    activation_path = Path(activation_path_value)
+    try:
+        activation_info = os.lstat(activation_path)
+        if (
+            not activation_path.is_absolute()
+            or stat.S_ISLNK(activation_info.st_mode)
+            or not stat.S_ISREG(activation_info.st_mode)
+            or activation_info.st_uid != os.getuid()
+            or stat.S_IMODE(activation_info.st_mode) != 0o600
+            or activation_info.st_nlink != 1
+        ):
+            raise OSError("activation record is not a regular absolute file")
+        activation_bytes = activation_path.read_bytes()
+        shared_activation = json.loads(activation_bytes.decode("utf-8"))
+    except (OSError, ValueError, UnicodeError) as exc:
+        raise BoundaryLoadError("installed outbound boundary shared activation is unavailable") from exc
+    if "sha256:" + hashlib.sha256(activation_bytes).hexdigest() != activation_sha256:
+        raise BoundaryLoadError("installed outbound boundary shared activation changed")
+    profiles = shared_activation.get("profiles") if isinstance(shared_activation, dict) else None
+    own_entry = next(
+        (
+            item for item in profiles or []
+            if isinstance(item, dict)
+            and item.get("profile_id") == profile_id
+            and item.get("hook_dir") == str(hook_dir.absolute())
+        ),
+        None,
+    )
+    if (
+        not isinstance(shared_activation, dict)
+        or shared_activation.get("tuple_digest") != release_payload.get("tuple_digest")
+        or not isinstance(profiles, list)
+        or len(profiles) != 2
+        or {item.get("profile_id") for item in profiles if isinstance(item, dict)} != {"atlas", "yuange"}
+        or not isinstance(own_entry, dict)
+    ):
+        raise BoundaryLoadError("installed outbound boundary shared activation does not bind both Profiles")
+    try:
+        from gateway.hooks import HookRegistry
+
+        hooks = HookRegistry(hooks_dir=hook_dir.parent)
+        hooks.discover_and_load()
+    except Exception as exc:  # pragma: no cover - discovery is integration-owned
+        raise BoundaryLoadError("installed outbound boundary failed to load") from exc
+    expected_path = hook_dir.absolute()
+    if not any(
+        item.get("name") == "outbound-actionable"
+        and Path(str(item.get("path") or "")).absolute() == expected_path
+        and BEFORE_SEND in item.get("events", [])
+        for item in hooks.loaded_hooks
+    ):
+        raise BoundaryLoadError("installed outbound boundary is missing before-send handler")
+    return hooks
+
+
+def _run(coro: Any) -> Any:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    result: list[Any] = []
+    error: list[BaseException] = []
+
+    def runner() -> None:
+        try:
+            result.append(asyncio.run(coro))
+        except BaseException as exc:  # pragma: no cover - defensive thread bridge
+            error.append(exc)
+
+    import threading
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join()
+    if error:
+        raise error[0]
+    return result[0]
+
+
+def outbound_before_send_sync(hooks: Any, context: dict[str, Any]) -> OutboundDecision:
+    """Collect exactly one boundary decision, otherwise deny before transport."""
+    try:
+        collector = getattr(hooks, "emit_collect_strict", None)
+        if collector is None:
+            collector = hooks.emit_collect
+        results = _run(collector(BEFORE_SEND, dict(context)))
+    except Exception:
+        return OutboundDecision("deny", "boundary_unavailable", "", {})
+    normalized = [item for item in results if isinstance(item, dict) and item.get("decision") in DECISIONS]
+    if len(normalized) != 1:
+        return OutboundDecision("deny", "boundary_decision_missing_or_ambiguous", "", {})
+    raw = dict(normalized[0])
+    decision = str(raw["decision"])
+    if decision == "rewrite":
+        replacement = raw.get("content")
+        if not isinstance(replacement, str) or not replacement:
+            return OutboundDecision("deny", "boundary_rewrite_missing_content", "", {})
+        content = replacement
+    elif decision == "allow":
+        content = str(context.get("content") or "")
+    else:
+        content = ""
+    return OutboundDecision(decision, str(raw.get("reason") or decision), content, raw)
+
+
+def outbound_after_send_sync(hooks: Any, context: dict[str, Any]) -> None:
+    """Replay only the durable outbound-actionable observer for a final result."""
+    named_collector = getattr(hooks, "emit_collect_strict_named", None)
+    if named_collector is not None:
+        _run(named_collector(AFTER_SEND, OUTBOUND_ACTIONABLE_HOOK, dict(context)))
+        return
+    collector = getattr(hooks, "emit_collect_strict", None)
+    if collector is None:
+        collector = hooks.emit_collect
+    _run(collector(AFTER_SEND, dict(context)))

--- a/gateway/outbound_boundary.py
+++ b/gateway/outbound_boundary.py
@@ -140,6 +140,46 @@ def _release_tuple_digest(version_tuple: dict[str, Any]) -> str:
     return "sha256:" + hashlib.sha256(canonical).hexdigest()
 
 
+def _ordered_profile_for_hook(
+    profiles: Any,
+    hook_dir: Path,
+    *,
+    profile_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Validate one ordered profile manifest and return this hook's entry."""
+    if not isinstance(profiles, list) or not profiles:
+        return None
+    if profile_id is not None and (not isinstance(profile_id, str) or not profile_id.strip()):
+        return None
+    own_hook_dir = os.path.abspath(os.fspath(hook_dir))
+    seen_profile_ids: set[str] = set()
+    seen_hook_dirs: set[str] = set()
+    matches: list[dict[str, Any]] = []
+    for entry in profiles:
+        if not isinstance(entry, dict):
+            return None
+        entry_profile_id = entry.get("profile_id")
+        entry_hook_dir = entry.get("hook_dir")
+        if (
+            not isinstance(entry_profile_id, str)
+            or not entry_profile_id.strip()
+            or not isinstance(entry_hook_dir, str)
+            or not entry_hook_dir
+            or not Path(entry_hook_dir).is_absolute()
+            or os.path.abspath(entry_hook_dir) != entry_hook_dir
+            or entry_profile_id in seen_profile_ids
+            or entry_hook_dir in seen_hook_dirs
+        ):
+            return None
+        seen_profile_ids.add(entry_profile_id)
+        seen_hook_dirs.add(entry_hook_dir)
+        if entry_hook_dir == own_hook_dir and (
+            profile_id is None or entry_profile_id == profile_id
+        ):
+            matches.append(entry)
+    return matches[0] if len(matches) == 1 else None
+
+
 def outbound_activation_is_ready(hook_dir: Path) -> bool:
     """Verify the release controls shared by generic Gateway and Cron loaders."""
     release = hook_dir / "release-tuple.json"
@@ -167,15 +207,9 @@ def outbound_activation_is_ready(hook_dir: Path) -> bool:
             return False
         profiles = shared.get("profiles") if isinstance(shared, dict) else None
         profile_id = activation_payload.get("profile_id")
-        own_entry = next(
-            (
-                item for item in profiles or []
-                if isinstance(item, dict)
-                and item.get("profile_id") == profile_id
-                and item.get("hook_dir") == str(hook_dir.absolute())
-            ),
-            None,
-        )
+        if not isinstance(profile_id, str) or not profile_id:
+            return False
+        own_entry = _ordered_profile_for_hook(profiles, hook_dir, profile_id=profile_id)
         fingerprint = own_entry.get("fingerprint") if isinstance(own_entry, dict) else None
         if (
             not isinstance(fingerprint, dict)
@@ -199,10 +233,6 @@ def outbound_activation_is_ready(hook_dir: Path) -> bool:
             and shared.get("schema_version") == "outbound-actionable-dual-activation/v1"
             and shared.get("tuple_digest") == release_payload.get("tuple_digest")
             and shared.get("version_tuple") == version_tuple
-            and isinstance(profiles, list)
-            and len(profiles) == 2
-            and {item.get("profile_id") for item in profiles if isinstance(item, dict)} == {"atlas", "yuange"}
-            and profile_id in {"atlas", "yuange"}
             and isinstance(own_entry, dict)
             and isinstance(own_entry.get("runtime_identity"), dict)
         )
@@ -231,22 +261,13 @@ def _prepared_release_for_hook(hook_dir: Path) -> tuple[dict[str, Any], dict[str
             return None
         prepared_payload = json.loads(prepared.read_text(encoding="utf-8"))
         profiles = prepared_payload.get("profiles") if isinstance(prepared_payload, dict) else None
-        own_entry = next(
-            (
-                entry for entry in profiles or []
-                if isinstance(entry, dict) and entry.get("hook_dir") == str(hook_dir.absolute())
-            ),
-            None,
-        )
+        own_entry = _ordered_profile_for_hook(profiles, hook_dir)
         fingerprint = own_entry.get("fingerprint") if isinstance(own_entry, dict) else None
         runtime_identity = own_entry.get("runtime_identity") if isinstance(own_entry, dict) else None
         if (
             prepared_payload.get("schema_version") != "outbound-actionable-dual-prepared/v1"
             or prepared_payload.get("tuple_digest") != tuple_digest
             or prepared_payload.get("version_tuple") != version_tuple
-            or not isinstance(profiles, list)
-            or len(profiles) != 2
-            or {entry.get("profile_id") for entry in profiles if isinstance(entry, dict)} != {"atlas", "yuange"}
             or not isinstance(own_entry, dict)
             or not isinstance(fingerprint, dict)
             or not isinstance(runtime_identity, dict)
@@ -411,12 +432,9 @@ def _activated_handler_snapshot(hook_dir: Path) -> tuple[Path, bytes] | None:
         shared = json.loads(shared_bytes.decode("utf-8"))
         profiles = shared.get("profiles") if isinstance(shared, dict) else None
         profile_id = activation_payload.get("profile_id")
-        own_entry = next(
-            item for item in profiles or []
-            if isinstance(item, dict)
-            and item.get("profile_id") == profile_id
-            and item.get("hook_dir") == str(hook_dir.absolute())
-        )
+        if not isinstance(profile_id, str) or not profile_id:
+            return None
+        own_entry = _ordered_profile_for_hook(profiles, hook_dir, profile_id=profile_id)
         fingerprint = own_entry.get("fingerprint") if isinstance(own_entry, dict) else None
         if (
             not isinstance(fingerprint, dict)
@@ -433,10 +451,7 @@ def _activated_handler_snapshot(hook_dir: Path) -> tuple[Path, bytes] | None:
             or shared.get("schema_version") != "outbound-actionable-dual-activation/v1"
             or shared.get("tuple_digest") != release_payload.get("tuple_digest")
             or shared.get("version_tuple") != version_tuple
-            or not isinstance(profiles, list)
-            or len(profiles) != 2
-            or {item.get("profile_id") for item in profiles if isinstance(item, dict)} != {"atlas", "yuange"}
-            or profile_id not in {"atlas", "yuange"}
+            or not isinstance(own_entry, dict)
             or not isinstance(own_entry.get("runtime_identity"), dict)
         ):
             return None
@@ -519,24 +534,13 @@ def load_installed_outbound_hooks(home: str | Path) -> Any | None:
     if "sha256:" + hashlib.sha256(activation_bytes).hexdigest() != activation_sha256:
         raise BoundaryLoadError("installed outbound boundary shared activation changed")
     profiles = shared_activation.get("profiles") if isinstance(shared_activation, dict) else None
-    own_entry = next(
-        (
-            item for item in profiles or []
-            if isinstance(item, dict)
-            and item.get("profile_id") == profile_id
-            and item.get("hook_dir") == str(hook_dir.absolute())
-        ),
-        None,
-    )
+    own_entry = _ordered_profile_for_hook(profiles, hook_dir, profile_id=profile_id)
     if (
         not isinstance(shared_activation, dict)
         or shared_activation.get("tuple_digest") != release_payload.get("tuple_digest")
-        or not isinstance(profiles, list)
-        or len(profiles) != 2
-        or {item.get("profile_id") for item in profiles if isinstance(item, dict)} != {"atlas", "yuange"}
         or not isinstance(own_entry, dict)
     ):
-        raise BoundaryLoadError("installed outbound boundary shared activation does not bind both Profiles")
+        raise BoundaryLoadError("installed outbound boundary shared activation does not bind this Profile")
     try:
         from gateway.hooks import HookRegistry
 

--- a/gateway/outbound_boundary.py
+++ b/gateway/outbound_boundary.py
@@ -61,6 +61,23 @@ class OutboundDecision:
         return self.decision in {"allow", "rewrite"}
 
 
+@dataclass(frozen=True)
+class _ActivatedRuntime:
+    version_tuple: dict[str, Any]
+    runtime_identity: dict[str, Any]
+    fingerprint: dict[str, Any]
+    root: Path
+    module_sources: dict[str, bytes]
+
+
+@dataclass(frozen=True)
+class _ActivatedHandlerSnapshot:
+    handler: Path
+    source: bytes
+    dependencies: dict[str, bytes]
+    runtime: _ActivatedRuntime
+
+
 def build_outbound_context(**values: Any) -> dict[str, Any]:
     """Return a detached event context without deriving authority from fields."""
     return dict(values)
@@ -147,7 +164,7 @@ def _ordered_profile_for_hook(
     profile_id: str | None = None,
 ) -> dict[str, Any] | None:
     """Validate one ordered profile manifest and return this hook's entry."""
-    if not isinstance(profiles, list) or not profiles:
+    if not isinstance(profiles, list) or len(profiles) < 2:
         return None
     if profile_id is not None and (not isinstance(profile_id, str) or not profile_id.strip()):
         return None
@@ -235,6 +252,7 @@ def outbound_activation_is_ready(hook_dir: Path) -> bool:
             and shared.get("version_tuple") == version_tuple
             and isinstance(own_entry, dict)
             and isinstance(own_entry.get("runtime_identity"), dict)
+            and _validated_activated_runtime(version_tuple, own_entry) is not None
         )
     except (KeyError, OSError, TypeError, ValueError, UnicodeError, BoundaryLoadError):
         return False
@@ -279,16 +297,11 @@ def _prepared_release_for_hook(hook_dir: Path) -> tuple[dict[str, Any], dict[str
         return None
 
 
-def _prepared_runtime_root(entry: dict[str, Any]) -> Path | None:
-    """Verify the already prepared seam bundle before its handler can import it."""
-    identity = entry.get("runtime_identity")
-    if not isinstance(identity, dict):
+def _runtime_module_sources(root: Path, module_hashes: Any) -> dict[str, bytes] | None:
+    """Rehash every module named by an immutable runtime identity."""
+    if not isinstance(module_hashes, dict) or not module_hashes:
         return None
-    raw_root = identity.get("raw_root")
-    module_hashes = identity.get("module_hashes")
-    if not isinstance(raw_root, str) or not raw_root or not isinstance(module_hashes, dict) or not module_hashes:
-        return None
-    root = Path(raw_root)
+    sources: dict[str, bytes] = {}
     try:
         if not root.is_dir() or root.is_symlink():
             return None
@@ -305,9 +318,85 @@ def _prepared_runtime_root(entry: dict[str, Any]) -> Path | None:
             contents = _read_regular_bytes(root / "scripts" / relative)
             if contents is None or hashlib.sha256(contents).hexdigest() != expected:
                 return None
+            sources[name] = contents
     except OSError:
         return None
-    return root
+    return sources
+
+
+def _prepared_runtime_root(entry: dict[str, Any]) -> Path | None:
+    """Verify the already prepared seam bundle before its handler can import it."""
+    identity = entry.get("runtime_identity")
+    if not isinstance(identity, dict):
+        return None
+    raw_root = identity.get("raw_root")
+    if not isinstance(raw_root, str) or not raw_root:
+        return None
+    root = Path(raw_root)
+    return root if _runtime_module_sources(root, identity.get("module_hashes")) is not None else None
+
+
+def _validated_activated_runtime(
+    version_tuple: dict[str, Any], entry: dict[str, Any],
+) -> _ActivatedRuntime | None:
+    """Bind current modules to the activation identity and versioned keg."""
+    identity = entry.get("runtime_identity")
+    fingerprint = entry.get("fingerprint")
+    if not isinstance(identity, dict) or not isinstance(fingerprint, dict):
+        return None
+    raw_keg = version_tuple.get("homebrew_keg_path")
+    raw_root = identity.get("raw_root")
+    canonical_root = identity.get("canonical_root")
+    if not all(isinstance(value, str) and value for value in (raw_keg, raw_root, canonical_root)):
+        return None
+    keg = Path(raw_keg)
+    root = Path(raw_root)
+    expected_root = keg / "libexec"
+    try:
+        keg_info = os.lstat(keg)
+        root_info = os.lstat(root)
+        if (
+            not keg.is_absolute()
+            or not root.is_absolute()
+            or stat.S_ISLNK(keg_info.st_mode)
+            or not stat.S_ISDIR(keg_info.st_mode)
+            or stat.S_ISLNK(root_info.st_mode)
+            or not stat.S_ISDIR(root_info.st_mode)
+            or root != expected_root
+            or root.resolve(strict=True) != expected_root
+            or str(root.resolve(strict=True)) != canonical_root
+        ):
+            return None
+    except OSError:
+        return None
+    module_hashes = identity.get("module_hashes")
+    sources = _runtime_module_sources(root, module_hashes)
+    if sources is None or "outbound_actionable_seam.py" not in sources:
+        return None
+    entry_path = root / "scripts" / "outbound_actionable_seam.py"
+    generation = hashlib.sha256(
+        json.dumps(module_hashes, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    identity_digest = _sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    if (
+        identity.get("entry_path") != str(entry_path)
+        or identity.get("executed_sha256") != module_hashes["outbound_actionable_seam.py"]
+        or identity.get("generation_sha256") != generation
+        or fingerprint.get("runtime_loader_identity") != identity_digest
+        or fingerprint.get("runtime_loader_generation") != generation
+        or "sha256:" + str(fingerprint.get("kit_root_paths") or "")
+        != fingerprint.get("kit_root_paths.py")
+    ):
+        return None
+    return _ActivatedRuntime(
+        version_tuple=dict(version_tuple),
+        runtime_identity=dict(identity),
+        fingerprint=dict(fingerprint),
+        root=root,
+        module_sources=sources,
+    )
 
 
 @contextmanager
@@ -339,16 +428,37 @@ def capture_pending_outbound_attestation(hook_dir: Path) -> None:
     runtime_root = _prepared_runtime_root(own_entry)
     if runtime_root is None:
         return
+    runtime_identity = own_entry.get("runtime_identity")
+    runtime_modules = _runtime_module_sources(
+        runtime_root,
+        runtime_identity.get("module_hashes") if isinstance(runtime_identity, dict) else None,
+    )
+    if runtime_modules is None:
+        return
     expected_manifest = release_payload["bundle_manifest_sha256"]
     entries = _validated_bundle_manifest(hook_dir, manifest, expected_manifest)
     expected_handler = entries.get("handler.py") if entries else None
     handler_bytes = _read_regular_bytes(handler) if isinstance(expected_handler, str) else None
     if handler_bytes is None or _sha256(handler_bytes) != expected_handler:
         return
+    dependencies: dict[str, bytes] = {}
+    for name in ("kit_root_paths.py", "runtime_loader_attestation.py"):
+        expected = entries.get(name) if entries else None
+        if expected is None:
+            continue
+        contents = _read_regular_bytes(hook_dir / name)
+        if contents is None or _sha256(contents) != expected:
+            return
+        dependencies[name] = contents
     try:
         with _pinned_prepared_runtime(runtime_root):
             module = _exec_pinned_handler(
-                "hermes_pending_outbound_attestation", handler, handler_bytes,
+                "hermes_pending_outbound_attestation",
+                handler,
+                handler_bytes,
+                runtime_root=runtime_root,
+                dependencies=dependencies,
+                runtime_modules=runtime_modules,
             )
             capture = getattr(module, "capture_runtime_attestation", None)
             if callable(capture):
@@ -357,11 +467,23 @@ def capture_pending_outbound_attestation(hook_dir: Path) -> None:
         return
 
 
-def _exec_pinned_handler(module_name: str, handler: Path, source: bytes) -> types.ModuleType:
+def _exec_pinned_handler(
+    module_name: str,
+    handler: Path,
+    source: bytes,
+    *,
+    runtime_root: Path | None = None,
+    dependencies: dict[str, bytes] | None = None,
+    runtime_modules: dict[str, bytes] | None = None,
+) -> types.ModuleType:
     """Execute exactly the handler bytes that manifest verification consumed."""
     module = types.ModuleType(module_name)
     module.__file__ = str(handler)
     module.__package__ = ""
+    module.__dict__["__hermes_pinned_handler_source__"] = source
+    module.__dict__["__hermes_pinned_dependencies__"] = dict(dependencies or {})
+    module.__dict__["__hermes_pinned_runtime_modules__"] = dict(runtime_modules or {})
+    module.__dict__["__hermes_runtime_root__"] = str(runtime_root) if runtime_root is not None else ""
     sys.modules[module_name] = module
     try:
         exec(compile(source, str(handler), "exec", dont_inherit=True), module.__dict__)
@@ -407,7 +529,7 @@ def _bundle_manifest_is_valid(root: Path, path: Path, expected_sha256: str | Non
     return _validated_bundle_manifest(root, path, expected_sha256) is not None
 
 
-def _activated_handler_snapshot(hook_dir: Path) -> tuple[Path, bytes] | None:
+def _activated_handler_snapshot(hook_dir: Path) -> _ActivatedHandlerSnapshot | None:
     """Pin all active controls and handler bytes to one self-consistent snapshot."""
     release_bytes = _read_private_bytes(hook_dir / "release-tuple.json")
     activation_bytes = _read_private_bytes(hook_dir / "release-activation.json")
@@ -455,13 +577,60 @@ def _activated_handler_snapshot(hook_dir: Path) -> tuple[Path, bytes] | None:
             or not isinstance(own_entry.get("runtime_identity"), dict)
         ):
             return None
+        runtime = _validated_activated_runtime(version_tuple, own_entry)
+        manifest_entries = _validated_bundle_manifest(
+            hook_dir,
+            hook_dir / BUNDLE_MANIFEST_NAME,
+            release_payload["bundle_manifest_sha256"],
+        )
+        if runtime is None or manifest_entries is None:
+            return None
         handler = hook_dir / "handler.py"
         source = _read_regular_bytes(handler)
-        if source is None or fingerprint.get("handler.py") != _sha256(source):
+        if (
+            source is None
+            or fingerprint.get("handler.py") != _sha256(source)
+            or manifest_entries.get("handler.py") != _sha256(source)
+        ):
             return None
-        return handler, source
+        dependencies: dict[str, bytes] = {}
+        for name in ("kit_root_paths.py", "runtime_loader_attestation.py"):
+            dependency = _read_regular_bytes(hook_dir / name)
+            if dependency is None or manifest_entries.get(name) != _sha256(dependency):
+                return None
+            dependencies[name] = dependency
+        return _ActivatedHandlerSnapshot(
+            handler=handler,
+            source=source,
+            dependencies=dependencies,
+            runtime=runtime,
+        )
     except (KeyError, OSError, StopIteration, TypeError, ValueError, UnicodeError, BoundaryLoadError):
         return None
+
+
+def _guard_activated_handler(handler: Any, runtime: _ActivatedRuntime) -> Any:
+    """Revalidate the activation runtime immediately before each invocation."""
+    entry = {
+        "runtime_identity": runtime.runtime_identity,
+        "fingerprint": runtime.fingerprint,
+    }
+
+    def require_current_runtime() -> None:
+        if _validated_activated_runtime(runtime.version_tuple, entry) is None:
+            raise BoundaryLoadError("installed outbound boundary runtime changed")
+
+    if asyncio.iscoroutinefunction(handler):
+        async def guarded(*args: Any, **kwargs: Any) -> Any:
+            require_current_runtime()
+            return await handler(*args, **kwargs)
+    else:
+        def guarded(*args: Any, **kwargs: Any) -> Any:
+            require_current_runtime()
+            return handler(*args, **kwargs)
+    guarded.__name__ = getattr(handler, "__name__", "handle")
+    guarded.__doc__ = getattr(handler, "__doc__", None)
+    return guarded
 
 
 def load_activated_outbound_handler(hook_dir: Path, module_name: str) -> types.ModuleType:
@@ -471,8 +640,18 @@ def load_activated_outbound_handler(hook_dir: Path, module_name: str) -> types.M
         if not _private_regular(hook_dir / "release-tuple.json") or not _private_regular(hook_dir / "release-activation.json"):
             raise BoundaryLoadError("installed outbound boundary is not release-activated")
         raise BoundaryLoadError("installed outbound boundary activation changed")
-    handler, source = snapshot
-    return _exec_pinned_handler(module_name, handler, source)
+    module = _exec_pinned_handler(
+        module_name,
+        snapshot.handler,
+        snapshot.source,
+        runtime_root=snapshot.runtime.root,
+        dependencies=snapshot.dependencies,
+        runtime_modules=snapshot.runtime.module_sources,
+    )
+    handle = getattr(module, "handle", None)
+    if callable(handle):
+        module.handle = _guard_activated_handler(handle, snapshot.runtime)
+    return module
 
 
 def load_installed_outbound_hooks(home: str | Path) -> Any | None:
@@ -556,6 +735,7 @@ def load_installed_outbound_hooks(home: str | Path) -> Any | None:
         for item in hooks.loaded_hooks
     ):
         raise BoundaryLoadError("installed outbound boundary is missing before-send handler")
+    hooks.outbound_profile_id = profile_id
     return hooks
 
 

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -418,6 +418,13 @@ class RelayAdapter(BasePlatformAdapter):
                 meta["user_id"] = author
         return meta
 
+    def bound_outbound_metadata(self, chat_id: str, metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Snapshot the Relay tenant discriminator before a protected claim."""
+        bound = self._with_scope(chat_id, metadata)
+        if not bound.get("scope_id") and not bound.get("user_id"):
+            raise ValueError("relay tenant discriminator is unavailable")
+        return bound
+
     def fronts_platform(self, platform: Any) -> bool:
         """Whether the authenticated relay transport advertises ``platform``.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23950,6 +23950,32 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+def _recover_protected_final_results_at_gateway_startup(profile_homes: list[Any] | None = None) -> list[str]:
+    """Drain durable observers once before the Gateway admits new work."""
+    from cron.scheduler import recover_protected_final_result_repairs_for_home
+
+    homes = profile_homes or [None]
+    errors: list[str] = []
+    for home in homes:
+        if isinstance(home, tuple):
+            if len(home) != 2 or not isinstance(home[1], (str, os.PathLike)):
+                errors.append(f"recovery_profile_invalid:{home!r}")
+                continue
+            path = home[1]
+        else:
+            path = home
+        try:
+            if path is None:
+                errors.extend(recover_protected_final_result_repairs_for_home())
+            else:
+                errors.extend(recover_protected_final_result_repairs_for_home(path))
+        except Exception as exc:
+            errors.append(f"recovery_sweep_failed:{path or 'default'}:{exc}")
+    for recovery_error in errors:
+        logger.warning("Protected final-result recovery pending at Gateway startup: %s", recovery_error)
+    return errors
+
+
 # Upper bound for cooperatively draining the cron ticker on shutdown. The cron
 # thread delivers via ``safe_schedule_threadsafe`` and blocks on
 # ``future.result(timeout=60)`` (see cron/scheduler.py::_deliver_result), so a
@@ -24438,6 +24464,24 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 
+    multiplex_profile_homes: list[Any] | None = None
+    if getattr(runner.config, "multiplex_profiles", False):
+        try:
+            from hermes_cli.profiles import profiles_to_serve
+
+            multiplex_profile_homes = list(profiles_to_serve(multiplex=True))
+        except Exception as exc:
+            logger.error("Could not resolve multiplex Profiles for protected-result recovery: %s", exc)
+            return False
+    recovery_errors = (
+        _recover_protected_final_results_at_gateway_startup(multiplex_profile_homes)
+        if multiplex_profile_homes
+        else _recover_protected_final_results_at_gateway_startup()
+    )
+    if recovery_errors:
+        logger.error("Gateway startup blocked until protected final-result recovery succeeds")
+        return False
+
     # Start the gateway
     success = await runner.start()
     if not success:
@@ -24492,21 +24536,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         isinstance(cron_provider, InProcessCronScheduler)
         and getattr(runner.config, "multiplex_profiles", False)
     ):
-        try:
-            from hermes_cli.profiles import profiles_to_serve
-
-            profile_homes = list(profiles_to_serve(multiplex=True))
-            if profile_homes:
-                cron_start_kwargs["profile_homes"] = profile_homes
-                logger.info(
-                    "Cron scheduler will tick %d profile(s) under multiplex: %s",
-                    len(profile_homes),
-                    [p[0] if isinstance(p, tuple) else p for p in profile_homes],
-                )
-        except Exception as exc:
-            logger.warning(
-                "Could not resolve profile homes for multiplex cron: %s",
-                exc,
+        if multiplex_profile_homes:
+            cron_start_kwargs["profile_homes"] = multiplex_profile_homes
+            logger.info(
+                "Cron scheduler will tick %d profile(s) under multiplex: %s",
+                len(multiplex_profile_homes),
+                [p[0] if isinstance(p, tuple) else p for p in multiplex_profile_homes],
             )
 
     # External cron providers own their remote scheduling contract. Only the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23950,6 +23950,37 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+def _discover_hooks_before_protected_result_recovery(
+    profile_homes: list[Any] | None = None,
+) -> None:
+    """Reach pending outbound attestation capture before recovery can block.
+
+    This deliberately uses throwaway registries: discovery may capture a
+    prepared release, but adapters and cron remain stopped until the durable
+    protected-result recovery gate below succeeds.
+    """
+    from gateway.hooks import HookRegistry
+    from hermes_cli.config import get_hermes_home
+
+    homes = profile_homes or [None]
+    for home in homes:
+        if isinstance(home, tuple):
+            if len(home) != 2 or not isinstance(home[1], (str, os.PathLike)):
+                continue
+            path = home[1]
+        else:
+            path = home
+        profile_home = get_hermes_home() if path is None else Path(path)
+        try:
+            HookRegistry(hooks_dir=profile_home / "hooks").discover_and_load()
+        except Exception as exc:
+            logger.warning(
+                "Gateway hook discovery before protected-result recovery failed for %s: %s",
+                profile_home,
+                exc,
+            )
+
+
 def _recover_protected_final_results_at_gateway_startup(profile_homes: list[Any] | None = None) -> list[str]:
     """Drain durable observers once before the Gateway admits new work."""
     from cron.scheduler import recover_protected_final_result_repairs_for_home
@@ -24473,6 +24504,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         except Exception as exc:
             logger.error("Could not resolve multiplex Profiles for protected-result recovery: %s", exc)
             return False
+    _discover_hooks_before_protected_result_recovery(multiplex_profile_homes)
     recovery_errors = (
         _recover_protected_final_results_at_gateway_startup(multiplex_profile_homes)
         if multiplex_profile_homes

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4363,6 +4363,7 @@ class TelegramAdapter(BasePlatformAdapter):
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
+            strict_route = bool((metadata or {}).get("_hermes_strict_route"))
             used_thread_fallback = False
             
             try:
@@ -4480,6 +4481,12 @@ class TelegramAdapter(BasePlatformAdapter):
                                         self.name, effective_thread_id,
                                     )
                                     continue
+                                if strict_route:
+                                    return SendResult(
+                                        success=False,
+                                        error=_redact_telegram_error_text(send_err),
+                                        retryable=False,
+                                    )
                                 # Second failure: the thread is genuinely gone.
                                 # Retry without ``message_thread_id`` so the
                                 # message still reaches the chat, and prune

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -68,6 +68,19 @@ def test_stale_claim_is_reclaimable(temp_home, monkeypatch):
     assert claim_job_for_fire(jid, claim_ttl_seconds=0) is True
 
 
+def test_stale_claim_takeover_retains_external_occurrence_identity(temp_home):
+    from cron.jobs import claim_job_for_fire, create_job, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="stable-fire")
+    assert claim_job_for_fire(job["id"]) is True
+    first = get_job(job["id"])["fire_claim"]["occurrence_id"]
+
+    assert claim_job_for_fire(job["id"], claim_ttl_seconds=0) is True
+    second = get_job(job["id"])["fire_claim"]["occurrence_id"]
+
+    assert second == first
+
+
 def test_mark_job_run_clears_claim(temp_home):
     """After a recurring job completes, its claim is cleared so the next fire
     can be claimed again."""

--- a/tests/cron/test_output_provenance.py
+++ b/tests/cron/test_output_provenance.py
@@ -1,0 +1,693 @@
+"""Focused invariants for Cron final-result provenance storage."""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import stat
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import cron.output_provenance as provenance
+from cron.output_provenance import ProvenanceError, ProvenanceStore, SCHEMA_VERSION
+
+
+NOW = datetime(2026, 7, 27, tzinfo=timezone.utc)
+
+
+def _issue(store: ProvenanceStore, *, target_id: str = "t1", route: str = "sha256:route") -> dict:
+    return store.issue(
+        profile_id="atlas",
+        job_id="job-1",
+        occurrence_id="2026-07-27T00:00:00Z",
+        target_id=target_id,
+        route_digest=route,
+        raw_body=b"daily report",
+        template_digest="sha256:template",
+        producer_class="llm_final",
+    )
+
+
+def test_bootstrap_and_issue_bind_raw_body(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    anchor = store.bootstrap()
+
+    issued = _issue(store)
+
+    assert anchor["schema_version"] == SCHEMA_VERSION
+    assert issued["proof"]["raw_sha256"].startswith("sha256:")
+    assert base64.b64decode(issued["raw_body_b64"]) == b"daily report"
+    assert issued["proof"]["state"] if "state" in issued["proof"] else True
+
+
+def test_bootstrap_uses_exclusive_store_without_mutating_existing_cron_state(tmp_path):
+    cron = tmp_path / "cron"
+    cron.mkdir()
+    jobs = cron / "jobs.json"
+    lock = cron / ".jobs.lock"
+    jobs.write_text('{"jobs":[]}', encoding="utf-8")
+    lock.write_text("existing lock\n", encoding="utf-8")
+    os.chmod(cron, 0o755)
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+
+    assert store.root == cron / "output-provenance"
+    assert jobs.read_text(encoding="utf-8") == '{"jobs":[]}'
+    assert lock.read_text(encoding="utf-8") == "existing lock\n"
+    assert stat.S_IMODE(cron.stat().st_mode) == 0o755
+
+
+def test_same_occurrence_target_cannot_issue_twice(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    _issue(store)
+
+    with pytest.raises(ProvenanceError, match="already issued"):
+        _issue(store)
+
+
+def test_same_target_route_cannot_be_substituted(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    _issue(store)
+
+    with pytest.raises(ProvenanceError, match="route changed"):
+        _issue(store, route="sha256:other-route")
+
+
+def test_issue_requires_secure_bootstrap(tmp_path):
+    with pytest.raises(ProvenanceError, match="missing provenance directory"):
+        _issue(ProvenanceStore(tmp_path))
+
+
+def test_claim_send_and_complete_are_ordered(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+
+    claim = store.verify_and_claim(
+        proof=issued["proof"],
+        raw_body_b64=issued["raw_body_b64"],
+        decision="allow",
+    )
+    body = base64.b64decode(claim["body_b64"])
+    store.begin_send(
+        capability_id=claim["capability_id"],
+        claim_id=claim["claim_id"],
+        body=body,
+        rendered_body=b"wrapped daily report",
+        route_digest="sha256:route",
+    )
+    store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent")
+    ledger = json.loads(store.ledger_path.read_text(encoding="utf-8"))
+    target = next(iter(next(iter(ledger["occurrences"].values()))["targets"].values()))
+    assert target["rendered_sha256"].startswith("sha256:")
+
+    with pytest.raises(ProvenanceError, match="not prepared"):
+        store.verify_and_claim(
+            proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow"
+        )
+
+
+def test_rewrite_requires_canonical_body_and_deny_is_terminal(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+
+    with pytest.raises(ProvenanceError, match="rewrite requires"):
+        store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="rewrite")
+
+    denied = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="deny")
+    assert denied["decision"] == "deny"
+
+
+def test_delimiter_bearing_occurrence_identity_does_not_collide(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    first = store.issue(
+        profile_id="a:b", job_id="c", occurrence_id="d", target_id="t", route_digest="sha256:r1",
+        raw_body=b"one", template_digest="sha256:t", producer_class="llm_final", now=NOW,
+    )
+    second = store.issue(
+        profile_id="a", job_id="b:c", occurrence_id="d", target_id="t", route_digest="sha256:r2",
+        raw_body=b"two", template_digest="sha256:t", producer_class="llm_final", now=NOW,
+    )
+    assert first["proof"]["capability_id"] != second["proof"]["capability_id"]
+
+
+def test_expired_claim_is_durably_blocked(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+
+    with pytest.raises(ProvenanceError, match="expired"):
+        monkeypatch.setattr(provenance, "_now", lambda: datetime(2026, 7, 28, tzinfo=timezone.utc))
+        store.verify_and_claim(
+            proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow",
+        )
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    with pytest.raises(ProvenanceError, match="not prepared"):
+        store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+
+
+def test_expired_claim_is_blocked_again_at_send_fence(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    monkeypatch.setattr(provenance, "_now", lambda: datetime(2026, 7, 28, tzinfo=timezone.utc))
+
+    with pytest.raises(ProvenanceError, match="expired before send"):
+        store.begin_send(
+            capability_id=claim["capability_id"], claim_id=claim["claim_id"],
+            body=base64.b64decode(claim["body_b64"]), rendered_body=b"daily report", route_digest="sha256:route",
+        )
+
+    ledger = json.loads(store.ledger_path.read_text(encoding="utf-8"))
+    target = next(iter(next(iter(ledger["occurrences"].values()))["targets"].values()))
+    assert target["state"] == "blocked"
+
+
+def test_malformed_expiry_at_send_fence_is_durably_blocked(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    ledger = json.loads(store.ledger_path.read_text(encoding="utf-8"))
+    target = next(iter(next(iter(ledger["occurrences"].values()))["targets"].values()))
+    target["proof"]["expires_at"] = "not-a-date"
+    store.ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+
+    with pytest.raises(ProvenanceError, match="invalid provenance expiry"):
+        store.begin_send(
+            capability_id=claim["capability_id"], claim_id=claim["claim_id"],
+            body=base64.b64decode(claim["body_b64"]), rendered_body=b"daily report", route_digest="sha256:route",
+        )
+    persisted = json.loads(store.ledger_path.read_text(encoding="utf-8"))
+    assert next(iter(next(iter(persisted["occurrences"].values()))["targets"].values()))["state"] == "blocked"
+
+
+def test_completion_persists_post_send_error(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    body = base64.b64decode(claim["body_b64"])
+    store.begin_send(capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=body, rendered_body=body, route_digest="sha256:route")
+    repair_context = {"event": "outbound:after_send", "route": {"platform": "telegram"}, "content": "daily report"}
+    store.complete_claim(
+        capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent",
+        post_send_error="frame write failed", post_send_repair_context=repair_context,
+    )
+    ledger = json.loads(store.ledger_path.read_text(encoding="utf-8"))
+    target = next(iter(next(iter(ledger["occurrences"].values()))["targets"].values()))
+    assert target["state"] == "sent"
+    assert target["post_send_error"] == "frame write failed"
+    event_id = f"after-send:{claim['capability_id']}:{claim['claim_id']}:sent"
+    expected_context = {**repair_context, "observer_event_id": event_id}
+    assert target["post_send_repair"] == {
+        "state": "pending", "error": "frame write failed", "context": expected_context,
+        "event_id": event_id, "attempts": 0,
+    }
+    assert store.pending_post_send_repairs() == [{
+        "capability_id": claim["capability_id"], "error": "frame write failed", "context": expected_context,
+    }]
+    repair = store.claim_post_send_repair(capability_id=claim["capability_id"])
+    assert repair["context"] == expected_context
+    assert repair["event_id"] == event_id
+    store.complete_post_send_repair(capability_id=claim["capability_id"], repair_id=repair["repair_id"], success=True)
+    assert store.pending_post_send_repairs() == []
+    repaired = json.loads(store.ledger_path.read_text(encoding="utf-8"))
+    repaired_target = next(iter(next(iter(repaired["occurrences"].values()))["targets"].values()))
+    assert repaired_target["state"] == "sent"
+    assert repaired_target["post_send_repair"]["state"] == "repaired"
+    with pytest.raises(ProvenanceError, match="repair is not pending"):
+        store.claim_post_send_repair(capability_id=claim["capability_id"])
+
+
+def test_post_send_repair_rejects_missing_context_and_wrong_repair_lease(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    body = base64.b64decode(claim["body_b64"])
+    store.begin_send(capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=body, rendered_body=body, route_digest="sha256:route")
+    with pytest.raises(ProvenanceError, match="context is required"):
+        store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent", post_send_error="observer failed")
+    store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent", post_send_error="observer failed", post_send_repair_context={"event": "after"})
+    repair = store.claim_post_send_repair(capability_id=claim["capability_id"])
+    with pytest.raises(ProvenanceError, match="repair is not claimed"):
+        store.complete_post_send_repair(capability_id=claim["capability_id"], repair_id="wrong", success=True)
+    store.complete_post_send_repair(capability_id=claim["capability_id"], repair_id=repair["repair_id"], success=False, error="still failed")
+    assert store.pending_post_send_repairs()[0]["error"] == "still failed"
+
+
+@pytest.mark.parametrize("terminal", ["blocked", "indeterminate"])
+def test_post_send_repair_is_consumable_for_every_terminal_without_resend(tmp_path, monkeypatch, terminal):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    body = base64.b64decode(claim["body_b64"])
+    store.begin_send(capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=body, rendered_body=body, route_digest="sha256:route")
+    store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result=terminal, post_send_error="observer failed", post_send_repair_context={"terminal": terminal})
+
+    repair = store.claim_post_send_repair(capability_id=claim["capability_id"])
+    assert repair["context"]["terminal"] == terminal
+    assert repair["context"]["observer_event_id"].endswith(f":{terminal}")
+    store.complete_post_send_repair(capability_id=claim["capability_id"], repair_id=repair["repair_id"], success=True)
+    assert store.pending_post_send_repairs() == []
+
+
+def test_post_send_repair_lease_reclaims_only_after_expiry(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    body = base64.b64decode(claim["body_b64"])
+    store.begin_send(capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=body, rendered_body=body, route_digest="sha256:route")
+    store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent", post_send_error="observer failed", post_send_repair_context={"event": "after"})
+    first = store.claim_post_send_repair(capability_id=claim["capability_id"])
+    with pytest.raises(ProvenanceError, match="not pending"):
+        store.claim_post_send_repair(capability_id=claim["capability_id"])
+    monkeypatch.setattr(provenance, "_now", lambda: NOW + timedelta(seconds=provenance.REPAIR_LEASE_SECONDS + 1))
+    second = store.claim_post_send_repair(capability_id=claim["capability_id"])
+
+    assert second["repair_id"] != first["repair_id"]
+    assert second["event_id"] == first["event_id"]
+    assert second["context"]["observer_event_id"] == first["context"]["observer_event_id"]
+    assert second["event_id"] == second["context"]["observer_event_id"]
+
+
+def test_post_send_repair_scan_reclaims_an_expired_worker_lease(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    body = base64.b64decode(claim["body_b64"])
+    store.begin_send(capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=body, rendered_body=body, route_digest="sha256:route")
+    store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent", post_send_repair_context={"event": "after"})
+    first = store.claim_post_send_repair(capability_id=claim["capability_id"])
+    assert store.pending_post_send_repairs() == []
+    monkeypatch.setattr(provenance, "_now", lambda: NOW + timedelta(seconds=provenance.REPAIR_LEASE_SECONDS + 1))
+    assert store.pending_post_send_repairs()[0]["capability_id"] == claim["capability_id"]
+    second = store.claim_post_send_repair(capability_id=claim["capability_id"])
+    assert second["repair_id"] != first["repair_id"]
+    assert second["event_id"] == first["event_id"]
+
+
+def test_post_send_repair_scan_reclaims_a_malformed_worker_lease(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    body = base64.b64decode(claim["body_b64"])
+    store.begin_send(capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=body, rendered_body=body, route_digest="sha256:route")
+    store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent", post_send_repair_context={"event": "after"})
+    ledger = json.loads(store.ledger_path.read_text(encoding="utf-8"))
+    target = next(iter(next(iter(ledger["occurrences"].values()))["targets"].values()))
+    target["post_send_repair"].update({"state": "claimed", "claimed_at": "not-a-date"})
+    store.ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+
+    assert store.pending_post_send_repairs()[0]["capability_id"] == claim["capability_id"]
+    reclaimed = store.claim_post_send_repair(capability_id=claim["capability_id"])
+    assert reclaimed["event_id"].endswith(":sent")
+
+
+def test_stale_send_started_converges_to_indeterminate_observer_repair(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    body = base64.b64decode(claim["body_b64"])
+    store.begin_send(
+        capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=body,
+        rendered_body=body, route_digest="sha256:route", post_send_repair_context={"content": "body"},
+    )
+    monkeypatch.setattr(provenance, "_now", lambda: NOW + timedelta(seconds=provenance.SEND_RECOVERY_SECONDS + 1))
+
+    assert store.pending_post_send_repairs() == [{
+        "capability_id": claim["capability_id"], "error": "send_started_recovery_pending", "context": {"content": "body"},
+    }]
+    repair = store.claim_post_send_repair(capability_id=claim["capability_id"])
+
+    assert repair["event_id"].endswith(":indeterminate")
+    assert repair["context"]["send_result"] == {"error": "send_started_recovered"}
+    assert repair["context"]["content"] == "body"
+
+
+def test_begin_send_rejects_route_substitution(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(
+        proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow"
+    )
+
+    with pytest.raises(ProvenanceError, match="route changed"):
+        store.begin_send(
+            capability_id=claim["capability_id"],
+            claim_id=claim["claim_id"],
+            body=base64.b64decode(claim["body_b64"]),
+            rendered_body=b"wrapped daily report",
+            route_digest="sha256:substituted-route",
+        )
+
+
+def test_claim_can_be_blocked_before_transport(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    claim = store.verify_and_claim(
+        proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow"
+    )
+
+    store.block_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"])
+
+    with pytest.raises(ProvenanceError, match="not prepared"):
+        store.verify_and_claim(
+            proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow"
+        )
+
+
+def test_bootstrap_requires_an_empty_private_store(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    store.root.mkdir(mode=0o700, parents=True)
+    (store.root / "leftover").write_text("x", encoding="utf-8")
+
+    with pytest.raises(ProvenanceError, match="empty store"):
+        store.bootstrap()
+
+
+@pytest.mark.parametrize("partial_name", [provenance.LOCK_NAME, provenance.LEDGER_NAME, provenance.KEY_NAME])
+def test_bootstrap_recovers_a_private_pre_anchor_interruption(tmp_path, partial_name):
+    store = ProvenanceStore(tmp_path)
+    store.root.mkdir(mode=0o700, parents=True)
+    partial = store.root / partial_name
+    partial.write_bytes(b"partial")
+    os.chmod(partial, 0o600)
+
+    anchor = store.bootstrap()
+
+    assert anchor["schema_version"] == provenance.SCHEMA_VERSION
+    assert store.anchor_path.is_file()
+    assert store.key_path.stat().st_size == 32
+
+
+def test_bootstrap_is_idempotent_after_another_initializer_commits_the_anchor(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    first = store.bootstrap()
+
+    assert store.bootstrap() == first
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda store: os.chmod(store.root, 0o755), "directory permissions"),
+        (lambda store: store.anchor_path.unlink(), "missing provenance path"),
+        (lambda store: store.anchor_path.write_text("not-json", encoding="utf-8"), "malformed provenance anchor"),
+        (lambda store: os.chmod(store.key_path, 0o644), "file permissions"),
+    ],
+)
+def test_store_rejects_tampered_private_state(tmp_path, mutate, message):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    mutate(store)
+
+    with pytest.raises(ProvenanceError, match=message):
+        _issue(store)
+
+
+def test_store_rejects_symlinked_private_state(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    target = tmp_path / "outside"
+    target.write_text("outside", encoding="utf-8")
+    store.key_path.unlink()
+    store.key_path.symlink_to(target)
+
+    with pytest.raises(ProvenanceError, match="regular file"):
+        _issue(store)
+
+
+def test_issue_rejects_incomplete_or_oversized_input(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+
+    with pytest.raises(ProvenanceError, match="identity"):
+        store.issue(
+            profile_id="", job_id="job", occurrence_id="occurrence", target_id="target",
+            route_digest="route", raw_body=b"x", template_digest="template", producer_class="final",
+        )
+    with pytest.raises(ProvenanceError, match="exceeds"):
+        store.issue(
+            profile_id="profile", job_id="job", occurrence_id="occurrence", target_id="target",
+            route_digest="route", raw_body=b"x" * (provenance.MAX_BODY_BYTES + 1),
+            template_digest="template", producer_class="final",
+        )
+
+
+def test_claim_rejects_tampering_and_invalid_decisions(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+
+    with pytest.raises(ProvenanceError, match="invalid provenance decision"):
+        store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="maybe")
+    with pytest.raises(ProvenanceError, match="raw proof body encoding"):
+        store.verify_and_claim(proof=issued["proof"], raw_body_b64="!", decision="allow")
+    with pytest.raises(ProvenanceError, match="raw proof body hash"):
+        store.verify_and_claim(
+            proof=issued["proof"], raw_body_b64=base64.b64encode(b"substitute").decode("ascii"), decision="allow"
+        )
+    tampered = dict(issued["proof"], mac="0" * 64)
+    with pytest.raises(ProvenanceError, match="durable capability"):
+        store.verify_and_claim(proof=tampered, raw_body_b64=issued["raw_body_b64"], decision="allow")
+
+
+def test_claim_rewrite_and_send_state_validation(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+
+    with pytest.raises(ProvenanceError, match="replacement body encoding"):
+        store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="rewrite", replacement_body_b64="!")
+    with pytest.raises(ProvenanceError, match="replacement body violates"):
+        store.verify_and_claim(
+            proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="rewrite",
+            replacement_body_b64=base64.b64encode(b"").decode("ascii"),
+        )
+    claim = store.verify_and_claim(
+        proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="rewrite",
+        replacement_body_b64=base64.b64encode(b"safe").decode("ascii"),
+    )
+    with pytest.raises(ProvenanceError, match="body changed"):
+        store.begin_send(
+            capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=b"other",
+            rendered_body=b"safe", route_digest="sha256:route",
+        )
+    with pytest.raises(ProvenanceError, match="rendered provenance"):
+        store.begin_send(
+            capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=b"safe",
+            rendered_body=b"", route_digest="sha256:route",
+        )
+    with pytest.raises(ProvenanceError, match="invalid provenance completion"):
+        store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="lost")
+
+
+def test_require_private_regular_rejects_wrong_inode_and_mode(tmp_path):
+    path = tmp_path / "private"
+    path.write_text("x", encoding="utf-8")
+    os.chmod(path, 0o600)
+    info = path.stat()
+    with pytest.raises(ProvenanceError, match="identity changed"):
+        provenance._require_private_regular(path, expected_inode=(info.st_dev, info.st_ino + 1))
+    os.chmod(path, stat.S_IMODE(info.st_mode) | 0o040)
+    with pytest.raises(ProvenanceError, match="permissions"):
+        provenance._require_private_regular(path)
+
+
+def test_private_directory_rejects_symlink(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir(mode=0o700)
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+    with pytest.raises(ProvenanceError, match="directory is invalid"):
+        provenance._require_private_dir(link)
+
+
+def test_atomic_write_cleans_a_partial_temp_file(tmp_path, monkeypatch):
+    path = tmp_path / "ledger"
+    monkeypatch.setattr(provenance.os, "fsync", lambda _fd: (_ for _ in ()).throw(OSError("disk full")))
+
+    with pytest.raises(OSError, match="disk full"):
+        provenance._atomic_write(path, b"contents")
+
+    assert not path.exists()
+    assert not list(tmp_path.glob(".ledger.*"))
+
+
+def test_atomic_write_keeps_original_error_when_cleanup_also_fails(tmp_path, monkeypatch):
+    path = tmp_path / "ledger"
+    real_close = provenance.os.close
+    real_unlink = provenance.os.unlink
+    leaked_fds: list[int] = []
+
+    def refuse_close(fd):
+        leaked_fds.append(fd)
+        raise OSError("close failed")
+
+    monkeypatch.setattr(provenance.os, "fsync", lambda _fd: (_ for _ in ()).throw(OSError("disk full")))
+    monkeypatch.setattr(provenance.os, "close", refuse_close)
+    monkeypatch.setattr(provenance.os, "unlink", lambda _path: (_ for _ in ()).throw(OSError("unlink failed")))
+    with pytest.raises(OSError, match="disk full"):
+        provenance._atomic_write(path, b"contents")
+
+    monkeypatch.setattr(provenance.os, "close", real_close)
+    monkeypatch.setattr(provenance.os, "unlink", real_unlink)
+    for fd in set(leaked_fds):
+        try:
+            real_close(fd)
+        except OSError:
+            pass
+    for temporary in tmp_path.glob(".ledger.*"):
+        real_unlink(temporary)
+
+
+def test_locking_rejects_missing_nofollow_and_changed_inode(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    nofollow = provenance.os.O_NOFOLLOW
+    monkeypatch.setattr(provenance.os, "O_NOFOLLOW", 0, raising=False)
+    with pytest.raises(ProvenanceError, match="O_NOFOLLOW"):
+        with store._locked():
+            pass
+    monkeypatch.setattr(provenance.os, "O_NOFOLLOW", nofollow, raising=False)
+
+    store = ProvenanceStore(tmp_path / "second")
+    store.bootstrap()
+    actual = provenance.os.fstat
+    monkeypatch.setattr(provenance.os, "fstat", lambda fd: os.stat_result((stat.S_IFREG | 0o600, 0, 0, 1, 0, 0, 0, 0, 0, 0)))
+    with pytest.raises(ProvenanceError, match="changed while opening"):
+        with store._locked():
+            pass
+    monkeypatch.setattr(provenance.os, "fstat", actual)
+
+
+@pytest.mark.parametrize(
+    ("ledger", "message"),
+    [
+        ("not-json", "malformed provenance ledger"),
+        (json.dumps({"schema_version": "wrong", "occurrences": {}}), "unexpected provenance ledger schema"),
+    ],
+)
+def test_locking_rejects_malformed_ledger(tmp_path, ledger, message):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    store.ledger_path.write_text(ledger, encoding="utf-8")
+    with pytest.raises(ProvenanceError, match=message):
+        _issue(store)
+
+
+def test_claim_rejects_unknown_and_oversized_encoded_body(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+
+    unknown = dict(issued["proof"], capability_id="unknown")
+    with pytest.raises(ProvenanceError, match="unknown provenance capability"):
+        store.verify_and_claim(proof=unknown, raw_body_b64=issued["raw_body_b64"], decision="allow")
+    with pytest.raises(ProvenanceError, match="raw proof body exceeds"):
+        store.verify_and_claim(
+            proof=issued["proof"],
+            raw_body_b64=base64.b64encode(b"x" * (provenance.MAX_BODY_BYTES + 1)).decode("ascii"),
+            decision="allow",
+        )
+
+
+def test_claim_rejects_durable_mac_and_expiry_tampering(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+    ledger = json.loads(store.ledger_path.read_text(encoding="utf-8"))
+    target = next(iter(next(iter(ledger["occurrences"].values()))["targets"].values()))
+
+    target["proof"]["mac"] = "0" * 64
+    store.ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+    with pytest.raises(ProvenanceError, match="invalid proof MAC"):
+        store.verify_and_claim(proof=target["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+
+    store = ProvenanceStore(tmp_path / "expiry")
+    store.bootstrap()
+    issued = _issue(store)
+    ledger = json.loads(store.ledger_path.read_text(encoding="utf-8"))
+    target = next(iter(next(iter(ledger["occurrences"].values()))["targets"].values()))
+    target["proof"]["expires_at"] = "not-a-date"
+    key = store.key_path.read_bytes()
+    target["proof"]["mac"] = provenance.hmac.new(
+        key, provenance._canonical(provenance.ProvenanceStore._proof_mac_body(target["proof"])), provenance.hashlib.sha256
+    ).hexdigest()
+    store.ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+    with pytest.raises(ProvenanceError, match="invalid proof expiry"):
+        store.verify_and_claim(proof=target["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+
+
+def test_allow_deny_and_terminal_state_checks(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = _issue(store)
+    monkeypatch.setattr(provenance, "_now", lambda: NOW)
+
+    with pytest.raises(ProvenanceError, match="allow must"):
+        store.verify_and_claim(
+            proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow", replacement_body_b64="eA=="
+        )
+    with pytest.raises(ProvenanceError, match="deny must"):
+        store.verify_and_claim(
+            proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="deny", replacement_body_b64="eA=="
+        )
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    with pytest.raises(ProvenanceError, match="not sendable"):
+        store.begin_send(capability_id=claim["capability_id"], claim_id="wrong", body=b"daily report", rendered_body=b"report", route_digest="sha256:route")
+    with pytest.raises(ProvenanceError, match="not blockable"):
+        store.block_claim(capability_id=claim["capability_id"], claim_id="wrong")
+    with pytest.raises(ProvenanceError, match="not in send_started"):
+        store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent")
+
+
+def test_health_check_rejects_invalid_key_and_ledger_without_rewriting(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    before = store.ledger_path.read_bytes()
+    store.health_check()
+    assert store.ledger_path.read_bytes() == before
+
+    store.key_path.write_bytes(b"too-short")
+    with pytest.raises(ProvenanceError, match="invalid provenance key"):
+        store.health_check()
+
+    store = ProvenanceStore(tmp_path / "ledger")
+    store.bootstrap()
+    store.ledger_path.write_text('{"schema_version":"wrong","occurrences":{}}', encoding="utf-8")
+    with pytest.raises(ProvenanceError, match="unexpected provenance ledger schema"):
+        store.health_check()

--- a/tests/cron/test_output_provenance.py
+++ b/tests/cron/test_output_provenance.py
@@ -26,6 +26,7 @@ def _issue(store: ProvenanceStore, *, target_id: str = "t1", route: str = "sha25
         raw_body=b"daily report",
         template_digest="sha256:template",
         producer_class="llm_final",
+        now=NOW,
     )
 
 
@@ -143,9 +144,10 @@ def test_expired_claim_is_durably_blocked(tmp_path, monkeypatch):
     store = ProvenanceStore(tmp_path)
     store.bootstrap()
     issued = _issue(store)
+    expired_now = NOW + timedelta(seconds=provenance.TTL_SECONDS + 1)
+    monkeypatch.setattr(provenance, "_now", lambda: expired_now)
 
     with pytest.raises(ProvenanceError, match="expired"):
-        monkeypatch.setattr(provenance, "_now", lambda: datetime(2026, 7, 28, tzinfo=timezone.utc))
         store.verify_and_claim(
             proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow",
         )
@@ -160,7 +162,8 @@ def test_expired_claim_is_blocked_again_at_send_fence(tmp_path, monkeypatch):
     issued = _issue(store)
     monkeypatch.setattr(provenance, "_now", lambda: NOW)
     claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
-    monkeypatch.setattr(provenance, "_now", lambda: datetime(2026, 7, 28, tzinfo=timezone.utc))
+    expired_now = NOW + timedelta(seconds=provenance.TTL_SECONDS + 1)
+    monkeypatch.setattr(provenance, "_now", lambda: expired_now)
 
     with pytest.raises(ProvenanceError, match="expired before send"):
         store.begin_send(
@@ -414,6 +417,49 @@ def test_bootstrap_is_idempotent_after_another_initializer_commits_the_anchor(tm
     first = store.bootstrap()
 
     assert store.bootstrap() == first
+
+
+def test_bootstrap_removes_only_safe_atomic_write_residue_and_fsyncs(tmp_path, monkeypatch):
+    store = ProvenanceStore(tmp_path)
+    expected = store.bootstrap()
+    residues = [
+        store.root / f".{name}.crash-residue"
+        for name in (
+            provenance.LOCK_NAME,
+            provenance.LEDGER_NAME,
+            provenance.KEY_NAME,
+            provenance.ANCHOR_NAME,
+        )
+    ]
+    for residue in residues:
+        residue.write_bytes(b"partial")
+        os.chmod(residue, 0o600)
+    fsync_calls = []
+    monkeypatch.setattr(provenance.os, "fsync", lambda descriptor: fsync_calls.append(descriptor))
+
+    assert store.bootstrap() == expected
+    assert not any(path.exists() for path in residues)
+    assert fsync_calls
+
+
+@pytest.mark.parametrize("residue_kind", ["unknown", "symlink"])
+def test_bootstrap_rejects_unknown_or_symlink_residue(tmp_path, residue_kind):
+    store = ProvenanceStore(tmp_path)
+    store.root.mkdir(parents=True, mode=0o700)
+    if residue_kind == "unknown":
+        residue = store.root / ".unrelated.crash-residue"
+        residue.write_bytes(b"unknown")
+        os.chmod(residue, 0o600)
+    else:
+        target = tmp_path / "outside"
+        target.write_bytes(b"partial")
+        os.chmod(target, 0o600)
+        residue = store.root / f".{provenance.LEDGER_NAME}.crash-residue"
+        residue.symlink_to(target)
+
+    with pytest.raises(ProvenanceError):
+        store.bootstrap()
+    assert residue.is_symlink() or residue.exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -11,6 +11,7 @@ the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
 import cron.scheduler as s
+import pytest
 
 
 def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final response",
@@ -28,7 +29,10 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         return f"/tmp/{jid}.txt"
 
     def fake_deliver(job, content, adapters=None, loop=None, **kwargs):
-        calls.append(("deliver", job["id"], kwargs.get("protect_final_result")))
+        calls.append((
+            "deliver", job["id"], kwargs.get("protect_final_result"),
+            kwargs.get("final_result_gate_mode"),
+        ))
         return None
 
     def fake_mark(jid, ok, err=None, delivery_error=None):
@@ -38,6 +42,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
     monkeypatch.setattr(s, "save_job_output", fake_save)
     monkeypatch.setattr(s, "_deliver_result", fake_deliver)
     monkeypatch.setattr(s, "mark_job_run", fake_mark)
+    monkeypatch.setattr(s, "load_config", lambda: {})
     return calls
 
 
@@ -51,7 +56,7 @@ def test_tick_process_job_sequence(monkeypatch):
     s.tick(verbose=False, sync=True)
 
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
-    assert calls[2] == ("deliver", "j1", True)
+    assert calls[2] == ("deliver", "j1", True, "enforce")
     assert calls[-1] == ("mark", "j1", True)
 
 
@@ -64,8 +69,74 @@ def test_run_one_job_success_sequence(monkeypatch):
 
     assert ok is True
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
-    assert calls[2] == ("deliver", "j2", True)
+    assert calls[2] == ("deliver", "j2", True, "enforce")
     assert calls[-1] == ("mark", "j2", True)
+
+
+def test_successful_cron_defaults_to_enforce_and_ignores_job_boundary_fields(monkeypatch):
+    calls = _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(s, "load_config", lambda: {})
+    job = {
+        "id": "j-profile-default", "name": "t",
+        "final_result_boundary_enabled": False,
+        "final_result_gate_mode": "off",
+        "cron": {"final_result_boundary_enabled": False, "final_result_gate_mode": "off"},
+    }
+
+    assert s.run_one_job(job) is True
+    assert next(call for call in calls if call[0] == "deliver") == (
+        "deliver", "j-profile-default", True, "enforce",
+    )
+
+
+@pytest.mark.parametrize(
+    ("cron_config", "expected_mode"),
+    [
+        ({"final_result_boundary_enabled": False}, "enforce"),
+        ({"final_result_gate_mode": "off"}, "off"),
+    ],
+)
+def test_profile_config_can_disable_successful_final_result_boundary(
+    monkeypatch, cron_config, expected_mode,
+):
+    calls = _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(s, "load_config", lambda: {"cron": cron_config})
+
+    assert s.run_one_job({"id": "j-profile-off", "name": "t"}) is True
+    assert next(call for call in calls if call[0] == "deliver") == (
+        "deliver", "j-profile-off", False, expected_mode,
+    )
+
+
+@pytest.mark.parametrize("gate_mode", ["enforce", "observe", "warn", "downgrade"])
+def test_profile_non_off_gate_modes_keep_boundary_enabled(monkeypatch, gate_mode):
+    calls = _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(
+        s, "load_config", lambda: {"cron": {"final_result_gate_mode": gate_mode}},
+    )
+
+    assert s.run_one_job({"id": "j-profile-mode", "name": "t"}) is True
+    assert next(call for call in calls if call[0] == "deliver") == (
+        "deliver", "j-profile-mode", True, gate_mode,
+    )
+
+
+@pytest.mark.parametrize(
+    "cron_config",
+    [
+        {"final_result_gate_mode": "bypass"},
+        {"final_result_gate_mode": 0},
+        {"final_result_boundary_enabled": "false"},
+    ],
+)
+def test_invalid_profile_boundary_config_falls_back_to_enforce(monkeypatch, cron_config):
+    calls = _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(s, "load_config", lambda: {"cron": cron_config})
+
+    assert s.run_one_job({"id": "j-profile-invalid", "name": "t"}) is True
+    assert next(call for call in calls if call[0] == "deliver") == (
+        "deliver", "j-profile-invalid", True, "enforce",
+    )
 
 
 def test_run_one_job_silent_skips_delivery(monkeypatch):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -27,8 +27,8 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
-    def fake_deliver(job, content, adapters=None, loop=None):
-        calls.append(("deliver", job["id"]))
+    def fake_deliver(job, content, adapters=None, loop=None, **kwargs):
+        calls.append(("deliver", job["id"], kwargs.get("protect_final_result")))
         return None
 
     def fake_mark(jid, ok, err=None, delivery_error=None):
@@ -51,6 +51,7 @@ def test_tick_process_job_sequence(monkeypatch):
     s.tick(verbose=False, sync=True)
 
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
+    assert calls[2] == ("deliver", "j1", True)
     assert calls[-1] == ("mark", "j1", True)
 
 
@@ -63,6 +64,7 @@ def test_run_one_job_success_sequence(monkeypatch):
 
     assert ok is True
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
+    assert calls[2] == ("deliver", "j2", True)
     assert calls[-1] == ("mark", "j2", True)
 
 
@@ -117,6 +119,29 @@ def test_run_one_job_exception_marks_failure(monkeypatch):
 
     assert ok is False
     assert marks == [("j6", False)]
+
+
+def test_run_one_job_tears_down_deferred_agent_when_run_raises(monkeypatch):
+    """A failing run still returns its deferred agent for immediate cleanup."""
+    order = []
+
+    class FakeAgent:
+        def close(self):
+            order.append("agent.close")
+
+    def boom(job, *, defer_agent_teardown=None):
+        defer_agent_teardown.append(FakeAgent())
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(s, "run_job", boom)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+    import agent.auxiliary_client as aux
+    monkeypatch.setattr(
+        aux, "cleanup_stale_async_clients", lambda: order.append("cleanup_stale")
+    )
+
+    assert s.run_one_job({"id": "j6-cleanup", "name": "t"}) is False
+    assert order == ["agent.close", "cleanup_stale"]
 
 
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):
@@ -184,7 +209,7 @@ def test_run_one_job_delivers_before_agent_teardown(monkeypatch):
         defer_agent_teardown.append(FakeAgent())
         return (True, "out", "final response", None)
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(job, content, adapters=None, loop=None, **kwargs):
         order.append("deliver")
         return None
 
@@ -219,7 +244,7 @@ def test_run_one_job_tears_down_deferred_agent_when_delivery_raises(monkeypatch)
         defer_agent_teardown.append(FakeAgent())
         return (True, "out", "final response", None)
 
-    def boom_deliver(job, content, adapters=None, loop=None):
+    def boom_deliver(job, content, adapters=None, loop=None, **kwargs):
         order.append("deliver-raise")
         raise RuntimeError("send blew up")
 

--- a/tests/cron/test_scheduler_final_result_boundary.py
+++ b/tests/cron/test_scheduler_final_result_boundary.py
@@ -1,0 +1,1036 @@
+"""End-to-end Core seam coverage for #1478 final-result delivery."""
+from __future__ import annotations
+
+import asyncio
+import json
+from concurrent.futures import TimeoutError
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cron.output_provenance import ProvenanceStore
+
+
+class _Hooks:
+    def __init__(self, decision: dict):
+        self.decision = decision
+        self.events: list[str] = []
+        self.contexts: list[dict] = []
+
+    async def emit_collect_strict(self, event: str, context: dict):
+        self.events.append(event)
+        self.contexts.append(dict(context))
+        return [self.decision] if event == "outbound:before_send" else []
+
+
+def _config():
+    from gateway.config import Platform
+
+    pconfig = MagicMock()
+    pconfig.enabled = True
+    config = MagicMock()
+    config.platforms = {Platform.TELEGRAM: pconfig}
+    return config
+
+
+def _job():
+    return {
+        "id": "final-result-job",
+        "name": "daily report",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "123"},
+        "next_run_at": "2026-07-27T09:00:00+00:00",
+    }
+
+
+def _ledger(store: ProvenanceStore) -> dict:
+    return json.loads(store.ledger_path.read_text(encoding="utf-8"))
+
+
+def _pinned_live_transport(monkeypatch, *, result: object) -> tuple[object, AsyncMock]:
+    """Install one resolved native transport and synchronously run its coroutine."""
+    from gateway.config import Platform
+    from gateway.delivery import DeliveryTransport
+
+    adapter = SimpleNamespace(send=AsyncMock(return_value=result))
+    transport = DeliveryTransport(
+        adapter=adapter,
+        config=_config().platforms[Platform.TELEGRAM],
+        transport_platform=Platform.TELEGRAM,
+    )
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    monkeypatch.setattr("gateway.delivery.resolve_delivery_transport", lambda *_args: transport)
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe",
+        lambda coro, _loop: _Future(result=asyncio.run(coro)),
+    )
+    return loop, adapter.send
+
+
+def test_protected_final_result_claims_then_sends_once(tmp_path, monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "allow", "reason": "safe"})
+    loop, send = _pinned_live_transport(monkeypatch, result={"success": True, "delivered": True})
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(
+            _job(),
+            "business-safe final result",
+            protect_final_result=True,
+            outbound_hooks=hooks,
+            provenance_store=store,
+            loop=loop,
+        )
+
+    assert result is None
+    send.assert_awaited_once()
+    assert hooks.contexts[0]["source_kind"] == "gateway_reply"
+    assert hooks.events == ["outbound:before_send", "outbound:after_send"]
+    assert hooks.contexts[1]["success"] is True
+    targets = next(iter(_ledger(store)["occurrences"].values()))["targets"]
+    assert list(targets.values())[0]["state"] == "sent"
+
+
+def test_post_send_repair_replays_only_persisted_observer_context(tmp_path):
+    from cron.scheduler import repair_protected_final_result_after_send
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = store.issue(
+        profile_id="profile", job_id="job", occurrence_id="occurrence", target_id="target",
+        route_digest="sha256:route", raw_body=b"body", template_digest="sha256:template", producer_class="llm_final",
+    )
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    store.begin_send(
+        capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=b"body", rendered_body=b"body", route_digest="sha256:route",
+    )
+    context = {"source_kind": "gateway_reply", "content": "body", "send_result": {"success": True}}
+    store.complete_claim(
+        capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent",
+        post_send_error="frame unavailable", post_send_repair_context=context,
+    )
+    hooks = _Hooks({"decision": "allow"})
+
+    assert repair_protected_final_result_after_send(
+        provenance_store=store, hooks=hooks, capability_id=claim["capability_id"],
+    ) is None
+    assert hooks.events == ["outbound:after_send"]
+    assert hooks.contexts == [{
+        **context,
+        "observer_event_id": f"after-send:{claim['capability_id']}:{claim['claim_id']}:sent",
+    }]
+    assert store.pending_post_send_repairs() == []
+
+
+def test_post_send_repair_failure_remains_pending_without_transport(tmp_path):
+    from cron.scheduler import repair_protected_final_result_after_send
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = store.issue(profile_id="profile", job_id="job", occurrence_id="occurrence", target_id="target", route_digest="sha256:route", raw_body=b"body", template_digest="sha256:template", producer_class="llm_final")
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    store.begin_send(capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=b"body", rendered_body=b"body", route_digest="sha256:route")
+    store.complete_claim(capability_id=claim["capability_id"], claim_id=claim["claim_id"], result="sent", post_send_error="broken", post_send_repair_context={"content": "body"})
+    class BrokenHooks:
+        async def emit_collect_strict(self, *_args, **_kwargs):
+            raise RuntimeError("observer still broken")
+    result = repair_protected_final_result_after_send(provenance_store=store, hooks=BrokenHooks(), capability_id=claim["capability_id"])
+    assert "repair failed" in result
+    assert store.pending_post_send_repairs()[0]["error"] == "observer still broken"
+
+
+def test_next_protected_delivery_drains_a_stale_send_started_without_resending(tmp_path, monkeypatch):
+    from cron.scheduler import recover_protected_final_result_repairs
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = store.issue(profile_id="profile", job_id="job", occurrence_id="occurrence", target_id="target", route_digest="sha256:route", raw_body=b"body", template_digest="sha256:template", producer_class="llm_final")
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    store.begin_send(capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=b"body", rendered_body=b"body", route_digest="sha256:route", post_send_repair_context={"content": "body"})
+    ledger = _ledger(store)
+    target = next(iter(next(iter(ledger["occurrences"].values()))["targets"].values()))
+    target["send_started_at"] = "invalid"
+    store.ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+    hooks = _Hooks({"decision": "allow"})
+
+    assert recover_protected_final_result_repairs(provenance_store=store, hooks=hooks) == []
+    assert hooks.events == ["outbound:after_send"]
+    assert store.pending_post_send_repairs() == []
+
+
+def test_fresh_send_started_is_immediately_visible_to_the_restart_hard_gate(tmp_path):
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    issued = store.issue(profile_id="profile", job_id="job", occurrence_id="occurrence", target_id="target", route_digest="sha256:route", raw_body=b"body", template_digest="sha256:template", producer_class="llm_final")
+    claim = store.verify_and_claim(proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow")
+    store.begin_send(capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=b"body", rendered_body=b"body", route_digest="sha256:route")
+
+    assert store.pending_post_send_repairs() == [{
+        "capability_id": claim["capability_id"],
+        "error": "send_started_recovery_pending",
+        "context": {},
+    }]
+
+
+def test_recovery_reports_malformed_or_failed_durable_repairs(monkeypatch):
+    from cron.scheduler import recover_protected_final_result_repairs
+
+    class Store:
+        def pending_post_send_repairs(self):
+            return [{}, {"capability_id": "cap-1"}]
+
+    monkeypatch.setattr("cron.scheduler.repair_protected_final_result_after_send", lambda **_kwargs: "still pending")
+    assert recover_protected_final_result_repairs(provenance_store=Store(), hooks=object()) == [
+        "protected final-result repair has no capability id", "still pending",
+    ]
+    assert recover_protected_final_result_repairs(provenance_store=object(), hooks=object()) == []
+
+
+def test_scheduler_sweep_recovers_without_a_new_delivery(monkeypatch):
+    from cron.scheduler import sweep_protected_final_result_repairs
+
+    hooks = object()
+    store = object()
+    monkeypatch.setattr("gateway.outbound_boundary.load_installed_outbound_hooks", lambda _home: hooks)
+    monkeypatch.setattr("cron.output_provenance.ProvenanceStore", lambda _home: store)
+    monkeypatch.setattr("cron.scheduler.recover_protected_final_result_repairs", lambda **kwargs: ["recovered"] if kwargs == {"provenance_store": store, "hooks": hooks} else [])
+    assert sweep_protected_final_result_repairs() == ["recovered"]
+
+
+def test_profile_recovery_uses_the_requested_home_without_the_cron_jobs_lock(monkeypatch, tmp_path):
+    from cron.scheduler import recover_protected_final_result_repairs_for_home
+
+    hooks = object()
+    store = object()
+    monkeypatch.setattr("gateway.outbound_boundary.load_installed_outbound_hooks", lambda home: hooks if home == tmp_path else None)
+    monkeypatch.setattr("cron.output_provenance.ProvenanceStore", lambda home: store if home == tmp_path else None)
+    monkeypatch.setattr(
+        "cron.scheduler.recover_protected_final_result_repairs",
+        lambda **kwargs: ["recovered"] if kwargs == {"provenance_store": store, "hooks": hooks} else [],
+    )
+
+    assert recover_protected_final_result_repairs_for_home(tmp_path) == ["recovered"]
+
+
+def test_scheduler_sweep_skips_when_no_activated_hook(monkeypatch):
+    from cron.scheduler import sweep_protected_final_result_repairs
+    monkeypatch.setattr("gateway.outbound_boundary.load_installed_outbound_hooks", lambda _home: None)
+    assert sweep_protected_final_result_repairs() == []
+
+
+def test_tick_logs_and_continues_when_recovery_sweep_fails(tmp_path, monkeypatch):
+    from cron.scheduler import tick
+    monkeypatch.setattr("cron.scheduler._get_lock_paths", lambda: (tmp_path, tmp_path / ".tick.lock"))
+    monkeypatch.setattr("cron.scheduler.sweep_protected_final_result_repairs", lambda: (_ for _ in ()).throw(RuntimeError("bad sweep")))
+    monkeypatch.setattr("cron.scheduler.get_due_jobs", lambda: [])
+    assert tick(verbose=False) == 0
+
+
+def test_tick_reports_pending_recovery_before_empty_due_list(tmp_path, monkeypatch):
+    from cron.scheduler import tick
+    monkeypatch.setattr("cron.scheduler._get_lock_paths", lambda: (tmp_path, tmp_path / ".tick.lock"))
+    monkeypatch.setattr("cron.scheduler.sweep_protected_final_result_repairs", lambda: ["still pending"])
+    monkeypatch.setattr("cron.scheduler.get_due_jobs", lambda: [])
+    assert tick(verbose=False) == 0
+
+
+def test_protected_delivery_stops_when_prior_durable_recovery_is_unresolved(monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    store = _Store()
+    monkeypatch.setattr("cron.scheduler.recover_protected_final_result_repairs", lambda **_kwargs: ["observer still pending"])
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(
+            _job(), "safe", protect_final_result=True,
+            outbound_hooks=_Hooks({"decision": "allow"}), provenance_store=store,
+        )
+    assert result == "protected final-result recovery pending: observer still pending"
+
+
+@pytest.mark.parametrize(
+    ("is_home", "expected_metadata"),
+    [
+        (True, {"_relay_logical_platform": "telegram", "user_id": "u-1", "scope_id": "s-1"}),
+        (False, {"_relay_logical_platform": "telegram", "scope_id": "cached-s"}),
+    ],
+)
+def test_protected_relay_binds_exact_logical_target_before_proof(
+    tmp_path, monkeypatch, is_home, expected_metadata,
+):
+    from cron.scheduler import _deliver_result
+    from gateway.config import Platform
+    from gateway.delivery import DeliveryTransport
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "allow", "reason": "safe"})
+    adapter = SimpleNamespace(
+        send_for_platform=AsyncMock(return_value={"success": True, "delivered": True}),
+        bound_outbound_metadata=lambda _chat_id, metadata: metadata if metadata.get("scope_id") else metadata | {"scope_id": "cached-s"},
+    )
+    config = _config()
+    config.get_home_channel.return_value = SimpleNamespace(
+        chat_id="123" if is_home else "other", user_id="u-1", scope_id="s-1",
+    )
+    transport = DeliveryTransport(
+        adapter=adapter, config=config.platforms[Platform.TELEGRAM], transport_platform=Platform.RELAY,
+    )
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("gateway.delivery.resolve_delivery_transport", lambda *_args: transport)
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", lambda coro, _loop: _Future(result=asyncio.run(coro)),
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config):
+        assert _deliver_result(
+            _job(), "business-safe final result", protect_final_result=True,
+            outbound_hooks=hooks, provenance_store=store, loop=loop,
+        ) is None
+
+    sent_metadata = adapter.send_for_platform.await_args.kwargs["metadata"]
+    for key, value in expected_metadata.items():
+        assert sent_metadata[key] == value
+    target = next(iter(next(iter(_ledger(store)["occurrences"].values()))["targets"].values()))
+    assert target["route_digest"] != ""
+    assert target["proof"]["route_digest"] == target["route_digest"]
+
+
+def test_protected_final_result_deny_never_reaches_transport(tmp_path, monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "deny", "reason": "private_runtime_context"})
+    loop, send = _pinned_live_transport(monkeypatch, result={"success": True, "delivered": True})
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(
+            _job(),
+            "private final result",
+            protect_final_result=True,
+            outbound_hooks=hooks,
+            provenance_store=store,
+            loop=loop,
+        )
+
+    assert result is not None
+    assert "boundary denied" in result
+    send.assert_not_awaited()
+    targets = next(iter(_ledger(store)["occurrences"].values()))["targets"]
+    assert list(targets.values())[0]["state"] == "blocked"
+
+
+def test_protected_final_result_rewrite_sends_only_replacement_bytes(tmp_path, monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "rewrite", "reason": "projection", "content": "safe projected result"})
+    loop, send = _pinned_live_transport(monkeypatch, result={"success": True, "delivered": True})
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(
+            _job(),
+            "raw internal trace /Users/alice/.hermes/private.log",
+            protect_final_result=True,
+            outbound_hooks=hooks,
+            provenance_store=store,
+            loop=loop,
+        )
+
+    assert result is None
+    sent = send.await_args.args[1]
+    assert "safe projected result" in sent
+    assert "private.log" not in sent
+
+
+def test_protected_final_result_blocks_private_wrapper_bytes(tmp_path, monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "allow", "reason": "safe"})
+    send = AsyncMock(return_value={"success": True})
+    job = _job() | {"name": "/Users/alice/.hermes/private-job"}
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "tools.send_message_tool._send_to_platform", new=send
+    ):
+        result = _deliver_result(
+            job,
+            "business-safe final result",
+            protect_final_result=True,
+            outbound_hooks=hooks,
+            provenance_store=store,
+        )
+
+    assert result is not None
+    assert "private rendered bytes" in result
+    send.assert_not_awaited()
+
+
+def test_protected_final_result_blocks_bearer_value_in_wrapper_field(tmp_path, monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "allow", "reason": "safe"})
+    send = AsyncMock(return_value={"success": True})
+    job = _job() | {"name": "Bearer opaque-secret"}
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "tools.send_message_tool._send_to_platform", new=send
+    ):
+        result = _deliver_result(job, "business-safe final result", protect_final_result=True, outbound_hooks=hooks, provenance_store=store)
+
+    assert "private rendered bytes" in result
+    send.assert_not_awaited()
+
+
+def test_protected_final_result_rejects_media_before_hook_or_transport(tmp_path, monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "allow", "reason": "safe"})
+    send = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "gateway.platforms.base.BasePlatformAdapter.extract_media",
+        lambda _content: ([("/tmp/private.pdf", False)], "business-safe final result"),
+    )
+    monkeypatch.setattr(
+        "gateway.platforms.base.BasePlatformAdapter.filter_media_delivery_paths",
+        lambda media: media,
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "tools.send_message_tool._send_to_platform", new=send
+    ):
+        result = _deliver_result(
+            _job(),
+            "business-safe final result",
+            protect_final_result=True,
+            outbound_hooks=hooks,
+            provenance_store=store,
+        )
+
+    assert result is not None
+    assert "MEDIA attachments" in result
+    assert hooks.contexts == []
+    send.assert_not_awaited()
+
+
+def test_protected_delivery_uses_resolved_relay_adapter(monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    relay_adapter = MagicMock(name="relay-adapter")
+    seen = {}
+    monkeypatch.setattr(
+        "gateway.delivery.resolve_delivery_transport",
+        lambda *_args: SimpleNamespace(config=_config().platforms[next(iter(_config().platforms))], adapter=relay_adapter),
+    )
+    monkeypatch.setattr(
+        "cron.scheduler._deliver_protected_final_result",
+        lambda **kwargs: seen.setdefault("adapter", kwargs["runtime_adapter"]) and "blocked for test",
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(_job(), "safe", protect_final_result=True, outbound_hooks=_Hooks({"decision": "allow"}), provenance_store=_Store())
+
+    assert "blocked for test" in result
+    assert seen["adapter"] is relay_adapter
+
+
+def test_protected_delivery_preserves_mirror_after_success(monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    seen = []
+    monkeypatch.setattr("cron.scheduler._cron_mirror_delivery_enabled", lambda *_args: True)
+    monkeypatch.setattr("cron.scheduler._target_matches_origin", lambda *_args: True)
+    monkeypatch.setattr("cron.scheduler._deliver_protected_final_result", lambda **_kwargs: None)
+    monkeypatch.setattr("cron.scheduler._maybe_mirror_cron_delivery", lambda *args, **kwargs: seen.append((args, kwargs)))
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(_job(), "safe", protect_final_result=True, outbound_hooks=_Hooks({"decision": "allow"}), provenance_store=_Store())
+
+    assert result is None
+    assert seen and seen[0][1]["enabled"] is True
+
+
+def test_delivery_disables_mirroring_when_its_config_hook_raises(monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    monkeypatch.setattr(
+        "cron.scheduler._cron_mirror_delivery_enabled",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("bad mirror config")),
+    )
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(
+            _job(), "safe", protect_final_result=True,
+            outbound_hooks=_Hooks({"decision": "deny", "reason": "test"}),
+            provenance_store=_Store(),
+        )
+
+    assert "requires a live pinned transport" in result
+
+
+def test_protected_live_delivery_seeds_opened_thread_after_confirmed_send(monkeypatch):
+    from cron.scheduler import _deliver_result
+    from gateway.config import Platform
+
+    adapter = MagicMock()
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    seeded = []
+    monkeypatch.setattr("cron.scheduler._cron_mirror_delivery_enabled", lambda *_args: True)
+    monkeypatch.setattr("cron.scheduler._target_matches_origin", lambda *_args: True)
+    monkeypatch.setattr("cron.scheduler._open_continuable_cron_thread", lambda *_args: "thread-1")
+    monkeypatch.setattr("cron.scheduler._deliver_protected_final_result", lambda **_kwargs: None)
+    monkeypatch.setattr("cron.scheduler._seed_cron_thread_session", lambda *args, **kwargs: seeded.append((args, kwargs)))
+    monkeypatch.setattr("cron.scheduler._maybe_mirror_cron_delivery", lambda *_args, **_kwargs: None)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "gateway.delivery.resolve_delivery_transport",
+        return_value=SimpleNamespace(config=_config().platforms[Platform.TELEGRAM], adapter=adapter, is_relay=False),
+    ):
+        assert _deliver_result(_job(), "safe", adapters={Platform.TELEGRAM: adapter}, loop=loop, protect_final_result=True, outbound_hooks=_Hooks({"decision": "allow"}), provenance_store=_Store()) is None
+
+    assert seeded and seeded[0][0][4] == "thread-1"
+
+
+def test_protected_live_delivery_keeps_origin_when_thread_open_returns_none(monkeypatch):
+    from cron.scheduler import _deliver_result
+    from gateway.config import Platform
+
+    adapter = MagicMock()
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    seen = {}
+    monkeypatch.setattr("cron.scheduler._cron_mirror_delivery_enabled", lambda *_args: True)
+    monkeypatch.setattr("cron.scheduler._target_matches_origin", lambda *_args: True)
+    monkeypatch.setattr("cron.scheduler._open_continuable_cron_thread", lambda *_args: None)
+    monkeypatch.setattr(
+        "cron.scheduler._deliver_protected_final_result",
+        lambda **kwargs: seen.setdefault("thread_id", kwargs["thread_id"]),
+    )
+    monkeypatch.setattr("cron.scheduler._maybe_mirror_cron_delivery", lambda *_args, **_kwargs: None)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "gateway.delivery.resolve_delivery_transport",
+        return_value=SimpleNamespace(
+            config=_config().platforms[Platform.TELEGRAM], adapter=adapter, is_relay=False
+        ),
+    ):
+        assert _deliver_result(
+            _job(), "safe", adapters={Platform.TELEGRAM: adapter}, loop=loop,
+            protect_final_result=True, outbound_hooks=_Hooks({"decision": "allow"}),
+            provenance_store=_Store(),
+        ) is None
+
+    assert seen["thread_id"] is None
+
+
+def test_protected_live_delivery_seeds_inchannel_session_after_confirmed_send(monkeypatch):
+    from cron.scheduler import _deliver_result
+    from gateway.config import Platform
+
+    adapter = MagicMock(supports_inchannel_continuable=True)
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    pconfig = _config().platforms[Platform.TELEGRAM]
+    pconfig.extra = {"cron_continuable_surface": "in_channel"}
+    seeded = []
+    monkeypatch.setattr("cron.scheduler._cron_mirror_delivery_enabled", lambda *_args: True)
+    monkeypatch.setattr("cron.scheduler._target_matches_origin", lambda *_args: True)
+    monkeypatch.setattr("cron.scheduler._deliver_protected_final_result", lambda **_kwargs: None)
+    monkeypatch.setattr("cron.scheduler._seed_cron_channel_session", lambda *args, **kwargs: seeded.append((args, kwargs)) or True)
+    monkeypatch.setattr("cron.scheduler._maybe_mirror_cron_delivery", lambda *_args, **_kwargs: None)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "gateway.delivery.resolve_delivery_transport",
+        return_value=SimpleNamespace(config=pconfig, adapter=adapter, is_relay=False),
+    ):
+        assert _deliver_result(_job(), "safe", adapters={Platform.TELEGRAM: adapter}, loop=loop, protect_final_result=True, outbound_hooks=_Hooks({"decision": "allow"}), provenance_store=_Store()) is None
+
+    assert seeded
+
+
+def test_unprotected_relay_never_falls_back_to_native_sender(monkeypatch):
+    from cron.scheduler import _deliver_result
+    from gateway.config import Platform
+
+    relay = SimpleNamespace(config=_config().platforms[Platform.TELEGRAM], adapter=MagicMock(), is_relay=True)
+    monkeypatch.setattr("gateway.delivery.resolve_delivery_transport", lambda *_args: relay)
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(_job(), "safe")
+
+    assert result == "relay delivery to telegram:123 failed"
+
+
+def test_protected_final_result_unconfirmed_stays_indeterminate(tmp_path, monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "allow", "reason": "safe"})
+    loop, send = _pinned_live_transport(monkeypatch, result={"success": False, "delivered": False})
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(
+            _job(),
+            "business-safe final result",
+            protect_final_result=True,
+            outbound_hooks=hooks,
+            provenance_store=store,
+            loop=loop,
+        )
+
+    assert result is not None
+    assert "unconfirmed" in result
+    targets = next(iter(_ledger(store)["occurrences"].values()))["targets"]
+    assert list(targets.values())[0]["state"] == "indeterminate"
+    assert hooks.contexts[1]["success"] is False
+
+
+def test_protected_live_route_preserves_telegram_channel_dm_topic(monkeypatch):
+    from gateway.config import Platform
+    from cron.scheduler import _protected_live_route
+
+    monkeypatch.setattr("cron.scheduler._is_channel_dm_topic", lambda *_args: True)
+    loop = MagicMock()
+    loop.is_running.return_value = True
+
+    route, target, metadata = _protected_live_route(
+        job={"id": "topic-job"},
+        platform=Platform.TELEGRAM,
+        platform_name="telegram",
+        chat_id="123456",
+        thread_id="7",
+        adapter=MagicMock(),
+        loop=loop,
+    )
+
+    assert target.thread_id is None
+    assert metadata == {"job_id": "topic-job", "direct_messages_topic_id": "7"}
+    assert route["direct_messages_topic_id"] == "7"
+
+
+@pytest.mark.parametrize(
+    ("job", "expected"),
+    [
+        ({"fire_claim": {"occurrence_id": "claim-id", "at": "old"}}, "claim-id"),
+        ({"fire_claim": {"at": "2026-07-27T10:00:00Z"}}, "external:2026-07-27T10:00:00Z"),
+        ({"fire_claim": {}, "next_run_at": "2026-07-27T09:30:00Z"}, "scheduled:2026-07-27T09:30:00Z"),
+        ({"next_run_at": "2026-07-27T10:00:00Z"}, "scheduled:2026-07-27T10:00:00Z"),
+    ],
+)
+def test_provenance_occurrence_prefers_persisted_firing_identity(job, expected):
+    from cron.scheduler import _provenance_occurrence_id
+
+    assert _provenance_occurrence_id(job) == expected
+
+
+def test_provenance_occurrence_manual_runs_are_distinct(monkeypatch):
+    from cron.scheduler import _provenance_occurrence_id
+
+    values = iter(["one", "two"])
+    monkeypatch.setattr("cron.scheduler.uuid.uuid4", lambda: MagicMock(hex=next(values)))
+    assert _provenance_occurrence_id({}) == "manual:one"
+    assert _provenance_occurrence_id({}) == "manual:two"
+
+
+def test_final_rendered_byte_screen_rejects_non_utf8_and_private_values():
+    from cron.scheduler import _final_delivery_bytes_safe
+
+    assert _final_delivery_bytes_safe(b"business summary") is True
+    assert _final_delivery_bytes_safe(b"api_key=secret") is False
+    assert _final_delivery_bytes_safe(b"\xff") is False
+
+
+class _Store:
+    def __init__(self, *, decision="allow"):
+        self.decision = decision
+        self.events = []
+
+    def issue(self, **_kwargs):
+        self.events.append("issue")
+        return {"proof": {"capability_id": "cap"}, "raw_body_b64": "c2FmZQ=="}
+
+    def verify_and_claim(self, **_kwargs):
+        self.events.append("claim")
+        return {"decision": self.decision, "capability_id": "cap", "claim_id": "claim", "body_b64": "c2FmZQ=="}
+
+    def begin_send(self, **_kwargs):
+        self.events.append("begin")
+
+    def block_claim(self, **_kwargs):
+        self.events.append("blocked")
+
+    def complete_claim(self, **kwargs):
+        self.events.append(("complete", kwargs["result"]))
+
+
+def _direct_protected_call(monkeypatch, store, *, hooks=None, adapters=None, loop=None):
+    from cron.scheduler import _deliver_protected_final_result
+    from gateway.config import Platform
+
+    monkeypatch.setattr(
+        "cron.scheduler._protected_live_route",
+        lambda **_kwargs: (
+            {"platform": "telegram", "chat_id": "123", "thread_id": "", "direct_messages_topic_id": ""},
+            MagicMock(),
+            {"job_id": "final-result-job"},
+        ),
+    )
+    runtime_adapter = (adapters or {}).get(Platform.TELEGRAM)
+    runtime_transport = None
+    if runtime_adapter is not None:
+        runtime_transport = SimpleNamespace(
+            transport_platform=Platform.TELEGRAM,
+            send=AsyncMock(return_value={"success": True, "delivered": True}),
+        )
+    return _deliver_protected_final_result(
+        job=_job(), content="safe", platform=Platform.TELEGRAM, platform_name="telegram", chat_id="123",
+        thread_id=None,
+        pconfig=MagicMock(),
+        adapters=adapters,
+        runtime_adapter=runtime_adapter,
+        runtime_transport=runtime_transport,
+        loop=loop,
+        hooks=hooks or _Hooks({"decision": "allow"}), provenance_store=store,
+        wrap_response=False, occurrence_id="occurrence",
+    )
+
+
+def test_protected_delivery_provenance_or_boundary_failure_never_sends(monkeypatch):
+    class BrokenStore(_Store):
+        def issue(self, **_kwargs):
+            raise ValueError("bad proof")
+
+    result = _direct_protected_call(monkeypatch, BrokenStore())
+    assert result == "protected final-result boundary denied telegram:123: bad proof"
+
+
+def test_protected_delivery_private_render_blocks_and_survives_after_hook_failure(monkeypatch):
+    store = _Store()
+
+    class BrokenAfterHooks(_Hooks):
+        async def emit_collect_strict(self, event, context):
+            if event == "outbound:after_send":
+                raise RuntimeError("audit unavailable")
+            return await super().emit_collect_strict(event, context)
+
+    monkeypatch.setattr("cron.scheduler._render_cron_delivery_content", lambda *_args, **_kwargs: "api_key=secret")
+    result = _direct_protected_call(monkeypatch, store, hooks=BrokenAfterHooks({"decision": "allow"}))
+    assert "blocked private rendered bytes" in result
+    assert store.events == ["issue", "claim", "blocked"]
+
+
+def test_protected_delivery_without_live_transport_blocks_before_standalone_send(monkeypatch):
+    store = _Store()
+    send = AsyncMock(side_effect=RuntimeError("network lost"))
+    with patch("tools.send_message_tool._send_to_platform", new=send):
+        result = _direct_protected_call(monkeypatch, store)
+    assert "requires a live pinned transport" in result
+    send.assert_not_awaited()
+    assert store.events == ["issue", "claim", "begin", ("complete", "blocked")]
+
+
+def test_protected_delivery_without_live_transport_never_attempts_standalone(monkeypatch):
+    store = _Store()
+    send = AsyncMock(return_value="not a receipt")
+    with patch("tools.send_message_tool._send_to_platform", new=send):
+        result = _direct_protected_call(monkeypatch, store)
+    assert "requires a live pinned transport" in result
+    send.assert_not_awaited()
+    assert store.events[-1] == ("complete", "blocked")
+
+
+def test_protected_delivery_tolerates_after_send_observer_failure(monkeypatch):
+    store = _Store()
+
+    class BrokenAfterHooks(_Hooks):
+        async def emit_collect_strict(self, event, context):
+            if event == "outbound:after_send":
+                raise RuntimeError("audit unavailable")
+            return await super().emit_collect_strict(event, context)
+
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    from gateway.config import Platform
+    def scheduled(coro, _loop):
+        coro.close()
+        return _Future(result={"success": True, "delivered": True})
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", scheduled)
+    result = _direct_protected_call(
+        monkeypatch, store, hooks=BrokenAfterHooks({"decision": "allow"}),
+        adapters={Platform.TELEGRAM: MagicMock()}, loop=loop,
+    )
+    assert result is None
+    assert store.events[-1] == ("complete", "sent")
+
+
+def test_protected_delivery_never_runs_observer_before_terminal_persistence(monkeypatch):
+    store = _Store()
+    observer_calls = []
+
+    def reject_terminal(**_kwargs):
+        raise OSError("ledger unavailable")
+
+    store.complete_claim = reject_terminal
+    store.claim_post_send_repair = lambda **_kwargs: observer_calls.append("claimed")
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    from gateway.config import Platform
+
+    def scheduled(coro, _loop):
+        coro.close()
+        return _Future(result={"success": True, "delivered": True})
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", scheduled)
+    result = _direct_protected_call(
+        monkeypatch, store, adapters={Platform.TELEGRAM: MagicMock()}, loop=loop,
+    )
+
+    assert "indeterminate" in result
+    assert observer_calls == []
+
+
+def test_protected_delivery_keeps_persisted_observer_pending_when_worker_raises(monkeypatch):
+    store = _Store()
+    store.claim_post_send_repair = lambda **_kwargs: {"repair_id": "repair"}
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    from gateway.config import Platform
+
+    def scheduled(coro, _loop):
+        coro.close()
+        return _Future(result={"success": True, "delivered": True})
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", scheduled)
+    monkeypatch.setattr("cron.scheduler.repair_protected_final_result_after_send", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("observer unavailable")))
+    result = _direct_protected_call(
+        monkeypatch, store, adapters={Platform.TELEGRAM: MagicMock()}, loop=loop,
+    )
+
+    assert result is None
+    assert store.events[-1] == ("complete", "sent")
+
+
+def test_protected_delivery_live_non_dict_receipt_uses_adapter_confirmation(monkeypatch):
+    store = _Store()
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    from gateway.config import Platform
+    def scheduled(coro, _loop):
+        coro.close()
+        return _Future(result="adapter receipt")
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", scheduled)
+    monkeypatch.setattr("cron.scheduler._confirm_adapter_delivery", lambda _receipt: True)
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch("gateway.delivery.DeliveryRouter"):
+        result = _direct_protected_call(monkeypatch, store, adapters={Platform.TELEGRAM: MagicMock()}, loop=loop)
+    assert result is None
+    assert store.events[-1] == ("complete", "sent")
+
+
+def test_protected_live_delivery_bypasses_router_re_resolution(monkeypatch):
+    store = _Store()
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    from gateway.config import Platform
+    router = MagicMock()
+
+    def scheduled(coro, _loop):
+        coro.close()
+        return _Future(result={"success": True, "delivered": True})
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", scheduled)
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "gateway.delivery.DeliveryRouter", return_value=router
+    ):
+        assert _direct_protected_call(monkeypatch, store, adapters={Platform.TELEGRAM: MagicMock()}, loop=loop) is None
+
+    router._deliver_to_platform.assert_not_called()
+
+
+def test_protected_delivery_rejects_router_oversize_before_claimed_send(monkeypatch):
+    from gateway.delivery import MAX_PLATFORM_OUTPUT
+
+    store = _Store()
+    monkeypatch.setattr("cron.scheduler._render_cron_delivery_content", lambda *_args, **_kwargs: "x" * (MAX_PLATFORM_OUTPUT + 1))
+    result = _direct_protected_call(monkeypatch, store)
+
+    assert "oversized rendered bytes" in result
+    assert store.events == ["issue", "claim", "blocked"]
+
+
+def test_protected_standalone_sender_is_never_used(monkeypatch):
+    store = _Store()
+    send = AsyncMock(return_value={"success": True})
+    with patch("tools.send_message_tool._send_to_platform", new=send):
+        result = _direct_protected_call(monkeypatch, store)
+
+    assert "requires a live pinned transport" in result
+    send.assert_not_awaited()
+
+
+def test_protected_delivery_preserves_indeterminate_when_completion_fails(monkeypatch):
+    class CompletionBrokenStore(_Store):
+        def complete_claim(self, **_kwargs):
+            raise RuntimeError("ledger unavailable")
+
+    with patch("tools.send_message_tool._send_to_platform", new=AsyncMock(side_effect=RuntimeError("network lost"))):
+        result = _direct_protected_call(monkeypatch, CompletionBrokenStore())
+    assert "indeterminate" in result
+
+
+def test_protected_delivery_loader_paths_fail_closed(monkeypatch, tmp_path):
+    from cron.scheduler import _deliver_result
+
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("gateway.outbound_boundary.load_installed_outbound_hooks", lambda _home: (_ for _ in ()).throw(RuntimeError("handler missing")))
+    result = _deliver_result(_job(), "safe", protect_final_result=True)
+    assert result == "protected final-result boundary unavailable: handler missing"
+
+    monkeypatch.setattr("gateway.outbound_boundary.load_installed_outbound_hooks", lambda _home: None)
+    assert _deliver_result(_job(), "safe", protect_final_result=True) == (
+        "protected final-result boundary unavailable: required outbound hook is not installed"
+    )
+
+
+def test_protected_delivery_rejects_job_profile_id_that_differs_from_active_home(monkeypatch, tmp_path):
+    from cron.scheduler import _deliver_result
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    job = _job()
+    job["profile_id"] = "yuange"
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(
+            job, "safe", protect_final_result=True, outbound_hooks=_Hooks({"decision": "allow"}),
+            provenance_store=store,
+        )
+
+    assert result == "protected final-result boundary denied telegram:123: profile identity mismatch"
+
+
+def test_legacy_standalone_fallback_runs_in_a_fresh_thread_when_loop_is_active(monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    send = AsyncMock(return_value={"success": True})
+
+    async def invoke():
+        with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+            "tools.send_message_tool._send_to_platform", new=send
+        ):
+            return _deliver_result(_job(), "safe")
+
+    assert asyncio.run(invoke()) is None
+    assert send.await_count == 1
+
+
+def test_legacy_delivery_reports_interpreter_shutdown_as_skipped(monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    monkeypatch.setattr("cron.scheduler._interpreter_shutting_down", lambda *_args: True)
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "tools.send_message_tool._send_to_platform", new=AsyncMock(side_effect=RuntimeError("shutdown"))
+    ):
+        result = _deliver_result(_job(), "safe")
+
+    assert "skipped" in result
+    assert "interpreter is shutting down" in result
+
+
+def test_thread_pool_fallback_shutdown_is_skipped_without_escaping(monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    class BrokenPool:
+        def __init__(self, **_kwargs):
+            pass
+
+        def submit(self, _fn):
+            raise RuntimeError("pool shutdown")
+
+        def shutdown(self, **_kwargs):
+            pass
+
+    monkeypatch.setattr("cron.scheduler.concurrent.futures.ThreadPoolExecutor", BrokenPool)
+    monkeypatch.setattr("cron.scheduler._interpreter_shutting_down", lambda exc=None: str(exc) == "pool shutdown")
+
+    async def invoke():
+        with patch("gateway.config.load_gateway_config", return_value=_config()):
+            return _deliver_result(_job(), "safe")
+
+    result = asyncio.run(invoke())
+    assert "skipped" in result
+    assert "interpreter is shutting down" in result
+
+
+class _Future:
+    def __init__(self, *, result=None, error=None, cancel_result=False):
+        self._result = result
+        self._error = error
+        self._cancel_result = cancel_result
+
+    def result(self, timeout):
+        assert timeout == 60
+        if self._error:
+            raise self._error
+        return self._result
+
+    def cancel(self):
+        return self._cancel_result
+
+
+@pytest.mark.parametrize(
+    ("future", "expected", "terminal"),
+    [
+        (None, "could not schedule", "blocked"),
+        (_Future(error=TimeoutError(), cancel_result=True), "timed out before dispatch", "blocked"),
+        (_Future(error=TimeoutError(), cancel_result=False), "is indeterminate", "indeterminate"),
+        (_Future(result={"success": False}), "unconfirmed", "indeterminate"),
+        (_Future(result={"success": True, "delivered": True}), None, "sent"),
+    ],
+)
+def test_protected_live_delivery_fences_scheduler_dispositions(monkeypatch, future, expected, terminal):
+    store = _Store()
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    adapters = {object(): MagicMock()}
+    from gateway.config import Platform
+    adapters = {Platform.TELEGRAM: MagicMock()}
+
+    def scheduled(coro, _loop):
+        coro.close()
+        return future
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", scheduled)
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "gateway.delivery.DeliveryRouter"
+    ):
+        result = _direct_protected_call(monkeypatch, store, adapters=adapters, loop=loop)
+
+    assert store.events[-1] == ("complete", terminal)
+    if expected is None:
+        assert result is None
+    else:
+        assert expected in result

--- a/tests/cron/test_scheduler_final_result_boundary.py
+++ b/tests/cron/test_scheduler_final_result_boundary.py
@@ -97,6 +97,62 @@ def test_protected_final_result_claims_then_sends_once(tmp_path, monkeypatch):
     assert list(targets.values())[0]["state"] == "sent"
 
 
+@pytest.mark.parametrize("cancel_result", [True, False], ids=["cancel-accepted", "cancel-rejected"])
+def test_protected_final_result_timeout_is_indeterminate_without_resend(
+    tmp_path, monkeypatch, cancel_result,
+):
+    from cron.scheduler import _deliver_result
+    from gateway.config import Platform
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "allow", "reason": "safe"})
+    send = AsyncMock(return_value={"success": True, "delivered": True})
+    transport = SimpleNamespace(
+        adapter=SimpleNamespace(),
+        config=_config().platforms[Platform.TELEGRAM],
+        transport_platform=Platform.TELEGRAM,
+        send=send,
+    )
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    future = _Future(error=TimeoutError(), cancel_result=cancel_result)
+    schedule_count = 0
+
+    def schedule(coro, _loop):
+        nonlocal schedule_count
+        schedule_count += 1
+        coro.close()
+        return future
+
+    standalone_send = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr("gateway.delivery.resolve_delivery_transport", lambda *_args: transport)
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", schedule)
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()), patch(
+        "tools.send_message_tool._send_to_platform", new=standalone_send,
+    ):
+        first = _deliver_result(
+            _job(), "business-safe final result", protect_final_result=True,
+            outbound_hooks=hooks, provenance_store=store, loop=loop,
+        )
+        second = _deliver_result(
+            _job(), "business-safe final result", protect_final_result=True,
+            outbound_hooks=hooks, provenance_store=store, loop=loop,
+        )
+
+    assert first == "protected final-result delivery is indeterminate telegram:123"
+    assert "already issued" in second
+    assert schedule_count == 1
+    assert future.cancel_calls == 1
+    send.assert_called_once()
+    standalone_send.assert_not_awaited()
+    target = next(iter(next(iter(_ledger(store)["occurrences"].values()))["targets"].values()))
+    assert target["state"] == "indeterminate"
+    assert target["post_send_repair"]["context"]["send_result"] == {"error": "in_flight_timeout"}
+
+
 def test_post_send_repair_replays_only_persisted_observer_context(tmp_path):
     from cron.scheduler import repair_protected_final_result_after_send
 
@@ -684,7 +740,9 @@ class _Store:
         self.events.append(("complete", kwargs["result"]))
 
 
-def _direct_protected_call(monkeypatch, store, *, hooks=None, adapters=None, loop=None):
+def _direct_protected_call(
+    monkeypatch, store, *, hooks=None, adapters=None, loop=None, gate_mode="enforce",
+):
     from cron.scheduler import _deliver_protected_final_result
     from gateway.config import Platform
 
@@ -712,8 +770,19 @@ def _direct_protected_call(monkeypatch, store, *, hooks=None, adapters=None, loo
         runtime_transport=runtime_transport,
         loop=loop,
         hooks=hooks or _Hooks({"decision": "allow"}), provenance_store=store,
-        wrap_response=False, occurrence_id="occurrence",
+        wrap_response=False, occurrence_id="occurrence", gate_mode=gate_mode,
     )
+
+
+@pytest.mark.parametrize("gate_mode", ["enforce", "observe", "warn", "downgrade"])
+def test_protected_final_result_gate_mode_reaches_outbound_context(monkeypatch, gate_mode):
+    hooks = _Hooks({"decision": "allow"})
+
+    result = _direct_protected_call(monkeypatch, _Store(), hooks=hooks, gate_mode=gate_mode)
+
+    assert "requires a live pinned transport" in result
+    assert hooks.contexts[0]["boundary_enabled"] is True
+    assert hooks.contexts[0]["gate_mode"] == gate_mode
 
 
 def test_protected_delivery_provenance_or_boundary_failure_never_sends(monkeypatch):
@@ -990,6 +1059,7 @@ class _Future:
         self._result = result
         self._error = error
         self._cancel_result = cancel_result
+        self.cancel_calls = 0
 
     def result(self, timeout):
         assert timeout == 60
@@ -998,6 +1068,7 @@ class _Future:
         return self._result
 
     def cancel(self):
+        self.cancel_calls += 1
         return self._cancel_result
 
 
@@ -1005,8 +1076,6 @@ class _Future:
     ("future", "expected", "terminal"),
     [
         (None, "could not schedule", "blocked"),
-        (_Future(error=TimeoutError(), cancel_result=True), "timed out before dispatch", "blocked"),
-        (_Future(error=TimeoutError(), cancel_result=False), "is indeterminate", "indeterminate"),
         (_Future(result={"success": False}), "unconfirmed", "indeterminate"),
         (_Future(result={"success": True, "delivered": True}), None, "sent"),
     ],

--- a/tests/cron/test_scheduler_final_result_boundary.py
+++ b/tests/cron/test_scheduler_final_result_boundary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import json
 from concurrent.futures import TimeoutError
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,8 +14,9 @@ from cron.output_provenance import ProvenanceStore
 
 
 class _Hooks:
-    def __init__(self, decision: dict):
+    def __init__(self, decision: dict, *, profile_id: str = "atlas"):
         self.decision = decision
+        self.outbound_profile_id = profile_id
         self.events: list[str] = []
         self.contexts: list[dict] = []
 
@@ -153,6 +155,39 @@ def test_protected_final_result_timeout_is_indeterminate_without_resend(
     assert target["post_send_repair"]["context"]["send_result"] == {"error": "in_flight_timeout"}
 
 
+def test_route_metadata_drift_reuses_declared_target_and_never_resends(tmp_path, monkeypatch):
+    from cron.scheduler import _deliver_result
+
+    store = ProvenanceStore(tmp_path)
+    store.bootstrap()
+    hooks = _Hooks({"decision": "allow", "reason": "safe"})
+    loop, send = _pinned_live_transport(monkeypatch, result={"success": True, "delivered": True})
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+    route_versions = iter(("relay-metadata-v1", "relay-metadata-v2"))
+
+    def bind_drifting_route(*, route_metadata, route, **_kwargs):
+        route["transport_platform"] = "relay"
+        route["transport_metadata"] = next(route_versions)
+        return dict(route_metadata)
+
+    monkeypatch.setattr("cron.scheduler._protected_transport_metadata", bind_drifting_route)
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        first = _deliver_result(
+            _job(), "business-safe final result", protect_final_result=True,
+            outbound_hooks=hooks, provenance_store=store, loop=loop,
+        )
+        second = _deliver_result(
+            _job(), "business-safe final result", protect_final_result=True,
+            outbound_hooks=hooks, provenance_store=store, loop=loop,
+        )
+
+    assert first is None
+    assert "occurrence target route changed" in second
+    send.assert_awaited_once()
+    targets = next(iter(_ledger(store)["occurrences"].values()))["targets"]
+    assert len(targets) == 1
+
+
 def test_post_send_repair_replays_only_persisted_observer_context(tmp_path):
     from cron.scheduler import repair_protected_final_result_after_send
 
@@ -182,6 +217,25 @@ def test_post_send_repair_replays_only_persisted_observer_context(tmp_path):
         "observer_event_id": f"after-send:{claim['capability_id']}:{claim['claim_id']}:sent",
     }]
     assert store.pending_post_send_repairs() == []
+
+
+def test_prepared_startup_without_pending_observer_does_not_require_active_hook(monkeypatch, tmp_path):
+    from cron.scheduler import recover_protected_final_result_repairs_for_home
+
+    class EmptyStore:
+        def __init__(self, home):
+            assert Path(home) == tmp_path
+
+        def pending_post_send_repairs(self):
+            return []
+
+    monkeypatch.setattr("cron.output_provenance.ProvenanceStore", EmptyStore)
+    monkeypatch.setattr(
+        "gateway.outbound_boundary.load_installed_outbound_hooks",
+        lambda _home: (_ for _ in ()).throw(AssertionError("inactive prepared hook must not be loaded")),
+    )
+
+    assert recover_protected_final_result_repairs_for_home(tmp_path) == []
 
 
 def test_post_send_repair_failure_remains_pending_without_transport(tmp_path):
@@ -999,6 +1053,28 @@ def test_protected_delivery_rejects_job_profile_id_that_differs_from_active_home
         )
 
     assert result == "protected final-result boundary denied telegram:123: profile identity mismatch"
+
+
+def test_root_profile_uses_activated_profile_id_instead_of_home_basename(monkeypatch, tmp_path):
+    from cron.scheduler import _deliver_result
+
+    root_home = tmp_path / ".hermes"
+    store = ProvenanceStore(root_home)
+    store.bootstrap()
+    job = _job()
+    job["profile_id"] = "Atlas"
+    hooks = _Hooks({"decision": "allow"}, profile_id="Atlas")
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: root_home)
+
+    with patch("gateway.config.load_gateway_config", return_value=_config()):
+        result = _deliver_result(
+            job, "safe", protect_final_result=True,
+            outbound_hooks=hooks, provenance_store=store,
+        )
+
+    assert "profile identity mismatch" not in result
+    target = next(iter(next(iter(_ledger(store)["occurrences"].values()))["targets"].values()))
+    assert target["proof"]["profile_id"] == "Atlas"
 
 
 def test_legacy_standalone_fallback_runs_in_a_fresh_thread_when_loop_is_active(monkeypatch):

--- a/tests/cron/test_scheduler_final_result_boundary.py
+++ b/tests/cron/test_scheduler_final_result_boundary.py
@@ -50,6 +50,25 @@ def _ledger(store: ProvenanceStore) -> dict:
     return json.loads(store.ledger_path.read_text(encoding="utf-8"))
 
 
+def _seed_pending_repair(home: Path) -> ProvenanceStore:
+    store = ProvenanceStore(home)
+    store.bootstrap()
+    issued = store.issue(
+        profile_id="profile", job_id="job", occurrence_id="occurrence", target_id="target",
+        route_digest="sha256:route", raw_body=b"body", template_digest="sha256:template",
+        producer_class="llm_final",
+    )
+    claim = store.verify_and_claim(
+        proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow",
+    )
+    store.begin_send(
+        capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=b"body",
+        rendered_body=b"body", route_digest="sha256:route",
+        post_send_repair_context={"content": "body"},
+    )
+    return store
+
+
 def _pinned_live_transport(monkeypatch, *, result: object) -> tuple[object, AsyncMock]:
     """Install one resolved native transport and synchronously run its coroutine."""
     from gateway.config import Platform
@@ -92,6 +111,7 @@ def test_protected_final_result_claims_then_sends_once(tmp_path, monkeypatch):
 
     assert result is None
     send.assert_awaited_once()
+    assert send.await_args.kwargs["metadata"]["_hermes_strict_route"] is True
     assert hooks.contexts[0]["source_kind"] == "gateway_reply"
     assert hooks.events == ["outbound:before_send", "outbound:after_send"]
     assert hooks.contexts[1]["success"] is True
@@ -238,6 +258,20 @@ def test_prepared_startup_without_pending_observer_does_not_require_active_hook(
     assert recover_protected_final_result_repairs_for_home(tmp_path) == []
 
 
+def test_pending_observer_without_active_hook_returns_hard_error(monkeypatch, tmp_path):
+    from cron.scheduler import recover_protected_final_result_repairs_for_home
+
+    _seed_pending_repair(tmp_path)
+    monkeypatch.setattr(
+        "gateway.outbound_boundary.load_installed_outbound_hooks",
+        lambda _home: None,
+    )
+
+    assert recover_protected_final_result_repairs_for_home(tmp_path) == [
+        "protected_final_result_recovery_blocked:active_hook_unavailable"
+    ]
+
+
 def test_post_send_repair_failure_remains_pending_without_transport(tmp_path):
     from cron.scheduler import repair_protected_final_result_after_send
 
@@ -328,10 +362,27 @@ def test_profile_recovery_uses_the_requested_home_without_the_cron_jobs_lock(mon
     assert recover_protected_final_result_repairs_for_home(tmp_path) == ["recovered"]
 
 
-def test_scheduler_sweep_skips_when_no_activated_hook(monkeypatch):
-    from cron.scheduler import sweep_protected_final_result_repairs
-    monkeypatch.setattr("gateway.outbound_boundary.load_installed_outbound_hooks", lambda _home: None)
-    assert sweep_protected_final_result_repairs() == []
+def test_tick_blocks_pending_observer_when_active_hook_is_unavailable(
+    monkeypatch, tmp_path, caplog,
+):
+    from cron.scheduler import tick
+
+    _seed_pending_repair(tmp_path)
+    due_reads = []
+    monkeypatch.setattr("cron.scheduler._get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("cron.scheduler._get_lock_paths", lambda: (tmp_path, tmp_path / ".tick.lock"))
+    monkeypatch.setattr(
+        "gateway.outbound_boundary.load_installed_outbound_hooks",
+        lambda _home: None,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler.get_due_jobs",
+        lambda: due_reads.append(True) or [],
+    )
+
+    assert tick(verbose=False) == 0
+    assert due_reads == []
+    assert "protected_final_result_recovery_blocked:active_hook_unavailable" in caplog.text
 
 
 def test_tick_logs_and_continues_when_recovery_sweep_fails(tmp_path, monkeypatch):

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -365,6 +365,7 @@ def test_fire_due_default_claims_then_runs(monkeypatch):
     ran = []
     monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
     monkeypatch.setattr(jobs, "get_job", lambda jid: {"id": jid, "name": "t"})
+    monkeypatch.setattr(sched, "recover_protected_final_result_repairs_for_home", lambda: [])
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
 
     assert InProcessCronScheduler().fire_due("j1") is True
@@ -400,6 +401,36 @@ def test_fire_due_missing_job_does_not_run(monkeypatch):
 
     assert InProcessCronScheduler().fire_due("gone") is False
     assert ran == []
+
+
+def test_fire_due_does_not_claim_when_profile_recovery_raises(monkeypatch):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    monkeypatch.setattr(sched, "recover_protected_final_result_repairs_for_home", lambda: (_ for _ in ()).throw(RuntimeError("recovery unavailable")))
+    claimed = []
+    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda _job_id: claimed.append(True) or True, raising=False)
+    monkeypatch.setattr(jobs, "get_job", lambda job_id: {"id": job_id})
+    monkeypatch.setattr(executions, "create_execution", lambda *_args, **_kwargs: {"id": "execution"})
+    monkeypatch.setattr(sched, "run_one_job", lambda *_args, **_kwargs: True)
+
+    assert InProcessCronScheduler().fire_due("job") is False
+    assert claimed == []
+
+
+def test_fire_due_does_not_claim_while_protected_recovery_remains_pending(monkeypatch):
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    claimed = []
+    monkeypatch.setattr(sched, "recover_protected_final_result_repairs_for_home", lambda: ["repair pending"])
+    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda _job_id: claimed.append(True) or True, raising=False)
+
+    assert InProcessCronScheduler().fire_due("job") is False
+    assert claimed == []
 
 
 # ── F2a: ticker liveness — survival, heartbeat, honest status (#32612, #32895) ──

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -21,6 +21,26 @@ import time
 from unittest.mock import patch
 
 
+def _seed_pending_repair(home):
+    from cron.output_provenance import ProvenanceStore
+
+    store = ProvenanceStore(home)
+    store.bootstrap()
+    issued = store.issue(
+        profile_id="profile", job_id="job", occurrence_id="occurrence", target_id="target",
+        route_digest="sha256:route", raw_body=b"body", template_digest="sha256:template",
+        producer_class="llm_final",
+    )
+    claim = store.verify_and_claim(
+        proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow",
+    )
+    store.begin_send(
+        capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=b"body",
+        rendered_body=b"body", route_digest="sha256:route",
+        post_send_repair_context={"content": "body"},
+    )
+
+
 def _wait_until(predicate, timeout=10.0, interval=0.005):
     """Block until ``predicate()`` is truthy or ``timeout`` elapses.
 
@@ -420,13 +440,20 @@ def test_fire_due_does_not_claim_when_profile_recovery_raises(monkeypatch):
     assert claimed == []
 
 
-def test_fire_due_does_not_claim_while_protected_recovery_remains_pending(monkeypatch):
+def test_fire_due_does_not_claim_when_pending_repair_has_no_active_hook(
+    monkeypatch, tmp_path,
+):
     import cron.jobs as jobs
     import cron.scheduler as sched
     from cron.scheduler_provider import InProcessCronScheduler
 
+    _seed_pending_repair(tmp_path)
     claimed = []
-    monkeypatch.setattr(sched, "recover_protected_final_result_repairs_for_home", lambda: ["repair pending"])
+    monkeypatch.setattr(sched, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "gateway.outbound_boundary.load_installed_outbound_hooks",
+        lambda _home: None,
+    )
     monkeypatch.setattr(jobs, "claim_job_for_fire", lambda _job_id: claimed.append(True) or True, raising=False)
 
     assert InProcessCronScheduler().fire_due("job") is False

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -533,6 +533,25 @@ async def test_long_output_preserved_for_chunking_adapter(tmp_path, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_exact_content_mode_never_adds_a_local_audit_path(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = NonChunkingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.DISCORD: adapter})
+    target = DeliveryTarget.parse("discord:123")
+
+    long_content = "x" * 5000
+    await router._deliver_to_platform(
+        target,
+        long_content,
+        metadata={"job_id": "protected"},
+        preserve_exact_content=True,
+    )
+
+    assert adapter.calls[0]["content"] == long_content
+    assert not list(tmp_path.glob("cron/output/*.txt"))
+
+
+@pytest.mark.asyncio
 async def test_short_output_never_truncated(tmp_path, monkeypatch):
     """Output under the limit passes through untouched for any adapter."""
     monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
@@ -600,5 +619,4 @@ async def test_save_failure_during_truncation_raises_for_non_chunking_adapter(tm
     # retry (footer needs the path) re-raises.
     with pytest.raises(OSError, match="No space left on device"):
         await router._deliver_to_platform(target, long_content, metadata={"job_id": "job7"})
-
 

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -110,6 +110,25 @@ class TestDiscoverAndLoad:
 
         assert len(reg.loaded_hooks) == 2
 
+    def test_skips_generic_hook_when_no_loader_can_be_created(self, tmp_path, monkeypatch):
+        _create_hook(tmp_path, "generic", '["agent:start"]', "def handle(*_args): pass\n")
+        reg = HookRegistry()
+        monkeypatch.setattr("gateway.hooks.importlib.util.spec_from_file_location", lambda *_args: None)
+
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
+            reg.discover_and_load()
+
+        assert reg.loaded_hooks == []
+
+    def test_skips_generic_hook_when_module_execution_fails(self, tmp_path):
+        _create_hook(tmp_path, "generic", '["agent:start"]', "raise RuntimeError('bad handler')\n")
+        reg = HookRegistry()
+
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
+            reg.discover_and_load()
+
+        assert reg.loaded_hooks == []
+
 
 class TestEmit:
     @pytest.mark.asyncio

--- a/tests/gateway/test_outbound_boundary.py
+++ b/tests/gateway/test_outbound_boundary.py
@@ -1,0 +1,799 @@
+import asyncio
+import hashlib
+import json
+import os
+import stat
+from types import SimpleNamespace
+from pathlib import Path
+
+from gateway.hooks import HookRegistry
+import pytest
+
+from gateway.outbound_boundary import (
+    BoundaryLoadError,
+    load_installed_outbound_hooks,
+    outbound_after_send_sync,
+    outbound_before_send_sync,
+)
+
+
+def _activate(hook_dir):
+    version_tuple = {
+        "hak_commit": "h", "hak_tag": "v", "hak_source_path": "source", "hak_archive_path": "archive", "hak_archive_sha256": "sha256:archive",
+        "homebrew_keg_path": "keg", "homebrew_keg_sha256": "sha256:keg", "core_commit": "core",
+        "core_runtime_path": "runtime", "core_patch_path": "patch", "core_patch_sha256": "sha256:patch",
+    }
+    from gateway.outbound_boundary import _release_tuple_digest
+    tuple_digest = _release_tuple_digest(version_tuple)
+    for name, contents in {
+        "kit-root.txt": "/trusted/kit\n",
+        "kit_root_paths.py": "# pinned kit root helper\n",
+        "runtime_loader_attestation.py": "# pinned runtime attestation helper\n",
+    }.items():
+        (hook_dir / name).write_text(contents, encoding="utf-8")
+    files = [
+        {"path": name, "sha256": hashlib.sha256((hook_dir / name).read_bytes()).hexdigest()}
+        for name in (
+            "HOOK.yaml", "handler.py", "kit-root.txt", "kit_root_paths.py", "runtime_loader_attestation.py",
+        )
+    ]
+    unsigned_bundle = {"schema_version": 1, "files": files}
+    (hook_dir / "kit-bundle-manifest.json").write_text(json.dumps({
+        **unsigned_bundle,
+        "bundle_sha256": hashlib.sha256(
+            json.dumps(unsigned_bundle, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest(),
+    }), encoding="utf-8")
+    release = hook_dir / "release-tuple.json"
+    release.write_text(json.dumps({
+        "schema_version": "outbound-actionable-release/v1",
+        "tuple_digest": tuple_digest,
+        "version_tuple": version_tuple,
+        "bundle_manifest_sha256": "sha256:" + hashlib.sha256(
+            (hook_dir / "kit-bundle-manifest.json").read_bytes()
+        ).hexdigest(),
+    }), encoding="utf-8")
+    os.chmod(release, 0o600)
+    shared = hook_dir.parents[1] / "shared-activation.json"
+    payload = {
+        "schema_version": "outbound-actionable-dual-activation/v1",
+        "tuple_digest": tuple_digest,
+        "version_tuple": version_tuple,
+        "profiles": [
+            {"profile_id": "atlas", "hook_dir": str(hook_dir.absolute()), "fingerprint": {
+                name: "sha256:" + hashlib.sha256((hook_dir / name).read_bytes()).hexdigest()
+                for name in (
+                    "HOOK.yaml", "handler.py", "kit-bundle-manifest.json", "kit-root.txt",
+                    "kit_root_paths.py", "runtime_loader_attestation.py", "release-tuple.json",
+                )
+            } | {
+                "kit_root_paths": "sha256:resolver",
+                "runtime_loader_identity": "sha256:runtime-identity",
+                "runtime_loader_generation": "sha256:runtime-generation",
+            }, "runtime_identity": {}},
+            {"profile_id": "yuange", "hook_dir": str(hook_dir.parent / "peer"), "fingerprint": {}, "runtime_identity": {}},
+        ],
+    }
+    data = json.dumps(payload, sort_keys=True).encode("utf-8") + b"\n"
+    shared.write_bytes(data)
+    os.chmod(shared, 0o600)
+    (hook_dir / "release-activation.json").write_text(json.dumps({
+        "schema_version": "outbound-actionable-dual-activation/v1", "tuple_digest": tuple_digest,
+        "profile_id": "atlas", "activation_path": str(shared),
+        "activation_sha256": "sha256:" + hashlib.sha256(data).hexdigest(),
+    }), encoding="utf-8")
+    os.chmod(hook_dir / "release-activation.json", 0o600)
+
+
+def _prepare_capture(hook_dir):
+    from gateway.outbound_boundary import _release_tuple_digest
+
+    keg = hook_dir.parents[2] / "keg"
+    keg.mkdir(exist_ok=True)
+    version_tuple = {
+        "hak_commit": "h", "hak_tag": "v", "hak_source_path": "source", "hak_archive_path": "archive", "hak_archive_sha256": "sha256:archive",
+        "homebrew_keg_path": str(keg), "homebrew_keg_sha256": "sha256:keg", "core_commit": "core",
+        "core_runtime_path": "runtime", "core_patch_path": "patch", "core_patch_sha256": "sha256:patch",
+    }
+    tuple_digest = _release_tuple_digest(version_tuple)
+    manifest_sha = "sha256:" + hashlib.sha256((hook_dir / "kit-bundle-manifest.json").read_bytes()).hexdigest()
+    (hook_dir / "release-tuple.json").write_text(json.dumps({
+        "schema_version": "outbound-actionable-release/v1", "tuple_digest": tuple_digest,
+        "version_tuple": version_tuple, "bundle_manifest_sha256": manifest_sha,
+    }), encoding="utf-8")
+    os.chmod(hook_dir / "release-tuple.json", 0o600)
+    prepared_dir = keg.parent / ".outbound-actionable-activations"
+    prepared_dir.mkdir(mode=0o700, exist_ok=True)
+    os.chmod(prepared_dir, 0o700)
+    prepared = prepared_dir / f"{tuple_digest.removeprefix('sha256:')}.prepared.json"
+    trusted_root = hook_dir.parents[2] / "trusted-kit"
+    trusted_scripts = trusted_root / "scripts"
+    trusted_scripts.mkdir(parents=True, exist_ok=True)
+    trusted_module = trusted_scripts / "trusted.py"
+    trusted_module.write_text("# prepared runtime bundle\n", encoding="utf-8")
+    runtime_identity = {
+        "raw_root": str(trusted_root),
+        "module_hashes": {"trusted.py": hashlib.sha256(trusted_module.read_bytes()).hexdigest()},
+    }
+    prepared.write_text(json.dumps({
+        "schema_version": "outbound-actionable-dual-prepared/v1", "tuple_digest": tuple_digest,
+        "version_tuple": version_tuple,
+        "profiles": [
+            {"profile_id": "atlas", "hook_dir": str(hook_dir.absolute()), "fingerprint": {"kit-bundle-manifest.json": manifest_sha}, "runtime_identity": runtime_identity},
+            {"profile_id": "yuange", "hook_dir": str(hook_dir.parent / "peer"), "fingerprint": {"kit-bundle-manifest.json": manifest_sha}, "runtime_identity": runtime_identity},
+        ],
+    }), encoding="utf-8")
+    os.chmod(prepared, 0o600)
+
+
+def test_missing_boundary_decision_fails_closed():
+    decision = outbound_before_send_sync(HookRegistry(), {"content": "report"})
+    assert decision.decision == "deny"
+
+
+def test_single_rewrite_decision_is_carried_to_transport():
+    hooks = HookRegistry()
+    hooks._handlers["outbound:before_send"] = [lambda _event, _ctx: {"decision": "rewrite", "content": "safe", "reason": "projection"}]
+    decision = outbound_before_send_sync(hooks, {"content": "raw"})
+    assert decision.transmit and decision.content == "safe"
+
+
+def test_malformed_rewrite_fails_closed_without_falling_back_to_raw_content():
+    hooks = HookRegistry()
+    hooks._handlers["outbound:before_send"] = [lambda _event, _ctx: {"decision": "rewrite"}]
+
+    decision = outbound_before_send_sync(hooks, {"content": "raw private result"})
+
+    assert decision.decision == "deny"
+    assert decision.reason == "boundary_rewrite_missing_content"
+    assert decision.content == ""
+
+
+def test_handler_failure_fails_closed_even_when_another_handler_allows():
+    hooks = HookRegistry()
+
+    def raise_error(_event, _ctx):
+        raise RuntimeError("projection unavailable")
+
+    hooks._handlers["outbound:before_send"] = [
+        lambda _event, _ctx: {"decision": "allow"},
+        raise_error,
+    ]
+
+    decision = outbound_before_send_sync(hooks, {"content": "report"})
+
+    assert decision.decision == "deny"
+    assert decision.reason == "boundary_unavailable"
+
+
+def test_missing_manifest_keeps_boundary_optional(tmp_path):
+    assert load_installed_outbound_hooks(tmp_path) is None
+
+
+def test_copied_hook_without_release_activation_fails_closed(tmp_path):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+    (hook_dir / "release-tuple.json").write_text('{"tuple_digest":"sha256:test"}', encoding="utf-8")
+
+    with pytest.raises(BoundaryLoadError, match="not release-activated"):
+        load_installed_outbound_hooks(tmp_path)
+
+
+def test_generic_hook_registry_skips_unactivated_outbound_bundle(tmp_path):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("name: outbound-actionable\nevents: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("def handle(*_args):\n    return {'decision': 'allow'}\n", encoding="utf-8")
+
+    registry = HookRegistry(hooks_dir=hook_dir.parent)
+    registry.discover_and_load()
+
+    assert registry.loaded_hooks == []
+
+
+def test_generic_hook_registry_captures_pending_runtime_identity_without_registration(tmp_path):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("name: outbound-actionable\nevents: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text(
+        "from pathlib import Path\n"
+        "def capture_runtime_attestation(profile):\n"
+        "    (Path(profile) / 'capture').write_text('captured')\n"
+        "def handle(*_args):\n"
+        "    return {'decision': 'allow'}\n",
+        encoding="utf-8",
+    )
+    files = [
+        {"path": name, "sha256": hashlib.sha256((hook_dir / name).read_bytes()).hexdigest()}
+        for name in ("HOOK.yaml", "handler.py")
+    ]
+    unsigned = {"schema_version": 1, "files": files}
+    (hook_dir / "kit-bundle-manifest.json").write_text(json.dumps({
+        **unsigned, "bundle_sha256": hashlib.sha256(json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()).hexdigest(),
+    }), encoding="utf-8")
+    _prepare_capture(hook_dir)
+
+    registry = HookRegistry(hooks_dir=hook_dir.parent)
+    registry.discover_and_load()
+
+    assert (tmp_path / "capture").read_text(encoding="utf-8") == "captured"
+    assert registry.loaded_hooks == []
+
+
+def test_pending_capture_executes_the_verified_handler_bytes_after_path_replacement(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "handler.py").write_text(
+        "from pathlib import Path\n"
+        "def capture_runtime_attestation(profile):\n"
+        "    Path(profile).joinpath('captured').write_text('verified')\n",
+        encoding="utf-8",
+    )
+    files = [{"path": "handler.py", "sha256": hashlib.sha256((hook_dir / "handler.py").read_bytes()).hexdigest()}]
+    unsigned = {"schema_version": 1, "files": files}
+    (hook_dir / "kit-bundle-manifest.json").write_text(json.dumps({
+        **unsigned, "bundle_sha256": hashlib.sha256(
+            json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest(),
+    }), encoding="utf-8")
+    _prepare_capture(hook_dir)
+    from gateway import outbound_boundary
+    original_exec = outbound_boundary._exec_pinned_handler
+
+    def replace_after_read(module_name, handler, source):
+        (hook_dir / "handler.py").write_text("raise RuntimeError('replacement executed')\n", encoding="utf-8")
+        return original_exec(module_name, handler, source)
+
+    monkeypatch.setattr(outbound_boundary, "_exec_pinned_handler", replace_after_read)
+    outbound_boundary.capture_pending_outbound_attestation(hook_dir)
+
+    assert (tmp_path / "captured").read_text(encoding="utf-8") == "verified"
+
+
+def test_pending_capture_pins_the_prepared_runtime_and_restores_environment(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "handler.py").write_text(
+        "import os\nfrom pathlib import Path\n"
+        "def capture_runtime_attestation(profile):\n"
+        "    Path(profile).joinpath('runtime').write_text(os.environ.get('HERMES_AGENT_KIT_HOME', '') + '|' + os.environ.get('HERMES_AGENT_KIT_SCRIPTS', ''))\n",
+        encoding="utf-8",
+    )
+    files = [{"path": "handler.py", "sha256": hashlib.sha256((hook_dir / "handler.py").read_bytes()).hexdigest()}]
+    unsigned = {"schema_version": 1, "files": files}
+    (hook_dir / "kit-bundle-manifest.json").write_text(json.dumps({
+        **unsigned, "bundle_sha256": hashlib.sha256(json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()).hexdigest(),
+    }), encoding="utf-8")
+    _prepare_capture(hook_dir)
+    monkeypatch.setenv("HERMES_AGENT_KIT_SCRIPTS", "/attacker/scripts")
+
+    from gateway.outbound_boundary import capture_pending_outbound_attestation
+    capture_pending_outbound_attestation(hook_dir)
+
+    assert (tmp_path / "runtime").read_text(encoding="utf-8") == f"{hook_dir.parents[2] / 'trusted-kit'}|"
+    assert os.environ["HERMES_AGENT_KIT_SCRIPTS"] == "/attacker/scripts"
+
+
+def test_pending_capture_does_not_execute_when_prepared_runtime_identity_cannot_be_reverified(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "handler.py").write_text("raise RuntimeError('must remain inert')\n", encoding="utf-8")
+    files = [{"path": "handler.py", "sha256": hashlib.sha256((hook_dir / "handler.py").read_bytes()).hexdigest()}]
+    unsigned = {"schema_version": 1, "files": files}
+    (hook_dir / "kit-bundle-manifest.json").write_text(json.dumps({
+        **unsigned, "bundle_sha256": hashlib.sha256(json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()).hexdigest(),
+    }), encoding="utf-8")
+    _prepare_capture(hook_dir)
+    from gateway import outbound_boundary
+    monkeypatch.setattr(outbound_boundary, "_prepared_runtime_root", lambda _entry: None)
+
+    outbound_boundary.capture_pending_outbound_attestation(hook_dir)
+
+
+def test_activated_snapshot_rejects_corrupt_shared_control_and_handler_reread(tmp_path, monkeypatch):
+    from gateway import outbound_boundary
+
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("def handle(*_args): return None\n", encoding="utf-8")
+    _activate(hook_dir)
+    activation = json.loads((hook_dir / "release-activation.json").read_text(encoding="utf-8"))
+    activation["activation_sha256"] = "sha256:wrong"
+    (hook_dir / "release-activation.json").write_text(json.dumps(activation), encoding="utf-8")
+    os.chmod(hook_dir / "release-activation.json", 0o600)
+    assert outbound_boundary._activated_handler_snapshot(hook_dir) is None
+
+    _activate(hook_dir)
+    original_reader = outbound_boundary._read_regular_bytes
+    handler_reads = 0
+
+    def changed_on_execution(path):
+        nonlocal handler_reads
+        if Path(path).name == "handler.py":
+            handler_reads += 1
+            if handler_reads == 2:
+                return b"changed"
+        return original_reader(path)
+
+    monkeypatch.setattr(outbound_boundary, "_bundle_manifest_is_valid", lambda *_args: True)
+    monkeypatch.setattr(outbound_boundary, "_read_regular_bytes", changed_on_execution)
+    assert outbound_boundary._activated_handler_snapshot(hook_dir) is None
+
+    monkeypatch.undo()
+    _activate(hook_dir)
+    (hook_dir / "release-tuple.json").write_text("{", encoding="utf-8")
+    os.chmod(hook_dir / "release-tuple.json", 0o600)
+    assert outbound_boundary._activated_handler_snapshot(hook_dir) is None
+
+
+def test_prepared_runtime_root_rejects_empty_or_mismatched_bundle(tmp_path):
+    from gateway import outbound_boundary
+    from gateway.outbound_boundary import _prepared_runtime_root
+
+    assert _prepared_runtime_root({}) is None
+    assert _prepared_runtime_root({"runtime_identity": {"raw_root": str(tmp_path / "missing"), "module_hashes": {"seam.py": "x"}}}) is None
+    assert _prepared_runtime_root({"runtime_identity": {"raw_root": str(tmp_path), "module_hashes": {}}}) is None
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "seam.py").write_text("trusted", encoding="utf-8")
+    assert _prepared_runtime_root({"runtime_identity": {"raw_root": str(tmp_path), "module_hashes": {"seam.py": "wrong"}}}) is None
+    assert _prepared_runtime_root({"runtime_identity": {"raw_root": str(tmp_path), "module_hashes": {"../seam.py": "wrong"}}}) is None
+    original_reader = outbound_boundary._read_regular_bytes
+    outbound_boundary._read_regular_bytes = lambda _path: (_ for _ in ()).throw(OSError("unreadable"))
+    try:
+        assert _prepared_runtime_root({"runtime_identity": {"raw_root": str(tmp_path), "module_hashes": {"seam.py": "x"}}}) is None
+    finally:
+        outbound_boundary._read_regular_bytes = original_reader
+
+
+def test_pending_capture_does_not_execute_an_unmanifested_handler(tmp_path):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "handler.py").write_text("from pathlib import Path\nPath(__file__).parents[2].joinpath('executed').write_text('bad')\n", encoding="utf-8")
+    from gateway.outbound_boundary import capture_pending_outbound_attestation
+    capture_pending_outbound_attestation(hook_dir)
+    assert not (tmp_path / "executed").exists()
+
+
+def test_descriptor_reader_fails_closed_for_open_invalid_metadata_and_read_errors(tmp_path, monkeypatch):
+    from gateway import outbound_boundary
+
+    assert outbound_boundary._read_regular_bytes(tmp_path / "missing") is None
+    target = tmp_path / "managed.py"
+    target.write_text("trusted", encoding="utf-8")
+    descriptor = os.open(target, os.O_RDONLY)
+    monkeypatch.setattr(outbound_boundary.os, "open", lambda *_args: descriptor)
+    monkeypatch.setattr(
+        outbound_boundary.os, "fstat",
+        lambda _descriptor: SimpleNamespace(st_mode=stat.S_IFDIR, st_uid=os.getuid(), st_nlink=1),
+    )
+    assert outbound_boundary._read_regular_bytes(target) is None
+    monkeypatch.undo()
+
+    descriptor = os.open(target, os.O_RDONLY)
+    monkeypatch.setattr(outbound_boundary.os, "open", lambda *_args: descriptor)
+
+    class BrokenReader:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            raise OSError("read failed")
+
+    monkeypatch.setattr(outbound_boundary.os, "fdopen", lambda *_args, **_kwargs: BrokenReader())
+    assert outbound_boundary._read_regular_bytes(target) is None
+    monkeypatch.undo()
+
+    private = tmp_path / "private-control.json"
+    private.write_text("control", encoding="utf-8")
+    os.chmod(private, 0o644)
+    assert outbound_boundary._read_private_bytes(private) is None
+    os.chmod(private, 0o600)
+    monkeypatch.setattr(outbound_boundary.os, "fdopen", lambda *_args, **_kwargs: BrokenReader())
+    assert outbound_boundary._read_private_bytes(private) is None
+
+
+def test_manifest_and_active_loader_reject_malformed_or_changed_inputs(tmp_path, monkeypatch):
+    from gateway import outbound_boundary
+
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    manifest = hook_dir / "kit-bundle-manifest.json"
+    manifest.write_bytes(b"not json")
+    assert outbound_boundary._validated_bundle_manifest(hook_dir, manifest) is None
+    assert outbound_boundary._validated_bundle_manifest(hook_dir, manifest, "sha256:wrong") is None
+    with pytest.raises(BoundaryLoadError, match="not release-activated"):
+        outbound_boundary.load_activated_outbound_handler(hook_dir, "inactive")
+
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("def handle(*_args): return None\n", encoding="utf-8")
+    _activate(hook_dir)
+    monkeypatch.setattr(outbound_boundary, "outbound_activation_is_ready", lambda _hook: True)
+    (hook_dir / "release-activation.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(BoundaryLoadError, match="activation changed"):
+        outbound_boundary.load_activated_outbound_handler(hook_dir, "malformed")
+    _activate(hook_dir)
+    (hook_dir / "handler.py").write_text("def handle(*_args): return 'changed'\n", encoding="utf-8")
+    with pytest.raises(BoundaryLoadError, match="activation changed"):
+        outbound_boundary.load_activated_outbound_handler(hook_dir, "drifted")
+
+
+def test_inert_capture_requires_a_well_formed_external_preparation_record(tmp_path):
+    from gateway import outbound_boundary
+
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+    files = [{"path": "handler.py", "sha256": hashlib.sha256((hook_dir / "handler.py").read_bytes()).hexdigest()}]
+    unsigned = {"schema_version": 1, "files": files}
+    (hook_dir / "kit-bundle-manifest.json").write_text(json.dumps({
+        **unsigned, "bundle_sha256": hashlib.sha256(
+            json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest(),
+    }), encoding="utf-8")
+    _prepare_capture(hook_dir)
+    release = hook_dir / "release-tuple.json"
+    release_payload = json.loads(release.read_text(encoding="utf-8"))
+    release_payload["schema_version"] = "wrong"
+    release.write_text(json.dumps(release_payload), encoding="utf-8")
+    os.chmod(release, 0o600)
+    assert outbound_boundary._prepared_release_for_hook(hook_dir) is None
+
+    _prepare_capture(hook_dir)
+    tuple_digest = json.loads(release.read_text(encoding="utf-8"))["tuple_digest"]
+    prepared = Path(release_payload["version_tuple"]["homebrew_keg_path"]).parent / ".outbound-actionable-activations" / f"{tuple_digest.removeprefix('sha256:')}.prepared.json"
+    prepared.unlink()
+    assert outbound_boundary._prepared_release_for_hook(hook_dir) is None
+
+    _prepare_capture(hook_dir)
+    prepared.write_text(json.dumps({"schema_version": "wrong", "profiles": []}), encoding="utf-8")
+    os.chmod(prepared, 0o600)
+    assert outbound_boundary._prepared_release_for_hook(hook_dir) is None
+    prepared.write_text("not json", encoding="utf-8")
+    os.chmod(prepared, 0o600)
+    assert outbound_boundary._prepared_release_for_hook(hook_dir) is None
+
+
+@pytest.mark.parametrize("payload", [{}, {"schema_version": 1, "files": []}, {"schema_version": 1, "files": [{"path": "../escape", "sha256": "x"}], "bundle_sha256": "bad"}])
+def test_pending_capture_manifest_rejects_invalid_shapes(tmp_path, payload):
+    from gateway.outbound_boundary import _bundle_manifest_is_valid
+    hook_dir = tmp_path / "outbound-actionable"
+    hook_dir.mkdir()
+    manifest = hook_dir / "kit-bundle-manifest.json"
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+    assert _bundle_manifest_is_valid(hook_dir, manifest) is False
+
+
+def test_pending_capture_manifest_rejects_unsafe_or_drifted_entries(tmp_path):
+    from gateway.outbound_boundary import _bundle_manifest_is_valid
+    hook_dir = tmp_path / "outbound-actionable"
+    hook_dir.mkdir()
+    for entry in ({"path": "../escape", "sha256": "x"}, {"path": "handler.py", "sha256": "wrong"}):
+        files = [entry]
+        unsigned = {"schema_version": 1, "files": files}
+        (hook_dir / "kit-bundle-manifest.json").write_text(json.dumps({**unsigned, "bundle_sha256": hashlib.sha256(json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()).hexdigest()}), encoding="utf-8")
+        (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+        assert _bundle_manifest_is_valid(hook_dir, hook_dir / "kit-bundle-manifest.json") is False
+
+
+def test_generic_hook_registry_keeps_unactivated_bundle_inert_when_attestation_capture_fails(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("name: outbound-actionable\nevents: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("def handle(*_args):\n    return {'decision': 'allow'}\n", encoding="utf-8")
+    monkeypatch.setattr("gateway.outbound_boundary.capture_pending_outbound_attestation", lambda _hook: (_ for _ in ()).throw(RuntimeError("capture failed")))
+
+    registry = HookRegistry(hooks_dir=hook_dir.parent)
+    registry.discover_and_load()
+
+    assert registry.loaded_hooks == []
+
+
+def test_shared_activation_record_must_bind_this_profile(tmp_path):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+    _activate(hook_dir)
+    record = json.loads((hook_dir / "release-activation.json").read_text(encoding="utf-8"))
+    record["profile_id"] = "missing"
+    (hook_dir / "release-activation.json").write_text(json.dumps(record), encoding="utf-8")
+    os.chmod(hook_dir / "release-activation.json", 0o600)
+
+    with pytest.raises(BoundaryLoadError, match="not release-activated"):
+        load_installed_outbound_hooks(tmp_path)
+
+
+def test_shared_activation_record_rejects_missing_or_tampered_record(tmp_path):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+    (hook_dir / "release-tuple.json").write_text(json.dumps({"tuple_digest": "sha256:test"}), encoding="utf-8")
+    (hook_dir / "release-activation.json").write_text(json.dumps({"tuple_digest": "sha256:test"}), encoding="utf-8")
+    with pytest.raises(BoundaryLoadError, match="not release-activated"):
+        load_installed_outbound_hooks(tmp_path)
+
+    _activate(hook_dir)
+    (hook_dir / "handler.py").write_text("# drift\n", encoding="utf-8")
+    with pytest.raises(BoundaryLoadError, match="not release-activated"):
+        load_installed_outbound_hooks(tmp_path)
+
+    _activate(hook_dir)
+    shared = hook_dir.parents[1] / "shared-activation.json"
+    os.chmod(shared, 0o644)
+    with pytest.raises(BoundaryLoadError, match="not release-activated"):
+        load_installed_outbound_hooks(tmp_path)
+    os.chmod(shared, 0o600)
+    shared.write_bytes(shared.read_bytes() + b" ")
+    with pytest.raises(BoundaryLoadError, match="not release-activated"):
+        load_installed_outbound_hooks(tmp_path)
+
+
+def test_installed_manifest_without_loaded_before_send_handler_fails_closed(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+    _activate(hook_dir)
+
+    class EmptyRegistry:
+        loaded_hooks = []
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def discover_and_load(self):
+            return None
+
+    monkeypatch.setattr("gateway.hooks.HookRegistry", EmptyRegistry)
+    with pytest.raises(BoundaryLoadError, match="missing before-send"):
+        load_installed_outbound_hooks(tmp_path)
+
+
+def test_after_send_emits_transport_disposition():
+    hooks = HookRegistry()
+    seen = []
+    handler = lambda _event, context: seen.append(context)
+    hooks._handlers["outbound:after_send"] = [handler]
+    hooks._named_handlers["outbound:after_send"] = {"outbound-actionable": [handler]}
+
+    outbound_after_send_sync(hooks, {"success": True, "send_result": {"message_id": "m1"}})
+
+    assert seen == [{"success": True, "send_result": {"message_id": "m1"}}]
+
+
+def test_after_send_does_not_fan_out_to_an_unrelated_loaded_hook():
+    hooks = HookRegistry()
+    seen = []
+    hooks._named_handlers["outbound:after_send"] = {
+        "outbound-actionable": [lambda _event, context: seen.append(("trusted", context))],
+        "unrelated": [lambda _event, context: seen.append(("unrelated", context))],
+    }
+    hooks._handlers["outbound:after_send"] = [
+        *hooks._named_handlers["outbound:after_send"]["outbound-actionable"],
+        *hooks._named_handlers["outbound:after_send"]["unrelated"],
+    ]
+
+    outbound_after_send_sync(hooks, {"observer_event_id": "after-send:one"})
+
+    assert seen == [("trusted", {"observer_event_id": "after-send:one"})]
+
+
+def test_named_strict_collector_requires_the_trusted_hook_and_awaits_it():
+    hooks = HookRegistry()
+    with pytest.raises(RuntimeError, match="not registered"):
+        asyncio.run(hooks.emit_collect_strict_named("outbound:after_send", "outbound-actionable"))
+
+    async def trusted(_event, context):
+        return {"event": context["observer_event_id"]}
+
+    hooks._named_handlers["outbound:after_send"] = {"outbound-actionable": [trusted]}
+    assert asyncio.run(hooks.emit_collect_strict_named(
+        "outbound:after_send", "outbound-actionable", {"observer_event_id": "after-send:trusted"},
+    )) == [{"event": "after-send:trusted"}]
+
+
+def test_after_send_uses_legacy_collector_when_strict_is_unavailable():
+    seen = []
+
+    class LegacyHooks:
+        async def emit_collect(self, event, context):
+            seen.append((event, context))
+            return []
+
+    outbound_after_send_sync(LegacyHooks(), {"success": False})
+    assert seen == [("outbound:after_send", {"success": False})]
+
+
+def test_boundary_uses_legacy_collector_and_rejects_ambiguous_decisions():
+    class LegacyHooks:
+        async def emit_collect(self, _event, _context):
+            return [{"decision": "allow"}, {"decision": "deny"}, "ignored"]
+
+    decision = outbound_before_send_sync(LegacyHooks(), {"content": "raw"})
+    assert decision.decision == "deny"
+    assert decision.reason == "boundary_decision_missing_or_ambiguous"
+
+
+def test_boundary_context_is_detached():
+    from gateway.outbound_boundary import build_outbound_context
+
+    source = {"route": "chat"}
+    context = build_outbound_context(**source)
+    source["route"] = "changed"
+    assert context == {"route": "chat"}
+
+
+def test_boundary_thread_bridge_propagates_handler_failure_inside_running_loop():
+    class BrokenHooks:
+        async def emit_collect_strict(self, _event, _context):
+            raise RuntimeError("boom")
+
+    async def invoke():
+        return outbound_before_send_sync(BrokenHooks(), {"content": "raw"})
+
+    decision = asyncio.run(invoke())
+    assert decision.reason == "boundary_unavailable"
+
+
+def test_manifest_loader_wraps_discovery_failure(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+    _activate(hook_dir)
+
+    class BrokenRegistry:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def discover_and_load(self):
+            raise RuntimeError("bad handler")
+
+    monkeypatch.setattr("gateway.hooks.HookRegistry", BrokenRegistry)
+    with pytest.raises(BoundaryLoadError, match="failed to load"):
+        load_installed_outbound_hooks(tmp_path)
+
+
+def test_manifest_loader_returns_an_active_boundary(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+    _activate(hook_dir)
+
+    class ActiveRegistry:
+        def __init__(self, *args, **kwargs):
+            self.loaded_hooks = [{
+                "name": "outbound-actionable",
+                "path": str(hook_dir),
+                "events": ["outbound:before_send"],
+            }]
+
+        def discover_and_load(self):
+            return None
+
+    monkeypatch.setattr("gateway.hooks.HookRegistry", ActiveRegistry)
+    assert isinstance(load_installed_outbound_hooks(tmp_path), ActiveRegistry)
+
+
+def test_loader_discovers_only_the_requested_profile_bundle(tmp_path):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text(
+        "name: outbound-actionable\nevents: [outbound:before_send]\n", encoding="utf-8"
+    )
+    (hook_dir / "handler.py").write_text(
+        "def handle(event_type, context):\n    return {'decision': 'allow', 'reason': 'profile-bound'}\n",
+        encoding="utf-8",
+    )
+    _activate(hook_dir)
+
+    hooks = load_installed_outbound_hooks(tmp_path)
+    decision = outbound_before_send_sync(hooks, {"content": "safe"})
+
+    assert decision.decision == "allow"
+    assert hooks.loaded_hooks == [
+        {
+            "name": "outbound-actionable",
+            "description": "",
+            "events": ["outbound:before_send"],
+            "path": str(hook_dir),
+        }
+    ]
+
+
+def test_active_registry_executes_pinned_handler_bytes_after_path_replacement(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text(
+        "name: outbound-actionable\nevents: [outbound:before_send]\n", encoding="utf-8"
+    )
+    (hook_dir / "handler.py").write_text(
+        "def handle(*_args):\n    return {'decision': 'allow', 'reason': 'pinned'}\n",
+        encoding="utf-8",
+    )
+    _activate(hook_dir)
+    from gateway import outbound_boundary
+    original_exec = outbound_boundary._exec_pinned_handler
+
+    def replace_after_read(module_name, handler, source):
+        (hook_dir / "handler.py").write_text("raise RuntimeError('replacement executed')\n", encoding="utf-8")
+        return original_exec(module_name, handler, source)
+
+    monkeypatch.setattr(outbound_boundary, "_exec_pinned_handler", replace_after_read)
+    hooks = load_installed_outbound_hooks(tmp_path)
+
+    assert outbound_before_send_sync(hooks, {"content": "safe"}).reason == "pinned"
+
+
+def test_loader_fails_when_the_requested_bundle_handler_is_broken(tmp_path):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text(
+        "name: outbound-actionable\nevents: [outbound:before_send]\n", encoding="utf-8"
+    )
+    (hook_dir / "handler.py").write_text("raise RuntimeError('broken bundle')\n", encoding="utf-8")
+    _activate(hook_dir)
+
+    with pytest.raises(BoundaryLoadError, match="missing before-send"):
+        load_installed_outbound_hooks(tmp_path)
+
+
+def test_loader_rejects_a_profile_hook_symlink(tmp_path):
+    other = tmp_path / "other" / "hooks" / "outbound-actionable"
+    other.mkdir(parents=True)
+    (other / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (other / "handler.py").write_text("# handler\n", encoding="utf-8")
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    (hooks / "outbound-actionable").symlink_to(other, target_is_directory=True)
+
+    with pytest.raises(BoundaryLoadError, match="symlink"):
+        load_installed_outbound_hooks(tmp_path)
+
+
+def test_loader_rejects_missing_or_non_file_managed_members(tmp_path):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").mkdir()
+    (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+    with pytest.raises(BoundaryLoadError, match="incomplete"):
+        load_installed_outbound_hooks(tmp_path)
+
+    (hook_dir / "HOOK.yaml").rmdir()
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").unlink()
+    with pytest.raises(BoundaryLoadError, match="incomplete"):
+        load_installed_outbound_hooks(tmp_path)
+
+
+def test_boundary_thread_bridge_returns_result_inside_running_loop():
+    class AllowHooks:
+        async def emit_collect_strict(self, _event, _context):
+            return [{"decision": "allow", "reason": "safe"}]
+
+    async def invoke():
+        return outbound_before_send_sync(AllowHooks(), {"content": "raw"})
+
+    decision = asyncio.run(invoke())
+    assert decision.decision == "allow"
+    assert decision.content == "raw"
+
+
+def test_strict_collector_initializes_context_and_awaits_handlers():
+    hooks = HookRegistry()
+
+    async def async_handler(_event, context):
+        assert context == {}
+        return {"decision": "allow"}
+
+    hooks._handlers["outbound:before_send"] = [async_handler]
+    assert asyncio.run(hooks.emit_collect_strict("outbound:before_send")) == [{"decision": "allow"}]

--- a/tests/gateway/test_outbound_boundary.py
+++ b/tests/gateway/test_outbound_boundary.py
@@ -18,9 +18,30 @@ from gateway.outbound_boundary import (
 
 
 def _activate(hook_dir):
+    keg = hook_dir.parents[1] / "Cellar" / "hermes-agent-kit" / "1.0.0"
+    runtime_root = keg / "libexec"
+    runtime_scripts = runtime_root / "scripts"
+    runtime_scripts.mkdir(parents=True, exist_ok=True)
+    seam = runtime_scripts / "outbound_actionable_seam.py"
+    seam.write_text("# activated runtime seam\n", encoding="utf-8")
+    seam_sha = hashlib.sha256(seam.read_bytes()).hexdigest()
+    module_hashes = {"outbound_actionable_seam.py": seam_sha}
+    generation = hashlib.sha256(
+        json.dumps(module_hashes, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    runtime_identity = {
+        "generation_sha256": generation,
+        "module_hashes": module_hashes,
+        "entry_path": str(seam.absolute()),
+        "executed_sha256": seam_sha,
+        "selected_source": "homebrew_keg",
+        "precedence_reason": "activated_release",
+        "raw_root": str(runtime_root.absolute()),
+        "canonical_root": str(runtime_root.resolve()),
+    }
     version_tuple = {
         "hak_commit": "h", "hak_tag": "v", "hak_source_path": "source", "hak_archive_path": "archive", "hak_archive_sha256": "sha256:archive",
-        "homebrew_keg_path": "keg", "homebrew_keg_sha256": "sha256:keg", "core_commit": "core",
+        "homebrew_keg_path": str(keg.absolute()), "homebrew_keg_sha256": "sha256:keg", "core_commit": "core",
         "core_runtime_path": "runtime", "core_patch_path": "patch", "core_patch_sha256": "sha256:patch",
     }
     from gateway.outbound_boundary import _release_tuple_digest
@@ -54,24 +75,27 @@ def _activate(hook_dir):
         ).hexdigest(),
     }), encoding="utf-8")
     os.chmod(release, 0o600)
+    file_fingerprint = {
+        name: "sha256:" + hashlib.sha256((hook_dir / name).read_bytes()).hexdigest()
+        for name in (
+            "HOOK.yaml", "handler.py", "kit-bundle-manifest.json", "kit-root.txt",
+            "kit_root_paths.py", "runtime_loader_attestation.py", "release-tuple.json",
+        )
+    }
     shared = hook_dir.parents[1] / "shared-activation.json"
     payload = {
         "schema_version": "outbound-actionable-dual-activation/v1",
         "tuple_digest": tuple_digest,
         "version_tuple": version_tuple,
         "profiles": [
-            {"profile_id": "atlas", "hook_dir": str(hook_dir.absolute()), "fingerprint": {
-                name: "sha256:" + hashlib.sha256((hook_dir / name).read_bytes()).hexdigest()
-                for name in (
-                    "HOOK.yaml", "handler.py", "kit-bundle-manifest.json", "kit-root.txt",
-                    "kit_root_paths.py", "runtime_loader_attestation.py", "release-tuple.json",
-                )
-            } | {
-                "kit_root_paths": "sha256:resolver",
-                "runtime_loader_identity": "sha256:runtime-identity",
-                "runtime_loader_generation": "sha256:runtime-generation",
-            }, "runtime_identity": {}},
-            {"profile_id": "yuange", "hook_dir": str(hook_dir.parent / "peer"), "fingerprint": {}, "runtime_identity": {}},
+            {"profile_id": "atlas", "hook_dir": str(hook_dir.absolute()), "fingerprint": file_fingerprint | {
+                "kit_root_paths": file_fingerprint["kit_root_paths.py"].removeprefix("sha256:"),
+                "runtime_loader_identity": "sha256:" + hashlib.sha256(
+                    json.dumps(runtime_identity, sort_keys=True, separators=(",", ":")).encode("utf-8")
+                ).hexdigest(),
+                "runtime_loader_generation": generation,
+            }, "runtime_identity": runtime_identity},
+            {"profile_id": "yuange", "hook_dir": str(hook_dir.parent / "peer"), "fingerprint": {}, "runtime_identity": runtime_identity},
         ],
     }
     data = json.dumps(payload, sort_keys=True).encode("utf-8") + b"\n"
@@ -272,9 +296,9 @@ def test_pending_capture_executes_the_verified_handler_bytes_after_path_replacem
     from gateway import outbound_boundary
     original_exec = outbound_boundary._exec_pinned_handler
 
-    def replace_after_read(module_name, handler, source):
+    def replace_after_read(module_name, handler, source, **kwargs):
         (hook_dir / "handler.py").write_text("raise RuntimeError('replacement executed')\n", encoding="utf-8")
-        return original_exec(module_name, handler, source)
+        return original_exec(module_name, handler, source, **kwargs)
 
     monkeypatch.setattr(outbound_boundary, "_exec_pinned_handler", replace_after_read)
     outbound_boundary.capture_pending_outbound_attestation(hook_dir)
@@ -490,8 +514,8 @@ def test_inert_capture_requires_a_well_formed_external_preparation_record(tmp_pa
     assert outbound_boundary._prepared_release_for_hook(hook_dir) is None
 
 
-@pytest.mark.parametrize("peer_count", [0, 2])
-def test_prepared_manifest_accepts_nonempty_unique_ordered_profiles(tmp_path, peer_count):
+@pytest.mark.parametrize("peer_count", [1, 2])
+def test_prepared_manifest_accepts_at_least_two_unique_ordered_profiles(tmp_path, peer_count):
     from gateway import outbound_boundary
 
     hook_dir = tmp_path / "hooks" / "outbound-actionable"
@@ -515,7 +539,7 @@ def test_prepared_manifest_accepts_nonempty_unique_ordered_profiles(tmp_path, pe
 
 @pytest.mark.parametrize(
     "invalid",
-    ["empty", "duplicate-profile-id", "duplicate-hook-dir", "relative-hook-dir", "missing-current-hook"],
+    ["empty", "single", "duplicate-profile-id", "duplicate-hook-dir", "relative-hook-dir", "missing-current-hook"],
 )
 def test_prepared_manifest_rejects_ambiguous_or_unbound_profiles(tmp_path, invalid):
     from gateway import outbound_boundary
@@ -529,6 +553,8 @@ def test_prepared_manifest_rejects_ambiguous_or_unbound_profiles(tmp_path, inval
     ))
     if invalid == "empty":
         profiles = []
+    elif invalid == "single":
+        profiles = profiles[:1]
     elif invalid == "duplicate-profile-id":
         profiles[1]["profile_id"] = profiles[0]["profile_id"]
     elif invalid == "duplicate-hook-dir":
@@ -542,8 +568,8 @@ def test_prepared_manifest_rejects_ambiguous_or_unbound_profiles(tmp_path, inval
     assert outbound_boundary._prepared_release_for_hook(hook_dir) is None
 
 
-@pytest.mark.parametrize("peer_count", [0, 2])
-def test_activation_manifest_accepts_nonempty_unique_ordered_profiles(tmp_path, peer_count):
+@pytest.mark.parametrize("peer_count", [1, 2])
+def test_activation_manifest_accepts_at_least_two_unique_ordered_profiles(tmp_path, peer_count):
     from gateway import outbound_boundary
 
     hook_dir = tmp_path / "hooks" / "outbound-actionable"
@@ -564,12 +590,47 @@ def test_activation_manifest_accepts_nonempty_unique_ordered_profiles(tmp_path, 
 
     assert outbound_boundary.outbound_activation_is_ready(hook_dir) is True
     assert outbound_boundary._activated_handler_snapshot(hook_dir) is not None
-    assert outbound_boundary.load_installed_outbound_hooks(tmp_path) is not None
+    hooks = outbound_boundary.load_installed_outbound_hooks(tmp_path)
+    assert hooks is not None
+    assert hooks.outbound_profile_id == "research"
+
+
+def test_activated_handler_pins_declared_runtime_and_rehashes_before_each_call(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text(
+        "name: outbound-actionable\nevents: [outbound:before_send]\n", encoding="utf-8",
+    )
+    (hook_dir / "handler.py").write_text(
+        "def handle(*_args):\n"
+        "    return {'decision': 'allow', 'runtime_root': __hermes_runtime_root__, "
+        "'modules': sorted(__hermes_pinned_runtime_modules__)}\n",
+        encoding="utf-8",
+    )
+    _activate(hook_dir)
+    monkeypatch.setenv("HERMES_AGENT_KIT_HOME", "/attacker/opt")
+    monkeypatch.setenv("HERMES_AGENT_KIT_SCRIPTS", "/attacker/scripts")
+
+    hooks = load_installed_outbound_hooks(tmp_path)
+    first = outbound_before_send_sync(hooks, {"content": "safe"})
+    activation = json.loads((hook_dir / "release-activation.json").read_text(encoding="utf-8"))
+    shared = json.loads(Path(activation["activation_path"]).read_text(encoding="utf-8"))
+    identity = shared["profiles"][0]["runtime_identity"]
+
+    assert first.decision == "allow"
+    assert first.raw["runtime_root"] == identity["raw_root"]
+    assert first.raw["modules"] == ["outbound_actionable_seam.py"]
+
+    Path(identity["entry_path"]).write_text("# mutable opt drift\n", encoding="utf-8")
+    second = outbound_before_send_sync(hooks, {"content": "safe"})
+
+    assert second.decision == "deny"
+    assert second.reason == "boundary_unavailable"
 
 
 @pytest.mark.parametrize(
     "invalid",
-    ["empty", "duplicate-profile-id", "duplicate-hook-dir", "relative-hook-dir", "profile-hook-mismatch"],
+    ["empty", "single", "duplicate-profile-id", "duplicate-hook-dir", "relative-hook-dir", "profile-hook-mismatch"],
 )
 def test_activation_manifest_rejects_ambiguous_or_unbound_profiles(tmp_path, invalid):
     from gateway.outbound_boundary import outbound_activation_is_ready
@@ -586,6 +647,8 @@ def test_activation_manifest_rejects_ambiguous_or_unbound_profiles(tmp_path, inv
     profile_id = "atlas"
     if invalid == "empty":
         profiles = []
+    elif invalid == "single":
+        profiles = profiles[:1]
     elif invalid == "duplicate-profile-id":
         profiles[1]["profile_id"] = profiles[0]["profile_id"]
     elif invalid == "duplicate-hook-dir":
@@ -863,9 +926,9 @@ def test_active_registry_executes_pinned_handler_bytes_after_path_replacement(tm
     from gateway import outbound_boundary
     original_exec = outbound_boundary._exec_pinned_handler
 
-    def replace_after_read(module_name, handler, source):
+    def replace_after_read(module_name, handler, source, **kwargs):
         (hook_dir / "handler.py").write_text("raise RuntimeError('replacement executed')\n", encoding="utf-8")
-        return original_exec(module_name, handler, source)
+        return original_exec(module_name, handler, source, **kwargs)
 
     monkeypatch.setattr(outbound_boundary, "_exec_pinned_handler", replace_after_read)
     hooks = load_installed_outbound_hooks(tmp_path)

--- a/tests/gateway/test_outbound_boundary.py
+++ b/tests/gateway/test_outbound_boundary.py
@@ -126,6 +126,36 @@ def _prepare_capture(hook_dir):
     os.chmod(prepared, 0o600)
 
 
+def _prepared_control_path(hook_dir):
+    release = json.loads((hook_dir / "release-tuple.json").read_text(encoding="utf-8"))
+    tuple_digest = release["tuple_digest"].removeprefix("sha256:")
+    keg = Path(release["version_tuple"]["homebrew_keg_path"])
+    return keg.parent / ".outbound-actionable-activations" / f"{tuple_digest}.prepared.json"
+
+
+def _rewrite_prepared_profiles(hook_dir, profiles):
+    prepared = _prepared_control_path(hook_dir)
+    payload = json.loads(prepared.read_text(encoding="utf-8"))
+    payload["profiles"] = profiles
+    prepared.write_text(json.dumps(payload), encoding="utf-8")
+    os.chmod(prepared, 0o600)
+
+
+def _rewrite_activation_profiles(hook_dir, profiles, *, profile_id):
+    activation = hook_dir / "release-activation.json"
+    activation_payload = json.loads(activation.read_text(encoding="utf-8"))
+    shared = Path(activation_payload["activation_path"])
+    shared_payload = json.loads(shared.read_text(encoding="utf-8"))
+    shared_payload["profiles"] = profiles
+    data = json.dumps(shared_payload, sort_keys=True).encode("utf-8") + b"\n"
+    shared.write_bytes(data)
+    os.chmod(shared, 0o600)
+    activation_payload["profile_id"] = profile_id
+    activation_payload["activation_sha256"] = "sha256:" + hashlib.sha256(data).hexdigest()
+    activation.write_text(json.dumps(activation_payload), encoding="utf-8")
+    os.chmod(activation, 0o600)
+
+
 def test_missing_boundary_decision_fails_closed():
     decision = outbound_before_send_sync(HookRegistry(), {"content": "report"})
     assert decision.decision == "deny"
@@ -458,6 +488,115 @@ def test_inert_capture_requires_a_well_formed_external_preparation_record(tmp_pa
     prepared.write_text("not json", encoding="utf-8")
     os.chmod(prepared, 0o600)
     assert outbound_boundary._prepared_release_for_hook(hook_dir) is None
+
+
+@pytest.mark.parametrize("peer_count", [0, 2])
+def test_prepared_manifest_accepts_nonempty_unique_ordered_profiles(tmp_path, peer_count):
+    from gateway import outbound_boundary
+
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "kit-bundle-manifest.json").write_text("{}", encoding="utf-8")
+    _prepare_capture(hook_dir)
+    prepared = json.loads(_prepared_control_path(hook_dir).read_text(encoding="utf-8"))
+    own = {**prepared["profiles"][0], "profile_id": "research"}
+    peers = [
+        {**prepared["profiles"][1], "profile_id": f"peer-{index}", "hook_dir": str(tmp_path / f"peer-{index}" / "hooks" / "outbound-actionable")}
+        for index in range(peer_count)
+    ]
+    profiles = peers[:1] + [own] + peers[1:]
+    _rewrite_prepared_profiles(hook_dir, profiles)
+
+    result = outbound_boundary._prepared_release_for_hook(hook_dir)
+
+    assert result is not None
+    assert result[1]["profile_id"] == "research"
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    ["empty", "duplicate-profile-id", "duplicate-hook-dir", "relative-hook-dir", "missing-current-hook"],
+)
+def test_prepared_manifest_rejects_ambiguous_or_unbound_profiles(tmp_path, invalid):
+    from gateway import outbound_boundary
+
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "kit-bundle-manifest.json").write_text("{}", encoding="utf-8")
+    _prepare_capture(hook_dir)
+    profiles = json.loads(json.dumps(
+        json.loads(_prepared_control_path(hook_dir).read_text(encoding="utf-8"))["profiles"]
+    ))
+    if invalid == "empty":
+        profiles = []
+    elif invalid == "duplicate-profile-id":
+        profiles[1]["profile_id"] = profiles[0]["profile_id"]
+    elif invalid == "duplicate-hook-dir":
+        profiles[1]["hook_dir"] = profiles[0]["hook_dir"]
+    elif invalid == "relative-hook-dir":
+        profiles[1]["hook_dir"] = "relative/hooks/outbound-actionable"
+    else:
+        profiles[0]["hook_dir"] = str(tmp_path / "other" / "hooks" / "outbound-actionable")
+    _rewrite_prepared_profiles(hook_dir, profiles)
+
+    assert outbound_boundary._prepared_release_for_hook(hook_dir) is None
+
+
+@pytest.mark.parametrize("peer_count", [0, 2])
+def test_activation_manifest_accepts_nonempty_unique_ordered_profiles(tmp_path, peer_count):
+    from gateway import outbound_boundary
+
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text(
+        "def handle(*_args):\n    return {'decision': 'allow'}\n", encoding="utf-8",
+    )
+    _activate(hook_dir)
+    activation = json.loads((hook_dir / "release-activation.json").read_text(encoding="utf-8"))
+    shared = json.loads(Path(activation["activation_path"]).read_text(encoding="utf-8"))
+    own = {**shared["profiles"][0], "profile_id": "research"}
+    peers = [
+        {**shared["profiles"][1], "profile_id": f"peer-{index}", "hook_dir": str(tmp_path / f"peer-{index}" / "hooks" / "outbound-actionable")}
+        for index in range(peer_count)
+    ]
+    _rewrite_activation_profiles(hook_dir, peers[:1] + [own] + peers[1:], profile_id="research")
+
+    assert outbound_boundary.outbound_activation_is_ready(hook_dir) is True
+    assert outbound_boundary._activated_handler_snapshot(hook_dir) is not None
+    assert outbound_boundary.load_installed_outbound_hooks(tmp_path) is not None
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    ["empty", "duplicate-profile-id", "duplicate-hook-dir", "relative-hook-dir", "profile-hook-mismatch"],
+)
+def test_activation_manifest_rejects_ambiguous_or_unbound_profiles(tmp_path, invalid):
+    from gateway.outbound_boundary import outbound_activation_is_ready
+
+    hook_dir = tmp_path / "hooks" / "outbound-actionable"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text("events: [outbound:before_send]\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text("# handler\n", encoding="utf-8")
+    _activate(hook_dir)
+    activation = json.loads((hook_dir / "release-activation.json").read_text(encoding="utf-8"))
+    profiles = json.loads(json.dumps(
+        json.loads(Path(activation["activation_path"]).read_text(encoding="utf-8"))["profiles"]
+    ))
+    profile_id = "atlas"
+    if invalid == "empty":
+        profiles = []
+    elif invalid == "duplicate-profile-id":
+        profiles[1]["profile_id"] = profiles[0]["profile_id"]
+    elif invalid == "duplicate-hook-dir":
+        profiles[1]["hook_dir"] = profiles[0]["hook_dir"]
+    elif invalid == "relative-hook-dir":
+        profiles[1]["hook_dir"] = "relative/hooks/outbound-actionable"
+    else:
+        profile_id = "yuange"
+    _rewrite_activation_profiles(hook_dir, profiles, profile_id=profile_id)
+
+    assert outbound_activation_is_ready(hook_dir) is False
 
 
 @pytest.mark.parametrize("payload", [{}, {"schema_version": 1, "files": []}, {"schema_version": 1, "files": [{"path": "../escape", "sha256": "x"}], "bundle_sha256": "bad"}])

--- a/tests/gateway/test_protected_final_result_recovery_startup.py
+++ b/tests/gateway/test_protected_final_result_recovery_startup.py
@@ -1,0 +1,196 @@
+"""Gateway startup recovery seam coverage for #1478."""
+
+import pytest
+
+from gateway.config import GatewayConfig
+
+
+def test_gateway_startup_recovery_delegates_to_the_profile_level_sweep(monkeypatch):
+    from gateway.run import _recover_protected_final_results_at_gateway_startup
+
+    monkeypatch.setattr(
+        "cron.scheduler.recover_protected_final_result_repairs_for_home",
+        lambda: ["durable observer replayed"],
+    )
+
+    assert _recover_protected_final_results_at_gateway_startup() == ["durable observer replayed"]
+
+
+def test_gateway_startup_recovery_reports_when_the_sweep_fails(monkeypatch):
+    from gateway.run import _recover_protected_final_results_at_gateway_startup
+
+    monkeypatch.setattr(
+        "cron.scheduler.recover_protected_final_result_repairs_for_home",
+        lambda: (_ for _ in ()).throw(RuntimeError("unavailable")),
+    )
+
+    assert _recover_protected_final_results_at_gateway_startup() == [
+        "recovery_sweep_failed:default:unavailable"
+    ]
+
+
+def test_gateway_startup_recovery_sweeps_every_multiplex_profile(monkeypatch):
+    from gateway.run import _recover_protected_final_results_at_gateway_startup
+
+    homes = []
+    monkeypatch.setattr(
+        "cron.scheduler.recover_protected_final_result_repairs_for_home",
+        lambda home: homes.append(home) or [],
+    )
+
+    assert _recover_protected_final_results_at_gateway_startup([("atlas", "/atlas"), ("yuange", "/yuange")]) == []
+    assert homes == ["/atlas", "/yuange"]
+    assert _recover_protected_final_results_at_gateway_startup([("atlas",)]) == [
+        "recovery_profile_invalid:('atlas',)"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_start_invokes_protected_recovery_before_starting_the_scheduler(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    calls = []
+
+    class RunningRunner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = True
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+            self._restart_requested = False
+            self._restart_via_service = False
+
+        async def start(self):
+            return True
+
+        async def wait_for_shutdown(self):
+            return None
+
+    class Provider:
+        def start(self, _stop, **_kwargs):
+            calls.append("scheduler")
+
+        def stop(self):
+            return None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "GatewayRunner", RunningRunner)
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: Provider())
+    monkeypatch.setattr(gateway_run, "_recover_protected_final_results_at_gateway_startup", lambda: calls.append("recovery") or [])
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+
+    assert await gateway_run.start_gateway(config=GatewayConfig(), replace=False, verbosity=0) is True
+    assert calls[:2] == ["recovery", "scheduler"]
+
+
+def _patch_gateway_boot_dependencies(monkeypatch, tmp_path, runner_type):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", runner_type)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_gateway_start_blocks_before_adapter_start_when_recovery_is_pending(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    calls = []
+
+    class Runner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = True
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+            self._restart_requested = False
+            self._restart_via_service = False
+
+    _patch_gateway_boot_dependencies(monkeypatch, tmp_path, Runner)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: (_ for _ in ()).throw(RuntimeError("offline")))
+    monkeypatch.setattr(gateway_run, "_recover_protected_final_results_at_gateway_startup", lambda: ["repair pending"])
+
+    assert await gateway_run.start_gateway(config=GatewayConfig(), replace=False, verbosity=0) is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_start_blocks_when_multiplex_profile_inventory_cannot_be_resolved(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    calls = []
+
+    class Runner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = True
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+            self._restart_requested = False
+            self._restart_via_service = False
+
+    _patch_gateway_boot_dependencies(monkeypatch, tmp_path, Runner)
+    monkeypatch.setattr("hermes_cli.profiles.profiles_to_serve", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("inventory unavailable")))
+
+    assert await gateway_run.start_gateway(config=GatewayConfig(multiplex_profiles=True), replace=False, verbosity=0) is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_start_passes_the_recovered_multiplex_profiles_to_inprocess_scheduler(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    calls = []
+
+    class Runner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = True
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+            self._restart_requested = False
+            self._restart_via_service = False
+
+        async def start(self):
+            calls.append("adapter_start")
+            return True
+
+        async def wait_for_shutdown(self):
+            return None
+
+    _patch_gateway_boot_dependencies(monkeypatch, tmp_path, Runner)
+    monkeypatch.setattr("hermes_cli.profiles.profiles_to_serve", lambda **_kwargs: [("atlas", "/atlas"), ("yuange", "/yuange")])
+    monkeypatch.setattr(gateway_run, "_recover_protected_final_results_at_gateway_startup", lambda homes: calls.append(("recovery", homes)) or [])
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: InProcessCronScheduler())
+    monkeypatch.setattr(InProcessCronScheduler, "start", lambda _self, _stop, **kwargs: calls.append(("scheduler", kwargs.get("profile_homes"))))
+
+    assert await gateway_run.start_gateway(config=GatewayConfig(multiplex_profiles=True), replace=False, verbosity=0) is True
+    assert ("recovery", [("atlas", "/atlas"), ("yuange", "/yuange")]) in calls
+    assert ("scheduler", [("atlas", "/atlas"), ("yuange", "/yuange")]) in calls

--- a/tests/gateway/test_protected_final_result_recovery_startup.py
+++ b/tests/gateway/test_protected_final_result_recovery_startup.py
@@ -45,6 +45,28 @@ def test_gateway_startup_recovery_sweeps_every_multiplex_profile(monkeypatch):
     ]
 
 
+def test_pre_recovery_hook_discovery_reaches_every_multiplex_profile(monkeypatch):
+    from gateway.run import _discover_hooks_before_protected_result_recovery
+
+    discovered = []
+
+    class Registry:
+        def __init__(self, *, hooks_dir):
+            self.hooks_dir = hooks_dir
+
+        def discover_and_load(self):
+            discovered.append(str(self.hooks_dir))
+
+    monkeypatch.setattr("gateway.hooks.HookRegistry", Registry)
+
+    _discover_hooks_before_protected_result_recovery([
+        ("atlas", "/profiles/atlas"),
+        ("yuange", "/profiles/yuange"),
+    ])
+
+    assert discovered == ["/profiles/atlas/hooks", "/profiles/yuange/hooks"]
+
+
 @pytest.mark.asyncio
 async def test_gateway_start_invokes_protected_recovery_before_starting_the_scheduler(monkeypatch, tmp_path):
     import gateway.run as gateway_run
@@ -128,10 +150,22 @@ async def test_gateway_start_blocks_before_adapter_start_when_recovery_is_pendin
 
     _patch_gateway_boot_dependencies(monkeypatch, tmp_path, Runner)
     monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: (_ for _ in ()).throw(RuntimeError("offline")))
-    monkeypatch.setattr(gateway_run, "_recover_protected_final_results_at_gateway_startup", lambda: ["repair pending"])
+    class Registry:
+        def __init__(self, **_kwargs):
+            pass
+
+        def discover_and_load(self):
+            calls.append("hook_discovery")
+
+    monkeypatch.setattr("gateway.hooks.HookRegistry", Registry)
+    monkeypatch.setattr(
+        gateway_run,
+        "_recover_protected_final_results_at_gateway_startup",
+        lambda: calls.append("recovery") or ["repair pending"],
+    )
 
     assert await gateway_run.start_gateway(config=GatewayConfig(), replace=False, verbosity=0) is False
-    assert calls == []
+    assert calls == ["hook_discovery", "recovery"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_protected_final_result_recovery_startup.py
+++ b/tests/gateway/test_protected_final_result_recovery_startup.py
@@ -5,6 +5,26 @@ import pytest
 from gateway.config import GatewayConfig
 
 
+def _seed_pending_repair(home):
+    from cron.output_provenance import ProvenanceStore
+
+    store = ProvenanceStore(home)
+    store.bootstrap()
+    issued = store.issue(
+        profile_id="profile", job_id="job", occurrence_id="occurrence", target_id="target",
+        route_digest="sha256:route", raw_body=b"body", template_digest="sha256:template",
+        producer_class="llm_final",
+    )
+    claim = store.verify_and_claim(
+        proof=issued["proof"], raw_body_b64=issued["raw_body_b64"], decision="allow",
+    )
+    store.begin_send(
+        capability_id=claim["capability_id"], claim_id=claim["claim_id"], body=b"body",
+        rendered_body=b"body", route_digest="sha256:route",
+        post_send_repair_context={"content": "body"},
+    )
+
+
 def test_gateway_startup_recovery_delegates_to_the_profile_level_sweep(monkeypatch):
     from gateway.run import _recover_protected_final_results_at_gateway_startup
 
@@ -148,6 +168,7 @@ async def test_gateway_start_blocks_before_adapter_start_when_recovery_is_pendin
             self._restart_requested = False
             self._restart_via_service = False
 
+    _seed_pending_repair(tmp_path)
     _patch_gateway_boot_dependencies(monkeypatch, tmp_path, Runner)
     monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: (_ for _ in ()).throw(RuntimeError("offline")))
     class Registry:
@@ -159,13 +180,12 @@ async def test_gateway_start_blocks_before_adapter_start_when_recovery_is_pendin
 
     monkeypatch.setattr("gateway.hooks.HookRegistry", Registry)
     monkeypatch.setattr(
-        gateway_run,
-        "_recover_protected_final_results_at_gateway_startup",
-        lambda: calls.append("recovery") or ["repair pending"],
+        "gateway.outbound_boundary.load_installed_outbound_hooks",
+        lambda _home: None,
     )
 
     assert await gateway_run.start_gateway(config=GatewayConfig(), replace=False, verbosity=0) is False
-    assert calls == ["hook_discovery", "recovery"]
+    assert calls == ["hook_discovery"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -437,6 +437,39 @@ async def test_send_retries_transient_thread_not_found_before_fallback():
 
 
 @pytest.mark.asyncio
+async def test_delivery_transport_strict_route_never_falls_back_from_telegram_topic():
+    """Protected transport retries may not escape the proven Telegram topic."""
+    from gateway.delivery import DeliveryTransport
+
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+    transport = DeliveryTransport(
+        adapter=adapter,
+        config=adapter.config,
+        transport_platform=Platform.TELEGRAM,
+    )
+
+    result = await transport.send(
+        Platform.TELEGRAM,
+        "-100123",
+        "protected final result",
+        {"thread_id": "99999"},
+        strict_route=True,
+    )
+
+    assert result.success is False
+    assert "thread not found" in result.error.lower()
+    assert call_log
+    assert all(call.get("message_thread_id") == 99999 for call in call_log)
+
+
+@pytest.mark.asyncio
 async def test_send_private_dm_topic_uses_direct_messages_topic_id():
     """Private Telegram topics route sends via direct_messages_topic_id."""
     adapter = _make_adapter()

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1434,6 +1434,17 @@ class TestSendTelegramThreadIdMapping:
         call2_kwargs = bot.send_message.await_args_list[1].kwargs
         assert "message_thread_id" not in call2_kwargs
 
+    def test_strict_route_does_not_retry_a_missing_thread_on_the_bare_chat(self, monkeypatch):
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+        bot.send_message = AsyncMock(side_effect=Exception("Bad Request: message thread not found"))
+
+        result = asyncio.run(_send_telegram("tok", "-1001234567890", "hello", thread_id="17585", strict_route=True))
+
+        assert "thread not found" in result["error"].lower()
+        assert bot.send_message.await_count == 1
+        assert bot.send_message.await_args.kwargs["message_thread_id"] == 17585
+
     def test_thread_not_found_for_media_retries_without_message_thread_id(self, monkeypatch, tmp_path):
         """Media send with stale thread_id retries without it (#27012)."""
         bot = self._make_bot()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -774,7 +774,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    strict_route=False,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -854,6 +863,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            strict_route=strict_route,
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1167,7 +1177,16 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(
+    token,
+    chat_id,
+    message,
+    media_files=None,
+    thread_id=None,
+    disable_link_previews=False,
+    force_document=False,
+    strict_route=False,
+):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1302,7 +1321,11 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                     # Thread not found — retry without message_thread_id so the
                     # message still delivers (matching the gateway adapter's
                     # fallback behaviour, issue #27012).
-                    if _is_telegram_thread_not_found(md_error) and text_kwargs.get("message_thread_id") is not None:
+                    if (
+                        not strict_route
+                        and _is_telegram_thread_not_found(md_error)
+                        and text_kwargs.get("message_thread_id") is not None
+                    ):
                         logger.warning(
                             "Thread %s not found in _send_telegram, retrying without message_thread_id",
                             text_kwargs.get("message_thread_id"),


### PR DESCRIPTION
## Summary

- bind recurring-job final results to exact Profile, Job, occurrence, stable declared target, resolved route, raw body, rendered body, and template provenance
- validate exact versioned Homebrew runtime bytes before every activated boundary call
- record accepted-but-unconfirmed sends as indeterminate and never automatically resend them
- recover only durable after-send observer work, while allowing prepared first-start attestation when no observer is pending
- expose Profile-owned enforce/observe/warn/downgrade/off controls while preventing Job payload bypass
- fail closed on stale or unsafe provenance state and partial Profile activation

## Verification

- `466 passed` across the focused cron, gateway, provider, delivery, and send-message suites
- Ruff, compileall, and diff checks pass
- downstream Hermes Agent Kit patch reverse/apply checks pass

Downstream tracking: madlouse/hermes-agent-kit#1478