### PR TITLE
Fix: ASCII welcome banner glitches and triple-prints in narrow non-interactive terminals

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -860,10 +860,15 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
         padding=(0, 2),
     )
 
-    console.print()
+    from rich.console import Group
+    from rich.text import Text
+    
+    renderables = [Text("")]
     term_width = shutil.get_terminal_size().columns
     if term_width >= 95:
         _logo = _bskin.banner_logo if _bskin and hasattr(_bskin, 'banner_logo') and _bskin.banner_logo else HERMES_AGENT_LOGO
-        console.print(_logo)
-        console.print()
-    console.print(outer_panel)
+        renderables.append(_logo)
+        renderables.append(Text(""))
+    renderables.append(outer_panel)
+    
+    console.print(Group(*renderables))


### PR DESCRIPTION
When starting Hermes in a narrow terminal window or a non-interactive IDE output pane, the welcome banner stutters and prints overlapping copies of itself (e.g., printing the first 3 lines, then the first 3 lines again, then the full banner). 

This progressive rendering artifact happens because `prompt_toolkit` attempts to erase and redraw the active prompt multiple times during the startup sequence since `build_welcome_banner` issues 4 separate `console.print()` commands in a row (newlines, logo, and the outer panel). When the banner wraps, the ANSI cursor-up commands fail to clear the previous frames.

### Solution
This PR wraps all 4 components in a single `rich.console.Group`. This bundles the banner into a single atomic renderable, firing `console.print()` (and triggering `patch_stdout`) exactly once, completely eliminating the visual glitch.