### PR TITLE
fix(insights): normalize skill identity by resolved path, not bare name

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -289,40 +289,68 @@ class InsightsEngine:
         ]
 
     def _get_skill_usage(self, cutoff: float, source: str = None) -> List[Dict]:
-        """Extract per-skill usage from assistant tool calls."""
-        skill_counts: Dict[str, Dict[str, Any]] = {}
+        """Extract per-skill usage from successful, canonical skill actions.
 
+        Windowed by each call's own message timestamp (not the session's
+        ``started_at``), so a long-lived session that spans the cutoff still
+        reports only the actions that actually happened inside the window.
+
+        Each ``skill_view``/``skill_manage`` call is correlated against its
+        tool-result message via ``tool_call_id``:
+
+        - Calls whose result positively marks ``"success": false`` are
+          excluded (a failed lookup/edit is not usage).
+        - ``skill_view`` loads prefer ``result["path"]`` (the resolved
+          ``category/skill/SKILL.md`` location, trailing ``/SKILL.md``
+          stripped) as the canonical identity, so short (``skill``),
+          categorized (``category/skill``), and colon-qualified
+          (``category:skill``) spellings of the same skill coalesce into one
+          entry instead of splitting — and two different skills that happen
+          to share a bare frontmatter ``name`` in different categories stay
+          distinct. Plugin skills have no ``path``; those fall back to the
+          already-qualified ``result["name"]`` (``plugin:skill``).
+        - ``skill_view`` calls whose result read a supporting file
+          (``result["file"]`` set to something other than ``SKILL.md`` — i.e. a
+          ``references/*``/``templates/*``/``assets/*``/``scripts/*`` read) are
+          not counted as a top-level SKILL.md load.
+
+        When a call has no ``tool_call_id`` or no correlated result (older
+        rows, interrupted turns), it falls back to the raw argument name and is
+        still counted — we never invent a failure or a canonical identity we
+        can't verify from actual tool-result metadata.
+        """
         if source:
             cursor = self._conn.execute(
-                """SELECT m.tool_calls, m.timestamp
+                """SELECT m.session_id, m.tool_calls, m.timestamp
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
-                   WHERE s.started_at >= ? AND s.source = ?
+                   WHERE m.timestamp >= ? AND s.source = ?
                      AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
                 (cutoff, source),
             )
         else:
             cursor = self._conn.execute(
-                """SELECT m.tool_calls, m.timestamp
+                """SELECT m.session_id, m.tool_calls, m.timestamp
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
-                   WHERE s.started_at >= ?
+                   WHERE m.timestamp >= ?
                      AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
                 (cutoff,),
             )
 
+        calls: List[Dict[str, Any]] = []
+        session_ids: set = set()
         for row in cursor.fetchall():
             try:
-                calls = row["tool_calls"]
-                if isinstance(calls, str):
-                    calls = json.loads(calls)
-                if not isinstance(calls, list):
+                tool_calls = row["tool_calls"]
+                if isinstance(tool_calls, str):
+                    tool_calls = json.loads(tool_calls)
+                if not isinstance(tool_calls, list):
                     continue
             except (json.JSONDecodeError, TypeError):
                 continue
 
-            timestamp = row["timestamp"]
-            for call in calls:
+            for call in tool_calls:
                 if not isinstance(call, dict):
                     continue
                 func = call.get("function", {})
@@ -343,24 +371,102 @@ class InsightsEngine:
                 if not isinstance(skill_name, str) or not skill_name.strip():
                     continue
 
-                entry = skill_counts.setdefault(
-                    skill_name,
-                    {
-                        "skill": skill_name,
-                        "view_count": 0,
-                        "manage_count": 0,
-                        "last_used_at": None,
-                    },
-                )
-                if tool_name == "skill_view":
-                    entry["view_count"] += 1
-                else:
-                    entry["manage_count"] += 1
+                calls.append({
+                    "session_id": row["session_id"],
+                    "timestamp": row["timestamp"],
+                    "tool_name": tool_name,
+                    "call_id": call.get("id"),
+                    "args_name": skill_name,
+                })
+                session_ids.add(row["session_id"])
 
-                if timestamp is not None and (
-                    entry["last_used_at"] is None or timestamp > entry["last_used_at"]
+        if not calls:
+            return []
+
+        # Correlate against tool-result rows (role='tool') to know whether a
+        # call succeeded and, for skill_view, to read the tool's resolved
+        # canonical name / file field. A result always lands at or after its
+        # call's timestamp, so the same cutoff bounds this fetch too.
+        results_by_call: Dict[tuple, Any] = {}
+        placeholders = ",".join("?" for _ in session_ids)
+        result_cursor = self._conn.execute(
+            f"""SELECT session_id, tool_call_id, content FROM messages
+                WHERE role = 'tool' AND tool_call_id IS NOT NULL
+                  AND timestamp >= ? AND session_id IN ({placeholders})""",
+            (cutoff, *session_ids),
+        )
+        for row in result_cursor.fetchall():
+            results_by_call[(row["session_id"], row["tool_call_id"])] = row["content"]
+
+        skill_counts: Dict[str, Dict[str, Any]] = {}
+
+        for call in calls:
+            result_content = None
+            if call["call_id"] is not None:
+                result_content = results_by_call.get((call["session_id"], call["call_id"]))
+
+            result_data = None
+            if isinstance(result_content, str):
+                try:
+                    parsed = json.loads(result_content)
+                    if isinstance(parsed, dict):
+                        result_data = parsed
+                except (json.JSONDecodeError, TypeError):
+                    result_data = None
+
+            succeeded = result_data is not None and result_data.get("success") is True
+            failed = result_data is not None and result_data.get("success") is False
+            if failed:
+                continue
+
+            canonical_name = call["args_name"]
+            is_reference_read = False
+            if call["tool_name"] == "skill_view" and succeeded:
+                file_field = result_data.get("file")
+                if (
+                    isinstance(file_field, str)
+                    and file_field.rsplit("/", 1)[-1] != "SKILL.md"
                 ):
-                    entry["last_used_at"] = timestamp
+                    is_reference_read = True
+                else:
+                    path_field = result_data.get("path")
+                    name_field = result_data.get("name")
+                    if isinstance(path_field, str) and path_field.strip():
+                        # Bare frontmatter names collide across categories
+                        # (e.g. two unrelated "axolotl" skills) — the
+                        # resolved path is the collision-safe identity.
+                        canonical_name = (
+                            path_field[: -len("/SKILL.md")]
+                            if path_field.endswith("/SKILL.md")
+                            else path_field
+                        )
+                    elif isinstance(name_field, str) and name_field.strip():
+                        # Plugin skills (namespace:bare) have no path; the
+                        # qualified name is already collision-safe.
+                        canonical_name = name_field
+
+            if is_reference_read:
+                continue
+
+            entry = skill_counts.setdefault(
+                canonical_name,
+                {
+                    "skill": canonical_name,
+                    "view_count": 0,
+                    "manage_count": 0,
+                    "last_used_at": None,
+                },
+            )
+            if call["tool_name"] == "skill_view":
+                entry["view_count"] += 1
+            else:
+                entry["manage_count"] += 1
+
+            timestamp = call["timestamp"]
+            if timestamp is not None and (
+                entry["last_used_at"] is None or timestamp > entry["last_used_at"]
+            ):
+                entry["last_used_at"] = timestamp
 
         return list(skill_counts.values())
 

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -339,7 +339,6 @@ class InsightsEngine:
             )
 
         calls: List[Dict[str, Any]] = []
-        session_ids: set = set()
         for row in cursor.fetchall():
             try:
                 tool_calls = row["tool_calls"]
@@ -378,7 +377,6 @@ class InsightsEngine:
                     "call_id": call.get("id"),
                     "args_name": skill_name,
                 })
-                session_ids.add(row["session_id"])
 
         if not calls:
             return []
@@ -386,14 +384,17 @@ class InsightsEngine:
         # Correlate against tool-result rows (role='tool') to know whether a
         # call succeeded and, for skill_view, to read the tool's resolved
         # canonical name / file field. A result always lands at or after its
-        # call's timestamp, so the same cutoff bounds this fetch too.
+        # call's timestamp, so the same cutoff bounds this fetch too. Not
+        # filtered by session_id — the IN (...) clause could exceed SQLite's
+        # bound-variable limit for large session sets — the lookup below is
+        # keyed by (session_id, tool_call_id), so extra rows from other
+        # sessions are simply never matched.
         results_by_call: Dict[tuple, Any] = {}
-        placeholders = ",".join("?" for _ in session_ids)
         result_cursor = self._conn.execute(
-            f"""SELECT session_id, tool_call_id, content FROM messages
+            """SELECT session_id, tool_call_id, content FROM messages
                 WHERE role = 'tool' AND tool_call_id IS NOT NULL
-                  AND timestamp >= ? AND session_id IN ({placeholders})""",
-            (cutoff, *session_ids),
+                  AND timestamp >= ?""",
+            (cutoff,),
         )
         for row in result_cursor.fetchall():
             results_by_call[(row["session_id"], row["tool_call_id"])] = row["content"]

--- a/contributors/emails/edison.huang@shopline.com
+++ b/contributors/emails/edison.huang@shopline.com
@@ -1,0 +1,1 @@
+EdisonSL

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -1,5 +1,6 @@
 """Tests for agent/insights.py — InsightsEngine analytics and reporting."""
 
+import json
 import time
 import pytest
 
@@ -56,6 +57,7 @@ def populated_db(db):
         role="assistant",
         content="Let me load the PR workflow skill.",
         tool_calls=[{"function": {"name": "skill_view", "arguments": '{"name":"github-pr-workflow"}'}}],
+        timestamp=now - 2 * day + 1800,
     )
     db.append_message("s1", role="user", content="Thanks!")
     db.append_message("s1", role="assistant", content="You're welcome!")
@@ -99,6 +101,7 @@ def populated_db(db):
         role="assistant",
         content="Load the debugging skill.",
         tool_calls=[{"function": {"name": "skill_view", "arguments": '{"name":"systematic-debugging"}'}}],
+        timestamp=now - 10 * day + 1800,
     )
 
     # Session 4: Discord, same model as s1, ended, 1 day ago
@@ -120,6 +123,7 @@ def populated_db(db):
             {"function": {"name": "skill_view", "arguments": '{"name":"github-pr-workflow"}'}},
             {"function": {"name": "skill_manage", "arguments": '{"name":"github-code-review"}'}},
         ],
+        timestamp=now - 1 * day + 300,
     )
 
     # Session 5: Old session, 45 days ago (should be excluded from 30-day window)
@@ -133,6 +137,19 @@ def populated_db(db):
     db.update_token_counts("s_old", input_tokens=5000, output_tokens=2000)
     db.append_message("s_old", role="user", content="old message")
     db.append_message("s_old", role="assistant", content="old reply")
+    # This session started 45 days ago (excluded from `_get_sessions`'s
+    # started_at window at any of the day cutoffs these tests use), but it
+    # received a skill_view call just now — e.g. a long-lived/resumed session.
+    # The skill action must still be windowed by its own message timestamp,
+    # not the session's started_at (#regression: skill action windows must
+    # follow message time).
+    db.append_message(
+        "s_old",
+        role="assistant",
+        content="Load a skill in this old session.",
+        tool_calls=[{"function": {"name": "skill_view", "arguments": '{"name":"ancient-session-skill"}'}}],
+        timestamp=now - 3600,
+    )
 
     db._conn.commit()
     return db
@@ -428,10 +445,14 @@ class TestInsightsPopulated:
         report = engine.generate(days=30)
         skills = report["skills"]
 
-        assert skills["summary"]["distinct_skills_used"] == 3
-        assert skills["summary"]["total_skill_loads"] == 3
+        # 4 distinct skills: github-pr-workflow, systematic-debugging,
+        # github-code-review, plus ancient-session-skill (s_old's session
+        # started 45 days ago, but its skill_view call happened an hour ago —
+        # see the message-timestamp windowing test below).
+        assert skills["summary"]["distinct_skills_used"] == 4
+        assert skills["summary"]["total_skill_loads"] == 4
         assert skills["summary"]["total_skill_edits"] == 1
-        assert skills["summary"]["total_skill_actions"] == 4
+        assert skills["summary"]["total_skill_actions"] == 5
 
         top_skill = skills["top_skills"][0]
         assert top_skill["skill"] == "github-pr-workflow"
@@ -445,12 +466,34 @@ class TestInsightsPopulated:
         report = engine.generate(days=3)
         skills = report["skills"]
 
-        assert skills["summary"]["distinct_skills_used"] == 2
-        assert skills["summary"]["total_skill_loads"] == 2
+        # github-pr-workflow (s1 + s4), github-code-review (s4), and
+        # ancient-session-skill (s_old, message an hour ago) fall inside the
+        # 3-day window; systematic-debugging's call happened 10 days ago.
+        assert skills["summary"]["distinct_skills_used"] == 3
+        assert skills["summary"]["total_skill_loads"] == 3
         assert skills["summary"]["total_skill_edits"] == 1
 
         skill_names = [s["skill"] for s in skills["top_skills"]]
         assert "systematic-debugging" not in skill_names
+        assert "ancient-session-skill" in skill_names
+
+    def test_skill_action_windowed_by_message_timestamp_not_session_start(
+        self, populated_db
+    ):
+        """A skill action's own message timestamp gates inclusion, not the
+        session's started_at — s_old started 45 days ago (clearly excluded
+        from session-level stats at a 3-day cutoff) but its skill_view call
+        happened an hour ago and must still be reported.
+        """
+        engine = InsightsEngine(populated_db)
+        cutoff = time.time() - 3 * 86400
+
+        sessions = engine._get_sessions(cutoff)
+        assert not any(s["id"] == "s_old" for s in sessions)
+
+        skill_usage = engine._get_skill_usage(cutoff)
+        skill_names = [s["skill"] for s in skill_usage]
+        assert "ancient-session-skill" in skill_names
 
     def test_activity_patterns(self, populated_db):
         engine = InsightsEngine(populated_db)
@@ -505,6 +548,265 @@ class TestInsightsPopulated:
 
         # All 5 sessions should be included
         assert report["overview"]["total_sessions"] == 5
+
+    def test_skill_breakdown_source_filter(self, populated_db):
+        """Skill breakdown source filtering still works after the fix."""
+        engine = InsightsEngine(populated_db)
+        report = engine.generate(days=30, source="cli")
+        skills = report["skills"]
+
+        skill_names = [s["skill"] for s in skills["top_skills"]]
+        # github-code-review (skill_manage) only occurs in s4, which is a
+        # discord session — it must not leak into the cli-only breakdown.
+        assert "github-code-review" not in skill_names
+        # github-pr-workflow, systematic-debugging, and ancient-session-skill
+        # all occur in cli sessions (s1, s3, s_old) and remain visible.
+        assert "github-pr-workflow" in skill_names
+        assert "systematic-debugging" in skill_names
+        assert "ancient-session-skill" in skill_names
+
+        pr_workflow = next(s for s in skills["top_skills"] if s["skill"] == "github-pr-workflow")
+        # Only s1 (cli) contributes here — s4's view is on discord.
+        assert pr_workflow["view_count"] == 1
+
+
+# =========================================================================
+# Skill usage accuracy — alias coalescing, reference reads, failed calls
+# =========================================================================
+
+class TestSkillUsageAccuracy:
+    """Regression tests for accurate, canonical skill-usage accounting.
+
+    These correlate assistant ``tool_calls`` with their ``role='tool'``
+    result message via ``tool_call_id``, the same way a real
+    skill_view/skill_manage turn is persisted.
+    """
+
+    @staticmethod
+    def _skill_view_call(call_id, name, file_path=None):
+        args = {"name": name}
+        if file_path:
+            args["file_path"] = file_path
+        return {
+            "id": call_id, "type": "function",
+            "function": {"name": "skill_view", "arguments": json.dumps(args)},
+        }
+
+    @staticmethod
+    def _skill_manage_call(call_id, action, name, **kwargs):
+        args = {"action": action, "name": name, **kwargs}
+        return {
+            "id": call_id, "type": "function",
+            "function": {"name": "skill_manage", "arguments": json.dumps(args)},
+        }
+
+    def test_alias_forms_coalesce_to_canonical_name(self, db):
+        """skill_view accepts short, categorized, and colon-qualified
+        spellings of the same skill; the tool's resolved path
+        (read from the successful result, not the raw argument or the bare
+        frontmatter name) must coalesce them into one entry keyed by
+        ``category/skill`` instead of splitting usage across three
+        different keys — and instead of collapsing onto the bare
+        (collision-prone) frontmatter name.
+        """
+        db.create_session(session_id="alias", source="cli", model="test")
+
+        db.append_message(
+            "alias", role="assistant", content="short form",
+            tool_calls=[self._skill_view_call("call_1", "axolotl")],
+        )
+        db.append_message(
+            "alias", role="tool", tool_call_id="call_1",
+            content=json.dumps({"success": True, "name": "axolotl", "path": "mlops/axolotl/SKILL.md"}),
+        )
+
+        db.append_message(
+            "alias", role="assistant", content="categorized form",
+            tool_calls=[self._skill_view_call("call_2", "mlops/axolotl")],
+        )
+        db.append_message(
+            "alias", role="tool", tool_call_id="call_2",
+            content=json.dumps({"success": True, "name": "axolotl", "path": "mlops/axolotl/SKILL.md"}),
+        )
+
+        db.append_message(
+            "alias", role="assistant", content="colon fallback form",
+            tool_calls=[self._skill_view_call("call_3", "mlops:axolotl")],
+        )
+        db.append_message(
+            "alias", role="tool", tool_call_id="call_3",
+            content=json.dumps({"success": True, "name": "axolotl", "path": "mlops/axolotl/SKILL.md"}),
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        skills = report["skills"]
+
+        assert skills["summary"]["distinct_skills_used"] == 1
+        assert skills["summary"]["total_skill_loads"] == 3
+        top = skills["top_skills"][0]
+        assert top["skill"] == "mlops/axolotl"
+        assert top["view_count"] == 3
+
+    def test_same_bare_name_different_category_not_merged(self, db):
+        """Two unrelated skills that happen to share a bare frontmatter
+        ``name`` (e.g. both called "axolotl") but live in different
+        categories resolve to different ``path`` values and must stay
+        distinct entries — collapsing onto the bare name would silently
+        merge unrelated skills' usage counts.
+        """
+        db.create_session(session_id="collision", source="cli", model="test")
+
+        db.append_message(
+            "collision", role="assistant", content="load mlops axolotl",
+            tool_calls=[self._skill_view_call("call_1", "mlops/axolotl")],
+        )
+        db.append_message(
+            "collision", role="tool", tool_call_id="call_1",
+            content=json.dumps({"success": True, "name": "axolotl", "path": "mlops/axolotl/SKILL.md"}),
+        )
+
+        db.append_message(
+            "collision", role="assistant", content="load research axolotl",
+            tool_calls=[self._skill_view_call("call_2", "research/axolotl")],
+        )
+        db.append_message(
+            "collision", role="tool", tool_call_id="call_2",
+            content=json.dumps({"success": True, "name": "axolotl", "path": "research/axolotl/SKILL.md"}),
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        skills = report["skills"]
+
+        assert skills["summary"]["distinct_skills_used"] == 2
+        skill_names = {s["skill"] for s in skills["top_skills"]}
+        assert skill_names == {"mlops/axolotl", "research/axolotl"}
+        for entry in skills["top_skills"]:
+            assert entry["view_count"] == 1
+
+    def test_plugin_skill_without_path_uses_qualified_name(self, db):
+        """Plugin skills have no ``path`` in their result — the tool's
+        already-qualified ``namespace:bare`` name is the canonical identity.
+        """
+        db.create_session(session_id="plugin", source="cli", model="test")
+
+        db.append_message(
+            "plugin", role="assistant", content="load a plugin skill",
+            tool_calls=[self._skill_view_call("call_1", "my-plugin:axolotl")],
+        )
+        db.append_message(
+            "plugin", role="tool", tool_call_id="call_1",
+            content=json.dumps({"success": True, "name": "my-plugin:axolotl"}),
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        skills = report["skills"]
+
+        assert skills["summary"]["distinct_skills_used"] == 1
+        top = skills["top_skills"][0]
+        assert top["skill"] == "my-plugin:axolotl"
+        assert top["view_count"] == 1
+
+    def test_reference_file_read_not_counted_as_load(self, db):
+        """A skill_view(file_path='references/...') read must not inflate
+        the top-level SKILL.md load count for that skill.
+        """
+        db.create_session(session_id="refs", source="cli", model="test")
+
+        db.append_message(
+            "refs", role="assistant", content="load the skill",
+            tool_calls=[self._skill_view_call("call_1", "axolotl")],
+        )
+        db.append_message(
+            "refs", role="tool", tool_call_id="call_1",
+            content=json.dumps({"success": True, "name": "axolotl", "path": "axolotl/SKILL.md"}),
+        )
+
+        db.append_message(
+            "refs", role="assistant", content="check the reference doc",
+            tool_calls=[self._skill_view_call("call_2", "axolotl", file_path="references/api.md")],
+        )
+        db.append_message(
+            "refs", role="tool", tool_call_id="call_2",
+            content=json.dumps({
+                "success": True, "name": "axolotl",
+                "file": "references/api.md", "content": "...", "file_type": ".md",
+            }),
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        skills = report["skills"]
+
+        assert skills["summary"]["distinct_skills_used"] == 1
+        assert skills["summary"]["total_skill_loads"] == 1
+        top = skills["top_skills"][0]
+        assert top["view_count"] == 1
+
+    def test_failed_skill_action_excluded(self, db):
+        """A skill_manage call whose tool result reports success=False must
+        not be counted as usage.
+        """
+        db.create_session(session_id="failed", source="cli", model="test")
+
+        db.append_message(
+            "failed", role="assistant", content="patch a skill that doesn't exist",
+            tool_calls=[self._skill_manage_call(
+                "call_1", "patch", "nonexistent-skill",
+                old_string="x", new_string="y",
+            )],
+        )
+        db.append_message(
+            "failed", role="tool", tool_call_id="call_1",
+            content=json.dumps({
+                "success": False,
+                "error": "Skill 'nonexistent-skill' not found in active profile 'default'.",
+            }),
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        skills = report["skills"]
+
+        assert skills["summary"]["total_skill_actions"] == 0
+        assert skills["top_skills"] == []
+
+    def test_successful_correlated_call_still_counts(self, db):
+        """A correlated, successful skill_manage call is counted normally —
+        the failure exclusion must not become an accidental allowlist.
+        """
+        db.create_session(session_id="ok", source="cli", model="test")
+
+        db.append_message(
+            "ok", role="assistant", content="patch the skill",
+            tool_calls=[self._skill_manage_call(
+                "call_1", "patch", "axolotl", old_string="x", new_string="y",
+            )],
+        )
+        db.append_message(
+            "ok", role="tool", tool_call_id="call_1",
+            content=json.dumps({
+                "success": True,
+                "message": "Patched SKILL.md in skill 'axolotl' (1 replacement).",
+            }),
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        skills = report["skills"]
+
+        assert skills["summary"]["total_skill_edits"] == 1
+        top = skills["top_skills"][0]
+        assert top["skill"] == "axolotl"
+        assert top["manage_count"] == 1
 
 
 # =========================================================================

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -808,6 +808,44 @@ class TestSkillUsageAccuracy:
         assert top["skill"] == "axolotl"
         assert top["manage_count"] == 1
 
+    def test_result_lookup_not_bounded_by_session_id_in_clause(self, db):
+        """The tool-result correlation query must not filter by
+        ``session_id IN (...)`` — that clause's parameter count scales with
+        the number of distinct sessions in the window and can exceed
+        SQLite's bound-variable limit (``sqlite3.OperationalError: too many
+        SQL variables``) once a report spans enough sessions. Force a tiny
+        limit here so the regression reproduces regardless of how the
+        SQLite build on any given machine is compiled.
+        """
+        import sqlite3
+
+        num_sessions = 10
+        for i in range(num_sessions):
+            session_id = f"many-{i}"
+            db.create_session(session_id=session_id, source="cli", model="test")
+            db.append_message(
+                session_id, role="assistant", content="load a skill",
+                tool_calls=[self._skill_view_call("call_1", "axolotl")],
+            )
+            db.append_message(
+                session_id, role="tool", tool_call_id="call_1",
+                content=json.dumps({"success": True, "name": "axolotl", "path": "axolotl/SKILL.md"}),
+            )
+        db._conn.commit()
+
+        # Applied only now, after setup writes (which themselves bind more
+        # than 4 params) — isolates the limit to the query under test.
+        db._conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 4)
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        skills = report["skills"]
+
+        assert skills["summary"]["distinct_skills_used"] == 1
+        top = skills["top_skills"][0]
+        assert top["skill"] == "axolotl"
+        assert top["view_count"] == num_sessions
+
 
 # =========================================================================
 # Formatting


### PR DESCRIPTION
## Summary

`hermes insights` under-reported and mis-attributed skill usage from `skill_view`/`skill_manage` tool calls:

- Every raw argument spelling (`axolotl`, `mlops/axolotl`, `mlops:axolotl`, ...) was counted as a separate skill instead of coalescing to one entry.
- Failed lookups/edits (`"success": false`) were counted as usage.
- Supporting-file reads (`references/*`, `templates/*`, `assets/*`, `scripts/*`) inflated the top-level SKILL.md load count.
- Skill actions were windowed by the session's `started_at` instead of the action's own message timestamp, so long-lived/resumed sessions dropped recent skill activity that fell outside the session-level window.

`_get_skill_usage` now correlates each `skill_view`/`skill_manage` call with its `role='tool'` result via `tool_call_id`:

- Calls whose result marks `"success": false` are excluded.
- `skill_view` calls that read a supporting file (`result["file"]` present and not `SKILL.md`) don't count as a top-level load.
- Successful `skill_view` loads are keyed by the tool's resolved `result["path"]` (category-qualified, trailing `/SKILL.md` stripped — e.g. `mlops/axolotl`) rather than the bare frontmatter `result["name"]`. Bare names can collide across categories, so two unrelated skills that happen to share a frontmatter `name` in different categories now stay distinct entries instead of silently merging. Plugin skills have no `path`; those fall back to the already-qualified `result["name"]` (`namespace:skill`).
- Calls with no `tool_call_id` or no correlated result (older rows, interrupted turns) conservatively fall back to the raw argument name — never inventing a failure or an identity we can't verify from actual tool-result metadata.
- Windowing now uses each call's own `messages.timestamp`, not the session's `started_at`.
- Source filtering (`source=` param) is preserved through the new correlation query.

## Test plan

- [x] `scripts/run_tests.sh tests/agent/test_insights.py` — 67/67 passed
- [x] `scripts/run_tests.sh tests/agent/test_insights.py tests/cli/test_cli_insights_command.py tests/gateway/test_insights_unicode_flags.py` — 81/81 passed
- [x] `scripts/run_tests.sh tests/tools/test_skill_view_path_check.py tests/tools/test_skills_tool.py` — 95/95 passed (confirms the `skill_view` result shape this fix relies on: `path`/`name`/`file` fields)
- [x] Verified the 7 new/updated regression assertions fail against the pre-fix code and pass after the fix (confirmed via temporary revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)