### PR TITLE
Fix skills audit misclassifying official multi-segment skills as community (#73099)

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1134,7 +1134,18 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
             c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
             continue
 
-        result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
+        # Audit-time must mirror the install-time special case for official
+        # bundles: a multi-segment identifier like
+        # "official/software-development/subagent-driven-development" must be
+        # scanned with source="official", not the full identifier (which the
+        # trust resolver only recognizes as the literal "official"). Otherwise
+        # installed official skills are misclassified as community and can flip
+        # an allowed CAUTION verdict into a BLOCKED one. See issue #73099.
+        _audit_source = (
+            "official" if entry.get("source") == "official"
+            else entry.get("identifier", entry["source"])
+        )
+        result = scan_skill(skill_path, source=_audit_source)
         c.print(format_scan_report(result))
 
         if deep:


### PR DESCRIPTION
## Summary
Fixes #73099

`hermes skills audit` misclassified installed official optional skills as `community` whenever their lockfile identifier was a multi-segment value such as `official/software-development/subagent-driven-development`.

### Root cause
At audit time, `do_audit` passed the full lockfile identifier into the trust resolver:
```python
result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
```
The trust resolver only recognizes the literal string `"official"`, so a multi-segment identifier fell through to the `community` branch — flipping an allowed `CAUTION` verdict into a misleading `BLOCKED` one, even though install-time scan (skills_hub.py:664) correctly treated the same bundle as `official/builtin`.

### Fix
Mirror the install-time special case: when `entry["source"] == "official"`, scan with `source="official"` at audit time too.

### Reproduction (before fix)
```bash
hermes skills install official/software-development/subagent-driven-development
hermes skills audit subagent-driven-development
# -> Scan: .../community | Verdict: CAUTION | Decision: BLOCKED (wrong)
```

### Test plan
- [x] ast.parse passes on the edited module
- [ ] Add regression test asserting official multi-segment skills audit as official not community
- [ ] Manual: hermes skills audit on an installed official optional skill shows source=official

### Impact
P3 / CLI / tool/skills — no behavioural change for non-official sources; only corrects the official-bundle audit classification.