### PR TITLE
fix(desktop): shrink model-visibility switches to xs

### DIFF
--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -114,7 +114,7 @@ export function ModelVisibilityDialog({
                           {name}
                           {tag ? <span className="text-(--ui-text-tertiary)"> {tag}</span> : null}
                         </span>
-                        <Switch checked={visible.has(key)} onCheckedChange={() => toggle(provider, family.id)} />
+                        <Switch checked={visible.has(key)} onCheckedChange={() => toggle(provider, family.id)} size="xs" />
                       </label>
                     )
                   })}


### PR DESCRIPTION
## Summary

The model-visibility dialog rendered its toggles at the `Switch` default size (`h-5 w-9`), which towered over the `text-xs` model rows. The `Switch` primitive already ships a compact `xs` variant (`h-4 w-7`) built for dense rows like this — the dialog just wasn't asking for it. Pass `size="xs"`.

## Test plan
- [ ] Open the model-visibility dialog; switches sit inline with the model labels instead of dominating each row.