### PR TITLE
fix(doctor): probe Anthropic at configured base_url instead of hardcoded api.anthropic.com

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2082,6 +2082,51 @@ def run_doctor(args):
         key = get_anthropic_key()
         if not key:
             return _ConnectivityResult("Anthropic API", [], [])
+
+        # --- resolve effective base_url (config → env → provider default) ---
+        from urllib.parse import urlparse
+        from agent.anthropic_adapter import (
+            _is_third_party_anthropic_endpoint,
+        )
+        from providers import get_provider_profile
+
+        base_url: str | None = None
+
+        # 1. config.yaml model.base_url (only when provider == "anthropic")
+        try:
+            import yaml
+            raw_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            raw_config = {}
+        model_section = raw_config.get("model") or {}
+        if isinstance(model_section, dict) and (model_section.get("provider") or "").strip().lower() == "anthropic":
+            cfg_base = (model_section.get("base_url") or "").strip()
+            if cfg_base:
+                base_url = cfg_base
+
+        # 2. ANTHROPIC_BASE_URL environment variable
+        if not base_url:
+            base_url = os.environ.get("ANTHROPIC_BASE_URL", "").strip() or None
+
+        # 3. provider profile default
+        if not base_url:
+            profile = get_provider_profile("anthropic")
+            if profile and profile.base_url:
+                base_url = profile.base_url
+
+        # --- build models_url and label ---
+        base = base_url.rstrip("/") if base_url else "https://api.anthropic.com"
+        if not base.endswith("/v1"):
+            base += "/v1"
+        models_url = base + "/models"
+
+        is_third_party = _is_third_party_anthropic_endpoint(base_url)
+        if is_third_party:
+            host = urlparse(base_url).netloc
+            label = f"Anthropic API (relay: {host})"
+        else:
+            label = "Anthropic API"
+
         try:
             import httpx
             from agent.anthropic_adapter import (
@@ -2090,6 +2135,7 @@ def run_doctor(args):
                 _OAUTH_ONLY_BETAS,
                 _CONTEXT_1M_BETA,
             )
+
             headers = {"anthropic-version": "2023-06-01"}
             is_oauth = _is_oauth_token(key)
             if is_oauth:
@@ -2098,7 +2144,7 @@ def run_doctor(args):
             else:
                 headers["x-api-key"] = key
             r = httpx.get(
-                "https://api.anthropic.com/v1/models",
+                models_url,
                 headers=headers, timeout=10,
             )
             # Reactive recovery: OAuth subscriptions without 1M context reject the
@@ -2116,32 +2162,32 @@ def run_doctor(args):
                     + list(_OAUTH_ONLY_BETAS)
                 )
                 r = httpx.get(
-                    "https://api.anthropic.com/v1/models",
+                    models_url,
                     headers=headers, timeout=10,
                 )
             if r.status_code == 200:
                 return _ConnectivityResult(
-                    "Anthropic API",
-                    [(color("✓", Colors.GREEN), "Anthropic API", "")],
+                    label,
+                    [(color("✓", Colors.GREEN), label, "")],
                     [],
                 )
             if r.status_code == 401:
                 return _ConnectivityResult(
-                    "Anthropic API",
-                    [(color("✗", Colors.RED), "Anthropic API",
+                    label,
+                    [(color("✗", Colors.RED), label,
                       color("(invalid API key)", Colors.DIM))],
                     [],
                 )
             return _ConnectivityResult(
-                "Anthropic API",
-                [(color("⚠", Colors.YELLOW), "Anthropic API",
+                label,
+                [(color("⚠", Colors.YELLOW), label,
                   color("(couldn't verify)", Colors.DIM))],
                 [],
             )
         except Exception as e:
             return _ConnectivityResult(
-                "Anthropic API",
-                [(color("⚠", Colors.YELLOW), "Anthropic API",
+                label,
+                [(color("⚠", Colors.YELLOW), label,
                   color(f"({e})", Colors.DIM))],
                 [],
             )

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1701,3 +1701,201 @@ terminal:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+@pytest.fixture
+def _doctor_probe_env(monkeypatch, tmp_path):
+    """Common monkeypatch setup for anthropic doctor probe tests."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    return home, project
+
+
+def test_run_doctor_anthropic_probe_uses_config_relay_base_url(monkeypatch, tmp_path, _doctor_probe_env):
+    home, project = _doctor_probe_env
+    (home / "config.yaml").write_text(
+        "model:\n  provider: anthropic\n  base_url: https://asia.qcode.cc/api\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text("ANTHROPIC_API_KEY=sk-test\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200, text="")
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert any(url == "https://asia.qcode.cc/api/v1/models" for url, _, _ in calls)
+    assert "relay: asia.qcode.cc" in out
+
+
+def test_run_doctor_anthropic_probe_default_endpoint_unchanged(monkeypatch, tmp_path, _doctor_probe_env):
+    home, project = _doctor_probe_env
+    (home / "config.yaml").write_text("model:\n  provider: anthropic\n", encoding="utf-8")
+    (home / ".env").write_text("ANTHROPIC_API_KEY=sk-test\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200, text="")
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert any(url == "https://api.anthropic.com/v1/models" for url, _, _ in calls)
+    assert "Anthropic API (relay:" not in out
+
+
+def test_run_doctor_anthropic_probe_relay_401_labels_host(monkeypatch, tmp_path, _doctor_probe_env):
+    home, project = _doctor_probe_env
+    (home / "config.yaml").write_text(
+        "model:\n  provider: anthropic\n  base_url: https://asia.qcode.cc/api\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text("ANTHROPIC_API_KEY=sk-bad\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-bad")
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=401, text="")
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert any(url == "https://asia.qcode.cc/api/v1/models" for url, _, _ in calls)
+    assert "relay: asia.qcode.cc" in out
+    assert "invalid API key" in out
+
+
+def test_run_doctor_anthropic_probe_silent_without_key(monkeypatch, tmp_path, _doctor_probe_env):
+    home, project = _doctor_probe_env
+    (home / "config.yaml").write_text(
+        "model:\n  provider: anthropic\n  base_url: https://asia.qcode.cc/api\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200, text="")
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert not any("anthropic.com" in url or "asia.qcode.cc" in url for url, _, _ in calls)
+    assert "Anthropic API" not in out
+
+
+def test_run_doctor_anthropic_probe_base_url_with_v1_not_duplicated(monkeypatch, tmp_path, _doctor_probe_env):
+    home, project = _doctor_probe_env
+    (home / "config.yaml").write_text(
+        "model:\n  provider: anthropic\n  base_url: https://x.com/v1\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text("ANTHROPIC_API_KEY=sk-test\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200, text="")
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    assert any(url == "https://x.com/v1/models" for url, _, _ in calls)
+    assert not any("/v1/v1/" in url for url, _, _ in calls)
+
+
+def test_run_doctor_anthropic_probe_uses_env_base_url_fallback(monkeypatch, tmp_path, _doctor_probe_env):
+    home, project = _doctor_probe_env
+    (home / "config.yaml").write_text("model:\n  provider: anthropic\n", encoding="utf-8")
+    (home / ".env").write_text("ANTHROPIC_API_KEY=sk-test\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://my-proxy.local")
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200, text="")
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert any(url == "https://my-proxy.local/v1/models" for url, _, _ in calls)
+    assert "relay: my-proxy.local" in out


### PR DESCRIPTION
## Problem

`hermes doctor` hardcodes `https://api.anthropic.com/v1/models` when probing Anthropic connectivity. For users who configure a third-party Anthropic relay via `model.base_url` in `config.yaml` (or `ANTHROPIC_BASE_URL`), the probe hits the **official** endpoint with a relay-issued key and reports:

```
✗ Anthropic API (invalid API key)
```

—a false negative, since the actual runtime (`agent/anthropic_adapter.py`) correctly routes API calls to the configured `base_url`. The doctor check was therefore misleading exactly for the users it should help most (relay/proxy users diagnosing connectivity).

## Root cause

In `hermes_cli/doctor.py`, `_probe_anthropic()` built the probe URL from a hardcoded constant instead of the effective configured `base_url`.

## Fix

`_probe_anthropic()` now resolves the effective base URL with the same precedence chain the runtime uses:

1. `config.yaml` → `model.base_url` (only when `model.provider == "anthropic"`)
2. `ANTHROPIC_BASE_URL` environment variable
3. provider profile default (`get_provider_profile("anthropic").base_url` → `https://api.anthropic.com`)

then builds `{base}/v1/models` (appending `/v1` only when absent, so `https://x.com/v1` does not become `/v1/v1/models`).

**Labeling:** when the resolved endpoint is third-party (reusing `_is_third_party_anthropic_endpoint()` from the runtime adapter), the report row is labeled with the relay host so users can see at a glance which endpoint was probed:

```
✓ Anthropic API (relay: asia.qcode.cc)
```

The official endpoint keeps the plain `Anthropic API` label — zero output change for default users. The label is computed before the request `try` block so all four result paths (200 / 401 / other / exception) carry the same label.

**Scope discipline:** OAuth 1M-beta retry logic unchanged; no-key path stays silent (unchanged); zero new dependencies (`urllib.parse`, `yaml` already used in this file); only `hermes_cli/doctor.py` + its test file touched.

## Tests

6 new behavior tests in `tests/hermes_cli/test_doctor.py` (via `run_doctor` end-to-end with `httpx.get` mocked, following the file's existing probe-test pattern; shared setup extracted to a `_doctor_probe_env` fixture):

1. relay `base_url` from config → probe hits `{relay}/v1/models`, label shows relay host
2. default endpoint unchanged (regression guard, exercises provider-profile fallback)
3. relay 401 → `✗` row labeled with relay host (fixes the original misdiagnosis)
4. no key → probe stays silent (unchanged behavior)
5. `base_url` already ending in `/v1` → no `/v1/v1` duplication
6. `ANTHROPIC_BASE_URL` env fallback (config without `base_url`) → env URL used

Red-green validated: tests 1/3/5 fail against the old hardcoded implementation, pass with the fix.

```
scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q
=== Summary: 1 files, 85 tests passed, 0 failed (100% complete) ===
```

Manual E2E with a relay-configured profile (`model.provider: anthropic`, `model.base_url: https://asia.qcode.cc/api`):

```
$ hermes --profile q-code-consultant doctor
✓ Anthropic API (relay: asia.qcode.cc)     # before: ✗ Anthropic API (invalid API key)
```

A profile without an Anthropic key shows no Anthropic row at all, as before.

## Security note

When a relay is configured, the probe now sends the configured key to that relay — the same behavior as the runtime adapter on every API call (`anthropic_adapter.py` uses the identical `base_url`). This is the intended purpose of configuring `model.base_url`; the probe change introduces no new trust surface. If maintainers want scheme validation (e.g. warn on `http://` relays) that would be a separate hardening discussion touching both the adapter and the probe.
