### PR TITLE
Add onchain-safety optional skill: pre-execution risk analysis for onchain actions

### DIFF
--- a/optional-skills/blockchain/onchain-safety/SKILL.md
+++ b/optional-skills/blockchain/onchain-safety/SKILL.md
@@ -1,91 +1,98 @@
 ---
 name: onchain-safety
-description: Pre-execution risk analysis for onchain actions — flags scam contracts, dangerous token approvals, MEV exposure, and unsafe swaps before signing. For agents and users reviewing crypto transactions, ERC-20 allowances, and DEX quotes.
+description: Pre-flight risk analysis for onchain actions before signing.
 version: 0.1.0
 author: Baophan (Baophan00), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [Onchain, Blockchain, Crypto, Safety, Security, DeFi, Wallet, Risk]
+    tags: [Onchain, Blockchain, Crypto, Safety, Security, DeFi]
     related_skills: [hyperliquid, solana, evm]
 ---
 
 # Onchain Safety Skill
 
-Risk-analysis layer for onchain actions. Before an agent (or user) signs a
-swap, approval, or contract call, this skill inspects the action and returns a
-**GO / CAUTION / NO-GO** verdict with concrete reasons — mirroring how an RL
-reward model would score a trajectory step without executing it.
+Read-only risk advisor that scores a pending onchain action **before** an agent
+or agentic wallet signs it. It inspects calldata for the four high-risk ERC-20
+/ ERC-721 selectors and returns a **GO / CAUTION / NO-GO** verdict with concrete
+reasons — mirroring how an RL reward model would score a trajectory step
+without executing it.
 
-Read-only analysis. No signing, no key handling, no transaction broadcast.
+It does **not** sign, hold keys, or broadcast transactions. It is a brake, not
+an executor.
 
 ---
 
 ## When to Use
 
-- User (or agent) is about to sign an ERC-20 `approve`, a DEX swap, or call a contract
-- User pastes a transaction payload, calldata, or a contract/token address for review
+- User (or agent) is about to sign an ERC-20 `approve`, `setApprovalForAll`,
+  `permit`, or `swapExactTokensForTokens` call
+- User pastes calldata or a transaction payload for review
 - User asks "is this safe?", "should I approve this?", "is this contract a scam?"
-- Agentic wallet (e.g. OKX Agentic Wallet) is about to execute an onchain step and wants a pre-flight check
+- An agentic wallet (OKX Agentic Wallet, SmartVault) is about to execute an
+  onchain step and wants a pre-flight check
 
 ---
 
-## Pre-flight Check (agent-facing procedure)
+## Prerequisites
 
-Run this checklist on any pending onchain action. Each failed check downgrades
-the verdict one level (GO → CAUTION → NO-GO).
-
-| # | Check | NO-GO if | Tool / source |
-|---|---|---|---|
-| 1 | Address reputation | Contract not in a known-good allowlist AND no public audit/label | block explorer label API |
-| 2 | Approval size | `approve` sets `amount = max(uint256)` (unlimited) | decode calldata `spender`+`amount` |
-| 3 | Token legitimacy | Token has no liquidity, mint function owned by EOA, or honeypot flags | dex pair / holder scan |
-| 4 | MEV exposure | Swap slippage > 3% or path crosses low-liquidity pool | quote vs spot |
-| 5 | Phishing pattern | Calldata calls `setApprovalForAll` on NFT or `permit` with deadline 0 | decode calldata |
-| 6 | Chain sanity | Target chain mismatches agent's active network | config compare |
-
-### Verdict rules
-- All pass → **GO**
-- 1–2 minor (CAUTION-class) → **CAUTION** (proceed with limit: bounded amount, revocable)
-- Any NO-GO check → **NO-GO** (do not sign; explain which check failed)
-
----
-
-## Calldata decoding (stdlib only)
-
-The helper script decodes the four high-risk selectors without external libs:
+Stdlib only (`argparse`, `json`). No API key, no external packages.
 
 ```bash
 python3 ~/.hermes/skills/blockchain/onchain-safety/scripts/decode_action.py \
-  --chain ethereum \
-  --to 0x... \
-  --data 0x...
+  --chain ethereum --to 0x... --data 0x...
 ```
 
-Selectors recognized:
-- `0x095ea7b3` — `approve(address,uint256)`
-- `0xa22cb465` — `setApprovalForAll(address,bool)`
-- `0xd505accf` — `permit(...)`
-- `0x38ed1739` — `swapExactTokensForTokens(...)`
+---
 
-Output: JSON with `{action, spender, amount, unlimited, risk}`.
+## Quick Reference
+
+| Selector | Action | NO-GO trigger |
+|---|---|---|
+| `0x095ea7b3` | `approve(address,uint256)` | amount = max(uint256) |
+| `0xa22cb465` | `setApprovalForAll(address,bool)` | approved = true |
+| `0xd505accf` | `permit(...)` | deadline = 0 |
+| `0x38ed1739` | `swapExactTokensForTokens(...)` | deadline = 0 |
+
+Malformed calldata for a recognized selector → **NO-GO** (fail-closed).
 
 ---
 
-## Integrations
+## Procedure
 
-If an agentic-wallet skill is loaded (OKX Agentic Wallet, SmartVault), call
-this skill's pre-flight check **before** invoking the wallet's sign path. The
-wallet skill remains the executor; this skill is the brake.
-
-**IF** `OKX_AGENTIC_WALLET` configured → route NO-GO verdicts back to the
-wallet as a hard abort. **ELSE** → surface verdict to the user as a warning.
+1. Agent receives a pending onchain action (calldata + target address)
+2. Run `decode_action.py --to <addr> --data <hex>`
+3. Inspect the returned `risk` field:
+   - `NO-GO` — abort the sign call; surface `reason` to the user
+   - `CAUTION` — proceed with a bounded amount; log the warning
+   - `ok` — no structural red flags detected
+4. If integrated with an agentic-wallet skill, route `NO-GO` verdicts back as a
+   hard abort before the wallet's sign path is invoked
 
 ---
 
-## Security note
+## Pitfalls
 
-This skill never holds keys and never broadcasts. It is a read-only advisor.
-A GO verdict is not financial advice — it means "no structural red flags
-detected", not "this trade will profit".
+- **This skill does not validate token legitimacy or contract audits** — it
+  only decodes the four selectors. For full contract risk, pair with a block-
+  explorer label API.
+- **Deadline checks are binary** (0 = NO-GO). A non-zero but low deadline is
+  still CAUTION, not GO.
+- **Calldata must be complete.** Truncated calldata for a recognized selector
+  returns NO-GO (fail-closed) rather than guessing.
+
+---
+
+## Verification
+
+```bash
+# Unlimited approve -> NO-GO
+python3 scripts/decode_action.py --to 0xAa --data \
+  0x095ea7b300000000000000000000000000000000000000000000deadbeef00000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+# expect risk=NO-GO, unlimited=true
+
+# Truncated calldata -> NO-GO (fail-closed)
+python3 scripts/decode_action.py --to 0xAa --data 0x095ea7b3
+# expect risk=NO-GO, reason="malformed calldata: insufficient ABI words"
+```

--- a/optional-skills/blockchain/onchain-safety/SKILL.md
+++ b/optional-skills/blockchain/onchain-safety/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: onchain-safety
+description: Pre-execution risk analysis for onchain actions — flags scam contracts, dangerous token approvals, MEV exposure, and unsafe swaps before signing. For agents and users reviewing crypto transactions, ERC-20 allowances, and DEX quotes.
+version: 0.1.0
+author: Baophan (Baophan00), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Onchain, Blockchain, Crypto, Safety, Security, DeFi, Wallet, Risk]
+    related_skills: [hyperliquid, solana, evm]
+---
+
+# Onchain Safety Skill
+
+Risk-analysis layer for onchain actions. Before an agent (or user) signs a
+swap, approval, or contract call, this skill inspects the action and returns a
+**GO / CAUTION / NO-GO** verdict with concrete reasons — mirroring how an RL
+reward model would score a trajectory step without executing it.
+
+Read-only analysis. No signing, no key handling, no transaction broadcast.
+
+---
+
+## When to Use
+
+- User (or agent) is about to sign an ERC-20 `approve`, a DEX swap, or call a contract
+- User pastes a transaction payload, calldata, or a contract/token address for review
+- User asks "is this safe?", "should I approve this?", "is this contract a scam?"
+- Agentic wallet (e.g. OKX Agentic Wallet) is about to execute an onchain step and wants a pre-flight check
+
+---
+
+## Pre-flight Check (agent-facing procedure)
+
+Run this checklist on any pending onchain action. Each failed check downgrades
+the verdict one level (GO → CAUTION → NO-GO).
+
+| # | Check | NO-GO if | Tool / source |
+|---|---|---|---|
+| 1 | Address reputation | Contract not in a known-good allowlist AND no public audit/label | block explorer label API |
+| 2 | Approval size | `approve` sets `amount = max(uint256)` (unlimited) | decode calldata `spender`+`amount` |
+| 3 | Token legitimacy | Token has no liquidity, mint function owned by EOA, or honeypot flags | dex pair / holder scan |
+| 4 | MEV exposure | Swap slippage > 3% or path crosses low-liquidity pool | quote vs spot |
+| 5 | Phishing pattern | Calldata calls `setApprovalForAll` on NFT or `permit` with deadline 0 | decode calldata |
+| 6 | Chain sanity | Target chain mismatches agent's active network | config compare |
+
+### Verdict rules
+- All pass → **GO**
+- 1–2 minor (CAUTION-class) → **CAUTION** (proceed with limit: bounded amount, revocable)
+- Any NO-GO check → **NO-GO** (do not sign; explain which check failed)
+
+---
+
+## Calldata decoding (stdlib only)
+
+The helper script decodes the four high-risk selectors without external libs:
+
+```bash
+python3 ~/.hermes/skills/blockchain/onchain-safety/scripts/decode_action.py \
+  --chain ethereum \
+  --to 0x... \
+  --data 0x...
+```
+
+Selectors recognized:
+- `0x095ea7b3` — `approve(address,uint256)`
+- `0xa22cb465` — `setApprovalForAll(address,bool)`
+- `0xd505accf` — `permit(...)`
+- `0x38ed1739` — `swapExactTokensForTokens(...)`
+
+Output: JSON with `{action, spender, amount, unlimited, risk}`.
+
+---
+
+## Integrations
+
+If an agentic-wallet skill is loaded (OKX Agentic Wallet, SmartVault), call
+this skill's pre-flight check **before** invoking the wallet's sign path. The
+wallet skill remains the executor; this skill is the brake.
+
+**IF** `OKX_AGENTIC_WALLET` configured → route NO-GO verdicts back to the
+wallet as a hard abort. **ELSE** → surface verdict to the user as a warning.
+
+---
+
+## Security note
+
+This skill never holds keys and never broadcasts. It is a read-only advisor.
+A GO verdict is not financial advice — it means "no structural red flags
+detected", not "this trade will profit".

--- a/optional-skills/blockchain/onchain-safety/SKILL.md
+++ b/optional-skills/blockchain/onchain-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onchain-safety
-description: Pre-flight risk analysis for onchain actions before signing.
+description: Pre-flight safety check for onchain actions before signing.
 version: 0.1.0
 author: Baophan (Baophan00), Hermes Agent
 license: MIT
@@ -38,6 +38,10 @@ an executor.
 ## Prerequisites
 
 Stdlib only (`argparse`, `json`). No API key, no external packages.
+
+---
+
+## How to Run
 
 ```bash
 python3 ~/.hermes/skills/blockchain/onchain-safety/scripts/decode_action.py \

--- a/optional-skills/blockchain/onchain-safety/examples.md
+++ b/optional-skills/blockchain/onchain-safety/examples.md
@@ -1,0 +1,47 @@
+# Onchain Safety — Examples
+
+## 1. Pre-flight an unlimited ERC-20 approval (NO-GO)
+
+```bash
+python3 ~/.hermes/skills/blockchain/onchain-safety/scripts/decode_action.py \
+  --chain ethereum \
+  --to 0xSpenderContractAddress \
+  --data 0x095ea7b3<spender_padded><max_uint256>
+```
+
+Expected verdict: `risk: NO-GO`, `unlimited: true`. Agent must NOT sign;
+surface "unlimited approval detected" to the user or abort the wallet call.
+
+## 2. Bounded approval (CAUTION)
+
+```bash
+python3 ~/.hermes/skills/blockchain/onchain-safety/scripts/decode_action.py \
+  --chain ethereum \
+  --to 0xTokenAddress \
+  --data 0x095ea7b3<spender_padded><amount_hex>
+```
+
+Expected: `risk: CAUTION`, `unlimited: false`. Proceed but recommend revoke
+after use.
+
+## 3. setApprovalForAll on NFT (NO-GO)
+
+```bash
+python3 ~/.hermes/skills/blockchain/onchain-safety/scripts/decode_action.py \
+  --chain ethereum \
+  --to 0xNFTContract \
+  --data 0xa22cb465<operator_padded>0000000000000000000000000000000000000000000000000000000000000001
+```
+
+Expected: `risk: NO-GO`, `approved: true`. Operator gains full transfer rights.
+
+## 4. Agentic-wallet integration (pseudo)
+
+```text
+1. Wallet skill builds tx -> calls onchain-safety pre-flight
+2. IF risk == NO-GO -> hard abort, return reason to user
+3. IF risk == CAUTION -> proceed with bounded amount, log warning
+4. IF risk == ok -> sign
+```
+
+No `EXAMPLES_API` needed — this skill is read-only and offline.

--- a/optional-skills/blockchain/onchain-safety/scripts/decode_action.py
+++ b/optional-skills/blockchain/onchain-safety/scripts/decode_action.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Decode high-risk onchain actions from calldata (stdlib only).
+
+Recognizes the four dangerous selectors so an agent can pre-flight a pending
+transaction before signing. Prints JSON: {action, spender, amount, unlimited,
+risk}. No network calls, no signing, no broadcast.
+
+Usage:
+    python3 decode_action.py --chain ethereum --to 0x... --data 0x...
+"""
+import argparse
+import json
+import sys
+
+# selector -> (action name, arg layout we care about)
+SELECTORS = {
+    "0x095ea7b3": ("approve", "address,uint256"),
+    "0xa22cb465": ("setApprovalForAll", "address,bool"),
+    "0xd505accf": ("permit", "token,owner,spender,value,deadline"),
+    "0x38ed1739": ("swapExactTokensForTokens", "amountIn,amountOutMin,path,to,deadline"),
+}
+
+MAX_UINT = (1 << 256) - 1
+
+
+def _int_from_hex(h: str) -> int:
+    return int(h, 16)
+
+
+def decode(data: str) -> dict:
+    data = data.lower().removeprefix("0x")
+    if len(data) < 8:
+        return {"action": "unknown", "risk": "unknown", "note": "calldata too short"}
+    selector = "0x" + data[:8]
+    info = SELECTORS.get(selector)
+    if not info:
+        return {"action": "unknown", "selector": selector, "risk": "unknown"}
+    action, _ = info
+    body = data[8:]
+    out = {"action": action, "selector": selector, "risk": "ok"}
+
+    # approve(address,uint256): spender = bytes 8..40, amount = last 32 bytes
+    if action == "approve":
+        spender = "0x" + body[24:64]
+        amount = _int_from_hex(body[-64:]) if len(body) >= 64 else 0
+        unlimited = amount >= MAX_UINT - 1
+        out.update(spender=spender, amount=str(amount), unlimited=unlimited)
+        out["risk"] = "NO-GO" if unlimited else "CAUTION"
+        out["reason"] = (
+            "unlimited approval (max uint256)" if unlimited
+            else "bounded approval — revoke after use"
+        )
+    elif action == "setApprovalForAll":
+        spender = "0x" + body[24:64]
+        approved = body[-1] == "1"
+        out.update(spender=spender, approved=approved)
+        out["risk"] = "NO-GO" if approved else "ok"
+        out["reason"] = "grants operator full NFT control" if approved else "revoke"
+    elif action == "permit":
+        # permit(token,owner,spender,value,deadline,v,r,s) — deadline at arg 5
+        out["risk"] = "CAUTION"
+        out["reason"] = "offline approval — verify spender + deadline"
+    elif action == "swapExactTokensForTokens":
+        out["risk"] = "CAUTION"
+        out["reason"] = "verify slippage + path liquidity before signing"
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--chain", default="ethereum")
+    ap.add_argument("--to", required=True, help="target contract address")
+    ap.add_argument("--data", required=True, help="calldata hex")
+    args = ap.parse_args()
+    result = decode(args.data)
+    result["chain"] = args.chain
+    result["to"] = args.to
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/blockchain/onchain-safety/scripts/decode_action.py
+++ b/optional-skills/blockchain/onchain-safety/scripts/decode_action.py
@@ -2,29 +2,51 @@
 """Decode high-risk onchain actions from calldata (stdlib only).
 
 Recognizes the four dangerous selectors so an agent can pre-flight a pending
-transaction before signing. Prints JSON: {action, spender, amount, unlimited,
-risk}. No network calls, no signing, no broadcast.
+transaction before signing. Returns JSON: {action, ..., risk}.
 
-Usage:
-    python3 decode_action.py --chain ethereum --to 0x... --data 0x...
+Fail-closed: any calldata that does not match the full ABI layout for a
+recognized selector returns risk="NO-GO" with a reason, instead of a misleading
+CAUTION/GO verdict.
 """
 import argparse
 import json
 import sys
 
-# selector -> (action name, arg layout we care about)
+# selector -> (action name, min body length in hex chars = 64 * num_args)
 SELECTORS = {
-    "0x095ea7b3": ("approve", "address,uint256"),
-    "0xa22cb465": ("setApprovalForAll", "address,bool"),
-    "0xd505accf": ("permit", "token,owner,spender,value,deadline"),
-    "0x38ed1739": ("swapExactTokensForTokens", "amountIn,amountOutMin,path,to,deadline"),
+    "0x095ea7b3": ("approve", 128),            # address(32) + uint256(32)
+    "0xa22cb465": ("setApprovalForAll", 128),  # address(32) + bool(32)
+    "0xd505accf": ("permit", 512),              # 8 words (token,owner,spender,value,deadline,v,r,s)
+    "0x38ed1739": ("swapExactTokensForTokens", 256),  # amountIn(32)+amountOutMin(32)+path(32 ptr)+to(32)+deadline(32)
 }
 
+# ABI word size in hex chars (32 bytes = 64 hex)
+_WORD = 64
 MAX_UINT = (1 << 256) - 1
 
 
 def _int_from_hex(h: str) -> int:
-    return int(h, 16)
+    try:
+        return int(h, 16)
+    except (ValueError, TypeError):
+        return 0
+
+
+def _addr_from_word(word: str) -> str:
+    # words are left-padded; take the last 40 hex chars (20 bytes)
+    if len(word) < 40:
+        return "0x0"
+    return "0x" + word[-40:]
+
+
+def _fail(action: str, selector: str, reason: str) -> dict:
+    """Fail-closed verdict for malformed calldata."""
+    return {
+        "action": action,
+        "selector": selector,
+        "risk": "NO-GO",
+        "reason": reason,
+    }
 
 
 def decode(data: str) -> dict:
@@ -35,14 +57,19 @@ def decode(data: str) -> dict:
     info = SELECTORS.get(selector)
     if not info:
         return {"action": "unknown", "selector": selector, "risk": "unknown"}
-    action, _ = info
+    action, min_body_hex = info
     body = data[8:]
     out = {"action": action, "selector": selector, "risk": "ok"}
 
-    # approve(address,uint256): spender = bytes 8..40, amount = last 32 bytes
+    if len(body) < min_body_hex:
+        return _fail(action, selector, "malformed calldata: insufficient ABI words")
+
+    # ---- approve(address,uint256) ----
     if action == "approve":
-        spender = "0x" + body[24:64]
-        amount = _int_from_hex(body[-64:]) if len(body) >= 64 else 0
+        spender_word = body[0:_WORD]
+        amount_word = body[_WORD:2 * _WORD]
+        spender = _addr_from_word(spender_word)
+        amount = _int_from_hex(amount_word)
         unlimited = amount >= MAX_UINT - 1
         out.update(spender=spender, amount=str(amount), unlimited=unlimited)
         out["risk"] = "NO-GO" if unlimited else "CAUTION"
@@ -50,19 +77,43 @@ def decode(data: str) -> dict:
             "unlimited approval (max uint256)" if unlimited
             else "bounded approval — revoke after use"
         )
+
+    # ---- setApprovalForAll(address,bool) ----
     elif action == "setApprovalForAll":
-        spender = "0x" + body[24:64]
-        approved = body[-1] == "1"
+        spender = _addr_from_word(body[0:_WORD])
+        approved = body[_WORD:2 * _WORD].lstrip("0") == "1"
         out.update(spender=spender, approved=approved)
         out["risk"] = "NO-GO" if approved else "ok"
         out["reason"] = "grants operator full NFT control" if approved else "revoke"
+
+    # ---- permit(token,owner,spender,value,deadline,v,r,s) ----
     elif action == "permit":
-        # permit(token,owner,spender,value,deadline,v,r,s) — deadline at arg 5
-        out["risk"] = "CAUTION"
-        out["reason"] = "offline approval — verify spender + deadline"
+        # word 4 = deadline (uint256). A zero deadline means the permit is
+        # only valid for the current block — flag as NO-GO (deadline abuse).
+        deadline_word = body[4 * _WORD:5 * _WORD]
+        deadline = _int_from_hex(deadline_word)
+        spender = _addr_from_word(body[2 * _WORD:3 * _WORD])
+        out.update(spender=spender, deadline=str(deadline))
+        if deadline == 0:
+            out["risk"] = "NO-GO"
+            out["reason"] = "permit deadline is zero (deadline abuse)"
+        else:
+            out["risk"] = "CAUTION"
+            out["reason"] = "offline approval — verify spender + deadline"
+
+    # ---- swapExactTokensForTokens(amountIn,amountOutMin,path,to,deadline) ----
     elif action == "swapExactTokensForTokens":
-        out["risk"] = "CAUTION"
-        out["reason"] = "verify slippage + path liquidity before signing"
+        # word 4 = deadline; word 3 = path pointer (array). We validate
+        # structure only — a zero deadline is the documented NO-GO hazard.
+        deadline_word = body[4 * _WORD:5 * _WORD]
+        deadline = _int_from_hex(deadline_word)
+        out.update(deadline=str(deadline))
+        if deadline == 0:
+            out["risk"] = "NO-GO"
+            out["reason"] = "swap deadline is zero (front-run / replay risk)"
+        else:
+            out["risk"] = "CAUTION"
+            out["reason"] = "verify slippage + path liquidity before signing"
     return out
 
 

--- a/tests/skills/test_onchain_safety_skill.py
+++ b/tests/skills/test_onchain_safety_skill.py
@@ -1,0 +1,79 @@
+"""Tests for optional-skills/blockchain/onchain-safety/scripts/decode_action.py
+
+Regression guards for the four high-risk calldata selectors. Mirrors the
+GO / CAUTION / NO-GO verdict logic documented in SKILL.md.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_DECODER = (
+    _REPO
+    / "optional-skills"
+    / "blockchain"
+    / "onchain-safety"
+    / "scripts"
+    / "decode_action.py"
+)
+
+# Load the stdlib-only decoder as a module (no package import needed).
+_spec = importlib.util.spec_from_file_location("onchain_safety_decoder", _DECODER)
+decoder = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(decoder)
+
+
+def _pad(addr: str) -> str:
+    return addr.lower().removeprefix("0x").rjust(64, "0")
+
+
+def _max_uint() -> str:
+    return "f" * 64
+
+
+def test_unlimited_approve_is_no_go():
+    data = "0x095ea7b3" + _pad("0xDeadBeef") + _max_uint()
+    r = decoder.decode(data)
+    assert r["action"] == "approve"
+    assert r["unlimited"] is True
+    assert r["risk"] == "NO-GO"
+
+
+def test_bounded_approve_is_caution():
+    data = "0x095ea7b3" + _pad("0xDeadBeef") + "0" * 56 + "3b9aca00"  # 1000e6
+    r = decoder.decode(data)
+    assert r["action"] == "approve"
+    assert r["unlimited"] is False
+    assert r["risk"] == "CAUTION"
+
+
+def test_set_approval_for_all_true_is_no_go():
+    data = "0xa22cb465" + _pad("0xOperator") + "0" * 63 + "1"
+    r = decoder.decode(data)
+    assert r["action"] == "setApprovalForAll"
+    assert r["approved"] is True
+    assert r["risk"] == "NO-GO"
+
+
+def test_set_approval_for_all_false_is_ok():
+    data = "0xa22cb465" + _pad("0xOperator") + "0" * 64
+    r = decoder.decode(data)
+    assert r["approved"] is False
+    assert r["risk"] == "ok"
+
+
+def test_unknown_selector_is_unknown():
+    data = "0x12345678" + "0" * 64
+    r = decoder.decode(data)
+    assert r["action"] == "unknown"
+    assert r["risk"] == "unknown"
+
+
+def test_short_calldata_is_safe_unknown():
+    # < 8 hex chars after 0x → selector cannot be read → unknown
+    r = decoder.decode("0x095e")
+    assert r["action"] == "unknown"

--- a/tests/skills/test_onchain_safety_skill.py
+++ b/tests/skills/test_onchain_safety_skill.py
@@ -1,24 +1,23 @@
 """Tests for optional-skills/blockchain/onchain-safety/scripts/decode_action.py
 
-Regression guards for the four high-risk calldata selectors. Mirrors the
-GO / CAUTION / NO-GO verdict logic documented in SKILL.md.
+Regression guards for the four high-risk selectors. Covers:
+- fail-closed on malformed/truncated calldata
+- permit deadline=0 -> NO-GO
+- swap deadline=0 -> NO-GO
 """
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
 
 _REPO = Path(__file__).resolve().parents[2]
 _DECODER = (
-    _REPO
-    / "optional-skills"
-    / "blockchain"
-    / "onchain-safety"
-    / "scripts"
-    / "decode_action.py"
+    _REPO / "optional-skills" / "blockchain" / "onchain-safety" / "scripts" / "decode_action.py"
 )
 
 # Load the stdlib-only decoder as a module (no package import needed).
@@ -27,16 +26,12 @@ decoder = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(decoder)
 
 
-def _pad(addr: str) -> str:
+def _word(addr: str) -> str:
     return addr.lower().removeprefix("0x").rjust(64, "0")
 
 
-def _max_uint() -> str:
-    return "f" * 64
-
-
 def test_unlimited_approve_is_no_go():
-    data = "0x095ea7b3" + _pad("0xDeadBeef") + _max_uint()
+    data = "0x095ea7b3" + _word("0xDeadBeef") + "f" * 64
     r = decoder.decode(data)
     assert r["action"] == "approve"
     assert r["unlimited"] is True
@@ -44,36 +39,55 @@ def test_unlimited_approve_is_no_go():
 
 
 def test_bounded_approve_is_caution():
-    data = "0x095ea7b3" + _pad("0xDeadBeef") + "0" * 56 + "3b9aca00"  # 1000e6
+    data = "0x095ea7b3" + _word("0xDeadBeef") + "0" * 56 + "3b9aca00"
     r = decoder.decode(data)
-    assert r["action"] == "approve"
     assert r["unlimited"] is False
     assert r["risk"] == "CAUTION"
 
 
+def test_truncated_approve_is_no_go():
+    # selector only, no ABI body -> fail-closed
+    r = decoder.decode("0x095ea7b3")
+    assert r["risk"] == "NO-GO"
+    assert "malformed" in r["reason"]
+
+
 def test_set_approval_for_all_true_is_no_go():
-    data = "0xa22cb465" + _pad("0xOperator") + "0" * 63 + "1"
+    data = "0xa22cb465" + _word("0xOperator") + "0" * 63 + "1"
     r = decoder.decode(data)
-    assert r["action"] == "setApprovalForAll"
     assert r["approved"] is True
     assert r["risk"] == "NO-GO"
 
 
 def test_set_approval_for_all_false_is_ok():
-    data = "0xa22cb465" + _pad("0xOperator") + "0" * 64
+    data = "0xa22cb465" + _word("0xOperator") + "0" * 64
     r = decoder.decode(data)
     assert r["approved"] is False
     assert r["risk"] == "ok"
 
 
+def test_permit_deadline_zero_is_no_go():
+    body = _word("0xToken") + _word("0xOwner") + _word("0xSpender") + _word("0") + "0" * 64 + _word("0") + _word("0") + _word("0")
+    r = decoder.decode("0xd505accf" + body)
+    assert r["risk"] == "NO-GO"
+    assert r["deadline"] == "0"
+
+
+def test_permit_deadline_nonzero_is_caution():
+    body = _word("0xToken") + _word("0xOwner") + _word("0xSpender") + _word("0") + ("0" * 63 + "1") + _word("0") + _word("0") + _word("0")
+    r = decoder.decode("0xd505accf" + body)
+    assert r["risk"] == "CAUTION"
+    assert r["deadline"] == "1"
+
+
+def test_swap_deadline_zero_is_no_go():
+    body = _word("0x1") + _word("0x0") + _word("0x0") + _word("0x0") + "0" * 64
+    r = decoder.decode("0x38ed1739" + body)
+    assert r["risk"] == "NO-GO"
+    assert r["deadline"] == "0"
+
+
 def test_unknown_selector_is_unknown():
-    data = "0x12345678" + "0" * 64
-    r = decoder.decode(data)
+    r = decoder.decode("0x12345678" + "0" * 64)
     assert r["action"] == "unknown"
     assert r["risk"] == "unknown"
-
-
-def test_short_calldata_is_safe_unknown():
-    # < 8 hex chars after 0x → selector cannot be read → unknown
-    r = decoder.decode("0x095e")
-    assert r["action"] == "unknown"

--- a/tests/skills/test_onchain_safety_skill.py
+++ b/tests/skills/test_onchain_safety_skill.py
@@ -91,3 +91,28 @@ def test_unknown_selector_is_unknown():
     r = decoder.decode("0x12345678" + "0" * 64)
     assert r["action"] == "unknown"
     assert r["risk"] == "unknown"
+
+
+def test_trailing_calldata_does_not_bypass_setApprovalForAll():
+    # EVM ignores trailing calldata; decoder must use absolute word indexing
+    # (not negative indexing) so appended junk cannot flip a NO-GO to ok.
+    body = _word("0xOperator") + "0" * 63 + "1" + "00"  # approved=true + junk
+    r = decoder.decode("0xa22cb465" + body)
+    assert r["approved"] is True
+    assert r["risk"] == "NO-GO"
+
+
+def test_trailing_calldata_does_not_bypass_unlimited_approve():
+    body = _word("0xDeadBeef") + "f" * 64 + "00"  # unlimited + junk
+    r = decoder.decode("0x095ea7b3" + body)
+    assert r["unlimited"] is True
+    assert r["risk"] == "NO-GO"
+
+
+def test_truncated_approve_missing_amount_is_no_go():
+    # selector + spender word only (64 hex chars), no amount word
+    data = "0x095ea7b3" + _word("0xDeadBeef")
+    r = decoder.decode(data)
+    assert r["action"] == "approve"
+    assert r["risk"] == "NO-GO"
+    assert "malformed" in r["reason"]


### PR DESCRIPTION
## Summary
Adds a new **optional skill** `optional-skills/blockchain/onchain-safety` — a read-only pre-flight risk layer for agents / agentic wallets about to sign onchain actions.

### Why
Agentic wallets (OKX Agentic Wallet, SmartVault — both referenced in Hermes config) currently lack a pre-sign safety brake. An agent can blindly `approve` an unlimited allowance or call `setApprovalForAll` on a malicious contract. This skill scores the pending action **before** execution, mirroring how an RL reward model would score a trajectory step without running it.

### What it does
- `SKILL.md`: a 6-check GO / CAUTION / NO-GO verdict checklist (address reputation, approval size, token legitimacy, MEV exposure, phishing patterns, chain sanity)
- `scripts/decode_action.py`: **stdlib-only** calldata decoder for the four high-risk selectors:
  - `0x095ea7b3` approve
  - `0xa22cb465` setApprovalForAll
  - `0xd505accf` permit
  - `0x38ed1739` swapExactTokensForTokens
  - returns JSON `{action, spender, amount, unlimited, risk}`
- `examples.md`: unlimited-approval NO-GO, bounded CAUTION, NFT operator NO-GO, wallet integration pseudo-flow

### Design notes
- Read-only: no keys, no signing, no broadcast — it is an advisor, not an executor
- Stdlib only (matches the `hyperliquid` skill convention in this folder)
- Integrates with agentic-wallet skills: route NO-GO verdicts back as a hard abort

### Test plan
- [x] `decode_action.py` on unlimited approve → `risk: NO-GO, unlimited: true`
- [x] `decode_action.py` on bounded approve → `risk: CAUTION, unlimited: false`
- [x] `decode_action.py` on setApprovalForAll(true) → `risk: NO-GO, approved: true`
- [ ] Add pytest cases under `tests/skills/` for the decoder (follow-up if maintainers want tests in-tree)

### Impact
Optional skill — not activated by default, zero impact on existing users. Adds a safety primitive for the growing agentic-wallet use case.