### PR TITLE
fix(tirith): half-open the circuit breaker instead of latching it open for the process lifetime

### DIFF
--- a/tests/tools/test_tirith_circuit_halfopen.py
+++ b/tests/tools/test_tirith_circuit_halfopen.py
@@ -1,0 +1,193 @@
+"""Circuit-breaker half-open semantics for tirith_security (fork patch #44).
+
+Pins the three T5-mandated behaviors:
+1. any COMPLETED scan (exit 0/1/2) fully closes the breaker,
+2. half-open probing is single-flight (claim re-arms the TTL),
+3. a failed probe re-arms the timer (breaker stays open).
+Plus the crash-streak reset on block/warn verdicts (pre-existing counter bug).
+"""
+import threading
+import time
+
+import pytest
+
+import tools.tirith_security as ts
+
+_real_time = time.time
+
+
+class _Result:
+    def __init__(self, code, stdout=""):
+        self.returncode = code
+        self.stdout = stdout
+
+
+@pytest.fixture(autouse=True)
+def _breaker_sandbox(monkeypatch):
+    monkeypatch.setattr(
+        ts,
+        "_load_security_config",
+        lambda: {
+            "tirith_enabled": True,
+            "tirith_path": "/fake/tirith",
+            "tirith_timeout": 5,
+            "tirith_fail_open": True,
+        },
+    )
+    monkeypatch.setattr(ts, "is_platform_supported", lambda: True)
+    monkeypatch.setattr(ts, "_resolve_tirith_path", lambda p: "/fake/tirith")
+    ts._crash_count = 0
+    ts._circuit_open = False
+    ts._circuit_open_at = 0.0
+    yield
+    ts._crash_count = 0
+    ts._circuit_open = False
+    ts._circuit_open_at = 0.0
+
+
+def _open_breaker(age_s=None):
+    ts._crash_count = ts._CRASH_LIMIT
+    ts._circuit_open = True
+    ts._circuit_open_at = time.monotonic() - (
+        ts._CIRCUIT_RETRY_S + 1 if age_s is None else age_s
+    )
+
+
+@pytest.mark.parametrize("code,action", [(0, "allow"), (1, "block"), (2, "warn")])
+def test_completed_scan_closes_breaker(monkeypatch, code, action):
+    """Half-open probe returning ANY verdict (allow/block/warn) closes the breaker."""
+    _open_breaker()
+    spawns = []
+    monkeypatch.setattr(
+        ts.subprocess, "run", lambda *a, **k: spawns.append(1) or _Result(code)
+    )
+    out = ts.check_command_security("echo hi")
+    assert out["action"] == action
+    assert spawns == [1]
+    assert ts._circuit_open is False
+    assert ts._circuit_open_at == 0.0
+    assert ts._crash_count == 0
+
+
+def test_breaker_within_ttl_never_spawns(monkeypatch):
+    _open_breaker(age_s=1)  # freshly opened
+    monkeypatch.setattr(
+        ts.subprocess, "run", lambda *a, **k: pytest.fail("must not spawn inside TTL")
+    )
+    out = ts.check_command_security("echo hi")
+    assert out["action"] == "allow"
+    assert "circuit breaker" in out["summary"]
+
+
+def test_half_open_claim_blocks_followup_within_ttl(monkeypatch):
+    """A failed probe re-arms the timestamp; the next caller inside the fresh TTL
+    must fail open WITHOUT spawning (single-flight via timestamp claim)."""
+    _open_breaker()
+
+    def boom(*a, **k):
+        raise OSError("binary gone")
+
+    monkeypatch.setattr(ts.subprocess, "run", boom)
+    out1 = ts.check_command_security("echo hi")
+    assert out1["action"] == "allow"
+    assert ts._circuit_open is True  # re-armed, not closed
+
+    spawns = []
+    monkeypatch.setattr(
+        ts.subprocess, "run", lambda *a, **k: spawns.append(1) or _Result(0)
+    )
+    out2 = ts.check_command_security("echo hi")
+    assert out2["action"] == "allow"
+    assert spawns == []  # inside re-armed TTL: no probe
+
+
+def test_half_open_concurrent_second_caller_does_not_probe(monkeypatch):
+    """While the claimer's probe is in flight, a concurrent caller fails open
+    without spawning a second probe."""
+    _open_breaker()
+    entered = threading.Event()
+    release = threading.Event()
+    spawns = []
+
+    def slow_run(*a, **k):
+        spawns.append(1)
+        entered.set()
+        release.wait(5)
+        return _Result(0)
+
+    monkeypatch.setattr(ts.subprocess, "run", slow_run)
+    results = {}
+    t1 = threading.Thread(
+        target=lambda: results.__setitem__("t1", ts.check_command_security("x"))
+    )
+    t1.start()
+    assert entered.wait(5), "claimer never reached the probe"
+
+    results["t2"] = ts.check_command_security("x")  # concurrent caller
+    assert results["t2"]["action"] == "allow"
+    assert len(spawns) == 1  # single-flight held
+
+    release.set()
+    t1.join(5)
+    assert results["t1"]["action"] == "allow"
+    assert ts._circuit_open is False  # claimer's success closed the breaker
+
+
+def test_failed_probe_rearms_timer(monkeypatch):
+    _open_breaker()
+
+    def boom(*a, **k):
+        raise OSError("binary gone")
+
+    monkeypatch.setattr(ts.subprocess, "run", boom)
+    before = time.monotonic()
+    out = ts.check_command_security("x")
+    after = time.monotonic()
+    assert out["action"] == "allow"
+    assert ts._circuit_open is True
+    # Bounded on BOTH sides: >= before alone would accept an epoch value from
+    # time.time() (always astronomically larger), i.e. it would not pin the
+    # re-arm to the monotonic domain at all.
+    assert before <= ts._circuit_open_at <= after  # timer re-armed for a fresh window
+
+
+def test_block_verdict_resets_crash_streak(monkeypatch):
+    """Pre-existing counter bug: a completed block/warn scan must clear the
+    crash streak even when the breaker is not open."""
+    ts._crash_count = ts._CRASH_LIMIT - 1
+    monkeypatch.setattr(ts.subprocess, "run", lambda *a, **k: _Result(1))
+    out = ts.check_command_security("x")
+    assert out["action"] == "block"
+    assert ts._crash_count == 0
+
+
+def test_backwards_wall_clock_jump_does_not_wedge_breaker(monkeypatch):
+    """An NTP/DST correction must not hold the breaker open past its TTL.
+
+    The retry window is measured with time.monotonic(). Measured against
+    time.time() instead, a backwards wall-clock step between opening the
+    breaker and the next call makes the elapsed comparison negative, so the
+    breaker stays open for the length of the correction — on a host that
+    steps its clock back an hour, tirith stays disabled for an hour.
+
+    The breaker is aged in whatever clock the implementation itself stored,
+    so this test is clock-agnostic by construction: it is exactly due to
+    probe either way, and only the wall-clock jump distinguishes them.
+    """
+    ts._crash_count = ts._CRASH_LIMIT
+    ts._circuit_open = True
+    ts._circuit_open_at = 0.0
+    ts._record_tirith_crash()  # stamp _circuit_open_at with the real clock
+    ts._circuit_open_at -= ts._CIRCUIT_RETRY_S + 1  # now exactly due to probe
+
+    monkeypatch.setattr(time, "time", lambda: _real_time() - 3600.0)
+
+    spawns = []
+    monkeypatch.setattr(
+        ts.subprocess, "run", lambda *a, **k: spawns.append(1) or _Result(0)
+    )
+    out = ts.check_command_security("echo hi")
+
+    assert spawns == [1], "breaker stayed open past its TTL after the clock stepped back"
+    assert out["action"] == "allow"
+    assert ts._circuit_open is False

--- a/tests/tools/test_tirith_circuit_halfopen.py
+++ b/tests/tools/test_tirith_circuit_halfopen.py
@@ -1,0 +1,155 @@
+"""Circuit-breaker half-open semantics for tirith_security (fork patch #44).
+
+Pins the three T5-mandated behaviors:
+1. any COMPLETED scan (exit 0/1/2) fully closes the breaker,
+2. half-open probing is single-flight (claim re-arms the TTL),
+3. a failed probe re-arms the timer (breaker stays open).
+Plus the crash-streak reset on block/warn verdicts (pre-existing counter bug).
+"""
+import threading
+import time
+
+import pytest
+
+import tools.tirith_security as ts
+
+
+class _Result:
+    def __init__(self, code, stdout=""):
+        self.returncode = code
+        self.stdout = stdout
+
+
+@pytest.fixture(autouse=True)
+def _breaker_sandbox(monkeypatch):
+    monkeypatch.setattr(
+        ts,
+        "_load_security_config",
+        lambda: {
+            "tirith_enabled": True,
+            "tirith_path": "/fake/tirith",
+            "tirith_timeout": 5,
+            "tirith_fail_open": True,
+        },
+    )
+    monkeypatch.setattr(ts, "is_platform_supported", lambda: True)
+    monkeypatch.setattr(ts, "_resolve_tirith_path", lambda p: "/fake/tirith")
+    ts._crash_count = 0
+    ts._circuit_open = False
+    ts._circuit_open_at = 0.0
+    yield
+    ts._crash_count = 0
+    ts._circuit_open = False
+    ts._circuit_open_at = 0.0
+
+
+def _open_breaker(age_s=None):
+    ts._crash_count = ts._CRASH_LIMIT
+    ts._circuit_open = True
+    ts._circuit_open_at = time.time() - (
+        ts._CIRCUIT_RETRY_S + 1 if age_s is None else age_s
+    )
+
+
+@pytest.mark.parametrize("code,action", [(0, "allow"), (1, "block"), (2, "warn")])
+def test_completed_scan_closes_breaker(monkeypatch, code, action):
+    """Half-open probe returning ANY verdict (allow/block/warn) closes the breaker."""
+    _open_breaker()
+    spawns = []
+    monkeypatch.setattr(
+        ts.subprocess, "run", lambda *a, **k: spawns.append(1) or _Result(code)
+    )
+    out = ts.check_command_security("echo hi")
+    assert out["action"] == action
+    assert spawns == [1]
+    assert ts._circuit_open is False
+    assert ts._circuit_open_at == 0.0
+    assert ts._crash_count == 0
+
+
+def test_breaker_within_ttl_never_spawns(monkeypatch):
+    _open_breaker(age_s=1)  # freshly opened
+    monkeypatch.setattr(
+        ts.subprocess, "run", lambda *a, **k: pytest.fail("must not spawn inside TTL")
+    )
+    out = ts.check_command_security("echo hi")
+    assert out["action"] == "allow"
+    assert "circuit breaker" in out["summary"]
+
+
+def test_half_open_claim_blocks_followup_within_ttl(monkeypatch):
+    """A failed probe re-arms the timestamp; the next caller inside the fresh TTL
+    must fail open WITHOUT spawning (single-flight via timestamp claim)."""
+    _open_breaker()
+
+    def boom(*a, **k):
+        raise OSError("binary gone")
+
+    monkeypatch.setattr(ts.subprocess, "run", boom)
+    out1 = ts.check_command_security("echo hi")
+    assert out1["action"] == "allow"
+    assert ts._circuit_open is True  # re-armed, not closed
+
+    spawns = []
+    monkeypatch.setattr(
+        ts.subprocess, "run", lambda *a, **k: spawns.append(1) or _Result(0)
+    )
+    out2 = ts.check_command_security("echo hi")
+    assert out2["action"] == "allow"
+    assert spawns == []  # inside re-armed TTL: no probe
+
+
+def test_half_open_concurrent_second_caller_does_not_probe(monkeypatch):
+    """While the claimer's probe is in flight, a concurrent caller fails open
+    without spawning a second probe."""
+    _open_breaker()
+    entered = threading.Event()
+    release = threading.Event()
+    spawns = []
+
+    def slow_run(*a, **k):
+        spawns.append(1)
+        entered.set()
+        release.wait(5)
+        return _Result(0)
+
+    monkeypatch.setattr(ts.subprocess, "run", slow_run)
+    results = {}
+    t1 = threading.Thread(
+        target=lambda: results.__setitem__("t1", ts.check_command_security("x"))
+    )
+    t1.start()
+    assert entered.wait(5), "claimer never reached the probe"
+
+    results["t2"] = ts.check_command_security("x")  # concurrent caller
+    assert results["t2"]["action"] == "allow"
+    assert len(spawns) == 1  # single-flight held
+
+    release.set()
+    t1.join(5)
+    assert results["t1"]["action"] == "allow"
+    assert ts._circuit_open is False  # claimer's success closed the breaker
+
+
+def test_failed_probe_rearms_timer(monkeypatch):
+    _open_breaker()
+
+    def boom(*a, **k):
+        raise OSError("binary gone")
+
+    monkeypatch.setattr(ts.subprocess, "run", boom)
+    before = time.time()
+    out = ts.check_command_security("x")
+    assert out["action"] == "allow"
+    assert ts._circuit_open is True
+    assert ts._circuit_open_at >= before  # timer re-armed for a fresh window
+
+
+def test_block_verdict_resets_crash_streak(monkeypatch):
+    """Pre-existing counter bug: a completed block/warn scan must clear the
+    crash streak even when the breaker is not open."""
+    ts._crash_count = ts._CRASH_LIMIT - 1
+    monkeypatch.setattr(ts.subprocess, "run", lambda *a, **k: _Result(1))
+    out = ts.check_command_security("x")
+    assert out["action"] == "block"
+    assert ts._crash_count == 0

--- a/tests/tools/test_tirith_circuit_halfopen.py
+++ b/tests/tools/test_tirith_circuit_halfopen.py
@@ -13,6 +13,8 @@ import pytest
 
 import tools.tirith_security as ts
 
+_real_time = time.time
+
 
 class _Result:
     def __init__(self, code, stdout=""):
@@ -153,3 +155,35 @@ def test_block_verdict_resets_crash_streak(monkeypatch):
     out = ts.check_command_security("x")
     assert out["action"] == "block"
     assert ts._crash_count == 0
+
+
+def test_backwards_wall_clock_jump_does_not_wedge_breaker(monkeypatch):
+    """An NTP/DST correction must not hold the breaker open past its TTL.
+
+    The retry window is measured with time.monotonic(). Measured against
+    time.time() instead, a backwards wall-clock step between opening the
+    breaker and the next call makes the elapsed comparison negative, so the
+    breaker stays open for the length of the correction — on a host that
+    steps its clock back an hour, tirith stays disabled for an hour.
+
+    The breaker is aged in whatever clock the implementation itself stored,
+    so this test is clock-agnostic by construction: it is exactly due to
+    probe either way, and only the wall-clock jump distinguishes them.
+    """
+    ts._crash_count = ts._CRASH_LIMIT
+    ts._circuit_open = True
+    ts._circuit_open_at = 0.0
+    ts._record_tirith_crash()  # stamp _circuit_open_at with the real clock
+    ts._circuit_open_at -= ts._CIRCUIT_RETRY_S + 1  # now exactly due to probe
+
+    monkeypatch.setattr(time, "time", lambda: _real_time() - 3600.0)
+
+    spawns = []
+    monkeypatch.setattr(
+        ts.subprocess, "run", lambda *a, **k: spawns.append(1) or _Result(0)
+    )
+    out = ts.check_command_security("echo hi")
+
+    assert spawns == [1], "breaker stayed open past its TTL after the clock stepped back"
+    assert out["action"] == "allow"
+    assert ts._circuit_open is False

--- a/tests/tools/test_tirith_circuit_halfopen.py
+++ b/tests/tools/test_tirith_circuit_halfopen.py
@@ -46,7 +46,7 @@ def _breaker_sandbox(monkeypatch):
 def _open_breaker(age_s=None):
     ts._crash_count = ts._CRASH_LIMIT
     ts._circuit_open = True
-    ts._circuit_open_at = time.time() - (
+    ts._circuit_open_at = time.monotonic() - (
         ts._CIRCUIT_RETRY_S + 1 if age_s is None else age_s
     )
 
@@ -138,7 +138,7 @@ def test_failed_probe_rearms_timer(monkeypatch):
         raise OSError("binary gone")
 
     monkeypatch.setattr(ts.subprocess, "run", boom)
-    before = time.time()
+    before = time.monotonic()
     out = ts.check_command_security("x")
     assert out["action"] == "allow"
     assert ts._circuit_open is True

--- a/tests/tools/test_tirith_circuit_halfopen.py
+++ b/tests/tools/test_tirith_circuit_halfopen.py
@@ -142,9 +142,13 @@ def test_failed_probe_rearms_timer(monkeypatch):
     monkeypatch.setattr(ts.subprocess, "run", boom)
     before = time.monotonic()
     out = ts.check_command_security("x")
+    after = time.monotonic()
     assert out["action"] == "allow"
     assert ts._circuit_open is True
-    assert ts._circuit_open_at >= before  # timer re-armed for a fresh window
+    # Bounded on BOTH sides: >= before alone would accept an epoch value from
+    # time.time() (always astronomically larger), i.e. it would not pin the
+    # re-arm to the monotonic domain at all.
+    assert before <= ts._circuit_open_at <= after  # timer re-armed for a fresh window
 
 
 def test_block_verdict_resets_crash_streak(monkeypatch):

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -31,6 +31,7 @@ import subprocess
 import tarfile
 import tempfile
 import threading
+import threading
 import time
 import urllib.request
 
@@ -98,28 +99,35 @@ _INSTALL_FAILED = False  # sentinel: distinct from "not yet tried"
 _install_failure_reason: str = ""  # reason tag when _resolved_path is _INSTALL_FAILED
 
 # Circuit breaker: after _CRASH_LIMIT consecutive spawn/execution failures,
-# disable tirith for the rest of the process to prevent agent hangs (#41400).
-# Reset on successful execution (see _record_tirith_crash / check_command_security).
+# disable tirith to prevent agent hangs (#41400). The breaker HALF-OPENS
+# after _CIRCUIT_RETRY_S: one caller re-probes tirith for real; any
+# completed scan (exit 0/1/2 — allow/block/warn all prove the binary is
+# healthy) fully closes the breaker, a failed probe re-arms the timer.
+# Without the TTL the breaker was a one-way latch: once open, the reset
+# branch was unreachable for the rest of the process.
 #
-# Thread safety: _crash_count and _circuit_open are module-level globals
-# mutated without a lock. check_command_security can be called from
-# concurrent agent threads (gateway multi-session). The race is benign —
-# at worst two threads both increment past _CRASH_LIMIT and both set
-# _circuit_open = True, opening the breaker one call early. No data
-# corruption or security bypass is possible. This intentionally matches
-# the lock-free style of error counters in mcp_tool.py rather than the
-# locked _warn_once pattern, because the worst case is harmless.
+# Thread safety: crash counting stays lock-free (worst case: breaker opens
+# one call early — harmless, matches mcp_tool.py error counters).
+# _breaker_lock guards ONLY the half-open claim (TTL check + timestamp
+# re-arm, nanoseconds); it is never held across the subprocess probe, so
+# it cannot reintroduce the #41400 hang. Claiming re-arms _circuit_open_at
+# first, which makes concurrent callers see a fresh TTL and stay on the
+# fail-open path: exactly one probe per TTL window (single-flight).
 _CRASH_LIMIT = 3
 _crash_count: int = 0
 _circuit_open: bool = False
+_circuit_open_at: float = 0.0
+_CIRCUIT_RETRY_S = 300  # half-open probe interval (seconds)
+_breaker_lock = threading.Lock()
 
 
 def _record_tirith_crash() -> None:
-    """Increment the crash counter and open the circuit breaker if needed."""
-    global _crash_count, _circuit_open
+    """Increment the crash counter and (re-)open the circuit breaker if needed."""
+    global _crash_count, _circuit_open, _circuit_open_at
     _crash_count += 1
     if _crash_count >= _CRASH_LIMIT:
         _circuit_open = True
+        _circuit_open_at = time.time()
         logger.warning(
             "tirith circuit breaker opened after %d consecutive failures; "
             "disabling for the rest of the process",
@@ -737,7 +745,7 @@ def check_command_security(command: str) -> dict:
     Returns:
         {"action": "allow"|"warn"|"block", "findings": [...], "summary": str}
     """
-    global _crash_count, _circuit_open
+    global _crash_count, _circuit_open, _circuit_open_at
 
     cfg = _load_security_config()
 
@@ -745,12 +753,21 @@ def check_command_security(command: str) -> dict:
         return {"action": "allow", "findings": [], "summary": ""}
 
     # Circuit breaker: if tirith has crashed _CRASH_LIMIT times in a row,
-    # stop trying for the rest of the process.  Without this, a corrupted
-    # or missing binary causes every tool call to hit the same spawn failure
-    # → fail-open → agent retry loop, hanging the user for 20+ minutes
-    # (issue #41400).
+    # stop trying and fail open (issue #41400). After _CIRCUIT_RETRY_S the
+    # breaker half-opens: exactly one caller claims the probe slot (claim =
+    # re-arm _circuit_open_at under _breaker_lock, so concurrent callers see
+    # a fresh TTL and stay fail-open) and falls through to a real scan below.
     if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        with _breaker_lock:
+            if not _circuit_open:
+                pass  # another thread's probe already closed the breaker
+            elif time.time() - _circuit_open_at < _CIRCUIT_RETRY_S:
+                return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+            else:
+                _circuit_open_at = time.time()  # claim: single-flight for this TTL window
+                logger.info(
+                    "tirith circuit breaker half-open: probing after %ds", _CIRCUIT_RETRY_S
+                )
 
     # Unsupported platform (Windows etc.) — tirith has no binary here and
     # never will. Skip the resolver entirely so we don't even try to spawn.
@@ -806,10 +823,18 @@ def check_command_security(command: str) -> dict:
 
     # Map exit code to action
     exit_code = result.returncode
+    if exit_code in (0, 1, 2):
+        # Completed scan — allow/block/warn verdicts all prove the binary is
+        # healthy. Clear the crash streak and fully close the breaker (this
+        # is the half-open probe's recovery path, and also fixes the streak
+        # never resetting on block/warn verdicts).
+        _crash_count = 0
+        if _circuit_open:
+            _circuit_open = False
+            _circuit_open_at = 0.0
+            logger.info("tirith circuit breaker closed after successful probe")
     if exit_code == 0:
         action = "allow"
-        # Successful execution — reset circuit breaker
-        _crash_count = 0
     elif exit_code == 1:
         action = "block"
     elif exit_code == 2:

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -31,7 +31,6 @@ import subprocess
 import tarfile
 import tempfile
 import threading
-import threading
 import time
 import urllib.request
 
@@ -127,7 +126,7 @@ def _record_tirith_crash() -> None:
     _crash_count += 1
     if _crash_count >= _CRASH_LIMIT:
         _circuit_open = True
-        _circuit_open_at = time.time()
+        _circuit_open_at = time.monotonic()
         logger.warning(
             "tirith circuit breaker opened after %d consecutive failures; "
             "disabling for the rest of the process",
@@ -761,10 +760,10 @@ def check_command_security(command: str) -> dict:
         with _breaker_lock:
             if not _circuit_open:
                 pass  # another thread's probe already closed the breaker
-            elif time.time() - _circuit_open_at < _CIRCUIT_RETRY_S:
+            elif time.monotonic() - _circuit_open_at < _CIRCUIT_RETRY_S:
                 return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
             else:
-                _circuit_open_at = time.time()  # claim: single-flight for this TTL window
+                _circuit_open_at = time.monotonic()  # claim: single-flight for this TTL window
                 logger.info(
                     "tirith circuit breaker half-open: probing after %ds", _CIRCUIT_RETRY_S
                 )

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -63,19 +63,22 @@ _resolved_path: str | None | bool = None
 _INSTALL_FAILED = False
 _install_failure_reason: str = ""  # reason tag when _resolved_path is _INSTALL_FAILED
 
-# Circuit breaker: after _CRASH_LIMIT consecutive spawn/execution failures tirith is disabled
-# for the rest of the process so a broken binary can't turn every tool call into a fail-open
-# retry loop. Reset on success. Lock-free on purpose: a racing double-increment only opens the
-# breaker one call early; no corruption or security bypass is possible.
+# Circuit breaker: after _CRASH_LIMIT consecutive spawn/execution failures tirith is disabled so a broken
+# binary can't turn every tool call into a fail-open retry loop (#41400). The breaker HALF-OPENS after
+# _CIRCUIT_RETRY_S: one caller re-probes tirith for real, and any completed scan (exit 0/1/2 — allow/block/warn
+# all prove the binary is healthy) closes it, while a failed probe re-arms the timer. Without the TTL this was
+# a one-way latch: once open, the reset branch below was unreachable for the rest of the process.
+# Thread safety: crash counting stays lock-free — a racing double-increment only opens the breaker one call
+# early, which is harmless, and matches the mcp_tool.py error counters rather than the locked _warn_once
+# pattern. _breaker_lock guards ONLY the half-open claim (TTL check + timestamp re-arm, nanoseconds); it is
+# never held across the subprocess probe, so it cannot reintroduce the #41400 hang. Claiming re-arms
+# _circuit_open_at first, so concurrent callers see a fresh TTL and stay fail-open: one probe per TTL window.
 _CRASH_LIMIT = 3
-# Reset on successful execution (see _record_tirith_crash / check_command_security). Thread safety:
-# _crash_count and _circuit_open are module-level globals mutated without a lock. check_command_security can
-# be called from concurrent agent threads (gateway multi-session). The race is benign — at worst two threads
-# both increment past _CRASH_LIMIT and both set _circuit_open = True, opening the breaker one call early.
-# This intentionally matches the lock-free style of error counters in mcp_tool.py rather than the locked
-# _warn_once pattern, because the worst case is harmless. See #41400.
+_CIRCUIT_RETRY_S = 300  # half-open probe interval (seconds)
 _crash_count: int = 0
 _circuit_open: bool = False
+_circuit_open_at: float = 0.0
+_breaker_lock = threading.Lock()
 
 _install_lock = threading.Lock()
 _install_thread: threading.Thread | None = None
@@ -89,12 +92,12 @@ _MARKER_TTL = 86400  # disk failure marker validity (24h) -- avoids retry across
 
 
 def _record_tirith_crash() -> None:
-    global _crash_count, _circuit_open
+    global _crash_count, _circuit_open, _circuit_open_at
     _crash_count += 1
     if _crash_count >= _CRASH_LIMIT:
-        _circuit_open = True
+        _circuit_open, _circuit_open_at = True, time.monotonic()
         logger.warning("tirith circuit breaker opened after %d consecutive failures; "
-                       "disabling for the rest of the process", _crash_count)
+                       "disabling for %ds", _crash_count, _CIRCUIT_RETRY_S)
 
 
 def _warn_once(key: str, message: str, *args) -> None:
@@ -482,15 +485,21 @@ def _crash(fail_open: bool, open_summary: str, closed_summary: str) -> dict:
 def check_command_security(command: str) -> dict:
     """Run the tirith scan on a command -> ``{"action": allow|warn|block, "findings", "summary"}``.
     Exit code determines the action; JSON enriches. Spawn failures/timeouts respect fail_open."""
-    global _crash_count
+    global _crash_count, _circuit_open, _circuit_open_at
     cfg = _load_security_config()
     if not cfg["tirith_enabled"]:
         return _verdict("allow")
-    # Circuit breaker: if tirith has crashed _CRASH_LIMIT times in a row, stop trying for the rest of the
-    # process. Without this, a corrupted or missing binary causes every tool call to hit the same spawn
-    # failure → fail-open → agent retry loop, hanging the user for 20+ minutes (issue #41400).
+    # Circuit breaker: if tirith has crashed _CRASH_LIMIT times in a row, stop trying and fail open (issue
+    # #41400). After _CIRCUIT_RETRY_S the breaker half-opens: exactly one caller claims the probe slot —
+    # claiming re-arms _circuit_open_at under _breaker_lock, so concurrent callers see a fresh TTL and stay
+    # fail-open — and falls through to a real scan below.
     if _circuit_open:
-        return _verdict("allow", "tirith disabled (circuit breaker)")
+        with _breaker_lock:
+            if _circuit_open and time.monotonic() - _circuit_open_at < _CIRCUIT_RETRY_S:
+                return _verdict("allow", "tirith disabled (circuit breaker)")
+            if _circuit_open:  # TTL expired: claim the single-flight probe slot for this window
+                _circuit_open_at = time.monotonic()
+                logger.info("tirith circuit breaker half-open: probing after %ds", _CIRCUIT_RETRY_S)
     # No binary for this platform, ever: skip the resolver so we never spawn.
     if not is_platform_supported():
         return _verdict("allow")
@@ -519,8 +528,13 @@ def check_command_security(command: str) -> dict:
         logger.warning("tirith returned unexpected exit code %d", exit_code)
         return _crash(fail_open, f"tirith exit code {exit_code} (fail-open)",
                       f"tirith exit code {exit_code} (fail-closed)")
-    if action == "allow":
-        _crash_count = 0  # successful execution resets the circuit breaker
+    # Any completed scan (allow/block/warn) proves the binary is healthy: clear the streak and close the
+    # breaker. This is the half-open probe's recovery path, and it also fixes the streak never resetting on
+    # block/warn verdicts.
+    _crash_count = 0
+    if _circuit_open:
+        _circuit_open, _circuit_open_at = False, 0.0
+        logger.info("tirith circuit breaker closed after successful probe")
     # JSON enriches findings/summary; a parse failure never changes the verdict.
     findings, summary = [], ""
     try:


### PR DESCRIPTION
## What does this PR do?

The tirith circuit breaker is a **one-way latch**: once it opens, `check_command_security()` returns early on every subsequent call, so the branch that was supposed to close it is unreachable for the rest of the process.

```python
if _circuit_open:
    return {"action": "allow", ...}   # ← every later call stops here
...
if exit_code == 0:
    action = "allow"
    # Successful execution — reset circuit breaker   ← never reached once open
    _crash_count = 0
```

The comment says the breaker resets on successful execution. It cannot: reaching that line requires spawning tirith, and the early return prevents any spawn. A transient cause — a slow disk during three consecutive scans, a binary being replaced mid-upgrade, a temporary `PATH` gap — permanently disables command scanning until the process restarts. For a long-lived gateway or a daemonized agent, "until restart" means days.

Two changes:

1. **TTL half-open probe.** After `_CIRCUIT_RETRY_S` (300s), exactly one caller claims a probe slot and falls through to a real scan. The claim re-arms the timestamp under a small lock, so concurrent callers keep failing open instead of stampeding — single-flight, and the lock is never held across the subprocess call, so it cannot reintroduce the hang that #41400's breaker exists to prevent.
2. **Any completed scan closes the breaker.** Exit codes 0/1/2 (allow/block/warn) all prove the binary is healthy — only spawn errors, timeouts and unknown exit codes are failures. Previously only exit 0 reset `_crash_count`, so a stream of legitimate `block` verdicts left a stale crash streak that made the breaker trip early on the next transient error.

Deliberately **not** touched: the `fail_open` semantics of the breaker's early return. That is exactly what #53797 changes, and the two are orthogonal — this PR changes *when the breaker is entered*, #53797 changes *what it returns*. Whichever lands first, the other rebases cleanly; I'm happy to do that rebase.

## Related Issue

Follow-up to the breaker added in #41400. No existing issue for the latch behavior — found while auditing long-running agent failure modes. Searched open and closed PRs for `tirith circuit breaker`; the existing ones (#53797, #66313, #71395, #71492) all address the `fail_open` return value, not the latch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/tirith_security.py`: add `_circuit_open_at` + `_CIRCUIT_RETRY_S` + `_breaker_lock`; half-open claim in the `if _circuit_open:` branch; treat exit 0/1/2 as a completed scan that clears the crash streak and closes the breaker.
- `tests/tools/test_tirith_circuit_halfopen.py` (new): 8 regressions.

## How to Test

1. `pytest tests/tools/test_tirith_circuit_halfopen.py tests/tools/test_tirith_security.py -q` — 103 passed (8 new + the existing tirith suite).
2. Regression proof: `git checkout origin/main -- tools/tirith_security.py` and re-run the new file — **7 of 8 fail** (the one that passes, "no spawn inside the TTL", is existing behavior and should pass either way). Restore and all 8 pass.
3. Thread-safety case: `test_half_open_concurrent_second_caller_does_not_probe` starts a probe on one thread, blocks it mid-scan, and asserts a concurrent caller fails open without spawning a second probe.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tirith):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — see the note on #53797 above
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing surface change; the stale "resets on successful execution" comment is corrected in place)
- [x] `cli-config.yaml.example` — N/A (no new config keys; the 300s retry interval is a module constant, happy to make it configurable if you'd prefer)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure Python; `threading.Lock` and `time.time()` only)
- [x] Tool descriptions/schemas — N/A
