### PR TITLE
Fix #72680: preserve unpersisted pending messages before shutdown clear (data loss)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6883,6 +6883,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 agent, context="shutdown finalize"
             )
 
+    def _preserve_pending_messages_on_shutdown(self) -> None:
+        """Best-effort dump of unpersisted pending messages before teardown.
+
+        Guards against silent data loss when the session SQLite/FTS store is
+        corrupt (#72680): messages that could not be written to disk live only
+        in ``self._pending_messages`` (memory=N, disk=0). The normal shutdown
+        path calls ``self._pending_messages.clear()`` unconditionally, which
+        destroys them. Instead of losing them, we serialize a recovery snapshot
+        to a JSON file outside the broken DB so an operator can salvage the
+        conversations after repairing state.db.
+
+        Failures here are non-fatal — shutdown must never block on a best-effort
+        backup, so every step is individually guarded.
+        """
+        pending = getattr(self, "_pending_messages", None)
+        if not pending:
+            return
+        try:
+            import json
+            import os
+            from datetime import datetime, timezone
+
+            hermes_home = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+            out_dir = os.path.join(hermes_home, "shutdown-recovery")
+            os.makedirs(out_dir, exist_ok=True)
+            stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            out_path = os.path.join(out_dir, f"pending_messages_{stamp}.json")
+            snapshot: dict = {}
+            for _key, _evt in pending.items():
+                try:
+                    snapshot[_key] = _evt if isinstance(_evt, (dict, list, str, int, float, bool, type(None))) else str(_evt)
+                except Exception:
+                    continue
+            with open(out_path, "w", encoding="utf-8") as _fh:
+                json.dump(
+                    {
+                        "reason": "shutdown-with-unpersisted-messages",
+                        "issue": "#72680",
+                        "count": len(snapshot),
+                        "messages": snapshot,
+                    },
+                    _fh,
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            logger.warning(
+                "Preserved %d unpersisted pending message(s) to %s "
+                "(possible FTS corruption — recover after repairing state.db)",
+                len(snapshot),
+                out_path,
+            )
+        except Exception as _e:
+            logger.debug("Pending-message shutdown preservation skipped: %s", _e)
+
     def _should_emit_long_running_notification(
         self,
         session_key: Optional[str],
@@ -9943,6 +9997,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._running_agents_ts.clear()
             if hasattr(self, "_active_session_leases"):
                 self._active_session_leases.clear()
+            # Best-effort preservation of unpersisted messages before teardown.
+            # When the FTS/SQLite index is corrupt (#72680), messages accumulate
+            # in _pending_messages (disk=0, memory=N) and a plain .clear() here
+            # discards them permanently. Serialize to an external JSON file so
+            # an operator can recover them after fixing the DB, instead of
+            # losing them silently.
+            self._preserve_pending_messages_on_shutdown()
             self._pending_messages.clear()
             self._pending_approvals.clear()
             if hasattr(self, '_busy_ack_ts'):

--- a/tests/gateway/test_pending_messages_shutdown_preserve.py
+++ b/tests/gateway/test_pending_messages_shutdown_preserve.py
@@ -1,0 +1,90 @@
+"""Regression tests for #72680 — pending messages must survive shutdown.
+
+Before the fix, GatewayRunner._stop_impl() called self._pending_messages.clear()
+unconditionally, permanently discarding messages that could not be persisted
+because the FTS/SQLite index was corrupt (disk=0, memory=N). The fix adds
+_preserve_pending_messages_on_shutdown(), which dumps a recovery JSON snapshot
+before clearing.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_GATEWAY_RUN = _REPO / "gateway" / "run.py"
+
+
+def _load_gateway_run():
+    # gateway.run imports heavy deps; load just the module object and inject a
+    # minimal fake for the bits we touch (logger) so we can instantiate the
+    # method without the full gateway stack.
+    spec = importlib.util.spec_from_file_location("gateway_run_72680", _GATEWAY_RUN)
+    mod = importlib.util.module_from_spec(spec)
+    # Stub logger referenced inside the method.
+    mod.logger = types.SimpleNamespace(debug=lambda *a, **k: None, warning=lambda *a, **k: None)
+    sys.modules["gateway_run_72680"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        # Some module-level imports may fail in isolation; we only need the
+        # class method, which is defined at parse time regardless.
+        pass
+    return mod
+
+
+def _make_runner(mod):
+    # Build a bare object with the method + the attribute it reads.
+    runner = types.SimpleNamespace()
+    runner._pending_messages = {}
+    # Bind the method onto our object.
+    runner._preserve_pending_messages_on_shutdown = (
+        mod.GatewayRunner._preserve_pending_messages_on_shutdown.__get__(runner, mod.GatewayRunner)
+    )
+    return runner
+
+
+def test_preserves_pending_messages_to_recovery_file(tmp_path, monkeypatch):
+    mod = _load_gateway_run()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    runner = _make_runner(mod)
+    runner._pending_messages = {
+        "session:1": {"role": "user", "content": "hello"},
+        "session:2": {"role": "assistant", "content": "hi there"},
+    }
+    runner._preserve_pending_messages_on_shutdown()
+
+    recovery_dir = tmp_path / "shutdown-recovery"
+    files = list(recovery_dir.glob("pending_messages_*.json"))
+    assert files, "expected a recovery snapshot file"
+    data = json.loads(files[0].read_text(encoding="utf-8"))
+    assert data["issue"] == "#72680"
+    assert data["count"] == 2
+    assert data["messages"]["session:1"]["content"] == "hello"
+
+
+def test_no_op_when_empty(tmp_path, monkeypatch):
+    mod = _load_gateway_run()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    runner = _make_runner(mod)
+    runner._pending_messages = {}
+    runner._preserve_pending_messages_on_shutdown()  # must not raise
+    assert not list((tmp_path / "shutdown-recovery").glob("*.json"))
+
+
+def test_non_fatal_on_write_error(tmp_path, monkeypatch):
+    mod = _load_gateway_run()
+    # Point HERMES_HOME at a file so makedirs fails -> exception must be swallowed.
+    bad = tmp_path / "not-a-dir"
+    bad.write_text("x")
+    monkeypatch.setenv("HERMES_HOME", str(bad))
+    runner = _make_runner(mod)
+    runner._pending_messages = {"s": {"role": "user", "content": "x"}}
+    # Must not raise even though the dump fails.
+    runner._preserve_pending_messages_on_shutdown()


### PR DESCRIPTION
## Summary
Fixes #72680 — a P1 data-loss bug in gateway shutdown.

### Root cause
`GatewayRunner._stop_impl()` called `self._pending_messages.clear()` unconditionally. When the session FTS/SQLite index is corrupt, messages that failed to persist live only in `_pending_messages` (disk=0, memory=N). The clear() destroyed them permanently.

Observed damage (2026-07-27): FTS corruption → 33 messages in gateway memory → restart → `_pending_messages.clear()` → **15 Telegram messages lost**.

### Fix
Added `_preserve_pending_messages_on_shutdown()`, called immediately before the clear(). It best-effort serializes the pending messages to a JSON recovery snapshot under `$HERMES_HOME/shutdown-recovery/pending_messages_<timestamp>.json` (tagged `issue: #72680`) so an operator can salvage conversations after repairing state.db.

The dump is fully guarded — every step is wrapped so any failure is swallowed and shutdown never blocks on a best-effort backup.

### Test plan
- [x] Logic verified: messages with content → recovery file written (count + issue correct)
- [x] Empty pending map → no-op (no file)
- [x] Write error (bad HERMES_HOME path) → non-fatal, no raise
- [x] `ast.parse` passes on gateway/run.py
- [ ] CI pytest: tests/gateway/test_pending_messages_shutdown_preserve.py (note: the test loads gateway/run.py in isolation; if module-level imports are too heavy in CI, the logic is also covered by the standalone verification above)

### Impact
P1 / gateway / session-state. No behaviour change on the healthy path (empty pending map → no file). Only adds a recovery side-channel when messages are stranded in memory at shutdown.

### Files
- `gateway/run.py` — new `_preserve_pending_messages_on_shutdown()`, called before `_pending_messages.clear()`
- `tests/gateway/test_pending_messages_shutdown_preserve.py` — regression tests