### PR TITLE
fix(gateway): stop scraping every /mnt/ PATH entry into WSL systemd interop unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2562,9 +2562,21 @@ def _build_wsl_interop_paths(path_entries: list[str]) -> list[str]:
         return []
 
     candidates: list[str] = []
-    for entry in os.environ.get("PATH", "").split(os.pathsep):
-        if entry.startswith("/mnt/"):
-            candidates.append(entry)
+    # NOTE: this function intentionally does NOT scrape every /mnt/ entry
+    # from the current shell's PATH. A prior version did, which persisted
+    # whatever happened to be on PATH at `hermes gateway install` time --
+    # not just Windows system tool directories, but any /mnt/ path the
+    # user's shell had (Desktop app install dirs, git, node, a venv, etc.).
+    # Those extra entries are exercised on every PATH resolution the
+    # (long-running, systemd-managed) gateway process does, and each one
+    # is a Plan 9 filesystem round-trip into the Windows side of WSL.
+    # Accumulated over weeks, that traffic can exceed WSL's Plan 9 service
+    # tolerance and trigger a `p9io AcceptAsync` disconnect that crashes
+    # the whole WSL VM -- taking the gateway down with it in a restart
+    # loop (issue #73163). The hardcoded system paths below, together
+    # with which() resolution (which searches the real PATH itself and
+    # needs no scraping here), already cover every path the gateway
+    # actually needs to invoke powershell.exe/cmd.exe/etc.
 
     for executable in ("powershell.exe", "cmd.exe", "explorer.exe", "wsl.exe"):
         resolved = shutil.which(executable)

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -1,6 +1,7 @@
 """Tests for WSL detection and WSL-aware gateway behavior."""
 
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, mock_open
 
@@ -144,3 +145,157 @@ class TestGatewayCommandWSLMessages:
         assert "WSL note" in out
         assert "tmux or screen" in out
 
+    def test_status_wsl_not_running(self, monkeypatch, capsys):
+        """hermes gateway status on WSL with no process shows WSL start advice."""
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway, "is_wsl", lambda: True)
+        # See test_status_wsl_running_manual.
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [])
+        monkeypatch.setattr(gateway, "_runtime_health_lines", lambda: [])
+        monkeypatch.setattr(
+            gateway, "get_systemd_unit_path",
+            lambda system=False: SimpleNamespace(exists=lambda: False),
+        )
+        monkeypatch.setattr(
+            gateway, "get_launchd_plist_path",
+            lambda: SimpleNamespace(exists=lambda: False),
+        )
+
+        args = SimpleNamespace(gateway_command="status", deep=False, system=False)
+        gateway.gateway_command(args)
+
+        out = capsys.readouterr().out
+        assert "hermes gateway run" in out
+        assert "tmux" in out
+
+
+class TestBuildWslInteropPaths:
+    """Regression tests for issue #73163: _build_wsl_interop_paths() used to
+    scrape EVERY /mnt/-prefixed entry from the current shell's PATH,
+    persisting unrelated paths (Desktop app install dirs, git, node, a venv,
+    etc.) into the generated systemd unit. Each of those extra entries is a
+    Plan 9 filesystem round-trip on every PATH resolution the long-running
+    gateway process does; accumulated over time this can exceed WSL's Plan 9
+    service tolerance and crash the whole WSL VM. Only hardcoded Windows
+    system paths and which()-resolved interop binaries should be persisted.
+    """
+
+    def test_non_windows_tool_paths_on_shell_path_are_not_scraped(self, monkeypatch):
+        """The core regression: an unrelated /mnt/ path on the current
+        shell's PATH (e.g. a Desktop app install dir) must NOT appear in
+        the result, even though the old code captured every /mnt/ entry."""
+        monkeypatch.setattr(gateway, "is_wsl", lambda: True)
+        monkeypatch.setenv(
+            "PATH",
+            "/usr/bin:/mnt/d/hermes-desktop/hermes/git/mingw64/bin:"
+            "/mnt/d/hermes-desktop/hermes/node:/mnt/c/WINDOWS/system32",
+        )
+        monkeypatch.setattr(gateway.shutil, "which", lambda exe: None)
+        with patch("hermes_cli.gateway.Path") as MockPath:
+            MockPath.side_effect = lambda p: SimpleNamespace(
+                exists=lambda: str(p) == "/mnt/c/WINDOWS/system32", parent=None
+            )
+            result = gateway._build_wsl_interop_paths([])
+
+        assert "/mnt/d/hermes-desktop/hermes/git/mingw64/bin" not in result
+        assert "/mnt/d/hermes-desktop/hermes/node" not in result
+
+    def test_hardcoded_windows_system_paths_still_included(self, monkeypatch):
+        """The hardcoded Windows interop paths (powershell, OpenSSH, WMI,
+        system32) must still be included when they exist -- the fix only
+        removes shell-PATH scraping, not the deliberate allowlist."""
+        monkeypatch.setattr(gateway, "is_wsl", lambda: True)
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setattr(gateway.shutil, "which", lambda exe: None)
+
+        real_exists = {
+            "/mnt/c/WINDOWS/system32",
+            "/mnt/c/WINDOWS",
+            "/mnt/c/WINDOWS/System32/Wbem",
+            "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/",
+            "/mnt/c/WINDOWS/System32/OpenSSH/",
+        }
+
+        class _FakePath:
+            def __init__(self, p):
+                self._p = str(p)
+
+            def exists(self):
+                return self._p in real_exists
+
+            @property
+            def parent(self):
+                return _FakePath(str(Path(self._p).parent))
+
+            def __str__(self):
+                return self._p
+
+        with patch("hermes_cli.gateway.Path", _FakePath):
+            result = gateway._build_wsl_interop_paths([])
+
+        assert "/mnt/c/WINDOWS/system32" in result
+        assert "/mnt/c/WINDOWS/System32/OpenSSH/" in result
+
+    def test_which_resolved_interop_binaries_still_included(self, monkeypatch):
+        """which()-resolved powershell.exe/cmd.exe/etc. directories must
+        still be added -- which() searches the real PATH itself and needs
+        no scraping loop to find them."""
+        monkeypatch.setattr(gateway, "is_wsl", lambda: True)
+        monkeypatch.setenv("PATH", "/usr/bin")
+
+        def _fake_which(exe):
+            if exe == "powershell.exe":
+                return "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe"
+            return None
+
+        monkeypatch.setattr(gateway.shutil, "which", _fake_which)
+
+        class _FakePath:
+            def __init__(self, p):
+                self._p = str(p)
+
+            def exists(self):
+                return False
+
+            @property
+            def parent(self):
+                return _FakePath("/".join(self._p.split("/")[:-1]))
+
+            def __str__(self):
+                return self._p
+
+        with patch("hermes_cli.gateway.Path", _FakePath):
+            result = gateway._build_wsl_interop_paths([])
+
+        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0" in result
+
+    def test_non_wsl_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+        assert gateway._build_wsl_interop_paths([]) == []
+
+    def test_deduplicates_against_existing_path_entries(self, monkeypatch):
+        monkeypatch.setattr(gateway, "is_wsl", lambda: True)
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setattr(gateway.shutil, "which", lambda exe: None)
+
+        class _FakePath:
+            def __init__(self, p):
+                self._p = str(p)
+
+            def exists(self):
+                return self._p == "/mnt/c/WINDOWS/system32"
+
+            @property
+            def parent(self):
+                return _FakePath(str(Path(self._p).parent))
+
+            def __str__(self):
+                return self._p
+
+        with patch("hermes_cli.gateway.Path", _FakePath):
+            result = gateway._build_wsl_interop_paths(["/mnt/c/WINDOWS/system32"])
+
+        assert "/mnt/c/WINDOWS/system32" not in result


### PR DESCRIPTION
## Context

Fixes #73163.

## Problem

`_build_wsl_interop_paths()` scraped EVERY `/mnt/`-prefixed entry off the current shell's PATH at `hermes gateway install` time -- not just Windows system tool directories, but any `/mnt/` path the installing shell happened to have (Desktop app install dirs, git, node, a venv, etc.). Each extra entry becomes a Plan 9 filesystem round-trip on every PATH resolution the long-running, systemd-managed gateway process does. Accumulated over weeks, this can exceed WSL's Plan 9 service tolerance and trigger a `p9io AcceptAsync` disconnect that crashes the whole WSL VM -- taking the gateway down in a restart loop every 30-50s.

## Fix

Remove the shell-PATH scraping loop entirely. The function already has two other sources that cover every real interop need: `which()`-resolved directories for the Windows interop binaries, and a hardcoded allowlist of the actual Windows system directories. No functional loss -- every gateway call site that invokes a Windows tool already uses a full path, not PATH resolution.

## Verification

5 new tests pass (the core regression, hardcoded-paths-still-included, which()-resolution-still-included, non-WSL no-op, dedup); 24/24 in the full `tests/hermes_cli/test_gateway_wsl.py` file. Reverting only the fix (keeping the test) reproduces the exact leak the bug report describes.