### PR TITLE
fix(tools): reject all-blank clarify choices instead of silent degradation (#73152)

### DIFF
--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -150,11 +150,18 @@ def clarify_tool(
         # user-facing text here — the single platform-agnostic entry point —
         # so the CLI panel, Discord buttons, and Telegram list all render clean
         # text and the resolved answer is never a raw Python dict repr.
+        raw_count = len(choices)
         choices = [s for s in (_flatten_choice(c) for c in choices) if s]
         if len(choices) > MAX_CHOICES:
             choices = choices[:MAX_CHOICES]
         if not choices:
-            choices = None  # empty list → open-ended
+            if raw_count > 0:
+                return tool_error(
+                    "choices contained no non-empty options after normalization; "
+                    "resend with meaningful labels or omit choices for an "
+                    "open-ended question."
+                )
+            choices = None  # empty input list → open-ended
 
     if callback is None:
         return json.dumps(


### PR DESCRIPTION
## Summary

When the model calls `clarify` with a non-empty `choices` array whose entries all normalize to empty (blank strings, `None`, dicts without canonical keys), the tool previously set `choices = None` and silently converted the request into an open-ended question.

This loses the distinction between:
- **Intentionally omitting choices** (open-ended mode) — the model wants a free-text answer
- **Providing choices that happen to be invalid** — the model made a malformed call

On Desktop, the user sees a pending input with no usable options and no concrete question — the turn stays blocked with no error feedback to the model.

## Fix

Track the original `len(choices)` before normalization. When `raw_count > 0` but no entries survive filtering, return a tool error:

> choices contained no non-empty options after normalization; resend with meaningful labels or omit choices for an open-ended question.

An empty input list (`choices=[]`) still becomes open-ended — only non-empty arrays that normalize to zero are rejected. The model can then retry with valid choices.

## Changes

- `tools/clarify_tool.py`: Added `raw_count` tracking before normalization; return `tool_error()` when all-blank entries detected

## Test Plan

- [x] All 48 existing `test_clarify_tool.py` tests pass
- [ ] Manual: call `clarify` with `choices=["", "", "", ""]` → should return error
- [ ] Manual: call `clarify` with `choices=[]` → should still become open-ended
- [ ] Manual: call `clarify` with `choices=["valid", ""]` → should keep "valid"

Fixes #73152