### PR TITLE
refactor: centralize HERMES_HOME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea/
 /venv/
 /venv.old/
 /_pycache/
@@ -112,6 +113,8 @@ models-dev-upstream/
 .cursor/
 .gemini/
 .zed/
+.opencode/
+.codegraph/
 .mcp.json
 opencode.json
 config/mcporter.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1188,14 +1188,28 @@ automatically scope to the active profile.
    print(f"Config saved to {display_hermes_home()}/config.yaml")
 
    # BAD — shows wrong path for profiles
-   print("Config saved to ~/.hermes/config.yaml")
-   ```
+    print("Config saved to ~/.hermes/config.yaml")
+    ```
 
-3. **Module-level constants are fine** — they cache `get_hermes_home()` at import time,
+3. **Do not read `HERMES_HOME` directly outside `hermes_constants.py`.** Core Python
+   code selects the appropriate accessor instead:
+   - `get_hermes_home()` for profile-scoped state paths.
+   - `get_process_hermes_home()` for launch-scoped paths that ignore task overrides.
+   - `get_explicit_hermes_home()` when behavior depends on whether an override was set.
+   - `get_hermes_home_env()` only when an unmodified environment string must be
+     propagated or restored.
+
+   Electron main-process code resolves the variable only through
+   `apps/desktop/electron/hermes-home.ts:resolveHermesHome()`, then passes the
+   resolved value to consumers. Standalone plugins and skill scripts remain
+   independently runnable; do not make them import the core accessor without a
+   dedicated portable-helper design.
+
+4. **Module-level constants are fine** — they cache `get_hermes_home()` at import time,
    which is AFTER `_apply_profile_override()` sets the env var. Just use `get_hermes_home()`,
    not `Path.home() / ".hermes"`.
 
-4. **Tests that mock `Path.home()` must also set `HERMES_HOME`** — since code now uses
+5. **Tests that mock `Path.home()` must also set `HERMES_HOME`** — since code now uses
    `get_hermes_home()` (reads env var), not `Path.home() / ".hermes"`:
    ```python
    with patch.object(Path, "home", return_value=tmp_path), \
@@ -1203,13 +1217,13 @@ automatically scope to the active profile.
        ...
    ```
 
-5. **Gateway platform adapters should use token locks** — if the adapter connects with
+6. **Gateway platform adapters should use token locks** — if the adapter connects with
    a unique credential (bot token, API key), call `acquire_scoped_lock()` from
    `gateway.status` in the `connect()`/`start()` method and `release_scoped_lock()` in
    `disconnect()`/`stop()`. This prevents two profiles from using the same credential.
    See `plugins/platforms/irc/adapter.py` for the canonical pattern.
 
-6. **Profile operations are HOME-anchored, not HERMES_HOME-anchored** — `_get_profiles_root()`
+7. **Profile operations are HOME-anchored, not HERMES_HOME-anchored** — `_get_profiles_root()`
    returns `Path.home() / ".hermes" / "profiles"`, NOT `get_hermes_home() / "profiles"`.
    This is intentional — it lets `hermes -p coder profile list` see all profiles regardless
    of which one is active.

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -30,10 +30,11 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
 import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger("agent.lsp.install")
 
@@ -122,10 +123,7 @@ def _is_windows() -> bool:
 
 def hermes_lsp_bin_dir() -> Path:
     """Return the Hermes-owned bin staging dir for LSP servers."""
-    home = os.environ.get("HERMES_HOME")
-    if home is None:
-        home = os.path.join(os.path.expanduser("~"), ".hermes")
-    p = Path(home) / "lsp" / "bin"
+    p = get_hermes_home() / "lsp" / "bin"
     p.mkdir(parents=True, exist_ok=True)
     return p
 

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from agent.lsp.workspace import nearest_root
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger("agent.lsp.servers")
 
@@ -710,10 +711,7 @@ def _find_pses_bundle(ctx: ServerContext) -> Optional[str]:
     env_path = os.environ.get("PSES_BUNDLE_PATH")
     if env_path:
         candidates.append(env_path)
-    home = os.environ.get("HERMES_HOME") or os.path.join(
-        os.path.expanduser("~"), ".hermes"
-    )
-    candidates.append(os.path.join(home, "lsp", "PowerShellEditorServices"))
+    candidates.append(str(get_hermes_home() / "lsp" / "PowerShellEditorServices"))
 
     for cand in candidates:
         if not cand:
@@ -796,12 +794,9 @@ def _spawn_powershell_es(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 def hermes_lsp_session_dir() -> str:
     """Return (and create) the dir for PSES session/log scratch files."""
-    home = os.environ.get("HERMES_HOME") or os.path.join(
-        os.path.expanduser("~"), ".hermes"
-    )
-    d = os.path.join(home, "lsp", "pses")
-    os.makedirs(d, exist_ok=True)
-    return d
+    directory = get_hermes_home() / "lsp" / "pses"
+    directory.mkdir(parents=True, exist_ok=True)
+    return str(directory)
 
 
 def _resolve_override(ctx: ServerContext, server_id: str) -> Optional[str]:

--- a/agent/secret_sources/_cache.py
+++ b/agent/secret_sources/_cache.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Generic, Optional, TypeVar
 
+from hermes_constants import get_hermes_home
+
 __all__ = [
     "FetchResult",
     "CachedFetch",
@@ -82,7 +84,7 @@ def resolve_cache_home(home_path: Optional[Path] = None) -> Path:
     (and tests that don't thread a home through) working.
     """
     if home_path is None:
-        home_path = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+        home_path = get_hermes_home()
     return home_path
 
 

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -470,7 +470,7 @@ function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, herme
           ...process.env,
           // Pass HERMES_HOME through so install.ps1 respects the caller's
           // choice rather than re-computing the default.
-          HERMES_HOME: hermesHome || process.env.HERMES_HOME || ''
+          HERMES_HOME: hermesHome || ''
         }
       })
     )
@@ -566,7 +566,7 @@ function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome 
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
-        HERMES_HOME: hermesHome || process.env.HERMES_HOME || ''
+        HERMES_HOME: hermesHome || ''
       }
     })
 

--- a/apps/desktop/electron/hermes-home.test.ts
+++ b/apps/desktop/electron/hermes-home.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { resolveHermesHome } from './hermes-home'
+
+const neverExists = () => false
+
+test('resolveHermesHome normalizes an explicit home override', () => {
+  const home = resolveHermesHome({
+    directoryExists: neverExists,
+    homeDirectory: '/Users/hermes',
+    isWindows: false,
+    env: { HERMES_HOME: '/data/profiles/coder' }
+  })
+
+  assert.equal(home, '/data')
+})
+
+test('resolveHermesHome uses the platform default without an override', () => {
+  const home = resolveHermesHome({
+    directoryExists: neverExists,
+    homeDirectory: '/Users/hermes',
+    isWindows: false,
+    env: {}
+  })
+
+  assert.equal(home, '/Users/hermes/.hermes')
+})

--- a/apps/desktop/electron/hermes-home.ts
+++ b/apps/desktop/electron/hermes-home.ts
@@ -1,0 +1,62 @@
+import path from 'node:path'
+
+import { normalizeHermesHomeRoot } from './backend-env'
+import { readWindowsUserEnvVar } from './windows-user-env'
+
+interface ResolveHermesHomeOptions {
+  directoryExists: (path: string) => boolean
+  homeDirectory: string
+  isWindows: boolean
+  localAppData?: string
+  userDataOverride?: string | null
+  env?: NodeJS.ProcessEnv
+}
+
+function normalizeHome(hermesHome: string, isWindows: boolean): string {
+  return normalizeHermesHomeRoot(hermesHome, { pathModule: isWindows ? path.win32 : path.posix })
+}
+
+function resolveHermesHome({
+  directoryExists,
+  homeDirectory,
+  isWindows,
+  localAppData,
+  userDataOverride,
+  env = process.env
+}: ResolveHermesHomeOptions): string {
+  const pathModule = isWindows ? path.win32 : path.posix
+  const configuredHome = env.HERMES_HOME
+  if (configuredHome) {
+    return normalizeHome(configuredHome, isWindows)
+  }
+
+  if (userDataOverride) {
+    return pathModule.join(pathModule.resolve(userDataOverride), 'hermes-home')
+  }
+
+  if (isWindows) {
+    // A GUI app launched from Explorer inherits the environment block captured
+    // at login, so a HERMES_HOME set via `setx` AFTER login is invisible in
+    // process.env even though the CLI (a fresh shell) sees it. Without this the
+    // backend silently falls back to %LOCALAPPDATA%\hermes and reports "No
+    // inference provider configured" despite a valid configured home (#45471).
+    // Consult the live User-scoped registry value before the default below.
+    const fromRegistry = readWindowsUserEnvVar('HERMES_HOME')
+    if (fromRegistry) {
+      return normalizeHome(fromRegistry, isWindows)
+    }
+  }
+
+  if (isWindows && localAppData) {
+    const localAppDataHome = pathModule.join(localAppData, 'hermes')
+    const legacyHome = pathModule.join(homeDirectory, '.hermes')
+
+    // Migrate transparently to LOCALAPPDATA, but honour an existing legacy
+    // ~/.hermes setup (no LOCALAPPDATA install yet) so users don't lose state.
+    return !directoryExists(localAppDataHome) && directoryExists(legacyHome) ? legacyHome : localAppDataHome
+  }
+
+  return pathModule.join(homeDirectory, '.hermes')
+}
+
+export { resolveHermesHome }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -38,6 +38,7 @@ import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure } from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { runBootstrap } from './bootstrap-runner'
+import { resolveHermesHome } from './hermes-home'
 import {
   authModeFromStatus,
   buildGatewayWsUrl,
@@ -159,7 +160,6 @@ import {
   writeSandboxMarker
 } from './windows-sandbox-fallback'
 import { installWindowsSystemCaTrust } from './windows-system-ca'
-import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
@@ -423,46 +423,13 @@ if (INSTALL_STAMP) {
 // HERMES_DESKTOP_USER_DATA_DIR (used by test:desktop:fresh) puts the sandbox
 // HERMES_HOME beneath the throwaway userData dir so a fresh-install run never
 // touches the user's real ~/.hermes / %LOCALAPPDATA%\hermes.
-function resolveHermesHome() {
-  if (process.env.HERMES_HOME) {
-    return normalizeHermesHomeRoot(process.env.HERMES_HOME)
-  }
-
-  if (USER_DATA_OVERRIDE) {
-    return path.join(path.resolve(USER_DATA_OVERRIDE), 'hermes-home')
-  }
-
-  if (IS_WINDOWS) {
-    // A GUI app launched from Explorer inherits the environment block captured
-    // at login, so a HERMES_HOME set via `setx` AFTER login is invisible in
-    // process.env even though the CLI (a fresh shell) sees it. Without this the
-    // backend silently falls back to %LOCALAPPDATA%\hermes and reports "No
-    // inference provider configured" despite a valid configured home (#45471).
-    // Consult the live User-scoped registry value before the default below.
-    const fromRegistry = readWindowsUserEnvVar('HERMES_HOME')
-
-    if (fromRegistry) {
-      return normalizeHermesHomeRoot(fromRegistry)
-    }
-  }
-
-  if (IS_WINDOWS && process.env.LOCALAPPDATA) {
-    const localappdata = path.join(process.env.LOCALAPPDATA, 'hermes')
-    const legacy = path.join(app.getPath('home'), '.hermes')
-
-    // Migrate transparently to LOCALAPPDATA, but honour an existing legacy
-    // ~/.hermes setup (no LOCALAPPDATA install yet) so users don't lose state.
-    if (!directoryExists(localappdata) && directoryExists(legacy)) {
-      return legacy
-    }
-
-    return localappdata
-  }
-
-  return path.join(app.getPath('home'), '.hermes')
-}
-
-const HERMES_HOME = resolveHermesHome()
+const HERMES_HOME = resolveHermesHome({
+  directoryExists,
+  homeDirectory: app.getPath('home'),
+  isWindows: IS_WINDOWS,
+  localAppData: process.env.LOCALAPPDATA,
+  userDataOverride: USER_DATA_OVERRIDE
+})
 
 function hermesManagedNodePathEntries() {
   // NOTE: keep this ordering in sync with iter_hermes_node_dirs() in

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -168,9 +168,11 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     # _PLANNED_STOP_MARKER_FILENAME); we use string literals here so the
     # signal-handler path stays import-light.
     try:
-        hermes_home_str = os.environ.get("HERMES_HOME")
-        if hermes_home_str:
-            takeover_path = Path(hermes_home_str) / ".gateway-takeover.json"
+        from hermes_constants import get_explicit_hermes_home
+
+        hermes_home = get_explicit_hermes_home()
+        if hermes_home:
+            takeover_path = hermes_home / ".gateway-takeover.json"
             if takeover_path.exists():
                 try:
                     raw = takeover_path.read_text(encoding="utf-8")
@@ -181,7 +183,7 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
                     )
                 except OSError:
                     pass
-            planned_stop_path = Path(hermes_home_str) / ".gateway-planned-stop.json"
+            planned_stop_path = hermes_home / ".gateway-planned-stop.json"
             if planned_stop_path.exists():
                 try:
                     raw = planned_stop_path.read_text(encoding="utf-8")

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -31,7 +31,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_process_hermes_home
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -46,10 +46,7 @@ _WATCHDOG_DUMP_RELATIVE = ("logs", "gateway-shutdown-watchdog.log")
 
 def _process_hermes_home() -> Path:
     """HERMES_HOME for process-level identity files (ignore profile overrides)."""
-    val = os.environ.get("HERMES_HOME", "").strip()
-    if val:
-        return Path(val)
-    return get_hermes_home()
+    return get_process_hermes_home()
 
 
 def get_loop_heartbeat_path(home: Optional[Path] = None) -> Path:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -23,7 +23,11 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from hermes_constants import get_hermes_home, _get_platform_default_hermes_home
+from hermes_constants import (
+    _get_platform_default_hermes_home,
+    get_hermes_home,
+    get_process_hermes_home,
+)
 from typing import Any, NamedTuple, Optional
 from utils import atomic_json_write
 
@@ -136,10 +140,7 @@ def _get_process_hermes_home() -> Path:
     profile directory when a profile-context task happens to be active at write
     time.  See issue #56986.
     """
-    val = os.environ.get("HERMES_HOME", "").strip()
-    if val:
-        return Path(val)
-    return _get_platform_default_hermes_home()
+    return get_process_hermes_home()
 
 
 def _get_pid_path() -> Path:

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_constants import get_hermes_home_env
+
 logger = logging.getLogger(__name__)
 
 
@@ -579,7 +581,7 @@ def _build_hermes_tools_mcp_entry() -> dict:
     # a sibling test's monkeypatch.setenv("HERMES_HOME", tmp_path) would
     # otherwise leak a transient pytest tempdir into the user's real
     # ~/.codex/config.toml and silently brick codex once the tempdir is GC'd.
-    hermes_home = os.environ.get("HERMES_HOME") or ""
+    hermes_home = get_hermes_home_env() or ""
     if hermes_home and _looks_like_test_tempdir(hermes_home):
         hermes_home = ""
     if hermes_home:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Set
 
+from hermes_constants import get_hermes_home
 from hermes_cli.secret_prompt import masked_secret_prompt
 
 logger = logging.getLogger(__name__)
@@ -5783,7 +5784,7 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
             f"this is deprecated."
         )
     if lines:
-        hint_path = os.environ.get("HERMES_HOME", "~/.hermes")
+        hint_path = str(get_hermes_home())
         lines.insert(0, "\033[33m⚠ Deprecated .env settings detected:\033[0m")
         lines.append(
             "  \033[2mMove to config.yaml instead:  "

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Sequence
 
+from hermes_constants import get_hermes_home_env
+
 log = logging.getLogger(__name__)
 
 # Only this desired state triggers automatic restart. Everything else
@@ -571,7 +573,7 @@ def main() -> int:
         )
         return 0
 
-    hermes_home = Path(os.environ.get("HERMES_HOME", "/opt/data"))
+    hermes_home = Path(get_hermes_home_env() or "/opt/data")
     scandir = Path(os.environ.get("S6_PROFILE_GATEWAY_SCANDIR", "/run/service"))
     actions = reconcile_profile_gateways(
         hermes_home=hermes_home, scandir=scandir,

--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -4,10 +4,8 @@ Profile-aware location: ``$HERMES_HOME/logs/dashboard-auth.log``.
 Format: one JSON object per line. Token-like fields are stripped before
 serialisation to avoid leaking refresh tokens or JWTs to disk.
 
-This module deliberately keeps a minimal dependency surface — no imports
-from ``hermes_constants`` or other hermes_cli modules — so it can be
-imported safely from middleware code that loads early in the startup
-sequence.
+This module deliberately keeps a minimal dependency surface so it can be
+imported safely from middleware code that loads early in the startup sequence.
 """
 from __future__ import annotations
 
@@ -19,6 +17,8 @@ import os
 import threading
 from pathlib import Path
 from typing import Any
+
+from hermes_constants import get_hermes_home
 
 _log = logging.getLogger(__name__)
 _write_lock = threading.Lock()
@@ -54,12 +54,9 @@ class AuditEvent(enum.Enum):
 def _resolve_log_path() -> Path:
     """``$HERMES_HOME/logs/dashboard-auth.log`` with the standard fallback.
 
-    Mirrors ``hermes_constants.get_hermes_home`` semantics: env var wins,
-    else ``~/.hermes``. A local copy avoids an import cycle with the
-    middleware which lives below ``hermes_cli``.
+    Follows the profile-aware Hermes home resolver.
     """
-    home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
-    return Path(home) / "logs" / "dashboard-auth.log"
+    return get_hermes_home() / "logs" / "dashboard-auth.log"
 
 
 def audit_log(event: AuditEvent, **fields: Any) -> None:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
+from hermes_constants import get_hermes_home
 from utils import atomic_replace, fast_safe_load
 
 
@@ -300,7 +301,10 @@ def load_hermes_dotenv(
     """
     loaded: list[Path] = []
 
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    if not hermes_home:
+        home_path = get_hermes_home()
+    else:
+        home_path = Path(hermes_home)
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -39,6 +39,7 @@ from gateway.restart import (
     is_gateway_supervisor_process,
     parse_restart_drain_timeout,
 )
+from hermes_constants import get_explicit_hermes_home
 from hermes_cli.config import (
     get_env_value,
     get_hermes_home,
@@ -1002,7 +1003,7 @@ def _sync_hermes_home_from_systemd_unit(system: bool) -> None:
         unit_home = _read_systemd_unit_environment(system=True).get("HERMES_HOME", "").strip()
     if not unit_home:
         return
-    current = os.environ.get("HERMES_HOME", "").strip()
+    current = str(get_explicit_hermes_home() or "")
     if current == unit_home:
         return
     os.environ["HERMES_HOME"] = unit_home
@@ -2625,12 +2626,7 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
       /root/.hermes/profiles/coder     → /home/alice/.hermes/profiles/coder
       /opt/custom-hermes               → /opt/custom-hermes  (kept as-is)
     """
-    current_hermes_raw = os.environ.get("HERMES_HOME", "").strip()
-    current_hermes = (
-        Path(current_hermes_raw).expanduser()
-        if current_hermes_raw
-        else get_hermes_home()
-    )
+    current_hermes = (get_explicit_hermes_home() or get_hermes_home()).expanduser()
     # Keep explicit custom paths lexical. Resolving a non-existent custom path
     # can rewrite it through host-specific path mappings, which would bake a
     # different HERMES_HOME into the generated service unit.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -240,12 +240,10 @@ def _config_default_interface_early() -> str:
         return _EARLY_INTERFACE_CACHE[0]
     value = "cli"
     try:
-        home = os.environ.get("HERMES_HOME")
-        if home:
-            cfg_path = os.path.join(home, "config.yaml")
-        else:
-            cfg_path = os.path.join(os.path.expanduser("~"), ".hermes", "config.yaml")
-        if os.path.exists(cfg_path):
+        from hermes_constants import get_hermes_home
+
+        cfg_path = get_hermes_home() / "config.yaml"
+        if cfg_path.exists():
             import yaml as _yaml_iface
 
             with open(cfg_path, encoding="utf-8") as _f:
@@ -467,7 +465,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 #
 # Many modules cache HERMES_HOME at import time (module-level constants).
 # We intercept --profile/-p from sys.argv here and set the env var so that
-# every subsequent ``os.getenv("HERMES_HOME", ...)`` resolves correctly.
+# every subsequent Hermes-home lookup resolves correctly.
 # The flag is stripped from sys.argv so argparse never sees it.
 # Falls back to ~/.hermes/active_profile for sticky default.
 # ---------------------------------------------------------------------------
@@ -586,9 +584,11 @@ def _apply_profile_override() -> None:
     # still read active_profile — the user may have switched profiles via
     # `hermes profile use` and the gateway should honour that choice.
     # See issue #22502.
-    hermes_home_env = os.environ.get("HERMES_HOME", "")
+    from hermes_constants import get_explicit_hermes_home
+
+    hermes_home_env = get_explicit_hermes_home()
     if profile_name is None and hermes_home_env:
-        if Path(hermes_home_env).parent.name == "profiles":
+        if hermes_home_env.parent.name == "profiles":
             return
 
     # 2. If no flag, check active_profile in the hermes root.
@@ -1749,7 +1749,9 @@ def _ensure_tui_node() -> None:
     if not helper.is_file():
         return
 
-    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    from hermes_constants import get_hermes_home
+
+    hermes_home = str(get_hermes_home())
     try:
         # Helper writes logs to stderr; we ask bash to print `command -v node`
         # on stdout once ensure_node succeeds. Subshell PATH edits don't leak

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -33,6 +33,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_constants import get_hermes_home_env
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
@@ -1704,7 +1705,7 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
 
     # Derive service name for this profile
     # Temporarily set HERMES_HOME so _profile_suffix resolves correctly
-    old_home = os.environ.get("HERMES_HOME")
+    old_home = get_hermes_home_env()
     try:
         os.environ["HERMES_HOME"] = str(profile_dir)
         from hermes_cli.gateway import get_service_name, get_launchd_plist_path
@@ -1742,8 +1743,8 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
     finally:
         if old_home is not None:
             os.environ["HERMES_HOME"] = old_home
-        elif "HERMES_HOME" in os.environ:
-            del os.environ["HERMES_HOME"]
+        else:
+            os.environ.pop("HERMES_HOME", None)
 
 
 def _stop_gateway_process(profile_dir: Path) -> None:

--- a/hermes_cli/security_audit_startup.py
+++ b/hermes_cli/security_audit_startup.py
@@ -28,6 +28,8 @@ import re
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger("hermes.security_audit")
 
 # Sentinel so the audit only runs once per process even if both the CLI and
@@ -168,9 +170,10 @@ def _path_is_mounted(path: Path) -> bool:
 def _container_no_volume_mount(hermes_home: Optional[Path]) -> Optional[str]:
     if not _in_container():
         return None
-    home = hermes_home or Path(
-        os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
-    )
+    if hermes_home is None:
+        home = get_hermes_home()
+    else:
+        home = hermes_home
     try:
         if _path_is_mounted(home):
             return None

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -20,6 +20,8 @@ import re
 from pathlib import Path
 from typing import Literal, Protocol, runtime_checkable
 
+from hermes_constants import get_hermes_home_env
+
 ServiceManagerKind = Literal["systemd", "launchd", "windows", "s6", "none"]
 
 # Profile name → service directory mapping. Profile names must be safe
@@ -344,11 +346,9 @@ def _profile_dir_for_gateway_service(name: str) -> Path:
     service suffix to either the root default profile or
     ``<root>/profiles/<profile>``.
     """
-    import os
-
     profile = name[len(S6_SERVICE_PREFIX):] if name.startswith(S6_SERVICE_PREFIX) else name
     validate_profile_name(profile)
-    hermes_home = Path(os.environ.get("HERMES_HOME", "/opt/data"))
+    hermes_home = Path(get_hermes_home_env() or "/opt/data")
     if hermes_home.parent.name == "profiles":
         root = hermes_home.parent.parent
     else:

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -22,6 +22,8 @@ import os
 import sys
 from pathlib import Path
 
+from hermes_constants import get_hermes_home
+
 
 def _build_full_manifest(
     bot_name: str,
@@ -195,12 +197,7 @@ def slack_manifest_command(args) -> int:
     if write_target is not None:
         if isinstance(write_target, bool) and write_target:
             # --write with no value → default location
-            try:
-                from hermes_constants import get_hermes_home
-
-                target = Path(get_hermes_home()) / "slack-manifest.json"
-            except Exception:
-                target = Path(os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")) / "slack-manifest.json"
+            target = get_hermes_home() / "slack-manifest.json"
         else:
             target = Path(write_target).expanduser()
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1853,15 +1853,17 @@ def _local_dashboard_request(request: Request) -> bool:
 
 
 def _default_hermes_root_is_opt_data() -> bool:
-    raw = os.environ.get("HERMES_HOME", "").strip()
-    if not raw:
+    from hermes_constants import get_explicit_hermes_home
+
+    home = get_explicit_hermes_home()
+    if home is None:
         return False
     try:
         from hermes_constants import get_default_hermes_root
 
         root = get_default_hermes_root().expanduser().resolve(strict=False)
     except (OSError, RuntimeError):
-        root = Path(raw).expanduser().resolve(strict=False)
+        root = home.expanduser().resolve(strict=False)
     return root == _HOSTED_MANAGED_FILES_ROOT
 
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -52,7 +52,9 @@ def _get_platform_default_hermes_home() -> Path:
     return Path.home() / ".hermes"
 
 
-def _hermes_home_from_env() -> Path:
+def _hermes_home_from_env(
+    *, warn_if_unset: bool = False, fallback: bool = True, raw: bool = False
+) -> Path | str | None:
     """Resolve HERMES_HOME from the process environment only.
 
     Reads the ``HERMES_HOME`` env var, falling back to the platform-native
@@ -61,10 +63,34 @@ def _hermes_home_from_env() -> Path:
     scope rather than a per-task profile.  Shared by :func:`get_hermes_home`
     and :func:`get_process_hermes_home` so the two never drift.
     """
-    val = os.environ.get("HERMES_HOME", "").strip()
+    raw_value = os.environ.get("HERMES_HOME")
+    if raw:
+        return raw_value
+    val = (raw_value or "").strip()
     if val:
         return Path(val)
-    return _get_platform_default_hermes_home()
+    if warn_if_unset:
+        _warn_profile_fallback_once()
+    return _get_platform_default_hermes_home() if fallback else None
+
+
+def get_explicit_hermes_home() -> Path | None:
+    """Return the explicitly configured process Hermes home, if any.
+
+    Unlike :func:`get_hermes_home`, this does not follow context-local profile
+    overrides or supply a default. Use it when code must distinguish an
+    explicitly exported ``HERMES_HOME`` from an implicit default.
+    """
+    home = _hermes_home_from_env(fallback=False)
+    assert home is None or isinstance(home, Path)
+    return home
+
+
+def get_hermes_home_env() -> str | None:
+    """Return the unmodified ``HERMES_HOME`` process value, if it is set."""
+    value = _hermes_home_from_env(raw=True)
+    assert value is None or isinstance(value, str)
+    return value
 
 
 def _warn_profile_fallback_once() -> None:
@@ -126,10 +152,9 @@ def get_hermes_home() -> Path:
     if override:
         return Path(override)
 
-    if not os.environ.get("HERMES_HOME", "").strip():
-        _warn_profile_fallback_once()
-
-    return _hermes_home_from_env()
+    home = _hermes_home_from_env(warn_if_unset=True)
+    assert isinstance(home, Path)
+    return home
 
 
 def get_process_hermes_home() -> Path:
@@ -148,7 +173,9 @@ def get_process_hermes_home() -> Path:
     for genuinely profile-scoped data (memories, backups, checkpoints,
     provider config) — those should keep following the override.
     """
-    return _hermes_home_from_env()
+    home = _hermes_home_from_env()
+    assert isinstance(home, Path)
+    return home
 
 
 def get_default_hermes_root() -> Path:
@@ -169,10 +196,11 @@ def get_default_hermes_root() -> Path:
     Import-safe — no dependencies beyond stdlib.
     """
     native_home = _get_platform_default_hermes_home()
-    env_home = os.environ.get("HERMES_HOME", "")
-    if not env_home:
+    env_home = _hermes_home_from_env(fallback=False)
+    assert env_home is None or isinstance(env_home, Path)
+    if env_home is None:
         return native_home
-    env_path = Path(env_home)
+    env_path = env_home
     try:
         env_path.resolve().relative_to(native_home.resolve())
         # HERMES_HOME is under ~/.hermes (normal or profile mode)
@@ -722,7 +750,7 @@ def _norm_home_path(path: str | None) -> str:
 
 def _profile_home_path(env: dict[str, str] | None = None) -> str | None:
     """Return ``{HERMES_HOME}/home`` when the profile-home directory exists."""
-    hermes_home = get_hermes_home_override() or (env or {}).get("HERMES_HOME") or os.getenv("HERMES_HOME")
+    hermes_home = get_hermes_home_override() or (env or {}).get("HERMES_HOME") or _hermes_home_from_env(fallback=False)
     if not hermes_home:
         return None
     profile_home = os.path.join(hermes_home, "home")

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -41,6 +41,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger("hermes.mcp_serve")
 
 # ---------------------------------------------------------------------------
@@ -62,11 +64,7 @@ except ImportError:
 
 def _get_sessions_dir() -> Path:
     """Return the sessions directory using HERMES_HOME."""
-    try:
-        from hermes_constants import get_hermes_home
-        return get_hermes_home() / "sessions"
-    except ImportError:
-        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "sessions"
+    return get_hermes_home() / "sessions"
 
 
 def _get_session_db():
@@ -194,13 +192,7 @@ def _load_sessions_index_from_json() -> dict:
 
 def _load_channel_directory() -> dict:
     """Load the cached channel directory for available targets."""
-    try:
-        from hermes_constants import get_hermes_home
-        directory_file = get_hermes_home() / "channel_directory.json"
-    except ImportError:
-        directory_file = Path(
-            os.environ.get("HERMES_HOME", Path.home() / ".hermes")
-        ) / "channel_directory.json"
+    directory_file = get_hermes_home() / "channel_directory.json"
 
     if not directory_file.exists():
         return {}
@@ -450,11 +442,7 @@ class EventBridge:
         eliminating the old dual-file (sessions.json + state.db) race that
         could drop brand-new conversations (#8925).
         """
-        try:
-            from hermes_constants import get_hermes_home
-            db_file = get_hermes_home() / "state.db"
-        except ImportError:
-            db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
+        db_file = get_hermes_home() / "state.db"
 
         try:
             db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -118,6 +118,16 @@ class TestGetHermesHome:
 
         assert get_hermes_home() == local_appdata / "hermes"
 
+    def test_unset_home_warns_from_the_environment_accessor(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(hermes_constants, "_profile_fallback_warned", False)
+        warned = []
+        monkeypatch.setattr(hermes_constants, "_warn_profile_fallback_once", lambda: warned.append(True))
+
+        assert get_hermes_home() == tmp_path / ".hermes"
+        assert warned == [True]
+
 
 class TestGetProcessHermesHome:
     """Tests for get_process_hermes_home() — process launch scope.

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -48,6 +48,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger(__name__)
 
 
@@ -117,13 +119,7 @@ def _resolve_spill_dir(directory_override: Optional[str], session_id: Optional[s
     if directory_override:
         base = Path(os.path.expanduser(directory_override))
     else:
-        try:
-            from hermes_constants import get_hermes_home
-            base = Path(get_hermes_home()) / "hook_outputs"
-        except Exception:
-            # Last-resort fallback: HERMES_HOME env var, then ~/.hermes
-            home = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
-            base = Path(home) / "hook_outputs"
+        base = get_hermes_home() / "hook_outputs"
 
     # Group by session so spills are contained per conversation.
     session_segment = session_id or "no-session"

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -52,6 +52,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
+
+from hermes_constants import get_hermes_home
 from hermes_constants import secure_parent_dir
 
 logger = logging.getLogger(__name__)
@@ -137,11 +139,7 @@ def _get_token_dir(hermes_home: str | Path | None = None) -> Path:
     Uses HERMES_HOME so each profile gets its own OAuth tokens.
     Layout: ``HERMES_HOME/mcp-tokens/``
     """
-    try:
-        from hermes_constants import get_hermes_home
-        base = Path(hermes_home) if hermes_home is not None else Path(get_hermes_home())
-    except ImportError:
-        base = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    base = Path(hermes_home) if hermes_home is not None else get_hermes_home()
     return base / "mcp-tokens"
 
 

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
+from hermes_constants import get_hermes_home_env
+
 
 def now_ns() -> int:
     return time.perf_counter_ns()
@@ -105,6 +107,11 @@ class _HostTransport:
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
+
+
+def _explicit_hermes_home_text() -> str:
+    """Return the launch-time HERMES_HOME value without a fallback."""
+    return get_hermes_home_env() or ""
 
 
 def _build_sha() -> str:
@@ -638,7 +645,7 @@ def run_host(stdin: Any = None, stdout: Any = None) -> None:
             "boot_id": host._boot_id,
             "build_sha": _build_sha(),
             "cwd": os.getcwd(),
-            "hermes_home": os.environ.get("HERMES_HOME", ""),
+            "hermes_home": _explicit_hermes_home_text(),
         }
     )
 


### PR DESCRIPTION
## Why

`HERMES_HOME` is currently read directly at multiple points in both the Python agent and the Electron desktop runtime. That duplication makes profile-aware path behavior harder to audit and allows each call site to diverge in fallback or normalization logic.

## What Changes

- Define one dedicated `HERMES_HOME` environment-access function in hermes-agent and one in the desktop runtime.
- Route all production path resolution that depends on `HERMES_HOME` through the local platform's dedicated function.
- Remove direct reads of the `HERMES_HOME` environment variable from all other functions.
- Add focused regression coverage proving each accessor's resolution behavior and guarding the no-direct-read boundary.

## Capabilities

### New Capabilities
- `hermes-home-access-boundary`: Centralized, profile-safe `HERMES_HOME` resolution for the Python agent and desktop runtime.

