### PR TITLE
fix(mcp): guard t.cancel() against closed event loop during shutdown

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2295,7 +2295,11 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
+                    try:
+                        t.cancel()
+                    except RuntimeError:
+                        # Event loop already closed during shutdown cleanup
+                        continue
                     try:
                         await t
                     except (asyncio.CancelledError, Exception):
@@ -2339,7 +2343,11 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
+                    try:
+                        t.cancel()
+                    except RuntimeError:
+                        # Event loop already closed during shutdown cleanup
+                        continue
                     try:
                         await t
                     except (asyncio.CancelledError, Exception):


### PR DESCRIPTION
## Problem

On CLI exit (`/exit`), parked MCP server tasks that failed initial connection and are waiting in `_wait_for_reconnect_or_shutdown` get garbage-collected **after** the event loop is already closed. Their `finally` block calls `t.cancel()` → `call_soon()` → `_check_closed()` → `RuntimeError: Event loop is closed`.

This prints noisy `Exception ignored in: <coroutine object MCPServerTask.run ...>` tracebacks on every exit when any MCP server was in a parked state.

## Fix

Wrap `t.cancel()` in `try/except RuntimeError` and skip the await when the loop is already gone — the tasks are being collected anyway, so there is nothing meaningful to cancel or await.

Both call sites (connected-path and parked-path `finally` blocks) are patched identically.

## Reproduction

1. Configure an MCP server that fails to connect (or is unreachable)
2. Start hermes CLI, let the server park
3. `/exit`
4. Observe `RuntimeError: Event loop is closed` tracebacks