### PR TITLE
fix: move plugin load before backend resolve in web_extract

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -855,8 +855,6 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_extract_backend()
-
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
             # tavily, firecrawl) now live as plugins. The dispatcher is a
             # registry lookup + delegation. Some providers' extract() is
@@ -871,6 +869,7 @@ async def web_extract_tool(
                 _disabled_web_plugin_for,
             )
 
+            backend = _get_extract_backend()
             provider = _wsp_get_provider(backend) if backend else None
             if provider is None or not provider.supports_extract():
                 # When the configured name IS registered but doesn't support


### PR DESCRIPTION
Extract should load plugins before checking registry, same as search. Now custom extract plugins can't be found on cold start.

## What does this PR do?

Fix init order in `web_extract_tool`: load plugins before checking registry, matching the pattern already used by `web_search_tool`. Without this, custom extract plugins can't be found on cold start.

## Related Issue

Fixes #73192

## Changes Made

- `tools/web_tools.py`: moved `_ensure_web_plugins_loaded()` before `_get_extract_backend()` in `web_extract_tool`

## How to Test

1. Configure a custom-plugin-based extract backend (e.g. `web.extract_backend: my-extractor`)
2. Start a fresh Hermes session and call `web_extract(urls=[...])` as the first web operation
3. Content is extracted successfully instead of returning "search-only backend" error
