### PR TITLE
fix: reject unusable clarify choices

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -126,8 +126,21 @@ describe('clarify.request stream hydration', () => {
     })
   })
 
-  it('merges with the real tool.start row even though its id differs from the request id', () => {
-    mountStream()
+  it('marks a non-empty all-invalid choice array as malformed', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    await mountStream()
+
+    clarifyRequest({ choices: ['', '   ', '\n'], question: 'Pick one', request_id: 'req-invalid' })
+
+    expect($clarifyRequests.get()[SID]).toMatchObject({
+      choices: null,
+      choicesMalformed: true,
+      requestId: 'req-invalid'
+    })
+  })
+
+  it('merges with the real tool.start row even though its id differs from the request id', async () => {
+    await mountStream()
 
     // Reality: tool.start carries the model's tool_call_id, clarify.request a
     // separately-generated request_id. They must still collapse to ONE card

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { clearClarifyRequest } from '@/store/clarify'
+import { $clarifyRequests, clearClarifyRequest } from '@/store/clarify'
 import type { RpcEvent } from '@/types/hermes'
 
 import { useMessageStream } from './index'
@@ -90,6 +90,19 @@ describe('clarify.request stream hydration', () => {
     expect(parts[0].type === 'tool-call' && parts[0].args).toMatchObject({
       choices: ['yes', 'no'],
       question: 'Ship it?'
+    })
+  })
+
+  it('marks a non-empty all-invalid choice array as malformed', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    await mountStream()
+
+    clarifyRequest({ choices: ['', '   ', '\n'], question: 'Pick one', request_id: 'req-invalid' })
+
+    expect($clarifyRequests.get()[SID]).toMatchObject({
+      choices: null,
+      choicesMalformed: true,
+      requestId: 'req-invalid'
     })
   })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -20,7 +20,13 @@ import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
 import { type AgentNoticePayload, clearAgentNotice, nativeNoticeInput, showAgentNotice } from '@/store/agent-notices'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { billingCtaLabel, clearBillingBlock, runBillingRecovery, setBillingBlock } from '@/store/billing-block'
-import { clearClarifyRequest, normalizeChoices, setClarifyRequest, warnDroppedChoices } from '@/store/clarify'
+import {
+  clearClarifyRequest,
+  hasMalformedStructuredChoices,
+  normalizeChoices,
+  setClarifyRequest,
+  warnDroppedChoices
+} from '@/store/clarify'
 import { setSessionCompacting } from '@/store/compaction'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
 import { $gateway } from '@/store/gateway'
@@ -876,9 +882,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const question = typeof payload?.question === 'string' ? payload.question : ''
         const rawChoices = payload?.choices
         const choices = normalizeChoices(rawChoices)
+        const choicesMalformed = hasMalformedStructuredChoices(rawChoices, choices)
 
         if (requestId && question) {
-          if (rawChoices != null && choices.length === 0) {
+          if (choicesMalformed) {
             warnDroppedChoices('gateway', question, rawChoices)
           }
 
@@ -886,6 +893,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             requestId,
             question,
             choices: choices.length > 0 ? choices : null,
+            choicesMalformed,
             sessionId: sessionId ?? null
           })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -4,6 +4,7 @@ import { restorePendingClarifyToolCall, settlePendingClarifyToolCall } from '@/l
 import {
   $clarifyRequests,
   clearClarifyRequest,
+  hasMalformedStructuredChoices,
   normalizeChoices,
   normalizeQuestions,
   setClarifyRequest,
@@ -44,6 +45,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     const rawChoices = payload?.choices
     const choices = normalizeChoices(rawChoices)
     const multiSelect = payload?.multi_select === true
+    const choicesMalformed = hasMalformedStructuredChoices(rawChoices, choices)
     // Batch (multi-question) clarify: `questions` replaces question/choices
     // on the wire. `answers` rides along only on reconnect replay, carrying
     // the per-question locks the server already accepted.
@@ -105,7 +107,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         title: translateNow('notifications.native.inputTitle')
       })
     } else if (requestId && question) {
-      if (rawChoices != null && choices.length === 0) {
+      if (choicesMalformed) {
         warnDroppedChoices('gateway', question, rawChoices)
       }
 
@@ -114,6 +116,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         question,
         choices: choices.length > 0 ? choices : null,
         multiSelect,
+        choicesMalformed,
         receivedAt: Date.now() / 1000,
         sessionId: sessionId ?? null
       }

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -44,7 +44,7 @@ afterEach(() => {
   $activeSessionId.set(null)
   $gateway.set(null)
   messageRunning = true
-  vi.clearAllMocks()
+  vi.restoreAllMocks()
 })
 
 function clarifyTree(ui: ReactNode) {
@@ -370,6 +370,62 @@ describe('ClarifyTool settled view', () => {
 })
 
 describe('ClarifyTool keyboard navigation', () => {
+  it('shows a recoverable error instead of free text for all-invalid choices', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest({
+      choices: null,
+      choicesMalformed: true,
+      question: 'Pre-flight decisions (4 items)',
+      requestId: 'request-invalid',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(
+      <ClarifyTool
+        {...liveClarifyProps(['', '   ', '\n'])}
+        args={{ choices: ['', '   ', '\n'], question: 'Pre-flight decisions (4 items)' }}
+      />
+    )
+
+    expect(screen.getByRole('alert').textContent).toContain('no usable options')
+    expect(screen.queryByPlaceholderText(/Type your answer/)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: '',
+        request_id: 'request-invalid'
+      })
+    })
+  })
+
+  it('accepts raw choice shapes that the backend can normalize', () => {
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn() } as never)
+    setClarifyRequest({
+      choices: ['descriptive label'],
+      choicesMalformed: false,
+      question: 'Pick a layout',
+      requestId: 'request-structured',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(
+      <ClarifyTool
+        {...liveClarifyProps()}
+        args={{ choices: [{ description: 'descriptive label' }], question: 'Pick a layout' }}
+      />
+    )
+
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.getByRole('button', { name: /descriptive label/ })).toBeTruthy()
+  })
+
   it('cycles through choices and Other with the arrow keys', () => {
     renderLiveClarify()
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
   clearClarifyRequest()
   $activeSessionId.set(null)
   $gateway.set(null)
-  vi.clearAllMocks()
+  vi.restoreAllMocks()
 })
 
 function renderClarify(ui: ReactNode) {
@@ -231,6 +231,62 @@ describe('ClarifyTool settled view', () => {
 })
 
 describe('ClarifyTool keyboard navigation', () => {
+  it('shows a recoverable error instead of free text for all-invalid choices', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest({
+      choices: null,
+      choicesMalformed: true,
+      question: 'Pre-flight decisions (4 items)',
+      requestId: 'request-invalid',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(
+      <ClarifyTool
+        {...liveClarifyProps(['', '   ', '\n'])}
+        args={{ choices: ['', '   ', '\n'], question: 'Pre-flight decisions (4 items)' }}
+      />
+    )
+
+    expect(screen.getByRole('alert').textContent).toContain('no usable options')
+    expect(screen.queryByPlaceholderText(/Type your answer/)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: '',
+        request_id: 'request-invalid'
+      })
+    })
+  })
+
+  it('accepts raw choice shapes that the backend can normalize', () => {
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn() } as never)
+    setClarifyRequest({
+      choices: ['descriptive label'],
+      choicesMalformed: false,
+      question: 'Pick a layout',
+      requestId: 'request-structured',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(
+      <ClarifyTool
+        {...liveClarifyProps()}
+        args={{ choices: [{ description: 'descriptive label' }], question: 'Pick a layout' }}
+      />
+    )
+
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.getByRole('button', { name: /descriptive label/ })).toBeTruthy()
+  })
+
   it('cycles through choices and Other with the arrow keys', () => {
     renderLiveClarify()
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -31,6 +31,7 @@ import {
   type ClarifyQuestion,
   type ClarifyRequest,
   clearClarifyRequest,
+  hasMalformedStructuredChoices,
   normalizeChoices,
   RECOMMENDED_LABEL,
   sessionClarifyRequest,
@@ -48,6 +49,7 @@ interface ClarifyArgs {
   choices?: string[] | null
   multiSelect?: boolean
   questions?: { question: string; choices?: string[] | null; multiSelect?: boolean }[]
+  choicesMalformed?: boolean
 }
 
 interface ClarifyResult {
@@ -70,10 +72,11 @@ function readClarifyArgs(args: unknown): ClarifyArgs {
   const row = parseMaybeObject(args)
   const rawChoices = row.choices
   const choices = normalizeChoices(rawChoices)
+  const choicesMalformed = hasMalformedStructuredChoices(rawChoices, choices)
 
   const question = stringField(row, 'question')
 
-  if (rawChoices != null && choices.length === 0 && question) {
+  if (choicesMalformed && question) {
     warnDroppedChoices('tool_args', question, rawChoices)
   }
 
@@ -110,7 +113,8 @@ function readClarifyArgs(args: unknown): ClarifyArgs {
     question,
     choices: choices.length > 0 ? choices : null,
     multiSelect: row.multi_select === true,
-    questions
+    questions,
+    choicesMalformed
   }
 }
 
@@ -436,6 +440,7 @@ function ClarifyToolSinglePending({
 
   const hasChoices = choices.length > 0
   const multiSelect = hasChoices && Boolean(matchingRequest?.multiSelect ?? fromArgs.multiSelect)
+  const choicesMalformed = Boolean(fromArgs.choicesMalformed || matchingRequest?.choicesMalformed)
 
   const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -705,6 +710,27 @@ function ClarifyToolSinglePending({
     return (
       <ClarifyShell aria-label={copy.loadingQuestion} className="my-1.5 grid min-h-12 place-items-center" role="status">
         <Loader2 aria-hidden className="size-4 animate-spin text-(--ui-text-tertiary)" />
+      </ClarifyShell>
+    )
+  }
+
+  if (choicesMalformed) {
+    return (
+      <ClarifyShell className="grid gap-2 px-2.5 py-2" data-clarify-malformed="">
+        <div className="flex items-start gap-2">
+          <span className="flex-1 whitespace-pre-wrap font-medium leading-(--conversation-line-height)">
+            {question}
+          </span>
+          <MessageQuestion aria-hidden className="mt-px size-4 shrink-0 text-(--ui-text-tertiary)" />
+        </div>
+        <p className="text-sm text-destructive" role="alert">
+          {copy.invalidChoices}
+        </p>
+        <div className="flex justify-end">
+          <Button disabled={submitting} onClick={() => void respond('')} size="xs" type="button" variant="text">
+            {copy.skip}
+          </Button>
+        </div>
       </ClarifyShell>
     )
   }

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -25,7 +25,13 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { clearClarifyRequest, normalizeChoices, sessionClarifyRequest, warnDroppedChoices } from '@/store/clarify'
+import {
+  clearClarifyRequest,
+  hasMalformedStructuredChoices,
+  normalizeChoices,
+  sessionClarifyRequest,
+  warnDroppedChoices
+} from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 
@@ -35,6 +41,7 @@ import { parseMaybeObject } from './tool/fallback-model/format'
 interface ClarifyArgs {
   question?: string
   choices?: string[] | null
+  choicesMalformed?: boolean
 }
 
 interface ClarifyResult {
@@ -57,16 +64,18 @@ function readClarifyArgs(args: unknown): ClarifyArgs {
   const row = parseMaybeObject(args)
   const rawChoices = row.choices
   const choices = normalizeChoices(rawChoices)
+  const choicesMalformed = hasMalformedStructuredChoices(rawChoices, choices)
 
   const question = stringField(row, 'question')
 
-  if (rawChoices != null && choices.length === 0 && question) {
+  if (choicesMalformed && question) {
     warnDroppedChoices('tool_args', question, rawChoices)
   }
 
   return {
     question,
-    choices: choices.length > 0 ? choices : null
+    choices: choices.length > 0 ? choices : null,
+    choicesMalformed
   }
 }
 
@@ -306,6 +315,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   )
 
   const hasChoices = choices.length > 0
+  const choicesMalformed = Boolean(fromArgs.choicesMalformed || matchingRequest?.choicesMalformed)
 
   const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -523,6 +533,27 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     return (
       <ClarifyShell aria-label={copy.loadingQuestion} className="my-1.5 grid min-h-12 place-items-center" role="status">
         <Loader2 aria-hidden className="size-4 animate-spin text-(--ui-text-tertiary)" />
+      </ClarifyShell>
+    )
+  }
+
+  if (choicesMalformed) {
+    return (
+      <ClarifyShell className="grid gap-2 px-2.5 py-2" data-clarify-malformed="">
+        <div className="flex items-start gap-2">
+          <span className="flex-1 whitespace-pre-wrap font-medium leading-(--conversation-line-height)">
+            {question}
+          </span>
+          <MessageQuestion aria-hidden className="mt-px size-4 shrink-0 text-(--ui-text-tertiary)" />
+        </div>
+        <p className="text-sm text-destructive" role="alert">
+          {copy.invalidChoices}
+        </p>
+        <div className="flex justify-end">
+          <Button disabled={submitting} onClick={() => void respond('')} size="xs" type="button" variant="text">
+            {copy.skip}
+          </Button>
+        </div>
       </ClarifyShell>
     )
   }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2332,6 +2332,7 @@ export const ar = defineLocale({
       gatewayDisconnected: 'البوابة غير متصلة',
       sendFailed: 'فشل الإرسال',
       loadingQuestion: 'جار تحميل السؤال...',
+      invalidChoices: 'لا يحتوي طلب التوضيح هذا على خيارات صالحة. تخطّه ليتمكن الوكيل من إعادة المحاولة.',
       other: 'غير ذلك',
       placeholder: 'اكتب إجابتك...',
       skip: 'تخطي',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2731,6 +2731,7 @@ export const ar = defineLocale({
       gatewayDisconnected: 'البوابة غير متصلة',
       sendFailed: 'فشل الإرسال',
       loadingQuestion: 'جار تحميل السؤال...',
+      invalidChoices: 'لا يحتوي طلب التوضيح هذا على خيارات صالحة. تخطّه ليتمكن الوكيل من إعادة المحاولة.',
       other: 'غير ذلك',
       placeholder: 'اكتب إجابتك...',
       skip: 'تخطي',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2775,6 +2775,7 @@ export const en: Translations = {
       gatewayDisconnected: 'Hermes gateway is not connected',
       sendFailed: 'Could not send clarify response',
       loadingQuestion: 'Loading question…',
+      invalidChoices: 'This clarification has no usable options. Skip it so the agent can retry.',
       other: 'Other (type your answer)',
       placeholder: 'Type your answer…',
       skip: 'Skip',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3580,6 +3580,7 @@ export const en: Translations = {
       gatewayDisconnected: 'Hermes gateway is not connected',
       sendFailed: 'Could not send clarify response',
       loadingQuestion: 'Loading question…',
+      invalidChoices: 'This clarification has no usable options. Skip it so the agent can retry.',
       other: 'Other (type your answer)',
       placeholder: 'Type your answer…',
       skip: 'Skip',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2593,6 +2593,7 @@ export const ja = defineLocale({
       gatewayDisconnected: 'Hermes ゲートウェイが接続されていません',
       sendFailed: '明確化応答を送信できませんでした',
       loadingQuestion: '質問を読み込み中…',
+      invalidChoices: 'この確認には使用可能な選択肢がありません。スキップすると、エージェントが再試行できます。',
       other: 'その他（回答を入力）',
       placeholder: '回答を入力…',
       skip: 'スキップ',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3174,6 +3174,7 @@ export const ja = defineLocale({
       gatewayDisconnected: 'Hermes ゲートウェイが接続されていません',
       sendFailed: '明確化応答を送信できませんでした',
       loadingQuestion: '質問を読み込み中…',
+      invalidChoices: 'この確認には使用可能な選択肢がありません。スキップすると、エージェントが再試行できます。',
       other: 'その他（回答を入力）',
       placeholder: '回答を入力…',
       skip: 'スキップ',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2365,6 +2365,7 @@ export interface Translations {
       gatewayDisconnected: string
       sendFailed: string
       loadingQuestion: string
+      invalidChoices: string
       other: string
       placeholder: string
       skip: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -3115,6 +3115,7 @@ export interface Translations {
       gatewayDisconnected: string
       sendFailed: string
       loadingQuestion: string
+      invalidChoices: string
       other: string
       placeholder: string
       skip: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2511,6 +2511,7 @@ export const zhHant = defineLocale({
       gatewayDisconnected: 'Hermes 閘道未連線',
       sendFailed: '無法傳送澄清回應',
       loadingQuestion: '正在載入問題…',
+      invalidChoices: '此澄清要求沒有可用選項。請略過，讓代理程式重試。',
       other: '其他（輸入您的答案）',
       placeholder: '輸入您的答案…',
       skip: '略過',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -3067,6 +3067,7 @@ export const zhHant = defineLocale({
       gatewayDisconnected: 'Hermes 閘道未連線',
       sendFailed: '無法傳送澄清回應',
       loadingQuestion: '正在載入問題…',
+      invalidChoices: '此澄清要求沒有可用選項。請略過，讓代理程式重試。',
       other: '其他（輸入您的答案）',
       placeholder: '輸入您的答案…',
       skip: '略過',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2950,6 +2950,7 @@ export const zh: Translations = {
       gatewayDisconnected: 'Hermes 网关未连接',
       sendFailed: '无法发送澄清响应',
       loadingQuestion: '正在加载问题…',
+      invalidChoices: '此澄清请求没有可用选项。请跳过，以便代理重试。',
       other: '其他 (输入你的答案)',
       placeholder: '输入你的答案…',
       skip: '跳过',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3722,6 +3722,7 @@ export const zh: Translations = {
       gatewayDisconnected: 'Hermes 网关未连接',
       sendFailed: '无法发送澄清响应',
       loadingQuestion: '正在加载问题…',
+      invalidChoices: '此澄清请求没有可用选项。请跳过，以便代理重试。',
       other: '其他 (输入你的答案)',
       placeholder: '输入你的答案…',
       skip: '跳过',

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -6,6 +6,7 @@ import {
   type ClarifyRequest,
   clearClarifyRequest,
   hasClarifyRequest,
+  hasMalformedStructuredChoices,
   normalizeChoices,
   normalizeQuestions,
   setClarifyRequest,
@@ -211,5 +212,25 @@ describe('normalizeQuestions', () => {
 
     expect(result[0]?.multiSelect).toBe(true)
     expect(result[1]?.multiSelect).toBe(false)
+  })
+})
+
+describe('hasMalformedStructuredChoices', () => {
+  it('distinguishes intentional open-ended prompts from invalid structured prompts', () => {
+    expect(hasMalformedStructuredChoices(undefined)).toBe(false)
+    expect(hasMalformedStructuredChoices(null)).toBe(false)
+    expect(hasMalformedStructuredChoices([])).toBe(false)
+    expect(hasMalformedStructuredChoices(['valid', ''])).toBe(false)
+  })
+
+  it('does not reject raw shapes that the backend converts to labels', () => {
+    expect(hasMalformedStructuredChoices([{ description: 'descriptive label' }])).toBe(false)
+    expect(hasMalformedStructuredChoices([1, 2])).toBe(false)
+    expect(hasMalformedStructuredChoices([[{ label: 'nested label' }]])).toBe(false)
+  })
+
+  it('detects non-empty arrays whose labels are all removed', () => {
+    expect(hasMalformedStructuredChoices(['', ' ', '\n'])).toBe(true)
+    expect(hasMalformedStructuredChoices([null, { value: 'raw-id' }, {}])).toBe(true)
   })
 })

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -6,6 +6,7 @@ import {
   type ClarifyRequest,
   clearClarifyRequest,
   hasClarifyRequest,
+  hasMalformedStructuredChoices,
   normalizeChoices,
   setClarifyRequest,
   skipClarifyRequest
@@ -162,5 +163,25 @@ describe('normalizeChoices', () => {
   it('returns empty array when nothing survives', () => {
     expect(normalizeChoices(['', '  ', null, undefined])).toEqual([])
     expect(normalizeChoices([])).toEqual([])
+  })
+})
+
+describe('hasMalformedStructuredChoices', () => {
+  it('distinguishes intentional open-ended prompts from invalid structured prompts', () => {
+    expect(hasMalformedStructuredChoices(undefined)).toBe(false)
+    expect(hasMalformedStructuredChoices(null)).toBe(false)
+    expect(hasMalformedStructuredChoices([])).toBe(false)
+    expect(hasMalformedStructuredChoices(['valid', ''])).toBe(false)
+  })
+
+  it('does not reject raw shapes that the backend converts to labels', () => {
+    expect(hasMalformedStructuredChoices([{ description: 'descriptive label' }])).toBe(false)
+    expect(hasMalformedStructuredChoices([1, 2])).toBe(false)
+    expect(hasMalformedStructuredChoices([[{ label: 'nested label' }]])).toBe(false)
+  })
+
+  it('detects non-empty arrays whose labels are all removed', () => {
+    expect(hasMalformedStructuredChoices(['', ' ', '\n'])).toBe(true)
+    expect(hasMalformedStructuredChoices([null, { value: 'raw-id' }, {}])).toBe(true)
   })
 })

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -18,6 +18,7 @@ export interface ClarifyRequest {
   multiSelect: boolean
   /** Local receipt time (Unix seconds), used to reject stale resume cleanup. */
   receivedAt?: number
+  choicesMalformed?: boolean
   sessionId: string | null
   /** Batch (multi-question) clarify: present instead of question/choices. */
   questions?: ClarifyQuestion[]
@@ -40,8 +41,9 @@ export const bareChoice = (choice: string): string =>
  * Validate and normalize a choices array.
  *
  * Keeps non-blank, newline-free strings of length ≤ 200; drops everything else
- * and returns an empty array when nothing usable survives — the caller then
- * falls back to a free-text answer instead of dead buttons.
+ * and returns an empty array when nothing usable survives. Callers can use
+ * `hasMalformedStructuredChoices` to distinguish that failure from a
+ * deliberately open-ended prompt.
  */
 export function normalizeChoices(choices: unknown): string[] {
   if (!Array.isArray(choices)) {
@@ -50,6 +52,55 @@ export function normalizeChoices(choices: unknown): string[] {
 
   return choices.filter(
     (c): c is string => typeof c === 'string' && c.trim().length > 0 && bareChoice(c).length <= 200 && !c.includes('\n')
+  )
+}
+
+/** Mirror the backend's permissive `_flatten_choice` just far enough to decide
+ * whether a raw tool argument can become a usable label before the gateway
+ * emits its normalized strings. The renderer still displays only strings from
+ * `normalizeChoices`; this helper prevents supported dict/scalar arguments from
+ * being mistaken for an all-invalid choice set during the tool.start race. */
+function flattenStructuredChoice(choice: unknown): string {
+  if (choice == null) {
+    return ''
+  }
+
+  if (typeof choice === 'string') {
+    return choice.trim()
+  }
+
+  if (Array.isArray(choice)) {
+    return choice.map(flattenStructuredChoice).join(' ').trim()
+  }
+
+  if (typeof choice === 'object') {
+    const row = choice as Record<string, unknown>
+
+    for (const key of ['label', 'description', 'text', 'title']) {
+      const value = row[key]
+
+      if (typeof value === 'string' && value.trim()) {
+        return value.trim()
+      }
+    }
+
+    return ''
+  }
+
+  return String(choice).trim()
+}
+
+/** True when a caller attempted a structured prompt but every option was
+ * rejected. Omitted, null, and explicitly empty choices remain open-ended. */
+export function hasMalformedStructuredChoices(
+  rawChoices: unknown,
+  normalizedChoices = normalizeChoices(rawChoices)
+): boolean {
+  return (
+    Array.isArray(rawChoices) &&
+    rawChoices.length > 0 &&
+    normalizedChoices.length === 0 &&
+    normalizeChoices(rawChoices.map(flattenStructuredChoice)).length === 0
   )
 }
 

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -7,6 +7,7 @@ export interface ClarifyRequest {
   requestId: string
   question: string
   choices: string[] | null
+  choicesMalformed?: boolean
   sessionId: string | null
 }
 
@@ -14,8 +15,9 @@ export interface ClarifyRequest {
  * Validate and normalize a choices array.
  *
  * Keeps non-blank, newline-free strings of length ≤ 200; drops everything else
- * and returns an empty array when nothing usable survives — the caller then
- * falls back to a free-text answer instead of dead buttons.
+ * and returns an empty array when nothing usable survives. Callers can use
+ * `hasMalformedStructuredChoices` to distinguish that failure from a
+ * deliberately open-ended prompt.
  */
 export function normalizeChoices(choices: unknown): string[] {
   if (!Array.isArray(choices)) {
@@ -24,6 +26,55 @@ export function normalizeChoices(choices: unknown): string[] {
 
   return choices.filter(
     (c): c is string => typeof c === 'string' && c.trim().length > 0 && c.length <= 200 && !c.includes('\n')
+  )
+}
+
+/** Mirror the backend's permissive `_flatten_choice` just far enough to decide
+ * whether a raw tool argument can become a usable label before the gateway
+ * emits its normalized strings. The renderer still displays only strings from
+ * `normalizeChoices`; this helper prevents supported dict/scalar arguments from
+ * being mistaken for an all-invalid choice set during the tool.start race. */
+function flattenStructuredChoice(choice: unknown): string {
+  if (choice == null) {
+    return ''
+  }
+
+  if (typeof choice === 'string') {
+    return choice.trim()
+  }
+
+  if (Array.isArray(choice)) {
+    return choice.map(flattenStructuredChoice).join(' ').trim()
+  }
+
+  if (typeof choice === 'object') {
+    const row = choice as Record<string, unknown>
+
+    for (const key of ['label', 'description', 'text', 'title']) {
+      const value = row[key]
+
+      if (typeof value === 'string' && value.trim()) {
+        return value.trim()
+      }
+    }
+
+    return ''
+  }
+
+  return String(choice).trim()
+}
+
+/** True when a caller attempted a structured prompt but every option was
+ * rejected. Omitted, null, and explicitly empty choices remain open-ended. */
+export function hasMalformedStructuredChoices(
+  rawChoices: unknown,
+  normalizedChoices = normalizeChoices(rawChoices)
+): boolean {
+  return (
+    Array.isArray(rawChoices) &&
+    rawChoices.length > 0 &&
+    normalizedChoices.length === 0 &&
+    normalizeChoices(rawChoices.map(flattenStructuredChoice)).length === 0
   )
 }
 

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -3,6 +3,8 @@
 import json
 from typing import List, Optional
 
+import pytest
+
 
 from tools.clarify_tool import (
     clarify_tool,
@@ -29,6 +31,32 @@ class TestClarifyToolBasics:
         assert result["choices_offered"] is None
         assert result["user_response"] == "blue"
 
+    def test_question_with_choices(self):
+        """Should pass choices to callback and return response."""
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            assert question == "Pick a number"
+            assert choices == ["1 (Recommended)", "2", "3"]
+            return "2"
+
+        result = json.loads(clarify_tool(
+            "Pick a number",
+            choices=["1", "2", "3"],
+            callback=mock_callback
+        ))
+        assert result["question"] == "Pick a number"
+        assert result["choices_offered"] == ["1", "2", "3"]
+        assert result["user_response"] == "2"
+
+    def test_empty_question_returns_error(self):
+        """Should return error for empty question."""
+        result = json.loads(clarify_tool("", callback=lambda q, c: "ignored"))
+        assert "error" in result
+        assert "no question provided" in result["error"].lower()
+
+    def test_whitespace_only_question_returns_error(self):
+        """Should return error for whitespace-only question."""
+        result = json.loads(clarify_tool("   \n\t  ", callback=lambda q, c: "ignored"))
+        assert "error" in result
 
     def test_no_callback_returns_error(self):
         """Should return error when no callback is provided."""
@@ -53,6 +81,83 @@ class TestClarifyToolChoicesValidation:
 
         assert len(choices_passed) == MAX_CHOICES
 
+    @pytest.mark.parametrize("choices", [None, []])
+    def test_null_or_empty_choices_are_open_ended(self, choices):
+        """Null and an explicitly empty list preserve open-ended mode."""
+        choices_received: list[object] = ["marker"]
+
+        def mock_callback(
+            question: str, normalized_choices: Optional[List[str]]
+        ) -> str:
+            choices_received.clear()
+            choices_received.append(normalized_choices)
+            return "answer"
+
+        clarify_tool("Open question?", choices=choices, callback=mock_callback)
+        assert choices_received == [None]
+
+    @pytest.mark.parametrize(
+        "choices",
+        [
+            ["", "   ", "\n"],
+            [None, {}, {"value": "raw-id"}, []],
+        ],
+    )
+    def test_nonempty_choices_with_no_usable_labels_return_error(self, choices):
+        """Malformed structured prompts must not silently become open-ended."""
+        callback_called = False
+
+        def mock_callback(
+            question: str, normalized_choices: Optional[List[str]]
+        ) -> str:
+            nonlocal callback_called
+            callback_called = True
+            return "unexpected"
+
+        result = json.loads(
+            clarify_tool("Pick one", choices=choices, callback=mock_callback)
+        )
+
+        assert result == {
+            "error": (
+                "choices contained no non-empty options; resend with meaningful "
+                "labels or omit choices for an open-ended question."
+            )
+        }
+        assert callback_called is False
+
+    def test_multi_select_with_no_usable_choices_returns_error(self):
+        result = json.loads(
+            clarify_tool(
+                "Pick several",
+                choices=["", "\n"],
+                multi_select=True,
+                callback=lambda *_args, **_kwargs: "unexpected",
+            )
+        )
+
+        assert "no non-empty options" in result["error"]
+
+    def test_choices_with_only_whitespace_stripped(self):
+        """Whitespace-only choices should be stripped out."""
+        choices_received = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            choices_received.extend(choices or [])
+            return "answer"
+
+        clarify_tool("Pick", choices=["valid", "  ", "", "also valid"], callback=mock_callback)
+        assert choices_received == ["valid (Recommended)", "also valid"]
+
+    def test_invalid_choices_type_returns_error(self):
+        """Non-list choices should return error."""
+        result = json.loads(clarify_tool(
+            "Question?",
+            choices="not a list",  # type: ignore
+            callback=lambda q, c: "ignored"
+        ))
+        assert "error" in result
+        assert "list" in result["error"].lower()
 
     def test_choices_converted_to_strings(self):
         """Non-string choices should be converted to strings."""
@@ -79,6 +184,16 @@ class TestClarifyToolCallbackHandling:
         assert "Failed to get user input" in result["error"]
         assert "User cancelled" in result["error"]
 
+    def test_callback_receives_stripped_question(self):
+        """Callback should receive trimmed question."""
+        received_question = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            received_question.append(question)
+            return "answer"
+
+        clarify_tool("  Question with spaces  \n", callback=mock_callback)
+        assert received_question[0] == "Question with spaces"
 
     def test_user_response_stripped(self):
         """User response should be stripped of whitespace."""
@@ -110,6 +225,27 @@ class TestClarifyDictChoices:
     def test_flatten_unwraps_label_first(self):
         assert _flatten_choice({"label": "Short", "description": "Long"}) == "Short"
 
+    def test_flatten_unwraps_description_when_no_label(self):
+        assert _flatten_choice({"description": "A loose layout"}) == "A loose layout"
+
+    def test_flatten_unwrap_order_label_over_description(self):
+        assert _flatten_choice({"description": "verbose", "label": "tight"}) == "tight"
+
+    def test_flatten_drops_name_value_only_dict(self):
+        # name/value are component-shaped fields, not user-facing labels —
+        # picking them would leak raw enum values / short model ids.
+        assert _flatten_choice({"name": "tight", "value": "x"}) == ""
+
+    def test_flatten_prefers_canonical_key_over_name(self):
+        assert _flatten_choice({"name": "tight", "description": "Tight desc"}) == "Tight desc"
+
+    def test_flatten_drops_keyless_dict(self):
+        assert _flatten_choice({"foo": "bar", "n": 1}) == ""
+
+    def test_flatten_passthrough_string_and_scalar(self):
+        assert _flatten_choice("plain") == "plain"
+        assert _flatten_choice(7) == "7"
+        assert _flatten_choice(None) == ""
 
     def test_dict_choices_reach_callback_as_clean_text(self):
         """The whole point: the UI callback never sees a dict repr."""
@@ -147,11 +283,39 @@ class TestClarifySchema:
         """Schema should have correct name."""
         assert CLARIFY_SCHEMA["name"] == "clarify"
 
+    def test_schema_has_description(self):
+        """Schema should have a description."""
+        assert "description" in CLARIFY_SCHEMA
+        assert len(CLARIFY_SCHEMA["description"]) > 50
+
+    def test_schema_question_required(self):
+        """Question parameter should be required (per item; batch advertises questions)."""
+        assert "questions" in CLARIFY_SCHEMA["parameters"]["required"]
+        item_spec = CLARIFY_SCHEMA["parameters"]["properties"]["questions"]["items"]
+        assert "question" in item_spec["required"]
+
+    def test_schema_choices_optional(self):
+        """Choices parameter should be optional."""
+        assert "choices" not in CLARIFY_SCHEMA["parameters"]["required"]
+
+    def test_schema_choices_max_items(self):
+        """Schema should specify max items for choices."""
+        choices_spec = CLARIFY_SCHEMA["parameters"]["properties"]["questions"]["items"]["properties"]["choices"]
+        assert choices_spec.get("maxItems") == MAX_CHOICES
 
     def test_max_choices_is_four(self):
         """MAX_CHOICES constant should be 4."""
         assert MAX_CHOICES == 4
 
+    def test_schema_multi_select_optional(self):
+        """multi_select should not be in required list."""
+        assert "multi_select" not in CLARIFY_SCHEMA["parameters"]["required"]
+
+    def test_schema_multi_select_is_boolean(self):
+        """multi_select should be a boolean parameter."""
+        ms_spec = CLARIFY_SCHEMA["parameters"]["properties"]["questions"]["items"]["properties"].get("multi_select")
+        assert ms_spec is not None
+        assert ms_spec["type"] == "boolean"
 
     def test_schema_multi_select_default_false(self):
         """multi_select should default to false (not in required)."""
@@ -231,6 +395,113 @@ class TestClarifyToolMultiSelect:
         assert result["user_response"] == ["red"]
         assert isinstance(result["user_response"], list)
 
+    def test_multi_select_with_json_array_response(self):
+        """Callback can return a JSON array string for multi-select."""
+        def mock_callback(question, choices):
+            return '["red", "blue"]'
+
+        result = json.loads(clarify_tool(
+            "Which colors?",
+            choices=["red", "blue", "green"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["red", "blue"]
+
+    def test_multi_select_no_choices_falls_back_to_single_string(self):
+        """When choices is None, multi_select has no effect on response type."""
+        def mock_callback(question, choices):
+            return "free form answer"
+
+        result = json.loads(clarify_tool(
+            "What do you think?",
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        # Without choices, falls back to single string response
+        assert result["user_response"] == "free form answer"
+        assert isinstance(result["user_response"], str)
+
+    def test_multi_select_default_is_false(self):
+        """Default multi_select should be False (backward compatible)."""
+        def mock_callback(question, choices):
+            return "picked"
+
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=["a", "b"],
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == "picked"
+        assert isinstance(result["user_response"], str)
+
+    def test_multi_select_callback_receives_flag(self):
+        """Callback should receive multi_select keyword argument when supported."""
+        received_flag = []
+
+        def mock_callback(question, choices, **kwargs):
+            received_flag.append(kwargs.get("multi_select"))
+            return "a, b"
+
+        clarify_tool(
+            "Pick",
+            choices=["a", "b", "c"],
+            multi_select=True,
+            callback=mock_callback,
+        )
+        assert received_flag == [True]
+
+    def test_multi_select_backward_compatible_callback(self):
+        """Callback that does not accept multi_select keyword should still work."""
+        def mock_callback(question, choices):
+            return "a, b"
+
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["a", "b", "c"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["a", "b"]
+
+    def test_multi_select_empty_selection_returns_empty_list(self):
+        """Empty response should produce empty list when multi_select=True."""
+        def mock_callback(question, choices):
+            return ""
+
+        result = json.loads(clarify_tool(
+            "Which?",
+            choices=["a", "b"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == []
+
+    def test_multi_select_whitespace_choices_stripped(self):
+        """Individual selections should be stripped of whitespace."""
+        def mock_callback(question, choices):
+            return "  a , b ,  c  "
+
+        result = json.loads(clarify_tool(
+            "Which?",
+            choices=["a", "b", "c"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["a", "b", "c"]
+
+    def test_multi_select_choices_offered_preserved(self):
+        """choices_offered should match what was passed in, not the response."""
+        def mock_callback(question, choices):
+            return "red, blue"
+
+        result = json.loads(clarify_tool(
+            "Which?",
+            choices=["red", "blue", "green"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["choices_offered"] == ["red", "blue", "green"]
 
     def test_multi_select_max_choices_enforced(self):
         """MAX_CHOICES enforcement should still work with multi_select."""
@@ -336,11 +607,20 @@ class TestInvokeCallbackDispatch:
             calls.append(1)
             raise TypeError("internal bug")
 
-        import pytest
         with pytest.raises(TypeError, match="internal bug"):
             _invoke_callback(bad_callback, "Q?", ["a"], True)
         assert len(calls) == 1
 
+    def test_legacy_two_arg_callback_supported(self):
+        from tools.clarify_tool import _invoke_callback
+        seen = {}
+
+        def legacy(question, choices):
+            seen["args"] = (question, choices)
+            return "ok"
+
+        assert _invoke_callback(legacy, "Q?", ["a"], True) == "ok"
+        assert seen["args"] == ("Q?", ["a"])
 
     def test_var_keyword_callback_receives_flag(self):
         from tools.clarify_tool import _invoke_callback

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -3,6 +3,8 @@
 import json
 from typing import List, Optional
 
+import pytest
+
 
 from tools.clarify_tool import (
     clarify_tool,
@@ -28,6 +30,32 @@ class TestClarifyToolBasics:
         assert result["choices_offered"] is None
         assert result["user_response"] == "blue"
 
+    def test_question_with_choices(self):
+        """Should pass choices to callback and return response."""
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            assert question == "Pick a number"
+            assert choices == ["1", "2", "3"]
+            return "2"
+
+        result = json.loads(clarify_tool(
+            "Pick a number",
+            choices=["1", "2", "3"],
+            callback=mock_callback
+        ))
+        assert result["question"] == "Pick a number"
+        assert result["choices_offered"] == ["1", "2", "3"]
+        assert result["user_response"] == "2"
+
+    def test_empty_question_returns_error(self):
+        """Should return error for empty question."""
+        result = json.loads(clarify_tool("", callback=lambda q, c: "ignored"))
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_whitespace_only_question_returns_error(self):
+        """Should return error for whitespace-only question."""
+        result = json.loads(clarify_tool("   \n\t  ", callback=lambda q, c: "ignored"))
+        assert "error" in result
 
     def test_no_callback_returns_error(self):
         """Should return error when no callback is provided."""
@@ -52,6 +80,83 @@ class TestClarifyToolChoicesValidation:
 
         assert len(choices_passed) == MAX_CHOICES
 
+    @pytest.mark.parametrize("choices", [None, []])
+    def test_null_or_empty_choices_are_open_ended(self, choices):
+        """Null and an explicitly empty list preserve open-ended mode."""
+        choices_received: list[object] = ["marker"]
+
+        def mock_callback(
+            question: str, normalized_choices: Optional[List[str]]
+        ) -> str:
+            choices_received.clear()
+            choices_received.append(normalized_choices)
+            return "answer"
+
+        clarify_tool("Open question?", choices=choices, callback=mock_callback)
+        assert choices_received == [None]
+
+    @pytest.mark.parametrize(
+        "choices",
+        [
+            ["", "   ", "\n"],
+            [None, {}, {"value": "raw-id"}, []],
+        ],
+    )
+    def test_nonempty_choices_with_no_usable_labels_return_error(self, choices):
+        """Malformed structured prompts must not silently become open-ended."""
+        callback_called = False
+
+        def mock_callback(
+            question: str, normalized_choices: Optional[List[str]]
+        ) -> str:
+            nonlocal callback_called
+            callback_called = True
+            return "unexpected"
+
+        result = json.loads(
+            clarify_tool("Pick one", choices=choices, callback=mock_callback)
+        )
+
+        assert result == {
+            "error": (
+                "choices contained no non-empty options; resend with meaningful "
+                "labels or omit choices for an open-ended question."
+            )
+        }
+        assert callback_called is False
+
+    def test_multi_select_with_no_usable_choices_returns_error(self):
+        result = json.loads(
+            clarify_tool(
+                "Pick several",
+                choices=["", "\n"],
+                multi_select=True,
+                callback=lambda *_args, **_kwargs: "unexpected",
+            )
+        )
+
+        assert "no non-empty options" in result["error"]
+
+    def test_choices_with_only_whitespace_stripped(self):
+        """Whitespace-only choices should be stripped out."""
+        choices_received = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            choices_received.extend(choices or [])
+            return "answer"
+
+        clarify_tool("Pick", choices=["valid", "  ", "", "also valid"], callback=mock_callback)
+        assert choices_received == ["valid", "also valid"]
+
+    def test_invalid_choices_type_returns_error(self):
+        """Non-list choices should return error."""
+        result = json.loads(clarify_tool(
+            "Question?",
+            choices="not a list",  # type: ignore
+            callback=lambda q, c: "ignored"
+        ))
+        assert "error" in result
+        assert "list" in result["error"].lower()
 
     def test_choices_converted_to_strings(self):
         """Non-string choices should be converted to strings."""
@@ -78,6 +183,16 @@ class TestClarifyToolCallbackHandling:
         assert "Failed to get user input" in result["error"]
         assert "User cancelled" in result["error"]
 
+    def test_callback_receives_stripped_question(self):
+        """Callback should receive trimmed question."""
+        received_question = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            received_question.append(question)
+            return "answer"
+
+        clarify_tool("  Question with spaces  \n", callback=mock_callback)
+        assert received_question[0] == "Question with spaces"
 
     def test_user_response_stripped(self):
         """User response should be stripped of whitespace."""
@@ -109,6 +224,27 @@ class TestClarifyDictChoices:
     def test_flatten_unwraps_label_first(self):
         assert _flatten_choice({"label": "Short", "description": "Long"}) == "Short"
 
+    def test_flatten_unwraps_description_when_no_label(self):
+        assert _flatten_choice({"description": "A loose layout"}) == "A loose layout"
+
+    def test_flatten_unwrap_order_label_over_description(self):
+        assert _flatten_choice({"description": "verbose", "label": "tight"}) == "tight"
+
+    def test_flatten_drops_name_value_only_dict(self):
+        # name/value are component-shaped fields, not user-facing labels —
+        # picking them would leak raw enum values / short model ids.
+        assert _flatten_choice({"name": "tight", "value": "x"}) == ""
+
+    def test_flatten_prefers_canonical_key_over_name(self):
+        assert _flatten_choice({"name": "tight", "description": "Tight desc"}) == "Tight desc"
+
+    def test_flatten_drops_keyless_dict(self):
+        assert _flatten_choice({"foo": "bar", "n": 1}) == ""
+
+    def test_flatten_passthrough_string_and_scalar(self):
+        assert _flatten_choice("plain") == "plain"
+        assert _flatten_choice(7) == "7"
+        assert _flatten_choice(None) == ""
 
     def test_dict_choices_reach_callback_as_clean_text(self):
         """The whole point: the UI callback never sees a dict repr."""
@@ -146,11 +282,37 @@ class TestClarifySchema:
         """Schema should have correct name."""
         assert CLARIFY_SCHEMA["name"] == "clarify"
 
+    def test_schema_has_description(self):
+        """Schema should have a description."""
+        assert "description" in CLARIFY_SCHEMA
+        assert len(CLARIFY_SCHEMA["description"]) > 50
+
+    def test_schema_question_required(self):
+        """Question parameter should be required."""
+        assert "question" in CLARIFY_SCHEMA["parameters"]["required"]
+
+    def test_schema_choices_optional(self):
+        """Choices parameter should be optional."""
+        assert "choices" not in CLARIFY_SCHEMA["parameters"]["required"]
+
+    def test_schema_choices_max_items(self):
+        """Schema should specify max items for choices."""
+        choices_spec = CLARIFY_SCHEMA["parameters"]["properties"]["choices"]
+        assert choices_spec.get("maxItems") == MAX_CHOICES
 
     def test_max_choices_is_four(self):
         """MAX_CHOICES constant should be 4."""
         assert MAX_CHOICES == 4
 
+    def test_schema_multi_select_optional(self):
+        """multi_select should not be in required list."""
+        assert "multi_select" not in CLARIFY_SCHEMA["parameters"]["required"]
+
+    def test_schema_multi_select_is_boolean(self):
+        """multi_select should be a boolean parameter."""
+        ms_spec = CLARIFY_SCHEMA["parameters"]["properties"].get("multi_select")
+        assert ms_spec is not None
+        assert ms_spec["type"] == "boolean"
 
     def test_schema_multi_select_default_false(self):
         """multi_select should default to false (not in required)."""
@@ -203,6 +365,113 @@ class TestClarifyToolMultiSelect:
         assert result["user_response"] == ["red"]
         assert isinstance(result["user_response"], list)
 
+    def test_multi_select_with_json_array_response(self):
+        """Callback can return a JSON array string for multi-select."""
+        def mock_callback(question, choices):
+            return '["red", "blue"]'
+
+        result = json.loads(clarify_tool(
+            "Which colors?",
+            choices=["red", "blue", "green"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["red", "blue"]
+
+    def test_multi_select_no_choices_falls_back_to_single_string(self):
+        """When choices is None, multi_select has no effect on response type."""
+        def mock_callback(question, choices):
+            return "free form answer"
+
+        result = json.loads(clarify_tool(
+            "What do you think?",
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        # Without choices, falls back to single string response
+        assert result["user_response"] == "free form answer"
+        assert isinstance(result["user_response"], str)
+
+    def test_multi_select_default_is_false(self):
+        """Default multi_select should be False (backward compatible)."""
+        def mock_callback(question, choices):
+            return "picked"
+
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=["a", "b"],
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == "picked"
+        assert isinstance(result["user_response"], str)
+
+    def test_multi_select_callback_receives_flag(self):
+        """Callback should receive multi_select keyword argument when supported."""
+        received_flag = []
+
+        def mock_callback(question, choices, **kwargs):
+            received_flag.append(kwargs.get("multi_select"))
+            return "a, b"
+
+        clarify_tool(
+            "Pick",
+            choices=["a", "b", "c"],
+            multi_select=True,
+            callback=mock_callback,
+        )
+        assert received_flag == [True]
+
+    def test_multi_select_backward_compatible_callback(self):
+        """Callback that does not accept multi_select keyword should still work."""
+        def mock_callback(question, choices):
+            return "a, b"
+
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["a", "b", "c"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["a", "b"]
+
+    def test_multi_select_empty_selection_returns_empty_list(self):
+        """Empty response should produce empty list when multi_select=True."""
+        def mock_callback(question, choices):
+            return ""
+
+        result = json.loads(clarify_tool(
+            "Which?",
+            choices=["a", "b"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == []
+
+    def test_multi_select_whitespace_choices_stripped(self):
+        """Individual selections should be stripped of whitespace."""
+        def mock_callback(question, choices):
+            return "  a , b ,  c  "
+
+        result = json.loads(clarify_tool(
+            "Which?",
+            choices=["a", "b", "c"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["a", "b", "c"]
+
+    def test_multi_select_choices_offered_preserved(self):
+        """choices_offered should match what was passed in, not the response."""
+        def mock_callback(question, choices):
+            return "red, blue"
+
+        result = json.loads(clarify_tool(
+            "Which?",
+            choices=["red", "blue", "green"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["choices_offered"] == ["red", "blue", "green"]
 
     def test_multi_select_max_choices_enforced(self):
         """MAX_CHOICES enforcement should still work with multi_select."""
@@ -236,11 +505,20 @@ class TestInvokeCallbackDispatch:
             calls.append(1)
             raise TypeError("internal bug")
 
-        import pytest
         with pytest.raises(TypeError, match="internal bug"):
             _invoke_callback(bad_callback, "Q?", ["a"], True)
         assert len(calls) == 1
 
+    def test_legacy_two_arg_callback_supported(self):
+        from tools.clarify_tool import _invoke_callback
+        seen = {}
+
+        def legacy(question, choices):
+            seen["args"] = (question, choices)
+            return "ok"
+
+        assert _invoke_callback(legacy, "Q?", ["a"], True) == "ok"
+        assert seen["args"] == ("Q?", ["a"])
 
     def test_var_keyword_callback_receives_flag(self):
         from tools.clarify_tool import _invoke_callback

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -22,6 +22,11 @@ from typing import List, Optional, Callable
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
 
+INVALID_CHOICES_ERROR = (
+    "choices contained no non-empty options; resend with meaningful labels "
+    "or omit choices for an open-ended question."
+)
+
 
 def _flatten_choice(c) -> str:
     """Coerce a single choice into its user-facing display string.
@@ -145,6 +150,7 @@ def clarify_tool(
     if choices is not None:
         if not isinstance(choices, list):
             return tool_error("choices must be a list of strings.")
+        choices_were_provided = bool(choices)
         # LLMs sometimes emit dict-shaped choices (e.g. [{"description": "..."}])
         # instead of bare strings. _flatten_choice unwraps them to their
         # user-facing text here — the single platform-agnostic entry point —
@@ -153,6 +159,8 @@ def clarify_tool(
         choices = [s for s in (_flatten_choice(c) for c in choices) if s]
         if len(choices) > MAX_CHOICES:
             choices = choices[:MAX_CHOICES]
+        if choices_were_provided and not choices:
+            return tool_error(INVALID_CHOICES_ERROR)
         if not choices:
             choices = None  # empty list → open-ended
 

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -15,6 +15,10 @@ TIMEOUT_RESPONSE = ("The user did not provide a response within the time limit. 
 # Applied to the first choice here (not per-surface) so every adapter renders it identically.
 RECOMMENDED_LABEL = "(Recommended)"
 _UNAVAILABLE = "Clarify tool is not available in this execution context."
+INVALID_CHOICES_ERROR = (
+    "choices contained no non-empty options; resend with meaningful labels "
+    "or omit choices for an open-ended question."
+)
 
 
 def _flatten_choice(c) -> str:
@@ -216,7 +220,10 @@ def clarify_tool(question: str, choices: Optional[List[str]] = None, multi_selec
     if choices is not None:
         if not isinstance(choices, list):
             return tool_error("choices must be a list of strings.")
+        choices_were_provided = bool(choices)
         choices = _clean_choices(choices)
+        if choices_were_provided and choices is None:
+            return tool_error(INVALID_CHOICES_ERROR)
     if callback is None:
         return tool_error(_UNAVAILABLE)
     # The bare list goes back to the agent; the "(Recommended)" label is presentation only.


### PR DESCRIPTION
## Summary

- reject explicitly non-empty `choices` arrays when every entry normalizes away, instead of silently switching to open-ended mode
- preserve backwards-compatible open-ended behavior for omitted, `null`, and `[]` choices
- surface malformed structured prompts in Desktop as a clear recoverable error with **Skip**, while preserving dict/scalar choice shapes supported by the Python normalizer
- cover the tool boundary, Desktop normalization/store, gateway hydration, and rendered recovery path

## Testing

- `scripts/run_tests.sh tests/tools/test_clarify_tool.py -q` — 52 passed
- Desktop UI suite under Node 22 — 315 files / 2747 tests passed
- `npm run typecheck`
- targeted ESLint — 0 errors (pre-existing test-file warnings only)
- Ruff and Prettier checks passed
- `git diff --check` passed

Fixes #73152