### PR TITLE
test: prevent any test from opening a real browser window

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -440,6 +440,23 @@ def _isolate_hermes_home(_hermetic_environment):
     return None
 
 
+@pytest.fixture(autouse=True)
+def _no_real_browser(monkeypatch):
+    """No test may open a real browser window.
+
+    Several OAuth login paths (xAI/Anthropic/Spotify loopback logins) call
+    ``webbrowser.open(authorize_url)`` when a graphical browser is available.
+    On a developer's machine (macOS: always graphical) a test that reaches
+    that path without stubbing ``open_browser=False`` pops a real auth page —
+    e.g. ``test_auth_manual_paste`` popping ``auth.x.ai`` during a local full
+    run. CI never caught it (headless → guard returns False). Patch the single
+    chokepoint ``webbrowser.open`` to a no-op so no test can ever hijack the
+    dev's browser, regardless of which login path it exercises.
+    """
+    import webbrowser
+    monkeypatch.setattr(webbrowser, "open", lambda *a, **k: True, raising=True)
+
+
 # ── Module-level state reset — replaced by per-file process isolation ──────
 #
 # Each test FILE runs in a freshly-spawned ``python -m pytest <file>``


### PR DESCRIPTION
## What does this PR do?

Adds one autouse fixture to `tests/conftest.py` that stubs `webbrowser.open` to a no-op, so no test can ever pop a real browser window on a contributor's machine.

Several interactive login paths call `webbrowser.open(authorize_url)` when a graphical browser is available (`hermes_cli/auth.py` has a handful of these across the OAuth flows). CI never hits it — headless environments make the availability guard return False — so this failure mode lands **only** on contributors running the suite locally, which is also the least likely place for it to be caught in review.

The suite already defends against this per-test: `tests/tools/test_mcp_oauth.py` monkeypatches `webbrowser.open` in three places, one of them with `MagicMock(side_effect=AssertionError("must not open browser"))`. This PR is the fail-safe underneath those, not a replacement for them — a newly added test that happens to reach a login path can't hijack the browser just because its author didn't know to patch.

Tests that specifically assert on browser-opening behaviour keep working: their own `monkeypatch.setattr` is applied after this fixture and takes precedence.

## Related Issue

No existing issue. Searched open and closed PRs for `webbrowser` / `conftest browser` — nothing prior.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/conftest.py`: new autouse `_no_real_browser` fixture (17 lines including the docstring).

## How to Test

1. `pytest tests/tools/test_mcp_oauth.py tests/hermes_cli/test_subscription_cli.py -q` — 128 passed; the existing per-test browser mocks (including the one that asserts the browser is *not* opened) are unaffected.
2. Full-suite impact check on the two directories most likely to touch login paths, with and without the fixture:
   - with fixture: `pytest tests/hermes_cli/ tests/tools/ -q -n auto` → 92 failed, 18807 passed
   - without fixture (`git checkout origin/main -- tests/conftest.py`) → 105 failed, 18794 passed
   - The 4 tests that appear only in the "with fixture" set all pass when re-run serially — parallel-execution flakiness, not fixture-induced. One of them (`test_approval.py::...test_approving_find_exec_does_not_approve_find_delete`) fails on unmodified `origin/main` too, so it's pre-existing and unrelated.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`test:`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes — N/A (this *is* test infrastructure)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.12

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (happy to add a line to the testing section if you'd like it documented)
- [x] Cross-platform impact — the fixture is platform-agnostic; it matters most on macOS, where a graphical browser is always available
- [x] Tool descriptions/schemas — N/A
