### PR TITLE
fix(email): prevent thread context overwrite in concurrent conversations

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -31,6 +31,7 @@ from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email.utils import formatdate
 from email import encoders
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -481,8 +482,11 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
-        # Map chat_id (sender email) -> last subject + message-id for threading
-        self._thread_context: Dict[str, Dict[str, str]] = {}
+        # Map chat_id (sender email) -> message_id -> thread context
+        # Multiple threads per sender are tracked by their Message-ID
+        # so concurrent conversations don't overwrite each other (#PR).
+        self._thread_context: Dict[str, Dict[str, Dict[str, str]]] = {}
+        self._max_threads_per_sender: int = 20
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
@@ -505,6 +509,64 @@ class EmailAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+
+    # ── Thread context helpers ────────────────────────────────────────────
+
+    def _get_thread_context(
+        self,
+        to_addr: str,
+        reply_to_msg_id: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Look up thread context for an outgoing reply.
+
+        Returns the thread context (subject + message_id) that best matches
+        the outgoing reply.  Priority:
+
+        1. If *reply_to_msg_id* is given and there is a thread keyed by that
+           exact Message-ID, return that thread's context.
+        2. Otherwise return the most recent thread context for this sender.
+        3. As a last resort return an empty dict (the caller will produce an
+           unthreaded reply).
+
+        Also trims stale entries for *to_addr* when they exceed
+        ``_max_threads_per_sender`` to prevent unbounded memory growth.
+        """
+        sender_threads = self._thread_context.get(to_addr, {})
+        if not sender_threads:
+            return {}
+
+        # Exact match by the reply target's Message-ID
+        if reply_to_msg_id and reply_to_msg_id in sender_threads:
+            return sender_threads[reply_to_msg_id]
+
+        # Check if reply_to_msg_id matches the *original* message in any thread
+        # (i.e. the reply_to_msg_id is the first message in the chain, and the
+        # thread context was stored under a later message_id in that same chain).
+        if reply_to_msg_id:
+            for ctx in sender_threads.values():
+                if ctx.get("reply_target") == reply_to_msg_id:
+                    return ctx
+
+        # Fall back to the most recent thread for this sender
+        last_key = next(reversed(sender_threads))
+        return sender_threads[last_key]
+
+    def _store_thread_context(self, sender_addr: str, subject: str, message_id: str) -> None:
+        """Record thread context for an incoming email.
+
+        Stores context keyed by the email's Message-ID so that replies can be
+        correctly threaded even when multiple conversations from the same sender
+        overlap.
+        """
+        sender_threads = self._thread_context.setdefault(sender_addr, OrderedDict())
+        sender_threads[message_id] = {
+            "subject": subject,
+            "message_id": message_id,
+        }
+        # Trim oldest entries when this sender exceeds the cap
+        while len(sender_threads) > self._max_threads_per_sender:
+            oldest_key = next(iter(sender_threads))
+            del sender_threads[oldest_key]
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
@@ -864,10 +926,7 @@ class EmailAdapter(BasePlatformAdapter):
                 msg_type = MessageType.DOCUMENT
 
         # Store thread context for reply threading
-        self._thread_context[sender_addr] = {
-            "subject": subject,
-            "message_id": msg_data["message_id"],
-        }
+        self._store_thread_context(sender_addr, subject, msg_data["message_id"])
 
         source = self.build_source(
             chat_id=sender_addr,
@@ -929,8 +988,10 @@ class EmailAdapter(BasePlatformAdapter):
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
+        # Thread context for reply — use the reply-to message ID when available
+        # to correctly thread across multiple concurrent conversations from the
+        # same sender.
+        ctx = self._get_thread_context(to_addr, reply_to_msg_id)
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -987,6 +1048,7 @@ class EmailAdapter(BasePlatformAdapter):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
+        reply_to: Optional[str] = None,
     ) -> None:
         """Send a batch of images as a single email with multiple MIME attachments.
 
@@ -1028,6 +1090,7 @@ class EmailAdapter(BasePlatformAdapter):
                 chat_id,
                 body,
                 local_paths,
+                reply_to,
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1038,19 +1101,23 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        # Thread context for reply — use the reply-to message ID when available
+        # to correctly thread across multiple concurrent conversations from the
+        # same sender.
+        ctx = self._get_thread_context(to_addr, reply_to_msg_id)
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        original_msg_id = ctx.get("message_id")
+        original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
@@ -1106,6 +1173,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                reply_to,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1118,19 +1186,23 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        # Thread context for reply — use the reply-to message ID when available
+        # to correctly thread across multiple concurrent conversations from the
+        # same sender.
+        ctx = self._get_thread_context(to_addr, reply_to_msg_id)
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        original_msg_id = ctx.get("message_id")
+        original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
@@ -1166,7 +1238,7 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""
-        ctx = self._thread_context.get(chat_id, {})
+        ctx = self._get_thread_context(chat_id)
         return {
             "name": chat_id,
             "type": "dm",

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -539,14 +539,6 @@ class EmailAdapter(BasePlatformAdapter):
         if reply_to_msg_id and reply_to_msg_id in sender_threads:
             return sender_threads[reply_to_msg_id]
 
-        # Check if reply_to_msg_id matches the *original* message in any thread
-        # (i.e. the reply_to_msg_id is the first message in the chain, and the
-        # thread context was stored under a later message_id in that same chain).
-        if reply_to_msg_id:
-            for ctx in sender_threads.values():
-                if ctx.get("reply_target") == reply_to_msg_id:
-                    return ctx
-
         # Fall back to the most recent thread for this sender
         last_key = next(reversed(sender_threads))
         return sender_threads[last_key]
@@ -1056,7 +1048,16 @@ class EmailAdapter(BasePlatformAdapter):
         appended to the body (email adapter does not download remote
         images). No hard cap — email clients handle dozens of
         attachments fine, subject to SMTP message size limits.
+
+        When called via the gateway media delivery path, the reply anchor
+        arrives in *metadata* (``thread_id`` or ``message_id``) rather than
+        ``reply_to``. Extract it here so attachment-based responses thread
+        correctly across concurrent conversations from the same sender.
         """
+        # Extract reply anchor from metadata when not passed directly
+        if reply_to is None and metadata and isinstance(metadata, dict):
+            reply_to = metadata.get("message_id") or metadata.get("thread_id")
+
         if not images:
             return
 
@@ -1163,7 +1164,17 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         **kwargs,
     ) -> SendResult:
-        """Send a file as an email attachment."""
+        """Send a file as an email attachment.
+
+        When called via the gateway media delivery path, the reply anchor
+        arrives in *metadata* (via **kwargs) rather than ``reply_to``.
+        Extract it here so attachment-based responses thread correctly
+        across concurrent conversations from the same sender.
+        """
+        # Extract reply anchor from metadata when not passed directly
+        if reply_to is None and kwargs.get("metadata") and isinstance(kwargs["metadata"], dict):
+            reply_to = kwargs["metadata"].get("message_id") or kwargs["metadata"].get("thread_id")
+
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -798,7 +798,10 @@ class TestThreadContext(unittest.TestCase):
         }
 
         asyncio.run(adapter._dispatch_message(msg_data))
-        ctx = adapter._thread_context.get("user@test.com")
+        sender_ctx = adapter._thread_context.get("user@test.com")
+        self.assertIsNotNone(sender_ctx)
+        # _store_thread_context stores in nested dict: message_id → {subject, message_id}
+        ctx = sender_ctx.get("<original@test.com>")
         self.assertIsNotNone(ctx)
         self.assertEqual(ctx["subject"], "Project question")
         self.assertEqual(ctx["message_id"], "<original@test.com>")
@@ -806,10 +809,13 @@ class TestThreadContext(unittest.TestCase):
     def test_reply_uses_re_prefix(self):
         """Reply subject should have Re: prefix."""
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {
-            "subject": "Project question",
-            "message_id": "<original@test.com>",
-        }
+        from collections import OrderedDict
+        adapter._thread_context["user@test.com"] = OrderedDict({
+            "<original@test.com>": {
+                "subject": "Project question",
+                "message_id": "<original@test.com>",
+            },
+        })
 
         with patch("smtplib.SMTP") as mock_smtp:
             mock_server = MagicMock()
@@ -827,10 +833,13 @@ class TestThreadContext(unittest.TestCase):
     def test_reply_does_not_double_re(self):
         """If subject already has Re:, don't add another."""
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {
-            "subject": "Re: Project question",
-            "message_id": "<reply@test.com>",
-        }
+        from collections import OrderedDict
+        adapter._thread_context["user@test.com"] = OrderedDict({
+            "<reply@test.com>": {
+                "subject": "Re: Project question",
+                "message_id": "<reply@test.com>",
+            },
+        })
 
         with patch("smtplib.SMTP") as mock_smtp:
             mock_server = MagicMock()
@@ -965,7 +974,10 @@ class TestSendMethods(unittest.TestCase):
         """get_chat_info should return email address as chat info."""
         import asyncio
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {"subject": "Test", "message_id": "<m@t>"}
+        from collections import OrderedDict
+        adapter._thread_context["user@test.com"] = OrderedDict({
+            "<m@t>": {"subject": "Test", "message_id": "<m@t>"},
+        })
 
         info = asyncio.run(
             adapter.get_chat_info("user@test.com")
@@ -1773,6 +1785,140 @@ class TestSenderAuthentication(unittest.TestCase):
             authserv_id="mx.ourserver.com",
         )
         self.assertFalse(ok, reason)
+
+
+class TestConcurrentSameSenderThreads(unittest.TestCase):
+    """Regression tests: two concurrent threads from the same sender must
+    produce correctly threaded replies (text, document, and image paths).
+
+    The gateway media delivery path passes ``metadata=_thread_meta`` instead
+    of ``reply_to=...``, so :meth:`send_multiple_images` and
+    :meth:`send_document` must extract the reply anchor from metadata.
+    """
+
+    def setUp(self):
+        self._prev_allow_all = os.environ.get("EMAIL_ALLOW_ALL_USERS")
+        os.environ["EMAIL_ALLOW_ALL_USERS"] = "true"
+
+    def tearDown(self):
+        if self._prev_allow_all is None:
+            os.environ.pop("EMAIL_ALLOW_ALL_USERS", None)
+        else:
+            os.environ["EMAIL_ALLOW_ALL_USERS"] = self._prev_allow_all
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def test_text_replies_separate_concurrent_threads(self):
+        """Two concurrent same-sender text threads: each reply matches its own thread."""
+        adapter = self._make_adapter()
+
+        # Simulate two concurrent incoming emails from the same sender
+        adapter._store_thread_context("user@test.com", "Project Alpha", "<alpha-1@test.com>")
+        adapter._store_thread_context("user@test.com", "Project Beta", "<beta-1@test.com>")
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            # Reply to Beta — should use Beta's context
+            adapter._send_email("user@test.com", "Beta reply.", "<beta-1@test.com>")
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: Project Beta")
+            self.assertEqual(send_call["In-Reply-To"], "<beta-1@test.com>")
+
+            # Reply to Alpha — should use Alpha's context
+            adapter._send_email("user@test.com", "Alpha reply.", "<alpha-1@test.com>")
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: Project Alpha")
+            self.assertEqual(send_call["In-Reply-To"], "<alpha-1@test.com>")
+
+    def test_document_attachment_reply_from_metadata(self):
+        """send_document via metadata path should thread correctly.
+
+        The gateway calls send_document(chat_id, file_path, metadata=...)
+        without reply_to=... — the adapter must extract the anchor from metadata.
+        """
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter()
+
+        # Store two concurrent threads
+        adapter._store_thread_context("user@test.com", "Thread A", "<a-msg@test.com>")
+        adapter._store_thread_context("user@test.com", "Thread B", "<b-msg@test.com>")
+
+        # Create a temp file to attach
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False, mode="w") as f:
+            f.write("test content")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+
+                # Send a document with metadata containing thread_id (simulating
+                # the gateway's post-stream delivery call pattern)
+                result = asyncio.run(adapter.send_document(
+                    chat_id="user@test.com",
+                    file_path=tmp_path,
+                    caption="Document for Thread B",
+                    metadata={"thread_id": "<b-msg@test.com>"},
+                ))
+
+                self.assertTrue(result.success)
+                send_call = mock_server.send_message.call_args[0][0]
+                self.assertEqual(send_call["Subject"], "Re: Thread B")
+                self.assertEqual(send_call["In-Reply-To"], "<b-msg@test.com>")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_send_multiple_images_reply_from_metadata(self):
+        """send_multiple_images via metadata path should thread correctly.
+
+        The gateway calls send_multiple_images(chat_id, images, metadata=...)
+        without reply_to=... — the adapter must extract the anchor from metadata.
+        """
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter()
+
+        # Store two concurrent threads
+        adapter._store_thread_context("user@test.com", "Images A", "<img-a@test.com>")
+        adapter._store_thread_context("user@test.com", "Images B", "<img-b@test.com>")
+
+        # Create a temp image file
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False, mode="wb") as f:
+            f.write(b"fake png content")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+
+                # Send images with metadata containing thread_id (simulating
+                # the gateway's post-stream delivery call pattern)
+                asyncio.run(adapter.send_multiple_images(
+                    chat_id="user@test.com",
+                    images=[("file://" + tmp_path, "screenshot")],
+                    metadata={"thread_id": "<img-b@test.com>"},
+                ))
+
+                send_call = mock_server.send_message.call_args[0][0]
+                self.assertEqual(send_call["Subject"], "Re: Images B")
+                self.assertEqual(send_call["In-Reply-To"], "<img-b@test.com>")
+        finally:
+            os.unlink(tmp_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The email adapter tracked thread context as a single-entry-per-sender map (`Dict[str, Dict[str, str]]`). When a user forwarded multiple emails from the same address (e.g. one about Project A and one about Project B), each one overwrote the previous context. The `In-Reply-To` header on outgoing replies would then point to the wrong message, causing email clients to mis-thread responses into the wrong conversation.

Two additional bugs compounded this:

1. `_send_email_with_attachments` and `_send_email_with_attachment` did not accept a `reply_to_msg_id` parameter at all — they always fell back to the stored context, making the overwrite bug fatal for any email with attachments.
2. `send_document` and `send_multiple_images` accepted but did not forward `reply_to` to the underlying send methods.

## Changes

All changes are in `plugins/platforms/email/adapter.py`.

| Change | Detail |
|--------|--------|
| **Thread context storage** | Changed from `Dict[str, Dict[str, str]]` to `Dict[str, Dict[str, Dict[str, str]]]` — sender → `message_id` → context, using `OrderedDict` for insertion-order preservation, with a per-sender cap of 20 entries. |
| **`_get_thread_context`** | New helper. Exact match by `reply_to_msg_id`, then falls back to the most recent thread for that sender. |
| **`_store_thread_context`** | New helper. Stores context keyed by the incoming email's own `Message-ID`. Auto-trims oldest entries when the per-sender cap is exceeded. |
| **`_send_email`** | Uses `_get_thread_context(to_addr, reply_to_msg_id)` instead of raw `_thread_context.get(to_addr)`. |
| **`_send_email_with_attachments`** | Added `reply_to_msg_id` parameter. Uses `_get_thread_context`. Prefers `reply_to_msg_id` in `In-Reply-To` header. |
| **`_send_email_with_attachment`** | Added `reply_to_msg_id` parameter. Uses `_get_thread_context`. Prefers `reply_to_msg_id` in `In-Reply-To` header. |
| **`send_document`** | Now forwards `reply_to` to `_send_email_with_attachment`. |
| **`send_multiple_images`** | Added `reply_to` parameter, forwards it to `_send_email_with_attachments`. |
| **`get_chat_info`** | Uses `_get_thread_context` instead of raw dict lookup. |

## How to reproduce the bug

1. Have the agent on an email platform (e.g. Gmail).
2. Forward two emails from different threads to the agent from the same email address.
3. The agent's response to the first email arrives in the second email's thread.

## Verification

- Single-thread replies are unaffected (the most-recent fallback preserves the old behaviour when only one thread is active).
- Multiple concurrent threads from the same sender are now correctly separated.
- Attachments keep the correct threading headers.
