### PR TITLE
fix(credential-pool): refresh expired Codex token before quota probe during rotation

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1700,6 +1700,23 @@ class CredentialPool:
                     # while the account is already usable again — a throttled
                     # live probe of the Codex usage endpoint detects that and
                     # lifts the stale cooldown (issue #43747).
+                    #
+                    # Before probing, try to refresh the Codex access token if
+                    # it has expired while the credential was exhausted. The
+                    # probe makes an HTTP request with the access token — an
+                    # expired token returns 401, so the probe would always
+                    # return False/None and the entry stays stuck until
+                    # last_error_reset_at elapses (issue #72941).
+                    if (
+                        clear_expired
+                        and self.provider == "openai-codex"
+                        and entry.auth_type == AUTH_TYPE_OAUTH
+                        and entry.refresh_token
+                        and self._entry_needs_refresh(entry)
+                    ):
+                        refreshed = self._refresh_entry(entry, force=False)
+                        if refreshed is not None and refreshed is not entry:
+                            entry = refreshed
                     if not (
                         clear_expired
                         and self._codex_quota_restored_upstream(entry)


### PR DESCRIPTION
## Problem

When a Codex access token expires while the credential is in exhaustion cooldown (e.g., after a 429 rate-limit), the quota-restored probe (`_codex_quota_restored_upstream`) always fails. The probe makes an HTTP request to the Codex usage endpoint with the bearer token — an expired JWT returns 401, so the probe returns `False`/`None`, and the credential stays frozen until `last_error_reset_at` elapses (potentially days for weekly windows). Even if another credential with full quota exists in the pool, the exhausted entry is skipped before the refresh check runs.

## Fix

Before running the quota probe for exhausted openai-codex entries, check whether the access token has expired (`_entry_needs_refresh`) and, if so, refresh it first via `_refresh_entry`. After a successful refresh the probe can authenticate and correctly report whether the account's quota has been restored, allowing the pool to resume using the credential.

## Testing

```
tests/agent/test_credential_pool.py ................... [100%] 100 passed
tests/agent/test_credential_pool_unmatched_rotation_bound.py ... [100%] 5 passed
tests/agent/test_credential_pool_oat_authtype.py .... [100%] 7 passed
tests/agent/test_credential_pool_no_entries_log_throttle.py ... [100%] 3 passed
tests/hermes_cli/test_auth_codex_quota_probe.py ..... [100%] 21 passed
```

Fixes #72941