### PR TITLE
fix(skills): default write_approval on so bg review stages skill edits

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1709,15 +1709,17 @@ DEFAULT_CONFIG = {
         # Approval gate for skill_manage (create/edit/patch/write_file/delete/
         # remove_file), applied to BOTH foreground agent turns and the
         # background self-improvement review fork.
-        #   false (default) — write freely; the gate is off (pre-gate behaviour)
-        #   true            — require approval: stage the write for review
+        #   true (default)  — require approval: stage the write for review
         #                     instead of committing (a SKILL.md is too large to
         #                     review inline, so skills always stage rather than
         #                     prompt). List with /skills pending, inspect with
         #                     /skills diff <id> (full diff — CLI/dashboard/file,
         #                     never crammed into a chat bubble), apply with
         #                     /skills approve <id> or drop with /skills reject <id>.
-        "write_approval": False,
+        #   false           — write freely; the gate is off (pre-gate behaviour).
+        # Default flipped to true so unsupervised background skill review cannot
+        # rewrite user-authored skills on a stock install (#70128).
+        "write_approval": True,
     },
 
     # Curator — background skill maintenance.

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -743,6 +743,10 @@ class TestConfigSupportFloor:
         "model": {"default": "anthropic/claude-fable-5", "provider": "nous"},
         "model_catalog": {"ttl_hours": 1},
         "plugins": {"disabled": ["foo"], "enabled": []},
+        # skills.write_mode "on" → write_approval=False (v28→29). That is the
+        # legacy explicit dump of the OLD default; with #70128 skills default
+        # on, False is a non-default so it remains materialized on disk.
+        "skills": {"write_approval": False},
     }
 
     _ENV_FIXTURE = (

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1104,10 +1104,19 @@ class TestWriteApprovalMigration:
                         "skills:\n  write_mode: approve\n")
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
+            loaded = load_config()
+            # memory.write_approval defaults to False, so approve->True differs
+            # from the default and is materialised to disk.
             assert raw["memory"]["write_approval"] is True
-            assert raw["skills"]["write_approval"] is True
+            # skills.write_approval defaults to True (#70128), so approve->True
+            # equals the default and is NOT materialised to disk (lean-config
+            # invariant) — the legacy write_mode key is gone and the effective
+            # value resolves to True via load_config()'s deep-merge.
+            assert "write_approval" not in raw.get("skills", {})
+            assert loaded["memory"]["write_approval"] is True
+            assert loaded["skills"]["write_approval"] is True
             assert "write_mode" not in raw["memory"]
-            assert "write_mode" not in raw["skills"]
+            assert "write_mode" not in raw.get("skills", {})
 
     def test_on_and_off_map_to_false(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -30,9 +30,15 @@ from agent.skill_utils import (
 @contextmanager
 def _skill_dir(tmp_path):
     """Patch both SKILLS_DIR and get_all_skills_dirs so _find_skill searches
-    only the temp directory — not the real ~/.hermes/skills/."""
+    only the temp directory — not the real ~/.hermes/skills/.
+
+    Also forces the skills write-approval gate OFF so these tests exercise the
+    direct write/dispatch paths. The gate defaults on after #70128; its staging
+    behaviour has dedicated coverage in tests/tools/test_write_approval.py.
+    """
     with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
-         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+         patch("tools.write_approval.write_approval_enabled", return_value=False):
         yield
 
 
@@ -791,6 +797,7 @@ def _curator_pass(tmp_path, *, monkeypatch):
          patch("tools.skills_tool.SKILLS_DIR", skills_root), \
          patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_root]), \
          patch("tools.skill_usage._is_curator_managed_record", return_value=True), \
+         patch("tools.write_approval.write_approval_enabled", return_value=False), \
          patch("tools.skill_provenance.is_background_review", return_value=True):
         yield skills_root
 

--- a/tests/tools/test_skill_size_limits.py
+++ b/tests/tools/test_skill_size_limits.py
@@ -24,6 +24,10 @@ def isolate_skills(tmp_path, monkeypatch):
     monkeypatch.setattr("tools.skill_manager_tool.SKILLS_DIR", skills_dir)
     monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Force the skills write-approval gate OFF so size-limit validation runs on
+    # the direct write path. The gate defaults on after #70128 (staging has its
+    # own coverage in tests/tools/test_write_approval.py).
+    monkeypatch.setattr("tools.write_approval.write_approval_enabled", lambda subsystem: False)
     return skills_dir
 
 

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -1,8 +1,8 @@
 """Tests for the memory/skill write-approval gate (tools/write_approval.py)
 and the shared slash-command handlers (hermes_cli/write_approval_commands.py).
 
-Covers the boolean write_approval gate (off by default = write freely; on =
-require approval) for both subsystems, the foreground-vs-background staging
+Covers the boolean write_approval gate (memory off by default; skills on by
+default after #70128) for both subsystems, the foreground-vs-background staging
 split, pending store CRUD, and the list/approve/reject/diff/approval
 subcommand dispatch.
 """
@@ -36,11 +36,13 @@ def _set_approval(subsystem, enabled):
 # Config resolution
 # ---------------------------------------------------------------------------
 
-def test_default_gate_is_off(hermes_home):
+def test_default_gates(hermes_home):
     from tools import write_approval as wa
-    # Default: gate off → writes flow freely.
+    # Memory still defaults to gate-off (pre-existing behaviour).
     assert wa.write_approval_enabled("memory") is False
-    assert wa.write_approval_enabled("skills") is False
+    # Skills default on so unattended background skill review stages writes
+    # for approval instead of rewriting SKILL.md on a stock install (#70128).
+    assert wa.write_approval_enabled("skills") is True
 
 
 def test_invalid_subsystem_is_off(hermes_home):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1531,10 +1531,11 @@ def skill_manage(
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)
 
-    # Approval gate: when on, stages the write for review (skills are too large
-    # to review inline, so they always stage regardless of origin); when off
-    # (default) passes straight through. The gate is bypassed when this call is
-    # itself replaying an already-approved staged write (_skill_apply_pending).
+    # Approval gate: when on (skills default), stages the write for review
+    # (skills are too large to review inline, so they always stage regardless
+    # of origin); when off passes straight through. The gate is bypassed when
+    # this call is itself replaying an already-approved staged write
+    # (_skill_apply_pending).
     gate_result = _apply_skill_write_gate(
         action, name, content=content, category=category,
         file_path=file_path, file_content=file_content,

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -18,10 +18,10 @@ Both stores are written from two origins:
 This module lets the user gate those writes per-subsystem with a boolean
 ``write_approval``:
 
-  * ``false`` (default) — write freely (the pre-gate behaviour)
-  * ``true``            — require approval: do not commit the write; either
-    prompt inline (memory, interactive CLI only) or **stage** it to a pending
-    store and surface it for the user to approve or reject out-of-band
+  * ``false`` — write freely (the pre-gate behaviour; still the default for memory)
+  * ``true``  — require approval: do not commit the write; either prompt inline
+    (memory, interactive CLI only) or **stage** it to a pending store and surface
+    it for the user to approve or reject out-of-band (default for skills, #70128)
 
 The size asymmetry between memory and skills is real and unavoidable: a memory
 entry can be reviewed inline in a chat bubble; a 100 KB SKILL.md cannot. So
@@ -74,16 +74,18 @@ CONFIG_KEY = "write_approval"
 def write_approval_enabled(subsystem: str) -> bool:
     """Return whether the approval gate is enabled for ``subsystem``.
 
-    Reads ``<subsystem>.write_approval`` from config.yaml. Defaults to
-    ``False`` (gate off — writes flow freely) for any unset / invalid value so
-    existing installs keep their current behaviour until the user opts in.
+    Reads ``<subsystem>.write_approval`` from config.yaml. When the key is
+    unset, falls back to ``DEFAULT_CONFIG`` values via ``load_config()``
+    (memory defaults to off; skills defaults to on after #70128). Invalid
+    subsystem names always return ``False``.
     """
     if subsystem not in _SUBSYSTEMS:
         return False
     try:
-        from hermes_cli.config import load_config, cfg_get
+        from hermes_cli.config import load_config, cfg_get, DEFAULT_CONFIG
         cfg = load_config()
-        raw = cfg_get(cfg, subsystem, CONFIG_KEY, default=False)
+        default = cfg_get(DEFAULT_CONFIG, subsystem, CONFIG_KEY, default=False)
+        raw = cfg_get(cfg, subsystem, CONFIG_KEY, default=default)
     except Exception:
         return False
     return _normalize_enabled(raw)

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -263,8 +263,8 @@ def evaluate_gate(subsystem: str, *, inline_summary: str = "",
         inline_detail: full content shown in the inline prompt (memory entries
             are small; skills never take the inline path).
 
-    Decision matrix:
-        gate off (default)                    → allow (writes flow freely)
+    Decision matrix (memory defaults gate off; skills defaults gate on):
+        gate off                              → allow (writes flow freely)
         gate on, memory + interactive CLI     → inline approve/deny prompt
         gate on, memory + gateway/script/bg   → stage
         gate on, skills (any origin)          → stage (too big to review inline)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -641,7 +641,7 @@ Independent of the content scanner above, `skills.write_approval` gates **every*
 
 ```yaml
 skills:
-  write_approval: false   # false = write freely (default) | true = stage every write for review
+  write_approval: true    # true = stage every write for review (default) | false = write freely
 ```
 
 When on, skill writes are staged under `~/.hermes/pending/skills/` and reviewed with `/skills pending`, `/skills diff <id>`, `/skills approve <id>`, `/skills reject <id>` — from the CLI or any messaging platform. Toggle at runtime with `/skills approval on|off`. Memory has the same gate (`memory.write_approval`, below). Full walkthrough: [Gating agent skill writes](/user-guide/features/skills#gating-agent-skill-writes-skillswrite_approval).

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -320,7 +320,7 @@ Skills use the same on/off gate, but the review UX differs because a
 
 ```yaml
 skills:
-  write_approval: false     # false = write freely (default) | true = require approval
+  write_approval: true      # true = require approval (default) | false = write freely
 ```
 
 When `write_approval: true`, skill writes (create / edit / patch / write_file /

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -473,15 +473,15 @@ The `patch` action is preferred for updates — it's more token-efficient than `
 
 ### Gating agent skill writes (`skills.write_approval`)
 
-By default the agent writes skills freely — including from the [background
+By default skill writes require approval — including from the [background
 self-improvement review](/user-guide/features/memory#controlling-memory-writes-write_approval)
-that runs after a turn. If you'd rather approve every skill write first
-(small models that misjudge what they learned, secure environments, or just
-wanting eyes on the self-improvement loop), turn on the write-approval gate:
+that runs after a turn — so unsupervised background review cannot rewrite
+your skills on a stock install (#70128). If you'd rather let the agent write
+skills freely, turn the gate off:
 
 ```yaml
 skills:
-  write_approval: false     # false = write freely (default) | true = require approval
+  write_approval: true      # true = require approval (default) | false = write freely
 ```
 
 When `write_approval: true`, every `skill_manage` write (create / edit /


### PR DESCRIPTION
## Summary
Default `skills.write_approval` to true so unsupervised background skill review stages SKILL.md edits instead of rewriting them on a stock install. Closes #70128.

## Motivation
Background skill review can rewrite user-authored skills while the approval gate shipped off.

## Verification
`pytest tests/tools/test_write_approval.py -q` (34 passed)