### PR TITLE
fix(terminal): strip package-registry tokens; noninteractive git

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -1830,3 +1830,53 @@ class TestHermesInternalDynamicSecrets:
         ):
             run_env = _make_run_env({})
         assert run_env.get("GIT_TERMINAL_PROMPT") == "0"
+
+
+class TestPostSourceSnapshotHardening:
+    """Session snapshot source can restore tokens / git prompt; re-harden after."""
+
+    def test_post_source_script_unsets_package_tokens_and_forces_git(self):
+        from tools.environments.local import _post_source_env_hardening_script
+
+        script = _post_source_env_hardening_script()
+        assert "NPM_TOKEN" in script
+        assert "CARGO_REGISTRY_TOKEN" in script
+        assert "GIT_TERMINAL_PROMPT=0" in script
+        assert "GCM_INTERACTIVE=Never" in script
+
+    def test_wrap_command_reapplies_hardening_after_snapshot_source(self):
+        from tools.environments.base import BaseEnvironment
+
+        class _Stub(BaseEnvironment):
+            def cleanup(self):
+                pass
+
+            def _run_bash(self, *a, **k):
+                raise NotImplementedError
+
+        env = _Stub(cwd="/tmp", timeout=10)
+        env._snapshot_ready = True
+        env._snapshot_path = "/tmp/hermes-snap-test.sh"
+        wrapped = env._wrap_command("echo hi", "/tmp")
+        src_i = wrapped.find("source ")
+        hard_i = wrapped.find("GIT_TERMINAL_PROMPT=0")
+        eval_i = wrapped.find("eval '")
+        assert src_i != -1 and hard_i != -1 and eval_i != -1
+        assert src_i < hard_i < eval_i
+        assert "unset -v NPM_TOKEN" in wrapped
+        assert "GCM_INTERACTIVE=Never" in wrapped
+
+    def test_make_run_env_sets_gcm_interactive(self):
+        from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+
+        with patch.dict(os.environ, {"PATH": "/usr/bin", "GCM_INTERACTIVE": "Always"}, clear=True):
+            run_env = _make_run_env({})
+        assert run_env.get("GCM_INTERACTIVE") == "Never"
+        assert run_env.get("GIT_TERMINAL_PROMPT") == "0"
+
+        result = _sanitize_subprocess_env(
+            {"PATH": "/usr/bin", "NPM_TOKEN": "x", "GIT_TERMINAL_PROMPT": "1"}
+        )
+        assert "NPM_TOKEN" not in result
+        assert result.get("GIT_TERMINAL_PROMPT") == "0"
+        assert result.get("GCM_INTERACTIVE") == "Never"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -1786,3 +1786,29 @@ class TestHermesInternalDynamicSecrets:
         assert "GATEWAY_RELAY_SECRET" in _HERMES_PROVIDER_ENV_BLOCKLIST
         assert "GATEWAY_RELAY_DELIVERY_KEY" in _HERMES_PROVIDER_ENV_BLOCKLIST
         assert "GATEWAY_RELAY_ID" in _HERMES_PROVIDER_ENV_BLOCKLIST
+
+
+    def test_package_registry_tokens_stripped(self):
+        """npm/PyPI/Cargo publish tokens must not leak into agent subprocesses."""
+        tokens = {
+            "NPM_TOKEN": "npm-secret",
+            "NPM_AUTH_TOKEN": "npm-auth",
+            "NODE_AUTH_TOKEN": "node-auth",
+            "PYPI_TOKEN": "pypi-secret",
+            "TWINE_PASSWORD": "twine-secret",
+            "CARGO_REGISTRY_TOKEN": "cargo-secret",
+        }
+        result_env = _run_with_env(extra_os_env=tokens)
+        for var in tokens:
+            assert var not in result_env, f"{var} leaked into subprocess env"
+        for var in tokens:
+            assert var in _HERMES_PROVIDER_ENV_BLOCKLIST
+
+    def test_git_terminal_prompt_disabled(self):
+        """Subprocess env must set GIT_TERMINAL_PROMPT=0 (non-interactive git)."""
+        from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+        result = _sanitize_subprocess_env({"PATH": "/usr/bin"})
+        assert result.get("GIT_TERMINAL_PROMPT") == "0"
+        with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True):
+            run_env = _make_run_env({})
+        assert run_env.get("GIT_TERMINAL_PROMPT") == "0"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -706,3 +706,21 @@ class TestHermesInternalDynamicSecrets:
         with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True):
             run_env = _make_run_env({})
         assert run_env.get("GIT_TERMINAL_PROMPT") == "0"
+
+    def test_git_terminal_prompt_inherited_enabled_is_overridden(self):
+        """An inherited GIT_TERMINAL_PROMPT=1 must be forced back to 0."""
+        from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+
+        # _sanitize_subprocess_env path: enabled value supplied via base_env.
+        result = _sanitize_subprocess_env(
+            {"PATH": "/usr/bin", "GIT_TERMINAL_PROMPT": "1"}
+        )
+        assert result.get("GIT_TERMINAL_PROMPT") == "0"
+
+        # Foreground run path (_make_run_env) with inherited enabled prompt
+        # via os.environ (merged as os.environ | env).
+        with patch.dict(
+            os.environ, {"PATH": "/usr/bin", "GIT_TERMINAL_PROMPT": "1"}, clear=True
+        ):
+            run_env = _make_run_env({})
+        assert run_env.get("GIT_TERMINAL_PROMPT") == "0"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -1812,3 +1812,21 @@ class TestHermesInternalDynamicSecrets:
         with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True):
             run_env = _make_run_env({})
         assert run_env.get("GIT_TERMINAL_PROMPT") == "0"
+
+    def test_git_terminal_prompt_inherited_enabled_is_overridden(self):
+        """An inherited GIT_TERMINAL_PROMPT=1 must be forced back to 0."""
+        from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+
+        # _sanitize_subprocess_env path: enabled value supplied via base_env.
+        result = _sanitize_subprocess_env(
+            {"PATH": "/usr/bin", "GIT_TERMINAL_PROMPT": "1"}
+        )
+        assert result.get("GIT_TERMINAL_PROMPT") == "0"
+
+        # Foreground run path (_make_run_env) with inherited enabled prompt
+        # via os.environ (merged as os.environ | env).
+        with patch.dict(
+            os.environ, {"PATH": "/usr/bin", "GIT_TERMINAL_PROMPT": "1"}, clear=True
+        ):
+            run_env = _make_run_env({})
+        assert run_env.get("GIT_TERMINAL_PROMPT") == "0"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -680,3 +680,29 @@ class TestHermesInternalDynamicSecrets:
         assert "GATEWAY_RELAY_SECRET" in _HERMES_PROVIDER_ENV_BLOCKLIST
         assert "GATEWAY_RELAY_DELIVERY_KEY" in _HERMES_PROVIDER_ENV_BLOCKLIST
         assert "GATEWAY_RELAY_ID" in _HERMES_PROVIDER_ENV_BLOCKLIST
+
+
+    def test_package_registry_tokens_stripped(self):
+        """npm/PyPI/Cargo publish tokens must not leak into agent subprocesses."""
+        tokens = {
+            "NPM_TOKEN": "npm-secret",
+            "NPM_AUTH_TOKEN": "npm-auth",
+            "NODE_AUTH_TOKEN": "node-auth",
+            "PYPI_TOKEN": "pypi-secret",
+            "TWINE_PASSWORD": "twine-secret",
+            "CARGO_REGISTRY_TOKEN": "cargo-secret",
+        }
+        result_env = _run_with_env(extra_os_env=tokens)
+        for var in tokens:
+            assert var not in result_env, f"{var} leaked into subprocess env"
+        for var in tokens:
+            assert var in _HERMES_PROVIDER_ENV_BLOCKLIST
+
+    def test_git_terminal_prompt_disabled(self):
+        """Subprocess env must set GIT_TERMINAL_PROMPT=0 (non-interactive git)."""
+        from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+        result = _sanitize_subprocess_env({"PATH": "/usr/bin"})
+        assert result.get("GIT_TERMINAL_PROMPT") == "0"
+        with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True):
+            run_env = _make_run_env({})
+        assert run_env.get("GIT_TERMINAL_PROMPT") == "0"

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -928,6 +928,8 @@ class BaseEnvironment(ABC):
                     parts.append(harden)
             except Exception:
                 parts.append(
+                    "unset -v NPM_TOKEN NPM_AUTH_TOKEN NODE_AUTH_TOKEN "
+                    "PYPI_TOKEN TWINE_PASSWORD CARGO_REGISTRY_TOKEN 2>/dev/null || true\n"
                     "export GIT_TERMINAL_PROMPT=0\n"
                     "export GCM_INTERACTIVE=Never"
                 )

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -915,6 +915,22 @@ class BaseEnvironment(ABC):
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
             )
+            # Snapshot ``export -p`` can restore secrets / GIT_TERMINAL_PROMPT
+            # after the Popen env was sanitized. Re-apply terminal hardening
+            # immediately before the user command (local policy helper).
+            try:
+                from tools.environments.local import (
+                    _post_source_env_hardening_script,
+                )
+
+                harden = _post_source_env_hardening_script()
+                if harden:
+                    parts.append(harden)
+            except Exception:
+                parts.append(
+                    "export GIT_TERMINAL_PROMPT=0\n"
+                    "export GCM_INTERACTIVE=Never"
+                )
 
         for name, present, value in saved_names:
             parts.append(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -320,6 +320,14 @@ def _build_provider_env_blocklist() -> frozenset:
         "VERCEL_TOKEN",
         "VERCEL_PROJECT_ID",
         "VERCEL_TEAM_ID",
+        # Package-registry / publish tokens — high value if a tool subprocess
+        # exfiltrates env; not part of the user shell AWS posture exception.
+        "NPM_TOKEN",
+        "NPM_AUTH_TOKEN",
+        "NODE_AUTH_TOKEN",
+        "PYPI_TOKEN",
+        "TWINE_PASSWORD",
+        "CARGO_REGISTRY_TOKEN",
     })
     # CLAUDE_CODE_OAUTH_TOKEN is deliberately NOT stripped.  It is set and
     # owned by the user's Claude Code install (subscription OAuth), not a
@@ -496,6 +504,12 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     _apply_windows_msys_bash_env_defaults(sanitized)
 
     sanitized = _scrub_delegated_child_kanban_env(sanitized)
+
+    # Non-interactive git: never hang a tool subprocess on credential prompts
+    # (clone/fetch/push over https). Users can still set credentials via
+    # git credential helpers or URL-embedded tokens; GIT_TERMINAL_PROMPT=0 only
+    # disables interactive stdin prompts.
+    sanitized.setdefault("GIT_TERMINAL_PROMPT", "0")
 
     return sanitized
 
@@ -1266,6 +1280,10 @@ def _make_run_env(env: dict) -> dict:
     _apply_windows_msys_bash_env_defaults(run_env)
 
     run_env = _scrub_delegated_child_kanban_env(run_env)
+
+    # See _sanitize_subprocess_env — same non-interactive git policy for the
+    # primary terminal run path.
+    run_env.setdefault("GIT_TERMINAL_PROMPT", "0")
 
     return run_env
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -421,6 +421,14 @@ def _build_provider_env_blocklist() -> frozenset:
         "VERCEL_TOKEN",
         "VERCEL_PROJECT_ID",
         "VERCEL_TEAM_ID",
+        # Package-registry / publish tokens — high value if a tool subprocess
+        # exfiltrates env; not part of the user shell AWS posture exception.
+        "NPM_TOKEN",
+        "NPM_AUTH_TOKEN",
+        "NODE_AUTH_TOKEN",
+        "PYPI_TOKEN",
+        "TWINE_PASSWORD",
+        "CARGO_REGISTRY_TOKEN",
     })
     # CLAUDE_CODE_OAUTH_TOKEN is deliberately NOT stripped.  It is set and
     # owned by the user's Claude Code install (subscription OAuth), not a
@@ -769,6 +777,12 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     _apply_windows_msys_bash_env_defaults(sanitized)
 
     sanitized = _scrub_delegated_child_kanban_env(sanitized)
+
+    # Non-interactive git: never hang a tool subprocess on credential prompts
+    # (clone/fetch/push over https). Users can still set credentials via
+    # git credential helpers or URL-embedded tokens; GIT_TERMINAL_PROMPT=0 only
+    # disables interactive stdin prompts.
+    sanitized.setdefault("GIT_TERMINAL_PROMPT", "0")
 
     return sanitized
 
@@ -1588,6 +1602,10 @@ def _make_run_env(env: dict) -> dict:
     _apply_windows_msys_bash_env_defaults(run_env)
 
     run_env = _scrub_delegated_child_kanban_env(run_env)
+
+    # See _sanitize_subprocess_env — same non-interactive git policy for the
+    # primary terminal run path.
+    run_env.setdefault("GIT_TERMINAL_PROMPT", "0")
 
     return run_env
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -781,8 +781,9 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # Non-interactive git: never hang a tool subprocess on credential prompts
     # (clone/fetch/push over https). Users can still set credentials via
     # git credential helpers or URL-embedded tokens; GIT_TERMINAL_PROMPT=0 only
-    # disables interactive stdin prompts.
-    sanitized.setdefault("GIT_TERMINAL_PROMPT", "0")
+    # disables interactive stdin prompts. Assign unconditionally so an
+    # inherited GIT_TERMINAL_PROMPT=1 cannot re-enable prompts.
+    sanitized["GIT_TERMINAL_PROMPT"] = "0"
 
     return sanitized
 
@@ -1604,8 +1605,9 @@ def _make_run_env(env: dict) -> dict:
     run_env = _scrub_delegated_child_kanban_env(run_env)
 
     # See _sanitize_subprocess_env — same non-interactive git policy for the
-    # primary terminal run path.
-    run_env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    # primary terminal run path. Assign unconditionally so an inherited
+    # GIT_TERMINAL_PROMPT=1 cannot re-enable prompts.
+    run_env["GIT_TERMINAL_PROMPT"] = "0"
 
     return run_env
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -695,6 +695,49 @@ def _inject_session_context_env(env: dict) -> None:
             env.pop(var_name, None)
 
 
+
+def _apply_terminal_env_hardening(env: dict) -> None:
+    """Force non-interactive git + drop package-publish tokens on *env*.
+
+    Called at the end of every local spawn-env builder so an inherited
+    ``GIT_TERMINAL_PROMPT=1`` (or a restored package token) cannot survive on
+    the process environment. Shell-level session snapshots can still overwrite
+    these after ``source``; that path is re-hardened in
+    :meth:`BaseEnvironment._wrap_command` via
+    :func:`_post_source_env_hardening_script`.
+    """
+    for key in (
+        "NPM_TOKEN",
+        "NPM_AUTH_TOKEN",
+        "NODE_AUTH_TOKEN",
+        "PYPI_TOKEN",
+        "TWINE_PASSWORD",
+        "CARGO_REGISTRY_TOKEN",
+    ):
+        env.pop(key, None)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    # Git Credential Manager (Windows default helper) — match internal git
+    # policy in hermes_cli._subprocess_compat.
+    env["GCM_INTERACTIVE"] = "Never"
+
+
+def _post_source_env_hardening_script() -> str:
+    """Shell snippet re-applied *after* session-snapshot ``source``.
+
+    Login-profile / session-snapshot state is dumped with ``export -p`` and
+    re-sourced before each command. That can restore package-registry tokens
+    and re-enable git prompting even when the Popen env was sanitized. Re-run
+    the filters immediately before the user command so the trust boundary
+    holds at execution time.
+    """
+    return (
+        "unset -v NPM_TOKEN NPM_AUTH_TOKEN NODE_AUTH_TOKEN "
+        "PYPI_TOKEN TWINE_PASSWORD CARGO_REGISTRY_TOKEN 2>/dev/null || true\n"
+        "export GIT_TERMINAL_PROMPT=0\n"
+        "export GCM_INTERACTIVE=Never"
+    )
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -778,12 +821,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
 
     sanitized = _scrub_delegated_child_kanban_env(sanitized)
 
-    # Non-interactive git: never hang a tool subprocess on credential prompts
-    # (clone/fetch/push over https). Users can still set credentials via
-    # git credential helpers or URL-embedded tokens; GIT_TERMINAL_PROMPT=0 only
-    # disables interactive stdin prompts. Assign unconditionally so an
-    # inherited GIT_TERMINAL_PROMPT=1 cannot re-enable prompts.
-    sanitized["GIT_TERMINAL_PROMPT"] = "0"
+    # Non-interactive git + package-token posture (see _apply_terminal_env_hardening).
+    _apply_terminal_env_hardening(sanitized)
 
     return sanitized
 
@@ -1604,10 +1643,9 @@ def _make_run_env(env: dict) -> dict:
 
     run_env = _scrub_delegated_child_kanban_env(run_env)
 
-    # See _sanitize_subprocess_env — same non-interactive git policy for the
-    # primary terminal run path. Assign unconditionally so an inherited
-    # GIT_TERMINAL_PROMPT=1 cannot re-enable prompts.
-    run_env["GIT_TERMINAL_PROMPT"] = "0"
+    # See _sanitize_subprocess_env — same non-interactive git / token policy
+    # for the primary terminal run path.
+    _apply_terminal_env_hardening(run_env)
 
     return run_env
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -508,8 +508,9 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # Non-interactive git: never hang a tool subprocess on credential prompts
     # (clone/fetch/push over https). Users can still set credentials via
     # git credential helpers or URL-embedded tokens; GIT_TERMINAL_PROMPT=0 only
-    # disables interactive stdin prompts.
-    sanitized.setdefault("GIT_TERMINAL_PROMPT", "0")
+    # disables interactive stdin prompts. Assign unconditionally so an
+    # inherited GIT_TERMINAL_PROMPT=1 cannot re-enable prompts.
+    sanitized["GIT_TERMINAL_PROMPT"] = "0"
 
     return sanitized
 
@@ -1282,8 +1283,9 @@ def _make_run_env(env: dict) -> dict:
     run_env = _scrub_delegated_child_kanban_env(run_env)
 
     # See _sanitize_subprocess_env — same non-interactive git policy for the
-    # primary terminal run path.
-    run_env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    # primary terminal run path. Assign unconditionally so an inherited
+    # GIT_TERMINAL_PROMPT=1 cannot re-enable prompts.
+    run_env["GIT_TERMINAL_PROMPT"] = "0"
 
     return run_env
 


### PR DESCRIPTION
## Summary
Strip npm/PyPI/Cargo publish tokens from terminal subprocess env and set `GIT_TERMINAL_PROMPT=0` so tool loops cannot exfil those tokens or hang on git credential prompts.

## Motivation
High-value package-publish credentials were still inheritable into agent shells alongside intentional AWS operator-shell inheritance.

## Verification
`pytest tests/tools/test_local_env_blocklist.py -q` (passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal environment security by removing package registry and publishing credentials from executed commands.
  - Git operations now run in non-interactive mode, preventing unexpected prompts for credentials or terminal input.
  - Security settings are restored automatically after loading saved environment snapshots.
  - Applied these protections consistently across subprocesses and primary terminal commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->