### PR TITLE
fix(title): ignore internal user scaffolding in first-exchange gate

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -32,6 +32,7 @@ from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
 from agent.turn_context import substitute_api_content
 from agent.gemini_native_adapter import is_native_gemini_base_url
+from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
 from agent.model_metadata import is_local_endpoint
 from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
@@ -1989,12 +1990,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
 
-    summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
-    )
-    messages.append({"role": "user", "content": summary_request})
+    messages.append({"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST})
 
     try:
         # Build API messages, stripping internal-only fields

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -46,6 +46,7 @@ from agent.context_engine import (
     automatic_compaction_status_message,
     sanitize_memory_context,
 )
+from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
 from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
@@ -1044,7 +1045,7 @@ _SYNTHETIC_USER_FLAGS = (
 )
 
 
-def _is_real_user_message(message: Any) -> bool:
+def is_real_user_message(message: Any) -> bool:
     """Distinguish human intent from user-role runtime scaffolding.
 
     A compaction summary pinned to ``role="user"`` (the compressor flips the
@@ -1060,11 +1061,17 @@ def _is_real_user_message(message: Any) -> bool:
     text = _message_text(message).strip()
     if not text:
         return False
+    if text == MAX_ITERATIONS_SUMMARY_REQUEST:
+        return False
     if text.startswith(_SYNTHETIC_USER_PREFIXES):
         return False
     from agent.context_compressor import ContextCompressor
 
     return not ContextCompressor._is_synthetic_compression_user_turn(message)
+
+
+# Backward-compatible private name for existing compression call sites.
+_is_real_user_message = is_real_user_message
 
 
 def _strip_stale_todo_snapshot(content: Any) -> Any:

--- a/agent/internal_user_messages.py
+++ b/agent/internal_user_messages.py
@@ -1,0 +1,7 @@
+"""Stable content markers for Hermes-authored user-role messages."""
+
+MAX_ITERATIONS_SUMMARY_REQUEST = (
+    "You've reached the maximum number of tool-calling iterations allowed. "
+    "Please provide a final response summarizing what you've found and accomplished so far, "
+    "without calling any more tools."
+)

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -373,11 +373,13 @@ def maybe_auto_title(
     if not session_db or not session_id or not user_message or not assistant_response:
         return
 
-    # Count user messages in history to detect first exchange.
-    # conversation_history includes the exchange that just happened,
-    # so for a first exchange we expect exactly 1 user message
-    # (or 2 counting system). Be generous: generate on first 2 exchanges.
-    user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
+    from agent.conversation_compression import is_real_user_message
+
+    # Long turns can add Hermes-authored user-role scaffolding. Count only
+    # genuine user intent so those internal rows cannot close the title gate.
+    user_msg_count = sum(
+        1 for message in (conversation_history or []) if is_real_user_message(message)
+    )
     if user_msg_count > 2:
         return
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -430,6 +430,129 @@ class TestAutoTitleSession:
             auto_title_session(db, "sess-1", "hi", "hello", failure_callback=bad_cb)
 
 
+class TestRealUserMessageClassification:
+    """Shared classifier coverage for the title gate and compression."""
+
+    def test_compaction_metadata_and_projected_content_are_internal(self):
+        from agent.context_compressor import (
+            COMPRESSED_SUMMARY_METADATA_KEY,
+            LEGACY_SUMMARY_PREFIX,
+            SUMMARY_PREFIX,
+            _HISTORICAL_SUMMARY_PREFIXES,
+        )
+        from agent.conversation_compression import is_real_user_message
+
+        marked = {
+            "role": "user",
+            "content": "summary body",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+        projected = {
+            "role": "user",
+            "content": f"{SUMMARY_PREFIX}\nsummary body",
+        }
+        legacy = {
+            "role": "user",
+            "content": f"{LEGACY_SUMMARY_PREFIX}\nsummary body",
+        }
+        historical = {
+            "role": "user",
+            "content": f"{_HISTORICAL_SUMMARY_PREFIXES[0]}\nsummary body",
+        }
+        structured = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"{SUMMARY_PREFIX}\nsummary body",
+                }
+            ],
+        }
+
+        for message in (marked, projected, legacy, historical, structured):
+            assert not is_real_user_message(message)
+
+    def test_todo_and_compression_continuation_rows_are_internal(self):
+        from agent.context_compressor import (
+            COMPRESSION_CONTINUATION_USER_CONTENT,
+            _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
+        )
+        from agent.conversation_compression import is_real_user_message
+        from tools.todo_tool import TODO_INJECTION_HEADER
+
+        messages = [
+            {
+                "role": "user",
+                "content": f"{TODO_INJECTION_HEADER}\n- [>] Continue",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"{TODO_INJECTION_HEADER}\n- [>] Continue",
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": COMPRESSION_CONTINUATION_USER_CONTENT,
+            },
+            {
+                "role": "user",
+                "content": _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
+            },
+        ]
+
+        assert all(not is_real_user_message(message) for message in messages)
+
+    def test_exact_max_iteration_summary_request_is_internal(self):
+        from agent.conversation_compression import is_real_user_message
+        from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
+
+        assert not is_real_user_message(
+            {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST}
+        )
+        assert not is_real_user_message(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": MAX_ITERATIONS_SUMMARY_REQUEST,
+                    }
+                ],
+            }
+        )
+
+    def test_existing_synthetic_flags_are_internal(self):
+        from agent.conversation_compression import (
+            _SYNTHETIC_USER_FLAGS,
+            is_real_user_message,
+        )
+
+        for flag in _SYNTHETIC_USER_FLAGS:
+            message = {"role": "user", "content": "runtime row", flag: True}
+            assert not is_real_user_message(message), flag
+
+    def test_internal_phrases_inside_ordinary_user_content_remain_real(self):
+        from agent.context_compressor import SUMMARY_PREFIX
+        from agent.conversation_compression import is_real_user_message
+        from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
+        from tools.todo_tool import TODO_INJECTION_HEADER
+
+        contents = [
+            f"Why did Hermes say: {MAX_ITERATIONS_SUMMARY_REQUEST}",
+            f"Please explain this marker: {TODO_INJECTION_HEADER}",
+            f"Please analyze this header:\n{SUMMARY_PREFIX}",
+        ]
+
+        assert all(
+            is_real_user_message({"role": "user", "content": content})
+            for content in contents
+        )
+
+
 class TestMaybeAutoTitle:
     """Tests for maybe_auto_title() — the fire-and-forget entry point."""
 
@@ -479,6 +602,140 @@ class TestMaybeAutoTitle:
                 title_callback=None,
                 runtime_validator=None,
             )
+
+    def test_fires_when_first_exchange_contains_internal_user_scaffolding(self):
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "Investigate the Telegram rename bug"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call-1"}],
+            },
+            {
+                "role": "user",
+                "content": (
+                    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were "
+                    "compacted into this summary."
+                ),
+            },
+            {"role": "assistant", "content": "Continuing the investigation."},
+            {
+                "role": "user",
+                "content": (
+                    "[Your active task list was preserved across context compression]\n"
+                    "- [>] Find the root cause"
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call-2"}],
+            },
+            {
+                "role": "user",
+                "content": (
+                    "You've reached the maximum number of tool-calling iterations allowed. "
+                    "Please provide a final response summarizing what you've found and "
+                    "accomplished so far, without calling any more tools."
+                ),
+            },
+            {"role": "assistant", "content": "The title gate counted scaffolding."},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            import threading
+
+            called = threading.Event()
+            mock_auto.side_effect = lambda *args, **kwargs: called.set()
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "Investigate the Telegram rename bug",
+                "The title gate counted scaffolding.",
+                history,
+            )
+            assert called.wait(timeout=10), "auto_title thread never ran"
+
+        mock_auto.assert_called_once()
+
+    def test_fires_with_two_real_user_turns_plus_internal_scaffolding(self):
+        from agent.context_compressor import (
+            COMPRESSION_CONTINUATION_USER_CONTENT,
+            SUMMARY_PREFIX,
+        )
+        from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
+
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "first request"},
+            {"role": "assistant", "content": "first response"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\nsummary body"},
+            {
+                "role": "user",
+                "content": (
+                    "[Your active task list was preserved across context compression]\n"
+                    "- [>] Continue"
+                ),
+            },
+            {"role": "user", "content": "second request"},
+            {"role": "assistant", "content": "working"},
+            {"role": "user", "content": COMPRESSION_CONTINUATION_USER_CONTENT},
+            {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST},
+            {"role": "assistant", "content": "final response"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            import threading
+
+            called = threading.Event()
+            mock_auto.side_effect = lambda *args, **kwargs: called.set()
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "second request",
+                "final response",
+                history,
+            )
+            assert called.wait(timeout=10), "auto_title thread never ran"
+
+        mock_auto.assert_called_once()
+
+    def test_skips_with_three_real_user_turns_plus_internal_scaffolding(self):
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "first request"},
+            {"role": "assistant", "content": "first response"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\nsummary body"},
+            {"role": "user", "content": "second request"},
+            {"role": "assistant", "content": "second response"},
+            {
+                "role": "user",
+                "content": (
+                    "[Your active task list was preserved across context compression]\n"
+                    "- [>] Continue"
+                ),
+            },
+            {"role": "user", "content": "third request"},
+            {"role": "assistant", "content": "third response"},
+        ]
+
+        with (
+            patch("agent.title_generator.threading.Thread") as mock_thread,
+            patch("agent.title_generator.auto_title_session") as mock_auto,
+        ):
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "third request",
+                "third response",
+                history,
+            )
+
+        mock_thread.assert_not_called()
+        mock_auto.assert_not_called()
 
     def test_skips_when_title_generation_disabled(self):
         """Disabled title generation should not even start the background worker."""


### PR DESCRIPTION
## What does this PR do?

Long first turns can add Hermes-authored `role=user` rows for context compaction, preserved todos, and the max-iteration final-summary request. `maybe_auto_title()` counted those rows as genuine user turns, crossed its `> 2` first-exchange guard, and never launched the title worker. Dynamic Telegram topics consequently stayed at their placeholder name because the existing rename callback never received a generated title.

This PR makes the gate count genuine user-authored turns through the existing compression classifier. It promotes that classifier for reuse, preserves its metadata/current/legacy/historical summary handling, and gives the max-iteration nudge one stable shared constant so generation and classification cannot drift.

The existing allowance of up to two real user turns is unchanged. More than two real turns still skip auto-title. Title-generation config, daemon-thread behavior, manual-title race protection, final-response timing, static `dm_topics`, and Telegram callback/rename logic are unchanged.

## Related Issue

No exact issue found. Existing Telegram topic-title reports found during duplicate search cover different adapter or binding paths.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/title_generator.py`: count only genuine user-authored turns in the first-exchange gate.
- `agent/conversation_compression.py`: expose the existing narrow real-user classifier and recognize the exact max-iteration summary nudge.
- `agent/internal_user_messages.py` and `agent/chat_completion_helpers.py`: share the stable max-iteration request text with its producer.
- `tests/agent/test_title_generator.py`: cover the observed long-first-turn history, two/three-real-turn boundaries, canonical summary forms and metadata projection, structured content, todo/continuation rows, synthetic flags, exact max-iteration matching, and ordinary user text containing internal phrases.

## How to Test

1. RED on unmodified `main`:

   ```text
   pytest tests/agent/test_title_generator.py::TestMaybeAutoTitle::test_fires_when_first_exchange_contains_internal_user_scaffolding -v -o 'addopts='
   FAILED ... AssertionError: auto_title thread never ran
   1 failed
   ```

2. GREEN with this commit:

   ```text
   pytest tests/agent/test_title_generator.py::TestMaybeAutoTitle::test_fires_when_first_exchange_contains_internal_user_scaffolding -v -o 'addopts='
   1 passed
   ```

3. Focused and adjacent suites:

   ```text
   pytest tests/agent/test_title_generator.py -q -o 'addopts='
   55 passed

   pytest tests/gateway/test_telegram_topic_mode.py -q -o 'addopts='
   47 passed

   pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations tests/agent/test_api_content_sidecar.py::TestMaxIterationsSummaryReplay -q -o 'addopts='
   15 passed

   pytest tests/agent/test_compressed_summary_metadata.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_context_compressor_zero_user_provenance.py tests/agent/test_compression_rotation_state.py tests/agent/test_compressor_actionable_tail_anchor.py tests/agent/test_compressor_assistant_tail_anchor.py tests/agent/test_context_compressor.py -q -o 'addopts='
   349 passed
   ```

4. Static checks:

   ```text
   ruff check agent/internal_user_messages.py agent/chat_completion_helpers.py agent/conversation_compression.py agent/title_generator.py tests/agent/test_title_generator.py
   All checks passed!

   python -m py_compile agent/internal_user_messages.py agent/chat_completion_helpers.py agent/conversation_compression.py agent/title_generator.py
   # passed
   ```

5. Full-suite status:

   ```text
   pytest tests/ -q -o 'addopts='
   ```

   On Windows, collection stopped before test execution on three unrelated environment/baseline issues: POSIX-only `termios`, the installed MCP package lacking `CreateMessageResultWithTools`, and a test invoking Unix `which`. Result: 20 skipped, 3 collection errors. CI is the authoritative full-suite run.

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs/issues to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (Windows collection blockers documented above)
- [x] I've added tests for the change
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior and rationale are covered in code/tests
- [x] `cli-config.yaml.example`: N/A; no configuration changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture changed
- [x] Cross-platform impact considered; the change is pure Python and platform-independent
- [x] Tool descriptions/schemas: N/A; no tool schema changed