### PR TITLE
fix(desktop): stop the model-pill tooltip popping open after a mouse pick

### DIFF
--- a/apps/desktop/src/components/ui/tooltip.test.tsx
+++ b/apps/desktop/src/components/ui/tooltip.test.tsx
@@ -6,6 +6,11 @@ import { suppressNonKeyboardFocusOpen } from './tooltip'
 // their trigger on close, which left tips stuck open after a mouse pick (e.g.
 // the composer model pill). The trigger's focus handler must preventDefault —
 // which Radix's composed handler honors — for non-keyboard focus only.
+//
+// The regression these guard: `:focus-visible` on its own says "true" for a
+// mouse pick out of a Radix menu, because the menu's autofocus/arrow-key
+// navigation puts Chromium in keyboard modality before focus returns to the
+// trigger. Only the last real input device separates the two cases.
 
 const focusEvent = (matchesImpl: (selector: string) => boolean) => {
   const preventDefault = vi.fn()
@@ -19,30 +24,59 @@ const focusEvent = (matchesImpl: (selector: string) => boolean) => {
   }
 }
 
-describe('suppressNonKeyboardFocusOpen', () => {
-  it('suppresses the focus-open when focus is not keyboard-visible (menu close restore)', () => {
-    const { event, preventDefault } = focusEvent(selector => selector !== ':focus-visible')
+const focusVisible = (selector: string) => selector === ':focus-visible'
+const notFocusVisible = (selector: string) => selector !== ':focus-visible'
 
-    suppressNonKeyboardFocusOpen(event)
+describe('suppressNonKeyboardFocusOpen', () => {
+  it('suppresses the focus-open when a mouse pick restores focus to the trigger', () => {
+    // The menu leaves Chromium in keyboard modality, so :focus-visible matches
+    // even though the user clicked — this is the model-pill bug.
+    const { event, preventDefault } = focusEvent(focusVisible)
+
+    suppressNonKeyboardFocusOpen(event, 'pointer')
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('suppresses the focus-open when focus is not keyboard-visible', () => {
+    const { event, preventDefault } = focusEvent(notFocusVisible)
+
+    suppressNonKeyboardFocusOpen(event, 'pointer')
 
     expect(preventDefault).toHaveBeenCalledOnce()
   })
 
   it('keeps the focus-open for keyboard (Tab) focus — a11y path', () => {
-    const { event, preventDefault } = focusEvent(selector => selector === ':focus-visible')
+    const { event, preventDefault } = focusEvent(focusVisible)
 
-    suppressNonKeyboardFocusOpen(event)
+    suppressNonKeyboardFocusOpen(event, 'keyboard')
 
     expect(preventDefault).not.toHaveBeenCalled()
   })
 
-  it('fails open when :focus-visible is unsupported', () => {
-    const { event, preventDefault } = focusEvent(() => {
+  it('still suppresses a programmatic focus that is not focus-visible in keyboard modality', () => {
+    const { event, preventDefault } = focusEvent(notFocusVisible)
+
+    suppressNonKeyboardFocusOpen(event, 'keyboard')
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to the modality when :focus-visible is unsupported', () => {
+    const unsupported = () => {
       throw new Error('unsupported selector')
-    })
+    }
 
-    suppressNonKeyboardFocusOpen(event)
+    const keyboard = focusEvent(unsupported)
 
-    expect(preventDefault).not.toHaveBeenCalled()
+    suppressNonKeyboardFocusOpen(keyboard.event, 'keyboard')
+
+    expect(keyboard.preventDefault).not.toHaveBeenCalled()
+
+    const pointer = focusEvent(unsupported)
+
+    suppressNonKeyboardFocusOpen(pointer.event, 'pointer')
+
+    expect(pointer.preventDefault).toHaveBeenCalledOnce()
   })
 })

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -2,6 +2,7 @@ import { Tooltip as TooltipPrimitive } from 'radix-ui'
 import * as React from 'react'
 
 import { useI18n } from '@/i18n'
+import { type InputModality, lastInputModality } from '@/lib/input-modality'
 import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
 import { cn } from '@/lib/utils'
 
@@ -47,17 +48,25 @@ function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root
 // covers clicks on the trigger itself). Menus and dialogs return focus to
 // their trigger when they close, so "open the model menu, pick a model" left
 // the trigger's tip stuck open over the fresh selection. Gate focus-opens to
-// KEYBOARD focus (:focus-visible): Chromium keeps modality, so a mouse pick's
-// focus restore is suppressed while Tab-focus still shows the tip for a11y.
-// preventDefault doesn't cancel the focus itself — Radix's composed handler
-// just skips its onOpen when the event is defaultPrevented.
-export function suppressNonKeyboardFocusOpen(event: React.FocusEvent<HTMLElement>): void {
-  let keyboardFocus = true
+// KEYBOARD focus so a mouse pick's focus restore is suppressed while Tab-focus
+// still shows the tip for a11y. preventDefault doesn't cancel the focus itself
+// — Radix's composed handler just skips its onOpen when defaultPrevented.
+//
+// `:focus-visible` ALONE is not that gate. Radix menus autofocus their content
+// and keyboard-navigate their items, so Chromium is in keyboard modality by the
+// time a mouse pick restores focus and matches `:focus-visible` — the model
+// pill's tip reopened over every selection. Qualify it with the device behind
+// the last real interaction, which a mouse pick reports as `pointer`.
+export function suppressNonKeyboardFocusOpen(
+  event: React.FocusEvent<HTMLElement>,
+  modality: InputModality = lastInputModality()
+): void {
+  let keyboardFocus = modality === 'keyboard'
 
   try {
-    keyboardFocus = event.currentTarget.matches(':focus-visible')
+    keyboardFocus &&= event.currentTarget.matches(':focus-visible')
   } catch {
-    // Selector unsupported (older jsdom) — keep Radix's default focus-open.
+    // Selector unsupported (older jsdom) — fall back to the modality alone.
   }
 
   if (!keyboardFocus) {

--- a/apps/desktop/src/lib/input-modality.test.ts
+++ b/apps/desktop/src/lib/input-modality.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { lastInputModality } from './input-modality'
+
+describe('lastInputModality', () => {
+  it('defaults to keyboard before any input', () => {
+    expect(lastInputModality()).toBe('keyboard')
+  })
+
+  it('tracks the device behind the last interaction', () => {
+    document.dispatchEvent(new Event('pointerdown'))
+
+    expect(lastInputModality()).toBe('pointer')
+
+    document.dispatchEvent(new Event('keydown'))
+
+    expect(lastInputModality()).toBe('keyboard')
+  })
+
+  it('sees events a handler stops from bubbling (capture phase)', () => {
+    const target = document.createElement('button')
+
+    document.body.append(target)
+    target.addEventListener('pointerdown', event => event.stopPropagation())
+    target.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+
+    expect(lastInputModality()).toBe('pointer')
+
+    target.remove()
+  })
+})

--- a/apps/desktop/src/lib/input-modality.ts
+++ b/apps/desktop/src/lib/input-modality.ts
@@ -1,0 +1,26 @@
+/** Which input device drove the most recent interaction.
+ *
+ *  Chromium's `:focus-visible` is not enough to tell a mouse pick from a Tab.
+ *  Radix menus autofocus their content on open and keyboard-navigate their
+ *  items, so by the time a mouse click closes the menu and restores focus to
+ *  the trigger, Chromium has decided the page is in keyboard modality and
+ *  matches `:focus-visible` on that restore (verified in Chrome — the model
+ *  pill's tooltip popped open after every mouse pick). Track the device
+ *  ourselves and use it to qualify `:focus-visible`.
+ */
+
+export type InputModality = 'keyboard' | 'pointer'
+
+let modality: InputModality = 'keyboard'
+
+/** Capture-phase so a `stopPropagation` deeper in the tree can't blind us. */
+if (typeof document !== 'undefined') {
+  document.addEventListener('pointerdown', () => (modality = 'pointer'), { capture: true, passive: true })
+  document.addEventListener('keydown', () => (modality = 'keyboard'), { capture: true, passive: true })
+}
+
+/** The device behind the last pointerdown/keydown. Defaults to `keyboard` so a
+ *  surface that has seen no input yet keeps the accessible behavior. */
+export function lastInputModality(): InputModality {
+  return modality
+}


### PR DESCRIPTION
Clicking an item in any dropdown menu leaves the trigger's tooltip popped open over whatever you just did. Most visible on the composer's model pill: choose a model, menu closes, tooltip.

Tooltips open on any trigger focus, and Radix overlays restore focus to their trigger when they close, so every mouse-driven pick ends with a phantom tip. 7f69494c3 already guards against this, suppressing the focus-open unless the trigger matches `:focus-visible`. That holds for dialogs and popovers, which restore focus without it. It does not hold for menus: Radix's menu keyboard navigation puts Chromium in keyboard modality on the way out, so the restored focus matches `:focus-visible` and the guard waves it through.

Qualify the check with the device behind the last real interaction, tracked from capture-phase `pointerdown`/`keydown`. A mouse pick reports `pointer` no matter what Chromium decided about the focus ring; Tab still reports `keyboard` and still gets its tooltip.

Tooltip behavior after a mouse pick, measured in Chrome against real Radix overlays:

| | before 7f69494c3 | on main | here |
|---|---|---|---|
| menu (model pill, kebabs, context menus) | tooltip | tooltip | silent |
| dialog | tooltip | silent | silent |
| popover | tooltip | silent | silent |
