### PR TITLE
fix: hide macOS setup launcher from Dock

### DIFF
--- a/apps/bootstrap-installer/src-tauri/Info.plist
+++ b/apps/bootstrap-installer/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>LSUIElement</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/bootstrap-installer/src-tauri/Info.plist
+++ b/apps/bootstrap-installer/src-tauri/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>LSUIElement</key>
+  <true/>
   <key>NSAudioCaptureUsageDescription</key>
   <string>Hermes launches the desktop app, which uses audio capture for voice conversations.</string>
   <key>NSMicrophoneUsageDescription</key>

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -363,14 +363,13 @@ fn write_bootstrap_complete_marker(install_root: &Path, pin: &Pin) -> Result<ser
     Ok(marker)
 }
 
-const DESKTOP_HANDOFF_POLL_INTERVAL: std::time::Duration =
-    std::time::Duration::from_millis(10);
-const DESKTOP_HANDOFF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-
 /// Spawn the already-built desktop app, detached. Returns Err if no built app
 /// exists or the spawn fails, so the caller can fall back to showing the
-/// installer UI.
-pub(crate) fn spawn_installed_desktop(install_root: &std::path::Path) -> std::io::Result<()> {
+/// installer UI. The caller owns the bounded hand-off poll and decides whether
+/// an observed child exit represents a successful launch.
+pub(crate) fn spawn_installed_desktop(
+    install_root: &std::path::Path,
+) -> std::io::Result<std::process::Child> {
     let exe = resolve_hermes_desktop_exe(install_root).ok_or_else(|| {
         std::io::Error::new(std::io::ErrorKind::NotFound, "no built Hermes desktop app")
     })?;
@@ -384,15 +383,7 @@ pub(crate) fn spawn_installed_desktop(install_root: &std::path::Path) -> std::io
         // Windows doesn't reintroduce the relaunch race.
         cmd.creation_flags(0x0000_0008);
     }
-    let mut child = cmd.spawn()?;
-    let start = std::time::Instant::now();
-    while start.elapsed() < DESKTOP_HANDOFF_TIMEOUT {
-        if child.try_wait()?.is_some() {
-            return Ok(());
-        }
-        std::thread::sleep(DESKTOP_HANDOFF_POLL_INTERVAL);
-    }
-    Ok(())
+    cmd.spawn()
 }
 
 #[cfg(target_os = "macos")]

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -363,6 +363,10 @@ fn write_bootstrap_complete_marker(install_root: &Path, pin: &Pin) -> Result<ser
     Ok(marker)
 }
 
+const DESKTOP_HANDOFF_POLL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(10);
+const DESKTOP_HANDOFF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 /// Spawn the already-built desktop app, detached. Returns Err if no built app
 /// exists or the spawn fails, so the caller can fall back to showing the
 /// installer UI.
@@ -380,7 +384,15 @@ pub(crate) fn spawn_installed_desktop(install_root: &std::path::Path) -> std::io
         // Windows doesn't reintroduce the relaunch race.
         cmd.creation_flags(0x0000_0008);
     }
-    cmd.spawn().map(|_child| ())
+    let mut child = cmd.spawn()?;
+    let start = std::time::Instant::now();
+    while start.elapsed() < DESKTOP_HANDOFF_TIMEOUT {
+        if child.try_wait()?.is_some() {
+            return Ok(());
+        }
+        std::thread::sleep(DESKTOP_HANDOFF_POLL_INTERVAL);
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -361,6 +361,10 @@ fn write_bootstrap_complete_marker(install_root: &Path, pin: &Pin) -> Result<ser
     Ok(marker)
 }
 
+const DESKTOP_HANDOFF_POLL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(10);
+const DESKTOP_HANDOFF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 /// Spawn the already-built desktop app, detached. Returns Err if no built app
 /// exists or the spawn fails, so the caller can fall back to showing the
 /// installer UI.
@@ -378,7 +382,15 @@ pub(crate) fn spawn_installed_desktop(install_root: &std::path::Path) -> std::io
         // Windows doesn't reintroduce the relaunch race.
         cmd.creation_flags(0x0000_0008);
     }
-    cmd.spawn().map(|_child| ())
+    let mut child = cmd.spawn()?;
+    let start = std::time::Instant::now();
+    while start.elapsed() < DESKTOP_HANDOFF_TIMEOUT {
+        if child.try_wait()?.is_some() {
+            return Ok(());
+        }
+        std::thread::sleep(DESKTOP_HANDOFF_POLL_INTERVAL);
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -361,14 +361,13 @@ fn write_bootstrap_complete_marker(install_root: &Path, pin: &Pin) -> Result<ser
     Ok(marker)
 }
 
-const DESKTOP_HANDOFF_POLL_INTERVAL: std::time::Duration =
-    std::time::Duration::from_millis(10);
-const DESKTOP_HANDOFF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-
 /// Spawn the already-built desktop app, detached. Returns Err if no built app
 /// exists or the spawn fails, so the caller can fall back to showing the
-/// installer UI.
-pub(crate) fn spawn_installed_desktop(install_root: &std::path::Path) -> std::io::Result<()> {
+/// installer UI. The caller owns the bounded hand-off poll and decides whether
+/// an observed child exit represents a successful launch.
+pub(crate) fn spawn_installed_desktop(
+    install_root: &std::path::Path,
+) -> std::io::Result<std::process::Child> {
     let exe = resolve_hermes_desktop_exe(install_root).ok_or_else(|| {
         std::io::Error::new(std::io::ErrorKind::NotFound, "no built Hermes desktop app")
     })?;
@@ -382,15 +381,7 @@ pub(crate) fn spawn_installed_desktop(install_root: &std::path::Path) -> std::io
         // Windows doesn't reintroduce the relaunch race.
         cmd.creation_flags(0x0000_0008);
     }
-    let mut child = cmd.spawn()?;
-    let start = std::time::Instant::now();
-    while start.elapsed() < DESKTOP_HANDOFF_TIMEOUT {
-        if child.try_wait()?.is_some() {
-            return Ok(());
-        }
-        std::thread::sleep(DESKTOP_HANDOFF_POLL_INTERVAL);
-    }
-    Ok(())
+    cmd.spawn()
 }
 
 #[cfg(target_os = "macos")]

--- a/apps/bootstrap-installer/src-tauri/src/lib.rs
+++ b/apps/bootstrap-installer/src-tauri/src/lib.rs
@@ -112,11 +112,50 @@ pub fn run() {
         let install_root = paths::hermes_home().join("hermes-agent");
         if bootstrap::hermes_is_installed(&install_root) {
             match bootstrap::spawn_installed_desktop(&install_root) {
-                Ok(()) => {
-                    tracing::info!(
-                        "hermes already installed — relaunched desktop; exiting installer"
-                    );
-                    return;
+                Ok(mut child) => {
+                    // Bounded hand-off grace: poll the spawned child instead of
+                    // sleeping a fixed duration. On macOS the child is normally
+                    // `/usr/bin/open`, so a successful early exit confirms
+                    // LaunchServices accepted the hand-off. A non-zero exit or
+                    // wait error is a failed hand-off and falls through to the
+                    // visible installer UI; a still-live child at the deadline
+                    // is also a successful in-progress hand-off.
+                    let deadline =
+                        std::time::Instant::now() + std::time::Duration::from_secs(15);
+                    let handoff_succeeded = loop {
+                        match child.try_wait() {
+                            Ok(Some(status)) if status.success() => break true,
+                            Ok(Some(status)) => {
+                                tracing::warn!(
+                                    ?status,
+                                    "installed desktop launcher exited unsuccessfully; showing installer UI"
+                                );
+                                break false;
+                            }
+                            Ok(None) if std::time::Instant::now() < deadline => {
+                                std::thread::sleep(std::time::Duration::from_millis(10));
+                            }
+                            Ok(None) => {
+                                tracing::info!(
+                                    "installed desktop launcher still running after hand-off grace"
+                                );
+                                break true;
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    ?err,
+                                    "could not observe installed desktop launcher; showing installer UI"
+                                );
+                                break false;
+                            }
+                        }
+                    };
+                    if handoff_succeeded {
+                        tracing::info!(
+                            "hermes already installed — relaunched desktop; exiting installer"
+                        );
+                        return;
+                    }
                 }
                 Err(err) => {
                     tracing::warn!(

--- a/apps/bootstrap-installer/src-tauri/src/lib.rs
+++ b/apps/bootstrap-installer/src-tauri/src/lib.rs
@@ -105,58 +105,54 @@ pub fn run() {
     let force_setup = force_setup_from_args(std::env::args().skip(1));
     tracing::info!(?mode, force_setup, "Hermes installer starting");
 
+    // macOS launcher fast path: hand off before constructing Tauri/AppKit.
+    // Entering the Tauri runtime, even with LSUIElement set, can briefly
+    // register this bootstrap process as a regular Dock application.
+    if cfg!(target_os = "macos") && mode == AppMode::Install && !force_setup {
+        let install_root = paths::hermes_home().join("hermes-agent");
+        if bootstrap::hermes_is_installed(&install_root) {
+            match bootstrap::spawn_installed_desktop(&install_root) {
+                Ok(()) => {
+                    // Brief grace so the spawned app is registered before the
+                    // launcher process exits (mirrors launch_hermes_desktop).
+                    std::thread::sleep(std::time::Duration::from_millis(200));
+                    tracing::info!(
+                        "hermes already installed — relaunched desktop; exiting installer"
+                    );
+                    return;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        "relaunch of installed desktop failed; showing installer UI"
+                    );
+                }
+            }
+        }
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
         .manage(Arc::new(AppState::new(mode)))
-        .setup(move |app| {
+        .setup(|app| {
             use tauri::Manager;
-            // Launcher fast path (macOS only): a bare ("Install") launch when
-            // Hermes is already installed should NOT show the installer or
-            // rebuild — it should just open the app, so the /Applications
-            // "Hermes" doubles as a normal launcher (first run installs, every
-            // later run launches instantly). The window is kept hidden until
-            // here via `"visible": false` so this path never flashes a window.
-            //
-            // Gated to macOS deliberately: on Windows/Linux the installer keeps
-            // its existing behavior (Windows users relaunch via the Start
-            // Menu/Desktop "Hermes" shortcuts that install.ps1 creates, and a
-            // reliable detached relaunch there needs the DETACHED_PROCESS +
-            // startup-grace handling used by launch_hermes_desktop — out of
-            // scope here). So this is a pure no-op on non-macOS.
-            //
-            // `--reinstall`/`--repair` opts out so a broken install can be
-            // repaired by re-running setup instead of launching the bad app.
-            if cfg!(target_os = "macos") && mode == AppMode::Install && !force_setup {
-                let install_root = paths::hermes_home().join("hermes-agent");
-                if bootstrap::hermes_is_installed(&install_root) {
-                    match bootstrap::spawn_installed_desktop(&install_root) {
-                        Ok(()) => {
-                            // Brief grace so the spawned app is registered
-                            // before we exit (mirrors launch_hermes_desktop).
-                            std::thread::sleep(std::time::Duration::from_millis(200));
-                            tracing::info!(
-                                "hermes already installed — relaunched desktop; exiting installer"
-                            );
-                            app.handle().exit(0);
-                            return Ok(());
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                ?err,
-                                "relaunch of installed desktop failed; showing installer UI"
-                            );
-                        }
-                    }
-                }
-            }
+            // A visible installer must behave like a normal foreground app so
+            // first-run, repair, and update windows remain discoverable in the
+            // Dock and Cmd-Tab. The successful launcher fast path returned
+            // before Tauri was constructed and can never reach this callback.
+            #[cfg(target_os = "macos")]
+            app.set_activation_policy(tauri::ActivationPolicy::Regular);
+
             // First run / repair install, or Update mode: reveal the UI.
             match app.get_webview_window("main") {
                 Some(win) => {
                     if let Err(err) = win.show() {
                         tracing::error!(?err, "failed to show main installer window");
+                    } else if let Err(err) = win.set_focus() {
+                        tracing::warn!(?err, "failed to focus main installer window");
                     }
                 }
                 None => {

--- a/apps/bootstrap-installer/src-tauri/src/lib.rs
+++ b/apps/bootstrap-installer/src-tauri/src/lib.rs
@@ -113,9 +113,6 @@ pub fn run() {
         if bootstrap::hermes_is_installed(&install_root) {
             match bootstrap::spawn_installed_desktop(&install_root) {
                 Ok(()) => {
-                    // Brief grace so the spawned app is registered before the
-                    // launcher process exits (mirrors launch_hermes_desktop).
-                    std::thread::sleep(std::time::Duration::from_millis(200));
                     tracing::info!(
                         "hermes already installed — relaunched desktop; exiting installer"
                     );

--- a/apps/bootstrap-installer/src-tauri/tauri.conf.json
+++ b/apps/bootstrap-installer/src-tauri/tauri.conf.json
@@ -58,7 +58,8 @@
     "macOS": {
       "minimumSystemVersion": "11.0",
       "hardenedRuntime": true,
-      "entitlements": "entitlements.plist"
+      "entitlements": "entitlements.plist",
+      "infoPlist": "Info.plist"
     }
   },
   "plugins": {

--- a/apps/bootstrap-installer/src-tauri/tauri.conf.json
+++ b/apps/bootstrap-installer/src-tauri/tauri.conf.json
@@ -57,7 +57,8 @@
     },
     "macOS": {
       "minimumSystemVersion": "11.0",
-      "hardenedRuntime": true
+      "hardenedRuntime": true,
+      "infoPlist": "Info.plist"
     }
   },
   "plugins": {

--- a/apps/desktop/scripts/package-build-config.test.mjs
+++ b/apps/desktop/scripts/package-build-config.test.mjs
@@ -1,0 +1,21 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const packageJsonPath = resolve(desktopRoot, 'package.json')
+
+async function readPackageJson() {
+  return JSON.parse(await readFile(packageJsonPath, 'utf8'))
+}
+
+describe('desktop package build metadata', () => {
+  it('keeps the real desktop app visible in the macOS Dock', async () => {
+    const packageJson = await readPackageJson()
+
+    expect(packageJson.build.appId).toBe('com.nousresearch.hermes')
+    expect(packageJson.build.mac.extendInfo).not.toHaveProperty('LSUIElement')
+  })
+})

--- a/apps/desktop/src/build-config.macos.test.ts
+++ b/apps/desktop/src/build-config.macos.test.ts
@@ -1,0 +1,11 @@
+import desktopPackage from '../package.json'
+import { describe, expect, it } from 'vitest'
+
+describe('macOS Desktop bundle metadata', () => {
+  it('keeps the real Desktop app visible in Dock and Cmd-Tab', () => {
+    const macExtendInfo = desktopPackage.build.mac.extendInfo
+
+    expect(desktopPackage.build.appId).toBe('com.nousresearch.hermes')
+    expect(macExtendInfo).not.toHaveProperty('LSUIElement')
+  })
+})

--- a/tests/test_bootstrap_installer_macos_bundle.py
+++ b/tests/test_bootstrap_installer_macos_bundle.py
@@ -13,7 +13,11 @@ TAURI_CONFIG = TAURI_DIR / "tauri.conf.json"
 
 
 def test_only_bootstrap_launcher_is_hidden_from_the_macos_dock() -> None:
-    """The setup hand-off launcher is a dockless macOS helper app."""
+    """The setup hand-off launcher is a dockless macOS helper app.
+
+    The complementary Desktop package metadata contract lives in the Vitest
+    suite because it reads a JavaScript-side ``package.json`` artifact.
+    """
     setup_config = json.loads(TAURI_CONFIG.read_text(encoding="utf-8"))
     info_plist = TAURI_DIR / setup_config["bundle"]["macOS"]["infoPlist"]
 

--- a/tests/test_bootstrap_installer_macos_bundle.py
+++ b/tests/test_bootstrap_installer_macos_bundle.py
@@ -1,0 +1,28 @@
+"""Regression coverage for the macOS bootstrap installer bundle."""
+
+from __future__ import annotations
+
+import json
+import plistlib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TAURI_DIR = REPO_ROOT / "apps" / "bootstrap-installer" / "src-tauri"
+TAURI_CONFIG = TAURI_DIR / "tauri.conf.json"
+DESKTOP_PACKAGE = REPO_ROOT / "apps" / "desktop" / "package.json"
+
+
+def test_only_bootstrap_launcher_is_hidden_from_the_macos_dock() -> None:
+    """The setup hand-off stays dockless while the real desktop owns the icon."""
+    setup_config = json.loads(TAURI_CONFIG.read_text(encoding="utf-8"))
+    desktop_package = json.loads(DESKTOP_PACKAGE.read_text(encoding="utf-8"))
+    info_plist = TAURI_DIR / setup_config["bundle"]["macOS"]["infoPlist"]
+
+    with info_plist.open("rb") as handle:
+        bundle_metadata = plistlib.load(handle)
+
+    assert setup_config["identifier"] == "com.nousresearch.hermes.setup"
+    assert desktop_package["build"]["appId"] == "com.nousresearch.hermes"
+    assert bundle_metadata["LSUIElement"] is True
+    assert "LSUIElement" not in desktop_package["build"]["mac"]["extendInfo"]

--- a/tests/test_bootstrap_installer_macos_bundle.py
+++ b/tests/test_bootstrap_installer_macos_bundle.py
@@ -10,19 +10,15 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TAURI_DIR = REPO_ROOT / "apps" / "bootstrap-installer" / "src-tauri"
 TAURI_CONFIG = TAURI_DIR / "tauri.conf.json"
-DESKTOP_PACKAGE = REPO_ROOT / "apps" / "desktop" / "package.json"
 
 
 def test_only_bootstrap_launcher_is_hidden_from_the_macos_dock() -> None:
-    """The setup hand-off stays dockless while the real desktop owns the icon."""
+    """The setup hand-off launcher is a dockless macOS helper app."""
     setup_config = json.loads(TAURI_CONFIG.read_text(encoding="utf-8"))
-    desktop_package = json.loads(DESKTOP_PACKAGE.read_text(encoding="utf-8"))
     info_plist = TAURI_DIR / setup_config["bundle"]["macOS"]["infoPlist"]
 
     with info_plist.open("rb") as handle:
         bundle_metadata = plistlib.load(handle)
 
     assert setup_config["identifier"] == "com.nousresearch.hermes.setup"
-    assert desktop_package["build"]["appId"] == "com.nousresearch.hermes"
     assert bundle_metadata["LSUIElement"] is True
-    assert "LSUIElement" not in desktop_package["build"]["mac"]["extendInfo"]


### PR DESCRIPTION
## Summary

- merge `LSUIElement = true` into the Tauri bootstrap launcher bundle so LaunchServices treats it as a UI agent
- perform the already-installed macOS launcher hand-off before constructing Tauri/AppKit, preventing the bootstrap process from ever becoming a regular Dock application
- restore `Regular` activation and focus only for real installer, repair, update, or relaunch-failure UI paths
- preserve the Electron desktop as `com.nousresearch.hermes` with its normal Dock presence
- cover the setup and desktop bundle identity/visibility contract

## Verification

- `cargo test` — 45 passed
- `npm run check` — TypeScript and ESLint passed
- `python -m pytest tests/test_bootstrap_installer_macos_bundle.py -q` — passed
- Ruff and `git diff --check` passed
- release `tauri build --bundles app` succeeded
- generated release bundle inspected: `CFBundleIdentifier = com.nousresearch.hermes.setup`, `LSUIElement = true`
- iterative manual macOS testing showed that plist-only and setup-callback policy changes were still too late; the final hand-off now returns before Tauri/AppKit is constructed

Fixes #73151