### PR TITLE
feat(matrix): add channel prompts and skill bindings (salvage #25995)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1582,7 +1582,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
-                if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
+                if plat in {Platform.DISCORD, Platform.SLACK, Platform.MATRIX} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -185,7 +185,7 @@ def _str_keyed(value: Any) -> Any:
 
 
 _TELEGRAM = frozenset({Platform.TELEGRAM})
-_DISCORD_SLACK = frozenset({Platform.DISCORD, Platform.SLACK})
+_DISCORD_SLACK = frozenset({Platform.DISCORD, Platform.SLACK, Platform.MATRIX})
 
 def _plain(*keys: str) -> tuple:
     """Keys copied verbatim into ``extra`` for every platform."""

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -131,6 +131,8 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
+    resolve_channel_prompt,
+    resolve_channel_skills,
     resolve_proxy_url,
     proxy_kwargs_for_aiohttp,
     _ssrf_redirect_guard,
@@ -3116,6 +3118,8 @@ class MatrixAdapter(BasePlatformAdapter):
             raw_message=source_content,
             message_id=event_id,
             reply_to_message_id=reply_to,
+            auto_skill=resolve_channel_skills(self.config.extra, room_id),
+            channel_prompt=resolve_channel_prompt(self.config.extra, room_id),
         )
 
         if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
@@ -3323,6 +3327,8 @@ class MatrixAdapter(BasePlatformAdapter):
             message_id=event_id,
             media_urls=media_urls,
             media_types=media_types,
+            auto_skill=resolve_channel_skills(self.config.extra, room_id),
+            channel_prompt=resolve_channel_prompt(self.config.extra, room_id),
         )
 
         await self.handle_message(msg_event)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -60,7 +60,7 @@ except ImportError:
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     gateway_trust_env, BasePlatformAdapter,
-    SendResult, resolve_proxy_url, proxy_kwargs_for_aiohttp, _ssrf_redirect_guard,
+    SendResult, resolve_channel_prompt, resolve_channel_skills, resolve_proxy_url, proxy_kwargs_for_aiohttp, _ssrf_redirect_guard,
 )
 from gateway.platforms.event import MessageEvent, MessageType, ProcessingOutcome
 from gateway.platforms.helpers import ThreadParticipationTracker
@@ -2089,7 +2089,10 @@ class MatrixAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to, reply_to_text=reply_to_text, reply_to_author_id=reply_to_author_id,
             reply_to_author_name=reply_to_author_name,
             # Top-level sender fields mirror source.* — downstream prompt code reads them.
-            user_id=sender, user_name=display_name, **extra)
+            user_id=sender, user_name=display_name,
+            auto_skill=resolve_channel_skills(self.config.extra, room_id),
+            channel_prompt=resolve_channel_prompt(self.config.extra, room_id),
+            **extra)
 
     async def _handle_text_message(
         self, room_id: str, sender: str, event_id: str, event_ts: float, source_content: dict,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -789,6 +789,7 @@ class TestLoadGatewayConfig:
         )
 
 
+
     def test_bridges_unauthorized_dm_behavior_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
@@ -889,6 +890,36 @@ class TestLoadGatewayConfig:
         assert config.multiplex_profiles is True
         assert config.platforms[Platform.DISCORD].token == "worker-token"
         assert Platform.API_SERVER not in config.platforms
+
+
+    def test_bridges_matrix_channel_configuration_from_config_yaml(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "matrix:\n"
+            "  channel_prompts:\n"
+            '    "!room:example.org": Research mode\n'
+            "  channel_skill_bindings:\n"
+            '    - id: "!room:example.org"\n'
+            "      skills: [research]\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.MATRIX].extra["channel_prompts"] == {
+            "!room:example.org": "Research mode",
+        }
+        assert config.platforms[Platform.MATRIX].extra["channel_skill_bindings"] == [
+            {"id": "!room:example.org", "skills": ["research"]},
+        ]
 
 
 class TestWebhookPortBridging:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -899,6 +899,7 @@ class TestLoadGatewayConfig:
         )
 
 
+
     def test_bridges_unauthorized_dm_behavior_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
@@ -999,6 +1000,36 @@ class TestLoadGatewayConfig:
         assert config.multiplex_profiles is True
         assert config.platforms[Platform.DISCORD].token == "worker-token"
         assert Platform.API_SERVER not in config.platforms
+
+
+    def test_bridges_matrix_channel_configuration_from_config_yaml(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "matrix:\n"
+            "  channel_prompts:\n"
+            '    "!room:example.org": Research mode\n'
+            "  channel_skill_bindings:\n"
+            '    - id: "!room:example.org"\n'
+            "      skills: [research]\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.MATRIX].extra["channel_prompts"] == {
+            "!room:example.org": "Research mode",
+        }
+        assert config.platforms[Platform.MATRIX].extra["channel_skill_bindings"] == [
+            {"id": "!room:example.org", "skills": ["research"]},
+        ]
 
 
 class TestWebhookPortBridging:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -579,6 +579,66 @@ class TestMatrixBangCommandAlias:
         assert captured_event.message_type == MessageType.COMMAND
 
 
+class TestMatrixRoomConfiguration:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.captured_event = None
+        self.adapter._text_batch_delay_seconds = 0
+        self.adapter._is_dm_room = AsyncMock(return_value=True)
+        self.adapter._get_display_name = AsyncMock(return_value="Alice")
+        self.adapter._background_read_receipt = MagicMock()
+
+        async def capture(msg_event):
+            self.captured_event = msg_event
+
+        self.adapter.handle_message = capture
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("msgtype", "expected_type"),
+        [
+            ("m.text", MessageType.TEXT),
+            ("m.image", MessageType.PHOTO),
+        ],
+    )
+    async def test_configured_room_options_are_attached_to_inbound_event(
+        self, msgtype, expected_type
+    ):
+        self.adapter.config.extra["channel_prompts"] = {
+            "!room:example.org": "Research mode",
+        }
+        self.adapter.config.extra["channel_skill_bindings"] = [
+            {"id": "!room:example.org", "skills": ["research"]},
+        ]
+        source_content = {"msgtype": msgtype, "body": "hello"}
+
+        if msgtype == "m.text":
+            await self.adapter._handle_text_message(
+                room_id="!room:example.org",
+                sender="@alice:example.org",
+                event_id="$channel-prompt-text",
+                event_ts=0.0,
+                source_content=source_content,
+                relates_to={},
+            )
+        else:
+            source_content.update(body="chart.png", url="", info={})
+            await self.adapter._handle_media_message(
+                room_id="!room:example.org",
+                sender="@alice:example.org",
+                event_id="$channel-prompt-image",
+                event_ts=0.0,
+                source_content=source_content,
+                relates_to={},
+                msgtype=msgtype,
+            )
+
+        assert self.captured_event is not None
+        assert self.captured_event.message_type == expected_type
+        assert self.captured_event.channel_prompt == "Research mode"
+        assert self.captured_event.auto_skill == ["research"]
+
+
 # ---------------------------------------------------------------------------
 # Thread detection
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -88,6 +88,8 @@ matrix:
     - "@alice:matrix.org"
   allowed_rooms:                  # Matrix rooms allowed to trigger agent turns
     - "!abc123:matrix.org"
+  channel_prompts: {}             # Optional prompts keyed by internal room ID
+  channel_skill_bindings: []      # Optional skills keyed by internal room ID
   free_response_rooms:            # Rooms exempt from mention requirement
     - "!abc123:matrix.org"
   ignore_user_patterns:           # Bridge/appservice ghost users to ignore
@@ -571,6 +573,50 @@ alias:
 Hermes only normalizes `!command` when the command is known to the gateway, a
 registered plugin command, or an installed skill command. Ordinary exclamations
 such as `!important` remain normal chat messages.
+
+## Per-Room Prompts
+
+Use `matrix.channel_prompts` to give individual Matrix rooms persistent
+instructions. Keys must be full internal room IDs—not room names, aliases,
+user IDs, or Matrix thread event IDs. Matrix threads use the entry for their
+containing room.
+
+```yaml
+matrix:
+  channel_prompts:
+    "!abc123:matrix.org": |
+      You are a research assistant. Focus on academic sources,
+      citations, and concise synthesis.
+    "!def456:matrix.org": |
+      Code review mode. Be precise about edge cases and
+      performance implications.
+```
+
+On every future turn in a matching room, Hermes injects the configured prompt
+ephemerally. Changes take effect without a new session or history rewrite.
+Unmatched rooms and blank or whitespace-only entries apply no prompt.
+
+## Per-Room Skill Bindings
+
+Use `matrix.channel_skill_bindings` to auto-load one or more installed skills
+when a new session starts in a specific room:
+
+```yaml
+matrix:
+  channel_skill_bindings:
+    - id: "!abc123:matrix.org"
+      skills:
+        - arxiv
+        - writing-plans
+    - id: "!def456:matrix.org"
+      skill: code-review
+```
+
+Binding IDs are full internal room IDs—not names, aliases, user IDs, or Matrix
+thread event IDs. Matrix threads use their containing room's binding. Skills
+load only at session start, so after changing a binding, run `/new` or wait for
+the session to reset. Unmatched rooms and empty bindings load no skill. You can
+combine a skill binding with `channel_prompts` for per-turn room instructions.
 
 ## Troubleshooting
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -89,6 +89,8 @@ matrix:
     - "@alice:matrix.org"
   allowed_rooms:                  # Matrix rooms allowed to trigger agent turns
     - "!abc123:matrix.org"
+  channel_prompts: {}             # Optional prompts keyed by internal room ID
+  channel_skill_bindings: []      # Optional skills keyed by internal room ID
   free_response_rooms:            # Rooms exempt from mention requirement
     - "!abc123:matrix.org"
   ignore_user_patterns:           # Bridge/appservice ghost users to ignore
@@ -572,6 +574,50 @@ alias:
 Hermes only normalizes `!command` when the command is known to the gateway, a
 registered plugin command, or an installed skill command. Ordinary exclamations
 such as `!important` remain normal chat messages.
+
+## Per-Room Prompts
+
+Use `matrix.channel_prompts` to give individual Matrix rooms persistent
+instructions. Keys must be full internal room IDs—not room names, aliases,
+user IDs, or Matrix thread event IDs. Matrix threads use the entry for their
+containing room.
+
+```yaml
+matrix:
+  channel_prompts:
+    "!abc123:matrix.org": |
+      You are a research assistant. Focus on academic sources,
+      citations, and concise synthesis.
+    "!def456:matrix.org": |
+      Code review mode. Be precise about edge cases and
+      performance implications.
+```
+
+On every future turn in a matching room, Hermes injects the configured prompt
+ephemerally. Changes take effect without a new session or history rewrite.
+Unmatched rooms and blank or whitespace-only entries apply no prompt.
+
+## Per-Room Skill Bindings
+
+Use `matrix.channel_skill_bindings` to auto-load one or more installed skills
+when a new session starts in a specific room:
+
+```yaml
+matrix:
+  channel_skill_bindings:
+    - id: "!abc123:matrix.org"
+      skills:
+        - arxiv
+        - writing-plans
+    - id: "!def456:matrix.org"
+      skill: code-review
+```
+
+Binding IDs are full internal room IDs—not names, aliases, user IDs, or Matrix
+thread event IDs. Matrix threads use their containing room's binding. Skills
+load only at session start, so after changing a binding, run `/new` or wait for
+the session to reset. Unmatched rooms and empty bindings load no skill. You can
+combine a skill binding with `channel_prompts` for per-turn room instructions.
 
 ## Troubleshooting
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
@@ -61,6 +61,8 @@ matrix:
   require_mention: true           # 在房间中要求 @提及（默认：true）
   free_response_rooms:            # 免除提及要求的房间
     - "!abc123:matrix.org"
+  channel_prompts: {}             # 按内部房间 ID 配置的可选 Prompt
+  channel_skill_bindings: []      # 按内部房间 ID 配置的可选技能
   auto_thread: true               # 自动为响应创建线程（默认：true）
   dm_mention_threads: false       # 在 DM 中被 @提及时创建线程（默认：false）
 ```
@@ -375,6 +377,48 @@ MATRIX_ALLOWED_ROOMS="!abc123def456:matrix.example.org,!opsroom789:matrix.exampl
 :::tip
 查找房间 ID：在 Element 中，进入房间 → **设置** → **高级** → **内部房间 ID**（以 `!` 开头）。
 :::
+
+## 按房间设置 Prompt
+
+使用 `matrix.channel_prompts` 可为各个 Matrix 房间设置持续生效的指令。键必须是
+完整的内部房间 ID，而不是房间名称、别名、用户 ID 或 Matrix 线程事件 ID。
+Matrix 线程使用其所属房间的配置项。
+
+```yaml
+matrix:
+  channel_prompts:
+    "!abc123:matrix.org": |
+      You are a research assistant. Focus on academic sources,
+      citations, and concise synthesis.
+    "!def456:matrix.org": |
+      Code review mode. Be precise about edge cases and
+      performance implications.
+```
+
+在匹配房间后续的每一轮交互中，Hermes 都会临时注入对应 Prompt。更改配置无需
+新建会话，也不会重写历史记录；未匹配的房间以及空白或仅含空格的配置项不会应用
+任何 Prompt。
+
+## 按房间绑定技能
+
+使用 `matrix.channel_skill_bindings` 可在特定房间的新会话开始时自动加载一个或
+多个已安装的技能：
+
+```yaml
+matrix:
+  channel_skill_bindings:
+    - id: "!abc123:matrix.org"
+      skills:
+        - arxiv
+        - writing-plans
+    - id: "!def456:matrix.org"
+      skill: code-review
+```
+
+绑定 ID 必须是完整的内部房间 ID，而不是房间名称、别名、用户 ID 或 Matrix
+线程事件 ID。Matrix 线程使用其所属房间的绑定。技能仅在会话开始时加载；更改
+绑定后，请运行 `/new` 或等待会话自动重置。未匹配的房间和空绑定不会加载技能。
+你可以将技能绑定与 `channel_prompts` 结合使用，为房间添加每轮生效的指令。
 
 ## 故障排查
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
@@ -62,6 +62,8 @@ matrix:
   require_mention: true           # 在房间中要求 @提及（默认：true）
   free_response_rooms:            # 免除提及要求的房间
     - "!abc123:matrix.org"
+  channel_prompts: {}             # 按内部房间 ID 配置的可选 Prompt
+  channel_skill_bindings: []      # 按内部房间 ID 配置的可选技能
   auto_thread: true               # 自动为响应创建线程（默认：true）
   dm_mention_threads: false       # 在 DM 中被 @提及时创建线程（默认：false）
 ```
@@ -376,6 +378,48 @@ MATRIX_ALLOWED_ROOMS="!abc123def456:matrix.example.org,!opsroom789:matrix.exampl
 :::tip
 查找房间 ID：在 Element 中，进入房间 → **设置** → **高级** → **内部房间 ID**（以 `!` 开头）。
 :::
+
+## 按房间设置 Prompt
+
+使用 `matrix.channel_prompts` 可为各个 Matrix 房间设置持续生效的指令。键必须是
+完整的内部房间 ID，而不是房间名称、别名、用户 ID 或 Matrix 线程事件 ID。
+Matrix 线程使用其所属房间的配置项。
+
+```yaml
+matrix:
+  channel_prompts:
+    "!abc123:matrix.org": |
+      You are a research assistant. Focus on academic sources,
+      citations, and concise synthesis.
+    "!def456:matrix.org": |
+      Code review mode. Be precise about edge cases and
+      performance implications.
+```
+
+在匹配房间后续的每一轮交互中，Hermes 都会临时注入对应 Prompt。更改配置无需
+新建会话，也不会重写历史记录；未匹配的房间以及空白或仅含空格的配置项不会应用
+任何 Prompt。
+
+## 按房间绑定技能
+
+使用 `matrix.channel_skill_bindings` 可在特定房间的新会话开始时自动加载一个或
+多个已安装的技能：
+
+```yaml
+matrix:
+  channel_skill_bindings:
+    - id: "!abc123:matrix.org"
+      skills:
+        - arxiv
+        - writing-plans
+    - id: "!def456:matrix.org"
+      skill: code-review
+```
+
+绑定 ID 必须是完整的内部房间 ID，而不是房间名称、别名、用户 ID 或 Matrix
+线程事件 ID。Matrix 线程使用其所属房间的绑定。技能仅在会话开始时加载；更改
+绑定后，请运行 `/new` 或等待会话自动重置。未匹配的房间和空绑定不会加载技能。
+你可以将技能绑定与 `channel_prompts` 结合使用，为房间添加每轮生效的指令。
 
 ## 故障排查
 


### PR DESCRIPTION
## What does this PR do?

Salvages the safe, current-main-compatible portion of #25995 by @stig-codes. The rebased feature commit retains `stig-codes <stig-codes@users.noreply.github.com>` as its Git author.

Matrix already receives generic `channel_prompts` configuration, but its current plugin adapter does not attach the resolved prompt to inbound events. Matrix is also excluded from the shared `channel_skill_bindings` config bridge. This PR ports those two intended capabilities to the current adapter without changing session scope, prompt persistence, or skill lifecycle behavior.

The original `topic_as_prompt` proposal is intentionally excluded. Matrix room topics remain untrusted room metadata and are not promoted into ephemeral system instructions, addressing the security review on #25995.

## Related PR

Explicit salvage of #25995. This supersedes only the safe channel-prompt and channel-skill-binding portion; authorship is preserved in the commit.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Tests

## Changes Made

- `gateway/config.py`: allow Matrix through the existing generic `channel_skill_bindings` bridge.
- `plugins/platforms/matrix/adapter.py`: resolve room prompts and skills for both text/command and media `MessageEvent` paths.
- `tests/gateway/test_config.py`: cover Matrix prompt and skill-binding YAML propagation.
- `tests/gateway/test_matrix.py`: cover text and media event propagation.
- English and Simplified Chinese Matrix guides: document full-room-ID semantics, thread behavior, prompt ephemerality, and session-start skill loading.
- Remove `topic_as_prompt` from the salvaged scope.

## How to Test

```bash
scripts/run_tests.sh \
  tests/gateway/test_matrix.py \
  tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_matrix_channel_configuration_from_config_yaml \
  tests/gateway/test_discord_channel_prompts.py::TestResolveChannelPrompts \
  tests/gateway/test_slack_channel_skills.py::TestSlackResolveChannelSkills \
  -q
```

Observed: 19 selected tests passed, including the complete 252-test Matrix file; no failures.

A config-to-event smoke using a temporary `HERMES_HOME` also confirmed that a room's YAML prompt and skill binding reach the real Matrix adapter as `event.channel_prompt` and `event.auto_skill` without modifying message text.

The full hermetic repository suite was also run. It reported 33 failures in 12 unrelated files plus 10 unrelated collection/import errors (including missing optional `acp` and `pathspec` dependencies, ACP, desktop/web UI, WeCom, PTY, and SQLite-build-specific tests). No Matrix or changed config test failed. Those unrelated failures are intentionally outside this PR's scope.

## Checklist

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`
- [x] Searched existing issues and PRs; this is an attributed salvage of #25995
- [x] Kept the PR limited to the Matrix room-configuration feature
- [x] Added behavior-focused tests
- [x] Updated maintained English and Simplified Chinese documentation
- [x] Exercised the real config-to-event path on Linux
- [x] Preserved the original contributor's Git authorship
