### PR TITLE
fix(cli): let a typed answer win over the highlighted clarify choice (supersedes #5296)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12278,6 +12278,134 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             "Use your best judgement to make the choice and proceed."
         )
 
+    def _handle_clarify_enter(self, event) -> bool:
+        """Resolve Enter while the clarify choice list is on screen.
+
+        Returns ``True`` when the keypress was consumed so the caller stops
+        routing it, ``False`` when no clarify choice prompt is active (freetext
+        mode is handled by its own branch before this one).
+
+        The input buffer stays editable while the choice list is displayed, so a
+        user can type a custom answer without first selecting "Other". Reading
+        that buffer *before* falling back to the highlighted choice is what stops
+        the answer from being silently discarded.
+        """
+        if not self._clarify_state or self._clarify_freetext:
+            return False
+
+        state = self._clarify_state
+        selected = state["selected"]
+        choices = state.get("choices") or []
+
+        # A typed answer always wins over the highlighted/checked choices.
+        typed = event.app.current_buffer.text.strip()
+        if typed:
+            if state.get("multi_select"):
+                # Match the shape the "Other"-plus-choices freetext path
+                # produces: checked real choices first, then the typed answer.
+                indices = sorted(state.get("selected_indices") or ())
+                base = [choices[i] for i in indices if i < len(choices)]
+                if base:
+                    typed = ", ".join(base) + ", " + typed
+            state["response_queue"].put(typed)
+            self._clarify_state = None
+            self._clarify_freetext = False
+            self._clarify_multi_base = None
+            event.app.current_buffer.reset()
+            event.app.invalidate()
+            return True
+
+        # multi-select support: submit comma-joined list of checked choices
+        if state.get("multi_select"):
+            indices = state.get("selected_indices")
+            if not indices:
+                # Nothing checked → submit empty string (parses to [])
+                state["response_queue"].put("")
+                self._clarify_state = None
+                event.app.invalidate()
+                return True
+            sorted_idx = sorted(indices)
+            selected_choices = [choices[i] for i in sorted_idx if i < len(choices)]
+            other_checked = len(choices) in sorted_idx
+            if other_checked and selected_choices:
+                # "Other" + real choices: store base choices, switch to freetext
+                # so the user can type a custom answer that gets appended
+                self._clarify_multi_base = selected_choices
+                self._clarify_freetext = True
+                event.app.invalidate()
+                return True
+            if selected_choices:
+                state["response_queue"].put(", ".join(selected_choices))
+                self._clarify_state = None
+                event.app.invalidate()
+                return True
+            # Only "Other" was checked → switch to freetext
+            self._clarify_freetext = True
+            event.app.invalidate()
+            return True
+
+        # Original single-select behavior: submit the highlighted choice
+        if selected < len(choices):
+            state["response_queue"].put(choices[selected])
+            self._clarify_state = None
+            event.app.invalidate()
+        else:
+            # "Other" selected → switch to freetext
+            self._clarify_freetext = True
+            event.app.invalidate()
+        return True
+
+    def _make_clarify_number_handler(self, idx, char):
+        """Build the key handler for one clarify quick-select digit.
+
+        ``idx`` is the choice index the digit maps to; ``char`` is the literal
+        key that was pressed. ``char`` cannot be derived from ``idx`` because
+        "0" maps to index 9, so the caller passes both.
+
+        A digit is only a shortcut while the draft is empty. Once the user has
+        started typing an answer, the digit belongs to that answer — insert it
+        rather than resolving the prompt out from under them.
+        """
+
+        def handler(event):
+            if self._clarify_state and not self._clarify_freetext:
+                if event.app.current_buffer.text:
+                    event.app.current_buffer.insert_text(char)
+                    return
+                choices = self._clarify_state.get("choices") or []
+                # multi-select support: number keys toggle checkboxes instead of submitting
+                if self._clarify_state.get("multi_select"):
+                    if idx < len(choices):
+                        indices = self._clarify_state.get("selected_indices", set())
+                        if idx in indices:
+                            indices.discard(idx)
+                        else:
+                            indices.add(idx)
+                        event.app.invalidate()
+                    elif idx == len(choices):
+                        # Toggle "Other" in multi-select mode
+                        indices = self._clarify_state.get("selected_indices", set())
+                        if idx in indices:
+                            indices.discard(idx)
+                        else:
+                            indices.add(idx)
+                        event.app.invalidate()
+                    return
+                # Original single-select: number keys submit directly
+                # Map index to choice (treating "Other" as the last option)
+                if idx < len(choices):
+                    # Select a numbered choice
+                    self._clarify_state["response_queue"].put(choices[idx])
+                    self._clarify_state = None
+                    self._clarify_freetext = False
+                    event.app.invalidate()
+                elif idx == len(choices):
+                    # Select "Other" option
+                    self._clarify_freetext = True
+                    event.app.invalidate()
+
+        return handler
+
     def _sudo_password_callback(self) -> str:
         """
         Prompt for sudo password through the prompt_toolkit UI.
@@ -14264,48 +14392,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     event.app.invalidate()
                 return
 
-            # --- Clarify choice mode: confirm the highlighted selection ---
-            if self._clarify_state and not self._clarify_freetext:
-                state = self._clarify_state
-                selected = state["selected"]
-                choices = state.get("choices") or []
-                # multi-select support: submit comma-joined list of checked choices
-                if state.get("multi_select"):
-                    indices = state.get("selected_indices")
-                    if not indices:
-                        # Nothing checked → submit empty string (parses to [])
-                        state["response_queue"].put("")
-                        self._clarify_state = None
-                        event.app.invalidate()
-                        return
-                    sorted_idx = sorted(indices)
-                    selected_choices = [choices[i] for i in sorted_idx if i < len(choices)]
-                    other_checked = len(choices) in sorted_idx
-                    if other_checked and selected_choices:
-                        # "Other" + real choices: store base choices, switch to freetext
-                        # so the user can type a custom answer that gets appended
-                        self._clarify_multi_base = selected_choices
-                        self._clarify_freetext = True
-                        event.app.invalidate()
-                        return
-                    if selected_choices:
-                        state["response_queue"].put(", ".join(selected_choices))
-                        self._clarify_state = None
-                        event.app.invalidate()
-                        return
-                    # Only "Other" was checked → switch to freetext
-                    self._clarify_freetext = True
-                    event.app.invalidate()
-                    return
-                # Original single-select behavior: submit the highlighted choice
-                if selected < len(choices):
-                    state["response_queue"].put(choices[selected])
-                    self._clarify_state = None
-                    event.app.invalidate()
-                else:
-                    # "Other" selected → switch to freetext
-                    self._clarify_freetext = True
-                    event.app.invalidate()
+            # --- Clarify choice mode: typed answer, else highlighted selection ---
+            if self._handle_clarify_enter(event):
                 return
 
             # --- Normal input routing ---
@@ -14545,46 +14633,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 event.app.invalidate()
 
         # Number keys for quick clarify selection (1-9, 0 for 10th item)
-        def _make_clarify_number_handler(idx):
-            def handler(event):
-                if self._clarify_state and not self._clarify_freetext:
-                    choices = self._clarify_state.get("choices") or []
-                    # multi-select support: number keys toggle checkboxes instead of submitting
-                    if self._clarify_state.get("multi_select"):
-                        if idx < len(choices):
-                            indices = self._clarify_state.get("selected_indices", set())
-                            if idx in indices:
-                                indices.discard(idx)
-                            else:
-                                indices.add(idx)
-                            event.app.invalidate()
-                        elif idx == len(choices):
-                            # Toggle "Other" in multi-select mode
-                            indices = self._clarify_state.get("selected_indices", set())
-                            if idx in indices:
-                                indices.discard(idx)
-                            else:
-                                indices.add(idx)
-                            event.app.invalidate()
-                        return
-                    # Original single-select: number keys submit directly
-                    # Map index to choice (treating "Other" as the last option)
-                    if idx < len(choices):
-                        # Select a numbered choice
-                        self._clarify_state["response_queue"].put(choices[idx])
-                        self._clarify_state = None
-                        self._clarify_freetext = False
-                        event.app.invalidate()
-                    elif idx == len(choices):
-                        # Select "Other" option
-                        self._clarify_freetext = True
-                        event.app.invalidate()
-            return handler
-
         for _num in range(10):
             # 1-9 select items 0-8, 0 selects item 9 (10thitem)
             _idx = 9 if _num == 0 else _num - 1
-            kb.add(str(_num), filter=Condition(lambda: bool(self._clarify_state) and not self._clarify_freetext))(_make_clarify_number_handler(_idx))
+            kb.add(str(_num), filter=Condition(lambda: bool(self._clarify_state) and not self._clarify_freetext))(self._make_clarify_number_handler(_idx, str(_num)))
 
         # --- Dangerous command approval: arrow-key navigation ---
 

--- a/cli.py
+++ b/cli.py
@@ -15809,6 +15809,153 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — locked answers returned){_RST}")
         return {"answers": partial, "timed_out": True}
 
+    def _handle_clarify_enter(self, event) -> bool:
+        """Resolve Enter while a clarify choice list is on screen.
+
+        A typed draft is an explicit answer and must outrank the highlighted
+        choice. Returns False only when no choice-mode clarify prompt is active;
+        freetext is handled by the earlier Enter branch.
+        """
+        if not self._clarify_state or self._clarify_freetext:
+            return False
+
+        state = self._clarify_state
+        choices = state.get("choices") or []
+        typed = event.app.current_buffer.text.strip()
+        if typed:
+            if state.get("questions"):
+                if state.get("multi_select"):
+                    indices = sorted(state.get("selected_indices") or ())
+                    selected_choices = [
+                        choices[index] for index in indices if index < len(choices)
+                    ]
+                    answer = json.dumps(
+                        selected_choices + [typed], ensure_ascii=False
+                    )
+                    meta = {
+                        "kind": "multi",
+                        "choices": selected_choices,
+                        "other_text": typed,
+                    }
+                else:
+                    answer = typed
+                    meta = {"kind": "other", "other_text": typed}
+                self._clarify_batch_lock(state, answer, meta=meta)
+            else:
+                if state.get("multi_select"):
+                    indices = sorted(state.get("selected_indices") or ())
+                    selected_choices = [
+                        choices[index] for index in indices if index < len(choices)
+                    ]
+                    if selected_choices:
+                        typed = ", ".join(selected_choices) + ", " + typed
+                state["response_queue"].put(typed)
+                self._clarify_state = None
+                self._clarify_freetext = False
+                self._clarify_multi_base = None
+            event.app.current_buffer.reset()
+            event.app.invalidate()
+            return True
+
+        if state.get("questions"):
+            self._clarify_batch_enter(state)
+            # Editing an earlier "Other" answer: prefill the composer with the
+            # previously typed text.
+            if self._clarify_freetext and self._clarify_prefill:
+                event.app.current_buffer.text = self._clarify_prefill
+                event.app.current_buffer.cursor_position = len(
+                    self._clarify_prefill
+                )
+                self._clarify_prefill = ""
+            event.app.invalidate()
+            return True
+
+        selected = state["selected"]
+        if state.get("multi_select"):
+            indices = state.get("selected_indices")
+            if not indices:
+                # Nothing checked -> submit empty string (parses to []).
+                state["response_queue"].put("")
+                self._clarify_state = None
+                event.app.invalidate()
+                return True
+            sorted_idx = sorted(indices)
+            selected_choices = [choices[i] for i in sorted_idx if i < len(choices)]
+            other_checked = len(choices) in sorted_idx
+            if other_checked and selected_choices:
+                # "Other" + real choices: store base choices, switch to freetext
+                # so the user can type a custom answer that gets appended.
+                self._clarify_multi_base = selected_choices
+                self._clarify_freetext = True
+                event.app.invalidate()
+                return True
+            if selected_choices:
+                state["response_queue"].put(", ".join(selected_choices))
+                self._clarify_state = None
+                event.app.invalidate()
+                return True
+            # Only "Other" was checked -> switch to freetext.
+            self._clarify_freetext = True
+            event.app.invalidate()
+            return True
+
+        if selected < len(choices):
+            state["response_queue"].put(choices[selected])
+            self._clarify_state = None
+            event.app.invalidate()
+        else:
+            # "Other" selected -> switch to freetext.
+            self._clarify_freetext = True
+            event.app.invalidate()
+        return True
+
+    def _make_clarify_number_handler(self, idx, char):
+        """Build the key handler for one clarify quick-select digit."""
+
+        def handler(event):
+            state = self._clarify_state
+            if not state or self._clarify_freetext:
+                return
+            if event.app.current_buffer.text:
+                event.app.current_buffer.insert_text(char)
+                return
+
+            choices = state.get("choices") or []
+            # Multi-select number keys toggle checkboxes instead of submitting.
+            if state.get("multi_select"):
+                if idx < len(choices):
+                    indices = state.get("selected_indices", set())
+                    if idx in indices:
+                        indices.discard(idx)
+                    else:
+                        indices.add(idx)
+                    event.app.invalidate()
+                elif idx == len(choices):
+                    # Toggle "Other" in multi-select mode.
+                    indices = state.get("selected_indices", set())
+                    if idx in indices:
+                        indices.discard(idx)
+                    else:
+                        indices.add(idx)
+                    event.app.invalidate()
+                return
+
+            # Map an empty-draft digit to its numbered choice (or Other).
+            if idx < len(choices):
+                if state.get("questions"):
+                    self._clarify_batch_lock(state, choices[idx])
+                    event.app.invalidate()
+                    return
+                state["response_queue"].put(choices[idx])
+                self._clarify_state = None
+                self._clarify_freetext = False
+                event.app.invalidate()
+            elif idx == len(choices):
+                self._clarify_freetext = True
+                event.app.invalidate()
+
+        return handler
+
     def _sudo_password_callback(self) -> str:
         """
         Prompt for sudo password through the prompt_toolkit UI.
@@ -17949,60 +18096,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     event.app.invalidate()
                 return
 
-            # --- Clarify choice mode: confirm the highlighted selection ---
-            if self._clarify_state and not self._clarify_freetext:
-                state = self._clarify_state
-                # Batch mode: Enter locks the active question's answer and
-                # advances to the next unanswered question.
-                if state.get("questions"):
-                    self._clarify_batch_enter(state)
-                    # Editing an earlier "Other" answer: prefill the composer
-                    # with the previously typed text.
-                    if self._clarify_freetext and self._clarify_prefill:
-                        event.app.current_buffer.text = self._clarify_prefill
-                        event.app.current_buffer.cursor_position = len(self._clarify_prefill)
-                        self._clarify_prefill = ""
-                    event.app.invalidate()
-                    return
-                selected = state["selected"]
-                choices = state.get("choices") or []
-                # multi-select support: submit comma-joined list of checked choices
-                if state.get("multi_select"):
-                    indices = state.get("selected_indices")
-                    if not indices:
-                        # Nothing checked → submit empty string (parses to [])
-                        state["response_queue"].put("")
-                        self._clarify_state = None
-                        event.app.invalidate()
-                        return
-                    sorted_idx = sorted(indices)
-                    selected_choices = [choices[i] for i in sorted_idx if i < len(choices)]
-                    other_checked = len(choices) in sorted_idx
-                    if other_checked and selected_choices:
-                        # "Other" + real choices: store base choices, switch to freetext
-                        # so the user can type a custom answer that gets appended
-                        self._clarify_multi_base = selected_choices
-                        self._clarify_freetext = True
-                        event.app.invalidate()
-                        return
-                    if selected_choices:
-                        state["response_queue"].put(", ".join(selected_choices))
-                        self._clarify_state = None
-                        event.app.invalidate()
-                        return
-                    # Only "Other" was checked → switch to freetext
-                    self._clarify_freetext = True
-                    event.app.invalidate()
-                    return
-                # Original single-select behavior: submit the highlighted choice
-                if selected < len(choices):
-                    state["response_queue"].put(choices[selected])
-                    self._clarify_state = None
-                    event.app.invalidate()
-                else:
-                    # "Other" selected → switch to freetext
-                    self._clarify_freetext = True
-                    event.app.invalidate()
+            # --- Clarify choice mode: typed answer, else highlighted selection ---
+            if self._handle_clarify_enter(event):
                 return
 
             # --- Normal input routing ---
@@ -18402,52 +18497,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 event.app.invalidate()
 
         # Number keys for quick clarify selection (1-9, 0 for 10th item)
-        def _make_clarify_number_handler(idx):
-            def handler(event):
-                if self._clarify_state and not self._clarify_freetext:
-                    choices = self._clarify_state.get("choices") or []
-                    # multi-select support: number keys toggle checkboxes instead of submitting
-                    if self._clarify_state.get("multi_select"):
-                        if idx < len(choices):
-                            indices = self._clarify_state.get("selected_indices", set())
-                            if idx in indices:
-                                indices.discard(idx)
-                            else:
-                                indices.add(idx)
-                            event.app.invalidate()
-                        elif idx == len(choices):
-                            # Toggle "Other" in multi-select mode
-                            indices = self._clarify_state.get("selected_indices", set())
-                            if idx in indices:
-                                indices.discard(idx)
-                            else:
-                                indices.add(idx)
-                            event.app.invalidate()
-                        return
-                    # Original single-select: number keys submit directly
-                    # Map index to choice (treating "Other" as the last option)
-                    if idx < len(choices):
-                        # Batch mode: lock the numbered choice for the active
-                        # question instead of resolving the whole prompt.
-                        if self._clarify_state.get("questions"):
-                            self._clarify_batch_lock(self._clarify_state, choices[idx])
-                            event.app.invalidate()
-                            return
-                        # Select a numbered choice
-                        self._clarify_state["response_queue"].put(choices[idx])
-                        self._clarify_state = None
-                        self._clarify_freetext = False
-                        event.app.invalidate()
-                    elif idx == len(choices):
-                        # Select "Other" option
-                        self._clarify_freetext = True
-                        event.app.invalidate()
-            return handler
-
         for _num in range(10):
             # 1-9 select items 0-8, 0 selects item 9 (10thitem)
             _idx = 9 if _num == 0 else _num - 1
-            kb.add(str(_num), filter=Condition(lambda: bool(self._clarify_state) and not self._clarify_freetext))(_make_clarify_number_handler(_idx))
+            kb.add(str(_num), filter=Condition(lambda: bool(self._clarify_state) and not self._clarify_freetext))(self._make_clarify_number_handler(_idx, str(_num)))
 
         # --- Dangerous command approval: arrow-key navigation ---
 

--- a/cli.py
+++ b/cli.py
@@ -15916,7 +15916,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             state = self._clarify_state
             if not state or self._clarify_freetext:
                 return
-            if event.app.current_buffer.text:
+            if event.app.current_buffer.text.strip():
                 event.app.current_buffer.insert_text(char)
                 return
 

--- a/tests/cli/test_cli_clarify_batch.py
+++ b/tests/cli/test_cli_clarify_batch.py
@@ -3,14 +3,15 @@
 Drives ``_clarify_callback`` with a ``questions`` list on a background
 thread (the way the agent thread calls it) and simulates the keybinding
 handlers by calling the same helper methods they call
-(``_clarify_batch_set_active`` for Tab, ``_clarify_batch_enter`` for
-Enter, ``_clarify_batch_lock`` for the freetext submit path). No real
+(``_clarify_batch_set_active`` for Tab, ``_handle_clarify_enter`` for
+Enter, and ``_clarify_batch_lock`` for the freetext submit path). No real
 terminal needed — mirrors tests/cli/test_cli_approval_ui.py.
 """
 
 import json
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from cli import HermesCLI
@@ -38,6 +39,30 @@ def _q(index, question, choices=None, multi_select=False):
         "choices_offered": list(choices) if choices else None,
         "multi_select": bool(multi_select) and bool(choices),
     }
+
+
+class _FakeBuffer:
+    def __init__(self, text=""):
+        self.text = text
+        self.cursor_position = len(text)
+
+    def reset(self, append_to_history=False):
+        self.text = ""
+        self.cursor_position = 0
+
+    def insert_text(self, data):
+        position = self.cursor_position
+        self.text = self.text[:position] + data + self.text[position:]
+        self.cursor_position = position + len(data)
+
+
+def _make_event(text=""):
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            current_buffer=_FakeBuffer(text),
+            invalidate=MagicMock(),
+        )
+    )
 
 
 def _start_batch(cli, questions):
@@ -238,6 +263,75 @@ class TestClarifyBatchPanel:
         assert result["value"] == "a"
 
 
+class TestClarifyBatchTypedDraft:
+    def test_typed_answer_wins_over_highlighted_batch_choice(self):
+        cli = _make_cli_stub()
+        questions = [
+            _q(0, "Color?", ["red", "blue"]),
+            _q(1, "Size?", ["small", "large"]),
+        ]
+        thread, result = _start_batch(cli, questions)
+        state = cli._clarify_state
+        state["selected"] = 1
+        event = _make_event("chartreuse")
+
+        assert cli._handle_clarify_enter(event) is True
+
+        assert event.app.current_buffer.text == ""
+        assert state["answers"] == {"q0": "chartreuse"}
+        assert state["answer_meta"]["q0"] == {
+            "kind": "other",
+            "other_text": "chartreuse",
+        }
+        assert state["active"] == 1
+
+        assert cli._handle_clarify_enter(_make_event()) is True
+        thread.join(timeout=2)
+        assert result["value"] == {
+            "answers": {"q0": "chartreuse", "q1": "small"}
+        }
+
+    def test_typed_multi_select_answer_keeps_checked_choices_and_metadata(self):
+        cli = _make_cli_stub()
+        questions = [
+            _q(0, "Toppings?", ["ham", "olives", "basil"], multi_select=True),
+        ]
+        thread, result = _start_batch(cli, questions)
+        state = cli._clarify_state
+        state["selected_indices"].update({0, 3})
+
+        assert cli._handle_clarify_enter(_make_event("capers")) is True
+
+        thread.join(timeout=2)
+        assert json.loads(result["value"]["answers"]["q0"]) == ["ham", "capers"]
+        assert state["answer_meta"]["q0"] == {
+            "kind": "multi",
+            "choices": ["ham"],
+            "other_text": "capers",
+        }
+
+    def test_digit_in_a_batch_multi_select_draft_does_not_toggle_or_lock(self):
+        cli = _make_cli_stub()
+        questions = [
+            _q(0, "Targets?", ["staging", "prod"], multi_select=True),
+            _q(1, "Confirm?", ["yes", "no"]),
+        ]
+        thread, _ = _start_batch(cli, questions)
+        state = cli._clarify_state
+        state["selected_indices"].add(0)
+        event = _make_event("deploy v")
+
+        cli._make_clarify_number_handler(1, "2")(event)
+
+        assert event.app.current_buffer.text == "deploy v2"
+        assert state["selected_indices"] == {0}
+        assert state["answers"] == {}
+        assert cli._clarify_state is state
+
+        state["response_queue"].put("cancel")
+        thread.join(timeout=2)
+
+
 class TestClarifyBatchNavigation:
     """Shift-Tab, answer restore on re-visit, and Other edit-prefill."""
 
@@ -340,4 +434,3 @@ class TestClarifyBatchNavigation:
         cli._clarify_batch_enter(state)
         thread.join(timeout=2)
         assert result["value"] == {"answers": {"q0": "red", "q1": "small"}}
-

--- a/tests/cli/test_cli_clarify_typed_answer.py
+++ b/tests/cli/test_cli_clarify_typed_answer.py
@@ -1,0 +1,255 @@
+"""Clarify choice mode must not destroy an answer the user typed.
+
+While the clarify choice list is on screen the input buffer stays editable, so
+a user can type a custom answer without first selecting "Other". Two paths used
+to throw that answer away:
+
+* Enter submitted the *highlighted* choice and never looked at the buffer.
+* Every digit key was bound to immediate numbered selection, so typing an
+  answer containing a digit resolved the prompt mid-word.
+
+These tests drive ``HermesCLI._handle_clarify_enter`` and the handler object
+returned by ``HermesCLI._make_clarify_number_handler`` — the exact callables the
+``run()`` key bindings execute — rather than re-implementing the conditionals.
+"""
+
+import queue
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from cli import HermesCLI
+
+
+class _FakeBuffer:
+    def __init__(self, text=""):
+        self.text = text
+        self.cursor_position = len(text)
+
+    def reset(self, append_to_history=False):
+        self.text = ""
+        self.cursor_position = 0
+
+    def insert_text(self, data):
+        pos = self.cursor_position
+        self.text = self.text[:pos] + data + self.text[pos:]
+        self.cursor_position = pos + len(data)
+
+
+def _make_event(buffer):
+    return SimpleNamespace(
+        app=SimpleNamespace(invalidate=MagicMock(), current_buffer=buffer)
+    )
+
+
+def _make_cli_stub(choices, *, selected=0, multi_select=False, checked=None):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._clarify_state = {
+        "question": "Which cluster should I deploy to?",
+        "choices": list(choices),
+        "selected": selected,
+        "multi_select": multi_select,
+        "selected_indices": set(checked or ()) if multi_select else None,
+        "response_queue": queue.Queue(),
+    }
+    cli._clarify_freetext = False
+    cli._clarify_multi_base = None
+    return cli
+
+
+def _drain(cli_state):
+    return cli_state["response_queue"].get_nowait()
+
+
+class TestClarifyEnterTypedAnswer:
+    def test_typed_answer_wins_over_highlighted_choice(self):
+        cli = _make_cli_stub(["staging", "prod"], selected=0)
+        state = cli._clarify_state
+        buffer = _FakeBuffer("use the canary cluster")
+        event = _make_event(buffer)
+
+        assert cli._handle_clarify_enter(event) is True
+
+        assert _drain(state) == "use the canary cluster"
+        assert cli._clarify_state is None
+        assert cli._clarify_freetext is False
+        assert buffer.text == ""
+
+    def test_typed_answer_is_appended_to_checked_multi_select_choices(self):
+        cli = _make_cli_stub(
+            ["choice_a", "choice_b", "choice_c"],
+            multi_select=True,
+            checked={0, 2},
+        )
+        state = cli._clarify_state
+        event = _make_event(_FakeBuffer("and roll back on error"))
+
+        assert cli._handle_clarify_enter(event) is True
+
+        # Same shape the existing "Other"-plus-choices freetext path produces.
+        assert _drain(state) == "choice_a, choice_c, and roll back on error"
+        assert cli._clarify_state is None
+        assert cli._clarify_multi_base is None
+
+    def test_typed_answer_does_not_duplicate_the_other_entry(self):
+        # Index 3 == len(choices) is the synthetic "Other" row; the typed text
+        # *is* the other answer, so it must not also appear as a choice.
+        cli = _make_cli_stub(
+            ["choice_a", "choice_b", "choice_c"],
+            multi_select=True,
+            checked={1, 3},
+        )
+        state = cli._clarify_state
+        event = _make_event(_FakeBuffer("something else entirely"))
+
+        assert cli._handle_clarify_enter(event) is True
+        assert _drain(state) == "choice_b, something else entirely"
+
+    def test_typed_answer_with_nothing_checked_submits_only_the_text(self):
+        cli = _make_cli_stub(["choice_a", "choice_b"], multi_select=True)
+        state = cli._clarify_state
+        event = _make_event(_FakeBuffer("neither, use the old one"))
+
+        assert cli._handle_clarify_enter(event) is True
+        assert _drain(state) == "neither, use the old one"
+
+    def test_empty_buffer_still_submits_the_highlighted_choice(self):
+        cli = _make_cli_stub(["staging", "prod"], selected=1)
+        state = cli._clarify_state
+        event = _make_event(_FakeBuffer(""))
+
+        assert cli._handle_clarify_enter(event) is True
+        assert _drain(state) == "prod"
+        assert cli._clarify_state is None
+
+    def test_empty_buffer_on_other_row_still_switches_to_freetext(self):
+        cli = _make_cli_stub(["staging", "prod"], selected=2)
+        state = cli._clarify_state
+        event = _make_event(_FakeBuffer(""))
+
+        assert cli._handle_clarify_enter(event) is True
+        assert cli._clarify_freetext is True
+        assert cli._clarify_state is state
+        assert state["response_queue"].empty()
+
+    def test_empty_buffer_multi_select_still_joins_checked_choices(self):
+        cli = _make_cli_stub(
+            ["choice_a", "choice_b", "choice_c"],
+            multi_select=True,
+            checked={0, 2},
+        )
+        state = cli._clarify_state
+        event = _make_event(_FakeBuffer(""))
+
+        assert cli._handle_clarify_enter(event) is True
+        assert _drain(state) == "choice_a, choice_c"
+
+    def test_empty_buffer_multi_select_with_nothing_checked_submits_empty(self):
+        cli = _make_cli_stub(["choice_a", "choice_b"], multi_select=True)
+        state = cli._clarify_state
+        event = _make_event(_FakeBuffer(""))
+
+        assert cli._handle_clarify_enter(event) is True
+        assert _drain(state) == ""
+
+    def test_empty_buffer_multi_select_other_plus_choices_stores_base(self):
+        cli = _make_cli_stub(
+            ["choice_a", "choice_b"], multi_select=True, checked={0, 2}
+        )
+        state = cli._clarify_state
+        event = _make_event(_FakeBuffer(""))
+
+        assert cli._handle_clarify_enter(event) is True
+        assert cli._clarify_multi_base == ["choice_a"]
+        assert cli._clarify_freetext is True
+        assert state["response_queue"].empty()
+
+    def test_returns_false_when_no_clarify_prompt_is_open(self):
+        cli = HermesCLI.__new__(HermesCLI)
+        cli._clarify_state = None
+        cli._clarify_freetext = False
+        assert cli._handle_clarify_enter(_make_event(_FakeBuffer("hello"))) is False
+
+    def test_returns_false_in_freetext_mode(self):
+        cli = _make_cli_stub(["staging", "prod"])
+        cli._clarify_freetext = True
+        assert cli._handle_clarify_enter(_make_event(_FakeBuffer("hi"))) is False
+
+
+class TestClarifyDigitShortcut:
+    def test_numeric_custom_answer_is_typed_not_selected(self):
+        # "0" maps to choice index 9 — the case that made numeric answers unsafe.
+        cli = _make_cli_stub(["staging", "prod"])
+        state = cli._clarify_state
+        buffer = _FakeBuffer("port 808")
+        handler = cli._make_clarify_number_handler(9, "0")
+
+        handler(_make_event(buffer))
+
+        assert buffer.text == "port 8080"
+        assert state["response_queue"].empty()
+        assert cli._clarify_state is state
+        assert cli._clarify_freetext is False
+
+    def test_digit_within_range_is_typed_when_a_draft_exists(self):
+        cli = _make_cli_stub(["staging", "prod"])
+        state = cli._clarify_state
+        buffer = _FakeBuffer("keep v")
+        handler = cli._make_clarify_number_handler(1, "2")
+
+        handler(_make_event(buffer))
+
+        assert buffer.text == "keep v2"
+        assert state["response_queue"].empty()
+        assert cli._clarify_state is state
+
+    def test_digit_above_choice_count_is_typed_instead_of_swallowed(self):
+        cli = _make_cli_stub(["staging", "prod"])
+        buffer = _FakeBuffer("scale to ")
+        handler = cli._make_clarify_number_handler(6, "7")
+
+        handler(_make_event(buffer))
+
+        assert buffer.text == "scale to 7"
+
+    def test_digit_is_typed_in_multi_select_mode_when_a_draft_exists(self):
+        cli = _make_cli_stub(
+            ["choice_a", "choice_b"], multi_select=True
+        )
+        state = cli._clarify_state
+        buffer = _FakeBuffer("only after step ")
+        handler = cli._make_clarify_number_handler(0, "1")
+
+        handler(_make_event(buffer))
+
+        assert buffer.text == "only after step 1"
+        assert state["selected_indices"] == set()
+
+    def test_empty_draft_still_quick_selects(self):
+        cli = _make_cli_stub(["staging", "prod"])
+        state = cli._clarify_state
+        handler = cli._make_clarify_number_handler(1, "2")
+
+        handler(_make_event(_FakeBuffer("")))
+
+        assert _drain(state) == "prod"
+        assert cli._clarify_state is None
+
+    def test_empty_draft_still_toggles_multi_select_checkboxes(self):
+        cli = _make_cli_stub(["choice_a", "choice_b"], multi_select=True)
+        state = cli._clarify_state
+        handler = cli._make_clarify_number_handler(0, "1")
+
+        handler(_make_event(_FakeBuffer("")))
+        assert state["selected_indices"] == {0}
+
+        handler(_make_event(_FakeBuffer("")))
+        assert state["selected_indices"] == set()
+
+    def test_empty_draft_on_other_index_still_switches_to_freetext(self):
+        cli = _make_cli_stub(["staging", "prod"])
+        handler = cli._make_clarify_number_handler(2, "3")
+
+        handler(_make_event(_FakeBuffer("")))
+
+        assert cli._clarify_freetext is True
+        assert cli._clarify_state is not None

--- a/tests/cli/test_cli_clarify_typed_answer.py
+++ b/tests/cli/test_cli_clarify_typed_answer.py
@@ -193,12 +193,12 @@ class TestClarifyDigitShortcut:
     def test_digit_within_range_is_typed_when_a_draft_exists(self):
         cli = _make_cli_stub(["staging", "prod"])
         state = cli._clarify_state
-        buffer = _FakeBuffer("keep v")
+        buffer = _FakeBuffer("  keep v ")
         handler = cli._make_clarify_number_handler(1, "2")
 
         handler(_make_event(buffer))
 
-        assert buffer.text == "keep v2"
+        assert buffer.text == "  keep v 2"
         assert state["response_queue"].empty()
         assert cli._clarify_state is state
 
@@ -230,6 +230,16 @@ class TestClarifyDigitShortcut:
         handler = cli._make_clarify_number_handler(1, "2")
 
         handler(_make_event(_FakeBuffer("")))
+
+        assert _drain(state) == "prod"
+        assert cli._clarify_state is None
+
+    def test_whitespace_only_draft_still_quick_selects(self):
+        cli = _make_cli_stub(["staging", "prod"])
+        state = cli._clarify_state
+        handler = cli._make_clarify_number_handler(1, "2")
+
+        handler(_make_event(_FakeBuffer(" \t ")))
 
         assert _drain(state) == "prod"
         assert cli._clarify_state is None


### PR DESCRIPTION
## What does this PR do?

In the classic CLI, answer a clarify question by **typing** instead of picking a listed choice and your answer is destroyed:

- **Press Enter** → the *highlighted* choice is sent to the agent and the text you typed disappears.
- **Type any digit** → the digit is intercepted as a numbered quick-select, so "port 8080", "keep v2" or "3 hours" resolves the prompt mid-word with a choice you never picked. Digits past the end of the choice list are swallowed entirely instead of being typed.

The input buffer stays editable while the choice list is on screen (nothing makes it read-only, and `_editor_filter` — the only clarify-gated input filter — guards Ctrl+G only), so typing is reachable and this is the ordinary way a user tries to give a custom answer without first arrowing down to "Other".

Root cause, on `main`:

- `cli.py` clarify choice branch calls `state["response_queue"].put(choices[selected])` and returns; `event.app.current_buffer.text` is first read one line *later*, in the normal-input routing that the branch never reaches. Multi-select has the same blind spot — it submits `", ".join(selected_choices)` without looking at the buffer.
- `kb.add(str(_num), filter=Condition(lambda: bool(self._clarify_state) and not self._clarify_freetext))(...)` — the filter never inspects the buffer, so every digit fires the quick-select handler regardless of what the user has already typed.

**Fix:** in clarify choice mode, if the user is typing, typing wins.

- **Enter with a non-empty draft** submits the typed text. In multi-select the typed text is appended to the already-checked real choices, producing exactly the `", ".join(base) + ", " + text` shape the existing `_clarify_multi_base` "Other"-plus-choices path already produces (so downstream parsing is unchanged). The synthetic "Other" row is never duplicated into that list.
- **A digit with a non-empty draft** is inserted into the buffer as text.
- **An empty draft keeps today's behaviour exactly**: Enter confirms the highlighted choice, Enter on "Other" switches to freetext, a digit quick-selects, a digit toggles a multi-select checkbox, `0` maps to the 10th item. Nine of the eighteen tests below exist purely to pin that down.

## Related Issue

No filed issue. This supersedes **#5296** (@AlsayedHoota, opened 2026-04-05, no author activity since 2026-04-06), which identified the Enter path but was reviewed with two named deficiencies. Both are addressed here:

> - `tests/test_cli_clarify_submit.py:74-78` simulates the new conditional and calls `_submit_clarify_response` directly; it never exercises the nested `handle_enter` binding where the bug occurs.

Addressed by extracting rather than simulating — see "Test reachability" below.

> - Numeric free-text answers remain unsafe: `cli.py:13659-13677` binds every digit in choice mode to immediate numbered selection, so a typed answer containing a digit may resolve before Enter reaches this change.

Addressed as the second half of this PR — the digit-binding site is fixed and covered, including the numeric-custom-answer case by name (`test_numeric_custom_answer_is_typed_not_selected`).

Credit to @AlsayedHoota for identifying the input-loss path. This PR does **not** import that PR's `_submit_clarify_response`, because the `_clarify_multi_base` multi-select logic post-dates it and must survive; the multi-select branch is preserved verbatim.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py` — new `HermesCLI._handle_clarify_enter(event) -> bool`. Holds the clarify choice-mode Enter logic, moved out of the nested `handle_enter` in `run()` **unchanged** apart from `return` → `return True`, plus the new typed-answer branch ahead of the choice branches. `handle_enter` becomes `if self._handle_clarify_enter(event): return`.
- `cli.py` — `_make_clarify_number_handler` promoted from a nested function in `run()` to a method, now taking `(idx, char)`. `char` is the literal key pressed and cannot be derived from `idx` (`0` maps to index 9), so the registration loop passes both. The handler inserts `char` when the draft is non-empty; the quick-select body is otherwise unchanged.
- `tests/cli/test_cli_clarify_typed_answer.py` — new, 18 tests.

### Sibling-site sweep

`grep -n "kb.add(str(_num)\|_make_.*_number_handler" cli.py` finds exactly three numeric-key binding loops in `cli.py`:

| site | overlay | in this PR? |
|---|---|---|
| clarify (`_make_clarify_number_handler`) | clarify question | **Yes — this is the bug.** |
| `_make_approval_number_handler` | dangerous-command approval | No |
| `_make_slash_confirm_number_handler` | slash-command confirmation | No |

The other two are **deliberately excluded, not overlooked**: both drive a fixed choice set with no free-text answer mode, so a digit can only ever mean "pick choice N" — there is no typed answer for it to destroy and no ambiguity to resolve. Clarify is the only overlay where free text is a legal response, which is what makes the digit binding unsafe there and only there. Left byte-for-byte untouched.

Both sub-sites of the clarify root cause (the Enter branch and the digit bindings) are covered in this PR.

### Test reachability — what is and is not exercised

`kb = KeyBindings()` is a local inside `HermesCLI.run()` and `handle_enter` is nested inside it, so neither is reachable from a test without running the full app. The two extractions above put the real logic one frame below `kb`:

- The tests call `cli._handle_clarify_enter(event)` — **the exact method the Enter binding invokes**.
- The tests call `cli._make_clarify_number_handler(idx, char)` and drive the returned handler — **the exact object `kb.add(...)` registers**, since `kb.add(...)` registers that return value.

Nothing is re-implemented or simulated inside the tests. **Honest caveat:** binding *registration* itself (the `kb.add(...)` calls and their `Condition` filters) is still not exercised, because `kb` remains a local in `run()`. Making that testable would mean restructuring `run()`, which is out of scope here.

## How to Test

Automated:

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/cli/test_cli_clarify_typed_answer.py -v
```
→ `18 passed`.

Fails-before / passes-after, verified both directions:

1. **Against pristine `main`** (`git checkout origin/main -- cli.py`, new test file kept): **18 failed** — the methods don't exist yet.
2. **Against an extraction-only variant** — this PR's `cli.py` with *only* the two behavioural blocks removed (the `if typed:` branch and the `if event.app.current_buffer.text:` guard), i.e. `main`'s behaviour with this PR's structure: **8 failed, 10 passed**. The 8 failures are exactly the typed-answer cases; the 10 passes are the no-regression cases, confirming the extraction itself changes nothing.
3. **With the full fix**: **18 passed**.

Suite:

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/cli/ -q
```
→ `1 failed, 1247 passed`. The single failure is `tests/cli/test_resume_quiet_stderr.py::TestResumeQuietStderr::test_session_not_found_goes_to_stdout_in_full_mode`, which **also fails on clean `origin/main`** in a whole-directory run (cross-test capture pollution — it passes in isolation on both). Unrelated to this change; not touched here.

Manual, in the classic CLI: ask the agent something that triggers a clarify question with choices, then

1. type `use the canary cluster` and press Enter → the agent receives that text, not the highlighted choice;
2. type `port 8080` → the digits land in the draft instead of resolving the prompt;
3. press Enter or `2` on an empty draft → unchanged quick-select behaviour.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `pytest tests/cli/ -q` (result above); did not run the whole `tests/` tree locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings on both new methods; no user-facing docs describe this binding)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is pure prompt_toolkit buffer/state logic with no platform-specific behaviour, but it was only exercised on macOS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (the clarify tool's contract is unchanged; only which string reaches its response queue)

## Related / Positioning

Consolidating the intended clarify semantics in one place, as requested during triage. In choice mode the rule is a single sentence — **if the user is typing, typing wins** — which resolves both the Enter path and the numeric-shortcut path that previously contradicted each other:

| draft buffer | key | behaviour after this PR | changed? |
|---|---|---|---|
| empty | Enter, single-select | submit `choices[selected]` | no |
| empty | Enter on the "Other" row | switch to freetext | no |
| empty | Enter, multi-select, nothing checked | submit `""` | no |
| empty | Enter, multi-select, choices checked | submit `", ".join(checked)` | no |
| empty | Enter, multi-select, "Other" + choices checked | store base, switch to freetext | no |
| empty | digit `1`-`9`/`0`, single-select | quick-select that choice | no |
| empty | digit, multi-select | toggle that checkbox | no |
| empty | digit == "Other" row, single-select | switch to freetext | no |
| **non-empty** | Enter, single-select | **submit the typed text** | **yes** |
| **non-empty** | Enter, multi-select | **submit `", ".join(checked) + ", " + typed`** | **yes** |
| **non-empty** | any digit, either mode | **insert the digit into the draft** | **yes** |

Every "no" row has a dedicated regression test; the extraction-only run described under "How to Test" proves none of them shift.

Relationship to **#5296**: that PR covers the first "yes" row only, via a test that re-implements the conditional rather than exercising the handler. This PR is a strict superset — it covers all three, keeps the `_clarify_multi_base` multi-select logic that post-dates #5296 (which #5296's `_submit_clarify_response` would flatten), and drives the real callables. It also closes both deficiencies named in the review on #5296. If this lands, #5296 can be closed as superseded.

Out of scope by design: the approval and slash-confirm numeric shortcuts. They have no free-text answer mode, so a digit is never ambiguous there and their bindings are untouched — see the sibling-site sweep above.
