### PR TITLE
fix(gateway): exit 0 when gateway already running, not 1

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26258,7 +26258,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 pass
         else:
             hermes_home = str(get_hermes_home())
-            logger.error(
+            logger.warning(
                 "Another gateway instance is already running (PID %d, HERMES_HOME=%s). "
                 "Use 'hermes gateway restart' to replace it, or 'hermes gateway stop' first.",
                 existing_pid, hermes_home,
@@ -26269,7 +26269,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 f"   or 'hermes gateway stop' to kill it first.\n"
                 f"   Or use 'hermes gateway run --replace' to auto-replace.\n"
             )
-            return False
+            # Gateway is already running — that is the desired end-state.
+            # Return True (not False) so callers don't treat this as a
+            # failure and retry indefinitely (issue #73203).
+            return True
 
     # Sync bundled skills on gateway start (fast -- skips unchanged)
     try:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4853,7 +4853,10 @@ def _guard_supervised_gateway_conflict(force: bool = False) -> None:
         "  Pass --force to start a foreground gateway anyway (not recommended\n"
         "  while the service is running)."
     )
-    sys.exit(1)
+    # Exit 0, not 1 — the gateway is already supervised, which is the
+    # desired end-state. Exiting non-zero causes agents/scripts to retry
+    # indefinitely, creating respawn storms (issue #73203).
+    sys.exit(0)
 
 
 def _guard_existing_gateway_process_conflict(replace: bool = False) -> None:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4885,7 +4885,10 @@ def _guard_existing_gateway_process_conflict(replace: bool = False) -> None:
     print("  Use 'hermes gateway restart' to replace it,")
     print("  or 'hermes gateway stop' first.")
     print("  Or use 'hermes gateway run --replace' to auto-replace.")
-    sys.exit(1)
+    # Exit 0, not 1 — the gateway is already running, which is the
+    # desired end-state. Exiting non-zero causes agents/scripts to retry
+    # indefinitely, creating respawn storms (issue #73203).
+    sys.exit(0)
 
 
 def _guard_official_docker_root_gateway() -> None:

--- a/tests/hermes_cli/test_gateway_exit_0_fix.py
+++ b/tests/hermes_cli/test_gateway_exit_0_fix.py
@@ -6,6 +6,7 @@ Core contributor review (PR #73210, review #4820521856) requested:
 """
 
 import pytest
+from unittest.mock import MagicMock
 
 import hermes_cli.gateway as gateway
 
@@ -117,11 +118,46 @@ class TestStartGatewayExistingPidBranch:
         monkeypatch.setattr("gateway.run.get_hermes_home", lambda: tmp_path)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 123_456)
         monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet: None)
-        monkeypatch.setattr("hermes_logging.setup_logging", lambda **kw: None)
-        monkeypatch.setattr("gateway.code_skew.record_boot_fingerprint", lambda: None)
         monkeypatch.setattr("gateway.run.GatewayRunner", FakeRunner)
+        monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [123])
+        monkeypatch.setattr(gateway, "_profile_suffix", lambda: "")
+        
+        # Add a mock to track GatewayRunner constructor calls
+        mock_gateway_runner = MagicMock(side_effect=FakeRunner)
+        monkeypatch.setattr("gateway.run.GatewayRunner", mock_gateway_runner)
 
         from gateway.run import start_gateway
 
         result = await start_gateway()
         assert result is True
+        
+        # Assert that GatewayRunner was NOT called
+        mock_gateway_runner.assert_not_called()
+
+    async def test_returns_false_on_genuine_failure(self, monkeypatch, tmp_path):
+        """A genuine startup failure should still return False."""
+
+        async def failing_start_gateway(*args, **kwargs):
+            # Simulate a real failure inside the gateway logic
+            return False
+
+        monkeypatch.setattr("gateway.run.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet: None)
+        monkeypatch.setattr("hermes_logging.setup_logging", lambda **kw: None)
+        monkeypatch.setattr("gateway.code_skew.record_boot_fingerprint", lambda: None)
+        
+        # Mock GatewayRunner to simulate an internal startup failure
+        class FakeFailingRunner:
+            def __init__(self, *args, **kwargs): pass
+            async def start(self): return False
+            def stop(self): pass
+            should_exit_cleanly = False
+            _running = False
+        
+        monkeypatch.setattr("gateway.run.GatewayRunner", FakeFailingRunner)
+
+        from gateway.run import start_gateway
+        
+        result = await start_gateway()
+        assert result is False

--- a/tests/hermes_cli/test_gateway_exit_0_fix.py
+++ b/tests/hermes_cli/test_gateway_exit_0_fix.py
@@ -1,0 +1,127 @@
+"""Regression tests for PR #73210 — exit 0 when gateway already running.
+
+Core contributor review (PR #73210, review #4820521856) requested:
+1. Exit code tests for both CLI preflight guards
+2. Async start_gateway() test for existing-PID return value
+"""
+
+import pytest
+
+import hermes_cli.gateway as gateway
+
+
+# ── _guard_supervised_gateway_conflict ──────────────────────────
+
+
+class TestGuardSupervisedConflict:
+    """Exit contract: SystemExit(0) when a supervised gateway is already running."""
+
+    def test_exits_0_when_supervised(self, monkeypatch):
+        """Installed+running service manager → sys.exit(0)."""
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: False)
+        snapshot = gateway.GatewayRuntimeSnapshot(
+            manager="systemd (user)", service_installed=True, service_running=True
+        )
+        monkeypatch.setattr(gateway, "get_gateway_runtime_snapshot", lambda: snapshot)
+
+        with pytest.raises(SystemExit) as exc:
+            gateway._guard_supervised_gateway_conflict()
+        assert exc.value.code == 0
+
+    def test_returns_none_when_no_service(self, monkeypatch):
+        """No installed service → returns None."""
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: False)
+        snapshot = gateway.GatewayRuntimeSnapshot(
+            manager="systemd (user)", service_installed=False, service_running=False
+        )
+        monkeypatch.setattr(gateway, "get_gateway_runtime_snapshot", lambda: snapshot)
+
+        assert gateway._guard_supervised_gateway_conflict() is None
+
+    def test_returns_none_when_probe_fails(self, monkeypatch):
+        """Probe exception → returns None (best-effort)."""
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: False)
+        monkeypatch.setattr(
+            gateway, "get_gateway_runtime_snapshot",
+            lambda: (_ for _ in ()).throw(Exception("probe failed")),
+        )
+
+        assert gateway._guard_supervised_gateway_conflict() is None
+
+    def test_returns_none_when_force(self, monkeypatch):
+        """--force bypasses the guard."""
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: False)
+        assert gateway._guard_supervised_gateway_conflict(force=True) is None
+
+    def test_returns_none_when_already_under_supervisor(self, monkeypatch):
+        """Under supervisor → skip guard."""
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: True)
+        assert gateway._guard_supervised_gateway_conflict() is None
+
+
+# ── _guard_existing_gateway_process_conflict ────────────────────
+
+
+class TestGuardExistingProcessConflict:
+    """Exit contract: SystemExit(0) when a PID file exists."""
+
+    def test_exits_0_when_pid_exists(self, monkeypatch):
+        """Existing PID → sys.exit(0)."""
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: False)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
+
+        with pytest.raises(SystemExit) as exc:
+            gateway._guard_existing_gateway_process_conflict()
+        assert exc.value.code == 0
+
+    def test_returns_none_when_no_pid(self, monkeypatch):
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: False)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+
+        assert gateway._guard_existing_gateway_process_conflict() is None
+
+    def test_returns_none_when_probe_fails(self, monkeypatch):
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: False)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda: (_ for _ in ()).throw(Exception("probe failed")),
+        )
+
+        assert gateway._guard_existing_gateway_process_conflict() is None
+
+    def test_returns_none_when_replace(self, monkeypatch):
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: False)
+        assert gateway._guard_existing_gateway_process_conflict(replace=True) is None
+
+    def test_returns_none_when_under_supervisor(self, monkeypatch):
+        monkeypatch.setattr(gateway, "_running_under_gateway_supervisor", lambda: True)
+        assert gateway._guard_existing_gateway_process_conflict() is None
+
+
+# ── start_gateway existing-PID branch ──────────────────────────
+
+
+@pytest.mark.asyncio
+class TestStartGatewayExistingPidBranch:
+    """Return contract: True (not False) when an existing PID is found."""
+
+    async def test_returns_true_when_existing_pid(self, monkeypatch, tmp_path):
+        """An existing PID → start_gateway returns True (not False)."""
+        class FakeRunner:
+            def __init__(self, *args, **kwargs): pass
+            async def start(self): return True
+            def stop(self): pass
+            should_exit_cleanly = False
+            _running = True
+
+        monkeypatch.setattr("gateway.run.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 123_456)
+        monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet: None)
+        monkeypatch.setattr("hermes_logging.setup_logging", lambda **kw: None)
+        monkeypatch.setattr("gateway.code_skew.record_boot_fingerprint", lambda: None)
+        monkeypatch.setattr("gateway.run.GatewayRunner", FakeRunner)
+
+        from gateway.run import start_gateway
+
+        result = await start_gateway()
+        assert result is True


### PR DESCRIPTION
## Problem

`_guard_existing_gateway_process_conflict()` in `hermes_cli/gateway.py` calls `sys.exit(1)` when a gateway is already running. Agents and scripts interpret exit code 1 as failure and retry indefinitely, creating respawn storms:

```
ERROR gateway.run: Another gateway instance is already running (PID 548488)
WARNING hermes_cli.gateway: Gateway (re)started 6 times in 120s — backing off 10s
```

Each retry records to `gateway-starts.log`, triggers `record_start_and_check_storm()`, backs off, then fails again. The cycle continues until the agent session is killed — 40+ spawns observed.

**Root cause trace:**
```
hermes-webui → forked agent session → terminal("hermes gateway run") → _guard_existing_gateway_process_conflict() → exit 1 → agent retries
```

## Fix

Change `sys.exit(1)` → `sys.exit(0)`. The gateway is already running — that is the desired end-state, not a failure. The informational message is still printed to stderr so users know what happened, but the exit code no longer triggers agent retry loops.

## Verification

- Only caller is `run_gateway()` at line 4831 — no other code paths depend on exit code 1
- Two test files monkeypatch this function to `lambda replace=False: None` — no tests assert exit code 1
- Idempotent: running `hermes gateway run` when the gateway is already running now succeeds silently

Fixes #73203