### PR TITLE
fix(deps): bump pyasn1 lock to 0.6.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3185,11 +3185,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update uv.lock pyasn1 transitive resolution from 0.6.3 to 0.6.4
- leaves pyasn1-modules at 0.4.2; its requirement is pyasn1>=0.6.1,<0.7.0

## Verification
- /home/frank/.local/bin/hermes security audit --fail-on high reproduced pyasn1==0.6.3 HIGH GHSA-8ppf-4f7h-5ppj and GHSA-hm4w-wwcw-mr6r in the live control-plane venv
- uv lock --check
- uv run --no-project --with pyasn1==0.6.4 --with pyasn1-modules==0.4.2 python import smoke for pyasn1 ObjectIdentifier
- direct OSV query: pyasn1 0.6.3 returns GHSA-8ppf-4f7h-5ppj/GHSA-hm4w-wwcw-mr6r/PYSEC rows; pyasn1 0.6.4 returns []

Note: full uv run --locked hermes security audit in the fresh worktree timed out while downloading unrelated project deps (cryptography/Pillow), so the focused audit verification used OSV directly for pyasn1.