### PR TITLE
fix(gateway): verify origin in relay media URL detection (#71559)

### DIFF
--- a/gateway/relay/media.py
+++ b/gateway/relay/media.py
@@ -90,8 +90,27 @@ class RelayMediaClient:
         return make_upgrade_token(self._gateway_id, self._secret)
 
     def is_relay_media_url(self, url: str) -> bool:
-        """Is ``url`` a connector re-host reference (needs our bearer to GET)?"""
-        return "/relay/media/" in (url or "")
+        """Is ``url`` a connector re-host reference (needs our bearer to GET)?
+
+        Only URLs whose *origin* (scheme + host + port) matches the configured
+        connector base URL are treated as relay-media references.  External
+        origins that happen to contain ``/relay/media/`` in their path must
+        **not** receive our bearer token (GH-71559).
+        """
+        if not url or not self._base_url:
+            return False
+        try:
+            parsed = urllib.parse.urlparse(url)
+            base = urllib.parse.urlparse(self._base_url)
+        except Exception:
+            return False
+        if parsed.scheme != base.scheme:
+            return False
+        if (parsed.hostname or "").lower() != (base.hostname or "").lower():
+            return False
+        if parsed.port != base.port:
+            return False
+        return parsed.path.startswith("/relay/media/")
 
     async def upload(
         self,

--- a/tests/gateway/relay/test_relay_media.py
+++ b/tests/gateway/relay/test_relay_media.py
@@ -272,6 +272,28 @@ def test_client_recognizes_rehost_urls():
     assert c.is_relay_media_url("https://cdn.discordapp.com/a/b.png") is False
 
 
+def test_client_rejects_cross_origin_relay_paths():
+    """External origins with /relay/media/ in path must not match (GH-71559)."""
+    c = RelayMediaClient("https://connector.example", "gw1", "sec")
+    # Same origin → match
+    assert c.is_relay_media_url("https://connector.example/relay/media/abc") is True
+    # Different origin, same path → must NOT match
+    assert c.is_relay_media_url("https://evil.example/relay/media/abc") is False
+    assert c.is_relay_media_url("https://cdn.example/files/relay/media/photo.png") is False
+    # Different port → must NOT match
+    assert c.is_relay_media_url("https://connector.example:9999/relay/media/abc") is False
+    # Different scheme → must NOT match
+    assert c.is_relay_media_url("http://connector.example/relay/media/abc") is False
+    # Path prefix must start at /relay/media/, not just contain it
+    assert c.is_relay_media_url("https://connector.example/api/relay/media/abc") is False
+
+
+def test_client_rejects_empty_or_missing_base():
+    c = RelayMediaClient("", "gw1", "sec")
+    assert c.is_relay_media_url("https://c.example/relay/media/abc") is False
+    assert c.is_relay_media_url("") is False
+
+
 @pytest.mark.asyncio
 async def test_client_upload_rejects_oversize_and_missing(tmp_path: Path):
     c = RelayMediaClient("https://c.example", "gw1", "sec")


### PR DESCRIPTION
## Problem

`RelayMediaClient.is_relay_media_url()` classifies a URL as connector-hosted relay media by checking only whether the path contains `/relay/media/`. Any external origin can be treated as authenticated relay media, potentially leaking the relay bearer to non-connector hosts.

```
# All three return True (bug):
https://connector.example/relay/media/abc   ← correct
https://evil.example/relay/media/abc        ← wrong: different origin
https://cdn.example/files/relay/media/img   ← wrong: different origin
```

## Fix

Parse the URL and compare **scheme + hostname + port** against the configured connector base URL before checking the path prefix `/relay/media/`.

## Testing

- Existing 14 tests pass (no regressions).
- Added `test_client_rejects_cross_origin_relay_paths` covering:
  - Different hostname
  - Different port
  - Different scheme
  - Non-prefix path match (`/api/relay/media/`)
- Added `test_client_rejects_empty_or_missing_base` for edge cases.

Fixes #71559