### PR TITLE
fix(deps): pin httplib2==0.32.0 across all 3 install paths (GHSA-j5g9-f88f-gfj3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,6 +282,10 @@ google = [
   "google-api-python-client==2.194.0",
   "google-auth-oauthlib==1.3.1",
   "google-auth-httplib2==0.3.1",
+  # Transitive via google-api-python-client/google-auth-httplib2; keep explicit
+  # so fresh google-extra installs do not resolve vulnerable httplib2 0.31.2
+  # (GHSA-j5g9-f88f-gfj3 decompression bomb DoS).
+  "httplib2==0.32.0",
 ]
 youtube = [
   # Required by skills/media/youtube-content and

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -54,7 +54,17 @@ SCOPES = [
     "https://www.googleapis.com/auth/documents",
 ]
 
-REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
+# Exact pins: keep in sync with pyproject.toml [project.optional-dependencies].google
+# and tools/lazy_deps.py LAZY_DEPS['skill.google_workspace'].
+# Pinning all three protects against version drift and ensures the httplib2
+# GHSA-j5g9-f88f-gfj3 security fix is honoured regardless of install path.
+REQUIRED_PACKAGES = [
+    "google-api-python-client==2.194.0",
+    "google-auth-oauthlib==1.3.1",
+    "google-auth-httplib2==0.3.1",
+    # GHSA-j5g9-f88f-gfj3 — Decompression Bomb DoS via unbounded gzip/deflate
+    "httplib2==0.32.0",
+]
 
 # OAuth redirect for "out of band" manual code copy flow.
 # Google deprecated OOB, so we use a localhost redirect and tell the user to

--- a/tests/skills/test_google_workspace_setup_deps.py
+++ b/tests/skills/test_google_workspace_setup_deps.py
@@ -1,0 +1,201 @@
+"""Regression test: google-workspace setup.py REQUIRED_PACKAGES must pin httplib2.
+
+GHSA-j5g9-f88f-gfj3 (HIGH) — Decompression Bomb DoS via unbounded gzip/deflate
+response handling.  Fixed in httplib2 0.32.0.
+
+There are three install paths for google-workspace dependencies:
+  1. pyproject.toml [project.optional-dependencies].google
+  2. tools/lazy_deps.py LAZY_DEPS['skill.google_workspace']
+  3. skills/productivity/google-workspace/scripts/setup.py REQUIRED_PACKAGES
+
+This test ensures path 3 stays pinned and consistent with the other two.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SETUP_PY = REPO_ROOT / "skills/productivity/google-workspace/scripts/setup.py"
+PYPROJECT_TOML = REPO_ROOT / "pyproject.toml"
+LAZY_DEPS_PY = REPO_ROOT / "tools/lazy_deps.py"
+
+# ---------------------------------------------------------------------------
+# Static parsers
+# ---------------------------------------------------------------------------
+
+_GOOGLE_EXTRA_KEY = "google"
+_LAZY_DEPS_KEY = "skill.google_workspace"
+
+
+def _parse_setup_py_required_packages() -> list[str]:
+    """Parse setup.py and return the REQUIRED_PACKAGES list."""
+    tree = ast.parse(SETUP_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "REQUIRED_PACKAGES":
+                    if isinstance(node.value, ast.List):
+                        return [elt.value for elt in node.value.elts if isinstance(elt, ast.Constant)]
+    raise AssertionError("REQUIRED_PACKAGES not found in setup.py")
+
+
+def _parse_pyproject_google_extra() -> list[str]:
+    """Parse pyproject.toml and return the google extra dependency list."""
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+    data = tomllib.loads(PYPROJECT_TOML.read_text(encoding="utf-8"))
+    optional_deps = data["project"]["optional-dependencies"]
+    return list(optional_deps[_GOOGLE_EXTRA_KEY])
+
+
+def _parse_lazy_deps_google_workspace() -> list[str]:
+    """Parse tools/lazy_deps.py and return the LAZY_DEPS for skill.google_workspace."""
+    tree = ast.parse(LAZY_DEPS_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        # LAZY_DEPS is declared as AnnAssign: `LAZY_DEPS: dict[str, tuple[str, ...]] = {...}`
+        target_name = None
+        if isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name):
+                target_name = node.target.id
+        elif isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    target_name = t.id
+                    break
+        if target_name != "LAZY_DEPS":
+            continue
+        if isinstance(node, ast.AnnAssign) and isinstance(node.value, ast.Dict):
+            dict_val = node.value
+        elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Dict):
+            dict_val = node.value
+        else:
+            continue
+        for k, v in zip(dict_val.keys, dict_val.values):
+            if isinstance(k, ast.Constant) and k.value == _LAZY_DEPS_KEY:
+                if isinstance(v, (ast.Tuple, ast.List)):
+                    return [elt.value for elt in v.elts if isinstance(elt, ast.Constant)]  # pyright: ignore[reportReturnType]
+    raise AssertionError(f"LAZY_DEPS[{_LAZY_DEPS_KEY!r}] not found")
+
+
+def _extract_pins(packages: list[str]) -> dict[str, str]:
+    """Extract pinned versions: {package_name: version} for entries with == pin."""
+    pins: dict[str, str] = {}
+    for pkg in packages:
+        if "==" in pkg:
+            name, version = pkg.split("==", 1)
+            pins[name.strip()] = version.strip()
+    return pins
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleWorkspaceSetupDepsPins:
+    """Security pin consistency across all three google-workspace install paths."""
+
+    def test_setup_py_pins_httplib2(self):
+        """setup.py REQUIRED_PACKAGES must include httplib2==0.32.0."""
+        packages = _parse_setup_py_required_packages()
+        pins = _extract_pins(packages)
+        assert "httplib2" in pins, (
+            f"httplib2 not found in setup.py REQUIRED_PACKAGES.\n"
+            f"  Current entries: {packages}"
+        )
+        assert pins["httplib2"] == "0.32.0", (
+            f"httplib2 pin mismatch in setup.py: expected 0.32.0, got {pins['httplib2']}.\n"
+            f"  Full REQUIRED_PACKAGES: {packages}"
+        )
+
+    def test_setup_py_pins_match_pyproject_toml(self):
+        """httplib2 pin in setup.py must match pyproject.toml google extra."""
+        required_packages = _parse_setup_py_required_packages()
+        pyproject_packages = _parse_pyproject_google_extra()
+
+        required_pins = _extract_pins(required_packages)
+        pyproject_pins = _extract_pins(pyproject_packages)
+
+        for pkg in ("httplib2", "google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"):
+            setup_ver = required_pins.get(pkg)
+            toml_ver = pyproject_pins.get(pkg)
+            if setup_ver is None and toml_ver is None:
+                continue  # neither path pins it, skip
+            assert toml_ver is not None, (
+                f"{pkg} is pinned in setup.py ({setup_ver}) but NOT in pyproject.toml google extra.\n"
+                f"  setup.py: {required_pins}\n"
+                f"  pyproject.toml google: {pyproject_pins}"
+            )
+            assert setup_ver is not None, (
+                f"{pkg} is pinned in pyproject.toml ({toml_ver}) but NOT in setup.py.\n"
+                f"  pyproject.toml google: {pyproject_pins}\n"
+                f"  setup.py: {required_pins}"
+            )
+            assert setup_ver == toml_ver, (
+                f"{pkg} pin mismatch: setup.py has {setup_ver}, pyproject.toml has {toml_ver}.\n"
+                f"  setup.py: {required_pins}\n"
+                f"  pyproject.toml google: {pyproject_pins}"
+            )
+
+    def test_setup_py_pins_match_lazy_deps(self):
+        """httplib2 pin in setup.py must match tools/lazy_deps.py skill.google_workspace."""
+        required_packages = _parse_setup_py_required_packages()
+        lazy_packages = _parse_lazy_deps_google_workspace()
+
+        required_pins = _extract_pins(required_packages)
+        lazy_pins = _extract_pins(lazy_packages)
+
+        for pkg in ("httplib2", "google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"):
+            setup_ver = required_pins.get(pkg)
+            lazy_ver = lazy_pins.get(pkg)
+            if setup_ver is None and lazy_ver is None:
+                continue
+            assert lazy_ver is not None, (
+                f"{pkg} is pinned in setup.py ({setup_ver}) but NOT in lazy_deps.py.\n"
+                f"  setup.py: {required_pins}\n"
+                f"  lazy_deps.py: {lazy_pins}"
+            )
+            assert setup_ver is not None, (
+                f"{pkg} is pinned in lazy_deps.py ({lazy_ver}) but NOT in setup.py.\n"
+                f"  lazy_deps.py: {lazy_pins}\n"
+                f"  setup.py: {required_pins}"
+            )
+            assert setup_ver == lazy_ver, (
+                f"{pkg} pin mismatch: setup.py has {setup_ver}, lazy_deps.py has {lazy_ver}.\n"
+                f"  setup.py: {required_pins}\n"
+                f"  lazy_deps.py: {lazy_pins}"
+            )
+
+    def test_all_google_packages_are_pinned_in_all_paths(self):
+        """Every google workspace package that is version-pinned in any path must appear in all three."""
+        pyproject_packages = _parse_pyproject_google_extra()
+        lazy_packages = _parse_lazy_deps_google_workspace()
+        setup_packages = _parse_setup_py_required_packages()
+
+        all_pins: dict[str, set[str]] = {}
+        for label, pkgs in [
+            ("pyproject.toml", pyproject_packages),
+            ("lazy_deps.py", lazy_packages),
+            ("setup.py", setup_packages),
+        ]:
+            for pkg in pkgs:
+                if "==" in pkg:
+                    name, ver = pkg.split("==", 1)
+                    all_pins.setdefault(name.strip(), set()).add(f"{label}={ver.strip()}")
+
+        for pkg, entries in sorted(all_pins.items()):
+            versions = {e.split("=", 1)[1] for e in entries}
+            assert len(versions) == 1, (
+                f"{pkg} has inconsistent pins across install paths:\n"
+                + "\n".join(f"  {e}" for e in sorted(entries))
+            )
+            assert len(entries) == 3, (
+                f"{pkg} is not pinned in all three install paths.  Found {len(entries)}/3:\n"
+                + "\n".join(f"  {e}" for e in sorted(entries))
+            )

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -249,6 +249,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "google-api-python-client==2.194.0",
         "google-auth-oauthlib==1.3.1",
         "google-auth-httplib2==0.3.1",
+        # Transitive via google-api-python-client/google-auth-httplib2; keep explicit
+        # so lazy installs do not resolve vulnerable httplib2 0.31.2
+        # (GHSA-j5g9-f88f-gfj3 decompression bomb DoS).
+        "httplib2==0.32.0",
     ),
     "skill.youtube": ("youtube-transcript-api==1.2.4",),
 

--- a/uv.lock
+++ b/uv.lock
@@ -1444,7 +1444,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
     { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/a0/68afd1ebad40db87dac0a28ffa120726b98bf9c7c40c481b0f63c105d298/greenlet-3.5.3-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e18619ba655ac05d78d80fc83cac4ba892bd6927b99e3b8237aee861aaacc8bb", size = 626155, upload-time = "2026-06-26T19:24:14.44Z" },
     { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7f/e327d912239ec4b3b49999e3967389bcf1ee8722b9ee9194d2752ecd558a/greenlet-3.5.3-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d27c0c653a60d9535f690226474a5cc1036a8b0d7b57504d1c4f89c44a07a80c", size = 421083, upload-time = "2026-06-26T19:25:35.804Z" },
     { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
     { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
     { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
@@ -1452,7 +1454,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
     { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
     { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
     { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
     { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
     { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
     { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
@@ -1460,7 +1464,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
     { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
     { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
     { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
     { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
     { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
     { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
@@ -1593,6 +1599,7 @@ all = [
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "httplib2" },
     { name = "mcp" },
     { name = "python-multipart" },
     { name = "simple-term-menu" },
@@ -1654,6 +1661,7 @@ google = [
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "httplib2" },
 ]
 hindsight = [
     { name = "hindsight-client" },
@@ -1727,6 +1735,7 @@ termux-all = [
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
     { name = "honcho-ai" },
+    { name = "httplib2" },
     { name = "mcp" },
     { name = "python-multipart" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
@@ -1831,6 +1840,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
+    { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
@@ -1973,14 +1983,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pin httplib2==0.32.0 explicitly across all three google-workspace install paths to prevent resolution of vulnerable httplib2 0.31.2 (GHSA-j5g9-f88f-gfj3 — Decompression Bomb DoS via unbounded gzip/deflate).

## Changes (2 commits)

1. **Commit 1** (904ade32): pin httplib2 in pyproject.toml google extra + tools/lazy_deps.py + uv.lock
2. **Commit 2** (2afe56bb): pin httplib2 in skills/productivity/google-workspace/scripts/setup.py REQUIRED_PACKAGES + regression test

## Install paths covered

- pyproject.toml `[project.optional-dependencies].google`
- tools/lazy_deps.py `LAZY_DEPS['skill.google_workspace']`
- skills/productivity/google-workspace/scripts/setup.py `REQUIRED_PACKAGES`

## Verification

- **4/4** regression tests pass (both Python 3.11 and 3.12)
- pip-audit clean for httplib2 vulnerability
- httplib2 0.32.0 installed, no vulnerable 0.31.2 anywhere

## Acceptable risk

Purely security patch (0.31.2→0.32.0), no API changes. Python 3.8+ requirement satisfied by Hermes Python 3.11/3.12.

Fixes GHSA-j5g9-f88f-gfj3