### PR TITLE
fix(gateway): exclude Ollama Cloud from GLM truncation detection; propagate partial flag (#72316)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3544,12 +3544,13 @@ class APIServerAdapter(BasePlatformAdapter):
                         else ""
                     ),
                 )
+                is_partial = bool(result.get("partial")) if isinstance(result, dict) else False
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
                     "content": final_response,
                     "completed": True,
-                    "partial": False,
+                    "partial": is_partial,
                     "interrupted": False,
                     "runtime": effective_runtime,
                 }))

--- a/run_agent.py
+++ b/run_agent.py
@@ -1605,12 +1605,20 @@ class AIAgent:
         (LiteLLM/sglang/vLLM/LM Studio proxies, Tailscale boxes), which
         report finish_reason correctly and were the source of #13971's
         false-positive truncation continuations.
+
+        Also excludes Ollama Cloud (ollama.com) — the hosted service
+        correctly reports finish_reason and is not affected by the local
+        Ollama stop-reason bug (GH-72316).
         """
         model_lower = (self.model or "").lower()
         provider_lower = (self.provider or "").lower()
         if "glm" not in model_lower and provider_lower != "zai":
             return False
-        if "ollama" in self._base_url_lower or ":11434" in self._base_url_lower:
+        base = self._base_url_lower
+        # Exclude Ollama Cloud (ollama.com) — hosted service, not local Ollama
+        if "ollama.com" in base:
+            return False
+        if "ollama" in base or ":11434" in base:
             return True
         return provider_lower == "ollama"
 


### PR DESCRIPTION
## Problem

Two compounding bugs cause the WebUI to discard or misrender agent responses when using GLM-5.2 on Ollama Cloud:

**Bug 1 — False-positive truncation detection**: `_is_ollama_glm_backend()` in `run_agent.py` matches `"ollama"` in the base URL, which includes Ollama Cloud (`ollama.com`). The hosted service correctly reports `finish_reason` and is not affected by the local Ollama stop-reason bug. The false match causes a spurious `[System: Your previous response was truncated...]` continuation prompt.

**Bug 2 — SSE session stream hardcodes `partial: False`**: `_handle_session_chat_stream()` in `api_server.py` always sends `"partial": False` in the `assistant.completed` event, ignoring `result.get("partial")`. The WebUI cannot detect truncation and renders partial responses incorrectly (showing only the last few lines instead of the full response).

## Fix

1. Exclude `"ollama.com"` from `_is_ollama_glm_backend()` before the `"ollama"` substring check.
2. Read `result.get("partial")` in the session-chat-stream SSE path, matching the pattern used by other SSE paths in the same file.

## Testing

- Existing tests pass.
- Manual verification: `_is_ollama_glm_backend()` returns `False` for `base_url="https://ollama.com/v1"` and `True` for `base_url="http://localhost:11434"`.

Fixes #72316