### PR TITLE
fix: raise python-multipart core floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dependencies = [
   # FastAPI's UploadFile/Form depend on python-multipart; it is NOT pulled in
   # by fastapi itself, so the dashboard's multipart upload endpoint would 500
   # without an explicit dependency here (and in the `web` extra below).
-  "python-multipart>=0.0.9,<1",
+  "python-multipart>=0.0.30,<1",
   "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",
   "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
   # Desktop SSH's Windows remote runtime (hermes_cli/windows_ssh_runtime.py)

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -74,6 +74,23 @@ _UPDATE_DOWNGRADE_GUARD_FLOORS = {
 }
 
 
+def test_core_python_multipart_floor_blocks_ghsa_5rvq_cxj2_64vf():
+    """Core installs must reject python-multipart versions affected by GHSA-5RVQ-CXJ2-64VF."""
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    core = data["project"]["dependencies"]
+    specs = [dep for dep in core if _distribution_name(dep) == "python-multipart"]
+
+    assert specs, "python-multipart must stay a declared core dependency for dashboard uploads"
+    assert any(
+        ">=0.0.30" in spec and "<1" in spec
+        for spec in specs
+    ), (
+        "GHSA-5RVQ-CXJ2-64VF affects python-multipart <0.0.30; the core "
+        "dependency floor must force upgrades instead of accepting vulnerable "
+        "already-installed versions"
+    )
+
+
 def _version_tuple(spec: str) -> tuple[int, ...]:
     # "1.0.1" -> (1, 0, 1); tolerant of pre/post suffixes by truncating.
     head = spec.split("+", 1)[0]

--- a/uv.lock
+++ b/uv.lock
@@ -1822,7 +1822,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
-    { name = "python-multipart", specifier = ">=0.0.9,<1" },
+    { name = "python-multipart", specifier = ">=0.0.30,<1" },
     { name = "python-multipart", marker = "extra == 'web'", specifier = "==0.0.32" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = "==22.6" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = "==22.6" },


### PR DESCRIPTION
## Summary
- raise the core `python-multipart` dependency floor from `>=0.0.9,<1` to `>=0.0.30,<1` so vulnerable already-installed versions no longer satisfy core installs/updates
- keep the existing dashboard/web/lazy pins at `python-multipart==0.0.32`
- update `uv.lock` requires-dist and add a packaging regression guard for GHSA-5RVQ-CXJ2-64VF

## Verification
- `PYTHONPATH=. /home/frank/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_packaging_metadata.py::test_core_python_multipart_floor_blocks_ghsa_5rvq_cxj2_64vf -q -o 'addopts='` => 1 passed
- `uv lock --upgrade-package python-multipart` => Resolved 233 packages
- `UV_PROJECT_ENVIRONMENT=/home/frank/.hermes/hermes-agent/venv uv run --no-sync python -m pytest tests/test_project_metadata.py -q -o 'addopts='` => 12 passed
- `UV_PROJECT_ENVIRONMENT=/home/frank/.hermes/hermes-agent/venv uv run --no-sync python -m pytest tests/test_packaging_metadata.py -q -o 'addopts='` => 9 passed
- `uv lock --check` => Resolved 233 packages in 1ms
- import smoke for `multipart`, `starlette`, `fastapi`, `mcp` => `IMPORT_SMOKE_OK 0.0.30 1.0.1 0.133.1 mcp-imported`
- `/home/frank/.local/bin/hermes security audit --fail-on high` exits 1 for unrelated HIGHs; target `GHSA-5RVQ-CXJ2-64VF` absent and no HIGH python-multipart lines

## Scope notes
- clean branch from `origin/main` commit `1cd8f8c37`
- changed files: `pyproject.toml`, `uv.lock`, `tests/test_packaging_metadata.py`
- no production deploy, credentials/secrets, money, irreversible data operations, or new spend

Kanban: jarvis-os/t_932b04cd, source jarvis-os/t_30d78f66.
