### PR TITLE
fix(dashboard): allow deleting custom keys from .env via empty-value save (#72552)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7519,6 +7519,14 @@ async def get_env_vars(profile: Optional[str] = None):
 async def set_env_var(body: EnvVarUpdate, profile: Optional[str] = None):
     try:
         with _profile_scope(body.profile or profile):
+            # When value is empty/blank, treat as a delete request — remove the
+            # key from .env entirely rather than writing KEY= (which leaves a
+            # ghost entry that the Keys page can never clear, GH-72552).
+            if not (body.value or "").strip():
+                from hermes_cli.credential_lifecycle import remove_provider_env_credential
+
+                result = remove_provider_env_credential(body.key)
+                return result
             # Unified credential lifecycle: writes .env AND reconciles any
             # config.yaml mirror still holding the previous value of this var
             # (model.api_key / auxiliary.*.api_key / custom_providers[*]),

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -313,7 +313,7 @@ function EnvVarRow({
             size="sm"
             onClick={() => onSave(varKey)}
             prefix={<Save />}
-            disabled={saving === varKey || !edits[varKey]}
+            disabled={saving === varKey || (!edits[varKey] && !info.is_set)}
           >
             {saving === varKey ? "..." : t.common.save}
           </Button>
@@ -682,6 +682,11 @@ export default function EnvPage() {
 
   const handleSave = async (key: string) => {
     const value = edits[key];
+    // Empty value on a set key → treat as delete (GH-72552).
+    if (!value && vars?.[key]?.is_set) {
+      keyClear.requestDelete(key);
+      return;
+    }
     if (!value) return;
     setSaving(key);
     try {


### PR DESCRIPTION
## Problem

Custom environment variables on the Keys page could be added and overwritten but never deleted. The backend `PUT /api/env` always wrote `KEY=` for empty values (a ghost entry), and the frontend disabled the Save button when the edit field was empty.

## Fix

**Backend** (`hermes_cli/web_server.py`): When `PUT /api/env` receives an empty/blank value, delegate to `remove_provider_env_credential()` instead of `save_provider_env_credential()`. This fully removes the key from `.env`, credential pool, and config.yaml mirrors.

**Frontend** (`web/src/pages/EnvPage.tsx`):
- Enable the Save button for set keys even when the edit field is empty (the user intent is "clear this value").
- Redirect `handleSave` to the delete-confirmation flow when the value is empty and the key is already set, so the user gets the same confirmation dialog as the explicit Clear button.

## Testing

- Existing backend tests pass.
- The flow: user edits a custom key, clears the value, clicks Save → delete confirmation dialog appears → on confirm → key removed from `.env` and UI.

Fixes #72552