### PR TITLE
fix(cli): preserve live Kimi catalog on discovery failure

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -323,6 +323,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "kimi-coding": [
         "kimi-k3",
+        "k3-256k",
         "kimi-k2.7-code",
         "kimi-k2.6",
         "kimi-k2.5",
@@ -2592,6 +2593,24 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
     return merged
 
 
+class _ProviderModelCatalog(list[str]):
+    """List-compatible catalog carrying whether it is safe to persist.
+
+    Public callers still receive a normal ``list`` interface. The disk-cache
+    wrapper uses ``cacheable`` to avoid pinning a static fallback returned
+    after transient live discovery failures.
+    """
+
+    def __init__(self, models: list[str], *, cacheable: bool = True):
+        super().__init__(models)
+        self.cacheable = cacheable
+
+
+def _fallback_provider_models(models: list[str]) -> list[str]:
+    """Return a renderable static fallback that must not overwrite live cache."""
+    return _ProviderModelCatalog(list(models), cacheable=False)
+
+
 def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
     """Return the best known model catalog for a provider.
 
@@ -2778,6 +2797,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     # ── Profile-based generic live fetch (all simple api-key providers) ──
     # Handles any provider registered in providers/ with auth_type="api_key".
     # Replaces per-provider copy-paste blocks (stepfun, gmi, zai, etc.).
+    profile_live_attempted = False
     try:
         from providers import get_provider_profile
         from hermes_cli.auth import resolve_api_key_provider_credentials
@@ -2793,6 +2813,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if not base_url:
                 base_url = _p.base_url
             if api_key:
+                profile_live_attempted = True
                 live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
                 if live:
                     # Merge static curated list with live API results so
@@ -2829,13 +2850,18 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     return live
             # Use profile's fallback_models if defined
             if _p.fallback_models:
-                return list(_p.fallback_models)
+                fallback = list(_p.fallback_models)
+                if profile_live_attempted:
+                    return _fallback_provider_models(fallback)
+                return fallback
     except Exception:
         pass
 
     curated_static = list(_PROVIDER_MODELS.get(normalized, []))
     if normalized in _MODELS_DEV_PREFERRED:
         return _merge_with_models_dev(normalized, curated_static)
+    if profile_live_attempted:
+        return _fallback_provider_models(curated_static)
     return curated_static
 
 
@@ -2855,8 +2881,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
 #     normally reads. Swap your OPENAI_API_KEY and the entry invalidates.
 #   - 1h TTL by default. `force_refresh=True` skips the cache entirely
 #     and overwrites it on success.
-#   - Only NON-EMPTY results are cached. An empty/None response from a
-#     transient network error never gets pinned.
+#   - Only NON-EMPTY, cacheable results are cached. A static fallback returned
+#     after a transient live discovery failure is renderable but never pinned.
 #   - Cache file is best-effort. Any read/write error degrades silently
 #     to a live fetch — the picker keeps working.
 
@@ -2971,8 +2997,10 @@ def cached_provider_model_ids(
 ) -> list[str]:
     """Disk-cached wrapper around :func:`provider_model_ids`.
 
-    Hits the cache when fresh; otherwise calls the live function and
-    persists a non-empty result. Always returns a list (never None).
+    Hits the cache when fresh; otherwise calls the discovery function and
+    persists a non-empty result only when it is safe to cache. Static
+    fallbacks remain renderable but cannot replace a last-known live catalog.
+    Always returns a list (never None).
     """
     normalized = normalize_provider(provider) or (provider or "")
     if not normalized:
@@ -2993,20 +3021,24 @@ def cached_provider_model_ids(
     ):
         return list(entry["models"])
 
-    # Cache miss / stale / forced refresh — call the live path.
-    live = provider_model_ids(normalized, force_refresh=force_refresh)
-    if live:
+    # Cache miss / stale / forced refresh — run provider discovery. Static
+    # fallbacks are useful for rendering but are explicitly non-cacheable, so
+    # a transient failure cannot replace a last-known live-only catalog.
+    discovered = provider_model_ids(normalized, force_refresh=force_refresh)
+    models = list(discovered or [])
+    cacheable = bool(getattr(discovered, "cacheable", True))
+    if models and cacheable:
         cache[normalized] = {
             "fp": fp,
             "at": now,
-            "models": list(live),
+            "models": models,
         }
         _save_provider_models_cache(cache)
-        return list(live)
+        return models
 
-    # Live fetch returned nothing. If we have a stale entry with the
-    # SAME fingerprint, prefer it over an empty result — stale data
-    # beats no data when the network is flaky.
+    # Discovery returned nothing or only a non-cacheable fallback. If we have
+    # a stale entry with the SAME fingerprint, prefer it — last-known live
+    # data beats a degraded fallback when the network is flaky.
     if (
         isinstance(entry, dict)
         and entry.get("fp") == fp
@@ -3014,7 +3046,7 @@ def cached_provider_model_ids(
         and entry["models"]
     ):
         return list(entry["models"])
-    return list(live or [])
+    return models
 
 
 def clear_provider_models_cache(provider: Optional[str] = None) -> None:

--- a/tests/hermes_cli/test_provider_model_cache_provenance.py
+++ b/tests/hermes_cli/test_provider_model_cache_provenance.py
@@ -1,0 +1,178 @@
+"""Regression coverage for provider model-cache fallback provenance."""
+
+from copy import deepcopy
+
+from hermes_cli import models as models_mod
+
+
+def test_kimi_coding_fallback_keeps_current_long_context_model():
+    assert "k3-256k" in models_mod._PROVIDER_MODELS["kimi-coding"]
+
+
+def test_profile_fallback_is_marked_non_cacheable(monkeypatch):
+    import providers
+    from hermes_cli import auth
+
+    class FakeProfile:
+        auth_type = "api_key"
+        base_url = "https://api.kimi.com/coding/v1"
+        fallback_models = ("fallback-only",)
+
+        @staticmethod
+        def fetch_models(*, api_key, base_url):
+            assert api_key == "test-key"
+            assert base_url == "https://api.kimi.com/coding/v1"
+            return None
+
+    monkeypatch.setattr(providers, "get_provider_profile", lambda _slug: FakeProfile())
+    monkeypatch.setattr(
+        auth,
+        "resolve_api_key_provider_credentials",
+        lambda _slug: {
+            "api_key": "test-key",
+            "base_url": "https://api.kimi.com/coding/v1",
+        },
+    )
+
+    result = models_mod.provider_model_ids("kimi-coding", force_refresh=True)
+
+    assert result == ["fallback-only"]
+    assert getattr(result, "cacheable", True) is False
+
+
+def test_successful_profile_discovery_remains_cacheable(monkeypatch):
+    import providers
+    from hermes_cli import auth
+
+    class FakeProfile:
+        auth_type = "api_key"
+        base_url = "https://api.kimi.com/coding/v1"
+        fallback_models = ("fallback-only",)
+
+        @staticmethod
+        def fetch_models(*, api_key, base_url):
+            assert api_key == "test-key"
+            assert base_url == "https://api.kimi.com/coding/v1"
+            return ["kimi-for-coding", "k3", "k3-256k"]
+
+    monkeypatch.setattr(providers, "get_provider_profile", lambda _slug: FakeProfile())
+    monkeypatch.setattr(
+        auth,
+        "resolve_api_key_provider_credentials",
+        lambda _slug: {
+            "api_key": "test-key",
+            "base_url": "https://api.kimi.com/coding/v1",
+        },
+    )
+
+    result = models_mod.provider_model_ids("kimi-coding", force_refresh=True)
+
+    assert "k3-256k" in result
+    assert getattr(result, "cacheable", True) is True
+
+
+def test_failed_refresh_preserves_stale_live_only_models(monkeypatch):
+    stale_live = ["kimi-for-coding", "k3", "k3-256k"]
+    fallback = models_mod._ProviderModelCatalog(
+        list(models_mod._PROVIDER_MODELS["kimi-coding"]),
+        cacheable=False,
+    )
+    cache = {
+        "kimi-coding": {
+            "fp": "same-credentials",
+            "at": 1.0,
+            "models": stale_live,
+        }
+    }
+    saved = []
+
+    monkeypatch.setattr(models_mod, "_load_provider_models_cache", lambda: deepcopy(cache))
+    monkeypatch.setattr(
+        models_mod,
+        "_credential_fingerprint",
+        lambda _provider: "same-credentials",
+    )
+    monkeypatch.setattr(
+        models_mod,
+        "provider_model_ids",
+        lambda _provider, force_refresh=False: fallback,
+    )
+    monkeypatch.setattr(
+        models_mod,
+        "_save_provider_models_cache",
+        lambda data: saved.append(deepcopy(data)),
+    )
+
+    result = models_mod.cached_provider_model_ids(
+        "kimi-coding",
+        force_refresh=True,
+    )
+
+    assert result == stale_live
+    assert "k3-256k" in result
+    assert saved == []
+
+
+def test_fallback_is_rendered_but_not_cached_without_live_history(monkeypatch):
+    fallback = models_mod._ProviderModelCatalog(
+        list(models_mod._PROVIDER_MODELS["kimi-coding"]),
+        cacheable=False,
+    )
+    saved = []
+
+    monkeypatch.setattr(models_mod, "_load_provider_models_cache", lambda: {})
+    monkeypatch.setattr(
+        models_mod,
+        "_credential_fingerprint",
+        lambda _provider: "same-credentials",
+    )
+    monkeypatch.setattr(
+        models_mod,
+        "provider_model_ids",
+        lambda _provider, force_refresh=False: fallback,
+    )
+    monkeypatch.setattr(
+        models_mod,
+        "_save_provider_models_cache",
+        lambda data: saved.append(deepcopy(data)),
+    )
+
+    result = models_mod.cached_provider_model_ids(
+        "kimi-coding",
+        force_refresh=True,
+    )
+
+    assert result == list(fallback)
+    assert saved == []
+
+
+def test_successful_live_catalog_is_cached(monkeypatch):
+    live = ["kimi-for-coding", "k3", "k3-256k"]
+    saved = []
+
+    monkeypatch.setattr(models_mod, "_load_provider_models_cache", lambda: {})
+    monkeypatch.setattr(
+        models_mod,
+        "_credential_fingerprint",
+        lambda _provider: "same-credentials",
+    )
+    monkeypatch.setattr(
+        models_mod,
+        "provider_model_ids",
+        lambda _provider, force_refresh=False: live,
+    )
+    monkeypatch.setattr(
+        models_mod,
+        "_save_provider_models_cache",
+        lambda data: saved.append(deepcopy(data)),
+    )
+
+    result = models_mod.cached_provider_model_ids(
+        "kimi-coding",
+        force_refresh=True,
+    )
+
+    assert result == live
+    assert len(saved) == 1
+    assert saved[0]["kimi-coding"]["fp"] == "same-credentials"
+    assert saved[0]["kimi-coding"]["models"] == live


### PR DESCRIPTION
## Summary

- preserve the last successful live Kimi model catalog when a transient discovery request fails
- avoid caching the degraded static fallback as though it were a successful live response
- keep the static fallback available when no successful live catalog exists
- add `k3-256k` to the Kimi Coding fallback catalog
- add regression coverage for successful, failed, and fallback-only discovery paths

## Problem

A transient Kimi Code `/models` failure could return the static fallback list and cache it for the normal TTL. Because that fallback omitted live-only models such as `k3-256k`, the model picker could hide a model that was still available to the same credentials.

## Testing

Added focused regression tests covering:

- successful live discovery is cached
- a failed refresh preserves the last successful live catalog
- fallback data is still returned when no live catalog exists
- degraded fallback results are not pinned in the cache
- force refresh preserves the last known live catalog on failure
- the Kimi fallback includes `k3-256k`

Fixes #73184