### PR TITLE
fix(desktop): route /branch from tile to the tile's session, not the foreground chat

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -555,6 +555,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     activeSessionId,
     activeSessionIdRef,
     branchCurrentSession: branchInNewChat,
+    branchStoredSession,
     busyRef,
     createBackendSessionForSend,
     getRoutedStoredSessionId,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -150,6 +150,7 @@ function Harness({
     activeSessionId: activeSessionId === undefined ? RUNTIME_SESSION_ID : activeSessionId,
     activeSessionIdRef,
     branchCurrentSession: async () => true,
+    branchStoredSession: async () => true,
     busyRef: localBusyRef,
     createBackendSessionForSend: createBackendSessionForSend ?? (async () => RUNTIME_SESSION_ID),
     getRoutedStoredSessionId: getRoutedStoredSessionId ?? (() => null),

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -174,6 +174,7 @@ interface PromptActionsOptions {
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
   branchCurrentSession: () => Promise<boolean>
+  branchStoredSession: (storedSessionId: string, sessionProfile?: string | null) => Promise<boolean>
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
   getRoutedStoredSessionId: () => null | string
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
@@ -205,6 +206,7 @@ export function usePromptActions({
   activeSessionIdRef,
   busyRef,
   branchCurrentSession,
+  branchStoredSession,
   createBackendSessionForSend,
   getRoutedStoredSessionId,
   getRuntimeIdForStoredSession,
@@ -496,6 +498,7 @@ export function usePromptActions({
     activeSessionIdRef,
     appendSessionTextMessage,
     branchCurrentSession,
+    branchStoredSession,
     busyRef,
     copy,
     createBackendSessionForSend,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -78,6 +78,7 @@ interface SlashCommandDeps {
     storedSessionId?: string | null
   ) => void
   branchCurrentSession: () => Promise<boolean>
+  branchStoredSession: (storedSessionId: string, sessionProfile?: string | null) => Promise<boolean>
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
@@ -108,6 +109,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
     activeSessionIdRef,
     appendSessionTextMessage,
     branchCurrentSession,
+    branchStoredSession,
     busyRef,
     copy,
     createBackendSessionForSend,
@@ -426,7 +428,25 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         new: async () => {
           startFreshSessionDraft()
         },
-        branch: async () => {
+        branch: async ({ sessionHint }) => {
+          // When dispatched from a tile (⌘T tab, split pane), sessionHint
+          // carries the tile's runtime ID.  branchCurrentSession() reads
+          // foreground-only refs (activeSessionIdRef, $messages, busyRef),
+          // so it would branch the primary chat instead.  Route through
+          // branchStoredSession for non-foreground targets — it reads the
+          // stored transcript directly and does not depend on the active
+          // session or live message store.
+          if (sessionHint && sessionHint !== activeSessionIdRef.current) {
+            const states = $sessionStates.get()
+            const storedId = states[sessionHint]?.storedSessionId
+
+            if (storedId) {
+              await branchStoredSession(storedId)
+
+              return
+            }
+          }
+
           await branchCurrentSession()
         },
         // /compress (alias /compact) runs the gateway's dedicated
@@ -953,6 +973,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       activeSessionIdRef,
       appendSessionTextMessage,
       branchCurrentSession,
+      branchStoredSession,
       busyRef,
       copy,
       createBackendSessionForSend,


### PR DESCRIPTION
## Summary

Fixes #73207. When `/branch` is dispatched from a session tile (⌘T tab or split pane), the slash dispatcher forwards the tile's runtime ID as `sessionHint`. The `branch` action handler previously **ignored** `sessionHint` and called `branchCurrentSession()`, which reads foreground-only refs (`activeSessionIdRef`, `$messages`, `busyRef`, `selectedStoredSessionIdRef`) and always branches the primary chat — regardless of which tile the command was entered from.

## Root Cause

The `branch` handler at `slash.ts:429` was the only action handler that didn't destructure or forward `sessionHint` from the `SlashActionCtx`. All other session-targeting handlers (`yolo`, `handoff`, `skin`) already extract and use it:

```typescript
// Before (broken)
branch: async () => {
  await branchCurrentSession()
},

// yolo — already correct
yolo: async ({ sessionHint }) => {
  const sid = sessionHint || activeSessionIdRef.current
  // ...
```

## Fix

When `sessionHint` targets a non-foreground session, resolve the tile's stored session ID from `$sessionStates` and use `branchStoredSession()` instead. `branchStoredSession` reads the stored transcript directly from the backend — no active-session or live message-store dependency — so it correctly branches the tile's session.

The foreground path (no `sessionHint`, or `sessionHint === activeSessionIdRef.current`) is unchanged.

## Changes

| File | Change |
|------|--------|
| `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts` | Add `branchStoredSession` to `SlashCommandDeps`; update `branch` handler to check `sessionHint` |
| `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts` | Add `branchStoredSession` to `PromptActionsOptions`; forward to `useSlashCommand` |
| `apps/desktop/src/app/contrib/wiring.tsx` | Pass `branchStoredSession` from `useSessionActions` to `usePromptActions` |
| `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx` | Add mock `branchStoredSession` to test harness |

## Test Plan

- [ ] Desktop E2E tests pass (CI)
- [ ] Branching from the foreground chat still works (no regression)
- [ ] Branching from a tile creates the branch under the tile's session
- [ ] Branching from a tile with no stored session ID falls back to foreground behavior