### PR TITLE
fix(gateway): deliver generated media despite stale marker

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1491,6 +1491,52 @@ def _collect_auto_append_media_tags(
     return media_tags, has_voice_directive
 
 
+def _append_auto_media_tags_to_response(
+    final_response: str,
+    messages: List[Dict[str, Any]],
+    history_offset: int = 0,
+    history_media_paths: Optional[set] = None,
+) -> str:
+    """Append producer artifacts missing from the assistant's final response.
+
+    A literal or stale ``MEDIA:`` token is not proof that the response already
+    references the artifact produced this turn. In particular, models may echo
+    a sandbox-only path while ``image_generate`` also returned the distinct
+    host path that the gateway can deliver. Deduplicate by recognized path
+    instead of suppressing all auto-append behavior on a substring match.
+    """
+    media_tags, has_voice_directive = _collect_auto_append_media_tags(
+        messages,
+        history_offset=history_offset,
+        history_media_paths=history_media_paths,
+    )
+
+    existing_paths = {
+        match.group(1).strip().rstrip('",}')
+        for match in _TOOL_MEDIA_RE.finditer(final_response)
+    }
+    missing_tags: List[str] = []
+    seen_paths = set(existing_paths)
+    for tag in media_tags:
+        match = _TOOL_MEDIA_RE.fullmatch(tag)
+        if not match:
+            continue
+        path = match.group(1).strip().rstrip('",}')
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        missing_tags.append(tag)
+
+    directives: List[str] = []
+    if has_voice_directive and "[[audio_as_voice]]" not in final_response:
+        directives.append("[[audio_as_voice]]")
+    directives.extend(missing_tags)
+    if not directives:
+        return final_response
+    return final_response + "\n" + "\n".join(directives)
+
+
+
 def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
     """Collect every media path already delivered in prior assistant/tool output.
 
@@ -5277,23 +5323,12 @@ class TurnRunner:
         # also the sole guard on the fallback branch taken when mid-run
         # context compression shrinks the message list below the original
         # history length, preserving the compression-safe behaviour of #160.
-        if "MEDIA:" not in final_response:
-            media_tags, has_voice_directive = _collect_auto_append_media_tags(
-                result.get("messages", []),
-                history_offset=len(agent_history),
-                history_media_paths=_history_media_paths,
-            )
-
-            if media_tags:
-                seen = set()
-                unique_tags = []
-                for tag in media_tags:
-                    if tag not in seen:
-                        seen.add(tag)
-                        unique_tags.append(tag)
-                if has_voice_directive:
-                    unique_tags.insert(0, "[[audio_as_voice]]")
-                final_response = final_response + "\n" + "\n".join(unique_tags)
+        final_response = _append_auto_media_tags_to_response(
+            final_response,
+            result.get("messages", []),
+            history_offset=len(agent_history),
+            history_media_paths=_history_media_paths,
+        )
 
         # Auto-generate session title after first exchange (non-blocking)
         if final_response and self._runner._session_db:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1461,6 +1461,52 @@ def _collect_auto_append_media_tags(
     return media_tags, has_voice_directive
 
 
+def _append_auto_media_tags_to_response(
+    final_response: str,
+    messages: List[Dict[str, Any]],
+    history_offset: int = 0,
+    history_media_paths: Optional[set] = None,
+) -> str:
+    """Append producer artifacts missing from the assistant's final response.
+
+    A literal or stale ``MEDIA:`` token is not proof that the response already
+    references the artifact produced this turn. In particular, models may echo
+    a sandbox-only path while ``image_generate`` also returned the distinct
+    host path that the gateway can deliver. Deduplicate by recognized path
+    instead of suppressing all auto-append behavior on a substring match.
+    """
+    media_tags, has_voice_directive = _collect_auto_append_media_tags(
+        messages,
+        history_offset=history_offset,
+        history_media_paths=history_media_paths,
+    )
+
+    existing_paths = {
+        match.group(1).strip().rstrip('",}')
+        for match in _TOOL_MEDIA_RE.finditer(final_response)
+    }
+    missing_tags: List[str] = []
+    seen_paths = set(existing_paths)
+    for tag in media_tags:
+        match = _TOOL_MEDIA_RE.fullmatch(tag)
+        if not match:
+            continue
+        path = match.group(1).strip().rstrip('",}')
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        missing_tags.append(tag)
+
+    directives: List[str] = []
+    if has_voice_directive and "[[audio_as_voice]]" not in final_response:
+        directives.append("[[audio_as_voice]]")
+    directives.extend(missing_tags)
+    if not directives:
+        return final_response
+    return final_response + "\n" + "\n".join(directives)
+
+
+
 def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
     """Dedup set of media paths already delivered (JSON-payload and assistant-message shapes alike).
 

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1673,29 +1673,13 @@ class TurnRunner:
         extract_media() delivers each file once. Scoped to THIS turn (slice at len(agent_history)) so
         a stale MEDIA: path from an earlier turn never rides a later reply; the history-path dedup is
         the secondary guard — and the sole one when mid-run compression shrank the list."""
-        from gateway.run import _collect_auto_append_media_tags
-        if "MEDIA:" in final_response:
-            return final_response
-        # Scan tool results for MEDIA:<path> tags that need to be delivered as native audio/file
-        # attachments. The TTS tool embeds MEDIA: tags in its JSON response, but the model's final text
-        # reply usually doesn't include them. We collect unique tags from tool results and append any that
-        # aren't already present in the final response, so the adapter's extract_media() can find and
-        # deliver the files exactly once. Scope the scan to THIS turn's tool results only. ``agent_history``
-        # was passed into run_conversation as ``conversation_history``, so the agent's returned ``messages``
-        # list is ``agent_history`` followed by the messages produced this turn. Slicing at
-        # ``len(agent_history)`` isolates the current turn precisely, so a stale MEDIA: path emitted by a
-        # tool several turns earlier (still present in the full message list) can never leak onto a later
-        # text-only reply. (Fixes #34608) Path-based deduplication against _history_media_paths (collected
-        # before run_conversation) is retained as a secondary guard. It is also the sole guard on the
-        # fallback branch taken when mid-run context compression shrinks the message list below the original
-        # history length, preserving the compression-safe behaviour of #160.
-        media_tags, has_voice_directive = _collect_auto_append_media_tags(
-            result.get("messages", []), history_offset=len(agent_history), history_media_paths=history_media_paths,
+        from gateway.run import _append_auto_media_tags_to_response
+        return _append_auto_media_tags_to_response(
+            final_response,
+            result.get("messages", []),
+            history_offset=len(agent_history),
+            history_media_paths=history_media_paths,
         )
-        if not media_tags:
-            return final_response
-        unique_tags = (["[[audio_as_voice]]"] if has_voice_directive else []) + list(dict.fromkeys(media_tags))
-        return final_response + "\n" + "\n".join(unique_tags)
 
     def run_sync(self):
         """Executor-thread body of the turn; returns the gateway result dict.

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -326,6 +326,60 @@ caption
         assert tags == []
         assert voice is False
 
+    def test_gateway_auto_append_ignores_unrelated_media_placeholder(self):
+        """A bogus model path must not suppress the real generated-image path."""
+        from gateway.run import _append_auto_media_tags_to_response
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_img", "function": {"name": "image_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_img",
+                "content": (
+                    '{"success": true, "host_image": "/host/dog.jpg", '
+                    '"agent_visible_image": "/sandbox/dog.jpg"}'
+                ),
+            },
+        ]
+
+        response = _append_auto_media_tags_to_response(
+            "Here it is: MEDIA:/path/to/image",
+            messages,
+        )
+
+        assert response.endswith("MEDIA:/host/dog.jpg")
+
+    def test_gateway_auto_append_dedupes_existing_response_path(self):
+        """The producer path is not appended twice when the model used it."""
+        from gateway.run import _append_auto_media_tags_to_response
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_img", "function": {"name": "image_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_img",
+                "content": '{"success": true, "host_image": "/host/dog.jpg"}',
+            },
+        ]
+
+        response = _append_auto_media_tags_to_response(
+            "Here it is: MEDIA:/host/dog.jpg",
+            messages,
+        )
+
+        assert response.count("MEDIA:/host/dog.jpg") == 1
+
+
 
     def test_collect_history_media_paths_includes_image_generate_json(self):
         """Regression for #46627: the history media-path collector must pick up

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -138,6 +138,60 @@ caption
         assert tags == []
         assert voice is False
 
+    def test_gateway_auto_append_ignores_unrelated_media_placeholder(self):
+        """A bogus model path must not suppress the real generated-image path."""
+        from gateway.run import _append_auto_media_tags_to_response
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_img", "function": {"name": "image_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_img",
+                "content": (
+                    '{"success": true, "host_image": "/host/dog.jpg", '
+                    '"agent_visible_image": "/sandbox/dog.jpg"}'
+                ),
+            },
+        ]
+
+        response = _append_auto_media_tags_to_response(
+            "Here it is: MEDIA:/path/to/image",
+            messages,
+        )
+
+        assert response.endswith("MEDIA:/host/dog.jpg")
+
+    def test_gateway_auto_append_dedupes_existing_response_path(self):
+        """The producer path is not appended twice when the model used it."""
+        from gateway.run import _append_auto_media_tags_to_response
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_img", "function": {"name": "image_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_img",
+                "content": '{"success": true, "host_image": "/host/dog.jpg"}',
+            },
+        ]
+
+        response = _append_auto_media_tags_to_response(
+            "Here it is: MEDIA:/host/dog.jpg",
+            messages,
+        )
+
+        assert response.count("MEDIA:/host/dog.jpg") == 1
+
+
 
     def test_collect_history_media_paths_includes_image_generate_json(self):
         """Regression for #46627: the history media-path collector must pick up


### PR DESCRIPTION
## Problem

A successful `image_generate` call can return both a gateway-host path and an agent-visible sandbox path. If the model's final response contains any `MEDIA:` token—including a stale sandbox path or literal placeholder—the gateway skips auto-appending the valid host artifact entirely. The user sees `MEDIA:/path/to/image`, while the generated image is never delivered.

## Fix

Always collect current-turn producer artifacts, then deduplicate by recognized media path instead of gating on the presence of the `MEDIA:` substring. Existing history/compression guards and downstream path validation remain unchanged. TTS voice directives are preserved independently.

## Verification

- `scripts/run_tests.sh tests/gateway/test_media_extraction.py -q` — 17 passed
- Smoke: successful image tool result + literal `MEDIA:/path/to/image` produced the host image in `BasePlatformAdapter.extract_media`
- Focused reviewer: no findings