### PR TITLE
fix(model-switch): prevent auto-correct from stripping meaningful model qualifiers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -643,16 +643,16 @@ def strip_think_blocks(agent, content: str) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
 
     Handles four cases:
-      1. Closed tag pairs (``<think>…</think>``) — the common path when
+      1. Closed tag pairs (`` 执教… ``) — the common path when
          the provider emits complete reasoning blocks.
       2. Unterminated open tag at a block boundary (start of text or
          after a newline) — e.g. MiniMax M2.7 / NIM endpoints where the
          closing tag is dropped.  Everything from the open tag to end
          of string is stripped.  The block-boundary check mirrors
          ``gateway/stream_consumer.py``'s filter so models that mention
-         ``<think>`` in prose aren't over-stripped.
+         `` 执教`` in prose aren't over-stripped.
       3. Stray orphan open/close tags that slip through.
-      4. Tag variants: ``<think>``, ``<thinking>``, ``<reasoning>``,
+      4. Tag variants: `` 执教``, ``<thinking>``, ``<reasoning>``,
          ``<REASONING_SCRATCHPAD>``, ``<thought>`` (Gemma 4), all
          case-insensitive.
 
@@ -670,6 +670,21 @@ def strip_think_blocks(agent, content: str) -> str:
     after punctuation and carries a ``name="..."`` attribute) so prose
     mentions like "Use <function> in JavaScript" are preserved.
     """
+    # Defensive coercion: callers may pass multimodal content-parts lists
+    # (e.g. after vision turns or context compaction). Extract any text
+    # blocks and drop non-text parts before running regexes.
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        content = "\n".join(parts)
+    elif not isinstance(content, str):
+        content = str(content) if content is not None else ""
     if not content:
         return ""
     # 1. Closed tag pairs — case-insensitive for all variants so

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -32,6 +32,7 @@ from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
+from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -1125,7 +1126,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # reasoning fields are present (some models/providers embed thinking
     # directly in the content rather than returning separate API fields).
     if not reasoning_text:
-        content = assistant_message.content or ""
+        content = flatten_message_text(getattr(assistant_message, "content", None))
         think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
         if think_blocks:
             combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
@@ -1151,7 +1152,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
     # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
     # can return invalid surrogate code points that crash json.dumps() on persist.
-    _raw_content = assistant_message.content or ""
+    _raw_content = flatten_message_text(getattr(assistant_message, "content", None))
     _san_content = _sanitize_surrogates(_raw_content)
     if reasoning_text:
         reasoning_text = _sanitize_surrogates(reasoning_text)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -24,6 +24,7 @@ import re
 import ssl
 import threading
 import time
+import traceback
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -5519,7 +5520,44 @@ def run_conversation(
                 break
             
         except Exception as e:
-            error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+            # Phase-aware error classification. The huge outer try/except spans
+            # both the actual API request and all local post-processing of the
+            # returned assistant message. Deterministic local bugs (e.g.
+            # passing a multimodal content list into a regex helper after a
+            # vision turn or context compaction) should not be retried: they
+            # will fail identically on every iteration and only burn the
+            # iteration budget. We classify an error as local by inspecting the
+            # traceback: if the exception propagated through any of the known
+            # local post-processing helpers and never entered the interruptible
+            # API-call helpers, it is almost certainly a local processing bug.
+            # (#66267)
+            _local_processing_modules = {
+                "agent_runtime_helpers",
+                "conversation_loop",
+                "message_content",
+                "run_agent",
+            }
+            _api_call_modules = {
+                "chat_completion_helpers",
+            }
+
+            tb_stack = traceback.extract_tb(e.__traceback__)
+            tb_module_names = {
+                os.path.splitext(os.path.basename(frame.filename))[0]
+                for frame in tb_stack
+            }
+            _hit_local = bool(tb_module_names & _local_processing_modules)
+            _hit_api = bool(tb_module_names & _api_call_modules)
+
+            _is_local_processing_error = _hit_local and not _hit_api
+
+            if _is_local_processing_error:
+                error_msg = (
+                    f"Error during local message processing after "
+                    f"OpenAI-compatible API call #{api_call_count}: {str(e)}"
+                )
+            else:
+                error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
             try:
                 print(f"❌ {error_msg}")
             except (OSError, ValueError):
@@ -5566,10 +5604,19 @@ def run_conversation(
             # message pollutes history, burns tokens, and risks violating
             # role-alternation invariants.
 
-            # If we're near the limit, break to avoid infinite loops
-            if api_call_count >= agent.max_iterations - 1:
-                _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
-                final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
+            # If we're near the limit, break to avoid infinite loops.
+            # Local processing errors are deterministic — stop immediately
+            # rather than retrying until the budget is exhausted.
+            if (
+                _is_local_processing_error
+                or api_call_count >= agent.max_iterations - 1
+            ):
+                if _is_local_processing_error:
+                    _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
+                    final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
+                else:
+                    _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
+                    final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                 # Append as assistant so the history stays valid for
                 # session resume (avoids consecutive user messages).
                 messages.append({"role": "assistant", "content": final_response})

--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -80,6 +80,22 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     if not is_schema:
         return repaired
 
+    # Rule 3: every object schema must carry an explicit ``required`` array,
+    # even if it is empty.  Moonshot rejects top-level tool parameters that
+    # are typed as object but omit ``required`` (``required`` should be an
+    # array).  Applying this recursively keeps nested object schemas valid too.
+    if repaired.get("type") == "object":
+        if "properties" not in repaired:
+            repaired["properties"] = {}
+        if not isinstance(repaired.get("required"), list):
+            repaired["required"] = []
+        else:
+            props = repaired.get("properties") or {}
+            repaired["required"] = [
+                r for r in repaired["required"]
+                if isinstance(r, str) and r in props
+            ]
+
     # Rule 2: when anyOf is present, type belongs only on the children.
     # Additionally, Moonshot rejects null-type branches inside anyOf
     # (enum value (<nil>) does not match any type in [string]).
@@ -174,17 +190,19 @@ def sanitize_moonshot_tool_parameters(parameters: Any) -> Dict[str, Any]:
     applied.  Input is not mutated.
     """
     if not isinstance(parameters, dict):
-        return {"type": "object", "properties": {}}
+        return {"type": "object", "properties": {}, "required": []}
 
     repaired = _repair_schema(copy.deepcopy(parameters), is_schema=True)
     if not isinstance(repaired, dict):
-        return {"type": "object", "properties": {}}
+        return {"type": "object", "properties": {}, "required": []}
 
     # Top-level must be an object schema
     if repaired.get("type") != "object":
         repaired["type"] = "object"
     if "properties" not in repaired:
         repaired["properties"] = {}
+    if "required" not in repaired:
+        repaired["required"] = []
 
     return repaired
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1319,9 +1319,38 @@ def switch_model(
                 error_message=msg,
             )
 
-    # Apply auto-correction if validation found a closer match
+    # Apply auto-correction if validation found a closer match.
+    # Guard: skip the correction when the original model name is a
+    # strict superset of the candidate — i.e. the original contains
+    # every segment the correction has, plus extra segments of its own.
+    # E.g. the user chose `gemini-3.5-flash-lite-preview` and the fuzzy
+    # matcher returned `gemini-3.5-flash-preview` (similarity 0.9057 ≥
+    # 0.9 cutoff).  The "-lite" segment is a deliberate qualifier, not
+    # a typo, so overriding it silently changes the user's intent.
+    # Conversely, `gemini-3.5-flash-perview` → `gemini-3.5-flash-preview`
+    # is a genuine typo (the segments differ by replacement, not addition),
+    # and the correction should still be applied.  See #73208.
     if validation.get("corrected_model"):
-        new_model = validation["corrected_model"]
+        corrected = validation["corrected_model"]
+        _orig_segments = set(s for s in re.split(r"[-_]", raw_input.strip().lower()) if s)
+        _corr_segments = set(s for s in re.split(r"[-_]", corrected.lower()) if s)
+        # Only skip when original is a strict superset: it has every
+        # segment from the correction AND additional segments of its own.
+        if _corr_segments < _orig_segments:
+            logger.info(
+                "Skipping auto-correct %r → %r: original is a strict superset "
+                "(extra segments: %s)",
+                raw_input.strip(), corrected, _orig_segments - _corr_segments,
+            )
+            validation.pop("corrected_model", None)
+            # Downgrade the message to a suggestion instead of a correction.
+            if validation.get("message", "").startswith("Auto-corrected"):
+                validation["message"] = (
+                    f"Note: `{raw_input.strip()}` was not found in the model listing. "
+                    f"Did you mean `{corrected}`?"
+                )
+        else:
+            new_model = corrected
 
     # --- Copilot api_mode override ---
     if target_provider in {"copilot", "github-copilot"}:

--- a/run_agent.py
+++ b/run_agent.py
@@ -148,6 +148,7 @@ from tools.browser_tool import cleanup_browser
 from agent.memory_manager import sanitize_context
 from agent.error_classifier import FailoverReason
 from agent.redact import redact_sensitive_text
+from agent.message_content import flatten_message_text
 from agent.model_metadata import (
     estimate_request_tokens_rough,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.estimate_request_tokens_rough")
     is_local_endpoint,
@@ -4816,12 +4817,15 @@ class AIAgent:
         response can contain both commentary and a partial/final-answer message
         while tools are still pending; treating top-level content as progress
         in that shape leaks the answer before the tool call runs.
+
+        Content may be a string or a structured parts list (e.g. after vision
+        turns or context compaction), so flatten it before stripping reasoning.
         """
         visible = self._extract_codex_interim_visible_text(assistant_msg)
         if visible:
             return visible
         content = assistant_msg.get("content")
-        return self._strip_think_blocks(content or "").strip()
+        return self._strip_think_blocks(flatten_message_text(content)).strip()
 
     def _interim_text_was_delivered(self, text: str) -> bool:
         normalized = self._normalize_interim_visible_text(text)

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -184,15 +184,86 @@ class TestTopLevelGuarantees:
     """The returned top-level schema is always a well-formed object."""
 
     def test_non_dict_input_returns_empty_object(self):
-        assert sanitize_moonshot_tool_parameters(None) == {"type": "object", "properties": {}}
-        assert sanitize_moonshot_tool_parameters("garbage") == {"type": "object", "properties": {}}
-        assert sanitize_moonshot_tool_parameters([]) == {"type": "object", "properties": {}}
+        assert sanitize_moonshot_tool_parameters(None) == {"type": "object", "properties": {}, "required": []}
+        assert sanitize_moonshot_tool_parameters("garbage") == {"type": "object", "properties": {}, "required": []}
+        assert sanitize_moonshot_tool_parameters([]) == {"type": "object", "properties": {}, "required": []}
 
     def test_non_object_top_level_coerced(self):
         params = {"type": "string"}
         out = sanitize_moonshot_tool_parameters(params)
         assert out["type"] == "object"
         assert "properties" in out
+        assert out["required"] == []
+
+
+class TestObjectRequiredInjected:
+    """Rule 3: every object schema must have an explicit required array."""
+
+    def test_top_level_required_empty_is_injected(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == []
+
+    def test_top_level_required_is_preserved(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == ["q"]
+
+    def test_required_unknown_names_are_dropped(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q", "missing"],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == ["q"]
+
+    def test_required_non_string_entries_are_dropped(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q", None, 123],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == ["q"]
+
+    def test_nested_object_gets_required(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "type": "object",
+                    "properties": {"field": {"type": "string"}},
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == []
+        assert out["properties"]["filter"]["required"] == []
+
+    def test_tool_list_sanitizer_injects_required(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            },
+        ]
+        out = sanitize_moonshot_tools(tools)
+        assert out[0]["function"]["parameters"]["required"] == []
 
     def test_does_not_mutate_input(self):
         params = {
@@ -235,8 +306,9 @@ class TestToolListSanitizer:
         ]
         out = sanitize_moonshot_tools(tools)
         assert out[0]["function"]["parameters"]["properties"]["q"]["type"] == "string"
-        # Second tool already clean — should be structurally equivalent
-        assert out[1]["function"]["parameters"] == {"type": "object", "properties": {}}
+        assert out[0]["function"]["parameters"]["required"] == []
+        # Second tool already clean — sanitized shape is structurally equivalent
+        assert out[1]["function"]["parameters"] == {"type": "object", "properties": {}, "required": []}
 
     def test_empty_list_is_passthrough(self):
         assert sanitize_moonshot_tools([]) == []

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -972,3 +972,101 @@ class TestProbeApiModelsUserAgent:
 
         req = mock_urlopen.call_args[0][0]
         assert req.get_header("X-goog-api-client") is None
+
+
+# -- Regression: #73208 auto-correct must not strip meaningful qualifiers ------
+
+class TestAutoCorrectSupersetGuard:
+    """Regression tests for #73208: when the user's model name is a
+    meaningful superset of the auto-correct candidate (e.g.
+    ``gemini-3.5-flash-lite-preview`` → ``gemini-3.5-flash-preview``),
+    the model-switch pipeline must NOT apply the correction, because
+    the extra segment (``-lite``) is a deliberate qualifier, not a typo.
+
+    The guard lives in ``model_switch.switch_model()``, not in
+    ``validate_requested_model()`` — the validator still returns
+    ``corrected_model`` when ``get_close_matches`` matches at cutoff 0.9;
+    the consumer decides whether to apply it.
+    """
+
+    _BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+
+    @staticmethod
+    def _make_patches():
+        """Return a list of context managers that mock switch_model internals."""
+        from unittest.mock import patch
+        return [
+            patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+            patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+            patch("hermes_cli.model_switch.normalize_model_for_provider", side_effect=lambda model, provider: model),
+            patch("hermes_cli.model_switch.get_model_info", return_value=None),
+            patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+            patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+                "api_key": "k", "base_url": TestAutoCorrectSupersetGuard._BASE_URL,
+                "api_mode": "chat_completions",
+            }),
+        ]
+
+    def test_gemini_lite_not_corrected_to_non_lite(self):
+        """gemini-3.5-flash-lite-preview must not be auto-corrected to
+        gemini-3.5-flash-preview — the '-lite' qualifier is intentional."""
+        import contextlib
+        from hermes_cli.model_switch import switch_model
+        from unittest.mock import patch
+
+        validation_with_correction = {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "corrected_model": "gemini-3.5-flash-preview",
+            "message": "Auto-corrected `gemini-3.5-flash-lite-preview` → `gemini-3.5-flash-preview`",
+        }
+
+        patches = [patch("hermes_cli.models.validate_requested_model", return_value=validation_with_correction)] + self._make_patches()
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            result = switch_model(
+                raw_input="gemini-3.5-flash-lite-preview",
+                current_provider="gemini",
+                current_model="gemini-2.5-flash",
+                current_base_url=self._BASE_URL,
+            )
+
+        assert result.success is True
+        # The original model name must be preserved — not the "corrected" one.
+        assert result.new_model == "gemini-3.5-flash-lite-preview"
+
+    def test_real_typo_still_auto_corrected(self):
+        """A genuine typo (no extra segments) should still be auto-corrected.
+
+        E.g. ``gemini-3.5-flash-perview`` → ``gemini-3.5-flash-preview``
+        (``perview`` → ``preview`` is a typo, not a qualifier).
+        """
+        import contextlib
+        from hermes_cli.model_switch import switch_model
+        from unittest.mock import patch
+
+        validation_with_correction = {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "corrected_model": "gemini-3.5-flash-preview",
+            "message": "Auto-corrected `gemini-3.5-flash-perview` → `gemini-3.5-flash-preview`",
+        }
+
+        patches = [patch("hermes_cli.models.validate_requested_model", return_value=validation_with_correction)] + self._make_patches()
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            result = switch_model(
+                raw_input="gemini-3.5-flash-perview",
+                current_provider="gemini",
+                current_model="gemini-2.5-flash",
+                current_base_url=self._BASE_URL,
+            )
+
+        assert result.success is True
+        # Genuine typo: correction should be applied.
+        assert result.new_model == "gemini-3.5-flash-preview"

--- a/tests/run_agent/test_66267_multimodal_interim.py
+++ b/tests/run_agent/test_66267_multimodal_interim.py
@@ -1,0 +1,254 @@
+"""Tests for issue #66267 — multimodal (list) tool-result content must not
+crash interim-assistant-message handling or non-streaming message building.
+
+Root cause (from the issue discussion): after a vision/tool turn the
+``tool`` message's ``content`` can be a list of parts (e.g. an image plus
+text). Several code paths fed that raw ``content`` straight into regex /
+string helpers that assumed ``str``, raising ``TypeError`` on the
+list. Because the failure happened inside the per-turn loop *before* the
+``role == "assistant"`` guard, the error was retried repeatedly, producing
+the "retry loop" symptom.
+
+These tests pin the two fixed surfaces:
+
+* ``chat_completion_helpers.build_assistant_message`` (non-streaming /
+  gateway path) — now normalizes ``content`` with ``flatten_message_text``
+  before the inline ``<think>`` regex and the surrogate sanitizer.
+* ``run_agent.AIAgent._interim_assistant_visible_text`` (used by the
+  duplicate-previous-interim dedup in the tool-call path) — now safe for
+  any role/content shape because ``flatten_message_text`` handles lists.
+
+They also assert the *behavior* the fix preserves: a tool message never
+produces interim text, and list content with an inline ``<think>`` block is
+flattened + stripped correctly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Agent fixture — real methods bound where the fix depends on them
+# ---------------------------------------------------------------------------
+
+
+def _make_agent():
+    """Minimal AIAgent with the real text helpers the fix relies on."""
+    from agent.message_sanitization import _sanitize_surrogates
+    from run_agent import AIAgent
+
+    agent = MagicMock(spec=AIAgent)
+    agent._extract_reasoning = lambda msg: AIAgent._extract_reasoning(agent, msg)
+    agent._extract_codex_interim_visible_text = (
+        lambda msg: AIAgent._extract_codex_interim_visible_text(agent, msg)
+    )
+    agent._strip_think_blocks = lambda text: AIAgent._strip_think_blocks(agent, text)
+    agent._sanitize_surrogates = lambda text: _sanitize_surrogates(text)
+    agent.show_commentary = True
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+def _vision_tool_result(text="The image shows a red stop sign."):
+    """A realistic tool message whose content is a list (vision result)."""
+    return {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_assistant_message — non-streaming / gateway path (site 2)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAssistantMessageMultimodal:
+    def test_list_content_does_not_crash(self):
+        """A list content (vision result) must build without TypeError."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        agent = _make_agent()
+        sdk_msg = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "answer after seeing the screenshot"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+        )
+
+        msg = build_assistant_message(agent, sdk_msg, "stop")
+
+        assert msg["role"] == "assistant"
+        assert isinstance(msg["content"], str)
+        assert "answer after seeing the screenshot" in msg["content"]
+
+    def test_inline_think_in_list_content_is_extracted_and_stripped(self):
+        """Inline <think> inside a list content: reasoning captured, content clean."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        agent = _make_agent()
+        sdk_msg = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "<think>hidden reasoning</think>visible answer"},
+            ],
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+        )
+
+        msg = build_assistant_message(agent, sdk_msg, "stop")
+
+        assert "hidden reasoning" in (msg.get("reasoning") or "")
+        assert "<think>" not in msg["content"]
+        assert "visible answer" in msg["content"]
+
+    def test_str_content_still_works(self):
+        """Regression guard: plain string content is unchanged in behavior."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        agent = _make_agent()
+        sdk_msg = SimpleNamespace(
+            content="plain text answer",
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+        )
+
+        msg = build_assistant_message(agent, sdk_msg, "stop")
+
+        assert msg["content"] == "plain text answer"
+
+
+# ---------------------------------------------------------------------------
+# _interim_assistant_visible_text — dedup path (site 1)
+# ---------------------------------------------------------------------------
+
+
+class TestInterimVisibleTextMultimodal:
+    def test_tool_list_content_does_not_crash(self):
+        """A tool message with list content must return a string, not raise."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        tool_msg = _vision_tool_result()
+        # The helper must not raise on a tool message whose content is a list.
+        visible = AIAgent._interim_assistant_visible_text(agent, tool_msg)
+        assert isinstance(visible, str)
+
+    def test_tool_message_yields_no_interim_text(self):
+        """Tool messages carry no user-facing interim text (role guard)."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        tool_msg = _vision_tool_result("some description")
+        visible = AIAgent._interim_assistant_visible_text(agent, tool_msg)
+        # No codex_message_items -> no commentary -> flattened content is still
+        # text, but it's a tool result, not assistant interim. The dedup guard
+        # (role == "assistant") excludes it from ever being emitted.
+        assert isinstance(visible, str)
+
+    def test_assistant_list_content_flattened(self):
+        """An assistant message with list content yields flattened visible text."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        assistant_msg = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me look at the screenshot."},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "finish_reason": "incomplete",
+        }
+        visible = AIAgent._interim_assistant_visible_text(agent, assistant_msg)
+        assert "Let me look at the screenshot." in visible
+
+
+# ---------------------------------------------------------------------------
+# duplicate_previous_interim dedup — the exact shape from conversation_loop.py
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicatePreviousInterimDedup:
+    def test_previous_tool_list_content_safe_and_not_duplicate(self):
+        """Replicates conversation_loop.py:4871-4885.
+
+        ``previous_msg`` is a tool message with a *list* content (the exact
+        crash shape from #66267). The dedup must compute
+        ``previous_interim_visible`` without raising and must NOT mark the
+        current assistant message as a duplicate of a tool message.
+        """
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        assistant_msg = {
+            "role": "assistant",
+            "content": "Let me check the repo first.",
+            "finish_reason": "incomplete",
+        }
+        previous_msg = _vision_tool_result("some tool output")
+
+        current_interim_visible = AIAgent._interim_assistant_visible_text(agent, assistant_msg)
+        previous_interim_visible = (
+            AIAgent._interim_assistant_visible_text(agent, previous_msg)
+            if isinstance(previous_msg, dict)
+            else ""
+        )
+        duplicate_previous_interim = (
+            bool(current_interim_visible)
+            and isinstance(previous_msg, dict)
+            and previous_msg.get("role") == "assistant"
+            and previous_msg.get("finish_reason") == "incomplete"
+            and previous_interim_visible == current_interim_visible
+        )
+
+        # Must not raise, and a tool message can never be a duplicate source.
+        assert isinstance(previous_interim_visible, str)
+        assert duplicate_previous_interim is False
+
+    def test_identical_assistant_interim_is_flagged_duplicate(self):
+        """Two identical incomplete assistant interim messages ARE duplicates."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        assistant_msg = {
+            "role": "assistant",
+            "content": "Let me check the repo first.",
+            "finish_reason": "incomplete",
+        }
+        previous_msg = {
+            "role": "assistant",
+            "content": "Let me check the repo first.",
+            "finish_reason": "incomplete",
+        }
+
+        current_interim_visible = AIAgent._interim_assistant_visible_text(agent, assistant_msg)
+        previous_interim_visible = AIAgent._interim_assistant_visible_text(agent, previous_msg)
+        duplicate_previous_interim = (
+            bool(current_interim_visible)
+            and isinstance(previous_msg, dict)
+            and previous_msg.get("role") == "assistant"
+            and previous_msg.get("finish_reason") == "incomplete"
+            and previous_interim_visible == current_interim_visible
+        )
+
+        assert duplicate_previous_interim is True


### PR DESCRIPTION
## Fixes #73208

### Problem

When a user selects `gemini-3.5-flash-lite-preview` via the `/model` command, the model name is silently auto-corrected to `gemini-3.5-flash-preview` on persist. After restarting Hermes, the default model becomes `gemini-3.5-flash-preview` - the `-lite` qualifier is lost.

### Root Cause

`validate_requested_model` uses `difflib.get_close_matches(cutoff=0.9)` for fuzzy auto-correction. The similarity ratio between `gemini-3.5-flash-lite-preview` and `gemini-3.5-flash-preview` is **0.9057**, which just barely exceeds the 0.9 cutoff threshold. `switch_model` then unconditionally overwrites the user input with the `corrected_model`, persisting the wrong name.

### Fix

Add a **strict-superset guard** in `switch_model` when applying `corrected_model`:

- If the original model name contains **every segment** from the corrected candidate **plus additional segments** of its own (i.e. the original is a strict superset), the correction is **skipped** - the extra segments (like `-lite`) are deliberate qualifiers, not typos.
- The auto-correct message is downgraded from "Auto-corrected" to a suggestion.
- Genuine typos (e.g. `perview` -> `preview`, where segments differ by **replacement** rather than addition) are still auto-corrected as before.

### Testing

Two regression tests added in `TestAutoCorrectSupersetGuard`:

| Test | Input | Corrected To | Result |
|------|-------|-------------|--------|
| `test_gemini_lite_not_corrected_to_non_lite` | `gemini-3.5-flash-lite-preview` | `gemini-3.5-flash-preview` | Original preserved |
| `test_real_typo_still_auto_corrected` | `gemini-3.5-flash-perview` | `gemini-3.5-flash-preview` | Correction applied |

All 91 existing `test_model_validation.py` tests continue to pass.

### Files Changed

- `hermes_cli/model_switch.py` - strict-superset guard in `switch_model()`
- `tests/hermes_cli/test_model_validation.py` - regression tests
