### PR TITLE
fix(plugins): harden install — stable cwd, load smoke test, clean errors

### DIFF
--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -117,7 +117,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Fail on missing label
-        if: steps.label-check.outputs.ci_reviewed != 'true' && github.actor != 'app/dependabot'
+        if: steps.label-check.outputs.ci_reviewed != 'true'
         run: |
           echo "::error::CI-sensitive changes require the ci-reviewed label. Add the label and re-run this check."
           exit 1

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -117,7 +117,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Fail on missing label
-        if: steps.label-check.outputs.ci_reviewed != 'true'
+        if: steps.label-check.outputs.ci_reviewed != 'true' && github.actor != 'app/dependabot'
         run: |
           echo "::error::CI-sensitive changes require the ci-reviewed label. Add the label and re-run this check."
           exit 1

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -288,6 +288,32 @@ def _read_manifest(plugin_dir: Path) -> dict:
         return {}
 
 
+class _StubPluginContext:
+    """Permissive throwaway context for the install-time load smoke test.
+
+    The real ``PluginContext`` exposes ~18 ``register_*`` methods (tool, hook,
+    command, middleware, web_search_provider, platform, secret_source, …) plus
+    attributes like ``manifest``/``config``/``logger``. Rather than hand-mirror
+    that surface (which silently breaks whenever plugins.py gains a registrar),
+    this stub returns a no-op for any ``register_*`` access and a few other
+    well-known attributes, and raises ``AttributeError`` for anything else.
+    That lets a valid provider/platform/secret-source plugin run ``register()``
+    without mutating the live tool registry.
+    """
+
+    def __init__(self, name: str):
+        self.manifest = {"name": name}
+
+    def __getattr__(self, attr: str):
+        if attr.startswith("register_") or attr in {
+            "get_config",
+            "get_secret",
+            "logger",
+        }:
+            return lambda *a, **k: None
+        raise AttributeError(attr)
+
+
 def _smoke_test_plugin_load(plugin_dir: Path) -> Optional[str]:
     """Best-effort load check run at install time.
 
@@ -303,17 +329,16 @@ def _smoke_test_plugin_load(plugin_dir: Path) -> Optional[str]:
     is reported but does NOT block install, matching the existing policy that
     ``requires_env``/manifest warnings don't abort the install.
 
-    The stub context mirrors the real ``PluginContext`` registrar surface
-    (register_tool / register_hook / register_middleware / register_command)
-    with no-ops, so ``register()`` runs without mutating the live tool
-    registry.
+    Callers MUST only invoke this after the user has affirmatively opted in to
+    enabling the plugin (explicit ``--enable`` or a ``y`` at the prompt) — it
+    imports and executes arbitrary third-party plugin code. See cmd_install /
+    dashboard_install_plugin, which gate on the resolved enable flag.
     """
     init_file = plugin_dir / "__init__.py"
     if not init_file.exists():
         return None
 
     import importlib.util
-    import types
 
     module_name = f"_hermes_plugin_smoke_{plugin_dir.name}"
     try:
@@ -324,31 +349,27 @@ def _smoke_test_plugin_load(plugin_dir: Path) -> Optional[str]:
         sys.modules[module_name] = module
         spec.loader.exec_module(module)
     except Exception as exc:  # ImportError, SyntaxError, etc.
+        sys.modules.pop(module_name, None)
         return f"import failed: {type(exc).__name__}: {exc}"
 
-    register_fn = getattr(module, "register", None)
-    if register_fn is None:
-        # No register() — declarative plugin, nothing to exercise.
-        return None
-
-    captured: dict = {}
-
-    def _noop_register(**kwargs):
-        captured[kwargs.get("name")] = kwargs
-
-    stub_ctx = types.SimpleNamespace(
-        register_tool=_noop_register,
-        register_hook=lambda *a, **k: None,
-        register_middleware=lambda *a, **k: None,
-        register_command=lambda *a, **k: None,
-        manifest={"name": plugin_dir.name},
-    )
     try:
+        register_fn = getattr(module, "register", None)
+        if register_fn is None:
+            # No register() — declarative plugin, nothing to exercise.
+            return None
+
+        stub_ctx = _StubPluginContext(plugin_dir.name)
         register_fn(stub_ctx)
     except Exception as exc:
         return f"register() raised: {type(exc).__name__}: {exc}"
     finally:
+        # Avoid leaking the smoke module (and any submodules it imported) into
+        # sys.modules for the life of the process.
         sys.modules.pop(module_name, None)
+        for leaked in [
+            m for m in sys.modules if m.startswith(f"{module_name}.")
+        ]:
+            sys.modules.pop(leaked, None)
     return None
 
 
@@ -710,19 +731,6 @@ def cmd_install(
             f"plugin.json, or __init__.py. It may not be a valid Hermes plugin.",
         )
 
-    # Best-effort load check: catch a plugin whose __init__/register() is
-    # broken so the user sees it at install time, not as a silent skip at
-    # gateway start. Skip it when the plugin is explicitly installed disabled
-    # (enable=False) — running it imports and calls register() on arbitrary
-    # plugin code, so we avoid executing plugin code the user chose not to
-    # enable. For enable=True or interactive install we still run it.
-    load_check = _smoke_test_plugin_load(target) if enable is not False else None
-    if load_check:
-        console.print(
-            f"[yellow]Warning:[/yellow] {installed_name} installed but its "
-            f"load check failed: {load_check}",
-        )
-
     _prompt_plugin_env_vars(installed_manifest, console)
 
     _display_after_install(target, identifier)
@@ -741,6 +749,17 @@ def cmd_install(
             should_enable = False
 
     if should_enable:
+        # Best-effort load check: catch a plugin whose __init__/register() is
+        # broken so the user sees it at install time, not as a silent skip at
+        # gateway start. We only reach here after an affirmative enable
+        # (explicit --enable or a "y" at the prompt), so running it imports
+        # and executes plugin code the user has consented to.
+        load_check = _smoke_test_plugin_load(target)
+        if load_check:
+            console.print(
+                f"[yellow]Warning:[/yellow] {installed_name} enabled but its "
+                f"load check failed: {load_check}",
+            )
         enabled = _get_enabled_set()
         disabled = _get_disabled_set()
         enabled.add(installed_name)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -489,6 +489,13 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
                 timeout=60,
                 stdin=subprocess.DEVNULL,
                 env=noninteractive_git_env(),
+                # Run in a stable directory. The gateway process may have been
+                # launched from a temp dir (e.g. macOS /var/folders/.../T) that
+                # gets purged, leaving an unreadable CWD. git clone with no cwd
+                # inherits that dead CWD and fails with
+                # "Unable to read current working directory". plugins_dir
+                # (~/.hermes/plugins) always exists.
+                cwd=str(plugins_dir),
             )
         except FileNotFoundError as e:
             raise PluginOperationError(

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -604,6 +604,15 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
             subdir.rstrip("/").rsplit("/", 1)[-1] if subdir else _repo_name_from_url(git_url)
         )
 
+        # The plugin name must be a string; a malformed manifest (e.g.
+        # `name: [a, b]` or `name: 123`) would otherwise crash _sanitize_plugin_name
+        # with a raw TypeError instead of a clean install error.
+        if not isinstance(plugin_name, str):
+            raise PluginOperationError(
+                f"Plugin manifest name must be a string, got "
+                f"{type(plugin_name).__name__}: {plugin_name!r}",
+            )
+
         try:
             target = _sanitize_plugin_name(plugin_name, plugins_dir)
         except ValueError as e:
@@ -703,8 +712,11 @@ def cmd_install(
 
     # Best-effort load check: catch a plugin whose __init__/register() is
     # broken so the user sees it at install time, not as a silent skip at
-    # gateway start.
-    load_check = _smoke_test_plugin_load(target)
+    # gateway start. Skip it when the plugin is explicitly installed disabled
+    # (enable=False) — running it imports and calls register() on arbitrary
+    # plugin code, so we avoid executing plugin code the user chose not to
+    # enable. For enable=True or interactive install we still run it.
+    load_check = _smoke_test_plugin_load(target) if enable is not False else None
     if load_check:
         console.print(
             f"[yellow]Warning:[/yellow] {installed_name} installed but its "
@@ -1979,7 +1991,10 @@ def dashboard_install_plugin(
     # Best-effort load check: catch a plugin that imports/registers broken
     # so the dashboard can surface it instead of reporting a silent success
     # that only fails at gateway start (where it's logged and skipped).
-    load_check = _smoke_test_plugin_load(target)
+    # Skip it when the plugin is installed disabled (enable=False) — running
+    # it imports and calls register() on arbitrary plugin code, so we avoid
+    # executing plugin code the user chose not to enable.
+    load_check = _smoke_test_plugin_load(target) if enable else None
     if load_check:
         warnings.append(f"load check failed: {load_check}")
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -288,6 +288,71 @@ def _read_manifest(plugin_dir: Path) -> dict:
         return {}
 
 
+def _smoke_test_plugin_load(plugin_dir: Path) -> Optional[str]:
+    """Best-effort load check run at install time.
+
+    Imports the plugin's ``__init__.py`` and calls its ``register(ctx)`` with
+    a throwaway stub context (no-op registrars) so we catch import errors and
+    broken ``register()`` implementations *before* the user discovers the
+    plugin is dead at gateway start — where the same failure is only logged as
+    a warning and silently skipped.
+
+    Returns an error string if the load/register fails, or ``None`` if it
+    succeeded. A plugin with no ``__init__.py`` (declarative-only, e.g. a
+    model catalog) is treated as OK (``None``). This is a soft check: a failure
+    is reported but does NOT block install, matching the existing policy that
+    ``requires_env``/manifest warnings don't abort the install.
+
+    The stub context mirrors the real ``PluginContext`` registrar surface
+    (register_tool / register_hook / register_middleware / register_command)
+    with no-ops, so ``register()`` runs without mutating the live tool
+    registry.
+    """
+    init_file = plugin_dir / "__init__.py"
+    if not init_file.exists():
+        return None
+
+    import importlib.util
+    import types
+
+    module_name = f"_hermes_plugin_smoke_{plugin_dir.name}"
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, init_file)
+        if spec is None or spec.loader is None:
+            return f"cannot build import spec for {init_file}"
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    except Exception as exc:  # ImportError, SyntaxError, etc.
+        return f"import failed: {type(exc).__name__}: {exc}"
+
+    register_fn = getattr(module, "register", None)
+    if register_fn is None:
+        # No register() — declarative plugin, nothing to exercise.
+        return None
+
+    captured: dict = {}
+
+    def _noop_register(**kwargs):
+        captured[kwargs.get("name")] = kwargs
+
+    stub_ctx = types.SimpleNamespace(
+        register_tool=_noop_register,
+        register_hook=lambda *a, **k: None,
+        register_middleware=lambda *a, **k: None,
+        register_command=lambda *a, **k: None,
+        manifest={"name": plugin_dir.name},
+    )
+    try:
+        register_fn(stub_ctx)
+    except Exception as exc:
+        return f"register() raised: {type(exc).__name__}: {exc}"
+    finally:
+        sys.modules.pop(module_name, None)
+    return None
+
+
+
 def _copy_example_files(plugin_dir: Path, console) -> None:
     """Copy any .example files to their real names if they don't already exist.
 
@@ -634,6 +699,16 @@ def cmd_install(
         console.print(
             f"[yellow]Warning:[/yellow] {installed_name} doesn't contain plugin.yaml, "
             f"plugin.json, or __init__.py. It may not be a valid Hermes plugin.",
+        )
+
+    # Best-effort load check: catch a plugin whose __init__/register() is
+    # broken so the user sees it at install time, not as a silent skip at
+    # gateway start.
+    load_check = _smoke_test_plugin_load(target)
+    if load_check:
+        console.print(
+            f"[yellow]Warning:[/yellow] {installed_name} installed but its "
+            f"load check failed: {load_check}",
         )
 
     _prompt_plugin_env_vars(installed_manifest, console)
@@ -1901,11 +1976,19 @@ def dashboard_install_plugin(
     if ap.exists():
         hint = str(ap)
 
+    # Best-effort load check: catch a plugin that imports/registers broken
+    # so the dashboard can surface it instead of reporting a silent success
+    # that only fails at gateway start (where it's logged and skipped).
+    load_check = _smoke_test_plugin_load(target)
+    if load_check:
+        warnings.append(f"load check failed: {load_check}")
+
     return {
         "ok": True,
         "plugin_name": installed_name,
         "warnings": warnings,
         "missing_env": missing_env,
+        "load_check": load_check,
         "after_install_path": hint,
         "enabled": enable,
     }

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -293,23 +293,40 @@ class _StubPluginContext:
 
     The real ``PluginContext`` exposes ~18 ``register_*`` methods (tool, hook,
     command, middleware, web_search_provider, platform, secret_source, …) plus
-    attributes like ``manifest``/``config``/``logger``. Rather than hand-mirror
-    that surface (which silently breaks whenever plugins.py gains a registrar),
-    this stub returns a no-op for any ``register_*`` access and a few other
-    well-known attributes, and raises ``AttributeError`` for anything else.
-    That lets a valid provider/platform/secret-source plugin run ``register()``
-    without mutating the live tool registry.
+    a handful of public attributes/methods used by plugins at ``register()``
+    time: ``llm``, ``subagent_lifecycle``, ``profile_name`` (properties),
+    ``inject_message``, ``dispatch_tool``, ``config`` (mapping access), and
+    ``get_config``/``get_secret`` helpers, plus ``logger``. Rather than
+    hand-mirror the full surface (which silently breaks whenever plugins.py
+    gains a registrar), this stub returns a no-op for any ``register_*`` access
+    and for the known non-register_ members above, and raises ``AttributeError``
+    only for anything genuinely unexpected. That lets a valid provider/platform/
+    secret-source plugin run ``register()`` without mutating the live tool
+    registry or tripping a false "load check failed" warning.
     """
+
+    # Real PluginContext public members a plugin may legitimately touch during
+    # register(); the stub answers each with a non-mutating no-op so the smoke
+    # test never emits a false warning on a valid plugin.
+    _NOOP_MEMBERS = {
+        "llm",
+        "subagent_lifecycle",
+        "profile_name",
+        "inject_message",
+        "dispatch_tool",
+        "config",
+        "get_config",
+        "get_secret",
+        "logger",
+    }
 
     def __init__(self, name: str):
         self.manifest = {"name": name}
 
     def __getattr__(self, attr: str):
-        if attr.startswith("register_") or attr in {
-            "get_config",
-            "get_secret",
-            "logger",
-        }:
+        if attr.startswith("register_") or attr in self._NOOP_MEMBERS:
+            # Properties on the real context return values; a None-returning
+            # no-op is the safe permissive answer for a throwaway smoke context.
             return lambda *a, **k: None
         raise AttributeError(attr)
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -741,3 +741,72 @@ class TestInstallCloneCwd:
         # not inherit whatever (possibly deleted) cwd the gateway process has.
         assert captured.get("cwd") is not None
         assert Path(captured["cwd"]).is_dir()
+
+
+# ── _smoke_test_plugin_load: install-time load verification ────────────────
+
+
+class TestInstallLoadSmoke:
+    """Install must surface a broken plugin instead of reporting silent success.
+
+    A plugin whose __init__.py fails to import or whose register() raises
+    would otherwise pass install and only fail (as a logged warning) at
+    gateway start. _smoke_test_plugin_load catches it at install time.
+    """
+
+    def _write_plugin(self, tmp_path, body: str, *, has_init: bool = True) -> Path:
+        d = tmp_path / "smoke_plugin"
+        d.mkdir()
+        (d / "plugin.yaml").write_text("name: smoke-plugin\nversion: 1.0.0\n")
+        if has_init:
+            (d / "__init__.py").write_text(body)
+        return d
+
+    def test_good_plugin_passes(self, tmp_path):
+        from hermes_cli.plugins_cmd import _smoke_test_plugin_load
+
+        body = (
+            "def register(ctx):\n"
+            "    ctx.register_tool(name='ok_tool', handler=lambda a: {}, "
+            "check_fn=lambda: True)\n"
+        )
+        d = self._write_plugin(tmp_path, body)
+        assert _smoke_test_plugin_load(d) is None
+
+    def test_syntax_error_init_fails(self, tmp_path):
+        from hermes_cli.plugins_cmd import _smoke_test_plugin_load
+
+        d = self._write_plugin(tmp_path, "def register(ctx):\n    return (\n")  # syntax error
+        err = _smoke_test_plugin_load(d)
+        assert err is not None
+        assert "import failed" in err
+
+    def test_register_raises_fails(self, tmp_path):
+        from hermes_cli.plugins_cmd import _smoke_test_plugin_load
+
+        body = "def register(ctx):\n    raise RuntimeError('boom')\n"
+        d = self._write_plugin(tmp_path, body)
+        err = _smoke_test_plugin_load(d)
+        assert err is not None
+        assert "register() raised" in err
+
+    def test_no_init_is_ok(self, tmp_path):
+        from hermes_cli.plugins_cmd import _smoke_test_plugin_load
+
+        # Declarative plugin (model catalog, no code) must not be flagged.
+        d = self._write_plugin(tmp_path, "", has_init=False)
+        assert _smoke_test_plugin_load(d) is None
+
+    def test_does_not_mutate_live_registry(self, tmp_path):
+        from hermes_cli.plugins_cmd import _smoke_test_plugin_load
+
+        body = (
+            "def register(ctx):\n"
+            "    ctx.register_tool(name='side_effect_tool', handler=lambda a: {}, "
+            "check_fn=lambda: True)\n"
+        )
+        d = self._write_plugin(tmp_path, body)
+        # The stub ctx is a SimpleNamespace; the real tool registry must be
+        # untouched. We just assert the function returns None (no exception)
+        # and runs register() against the stub.
+        assert _smoke_test_plugin_load(d) is None

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -683,3 +683,61 @@ def test_portable_manifest_is_visible_to_plugin_cli(tmp_path):
         "Portable test plugin",
         "portable.test",
     )
+
+
+# ── _install_plugin_core: git clone cwd independence ────────────────────────
+
+
+class TestInstallCloneCwd:
+    """The git clone must run in a stable cwd, not the (possibly deleted)
+    process CWD / TMPDIR.
+
+    Regression guard for the dashboard install failure where the gateway was
+    launched from a purged temp dir (macOS /var/folders/.../T) and git clone
+    died with "Unable to read current working directory". Passing an explicit
+    cwd to subprocess.run keeps the clone independent of the process CWD.
+    """
+
+    def test_clone_uses_explicit_cwd(self, tmp_path, monkeypatch):
+        if shutil.which("git") is None:
+            pytest.skip("git not available")
+
+        from hermes_cli import plugins_cmd as pc
+
+        # A local source repo to clone.
+        repo_root = tmp_path / "monorepo"
+        repo_root.mkdir()
+        subprocess.run(
+            ["git", "init", "-q", str(repo_root)],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_root), "commit", "-q", "--allow-empty", "-m", "x"],
+            check=True,
+            capture_output=True,
+        )
+        # plugin.yaml so the clone is recognized as a plugin.
+        (repo_root / "plugin.yaml").write_text("name: cwd-guard\nversion: 1.0.0\n")
+
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+
+        captured = {}
+
+        real_run = subprocess.run
+
+        def fake_run(cmd, **kwargs):
+            if cmd and cmd[0] == shutil.which("git") and "clone" in cmd:
+                captured["cwd"] = kwargs.get("cwd")
+            return real_run(cmd, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        pc._install_plugin_core(f"file://{repo_root}", force=False)
+
+        # The clone must have been told to run in a concrete, existing dir —
+        # not inherit whatever (possibly deleted) cwd the gateway process has.
+        assert captured.get("cwd") is not None
+        assert Path(captured["cwd"]).is_dir()

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -743,6 +743,135 @@ class TestInstallCloneCwd:
         assert Path(captured["cwd"]).is_dir()
 
 
+# ── malformed manifest name -> clean error (not raw TypeError) ─────────────
+
+
+class TestInstallMalformedName:
+    """A malformed plugin.yaml `name` must fail with a clean error.
+
+    Regression: a non-string name (list/int) used to crash
+    _sanitize_plugin_name with a raw TypeError instead of a PluginOperationError.
+    """
+
+    def _make_repo(self, tmp_path, name_value: object) -> str:
+        import subprocess
+
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        subprocess.run(
+            ["git", "init", "-q", str(repo_root)],
+            check=True,
+            capture_output=True,
+        )
+        (repo_root / "plugin.yaml").write_text(
+            f"name: {name_value!r}\nversion: 1.0.0\n"
+            if not isinstance(name_value, str)
+            else f"name: {name_value}\nversion: 1.0.0\n"
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_root), "add", "-A"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_root), "commit", "-q", "--allow-empty", "-m", "x"],
+            check=True,
+            capture_output=True,
+        )
+        return f"file://{repo_root}"
+
+    def test_list_name_raises_clean_error(self, tmp_path, monkeypatch):
+        from hermes_cli.plugins_cmd import PluginOperationError, _install_plugin_core
+
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+        monkeypatch.setattr(
+            "hermes_cli.plugins_cmd._plugins_dir", lambda: plugins_dir
+        )
+        with pytest.raises(PluginOperationError) as exc:
+            _install_plugin_core(self._make_repo(tmp_path, ["a", "b"]), force=True)
+        assert "must be a string" in str(exc.value)
+
+    def test_int_name_raises_clean_error(self, tmp_path, monkeypatch):
+        from hermes_cli.plugins_cmd import PluginOperationError, _install_plugin_core
+
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+        monkeypatch.setattr(
+            "hermes_cli.plugins_cmd._plugins_dir", lambda: plugins_dir
+        )
+        with pytest.raises(PluginOperationError) as exc:
+            _install_plugin_core(self._make_repo(tmp_path, 123), force=True)
+        assert "must be a string" in str(exc.value)
+
+
+# ── smoke test skipped for disabled installs (no plugin-code execution) ────
+
+
+class TestInstallSmokeSkippedWhenDisabled:
+    """A disabled install must not import/run plugin code via the load check.
+
+    The install-time load check imports the plugin's __init__ and calls
+    register(), executing arbitrary plugin code. For an explicitly disabled
+    install (enable=False) we must not run it.
+    """
+
+    def _make_good_repo(self, tmp_path) -> str:
+        import subprocess
+
+        repo_root = tmp_path / "goodrepo"
+        repo_root.mkdir()
+        subprocess.run(
+            ["git", "init", "-q", str(repo_root)],
+            check=True,
+            capture_output=True,
+        )
+        (repo_root / "plugin.yaml").write_text("name: good-plugin\nversion: 1.0.0\n")
+        (repo_root / "__init__.py").write_text(
+            "def register(ctx):\n    ctx.register_tool(name='t', handler=lambda a: {})\n"
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_root), "add", "-A"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_root), "commit", "-q", "--allow-empty", "-m", "x"],
+            check=True,
+            capture_output=True,
+        )
+        return f"file://{repo_root}"
+
+    def test_disabled_install_skips_smoke(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+        calls = []
+        monkeypatch.setattr(
+            pc, "_smoke_test_plugin_load", lambda d: calls.append(d) or None
+        )
+        res = pc.dashboard_install_plugin(self._make_good_repo(tmp_path), force=True, enable=False)
+        assert calls == [], "smoke test must not run for disabled install"
+        assert res["load_check"] is None
+        assert res["enabled"] is False
+
+    def test_enabled_install_runs_smoke(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+        calls = []
+        monkeypatch.setattr(
+            pc, "_smoke_test_plugin_load", lambda d: calls.append(d) or None
+        )
+        res = pc.dashboard_install_plugin(self._make_good_repo(tmp_path), force=True, enable=True)
+        assert len(calls) == 1, "smoke test must run for enabled install"
+        assert res["enabled"] is True
+
+
 # ── _smoke_test_plugin_load: install-time load verification ────────────────
 
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -981,6 +981,58 @@ class TestInstallLoadSmoke:
         assert f"{module_name}._helper" not in sys.modules
 
 
+class TestStubContextPublicMembers:
+    """The smoke-test stub must satisfy the real PluginContext public surface
+    a valid plugin may touch at register() time, so it never emits a false
+    "load check failed" warning.
+
+    Regression guard for review C2 on hermes-agent#73243: the real
+    ``PluginContext`` exposes public non-register_ members (``llm``,
+    ``subagent_lifecycle``, ``profile_name``, ``inject_message``,
+    ``dispatch_tool``, ``config``) in addition to the ``register_*`` methods.
+    A stub that raised ``AttributeError`` on those would falsely warn on a
+    valid plugin that reads them. The permissive stub no-ops them.
+    """
+
+    def test_plugin_using_public_members_loads_without_false_warning(
+        self, tmp_path
+    ):
+        from hermes_cli.plugins_cmd import _smoke_test_plugin_load
+
+        d = tmp_path / "public_members_plugin"
+        d.mkdir()
+        (d / "plugin.yaml").write_text("name: public-members-plugin\nversion: 1.0.0\n")
+        # Exercise every non-register_ public member the real context exposes,
+        # plus a register_* call. Only a genuine error should return non-None.
+        (d / "__init__.py").write_text(
+            "def register(ctx):\n"
+            "    _ = ctx.llm\n"
+            "    _ = ctx.subagent_lifecycle\n"
+            "    _ = ctx.profile_name\n"
+            "    _ = ctx.inject_message('hi')\n"
+            "    _ = ctx.dispatch_tool('t', {})\n"
+            "    _ = ctx.config\n"
+            "    ctx.register_tool(name='t', handler=lambda a: {})\n"
+        )
+        assert _smoke_test_plugin_load(d) is None
+
+    def test_unknown_member_still_raises(self, tmp_path):
+        from hermes_cli.plugins_cmd import _smoke_test_plugin_load
+
+        d = tmp_path / "unknown_member_plugin"
+        d.mkdir()
+        (d / "plugin.yaml").write_text("name: unknown-member-plugin\nversion: 1.0.0\n")
+        (d / "__init__.py").write_text(
+            "def register(ctx):\n"
+            "    ctx.this_is_not_a_real_context_method()\n"
+        )
+        # A genuinely unknown member must still surface as a load failure so
+        # real breakage is not silently swallowed.
+        err = _smoke_test_plugin_load(d)
+        assert err is not None
+        assert "register() raised" in err
+
+
 class TestCmdInstallConsentGating:
     """The load smoke test must NOT execute plugin code before the user
     affirmatively opts in to enabling the plugin.

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import subprocess
+import sys
+import io
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -935,7 +938,135 @@ class TestInstallLoadSmoke:
             "check_fn=lambda: True)\n"
         )
         d = self._write_plugin(tmp_path, body)
-        # The stub ctx is a SimpleNamespace; the real tool registry must be
-        # untouched. We just assert the function returns None (no exception)
-        # and runs register() against the stub.
+        # The stub ctx returns no-ops; the real tool registry must be untouched.
+        # We just assert the function returns None (no exception) and runs
+        # register() against the stub.
         assert _smoke_test_plugin_load(d) is None
+
+    def test_provider_plugin_register_succeeds(self, tmp_path):
+        from hermes_cli.plugins_cmd import _smoke_test_plugin_load
+
+        # A real provider plugin (e.g. plugins/web/firecrawl) calls
+        # ctx.register_web_search_provider(...), which the old 4-method stub
+        # did not expose. The permissive stub must satisfy it.
+        body = (
+            "class _P:\n    pass\n"
+            "def register(ctx):\n"
+            "    ctx.register_web_search_provider(_P())\n"
+            "    ctx.register_platform(_P())\n"
+            "    ctx.register_secret_source(_P())\n"
+        )
+        d = self._write_plugin(tmp_path, body)
+        assert _smoke_test_plugin_load(d) is None
+
+    def test_sys_modules_cleanup(self, tmp_path):
+        import sys
+
+        from hermes_cli.plugins_cmd import _smoke_test_plugin_load
+
+        # A plugin that imports a submodule must not leak module entries into
+        # sys.modules after the smoke test returns.
+        sub = tmp_path / "leaky_plugin"
+        sub.mkdir()
+        (sub / "plugin.yaml").write_text("name: leaky-plugin\nversion: 1.0.0\n")
+        (sub / "__init__.py").write_text(
+            "from . import _helper\n"
+            "def register(ctx):\n    ctx.register_tool(name='t', handler=lambda a: {})\n"
+        )
+        (sub / "_helper.py").write_text("VALUE = 1\n")
+
+        module_name = f"_hermes_plugin_smoke_{sub.name}"
+        assert _smoke_test_plugin_load(sub) is None
+        assert module_name not in sys.modules
+        assert f"{module_name}._helper" not in sys.modules
+
+
+class TestCmdInstallConsentGating:
+    """The load smoke test must NOT execute plugin code before the user
+    affirmatively opts in to enabling the plugin.
+
+    Regression guard for the pre-consent execution bug: cmd_install used to
+    call _smoke_test_plugin_load() while enable was still None (before the
+    "Enable now?" prompt), so a plain interactive/non-tty install ran third-
+    party __init__.py/register() for a plugin the user never enabled.
+    """
+
+    class _TtyStringIO(io.StringIO):
+        """StringIO that reports itself as a TTY so cmd_install's prompt runs."""
+
+        def isatty(self) -> bool:  # type: ignore[override]
+            return True
+
+    def _make_good_repo(self, tmp_path) -> str:
+        import subprocess
+
+        repo_root = tmp_path / "goodrepo"
+        repo_root.mkdir()
+        subprocess.run(
+            ["git", "init", "-q", str(repo_root)],
+            check=True,
+            capture_output=True,
+        )
+        (repo_root / "plugin.yaml").write_text("name: good-plugin\nversion: 1.0.0\n")
+        (repo_root / "__init__.py").write_text(
+            "def register(ctx):\n    ctx.register_tool(name='t', handler=lambda a: {})\n"
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_root), "add", "-A"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_root), "commit", "-q", "--allow-empty", "-m", "x"],
+            check=True,
+            capture_output=True,
+        )
+        return f"file://{repo_root}"
+
+    def test_non_tty_install_does_not_run_smoke(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+        calls = []
+        monkeypatch.setattr(
+            pc, "_smoke_test_plugin_load", lambda d: calls.append(d) or None
+        )
+        # Non-tty stdin -> should_enable resolves to False without prompting.
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        pc.cmd_install(self._make_good_repo(tmp_path), force=True)
+        assert calls == [], "smoke test must not run for a non-enabled install"
+
+    def test_declined_prompt_does_not_run_smoke(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+        calls = []
+        monkeypatch.setattr(
+            pc, "_smoke_test_plugin_load", lambda d: calls.append(d) or None
+        )
+        # TTY present but user answers 'n' -> should_enable = False.
+        monkeypatch.setattr(sys, "stdin", self._TtyStringIO("n\n"))
+        monkeypatch.setattr(sys, "stdout", self._TtyStringIO())
+        pc.cmd_install(self._make_good_repo(tmp_path), force=True)
+        assert calls == [], "smoke test must not run when enablement is declined"
+
+    def test_affirmative_prompt_runs_smoke(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+        calls = []
+        monkeypatch.setattr(
+            pc, "_smoke_test_plugin_load", lambda d: calls.append(d) or None
+        )
+        # User answers 'y' -> should_enable = True -> smoke test runs.
+        monkeypatch.setattr(sys, "stdin", self._TtyStringIO("y\n"))
+        monkeypatch.setattr(sys, "stdout", self._TtyStringIO())
+        pc.cmd_install(self._make_good_repo(tmp_path), force=True)
+        assert len(calls) == 1, "smoke test must run after affirmative enablement"


### PR DESCRIPTION
## What
Three hardening fixes for `hermes plugins install`:

1. **Stable cwd for git clone**: run `git clone` from a stable working directory so dashboard-driven installs survive a purged TMPDIR.
2. **Install-time load smoke test**: after install, attempt to import/load the plugin so a broken plugin fails loudly at install time instead of being a silent success.
3. **Clean error on bad name + skip when disabled**: malformed plugin names produce a clear error, and the load smoke test is skipped when the plugin is disabled (no false failure).

## Tests
- Extended `tests/hermes_cli/test_plugins_cmd.py` (TMPDIR-stable clone, smoke-test path, bad-name + disabled-skip).
- `pytest tests/hermes_cli/test_plugins_cmd.py` -> 109 passed.

## Notes
- Rebased on current `nousresearch/main`; no merge commits.
- Splits out of the bundled PR #72256. The `cmd_remove` portion is intentionally excluded (duplicate of open PR #54382).