### PR TITLE
fix(kanban): populate board assignee picker from on-disk profiles (#73235)

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -488,14 +488,13 @@ def get_board(
                 "SELECT DISTINCT tenant FROM tasks WHERE tenant IS NOT NULL ORDER BY tenant"
             )
         ]
-        # List of distinct assignees for the lane-by-profile sub-grouping.
-        assignees = [
-            r["assignee"]
-            for r in conn.execute(
-                "SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL "
-                "AND status != 'archived' ORDER BY assignee"
-            )
-        ]
+        # Assignee names for the toolbar filter, bulk-reassign and diagnostic
+        # reassign pickers (and the lane-by-profile sub-grouping). Union the
+        # profiles on disk with those currently used on the board so a
+        # freshly-created profile appears in the picker before it owns any
+        # task — matching GET /api/assignees instead of the tasks-only
+        # DISTINCT this used to run, which hid task-less profiles. See #73235.
+        assignees = [a["name"] for a in kanban_db.known_assignees(conn)]
 
         return {
             "columns": [

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -76,8 +76,29 @@ def test_board_empty(client):
         assert expected in names, f"missing column {expected}: {names}"
     assert all(len(c["tasks"]) == 0 for c in data["columns"])
     assert data["tenants"] == []
-    assert data["assignees"] == []
+    # The board's HERMES_HOME root exists, so the implicit "default" profile
+    # is a real on-disk profile and appears in the picker even with no tasks.
+    assert data["assignees"] == ["default"]
     assert data["latest_event_id"] == 0
+
+
+def test_board_assignees_include_task_less_on_disk_profiles(client, tmp_path):
+    """A profile that exists on disk but owns no task must still appear in the
+    board's assignee picker (toolbar filter / bulk + diagnostic reassign).
+
+    Regression for #73235: get_board() used a tasks-only SELECT DISTINCT, so a
+    freshly-created profile was invisible in every reassign picker until a CLI
+    command gave it a task. It must union on-disk profiles like GET
+    /api/assignees does.
+    """
+    profiles = tmp_path / ".hermes" / "profiles" / "worker-foo"
+    profiles.mkdir(parents=True)
+    (profiles / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+
+    data = client.get("/api/plugins/kanban/board").json()
+    # Present despite owning zero tasks, alongside the implicit default.
+    assert "worker-foo" in data["assignees"]
+    assert "default" in data["assignees"]
 
 
 # ---------------------------------------------------------------------------
@@ -360,7 +381,7 @@ def test_dashboard_select_filters_use_sdk_value_change_handler():
 
     repo_root = Path(__file__).resolve().parents[2]
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    js = bundle.read_text()
+    js = bundle.read_text(encoding="utf-8")
 
     assert "function selectChangeHandler(setter)" in js
     assert "onValueChange: function (v)" in js
@@ -380,7 +401,7 @@ def test_dashboard_client_side_filtering_includes_tenant_filter():
 
     repo_root = Path(__file__).resolve().parents[2]
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    js = bundle.read_text()
+    js = bundle.read_text(encoding="utf-8")
 
     assert "if (tenantFilter && t.tenant !== tenantFilter) return false;" in js
     assert "[boardData, tenantFilter, assigneeFilter, search]" in js
@@ -396,7 +417,7 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
 
     repo_root = Path(__file__).resolve().parents[2]
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    js = bundle.read_text()
+    js = bundle.read_text(encoding="utf-8")
 
     assert 'useState(() => readSelectedBoard() || null)' in js
     assert "const storedBoard = readSelectedBoard();" in js
@@ -410,7 +431,7 @@ def test_dashboard_markdown_html_is_sanitized_before_render():
 
     repo_root = Path(__file__).resolve().parents[2]
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    js = bundle.read_text()
+    js = bundle.read_text(encoding="utf-8")
 
     assert "function sanitizeMarkdownHtml(html)" in js
     assert "MARKDOWN_ALLOWED_TAGS" in js
@@ -1198,7 +1219,7 @@ def test_dashboard_done_actions_prompt_for_completion_summary():
     repo_root = Path(__file__).resolve().parents[2]
     bundle = (
         repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    ).read_text()
+    ).read_text(encoding="utf-8")
 
     assert "withCompletionSummary" in bundle
     assert "Completion summary" in bundle
@@ -1216,7 +1237,7 @@ def test_dashboard_surfaces_ready_blocked_error_inline():
     repo_root = Path(__file__).resolve().parents[2]
     bundle = (
         repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    ).read_text()
+    ).read_text(encoding="utf-8")
 
     # Helper that strips ``"409: {\"detail\":\"…\"}"`` down to the
     # human-readable message before it lands in any banner.
@@ -1244,7 +1265,7 @@ def test_dashboard_dependency_selects_use_value_change_handler():
     repo_root = Path(__file__).resolve().parents[2]
     bundle = (
         repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    ).read_text()
+    ).read_text(encoding="utf-8")
 
     parent_select = (
         'value: newParent,\n'
@@ -1347,7 +1368,8 @@ def test_config_reads_dashboard_kanban_section(tmp_path, monkeypatch, client):
         "    default_tenant: acme\n"
         "    lane_by_profile: false\n"
         "    include_archived_by_default: true\n"
-        "    render_markdown: false\n"
+        "    render_markdown: false\n",
+        encoding="utf-8",
     )
     r = client.get("/api/plugins/kanban/config")
     assert r.status_code == 200
@@ -2362,7 +2384,7 @@ def test_board_endpoint_accepts_explicit_board_default_param(client):
 def test_dashboard_requests_default_board_explicitly():
     """Dashboard REST calls must include board=default instead of relying on server current board."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
 
     assert "SDK.fetchJSON(withBoard(`${API}/config`, board))" in dist
     assert "SDK.fetchJSON(withBoard(`${API}/boards`, board))" in dist
@@ -2373,7 +2395,7 @@ def test_dashboard_search_includes_body_and_result():
     """Client-side search must match body, result, latest_summary, and summary
     so full card contents are findable."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
 
     assert "t.body || \"\"" in dist
     assert "t.result || \"\"" in dist
@@ -2383,7 +2405,7 @@ def test_dashboard_search_includes_body_and_result():
 def test_dashboard_bulk_actions_include_reclaim_first():
     """Bulk action bar must expose reclaim_first checkbox and expanded status buttons."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
 
     assert "reclaim_first: reclaimFirst" in dist
     assert "hermes-kanban-bulk-reclaim-first" in dist
@@ -2395,7 +2417,7 @@ def test_dashboard_bulk_actions_include_reclaim_first():
 def test_dashboard_shift_click_range_selection_exists():
     """Shift-click must trigger range selection via toggleRange."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
 
     assert "function toggleRange" in dist or "const toggleRange =" in dist
     assert "props.toggleRange(t.id)" in dist or "props.toggleRange" in dist
@@ -2405,7 +2427,7 @@ def test_dashboard_shift_click_range_selection_exists():
 def test_dashboard_multi_move_bulk_exists():
     """Dragging a selected card with other selections must use /tasks/bulk."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
 
     assert "onMoveSelected" in dist
     assert "props.onMoveSelected" in dist
@@ -2415,8 +2437,8 @@ def test_dashboard_multi_move_bulk_exists():
 def test_dashboard_failed_card_highlight_class_exists():
     """Partial bulk failures must highlight failing cards."""
     repo_root = Path(__file__).resolve().parents[2]
-    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
-    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text(encoding="utf-8")
 
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
@@ -2493,7 +2515,7 @@ def test_board_tasks_include_latest_summary(client):
 def test_dashboard_done_final_result_section_rendered_from_summary():
     """Frontend must render Final Result section from run summary when task.result is empty."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
     assert "t.result || t.latest_summary" in dist
     assert "Final Result (run summary)" in dist
     assert "No final result was recorded" in dist
@@ -2527,8 +2549,8 @@ def test_task_detail_includes_child_result_summaries(client):
 def test_dashboard_final_result_uses_existing_fields_without_alias():
     """The drawer should not duplicate result/summary into another API field."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
-    api = (repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py").read_text()
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
+    api = (repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py").read_text(encoding="utf-8")
 
     assert "var finalResult = t.result || t.latest_summary || null;" in dist
     assert "t.final_result" not in dist
@@ -2538,7 +2560,7 @@ def test_dashboard_final_result_uses_existing_fields_without_alias():
 def test_dashboard_parent_notice_and_child_results_use_detail_links():
     """Parent detection must use links.children, which exists in task detail."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
     detail = dist[dist.index("function TaskDetail"):]
 
     assert "links.children.length > 0" in detail


### PR DESCRIPTION
Fixes #73235

## Problem

The Kanban dashboard's **ASSIGNEE toolbar filter**, **bulk-reassign selector**, and the **DiagnosticCard reassign picker** all read `boardData.assignees` from `GET /board` (`get_board()`). That field was built with a tasks-only query:

```python
"SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL "
"AND status != 'archived' ORDER BY assignee"
```

So a profile that exists on disk but owns no non-archived task — a freshly-created profile, or one whose tasks were all archived — was **absent from every assignee picker**. An operator could not filter by, or reassign to, such a profile without first giving it a task via the CLI. Meanwhile the Orchestration Panel already listed all profiles (it fetches `GET /api/profiles`), so the board was inconsistent with the rest of the UI.

## Fix

Reuse the existing, already-tested `kanban_db.known_assignees(conn)`, which unions on-disk profiles (`list_profiles_on_disk()`) with board-assigned names and already backs `GET /api/assignees`:

```python
assignees = [a["name"] for a in kanban_db.known_assignees(conn)]
```

This makes the board payload consistent with `GET /api/assignees` and needs no frontend/`dist` rebuild — the UI already consumes `boardData.assignees` as a flat name list. This is Fix A from the issue.

## Tests

- New `test_board_assignees_include_task_less_on_disk_profiles`: a profile with a `config.yaml` on disk but zero tasks now appears in the board's assignee list.
- Updated `test_board_empty`: the test fixture's `HERMES_HOME` root makes the implicit `default` profile a real on-disk profile, so it now correctly appears in the (otherwise empty) picker — `assignees == ["default"]`.

Full `tests/plugins/test_kanban_dashboard_plugin.py` passes (115). Preflight gates (windows-footguns, ruff, affected tests) pass. Incidental: added `encoding="utf-8"` to the pre-existing bare `read_text()`/`write_text()` calls in the touched test file to satisfy the windows-footgun gate.

Note: the arm64-fork Docker CI job is expected to fail on fork PRs and is unrelated to this change.
