### PR TITLE
fix(auth): preserve explicit credential status resets

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -659,11 +659,17 @@ class CredentialPool:
                 self._entries[idx] = new
                 return
 
-    def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+    def _persist(
+        self,
+        *,
+        removed_ids: Optional[List[str]] = None,
+        reset_status_ids: Optional[List[str]] = None,
+    ) -> None:
         write_credential_pool(
             self.provider,
             [entry.to_dict() for entry in self._entries],
             removed_ids=removed_ids,
+            reset_status_ids=reset_status_ids,
         )
 
     def _is_terminal_auth_failure(
@@ -2023,6 +2029,7 @@ class CredentialPool:
         with self._lock:
             count = 0
             new_entries = []
+            reset_ids = []
             for entry in self._entries:
                 if entry.last_status or entry.last_status_at or entry.last_error_code:
                     new_entries.append(
@@ -2037,11 +2044,12 @@ class CredentialPool:
                         )
                     )
                     count += 1
+                    reset_ids.append(entry.id)
                 else:
                     new_entries.append(entry)
             if count:
                 self._entries = new_entries
-                self._persist()
+                self._persist(reset_status_ids=reset_ids)
             return count
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1530,6 +1530,7 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    reset_status_ids: Optional[Iterable[str]] = None,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1547,9 +1548,13 @@ def write_credential_pool(
     snapshot cannot erase a cooldown/quarantine another process just wrote.
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
-    merge does not resurrect them from the on-disk copy.
+    merge does not resurrect them from the on-disk copy. Pass
+    ``reset_status_ids`` when an operator explicitly cleared credential status;
+    those entries bypass cooldown merging so the write cannot resurrect the
+    exact state being reset.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
+    status_resets = {rid for rid in (reset_status_ids or ()) if rid}
     with _auth_store_lock():
         auth_store = _load_auth_store()
         pool = auth_store.get("credential_pool")
@@ -1574,8 +1579,15 @@ def write_credential_pool(
             if isinstance(entry, dict) and entry.get("id")
         }
         merged: List[Dict[str, Any]] = [
-            _merge_disk_cooldown_state(
-                entry, existing_by_id.get(entry.get("id")), provider_id
+            (
+                entry
+                if (
+                    entry.get("id") in status_resets
+                    and all(entry.get(field) is None for field in _POOL_STATUS_FIELDS)
+                )
+                else _merge_disk_cooldown_state(
+                    entry, existing_by_id.get(entry.get("id")), provider_id
+                )
             )
             if isinstance(entry, dict)
             else entry

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -807,10 +807,12 @@ def test_auth_remove_prefers_exact_numeric_label_over_index(tmp_path, monkeypatc
 
 def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    now = time.time()
     _write_auth_store(
         tmp_path,
         {
             "version": 1,
+            "suppressed_sources": {"anthropic": ["claude_code", "hermes_pkce"]},
             "credential_pool": {
                 "anthropic": [
                     {
@@ -819,17 +821,23 @@ def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):
                         "auth_type": "api_key",
                         "priority": 0,
                         "source": "manual",
-                        "access_token": "sk-ant-api-primary",
+                        "access_token": "test-anthropic-key-primary",
                         "last_status": "exhausted",
-                        "last_status_at": 1711230000.0,
-                        "last_error_code": 402,
+                        "last_status_at": now,
+                        "last_error_code": 429,
+                        "last_error_reason": "rate_limit_error",
+                        "last_error_message": "Rate limit reached",
+                        "last_error_reset_at": now + 3600,
                     }
                 ]
             },
         },
     )
 
+    from agent.credential_pool import load_pool
     from hermes_cli.auth_commands import auth_reset_command
+
+    assert load_pool("anthropic").has_available() is False
 
     class _Args:
         provider = "anthropic"
@@ -844,6 +852,13 @@ def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):
     assert entry["last_status"] is None
     assert entry["last_status_at"] is None
     assert entry["last_error_code"] is None
+    assert entry["last_error_reason"] is None
+    assert entry["last_error_message"] is None
+    assert entry["last_error_reset_at"] is None
+
+    selected = load_pool("anthropic").select()
+    assert selected is not None
+    assert selected.id == "cred-1"
 
 
 def test_clear_provider_auth_removes_provider_pool_entries(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -587,6 +587,58 @@ def test_write_pool_stale_snapshot_keeps_newer_disk_cooldown(
     assert persisted["last_error_code"] == error_code
 
 
+def test_write_pool_explicit_status_reset_overrides_binding_disk_cooldown(classic_env):
+    """An operator reset must not be mistaken for a stale healthy snapshot."""
+    from hermes_cli.auth import write_credential_pool
+
+    benched_at = time.time()
+    _write(classic_env / "auth.json", _make_auth_store(pool={
+        "openrouter": [
+            _pool_entry(
+                last_status="exhausted",
+                last_status_at=benched_at,
+                last_error_code=429,
+                last_error_reset_at=benched_at + 3600,
+            ),
+            _pool_entry(
+                id="cred-y",
+                label="key-y",
+                access_token="sk-y",
+                last_status="exhausted",
+                last_status_at=benched_at,
+                last_error_code=429,
+                last_error_reset_at=benched_at + 3600,
+            ),
+        ],
+    }))
+
+    write_credential_pool(
+        "openrouter",
+        [
+            _pool_entry(),
+            _pool_entry(id="cred-y", label="key-y", access_token="sk-y"),
+        ],
+        reset_status_ids=["cred-x"],
+    )
+
+    data = json.loads((classic_env / "auth.json").read_text())
+    persisted = {
+        entry["id"]: entry
+        for entry in data["credential_pool"]["openrouter"]
+    }
+    reset_entry = persisted["cred-x"]
+    assert reset_entry.get("last_status") is None
+    assert reset_entry.get("last_status_at") is None
+    assert reset_entry.get("last_error_code") is None
+    assert reset_entry.get("last_error_reset_at") is None
+
+    untouched_entry = persisted["cred-y"]
+    assert untouched_entry["last_status"] == "exhausted"
+    assert untouched_entry["last_status_at"] == benched_at
+    assert untouched_entry["last_error_code"] == 429
+    assert untouched_entry["last_error_reset_at"] == benched_at + 3600
+
+
 def test_write_pool_expired_disk_cooldown_is_not_resurrected(classic_env):
     """An expired on-disk cooldown is NOT re-adopted onto the snapshot.
 


### PR DESCRIPTION
## What changed

- Thread explicitly reset credential IDs through `CredentialPool._persist()` into `write_credential_pool()`.
- Let only those named entries bypass the newer-on-disk cooldown merge, and only when every status field is actually cleared.
- Keep the existing stale-writer protection unchanged for ordinary writes and unrelated credentials.
- Strengthen the CLI regression with a still-binding future cooldown and add a direct persistence-boundary test.

## Why

`hermes auth reset <provider>` cleared status in memory, but `write_credential_pool()` immediately re-read the newer on-disk cooldown and merged it back. The command reported success while `hermes auth list` still showed the credential exhausted.

The existing test used an already-expired timestamp, so `_merge_disk_cooldown_state()` correctly declined to resurrect it and masked the bug. The updated test uses an unexpired provider reset window and proves the credential is selectable after an explicit operator reset.

This is narrower than changing general cooldown precedence: only explicit operator reset IDs bypass the merge. Genuine cooldowns from concurrent/stale writers remain protected.

Related: #51821. That PR improves explicit-reset coverage; this PR adds the persistence-boundary source fix required for still-binding cooldowns.

## Verification

- `pytest tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_profile_fallback.py tests/agent/test_credential_pool.py -q` — **176 passed**
- Focused stale-snapshot/reset tests — **6 passed**
- `python -m py_compile` for all four touched Python files — passed
- `git diff --check` — passed
- Manual repo-local CLI reproduction/readback — reset reported one credential, `auth list` selected it, persisted status fields were cleared
- Independent focused review — PASS; no correctness, concurrency, API compatibility, or security blockers

## Platform

Tested on Linux with Python 3.11.

## Security/data notes

- No credential values are logged or exposed.
- No provider calls are made by the regression tests.
- The new bypass is limited to named IDs whose status fields are all cleared.