### PR TITLE
fix(desktop): branch tiled slash commands from their own session

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -292,6 +292,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   const {
     bindGatewayRequest,
+    bindGatewayRequestForOwner,
     connectionRef,
     gateway,
     gatewayRef,
@@ -495,6 +496,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     activeSessionId,
     activeSessionIdRef,
     bindGatewayRequest,
+    bindGatewayRequestForOwner,
     busyRef,
     creatingSessionRef,
     ensureSessionState,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -491,6 +491,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     busyRef,
     creatingSessionRef,
     ensureSessionState,
+    gatewayRef,
     getRouteToken,
     getRoutedStoredSessionId,
     navigate,
@@ -595,8 +596,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const composer = useComposerActions({ activeSessionId, currentCwd, requestGateway })
 
   const branchInNewChat = useCallback(
-    async (messageId?: string) => {
-      const branched = await branchCurrentSession(messageId)
+    async (messageId?: string, targetSessionId?: string) => {
+      const branched = await branchCurrentSession(messageId, targetSessionId)
 
       if (branched) {
         await refreshSessions().catch(() => undefined)

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -290,7 +290,13 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     setMessages
   })
 
-  const { connectionRef, gateway, gatewayRef, requestGateway: ambientRequestGateway } = useGatewayRequest()
+  const {
+    bindGatewayRequest,
+    connectionRef,
+    gateway,
+    gatewayRef,
+    requestGateway: ambientRequestGateway
+  } = useGatewayRequest()
 
   // When chrome stays on the launch backend (Bot Mode / all-profiles
   // navigation), session-owned RPCs still have to hit the session's backend.
@@ -488,6 +494,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   } = useSessionActions({
     activeSessionId,
     activeSessionIdRef,
+    bindGatewayRequest,
     busyRef,
     creatingSessionRef,
     ensureSessionState,

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1346,7 +1346,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     // arg) — same contract as the sleep/wake reconnect: passing the active
     // profile would retarget the primary socket after a live profile swap.
     const lastCall = desktop.getConnection.mock.calls.at(-1) ?? []
-    expect(lastCall.length === 0 || lastCall[0] == null || lastCall[0] === '').toBe(true)
+    expect(lastCall.length === 0 || lastCall[0] == null || lastCall[0] === '' || lastCall[0] === 'default').toBe(true)
     expect(desktop.getGatewayWsUrl).toHaveBeenCalledTimes(2)
     expect(FakeWebSocket.instances).toHaveLength(2)
     expect($gatewayState.get()).toBe('open')
@@ -1512,7 +1512,9 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     const reconnectCalls = desktop.getConnection.mock.calls.slice(callsBeforeDrop)
     expect(reconnectCalls.some(args => (args[0] ?? '').trim() === 'coder')).toBe(false)
-    expect(reconnectCalls.some(args => args.length === 0 || args[0] == null || args[0] === '')).toBe(true)
+    expect(
+      reconnectCalls.some(args => args.length === 0 || args[0] == null || args[0] === '' || args[0] === 'default')
+    ).toBe(true)
 
     const primaryReconnectSockets = FakeWebSocket.instances
       .slice(socketsBeforeDrop)

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import type { HermesGateway } from '@/hermes'
 import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
-import { $gateway, ensureActiveGatewayOpen, isActivePrimary } from '@/store/gateway'
+import { $gateway, acquireGatewayRequestLease, ensureActiveGatewayOpen, isActivePrimary } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $gatewayState, setConnection } from '@/store/session'
 
@@ -160,7 +160,12 @@ export function useGatewayRequest() {
     [ensureGatewayOpen]
   )
 
-  return { connectionRef, gateway, gatewayRef, requestGateway }
+  const bindGatewayRequest = useCallback(
+    (gateway: HermesGateway, profile: string) => acquireGatewayRequestLease(gateway, profile),
+    []
+  )
+
+  return { bindGatewayRequest, connectionRef, gateway, gatewayRef, requestGateway }
 }
 
 const GATEWAY_TRANSPORT_ERROR_CODES = new Set([

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -4,7 +4,13 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import type { HermesGateway } from '@/hermes'
 import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
-import { $gateway, acquireGatewayRequestLease, ensureActiveGatewayOpen, isActivePrimary } from '@/store/gateway'
+import {
+  $gateway,
+  acquireGatewayRequestLease,
+  acquireGatewayRequestLeaseForAgent,
+  ensureActiveGatewayOpen,
+  isActivePrimary
+} from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $gatewayState, setConnection } from '@/store/session'
 
@@ -165,7 +171,12 @@ export function useGatewayRequest() {
     []
   )
 
-  return { bindGatewayRequest, connectionRef, gateway, gatewayRef, requestGateway }
+  const bindGatewayRequestForOwner = useCallback(
+    (connectionId: string, profile: string) => acquireGatewayRequestLeaseForAgent(connectionId, profile),
+    []
+  )
+
+  return { bindGatewayRequest, bindGatewayRequestForOwner, connectionRef, gateway, gatewayRef, requestGateway }
 }
 
 const GATEWAY_TRANSPORT_ERROR_CODES = new Set([

--- a/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
+++ b/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
@@ -308,6 +308,7 @@ function Harness({
     activeSessionId,
     activeSessionIdRef: cache.activeSessionIdRef,
     bindGatewayRequest: vi.fn() as never,
+    bindGatewayRequestForOwner: vi.fn() as never,
     busyRef,
     creatingSessionRef,
     ensureSessionState: cache.ensureSessionState,

--- a/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
+++ b/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
@@ -277,6 +277,7 @@ function Harness({
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)
+  const gatewayRef = useRef(null)
 
   const cache = useSessionStateCache({
     activeSessionId,
@@ -306,9 +307,11 @@ function Harness({
   const sessionActions = useSessionActions({
     activeSessionId,
     activeSessionIdRef: cache.activeSessionIdRef,
+    bindGatewayRequest: vi.fn() as never,
     busyRef,
     creatingSessionRef,
     ensureSessionState: cache.ensureSessionState,
+    gatewayRef,
     getRouteToken: () => 'token',
     getRoutedStoredSessionId: () => null,
     navigate: vi.fn() as never,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -108,6 +108,7 @@ interface HarnessHandle {
 
 function Harness({
   activeSessionIdRef: activeSessionIdRefProp,
+  branchCurrentSession,
   busyRef,
   getRoutedStoredSessionId,
   getRuntimeIdForStoredSession,
@@ -129,6 +130,7 @@ function Harness({
   createBackendSessionForSend
 }: {
   activeSessionIdRef?: MutableRefObject<string | null>
+  branchCurrentSession?: (messageId?: string, sessionId?: string) => Promise<boolean>
   busyRef?: MutableRefObject<boolean>
   getRoutedStoredSessionId?: () => null | string
   getRuntimeIdForStoredSession?: (storedSessionId: string) => null | string
@@ -188,7 +190,7 @@ function Harness({
   const actions = usePromptActions({
     activeSessionId: activeSessionId === undefined ? RUNTIME_SESSION_ID : activeSessionId,
     activeSessionIdRef,
-    branchCurrentSession: async () => true,
+    branchCurrentSession: branchCurrentSession ?? (async () => true),
     busyRef: localBusyRef,
     createBackendSessionForSend: createBackendSessionForSend ?? (async () => RUNTIME_SESSION_ID),
     getRoutedStoredSessionId: getRoutedStoredSessionId ?? (() => null),
@@ -1423,6 +1425,26 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
 
     dropSessionState(RUNTIME_SESSION_ID)
     $queuedPromptsBySession.set({})
+  })
+
+  it('branches the tile runtime that invoked /branch, not the foreground session', async () => {
+    const branchCurrentSession = vi.fn(async (_messageId?: string, _sessionId?: string) => true)
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId="foreground-runtime"
+        branchCurrentSession={branchCurrentSession}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={vi.fn(async () => ({}) as never)}
+        storedSessionId="foreground-stored"
+      />
+    )
+
+    await handle!.submitText('/branch', { sessionId: 'tile-runtime' })
+
+    expect(branchCurrentSession).toHaveBeenCalledWith(undefined, 'tile-runtime')
   })
 
   it('binds slash output and the busy queue to the TARGET session, not the foreground selection', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -231,7 +231,7 @@ interface PromptActionsOptions {
   activeSessionId: string | null
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
-  branchCurrentSession: () => Promise<boolean>
+  branchCurrentSession: (messageId?: string, targetSessionId?: string) => Promise<boolean>
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
   getRoutedStoredSessionId: () => null | string
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -132,7 +132,7 @@ interface SlashCommandDeps {
     text: string,
     storedSessionId?: string | null
   ) => void
-  branchCurrentSession: () => Promise<boolean>
+  branchCurrentSession: (messageId?: string, targetSessionId?: string) => Promise<boolean>
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
@@ -494,8 +494,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         new: async () => {
           startFreshSessionDraft()
         },
-        branch: async () => {
-          await branchCurrentSession()
+        branch: async ({ sessionHint }) => {
+          await branchCurrentSession(undefined, sessionHint)
         },
         // /compress (alias /compact) runs the gateway's dedicated
         // session.compress RPC — the TUI's path

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -119,16 +119,6 @@ vi.mock('@/components/pane-shell/tree/store', async importOriginal => ({
 
 const RUNTIME_SESSION_ID = 'rt-new-001'
 
-function deferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void
-
-  const promise = new Promise<T>(done => {
-    resolve = done
-  })
-
-  return { promise, resolve }
-}
-
 function gatewayWithRequest(
   request: (method: string, params?: Record<string, unknown>) => Promise<unknown>
 ): HermesGateway {
@@ -2010,7 +2000,7 @@ describe('branchStoredSession desktop source tagging', () => {
     const result = branchCurrentSession!(undefined, 'tile-runtime')
 
     expect(bindGatewayRequest).toHaveBeenCalledWith(sourceGatewayRef.current, 'work')
-    await waitFor(() => expect(getSession).toHaveBeenCalledWith('tile-stored'))
+    await waitFor(() => expect(getSession).toHaveBeenCalledWith('tile-stored', 'work'))
     profileLookup.resolve(storedSession({ id: 'tile-stored', profile: 'work' }))
     await waitFor(() =>
       expect(leasedSourceRequest).toHaveBeenCalledWith('session.branch', {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1818,7 +1818,7 @@ describe('branchStoredSession desktop source tagging', () => {
     expect(branchParams).toEqual({ session_id: 'live-parent', count: 2 })
   })
 
-  it('branches an explicit tile on its exact owner when two connections expose the same profile', async () => {
+  it('keeps a branch-from-branched tile on the exact owner when connections share a profile', async () => {
     vi.mocked(ensureGatewayProfile).mockClear()
     $activeGatewayProfile.set('default')
     setCurrentCwd('/foreground/workspace')
@@ -1854,11 +1854,15 @@ describe('branchStoredSession desktop source tagging', () => {
       { storedSessionId: 'tile-stored', ownerRoute: { connectionId: 'source-b', profile: 'default' } }
     ])
 
+    let branchNumber = 0
+
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.branch') {
+        branchNumber += 1
+
         return {
-          session_id: 'branch-runtime',
-          stored_session_id: 'branch-stored',
+          session_id: `branch-runtime-${branchNumber}`,
+          stored_session_id: `branch-stored-${branchNumber}`,
           title: 'Branch',
           message_count: 2,
           messages: [],
@@ -1917,30 +1921,46 @@ describe('branchStoredSession desktop source tagging', () => {
     expect($currentModel.get()).toBe('foreground-model')
     expect($currentProvider.get()).toBe('foreground-provider')
     expect($freshDraftReady.get()).toBe(true)
-    expect($sessions.get().find(session => session.id === 'branch-stored')).toMatchObject({
+    expect($sessions.get().find(session => session.id === 'branch-stored-1')).toMatchObject({
       cwd: '/tile/workspace',
       parent_session_id: 'tile-stored',
       profile: 'default'
     })
-    expect(sessionStateByRuntimeIdRef.current.get('branch-runtime')).toMatchObject({
+    expect(sessionStateByRuntimeIdRef.current.get('branch-runtime-1')).toMatchObject({
       cwd: '/tile/workspace',
       fast: true,
       messages: tileMessages,
       model: 'tile-model',
       provider: 'tile-provider',
-      storedSessionId: 'branch-stored'
+      storedSessionId: 'branch-stored-1'
     })
+    expect(sessionTileOwnerRoute('branch-stored-1')).toEqual({ connectionId: 'source-b', profile: 'default' })
+
+    await expect(branchCurrentSession!(undefined, 'branch-runtime-1')).resolves.toBe(true)
+
+    expect(requestGateway).toHaveBeenCalledWith('session.branch', {
+      session_id: 'branch-runtime-1',
+      count: 2
+    })
+    expect(tileOwnerBinder).toHaveBeenNthCalledWith(2, 'source-b', 'default')
+    expect($sessions.get().find(session => session.id === 'branch-stored-2')).toMatchObject({
+      parent_session_id: 'branch-stored-1',
+      profile: 'default'
+    })
+    expect(sessionTileOwnerRoute('branch-stored-2')).toEqual({ connectionId: 'source-b', profile: 'default' })
   })
 
   it('fails closed when an explicit tile has no exact connection owner', async () => {
     const tileMessages: ClientSessionState['messages'] = [
       { id: 'tile-q', role: 'user', parts: [{ type: 'text', text: 'tile question' }] }
     ]
+
     const sessionStateByRuntimeIdRef = {
       current: new Map<string, ClientSessionState>([
         ['tile-runtime', { ...createClientSessionState('tile-stored', tileMessages), cwd: '/tile/workspace' }]
       ])
     }
+
     const requestGateway = vi.fn(async () => ({}) as never)
     const bindGatewayRequestForOwner = vi.fn()
     let branchCurrentSession: ((messageId?: string, targetSessionId?: string) => Promise<boolean>) | null = null
@@ -2069,6 +2089,23 @@ describe('branchStoredSession desktop source tagging', () => {
     expect(approvalModeForProfile('work')).toBe('off')
     expect(approvalModeForProfile('other')).toBe('manual')
     expect(release).toHaveBeenCalledOnce()
+
+    const persistedTiles = JSON.parse(window.localStorage.getItem('hermes.desktop.sessionTiles.v2') ?? '{}') as Record<
+      string,
+      Array<{ ownerRoute?: SessionProfileRoute; storedSessionId: string }>
+    >
+
+    expect(persistedTiles.work).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ownerRoute: { connectionId: 'source-a', profile: 'work' },
+          storedSessionId: 'branch-stored-race'
+        })
+      ])
+    )
+
+    $activeGatewayProfile.set('work')
+    expect(sessionTileOwnerRoute('branch-stored-race')).toEqual({ connectionId: 'source-a', profile: 'work' })
   })
 
   it('releases the source lease after a terminal branch failure', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -75,7 +75,13 @@ import {
   setTurnStartedAt
 } from '@/store/session'
 import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
-import { $sessionTiles, closeSessionTile, reopenLastClosedTile, sessionTileOwnerRoute } from '@/store/session-states'
+import {
+  $sessionTiles,
+  closeSessionTile,
+  openSessionTileForProfile,
+  reopenLastClosedTile,
+  sessionTileOwnerRoute
+} from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
@@ -1768,7 +1774,7 @@ describe('branchStoredSession desktop source tagging', () => {
     })
   })
 
-  it('branches an open live chat via session.branch with a trimmed message count (bug #1/#3 fix)', async () => {
+  it('branches an open live chat via session.branch with a trimmed message count and preserves its backend target', async () => {
     let branchParams: Record<string, unknown> | undefined
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
@@ -1785,6 +1791,17 @@ describe('branchStoredSession desktop source tagging', () => {
         } as never
       }
 
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          message_count: 0,
+          messages: [],
+          resumed: 'branch-stored',
+          session_id: 'branch-runtime',
+          session_key: 'branch-stored'
+        } as never
+      }
+
       return {} as never
     })
 
@@ -1794,22 +1811,40 @@ describe('branchStoredSession desktop source tagging', () => {
       { id: 'q2', role: 'user', parts: [{ type: 'text', text: 'question two' }] },
       { id: 'a2', role: 'assistant', parts: [{ type: 'text', text: 'answer two' }] }
     ])
+    setSessions([storedSession({ id: 'stored-parent', profile: 'backend-default' })])
+    setSelectedStoredSessionId('stored-parent')
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'question one', role: 'user', timestamp: 1 },
+        { content: 'answer one', role: 'assistant', timestamp: 2 },
+        { content: 'question two', role: 'user', timestamp: 3 },
+        { content: 'answer two', role: 'assistant', timestamp: 4 }
+      ],
+      session_id: 'stored-parent'
+    } as never)
 
     let branchCurrentSession: ((messageId?: string) => Promise<boolean>) | null = null
-    const sourceOwnerRoute: SessionProfileRoute = { connectionId: 'source-a', profile: 'default' }
+    const leasedOwnerRoute: SessionProfileRoute = { connectionId: 'source-a', profile: 'default' }
+
+    const completeOwnerRoute: SessionProfileRoute = {
+      connectionId: 'source-a',
+      profile: 'default',
+      targetProfile: 'backend-default'
+    }
 
     render(
       <BranchHarness
         activeSessionId="live-parent"
-        bindGatewayRequest={gateway => ({ ...directGatewayLease(gateway), ownerRoute: sourceOwnerRoute })}
+        bindGatewayRequest={gateway => ({ ...directGatewayLease(gateway), ownerRoute: leasedOwnerRoute })}
         onCurrentReady={branch => (branchCurrentSession = branch)}
         onReady={() => undefined}
         requestGateway={requestGateway}
+        selectedStoredSessionId="stored-parent"
       />
     )
     await waitFor(() => expect(branchCurrentSession).not.toBeNull())
 
-    // Branch from the FIRST assistant reply ("a1"), not the last message �
+    // Branch from the FIRST assistant reply ("a1"), not the last message —
     // this is exactly the scenario that used to drop the question (bug #1):
     // only the clicked message survived instead of everything up to it.
     await expect(branchCurrentSession!('a1')).resolves.toBe(true)
@@ -1821,10 +1856,41 @@ describe('branchStoredSession desktop source tagging', () => {
     expect(branchParams).toEqual({ session_id: 'live-parent', count: 2 })
     expect($sessions.get().find(session => session.id === 'branch-stored')).toMatchObject({
       connection_id: 'source-a',
-      profile: 'default'
+      profile: 'backend-default'
     })
-    expect(getSessionOwnerHint('branch-stored')).toEqual(sourceOwnerRoute)
-    expect(sessionTileOwnerRoute('branch-stored')).toEqual(sourceOwnerRoute)
+    expect(getSessionOwnerHint('branch-stored')).toEqual(completeOwnerRoute)
+
+    // Persisting/reopening the child tile must retain the complete display-to-
+    // backend route, and every later session read must use the physical display
+    // profile while rewriting an explicit backend profile parameter.
+    setSelectedStoredSessionId(null)
+    openSessionTileForProfile('branch-stored', 'default', 'center', undefined, undefined, completeOwnerRoute)
+    closeSessionTile('branch-stored')
+    reopenLastClosedTile()
+    expect(sessionTileOwnerRoute('branch-stored')).toEqual(completeOwnerRoute)
+
+    vi.mocked(requestGatewayForAgent).mockClear()
+    vi.mocked(requestGatewayForAgent).mockResolvedValue({} as never)
+
+    for (const method of ['session.get', 'session.messages', 'session.read']) {
+      await requestForSessionProfile(knownSessionOwner($sessions.get(), 'branch-stored'), requestGateway, method, {
+        profile: 'default',
+        session_id: 'branch-stored'
+      })
+    }
+
+    expect(requestGatewayForAgent).toHaveBeenNthCalledWith(1, 'source-a', 'default', 'session.get', {
+      profile: 'backend-default',
+      session_id: 'branch-stored'
+    })
+    expect(requestGatewayForAgent).toHaveBeenNthCalledWith(2, 'source-a', 'default', 'session.messages', {
+      profile: 'backend-default',
+      session_id: 'branch-stored'
+    })
+    expect(requestGatewayForAgent).toHaveBeenNthCalledWith(3, 'source-a', 'default', 'session.read', {
+      profile: 'backend-default',
+      session_id: 'branch-stored'
+    })
   })
 
   it('keeps a branch-from-branched tile on the exact owner when connections share a profile', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -183,6 +183,7 @@ function Harness({
     activeSessionId,
     activeSessionIdRef: ref(activeSessionId),
     bindGatewayRequest: directGatewayLease,
+    bindGatewayRequestForOwner: vi.fn() as never,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
@@ -272,6 +273,7 @@ function StoredIdRotationHarness({
     activeSessionId: activeSessionIdRef.current,
     activeSessionIdRef,
     bindGatewayRequest: directGatewayLease,
+    bindGatewayRequestForOwner: vi.fn() as never,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
@@ -777,6 +779,7 @@ function ResumeHarness({
     activeSessionId: null,
     activeSessionIdRef: ref<string | null>(null),
     bindGatewayRequest: directGatewayLease,
+    bindGatewayRequestForOwner: vi.fn() as never,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
@@ -834,6 +837,7 @@ function ResumeTimerHarness({
     activeSessionId,
     activeSessionIdRef: cache.activeSessionIdRef,
     bindGatewayRequest: directGatewayLease,
+    bindGatewayRequestForOwner: vi.fn() as never,
     busyRef,
     creatingSessionRef: useRef(false),
     ensureSessionState: cache.ensureSessionState,
@@ -1529,6 +1533,7 @@ describe('session.resume turn timer contract', () => {
 function BranchHarness({
   activeSessionId = null,
   bindGatewayRequest = directGatewayLease,
+  bindGatewayRequestForOwner,
   busy = false,
   gatewayRef,
   navigate = vi.fn(),
@@ -1541,6 +1546,7 @@ function BranchHarness({
 }: {
   activeSessionId?: string | null
   bindGatewayRequest?: (gateway: HermesGateway, profile: string) => GatewayRequestLease
+  bindGatewayRequestForOwner?: (connectionId: string, profile: string) => GatewayRequestLease
   busy?: boolean
   gatewayRef?: MutableRefObject<HermesGateway | null>
   navigate?: ReturnType<typeof vi.fn>
@@ -1565,6 +1571,8 @@ function BranchHarness({
     activeSessionId,
     activeSessionIdRef,
     bindGatewayRequest,
+    bindGatewayRequestForOwner:
+      bindGatewayRequestForOwner ?? (() => directGatewayLease(gatewayWithRequest(requestGateway))),
     busyRef: ref(busy),
     creatingSessionRef: ref(false),
     ensureSessionState: (sessionId, storedSessionId) => {
@@ -1810,7 +1818,7 @@ describe('branchStoredSession desktop source tagging', () => {
     expect(branchParams).toEqual({ session_id: 'live-parent', count: 2 })
   })
 
-  it('branches an explicit tile runtime from its own cached session state', async () => {
+  it('branches an explicit tile on its exact owner when two connections expose the same profile', async () => {
     vi.mocked(ensureGatewayProfile).mockClear()
     $activeGatewayProfile.set('default')
     setCurrentCwd('/foreground/workspace')
@@ -1840,7 +1848,10 @@ describe('branchStoredSession desktop source tagging', () => {
     setMessages(foregroundMessages)
     setSessions([
       storedSession({ id: 'foreground-stored', profile: 'default' }),
-      storedSession({ id: 'tile-stored', profile: 'work' })
+      storedSession({ id: 'tile-stored', profile: 'default' })
+    ])
+    $sessionTiles.set([
+      { storedSessionId: 'tile-stored', ownerRoute: { connectionId: 'source-b', profile: 'default' } }
     ])
 
     const requestGateway = vi.fn(async (method: string) => {
@@ -1863,10 +1874,14 @@ describe('branchStoredSession desktop source tagging', () => {
       return {} as never
     })
 
+    const activeOwnerBinder = vi.fn(directGatewayLease)
+    const tileOwnerBinder = vi.fn(() => directGatewayLease(gatewayWithRequest(requestGateway)))
     let branchCurrentSession: ((messageId?: string, targetSessionId?: string) => Promise<boolean>) | null = null
     render(
       <BranchHarness
         activeSessionId="foreground-runtime"
+        bindGatewayRequest={activeOwnerBinder}
+        bindGatewayRequestForOwner={tileOwnerBinder}
         busy
         onCurrentReady={branch => (branchCurrentSession = branch)}
         onReady={() => undefined}
@@ -1887,6 +1902,8 @@ describe('branchStoredSession desktop source tagging', () => {
       'session.branch',
       expect.objectContaining({ session_id: 'foreground-runtime' })
     )
+    expect(tileOwnerBinder).toHaveBeenCalledWith('source-b', 'default')
+    expect(activeOwnerBinder).not.toHaveBeenCalled()
     // session.branch is runtime-scoped: switching to the stored row's profile
     // before the RPC would move requestGateway to another socket where this
     // runtime does not exist.
@@ -1903,7 +1920,7 @@ describe('branchStoredSession desktop source tagging', () => {
     expect($sessions.get().find(session => session.id === 'branch-stored')).toMatchObject({
       cwd: '/tile/workspace',
       parent_session_id: 'tile-stored',
-      profile: 'work'
+      profile: 'default'
     })
     expect(sessionStateByRuntimeIdRef.current.get('branch-runtime')).toMatchObject({
       cwd: '/tile/workspace',
@@ -1915,9 +1932,37 @@ describe('branchStoredSession desktop source tagging', () => {
     })
   })
 
-  it('uses the leased source requester and applies a delayed runtime response only to its owner profile', async () => {
-    const profileLookup = deferred<SessionInfo>()
+  it('fails closed when an explicit tile has no exact connection owner', async () => {
+    const tileMessages: ClientSessionState['messages'] = [
+      { id: 'tile-q', role: 'user', parts: [{ type: 'text', text: 'tile question' }] }
+    ]
+    const sessionStateByRuntimeIdRef = {
+      current: new Map<string, ClientSessionState>([
+        ['tile-runtime', { ...createClientSessionState('tile-stored', tileMessages), cwd: '/tile/workspace' }]
+      ])
+    }
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const bindGatewayRequestForOwner = vi.fn()
+    let branchCurrentSession: ((messageId?: string, targetSessionId?: string) => Promise<boolean>) | null = null
 
+    render(
+      <BranchHarness
+        activeSessionId="foreground-runtime"
+        bindGatewayRequestForOwner={bindGatewayRequestForOwner as never}
+        onCurrentReady={branch => (branchCurrentSession = branch)}
+        onReady={() => undefined}
+        requestGateway={requestGateway}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(branchCurrentSession).not.toBeNull())
+
+    await expect(branchCurrentSession!(undefined, 'tile-runtime')).resolves.toBe(false)
+    expect(bindGatewayRequestForOwner).not.toHaveBeenCalled()
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('uses the leased source requester and applies a delayed runtime response only to its owner profile', async () => {
     const branchRpc = deferred<{
       info: { approval_mode: 'off'; cwd: string }
       message_count: number
@@ -1947,7 +1992,7 @@ describe('branchStoredSession desktop source tagging', () => {
     $activeGatewayProfile.set('work')
     reconcileApprovalModeForProfile('other', 'manual')
     setSessions([storedSession({ id: 'foreground-stored', profile: 'work' })])
-    vi.mocked(getSession).mockImplementation(async () => profileLookup.promise)
+    $sessionTiles.set([{ storedSessionId: 'tile-stored', ownerRoute: { connectionId: 'source-a', profile: 'work' } }])
 
     const branchResponse = {
       session_id: 'branch-runtime-race',
@@ -1965,7 +2010,7 @@ describe('branchStoredSession desktop source tagging', () => {
     const leasedSourceRequest = vi.fn(async () => branchRpc.promise)
     const release = vi.fn()
 
-    const bindGatewayRequest = vi.fn((): GatewayRequestLease => ({
+    const bindGatewayRequestForOwner = vi.fn((): GatewayRequestLease => ({
       request: leasedSourceRequest as GatewayRequestLease['request'],
       release
     }))
@@ -1986,7 +2031,7 @@ describe('branchStoredSession desktop source tagging', () => {
     render(
       <BranchHarness
         activeSessionId="foreground-runtime"
-        bindGatewayRequest={bindGatewayRequest}
+        bindGatewayRequestForOwner={bindGatewayRequestForOwner}
         gatewayRef={sourceGatewayRef}
         onCurrentReady={branch => (branchCurrentSession = branch)}
         onReady={() => undefined}
@@ -1999,9 +2044,7 @@ describe('branchStoredSession desktop source tagging', () => {
 
     const result = branchCurrentSession!(undefined, 'tile-runtime')
 
-    expect(bindGatewayRequest).toHaveBeenCalledWith(sourceGatewayRef.current, 'work')
-    await waitFor(() => expect(getSession).toHaveBeenCalledWith('tile-stored', 'work'))
-    profileLookup.resolve(storedSession({ id: 'tile-stored', profile: 'work' }))
+    expect(bindGatewayRequestForOwner).toHaveBeenCalledWith('source-a', 'work')
     await waitFor(() =>
       expect(leasedSourceRequest).toHaveBeenCalledWith('session.branch', {
         session_id: 'tile-runtime',
@@ -2056,18 +2099,19 @@ describe('branchStoredSession desktop source tagging', () => {
 
     const release = vi.fn()
 
-    const bindGatewayRequest = vi.fn((): GatewayRequestLease => ({
+    const bindGatewayRequestForOwner = vi.fn((): GatewayRequestLease => ({
       request: leasedSourceRequest as GatewayRequestLease['request'],
       release
     }))
 
     setSessions([storedSession({ id: 'tile-stored', profile: 'work' })])
+    $sessionTiles.set([{ storedSessionId: 'tile-stored', ownerRoute: { connectionId: 'source-a', profile: 'work' } }])
 
     let branchCurrentSession: ((messageId?: string, targetSessionId?: string) => Promise<boolean>) | null = null
     render(
       <BranchHarness
         activeSessionId="foreground-runtime"
-        bindGatewayRequest={bindGatewayRequest}
+        bindGatewayRequestForOwner={bindGatewayRequestForOwner}
         gatewayRef={{ current: gatewayWithRequest(rawSourceGatewayRequest) }}
         onCurrentReady={branch => (branchCurrentSession = branch)}
         onReady={() => undefined}
@@ -2120,6 +2164,7 @@ describe('branchStoredSession desktop source tagging', () => {
       storedSession({ id: 'foreground-stored', profile: 'default' }),
       storedSession({ id: 'tile-stored', profile: 'work' })
     ])
+    $sessionTiles.set([{ storedSessionId: 'tile-stored', ownerRoute: { connectionId: 'source-a', profile: 'work' } }])
     vi.mocked(focusedSessionTabAnchor).mockReturnValue('session-tile:tile-stored')
     vi.mocked(revealTreePane).mockClear()
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1646,6 +1646,10 @@ describe('branchStoredSession desktop source tagging', () => {
       />
     )
     await waitFor(() => expect(branchStoredSession).not.toBeNull())
+    // Both capture and completion normalize the absent tree anchor to undefined.
+    // A stable no-anchor branch must still reveal its child pane.
+    vi.mocked(focusedSessionTabAnchor).mockReturnValue(null)
+    vi.mocked(revealTreePane).mockClear()
 
     await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
 
@@ -1703,7 +1707,8 @@ describe('branchStoredSession desktop source tagging', () => {
     // Branching a session that is not the one currently open must not steal
     // the user's active view — "stored-other" stays selected.
     expect($selectedStoredSessionId.get()).toBe('stored-other')
-    // The branch instead opens as its own tile.
+    // A stable no-anchor branch still reveals the child opened as its own tile.
+    expect(revealTreePane).toHaveBeenCalledWith('session-tile:branch-stored')
     expect($sessionTiles.get().some(tile => tile.storedSessionId === 'branch-stored')).toBe(true)
   })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1982,6 +1982,96 @@ describe('branchStoredSession desktop source tagging', () => {
     expect(requestGateway).not.toHaveBeenCalled()
   })
 
+  it.each(['removed', 'rebound'] as const)(
+    'fails closed when an offscreen target is %s while its source reconnects',
+    async mutation => {
+      const recovery = deferred<void>()
+
+      const tileMessages: ClientSessionState['messages'] = [
+        { id: 'tile-q', role: 'user', parts: [{ type: 'text', text: 'tile question' }] }
+      ]
+
+      const tileState = {
+        ...createClientSessionState('tile-stored', tileMessages),
+        cwd: '/tile/workspace'
+      }
+
+      const sessionStateByRuntimeIdRef = {
+        current: new Map<string, ClientSessionState>([['tile-runtime', tileState]])
+      }
+
+      const dispatched = vi.fn(async (_method: string, _params?: Record<string, unknown>) => ({}) as never)
+
+      const release = vi.fn()
+
+      const bindGatewayRequestForOwner = vi.fn((): GatewayRequestLease => ({
+        request: (async (
+          method: string,
+          params?: Record<string, unknown>,
+          _timeoutMs?: number,
+          _signal?: AbortSignal,
+          isStillValid?: () => boolean
+        ) => {
+          await recovery.promise
+
+          if (isStillValid && !isStillValid()) {
+            throw new Error('Hermes source session unavailable')
+          }
+
+          return dispatched(method, params)
+        }) as GatewayRequestLease['request'],
+        release
+      }))
+
+      $sessionTiles.set([
+        {
+          ownerRoute: { connectionId: 'source-a', profile: 'work' },
+          runtimeId: 'tile-runtime',
+          storedSessionId: 'tile-stored'
+        }
+      ])
+
+      let branchCurrentSession: ((messageId?: string, targetSessionId?: string) => Promise<boolean>) | null = null
+      render(
+        <BranchHarness
+          activeSessionId="foreground-runtime"
+          bindGatewayRequestForOwner={bindGatewayRequestForOwner}
+          onCurrentReady={branch => (branchCurrentSession = branch)}
+          onReady={() => undefined}
+          requestGateway={vi.fn(async () => ({}) as never)}
+          sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+        />
+      )
+      await waitFor(() => expect(branchCurrentSession).not.toBeNull())
+
+      const result = branchCurrentSession!(undefined, 'tile-runtime')
+      await waitFor(() => expect(bindGatewayRequestForOwner).toHaveBeenCalledWith('source-a', 'work'))
+
+      if (mutation === 'removed') {
+        sessionStateByRuntimeIdRef.current.delete('tile-runtime')
+        $sessionTiles.set([])
+      } else {
+        sessionStateByRuntimeIdRef.current.set('tile-runtime', {
+          ...createClientSessionState('other-stored', tileMessages),
+          cwd: '/other/workspace'
+        })
+        $sessionTiles.set([
+          {
+            ownerRoute: { connectionId: 'source-b', profile: 'work' },
+            runtimeId: 'tile-runtime',
+            storedSessionId: 'other-stored'
+          }
+        ])
+      }
+
+      recovery.resolve()
+
+      await expect(result).resolves.toBe(false)
+      expect(dispatched).not.toHaveBeenCalled()
+      expect(release).toHaveBeenCalledOnce()
+    }
+  )
+
   it('uses the leased source requester and applies a delayed runtime response only to its owner profile', async () => {
     const branchRpc = deferred<{
       info: { approval_mode: 'off'; cwd: string }
@@ -2066,10 +2156,16 @@ describe('branchStoredSession desktop source tagging', () => {
 
     expect(bindGatewayRequestForOwner).toHaveBeenCalledWith('source-a', 'work')
     await waitFor(() =>
-      expect(leasedSourceRequest).toHaveBeenCalledWith('session.branch', {
-        session_id: 'tile-runtime',
-        count: 2
-      })
+      expect(leasedSourceRequest).toHaveBeenCalledWith(
+        'session.branch',
+        {
+          session_id: 'tile-runtime',
+          count: 2
+        },
+        undefined,
+        undefined,
+        expect.any(Function)
+      )
     )
 
     activeGatewayRequest = switchedGatewayRequest

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -42,6 +42,7 @@ import {
   $currentModel,
   $currentProvider,
   $currentReasoningEffort,
+  $freshDraftReady,
   $messages,
   $messagingSessions,
   $newChatWorkspaceTarget,
@@ -63,6 +64,7 @@ import {
   setCurrentModel,
   setCurrentProvider,
   setCurrentReasoningEffort,
+  setFreshDraftReady,
   setMessages,
   setMessagingSessions,
   setNewChatWorkspaceTarget,
@@ -72,7 +74,7 @@ import {
   setTurnStartedAt
 } from '@/store/session'
 import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
-import { $sessionTiles, sessionTileOwnerRoute } from '@/store/session-states'
+import { $sessionTiles, closeSessionTile, sessionTileOwnerRoute } from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
@@ -1530,9 +1532,7 @@ function BranchHarness({
   busy?: boolean
   gatewayRef?: MutableRefObject<HermesGateway | null>
   navigate?: ReturnType<typeof vi.fn>
-  onCurrentReady?: (
-    branchCurrentSession: (messageId?: string, targetSessionId?: string) => Promise<boolean>
-  ) => void
+  onCurrentReady?: (branchCurrentSession: (messageId?: string, targetSessionId?: string) => Promise<boolean>) => void
   onReady: (branchStoredSession: (storedSessionId: string, sessionProfile?: string | null) => Promise<boolean>) => void
   onRefs?: (refs: {
     activeSessionIdRef: MutableRefObject<string | null>
@@ -1926,9 +1926,7 @@ describe('branchStoredSession desktop source tagging', () => {
 
     const sourceGatewayRequest = vi.fn(async (_method: string, _params?: Record<string, unknown>) => branchResponse)
 
-    const switchedGatewayRequest = vi.fn(
-      async (_method: string, _params?: Record<string, unknown>) => branchResponse
-    )
+    const switchedGatewayRequest = vi.fn(async (_method: string, _params?: Record<string, unknown>) => branchResponse)
 
     let activeGatewayRequest = sourceGatewayRequest
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -75,7 +75,7 @@ import {
   setTurnStartedAt
 } from '@/store/session'
 import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
-import { $sessionTiles, closeSessionTile, sessionTileOwnerRoute } from '@/store/session-states'
+import { $sessionTiles, closeSessionTile, reopenLastClosedTile, sessionTileOwnerRoute } from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
@@ -1796,9 +1796,12 @@ describe('branchStoredSession desktop source tagging', () => {
     ])
 
     let branchCurrentSession: ((messageId?: string) => Promise<boolean>) | null = null
+    const sourceOwnerRoute: SessionProfileRoute = { connectionId: 'source-a', profile: 'default' }
+
     render(
       <BranchHarness
         activeSessionId="live-parent"
+        bindGatewayRequest={gateway => ({ ...directGatewayLease(gateway), ownerRoute: sourceOwnerRoute })}
         onCurrentReady={branch => (branchCurrentSession = branch)}
         onReady={() => undefined}
         requestGateway={requestGateway}
@@ -1816,6 +1819,12 @@ describe('branchStoredSession desktop source tagging', () => {
       count: 2
     })
     expect(branchParams).toEqual({ session_id: 'live-parent', count: 2 })
+    expect($sessions.get().find(session => session.id === 'branch-stored')).toMatchObject({
+      connection_id: 'source-a',
+      profile: 'default'
+    })
+    expect(getSessionOwnerHint('branch-stored')).toEqual(sourceOwnerRoute)
+    expect(sessionTileOwnerRoute('branch-stored')).toEqual(sourceOwnerRoute)
   })
 
   it('keeps a branch-from-branched tile on the exact owner when connections share a profile', async () => {
@@ -1922,10 +1931,12 @@ describe('branchStoredSession desktop source tagging', () => {
     expect($currentProvider.get()).toBe('foreground-provider')
     expect($freshDraftReady.get()).toBe(true)
     expect($sessions.get().find(session => session.id === 'branch-stored-1')).toMatchObject({
+      connection_id: 'source-b',
       cwd: '/tile/workspace',
       parent_session_id: 'tile-stored',
       profile: 'default'
     })
+    expect(getSessionOwnerHint('branch-stored-1')).toEqual({ connectionId: 'source-b', profile: 'default' })
     expect(sessionStateByRuntimeIdRef.current.get('branch-runtime-1')).toMatchObject({
       cwd: '/tile/workspace',
       fast: true,
@@ -1934,6 +1945,15 @@ describe('branchStoredSession desktop source tagging', () => {
       provider: 'tile-provider',
       storedSessionId: 'branch-stored-1'
     })
+    expect(sessionTileOwnerRoute('branch-stored-1')).toEqual({ connectionId: 'source-b', profile: 'default' })
+
+    closeSessionTile('branch-stored-1')
+    expect(sessionTileOwnerRoute('branch-stored-1')).toBeUndefined()
+    expect(knownSessionOwner($sessions.get(), 'branch-stored-1')).toEqual({
+      connectionId: 'source-b',
+      profile: 'default'
+    })
+    reopenLastClosedTile()
     expect(sessionTileOwnerRoute('branch-stored-1')).toEqual({ connectionId: 'source-b', profile: 'default' })
 
     await expect(branchCurrentSession!(undefined, 'branch-runtime-1')).resolves.toBe(true)

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NO_PROJECT_ID } from '@/app/chat/sidebar/projects/workspace-groups'
 import { resolveSessionRpcOwner } from '@/app/contrib/wiring-routing'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
-import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
+import { focusedSessionTabAnchor, noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import {
   deleteSession,
   getAllSessionMessages,
@@ -111,6 +111,7 @@ vi.mock('@/store/gateway', async importOriginal => ({
 
 vi.mock('@/components/pane-shell/tree/store', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
+  focusedSessionTabAnchor: vi.fn(() => 'workspace'),
   noteActiveTreeGroup: vi.fn(),
   revealTreePane: vi.fn()
 }))
@@ -1973,7 +1974,7 @@ describe('branchStoredSession desktop source tagging', () => {
     expect(switchedGatewayRequest).not.toHaveBeenCalled()
   })
 
-  it('does not reveal a completed tile branch into a newer profile intent', async () => {
+  it('does not reveal a completed tile branch after focus moves to another tile', async () => {
     const branchRpc = deferred<{
       info: { cwd: string; fast: boolean; model: string; provider: string }
       message_count: number
@@ -2010,6 +2011,7 @@ describe('branchStoredSession desktop source tagging', () => {
       storedSession({ id: 'foreground-stored', profile: 'default' }),
       storedSession({ id: 'tile-stored', profile: 'work' })
     ])
+    vi.mocked(focusedSessionTabAnchor).mockReturnValue('session-tile:tile-stored')
     vi.mocked(revealTreePane).mockClear()
 
     const requestGateway = vi.fn(async (method: string) => {
@@ -2036,9 +2038,9 @@ describe('branchStoredSession desktop source tagging', () => {
     const result = branchCurrentSession!(undefined, 'tile-runtime')
 
     await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.branch', expect.any(Object)))
-    $activeGatewayProfile.set('other')
+    vi.mocked(focusedSessionTabAnchor).mockReturnValue('session-tile:other-existing')
     $sessionTiles.set([{ storedSessionId: 'other-existing' }])
-    const otherTilesBeforeCompletion = $sessionTiles.get()
+    const tilesBeforeCompletion = $sessionTiles.get()
 
     branchRpc.resolve({
       session_id: 'branch-runtime-stale',
@@ -2056,23 +2058,19 @@ describe('branchStoredSession desktop source tagging', () => {
 
     await expect(result).resolves.toBe(true)
 
-    const otherTilesAfterCompletion = $sessionTiles.get()
+    const tilesAfterCompletion = $sessionTiles.get()
     const revealedAfterCompletion = vi.mocked(revealTreePane).mock.calls
-
-    $activeGatewayProfile.set('default')
 
     const childPersistedForInvocationProfile = $sessionTiles
       .get()
       .some(tile => tile.storedSessionId === 'branch-stored-stale')
 
-    for (const profile of ['default', 'other']) {
-      $activeGatewayProfile.set(profile)
-      closeSessionTile('branch-stored-stale')
-    }
+    closeSessionTile('branch-stored-stale')
 
-    $activeGatewayProfile.set('default')
-
-    expect(otherTilesAfterCompletion).toEqual(otherTilesBeforeCompletion)
+    expect(tilesAfterCompletion).toEqual([
+      ...tilesBeforeCompletion,
+      expect.objectContaining({ storedSessionId: 'branch-stored-stale' })
+    ])
     expect(revealedAfterCompletion).toEqual([])
     expect(childPersistedForInvocationProfile).toBe(true)
     expect($currentCwd.get()).toBe('/foreground/workspace')

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -21,9 +21,10 @@ import {
   setSessionArchived
 } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { $approvalModes, approvalModeForProfile, reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
-import { requestGatewayForAgent, requestGatewayForProfile } from '@/store/gateway'
+import { type GatewayRequestLease, requestGatewayForAgent, requestGatewayForProfile } from '@/store/gateway'
 import { $pinnedSessionIds } from '@/store/layout'
 import { $activeGatewayProfile, $newChatProfile, $newChatRoute, $profiles, ensureGatewayProfile } from '@/store/profile'
 import {
@@ -134,6 +135,16 @@ function gatewayWithRequest(
   return { request } as unknown as HermesGateway
 }
 
+function directGatewayLease(gateway: HermesGateway): GatewayRequestLease {
+  return {
+    request: <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) =>
+      timeoutMs !== undefined || signal !== undefined
+        ? gateway.request<T>(method, params, timeoutMs, signal)
+        : gateway.request<T>(method, params),
+    release: vi.fn()
+  }
+}
+
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
   | 'archiveSession'
@@ -181,6 +192,7 @@ function Harness({
   const actions = useSessionActions({
     activeSessionId,
     activeSessionIdRef: ref(activeSessionId),
+    bindGatewayRequest: directGatewayLease,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
@@ -268,6 +280,7 @@ function StoredIdRotationHarness({
   useSessionActions({
     activeSessionId: activeSessionIdRef.current,
     activeSessionIdRef,
+    bindGatewayRequest: directGatewayLease,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
@@ -771,6 +784,7 @@ function ResumeHarness({
   const actions = useSessionActions({
     activeSessionId: null,
     activeSessionIdRef: ref<string | null>(null),
+    bindGatewayRequest: directGatewayLease,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
@@ -1519,6 +1533,7 @@ describe('session.resume turn timer contract', () => {
 
 function BranchHarness({
   activeSessionId = null,
+  bindGatewayRequest = directGatewayLease,
   busy = false,
   gatewayRef,
   navigate = vi.fn(),
@@ -1530,6 +1545,7 @@ function BranchHarness({
   sessionStateByRuntimeIdRef
 }: {
   activeSessionId?: string | null
+  bindGatewayRequest?: (gateway: HermesGateway, profile: string) => GatewayRequestLease
   busy?: boolean
   gatewayRef?: MutableRefObject<HermesGateway | null>
   navigate?: ReturnType<typeof vi.fn>
@@ -1553,6 +1569,7 @@ function BranchHarness({
   const actions = useSessionActions({
     activeSessionId,
     activeSessionIdRef,
+    bindGatewayRequest,
     busyRef: ref(busy),
     creatingSessionRef: ref(false),
     ensureSessionState: (sessionId, storedSessionId) => {
@@ -1599,6 +1616,7 @@ function BranchHarness({
 describe('branchStoredSession desktop source tagging', () => {
   afterEach(() => {
     cleanup()
+    $approvalModes.set({})
     $activeGatewayProfile.set('default')
     setFreshDraftReady(false)
     setSessions([])
@@ -1898,8 +1916,17 @@ describe('branchStoredSession desktop source tagging', () => {
     })
   })
 
-  it('keeps a tile branch on its invocation gateway across deferred profile resolution', async () => {
+  it('uses the leased source requester and applies a delayed runtime response only to its owner profile', async () => {
     const profileLookup = deferred<SessionInfo>()
+
+    const branchRpc = deferred<{
+      info: { approval_mode: 'off'; cwd: string }
+      message_count: number
+      messages: never[]
+      session_id: string
+      stored_session_id: string
+      title: string
+    }>()
 
     const tileMessages: ClientSessionState['messages'] = [
       { id: 'tile-q', role: 'user', parts: [{ type: 'text', text: 'tile question' }] },
@@ -1918,7 +1945,9 @@ describe('branchStoredSession desktop source tagging', () => {
       ])
     }
 
-    setSessions([storedSession({ id: 'foreground-stored', profile: 'default' })])
+    $activeGatewayProfile.set('work')
+    reconcileApprovalModeForProfile('other', 'manual')
+    setSessions([storedSession({ id: 'foreground-stored', profile: 'work' })])
     vi.mocked(getSession).mockImplementation(async () => profileLookup.promise)
 
     const branchResponse = {
@@ -1927,17 +1956,28 @@ describe('branchStoredSession desktop source tagging', () => {
       title: 'Branch',
       message_count: 2,
       messages: [],
-      info: { cwd: '/tile/workspace' }
+      info: { approval_mode: 'off' as const, cwd: '/tile/workspace' }
     }
 
-    const sourceGatewayRequest = vi.fn(async (_method: string, _params?: Record<string, unknown>) => branchResponse)
+    const rawSourceGatewayRequest = vi.fn(async (_method: string, _params?: Record<string, unknown>) => {
+      throw new Error('raw source request bypassed lease recovery')
+    })
+
+    const leasedSourceRequest = vi.fn(async () => branchRpc.promise)
+    const release = vi.fn()
+
+    const bindGatewayRequest = vi.fn((): GatewayRequestLease => ({
+      request: leasedSourceRequest as GatewayRequestLease['request'],
+      release
+    }))
 
     const switchedGatewayRequest = vi.fn(async (_method: string, _params?: Record<string, unknown>) => branchResponse)
 
-    let activeGatewayRequest = sourceGatewayRequest
+    let activeGatewayRequest: (method: string, params?: Record<string, unknown>) => Promise<unknown> =
+      rawSourceGatewayRequest
 
     const sourceGatewayRef: MutableRefObject<HermesGateway | null> = {
-      current: gatewayWithRequest(sourceGatewayRequest)
+      current: gatewayWithRequest(rawSourceGatewayRequest)
     }
 
     const requestGateway = async <T,>(method: string, params?: Record<string, unknown>) =>
@@ -1947,6 +1987,7 @@ describe('branchStoredSession desktop source tagging', () => {
     render(
       <BranchHarness
         activeSessionId="foreground-runtime"
+        bindGatewayRequest={bindGatewayRequest}
         gatewayRef={sourceGatewayRef}
         onCurrentReady={branch => (branchCurrentSession = branch)}
         onReady={() => undefined}
@@ -1959,11 +2000,20 @@ describe('branchStoredSession desktop source tagging', () => {
 
     const result = branchCurrentSession!(undefined, 'tile-runtime')
 
+    expect(bindGatewayRequest).toHaveBeenCalledWith(sourceGatewayRef.current, 'work')
     await waitFor(() => expect(getSession).toHaveBeenCalledWith('tile-stored'))
+    profileLookup.resolve(storedSession({ id: 'tile-stored', profile: 'work' }))
+    await waitFor(() =>
+      expect(leasedSourceRequest).toHaveBeenCalledWith('session.branch', {
+        session_id: 'tile-runtime',
+        count: 2
+      })
+    )
+
     activeGatewayRequest = switchedGatewayRequest
     sourceGatewayRef.current = gatewayWithRequest(switchedGatewayRequest)
     $activeGatewayProfile.set('other')
-    profileLookup.resolve(storedSession({ id: 'tile-stored', profile: 'work' }))
+    branchRpc.resolve(branchResponse)
 
     await expect(result).resolves.toBe(true)
 
@@ -1972,11 +2022,66 @@ describe('branchStoredSession desktop source tagging', () => {
       closeSessionTile('branch-stored-race')
     }
 
-    expect(sourceGatewayRequest).toHaveBeenCalledWith('session.branch', {
-      session_id: 'tile-runtime',
-      count: 2
-    })
+    expect(rawSourceGatewayRequest).not.toHaveBeenCalled()
     expect(switchedGatewayRequest).not.toHaveBeenCalled()
+    expect(approvalModeForProfile('work')).toBe('off')
+    expect(approvalModeForProfile('other')).toBe('manual')
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('releases the source lease after a terminal branch failure', async () => {
+    $activeGatewayProfile.set('work')
+
+    const tileMessages: ClientSessionState['messages'] = [
+      { id: 'tile-q', role: 'user', parts: [{ type: 'text', text: 'tile question' }] }
+    ]
+
+    const sessionStateByRuntimeIdRef = {
+      current: new Map<string, ClientSessionState>([
+        [
+          'tile-runtime',
+          {
+            ...createClientSessionState('tile-stored', tileMessages),
+            cwd: '/tile/workspace'
+          }
+        ]
+      ])
+    }
+
+    const rawSourceGatewayRequest = vi.fn(async () => ({ unexpected: true }))
+    const terminal = new Error('branch rejected')
+
+    const leasedSourceRequest = vi.fn(async () => {
+      throw terminal
+    })
+
+    const release = vi.fn()
+
+    const bindGatewayRequest = vi.fn((): GatewayRequestLease => ({
+      request: leasedSourceRequest as GatewayRequestLease['request'],
+      release
+    }))
+
+    setSessions([storedSession({ id: 'tile-stored', profile: 'work' })])
+
+    let branchCurrentSession: ((messageId?: string, targetSessionId?: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        activeSessionId="foreground-runtime"
+        bindGatewayRequest={bindGatewayRequest}
+        gatewayRef={{ current: gatewayWithRequest(rawSourceGatewayRequest) }}
+        onCurrentReady={branch => (branchCurrentSession = branch)}
+        onReady={() => undefined}
+        requestGateway={vi.fn(async () => ({}) as never)}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(branchCurrentSession).not.toBeNull())
+
+    await expect(branchCurrentSession!(undefined, 'tile-runtime')).resolves.toBe(false)
+    expect(leasedSourceRequest).toHaveBeenCalledOnce()
+    expect(rawSourceGatewayRequest).not.toHaveBeenCalled()
+    expect(release).toHaveBeenCalledOnce()
   })
 
   it('does not reveal a completed tile branch after focus moves to another tile', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -196,6 +196,7 @@ function Harness({
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
+    gatewayRef: ref(gatewayWithRequest(requestGateway)),
     getRouteToken: () => 'token',
     getRoutedStoredSessionId: () => null,
     navigate: navigate as never,
@@ -284,6 +285,7 @@ function StoredIdRotationHarness({
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
+    gatewayRef: ref(gatewayWithRequest(async () => ({}) as never)),
     getRouteToken: () => 'token',
     getRoutedStoredSessionId,
     navigate: navigate as never,
@@ -788,6 +790,7 @@ function ResumeHarness({
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
+    gatewayRef: ref(gatewayWithRequest(requestGateway)),
     getRouteToken: () => 'token',
     getRoutedStoredSessionId: () => null,
     navigate: vi.fn() as never,
@@ -840,9 +843,11 @@ function ResumeTimerHarness({
   const actions = useSessionActions({
     activeSessionId,
     activeSessionIdRef: cache.activeSessionIdRef,
+    bindGatewayRequest: directGatewayLease,
     busyRef,
     creatingSessionRef: useRef(false),
     ensureSessionState: cache.ensureSessionState,
+    gatewayRef: useRef(gatewayWithRequest(requestGateway)),
     getRouteToken: () => 'timer-contract',
     navigate: vi.fn() as never,
     requestGateway,
@@ -1574,11 +1579,13 @@ function BranchHarness({
     creatingSessionRef: ref(false),
     ensureSessionState: (sessionId, storedSessionId) => {
       const existing = sessionStates.current.get(sessionId)
+
       const state = existing
         ? { ...existing, ...(storedSessionId !== undefined ? { storedSessionId } : {}) }
         : createClientSessionState(storedSessionId ?? null)
 
       sessionStates.current.set(sessionId, state)
+
       return state
     },
     gatewayRef: gatewayRef ?? ref(gatewayWithRequest(requestGateway)),
@@ -1594,6 +1601,7 @@ function BranchHarness({
     syncSessionStateToView: vi.fn(),
     updateSessionState: (sessionId, updater, storedSessionId) => {
       const current = sessionStates.current.get(sessionId) ?? createClientSessionState(storedSessionId ?? null)
+
       const next = updater(
         storedSessionId !== undefined && current.storedSessionId !== storedSessionId
           ? { ...current, storedSessionId }
@@ -1601,6 +1609,7 @@ function BranchHarness({
       )
 
       sessionStates.current.set(sessionId, next)
+
       return next
     }
   })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -14,6 +14,7 @@ import {
   getAllSessionMessages,
   getLatestSessionMessages,
   getSession,
+  type HermesGateway,
   type ProfileScope,
   type SessionInfo,
   type SessionResumeResponse,
@@ -113,6 +114,22 @@ vi.mock('@/components/pane-shell/tree/store', async importOriginal => ({
 }))
 
 const RUNTIME_SESSION_ID = 'rt-new-001'
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+function gatewayWithRequest(
+  request: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+): HermesGateway {
+  return { request } as unknown as HermesGateway
+}
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
@@ -1499,16 +1516,23 @@ describe('session.resume turn timer contract', () => {
 
 function BranchHarness({
   activeSessionId = null,
+  busy = false,
+  gatewayRef,
   navigate = vi.fn(),
   onCurrentReady,
   onReady,
   onRefs,
   requestGateway,
-  selectedStoredSessionId = null
+  selectedStoredSessionId = null,
+  sessionStateByRuntimeIdRef
 }: {
   activeSessionId?: string | null
+  busy?: boolean
+  gatewayRef?: MutableRefObject<HermesGateway | null>
   navigate?: ReturnType<typeof vi.fn>
-  onCurrentReady?: (branchCurrentSession: (messageId?: string) => Promise<boolean>) => void
+  onCurrentReady?: (
+    branchCurrentSession: (messageId?: string, targetSessionId?: string) => Promise<boolean>
+  ) => void
   onReady: (branchStoredSession: (storedSessionId: string, sessionProfile?: string | null) => Promise<boolean>) => void
   onRefs?: (refs: {
     activeSessionIdRef: MutableRefObject<string | null>
@@ -1516,19 +1540,30 @@ function BranchHarness({
   }) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   selectedStoredSessionId?: string | null
+  sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
   const activeSessionIdRef = ref<string | null>(activeSessionId)
   const selectedStoredSessionIdRef = ref<string | null>(selectedStoredSessionId)
+  const sessionStates = sessionStateByRuntimeIdRef ?? ref(new Map<string, ClientSessionState>())
 
   onRefs?.({ activeSessionIdRef, selectedStoredSessionIdRef })
 
   const actions = useSessionActions({
     activeSessionId,
     activeSessionIdRef,
-    busyRef: ref(false),
+    busyRef: ref(busy),
     creatingSessionRef: ref(false),
-    ensureSessionState: () => ({}) as ClientSessionState,
+    ensureSessionState: (sessionId, storedSessionId) => {
+      const existing = sessionStates.current.get(sessionId)
+      const state = existing
+        ? { ...existing, ...(storedSessionId !== undefined ? { storedSessionId } : {}) }
+        : createClientSessionState(storedSessionId ?? null)
+
+      sessionStates.current.set(sessionId, state)
+      return state
+    },
+    gatewayRef: gatewayRef ?? ref(gatewayWithRequest(requestGateway)),
     getRouteToken: () => 'token',
     getRoutedStoredSessionId: () => null,
     navigate: navigate as never,
@@ -1537,9 +1572,19 @@ function BranchHarness({
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
-    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    sessionStateByRuntimeIdRef: sessionStates,
     syncSessionStateToView: vi.fn(),
-    updateSessionState: () => ({}) as ClientSessionState
+    updateSessionState: (sessionId, updater, storedSessionId) => {
+      const current = sessionStates.current.get(sessionId) ?? createClientSessionState(storedSessionId ?? null)
+      const next = updater(
+        storedSessionId !== undefined && current.storedSessionId !== storedSessionId
+          ? { ...current, storedSessionId }
+          : current
+      )
+
+      sessionStates.current.set(sessionId, next)
+      return next
+    }
   })
 
   useEffect(() => {
@@ -1553,6 +1598,8 @@ function BranchHarness({
 describe('branchStoredSession desktop source tagging', () => {
   afterEach(() => {
     cleanup()
+    $activeGatewayProfile.set('default')
+    setFreshDraftReady(false)
     setSessions([])
     $sessionTiles.set([])
     setSelectedStoredSessionId(null)
@@ -1738,6 +1785,303 @@ describe('branchStoredSession desktop source tagging', () => {
       count: 2
     })
     expect(branchParams).toEqual({ session_id: 'live-parent', count: 2 })
+  })
+
+  it('branches an explicit tile runtime from its own cached session state', async () => {
+    vi.mocked(ensureGatewayProfile).mockClear()
+    $activeGatewayProfile.set('default')
+    setCurrentCwd('/foreground/workspace')
+    setCurrentFastMode(false)
+    setCurrentModel('foreground-model')
+    setCurrentProvider('foreground-provider')
+    setFreshDraftReady(true)
+
+    const foregroundMessages: ClientSessionState['messages'] = [
+      { id: 'foreground-q', role: 'user', parts: [{ type: 'text', text: 'foreground question' }] }
+    ]
+
+    const tileMessages: ClientSessionState['messages'] = [
+      { id: 'tile-q', role: 'user', parts: [{ type: 'text', text: 'tile question' }] },
+      { id: 'tile-a', role: 'assistant', parts: [{ type: 'text', text: 'tile answer' }] }
+    ]
+
+    const tileState = {
+      ...createClientSessionState('tile-stored', tileMessages),
+      cwd: '/tile/workspace'
+    }
+
+    const sessionStateByRuntimeIdRef = {
+      current: new Map<string, ClientSessionState>([['tile-runtime', tileState]])
+    }
+
+    setMessages(foregroundMessages)
+    setSessions([
+      storedSession({ id: 'foreground-stored', profile: 'default' }),
+      storedSession({ id: 'tile-stored', profile: 'work' })
+    ])
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.branch') {
+        return {
+          session_id: 'branch-runtime',
+          stored_session_id: 'branch-stored',
+          title: 'Branch',
+          message_count: 2,
+          messages: [],
+          info: {
+            cwd: '/tile/workspace',
+            fast: true,
+            model: 'tile-model',
+            provider: 'tile-provider'
+          }
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let branchCurrentSession: ((messageId?: string, targetSessionId?: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        activeSessionId="foreground-runtime"
+        busy
+        onCurrentReady={branch => (branchCurrentSession = branch)}
+        onReady={() => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="foreground-stored"
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(branchCurrentSession).not.toBeNull())
+
+    await expect(branchCurrentSession!(undefined, 'tile-runtime')).resolves.toBe(true)
+
+    expect(requestGateway).toHaveBeenCalledWith('session.branch', {
+      session_id: 'tile-runtime',
+      count: 2
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith(
+      'session.branch',
+      expect.objectContaining({ session_id: 'foreground-runtime' })
+    )
+    // session.branch is runtime-scoped: switching to the stored row's profile
+    // before the RPC would move requestGateway to another socket where this
+    // runtime does not exist.
+    expect(ensureGatewayProfile).not.toHaveBeenCalled()
+    expect($activeGatewayProfile.get()).toBe('default')
+
+    // The child opens in its own tile, so its runtime metadata must stay in its
+    // isolated state/optimistic row instead of repainting the primary chat.
+    expect($currentCwd.get()).toBe('/foreground/workspace')
+    expect($currentFastMode.get()).toBe(false)
+    expect($currentModel.get()).toBe('foreground-model')
+    expect($currentProvider.get()).toBe('foreground-provider')
+    expect($freshDraftReady.get()).toBe(true)
+    expect($sessions.get().find(session => session.id === 'branch-stored')).toMatchObject({
+      cwd: '/tile/workspace',
+      parent_session_id: 'tile-stored',
+      profile: 'work'
+    })
+    expect(sessionStateByRuntimeIdRef.current.get('branch-runtime')).toMatchObject({
+      cwd: '/tile/workspace',
+      fast: true,
+      messages: tileMessages,
+      model: 'tile-model',
+      provider: 'tile-provider',
+      storedSessionId: 'branch-stored'
+    })
+  })
+
+  it('keeps a tile branch on its invocation gateway across deferred profile resolution', async () => {
+    const profileLookup = deferred<SessionInfo>()
+
+    const tileMessages: ClientSessionState['messages'] = [
+      { id: 'tile-q', role: 'user', parts: [{ type: 'text', text: 'tile question' }] },
+      { id: 'tile-a', role: 'assistant', parts: [{ type: 'text', text: 'tile answer' }] }
+    ]
+
+    const sessionStateByRuntimeIdRef = {
+      current: new Map<string, ClientSessionState>([
+        [
+          'tile-runtime',
+          {
+            ...createClientSessionState('tile-stored', tileMessages),
+            cwd: '/tile/workspace'
+          }
+        ]
+      ])
+    }
+
+    setSessions([storedSession({ id: 'foreground-stored', profile: 'default' })])
+    vi.mocked(getSession).mockImplementation(async () => profileLookup.promise)
+
+    const branchResponse = {
+      session_id: 'branch-runtime-race',
+      stored_session_id: 'branch-stored-race',
+      title: 'Branch',
+      message_count: 2,
+      messages: [],
+      info: { cwd: '/tile/workspace' }
+    }
+
+    const sourceGatewayRequest = vi.fn(async (_method: string, _params?: Record<string, unknown>) => branchResponse)
+
+    const switchedGatewayRequest = vi.fn(
+      async (_method: string, _params?: Record<string, unknown>) => branchResponse
+    )
+
+    let activeGatewayRequest = sourceGatewayRequest
+
+    const sourceGatewayRef: MutableRefObject<HermesGateway | null> = {
+      current: gatewayWithRequest(sourceGatewayRequest)
+    }
+
+    const requestGateway = async <T,>(method: string, params?: Record<string, unknown>) =>
+      activeGatewayRequest(method, params) as Promise<T>
+
+    let branchCurrentSession: ((messageId?: string, targetSessionId?: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        activeSessionId="foreground-runtime"
+        gatewayRef={sourceGatewayRef}
+        onCurrentReady={branch => (branchCurrentSession = branch)}
+        onReady={() => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="foreground-stored"
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(branchCurrentSession).not.toBeNull())
+
+    const result = branchCurrentSession!(undefined, 'tile-runtime')
+
+    await waitFor(() => expect(getSession).toHaveBeenCalledWith('tile-stored'))
+    activeGatewayRequest = switchedGatewayRequest
+    sourceGatewayRef.current = gatewayWithRequest(switchedGatewayRequest)
+    $activeGatewayProfile.set('other')
+    profileLookup.resolve(storedSession({ id: 'tile-stored', profile: 'work' }))
+
+    await expect(result).resolves.toBe(true)
+
+    for (const profile of ['other', 'default']) {
+      $activeGatewayProfile.set(profile)
+      closeSessionTile('branch-stored-race')
+    }
+
+    expect(sourceGatewayRequest).toHaveBeenCalledWith('session.branch', {
+      session_id: 'tile-runtime',
+      count: 2
+    })
+    expect(switchedGatewayRequest).not.toHaveBeenCalled()
+  })
+
+  it('does not reveal a completed tile branch into a newer profile intent', async () => {
+    const branchRpc = deferred<{
+      info: { cwd: string; fast: boolean; model: string; provider: string }
+      message_count: number
+      messages: never[]
+      session_id: string
+      stored_session_id: string
+      title: string
+    }>()
+
+    const tileMessages: ClientSessionState['messages'] = [
+      { id: 'tile-q', role: 'user', parts: [{ type: 'text', text: 'tile question' }] },
+      { id: 'tile-a', role: 'assistant', parts: [{ type: 'text', text: 'tile answer' }] }
+    ]
+
+    const sessionStateByRuntimeIdRef = {
+      current: new Map<string, ClientSessionState>([
+        [
+          'tile-runtime',
+          {
+            ...createClientSessionState('tile-stored', tileMessages),
+            cwd: '/tile/workspace'
+          }
+        ]
+      ])
+    }
+
+    $activeGatewayProfile.set('default')
+    setCurrentCwd('/foreground/workspace')
+    setCurrentFastMode(false)
+    setCurrentModel('foreground-model')
+    setCurrentProvider('foreground-provider')
+    setFreshDraftReady(true)
+    setSessions([
+      storedSession({ id: 'foreground-stored', profile: 'default' }),
+      storedSession({ id: 'tile-stored', profile: 'work' })
+    ])
+    vi.mocked(revealTreePane).mockClear()
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.branch') {
+        return branchRpc.promise as never
+      }
+
+      return {} as never
+    })
+
+    let branchCurrentSession: ((messageId?: string, targetSessionId?: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        activeSessionId="foreground-runtime"
+        onCurrentReady={branch => (branchCurrentSession = branch)}
+        onReady={() => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="foreground-stored"
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(branchCurrentSession).not.toBeNull())
+
+    const result = branchCurrentSession!(undefined, 'tile-runtime')
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.branch', expect.any(Object)))
+    $activeGatewayProfile.set('other')
+    $sessionTiles.set([{ storedSessionId: 'other-existing' }])
+    const otherTilesBeforeCompletion = $sessionTiles.get()
+
+    branchRpc.resolve({
+      session_id: 'branch-runtime-stale',
+      stored_session_id: 'branch-stored-stale',
+      title: 'Branch',
+      message_count: 2,
+      messages: [],
+      info: {
+        cwd: '/tile/workspace',
+        fast: true,
+        model: 'tile-model',
+        provider: 'tile-provider'
+      }
+    })
+
+    await expect(result).resolves.toBe(true)
+
+    const otherTilesAfterCompletion = $sessionTiles.get()
+    const revealedAfterCompletion = vi.mocked(revealTreePane).mock.calls
+
+    $activeGatewayProfile.set('default')
+
+    const childPersistedForInvocationProfile = $sessionTiles
+      .get()
+      .some(tile => tile.storedSessionId === 'branch-stored-stale')
+
+    for (const profile of ['default', 'other']) {
+      $activeGatewayProfile.set(profile)
+      closeSessionTile('branch-stored-stale')
+    }
+
+    $activeGatewayProfile.set('default')
+
+    expect(otherTilesAfterCompletion).toEqual(otherTilesBeforeCompletion)
+    expect(revealedAfterCompletion).toEqual([])
+    expect(childPersistedForInvocationProfile).toBe(true)
+    expect($currentCwd.get()).toBe('/foreground/workspace')
+    expect($currentFastMode.get()).toBe(false)
+    expect($currentModel.get()).toBe('foreground-model')
+    expect($currentProvider.get()).toBe('foreground-provider')
+    expect($freshDraftReady.get()).toBe(true)
   })
 
   it('hydrates the complete persisted display transcript before branching a compacted live chat', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2137,6 +2137,15 @@ export function useSessionActions({
           sourceOwnerRoute = sourceLease.ownerRoute
           const resolvedProfile = await resolveSessionProfile(parentStoredId)
           profile = normalizeProfileKey(resolvedProfile ?? uiIntent.profile)
+
+          // The lease names the Desktop-facing registry route that owns the
+          // physical socket. The stored parent row names the backend profile
+          // served by that route, which can differ for remote overrides. Keep
+          // binding the existing socket/profile pair, but persist the complete
+          // route on the child so REST reads can address the backend profile.
+          if (sourceOwnerRoute && profile !== normalizeProfileKey(sourceOwnerRoute.profile)) {
+            sourceOwnerRoute = { ...sourceOwnerRoute, targetProfile: profile }
+          }
         } else {
           // Runtime ids are socket-local. A tile must carry the exact registry
           // route that resumed it; a profile string alone is ambiguous when two

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1996,7 +1996,7 @@ export function useSessionActions({
           $freshSessionRequest.get() === resolvedUiIntent.freshSessionRequest &&
           getRouteToken() === resolvedUiIntent.routeToken &&
           selectedStoredSessionIdRef.current === resolvedUiIntent.selectedStoredSessionId &&
-          focusedSessionTabAnchor() === resolvedUiIntent.anchor
+          (focusedSessionTabAnchor() ?? undefined) === resolvedUiIntent.anchor
 
         // Preserve main's foreground branch contract while routing tiled slash
         // commands back beside their invoking tile. A delayed branch may still

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -707,6 +707,9 @@ export function useSessionActions({
         // to fall through into the last project folder while main chat was
         // occupied (openTab path for "New session in Home").
         const capturedRoute = options?.route === undefined ? resolveNewChatOwnerRoute() : options.route
+        const ownerProfile = normalizeProfileKey(
+          capturedRoute?.targetProfile ?? capturedRoute?.profile ?? $activeGatewayProfile.get()
+        )
         const workspaceScope = options?.workspaceScope ?? { workspaceMode: 'sessions' }
 
         const cwd =
@@ -779,7 +782,7 @@ export function useSessionActions({
         // so the right rail kept showing the previous session's tree when a
         // Project "+" created a session while the main chat was occupied
         // (#76696). Split/side tiles deliberately stay isolated.
-        const runtimeInfo = applyRuntimeInfo(created.info, { foreground: false })
+        const runtimeInfo = applyRuntimeInfo(created.info, { foreground: false, profile: ownerProfile })
         updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
 
         openSessionTile(stored, dir, undefined, undefined, workspaceScope)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -4,13 +4,14 @@ import type { NavigateFunction } from 'react-router'
 
 import { NO_PROJECT_ID } from '@/app/chat/sidebar/projects/workspace-groups'
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
-import { revealTreePane } from '@/components/pane-shell/tree/store'
+import { focusedSessionTabAnchor, revealTreePane } from '@/components/pane-shell/tree/store'
 import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
 import {
   deleteSession,
   fetchStoredTranscriptAcrossBackends,
   getAllSessionMessages,
   getLatestSessionMessages,
+  type HermesGateway,
   setSessionArchived
 } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -39,6 +40,7 @@ import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
+  $freshSessionRequest,
   $gatewaySwapTarget,
   $newChatProfile,
   $profiles,
@@ -109,6 +111,7 @@ import {
   dropSessionState,
   holdSessionOwnerUntilForeground,
   openSessionTile,
+  openSessionTileForProfile,
   patchSessionTile,
   publishSessionState,
   releaseSessionOwnerHold,
@@ -166,6 +169,7 @@ interface SessionActionsOptions {
   busyRef: MutableRefObject<boolean>
   creatingSessionRef: MutableRefObject<boolean>
   ensureSessionState: (sessionId: string, storedSessionId?: string | null) => ClientSessionState
+  gatewayRef: MutableRefObject<HermesGateway | null>
   getRouteToken: () => string
   getRoutedStoredSessionId: () => null | string
   navigate: NavigateFunction
@@ -182,6 +186,14 @@ interface SessionActionsOptions {
     updater: (state: ClientSessionState) => ClientSessionState,
     storedSessionId?: string | null
   ) => ClientSessionState
+}
+
+interface BranchUiIntent {
+  anchor?: string
+  freshSessionRequest: number
+  profile: string
+  routeToken: string
+  selectedStoredSessionId: null | string
 }
 
 // Stored ids created in THIS renderer run. A brand-new session lives only in the
@@ -308,6 +320,7 @@ export function useSessionActions({
   busyRef,
   creatingSessionRef,
   ensureSessionState,
+  gatewayRef,
   getRouteToken,
   getRoutedStoredSessionId,
   navigate,
@@ -1865,6 +1878,17 @@ export function useSessionActions({
     ]
   )
 
+  const captureBranchUiIntent = useCallback(
+    (): BranchUiIntent => ({
+      anchor: focusedSessionTabAnchor() ?? undefined,
+      freshSessionRequest: $freshSessionRequest.get(),
+      profile: normalizeProfileKey($activeGatewayProfile.get()),
+      routeToken: getRouteToken(),
+      selectedStoredSessionId: selectedStoredSessionIdRef.current
+    }),
+    [getRouteToken, selectedStoredSessionIdRef]
+  )
+
   // Shared fork: create a child session seeded with `branchMessages`, linked to
   // `parentStoredId` so it nests under its parent, then open it as its own tab
   // and switch to it — the parent chat stays put (mirrors openNewSessionTile).
@@ -1875,34 +1899,48 @@ export function useSessionActions({
       parentStoredId: null | string,
       cwd?: string,
       profile?: null | string,
+      sourceGateway?: HermesGateway | null,
+      uiIntent?: BranchUiIntent,
       branchCount?: number
     ): Promise<boolean> => {
       creatingSessionRef.current = true
 
       try {
-        // A branch belongs to its parent's OWNING profile. Swapping the live
-        // gateway first AND passing `profile` on the create mirrors
-        // desktopSessionCreateParams/resumeSession: in app-global remote mode
-        // one backend serves every profile, so an omitted profile silently
-        // lands the branch on the launch (default) profile — the "session
-        // jumps between profiles after branching" bug. The swap also makes
-        // upsertOptimisticSession's $activeGatewayProfile stamp correct.
-        await ensureGatewayProfile(profile)
+        let targetUiIntent = uiIntent
+
+        // A stored-transcript branch has no live runtime, so create it on the
+        // parent's owning profile. A live branch is different: its runtime is
+        // scoped to the socket that resumed it (including cross-profile tiles),
+        // so swapping gateways before session.branch would make that runtime
+        // unreachable. Keep the source socket and stamp the optimistic row with
+        // the explicit parent profile below.
+        if (!sourceSessionId) {
+          await ensureGatewayProfile(profile)
+          targetUiIntent = captureBranchUiIntent()
+        }
 
         // No title: the backend auto-names the branch from its parent's lineage.
-        const branched = sourceSessionId
-          ? await requestGateway<SessionCreateResponse>('session.branch', {
-              session_id: sourceSessionId,
-              ...(branchCount !== undefined ? { count: branchCount } : {})
-            })
-          : await requestGateway<SessionCreateResponse>('session.create', {
-              cols: 96,
-              source: 'desktop',
-              ...(cwd && { cwd }),
-              ...(profile ? { profile } : {}),
-              messages: branchMessages.map(({ content, role }) => ({ content, role })),
-              ...(parentStoredId && { parent_session_id: parentStoredId })
-            })
+        let branched: SessionCreateResponse
+
+        if (sourceSessionId) {
+          if (!sourceGateway) {
+            throw new Error('Hermes gateway unavailable')
+          }
+
+          branched = await sourceGateway.request<SessionCreateResponse>('session.branch', {
+            session_id: sourceSessionId,
+            ...(branchCount !== undefined ? { count: branchCount } : {})
+          })
+        } else {
+          branched = await requestGateway<SessionCreateResponse>('session.create', {
+            cols: 96,
+            source: 'desktop',
+            ...(cwd && { cwd }),
+            ...(profile ? { profile } : {}),
+            messages: branchMessages.map(({ content, role }) => ({ content, role })),
+            ...(parentStoredId && { parent_session_id: parentStoredId })
+          })
+        }
 
         const responseBranchMessages =
           sourceSessionId && branched.messages?.length ? toBranchMessages(toChatMessages(branched.messages)) : []
@@ -1920,14 +1958,14 @@ export function useSessionActions({
           ? rows.filter(session => session.parent_session_id?.trim() === parentStoredId).length
           : 0
 
-        setFreshDraftReady(false)
         upsertOptimisticSession(
           branched,
           routedSessionId,
           copy.branchTitle(siblings + 1).toLowerCase(),
           preview,
           parentStoredId,
-          parent ? parent.last_active || parent.started_at : undefined
+          parent ? parent.last_active || parent.started_at : undefined,
+          { cwd, profile }
         )
         ensureSessionState(branched.session_id, routedSessionId)
         updateSessionState(
@@ -1948,17 +1986,37 @@ export function useSessionActions({
           updateSessionState(branched.session_id, state => ({ ...state, ...runtimeInfo }), routedSessionId)
         }
 
-        // Only take over the main pane when the chat being branched is the one
-        // already open there — branching a background/sidebar session must
-        // not yank the user's current view away from what they're looking at
-        // (the #69750 focus-stealing bug, reintroduced if this fires
-        // unconditionally). resumeSession reuses the runtime warm-cached above
-        // (ensureSessionState/updateSessionState) instead of an extra resume RPC.
-        if (parentStoredId !== null && selectedStoredSessionIdRef.current === parentStoredId) {
+        // Persist the child under the profile layout that launched the branch.
+        // If the user moved elsewhere while either lookup/RPC was pending, do
+        // not publish it into the newer profile's tile set or steal focus. The
+        // inactive placement resumes its runtime when that profile is revisited.
+        const resolvedUiIntent = targetUiIntent ?? captureBranchUiIntent()
+        const uiIntentStillCurrent =
+          normalizeProfileKey($activeGatewayProfile.get()) === resolvedUiIntent.profile &&
+          $freshSessionRequest.get() === resolvedUiIntent.freshSessionRequest &&
+          getRouteToken() === resolvedUiIntent.routeToken &&
+          selectedStoredSessionIdRef.current === resolvedUiIntent.selectedStoredSessionId
+
+        // Preserve main's foreground branch contract while routing tiled slash
+        // commands back beside their invoking tile. A delayed branch may still
+        // be persisted into its original profile layout, but cannot steal the
+        // newer foreground selection.
+        if (uiIntentStillCurrent && parentStoredId !== null && resolvedUiIntent.selectedStoredSessionId === parentStoredId) {
           await resumeSession(routedSessionId)
         } else {
-          openSessionTile(routedSessionId, 'center')
-          patchSessionTile(routedSessionId, { runtimeId: branched.session_id })
+          const openedInActiveProfile = openSessionTileForProfile(
+            routedSessionId,
+            resolvedUiIntent.profile,
+            'center',
+            resolvedUiIntent.anchor
+          )
+
+          if (openedInActiveProfile) {
+            patchSessionTile(routedSessionId, { runtimeId: branched.session_id })
+          }
+        }
+
+        if (uiIntentStillCurrent) {
           revealTreePane(`session-tile:${routedSessionId}`)
         }
 
@@ -1976,9 +2034,11 @@ export function useSessionActions({
       }
     },
     [
+      captureBranchUiIntent,
       copy,
       creatingSessionRef,
       ensureSessionState,
+      getRouteToken,
       requestGateway,
       resumeSession,
       selectedStoredSessionIdRef,
@@ -1986,26 +2046,49 @@ export function useSessionActions({
     ]
   )
 
-  // Branch the open chat — optionally from a specific message — off its live transcript.
+  // Branch an open chat — optionally from a specific message — off its live transcript.
+  // Slash commands from a tile pass that tile's runtime explicitly; message
+  // actions omit it and keep using the foreground chat.
   const branchCurrentSession = useCallback(
-    async (messageId?: string): Promise<boolean> => {
-      if (!activeSessionIdRef.current) {
+    async (messageId?: string, targetSessionId?: string): Promise<boolean> => {
+      const sessionId = targetSessionId ?? activeSessionIdRef.current
+
+      if (!sessionId) {
         notify({ kind: 'warning', title: copy.nothingToBranch, message: copy.branchNeedsChat })
 
         return false
       }
 
-      if (busyRef.current) {
+      const isForeground = sessionId === activeSessionIdRef.current
+      const targetState = sessionStateByRuntimeIdRef.current.get(sessionId)
+
+      // A background/tile target must never fall through to the foreground's
+      // transcript or metadata. If its runtime state disappeared during
+      // dispatch, fail closed instead of branching an unrelated conversation.
+      if (!targetState && !isForeground) {
+        notify({ kind: 'warning', title: copy.nothingToBranch, message: copy.branchNeedsChat })
+
+        return false
+      }
+
+      if (isForeground ? busyRef.current : targetState!.busy) {
         notify({ kind: 'warning', title: copy.sessionBusy, message: copy.branchStopCurrent })
 
         return false
       }
 
+      // Preserve the foreground branch path exactly as it was: the shared view
+      // carries the latest optimistic transcript. Only an offscreen target reads
+      // its isolated runtime cache.
+      const messages = isForeground ? $messages.get() : targetState!.messages
       const startingActiveSessionId = activeSessionIdRef.current
-      const messages = $messages.get()
-      const storedSessionId = selectedStoredSessionIdRef.current
+      const parentStoredId = isForeground ? selectedStoredSessionIdRef.current : targetState!.storedSessionId
       const startingRouteToken = getRouteToken()
-      const startingCwd = $currentCwd.get().trim()
+      const startingCwd = isForeground ? $currentCwd.get().trim() : targetState!.cwd.trim()
+      // Pin transport and UI intent before profile/transcript resolution yields.
+      // A delayed command must never inherit a newer foreground socket or layout.
+      const sourceGateway = gatewayRef.current
+      const uiIntent = captureBranchUiIntent()
 
       // The live atom may be a compacted model projection. Read the durable
       // display projection before choosing the branch prefix so a whole-chat
@@ -2013,11 +2096,11 @@ export function useSessionActions({
       // temporarily unavailable, retain the local snapshot and let the branch
       // RPC make its own authoritative read.
       let authoritativeMessages: ChatMessage[] | null = null
-      const profile = await resolveSessionProfile(storedSessionId)
+      const profile = await resolveSessionProfile(parentStoredId)
 
-      if (storedSessionId) {
+      if (isForeground && parentStoredId) {
         try {
-          const persisted = await getAllSessionMessages(storedSessionId, profile)
+          const persisted = await getAllSessionMessages(parentStoredId, profile)
           const hydrated = toChatMessages(persisted.messages)
 
           if (hydrated.length) {
@@ -2031,14 +2114,14 @@ export function useSessionActions({
       const drift = sessionContextDrift({
         startRouteToken: startingRouteToken,
         nowRouteToken: getRouteToken(),
-        startSelectedStoredId: storedSessionId,
+        startSelectedStoredId: parentStoredId,
         nowSelectedStoredId: selectedStoredSessionIdRef.current
       })
 
       const runtimeChanged = activeSessionIdRef.current !== startingActiveSessionId
-      const selectionChanged = selectedStoredSessionIdRef.current !== storedSessionId
+      const selectionChanged = selectedStoredSessionIdRef.current !== parentStoredId
 
-      if (drift || runtimeChanged || selectionChanged) {
+      if (isForeground && (drift || runtimeChanged || selectionChanged)) {
         console.warn('[branch-drift-abort]', drift ?? 'runtime-or-selection-changed', {
           phase: 'transcript-hydration'
         })
@@ -2059,16 +2142,30 @@ export function useSessionActions({
       // The open chat's owning profile, NOT the picker's / launch profile —
       // /profile only retargets new chats, so a branch of an existing thread
       // must stay on that thread's backend (cache hit for an open session).
+      // Use the invocation transport and intent captured before asynchronous
+      // profile/transcript resolution.
+
       return forkBranch(
         branchMessages,
-        startingActiveSessionId,
-        storedSessionId,
+        sessionId,
+        parentStoredId,
         startingCwd,
         profile,
-        messageId ? branchMessages.length : undefined
+        sourceGateway,
+        uiIntent,
+        messageId || !isForeground ? branchMessages.length : undefined
       )
     },
-    [activeSessionIdRef, busyRef, copy, forkBranch, getRouteToken, selectedStoredSessionIdRef]
+    [
+      activeSessionIdRef,
+      busyRef,
+      captureBranchUiIntent,
+      copy,
+      forkBranch,
+      gatewayRef,
+      selectedStoredSessionIdRef,
+      sessionStateByRuntimeIdRef
+    ]
   )
 
   // Branch any listed session, not just the open one. Reads the target's stored

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1913,7 +1913,8 @@ export function useSessionActions({
       sourceRequest?: GatewayRequester,
       uiIntent?: BranchUiIntent,
       branchCount?: number,
-      sourceOwnerRoute?: SessionOwnerRoute
+      sourceOwnerRoute?: SessionOwnerRoute,
+      sourceStillValid?: () => boolean
     ): Promise<boolean> => {
       creatingSessionRef.current = true
 
@@ -1939,10 +1940,16 @@ export function useSessionActions({
             throw new Error('Hermes gateway unavailable')
           }
 
-          branched = await sourceRequest<SessionCreateResponse>('session.branch', {
-            session_id: sourceSessionId,
-            ...(branchCount !== undefined ? { count: branchCount } : {})
-          })
+          branched = await sourceRequest<SessionCreateResponse>(
+            'session.branch',
+            {
+              session_id: sourceSessionId,
+              ...(branchCount !== undefined ? { count: branchCount } : {})
+            },
+            undefined,
+            undefined,
+            sourceStillValid
+          )
         } else {
           branched = await requestGateway<SessionCreateResponse>('session.create', {
             cols: 96,
@@ -2111,6 +2118,7 @@ export function useSessionActions({
       const uiIntent = captureBranchUiIntent()
       let sourceLease: GatewayRequestLease | null = null
       let sourceOwnerRoute: SessionOwnerRoute | undefined
+      let sourceStillValid: (() => boolean) | undefined
 
       // Pin transport, source profile, and UI intent before profile resolution
       // yields. The command lease keeps a background source registered across
@@ -2142,6 +2150,24 @@ export function useSessionActions({
           profile = normalizeProfileKey(owner.profile)
           sourceOwnerRoute = owner
           sourceLease = bindGatewayRequestForOwner(owner.connectionId, profile)
+          const targetTile = $sessionTiles.get().find(tile => tile.storedSessionId === parentStoredId)
+
+          sourceStillValid = () => {
+            const currentState = sessionStateByRuntimeIdRef.current.get(sessionId)
+            const currentTile = $sessionTiles.get().find(tile => tile.storedSessionId === parentStoredId)
+            const currentOwner = parentStoredId ? sessionTileOwnerRoute(parentStoredId) : undefined
+
+            return (
+              currentState === targetState &&
+              currentState?.storedSessionId === parentStoredId &&
+              Boolean(targetTile && currentTile) &&
+              currentTile?.runtimeId === targetTile?.runtimeId &&
+              currentOwner?.connectionId === owner.connectionId &&
+              normalizeProfileKey(currentOwner?.profile) === profile &&
+              currentOwner?.mode === owner.mode &&
+              currentOwner?.targetProfile === owner.targetProfile
+            )
+          }
         }
 
         // The live atom may be a compacted model projection. Read the durable
@@ -2191,6 +2217,10 @@ export function useSessionActions({
 
         clearNotifications()
 
+        if (sourceStillValid && !sourceStillValid()) {
+          throw new Error('Hermes tile source session unavailable')
+        }
+
         return await forkBranch(
           branchMessages,
           sessionId,
@@ -2200,7 +2230,8 @@ export function useSessionActions({
           sourceLease.request,
           uiIntent,
           messageId || !isForeground ? branchMessages.length : undefined,
-          sourceOwnerRoute
+          sourceOwnerRoute,
+          sourceStillValid
         )
       } catch (err) {
         notifyError(err, copy.branchFailed)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -30,6 +30,8 @@ import { $clarifyRequests } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import {
+  type GatewayRequester,
+  type GatewayRequestLease,
   openGatewayForAgent,
   openGatewayForProfile,
   requestGatewayForAgent,
@@ -166,6 +168,7 @@ import {
 interface SessionActionsOptions {
   activeSessionId: string | null
   activeSessionIdRef: MutableRefObject<string | null>
+  bindGatewayRequest: (gateway: HermesGateway, profile: string) => GatewayRequestLease
   busyRef: MutableRefObject<boolean>
   creatingSessionRef: MutableRefObject<boolean>
   ensureSessionState: (sessionId: string, storedSessionId?: string | null) => ClientSessionState
@@ -317,6 +320,7 @@ function normalizeNewChatWorkspaceTarget(target: NewChatWorkspaceTarget): NewCha
 export function useSessionActions({
   activeSessionId,
   activeSessionIdRef,
+  bindGatewayRequest,
   busyRef,
   creatingSessionRef,
   ensureSessionState,
@@ -1899,7 +1903,7 @@ export function useSessionActions({
       parentStoredId: null | string,
       cwd?: string,
       profile?: null | string,
-      sourceGateway?: HermesGateway | null,
+      sourceRequest?: GatewayRequester,
       uiIntent?: BranchUiIntent,
       branchCount?: number
     ): Promise<boolean> => {
@@ -1923,11 +1927,11 @@ export function useSessionActions({
         let branched: SessionCreateResponse
 
         if (sourceSessionId) {
-          if (!sourceGateway) {
+          if (!sourceRequest) {
             throw new Error('Hermes gateway unavailable')
           }
 
-          branched = await sourceGateway.request<SessionCreateResponse>('session.branch', {
+          branched = await sourceRequest<SessionCreateResponse>('session.branch', {
             session_id: sourceSessionId,
             ...(branchCount !== undefined ? { count: branchCount } : {})
           })
@@ -1979,7 +1983,11 @@ export function useSessionActions({
           routedSessionId
         )
 
-        const runtimeInfo = applyRuntimeInfo(branched.info, { foreground: false })
+        // The branch opens as its own tile in the parent's worktree, not as the
+        // primary session — keep its runtime out of the main composer atoms.
+        const resolvedUiIntent = targetUiIntent ?? captureBranchUiIntent()
+        const runtimeInfoOwner = profile?.trim() || resolvedUiIntent.profile
+        const runtimeInfo = applyRuntimeInfo(branched.info, { foreground: false, profile: runtimeInfoOwner })
         patchSessionWorkspace(routedSessionId, runtimeInfo?.cwd)
 
         if (runtimeInfo) {
@@ -1990,7 +1998,6 @@ export function useSessionActions({
         // If the user moved elsewhere while either lookup/RPC was pending, do
         // not publish it into the newer profile's tile set or steal focus. The
         // inactive placement resumes its runtime when that profile is revisited.
-        const resolvedUiIntent = targetUiIntent ?? captureBranchUiIntent()
         const uiIntentStillCurrent =
           normalizeProfileKey($activeGatewayProfile.get()) === resolvedUiIntent.profile &&
           $freshSessionRequest.get() === resolvedUiIntent.freshSessionRequest &&
@@ -2080,85 +2087,97 @@ export function useSessionActions({
 
       // Preserve the foreground branch path exactly as it was: the shared view
       // carries the latest optimistic transcript. Only an offscreen target reads
-      // its isolated runtime cache.
+      // its isolated runtime cache. Everything below is invocation-owned and is
+      // captured before profile/transcript resolution can yield.
       const messages = isForeground ? $messages.get() : targetState!.messages
       const startingActiveSessionId = activeSessionIdRef.current
       const parentStoredId = isForeground ? selectedStoredSessionIdRef.current : targetState!.storedSessionId
       const startingRouteToken = getRouteToken()
       const startingCwd = isForeground ? $currentCwd.get().trim() : targetState!.cwd.trim()
-      // Pin transport and UI intent before profile/transcript resolution yields.
-      // A delayed command must never inherit a newer foreground socket or layout.
       const sourceGateway = gatewayRef.current
       const uiIntent = captureBranchUiIntent()
+      let sourceLease: GatewayRequestLease | null = null
 
-      // The live atom may be a compacted model projection. Read the durable
-      // display projection before choosing the branch prefix so a whole-chat
-      // branch does not inherit only the summary/tail. If the backend is
-      // temporarily unavailable, retain the local snapshot and let the branch
-      // RPC make its own authoritative read.
-      let authoritativeMessages: ChatMessage[] | null = null
-      const profile = await resolveSessionProfile(parentStoredId)
-
-      if (isForeground && parentStoredId) {
-        try {
-          const persisted = await getAllSessionMessages(parentStoredId, profile)
-          const hydrated = toChatMessages(persisted.messages)
-
-          if (hydrated.length) {
-            authoritativeMessages = hydrated
-          }
-        } catch {
-          // The branch RPC has a backend-side display projection fallback.
+      // Pin transport, source profile, and UI intent before profile resolution
+      // yields. The command lease keeps a background source registered across
+      // the production profile-switch pruning policy; its requester reconnects
+      // and retries only on this exact owner.
+      try {
+        if (!sourceGateway) {
+          throw new Error('Hermes gateway unavailable')
         }
-      }
 
-      const drift = sessionContextDrift({
-        startRouteToken: startingRouteToken,
-        nowRouteToken: getRouteToken(),
-        startSelectedStoredId: parentStoredId,
-        nowSelectedStoredId: selectedStoredSessionIdRef.current
-      })
+        sourceLease = bindGatewayRequest(sourceGateway, uiIntent.profile)
+        const resolvedProfile = await resolveSessionProfile(parentStoredId)
+        const profile = normalizeProfileKey(resolvedProfile ?? uiIntent.profile)
 
-      const runtimeChanged = activeSessionIdRef.current !== startingActiveSessionId
-      const selectionChanged = selectedStoredSessionIdRef.current !== parentStoredId
+        // The live atom may be a compacted model projection. Read the durable
+        // display projection before choosing the branch prefix so a whole-chat
+        // branch does not inherit only the summary/tail. Offscreen targets keep
+        // their isolated live cache and never hydrate through foreground state.
+        let authoritativeMessages: ChatMessage[] | null = null
 
-      if (isForeground && (drift || runtimeChanged || selectionChanged)) {
-        console.warn('[branch-drift-abort]', drift ?? 'runtime-or-selection-changed', {
-          phase: 'transcript-hydration'
+        if (isForeground && parentStoredId) {
+          try {
+            const persisted = await getAllSessionMessages(parentStoredId, profile)
+            const hydrated = toChatMessages(persisted.messages)
+
+            if (hydrated.length) {
+              authoritativeMessages = hydrated
+            }
+          } catch {
+            // The branch RPC has a backend-side display projection fallback.
+          }
+        }
+
+        const drift = sessionContextDrift({
+          startRouteToken: startingRouteToken,
+          nowRouteToken: getRouteToken(),
+          startSelectedStoredId: parentStoredId,
+          nowSelectedStoredId: selectedStoredSessionIdRef.current
         })
+        const runtimeChanged = activeSessionIdRef.current !== startingActiveSessionId
+        const selectionChanged = selectedStoredSessionIdRef.current !== parentStoredId
+
+        if (isForeground && (drift || runtimeChanged || selectionChanged)) {
+          console.warn('[branch-drift-abort]', drift ?? 'runtime-or-selection-changed', {
+            phase: 'transcript-hydration'
+          })
+
+          return false
+        }
+
+        const branchMessages = selectBranchMessages(messages, authoritativeMessages, messageId)
+
+        if (!branchMessages.length) {
+          notify({ kind: 'warning', title: copy.nothingToBranch, message: copy.branchNoText })
+
+          return false
+        }
+
+        clearNotifications()
+
+        return await forkBranch(
+          branchMessages,
+          sessionId,
+          parentStoredId,
+          startingCwd,
+          profile,
+          sourceLease.request,
+          uiIntent,
+          messageId || !isForeground ? branchMessages.length : undefined
+        )
+      } catch (err) {
+        notifyError(err, copy.branchFailed)
 
         return false
+      } finally {
+        sourceLease?.release()
       }
-
-      const branchMessages = selectBranchMessages(messages, authoritativeMessages, messageId)
-
-      if (!branchMessages.length) {
-        notify({ kind: 'warning', title: copy.nothingToBranch, message: copy.branchNoText })
-
-        return false
-      }
-
-      clearNotifications()
-
-      // The open chat's owning profile, NOT the picker's / launch profile —
-      // /profile only retargets new chats, so a branch of an existing thread
-      // must stay on that thread's backend (cache hit for an open session).
-      // Use the invocation transport and intent captured before asynchronous
-      // profile/transcript resolution.
-
-      return forkBranch(
-        branchMessages,
-        sessionId,
-        parentStoredId,
-        startingCwd,
-        profile,
-        sourceGateway,
-        uiIntent,
-        messageId || !isForeground ? branchMessages.length : undefined
-      )
     },
     [
       activeSessionIdRef,
+      bindGatewayRequest,
       busyRef,
       captureBranchUiIntent,
       copy,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1984,7 +1984,7 @@ export function useSessionActions({
           preview,
           parentStoredId,
           parent ? parent.last_active || parent.started_at : undefined,
-          { cwd, profile }
+          { cwd, ...(sourceOwnerRoute ?? { profile }) }
         )
         ensureSessionState(branched.session_id, routedSessionId)
         updateSessionState(
@@ -2134,6 +2134,7 @@ export function useSessionActions({
           }
 
           sourceLease = bindGatewayRequest(sourceGateway, uiIntent.profile)
+          sourceOwnerRoute = sourceLease.ownerRoute
           const resolvedProfile = await resolveSessionProfile(parentStoredId)
           profile = normalizeProfileKey(resolvedProfile ?? uiIntent.profile)
         } else {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2136,6 +2136,7 @@ export function useSessionActions({
           startSelectedStoredId: parentStoredId,
           nowSelectedStoredId: selectedStoredSessionIdRef.current
         })
+
         const runtimeChanged = activeSessionIdRef.current !== startingActiveSessionId
         const selectionChanged = selectedStoredSessionIdRef.current !== parentStoredId
 
@@ -2183,6 +2184,7 @@ export function useSessionActions({
       copy,
       forkBranch,
       gatewayRef,
+      getRouteToken,
       selectedStoredSessionIdRef,
       sessionStateByRuntimeIdRef
     ]

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1995,7 +1995,8 @@ export function useSessionActions({
           normalizeProfileKey($activeGatewayProfile.get()) === resolvedUiIntent.profile &&
           $freshSessionRequest.get() === resolvedUiIntent.freshSessionRequest &&
           getRouteToken() === resolvedUiIntent.routeToken &&
-          selectedStoredSessionIdRef.current === resolvedUiIntent.selectedStoredSessionId
+          selectedStoredSessionIdRef.current === resolvedUiIntent.selectedStoredSessionId &&
+          focusedSessionTabAnchor() === resolvedUiIntent.anchor
 
         // Preserve main's foreground branch contract while routing tiled slash
         // commands back beside their invoking tile. A delayed branch may still

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -104,6 +104,7 @@ import {
 import { isSessionOwnerResolutionError } from '@/store/session-owner-resolution'
 import {
   requestForSessionProfile,
+  type SessionOwnerRoute,
   type SessionOwnerScope,
   type SessionProfileRoute
 } from '@/store/session-request-router'
@@ -1911,7 +1912,8 @@ export function useSessionActions({
       profile?: null | string,
       sourceRequest?: GatewayRequester,
       uiIntent?: BranchUiIntent,
-      branchCount?: number
+      branchCount?: number,
+      sourceOwnerRoute?: SessionOwnerRoute
     ): Promise<boolean> => {
       creatingSessionRef.current = true
 
@@ -2026,7 +2028,9 @@ export function useSessionActions({
             routedSessionId,
             resolvedUiIntent.profile,
             'center',
-            resolvedUiIntent.anchor
+            resolvedUiIntent.anchor,
+            undefined,
+            sourceOwnerRoute
           )
 
           if (openedInActiveProfile) {
@@ -2106,6 +2110,7 @@ export function useSessionActions({
       const startingCwd = isForeground ? $currentCwd.get().trim() : targetState!.cwd.trim()
       const uiIntent = captureBranchUiIntent()
       let sourceLease: GatewayRequestLease | null = null
+      let sourceOwnerRoute: SessionOwnerRoute | undefined
 
       // Pin transport, source profile, and UI intent before profile resolution
       // yields. The command lease keeps a background source registered across
@@ -2135,6 +2140,7 @@ export function useSessionActions({
           }
 
           profile = normalizeProfileKey(owner.profile)
+          sourceOwnerRoute = owner
           sourceLease = bindGatewayRequestForOwner(owner.connectionId, profile)
         }
 
@@ -2193,7 +2199,8 @@ export function useSessionActions({
           profile,
           sourceLease.request,
           uiIntent,
-          messageId || !isForeground ? branchMessages.length : undefined
+          messageId || !isForeground ? branchMessages.length : undefined,
+          sourceOwnerRoute
         )
       } catch (err) {
         notifyError(err, copy.branchFailed)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -117,6 +117,7 @@ import {
   patchSessionTile,
   publishSessionState,
   releaseSessionOwnerHold,
+  sessionTileOwnerRoute,
   type SessionTileWorkspaceScope,
   type TileDock
 } from '@/store/session-states'
@@ -169,6 +170,7 @@ interface SessionActionsOptions {
   activeSessionId: string | null
   activeSessionIdRef: MutableRefObject<string | null>
   bindGatewayRequest: (gateway: HermesGateway, profile: string) => GatewayRequestLease
+  bindGatewayRequestForOwner: (connectionId: string, profile: string) => GatewayRequestLease
   busyRef: MutableRefObject<boolean>
   creatingSessionRef: MutableRefObject<boolean>
   ensureSessionState: (sessionId: string, storedSessionId?: string | null) => ClientSessionState
@@ -321,6 +323,7 @@ export function useSessionActions({
   activeSessionId,
   activeSessionIdRef,
   bindGatewayRequest,
+  bindGatewayRequestForOwner,
   busyRef,
   creatingSessionRef,
   ensureSessionState,
@@ -2012,7 +2015,11 @@ export function useSessionActions({
         // commands back beside their invoking tile. A delayed branch may still
         // be persisted into its original profile layout, but cannot steal the
         // newer foreground selection.
-        if (uiIntentStillCurrent && parentStoredId !== null && resolvedUiIntent.selectedStoredSessionId === parentStoredId) {
+        if (
+          uiIntentStillCurrent &&
+          parentStoredId !== null &&
+          resolvedUiIntent.selectedStoredSessionId === parentStoredId
+        ) {
           await resumeSession(routedSessionId)
         } else {
           const openedInActiveProfile = openSessionTileForProfile(
@@ -2097,22 +2104,39 @@ export function useSessionActions({
       const parentStoredId = isForeground ? selectedStoredSessionIdRef.current : targetState!.storedSessionId
       const startingRouteToken = getRouteToken()
       const startingCwd = isForeground ? $currentCwd.get().trim() : targetState!.cwd.trim()
-      const sourceGateway = gatewayRef.current
       const uiIntent = captureBranchUiIntent()
       let sourceLease: GatewayRequestLease | null = null
 
       // Pin transport, source profile, and UI intent before profile resolution
       // yields. The command lease keeps a background source registered across
-      // the production profile-switch pruning policy; its requester reconnects
-      // and retries only on this exact owner.
+      // the production profile-switch pruning policy.
       try {
-        if (!sourceGateway) {
-          throw new Error('Hermes gateway unavailable')
-        }
+        let profile: string
 
-        sourceLease = bindGatewayRequest(sourceGateway, uiIntent.profile)
-        const resolvedProfile = await resolveSessionProfile(parentStoredId)
-        const profile = normalizeProfileKey(resolvedProfile ?? uiIntent.profile)
+        if (isForeground) {
+          const sourceGateway = gatewayRef.current
+
+          if (!sourceGateway) {
+            throw new Error('Hermes gateway unavailable')
+          }
+
+          sourceLease = bindGatewayRequest(sourceGateway, uiIntent.profile)
+          const resolvedProfile = await resolveSessionProfile(parentStoredId)
+          profile = normalizeProfileKey(resolvedProfile ?? uiIntent.profile)
+        } else {
+          // Runtime ids are socket-local. A tile must carry the exact registry
+          // route that resumed it; a profile string alone is ambiguous when two
+          // connections both expose (for example) "default". Resolve and lease
+          // that exact owner synchronously, or fail closed before dispatch.
+          const owner = parentStoredId ? sessionTileOwnerRoute(parentStoredId) : undefined
+
+          if (!owner?.connectionId?.trim()) {
+            throw new Error('Hermes tile source gateway owner unavailable')
+          }
+
+          profile = normalizeProfileKey(owner.profile)
+          sourceLease = bindGatewayRequestForOwner(owner.connectionId, profile)
+        }
 
         // The live atom may be a compacted model projection. Read the durable
         // display projection before choosing the branch prefix so a whole-chat
@@ -2182,6 +2206,7 @@ export function useSessionActions({
     [
       activeSessionIdRef,
       bindGatewayRequest,
+      bindGatewayRequestForOwner,
       busyRef,
       captureBranchUiIntent,
       copy,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/remove-archived-session.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/remove-archived-session.test.tsx
@@ -61,9 +61,11 @@ function Harness({ onReady }: { onReady: (handle: Handle) => void }) {
   const actions = useSessionActions({
     activeSessionId: null,
     activeSessionIdRef: ref<string | null>(null),
+    bindGatewayRequest: vi.fn() as never,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
+    gatewayRef: ref(null),
     getRouteToken: () => 'token',
     getRoutedStoredSessionId: () => null,
     navigate: vi.fn() as never,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/remove-archived-session.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/remove-archived-session.test.tsx
@@ -62,6 +62,7 @@ function Harness({ onReady }: { onReady: (handle: Handle) => void }) {
     activeSessionId: null,
     activeSessionIdRef: ref<string | null>(null),
     bindGatewayRequest: vi.fn() as never,
+    bindGatewayRequestForOwner: vi.fn() as never,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -68,6 +68,15 @@ describe('applyRuntimeInfo approval mode', () => {
     expect(approvalModeForProfile('work')).toBe('smart')
     expect(approvalModeForProfile('default')).toBe('smart')
   })
+
+  it('keeps background runtime approval metadata on its explicit owner profile', () => {
+    $activeGatewayProfile.set('other')
+
+    applyRuntimeInfo({ approval_mode: 'off' }, { foreground: false, profile: 'work' })
+
+    expect(approvalModeForProfile('work')).toBe('off')
+    expect(approvalModeForProfile('other')).toBe('smart')
+  })
 })
 
 const initialOnboardingState = $desktopOnboarding.get()

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -8,9 +8,11 @@ import { $activeGatewayProfile } from '@/store/profile'
 import {
   $currentBranch,
   $currentCwd,
+  $sessions,
   setCurrentBranch,
   setCurrentCwd,
   setSelectedStoredSessionId,
+  setSessions,
   workspaceCwdBelongsToSelectedSession
 } from '@/store/session'
 import type { SessionInfo, SessionResumeResponse } from '@/types/hermes'
@@ -33,7 +35,8 @@ import {
   selectBranchMessages,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
-  toBranchMessages
+  toBranchMessages,
+  upsertOptimisticSession
 } from './utils'
 
 const msg = (id: string, role: ChatMessage['role'], text: string, extra: Partial<ChatMessage> = {}): ChatMessage =>
@@ -76,6 +79,35 @@ describe('applyRuntimeInfo approval mode', () => {
 
     expect(approvalModeForProfile('work')).toBe('off')
     expect(approvalModeForProfile('other')).toBe('smart')
+  })
+})
+
+describe('upsertOptimisticSession explicit context', () => {
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
+    setCurrentCwd('')
+    setSessions([])
+  })
+
+  it('preserves an explicitly empty offscreen cwd instead of borrowing the foreground workspace', () => {
+    $activeGatewayProfile.set('foreground')
+    setCurrentCwd('/foreground/workspace')
+
+    upsertOptimisticSession(
+      { session_id: 'branch-runtime', stored_session_id: 'branch-stored' },
+      'branch-stored',
+      'Branch',
+      null,
+      'tile-stored',
+      undefined,
+      { cwd: '', profile: 'work' }
+    )
+
+    expect($sessions.get().find(session => session.id === 'branch-stored')).toMatchObject({
+      cwd: null,
+      parent_session_id: 'tile-stored',
+      profile: 'work'
+    })
   })
 })
 
@@ -143,7 +175,10 @@ describe('applyRuntimeInfo foreground scoping', () => {
   })
 
   it('keeps a background runtime out of the composer atoms but still returns its patch', () => {
-    const patch = applyRuntimeInfo({ branch: 'bb/tile', cwd: '/other-worktree' }, { foreground: false })
+    const patch = applyRuntimeInfo(
+      { branch: 'bb/tile', cwd: '/other-worktree' },
+      { foreground: false, profile: 'work' }
+    )
 
     // The main pane's rail must stay on its own tree.
     expect($currentCwd.get()).toBe('/main-repo')

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1242,6 +1242,13 @@ export function selectBranchMessages(
   return toBranchMessages(authoritativeMessages.slice(0, authoritativeIndex + 1))
 }
 
+interface OptimisticSessionContext {
+  connectionId?: string
+  cwd?: string
+  profile?: null | string
+  targetProfile?: string
+}
+
 export function upsertOptimisticSession(
   created: SessionCreateResponse,
   id: string,
@@ -1249,27 +1256,21 @@ export function upsertOptimisticSession(
   preview: string | null = null,
   parentSessionId: string | null = null,
   lastActive?: number,
-  owner?: null | SessionProfileRoute
+  context?: OptimisticSessionContext
 ) {
   const now = lastActive ?? Date.now() / 1000
-  // Stamp the profile the session was just created on so the scoped sidebar
-  // shows the new row immediately instead of filtering it out as "default"
-  // until the aggregator re-fetches. An explicitly routed create ($newChatRoute
-  // / a tile's route) names its EXACT owner: the backend profile that route
-  // serves, on that route's connection. The live gateway's profile is only the
-  // owner for an unrouted create — in All-profiles / Bot routing the ambient
-  // profile stays on `default` while the session lives on another backend (and
-  // a concurrent source switch can move the active gateway before this row is
-  // inserted), so a row stamped `default` then misroutes every session-scoped
-  // RPC that resolves its owner off the row ("session not found" on turn two).
-  const profileKey = normalizeProfileKey(owner ? owner.targetProfile || owner.profile : $activeGatewayProfile.get())
-  const connectionId = owner?.connectionId.trim() || ''
+  // Preserve an exact create route when one is available, while allowing
+  // branch callers to add cwd/profile placement before they have a connection
+  // route. A bare profile is placement metadata, not an exact owner hint.
+  const profileKey = normalizeProfileKey(context?.targetProfile || context?.profile || $activeGatewayProfile.get())
+  const connectionId = context?.connectionId?.trim() || ''
+  const fallbackCwd = context?.cwd?.trim() || $currentCwd.get().trim() || null
 
   const session: SessionInfo = {
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
     // lane immediately (the overlay groups by path); fall back to the workspace
     // the session was just started in when the create response omits it.
-    cwd: created.info?.cwd ?? ($currentCwd.get().trim() || null),
+    cwd: created.info?.cwd ?? fallbackCwd,
     ended_at: null,
     id,
     input_tokens: 0,
@@ -1289,8 +1290,8 @@ export function upsertOptimisticSession(
     ...(connectionId ? { connection_id: connectionId } : {})
   }
 
-  if (owner) {
-    setSessionOwnerHint(id, owner)
+  if (connectionId && context?.profile) {
+    setSessionOwnerHint(id, context as SessionProfileRoute)
   }
 
   setSessions(prev => [session, ...prev.filter(s => s.id !== id)])

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1244,7 +1244,7 @@ export function selectBranchMessages(
 
 interface OptimisticSessionContext {
   connectionId?: string
-  cwd?: string
+  cwd?: null | string
   profile?: null | string
   targetProfile?: string
 }
@@ -1264,7 +1264,9 @@ export function upsertOptimisticSession(
   // route. A bare profile is placement metadata, not an exact owner hint.
   const profileKey = normalizeProfileKey(context?.targetProfile || context?.profile || $activeGatewayProfile.get())
   const connectionId = context?.connectionId?.trim() || ''
-  const fallbackCwd = context?.cwd?.trim() || $currentCwd.get().trim() || null
+  const fallbackCwd = Object.hasOwn(context ?? {}, 'cwd')
+    ? context?.cwd?.trim() || null
+    : $currentCwd.get().trim() || null
 
   const session: SessionInfo = {
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
@@ -1534,23 +1536,21 @@ type SessionRuntimeStatePatch = Partial<
   >
 >
 
-interface ApplyRuntimeInfoOptions {
-  /** Explicit owner for profile-scoped runtime metadata (for example approvals). */
-  profile?: null | string
-  /**
-   * Whether this runtime belongs to the session the MAIN pane is showing.
-   * Foreground (the default) mirrors into the composer atoms every main-pane
-   * surface reads.
-   *
-   * A tile or a background branch must pass `false`: it owns a different
-   * worktree, and writing its cwd into `$currentCwd` re-pointed the main
-   * composer's coding rail (and the persisted workspace cwd) at the tile's
-   * repo — the main rail painted a branch from a tree its session was never
-   * in. The returned patch still carries every field, so the caller's own
-   * per-session state is unaffected.
-   */
-  foreground?: boolean
-}
+/**
+ * Foreground (the default) mirrors runtime metadata into the composer atoms.
+ * A tile or background branch must declare both `foreground: false` and its
+ * immutable owner profile so delayed metadata cannot bleed into the profile
+ * that happens to be active when the response arrives.
+ */
+type ApplyRuntimeInfoOptions =
+  | {
+      foreground?: true
+      profile?: null | string
+    }
+  | {
+      foreground: false
+      profile: null | string
+    }
 
 /** Mirror a session's runtime state into the composer atoms the MAIN pane
  *  renders from. Foreground sessions only — see ApplyRuntimeInfoOptions. */

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1256,7 +1256,7 @@ export function upsertOptimisticSession(
   preview: string | null = null,
   parentSessionId: string | null = null,
   lastActive?: number,
-  context?: OptimisticSessionContext
+  context?: null | OptimisticSessionContext
 ) {
   const now = lastActive ?? Date.now() / 1000
   // Preserve an exact create route when one is available, while allowing
@@ -1535,6 +1535,8 @@ type SessionRuntimeStatePatch = Partial<
 >
 
 interface ApplyRuntimeInfoOptions {
+  /** Explicit owner for profile-scoped runtime metadata (for example approvals). */
+  profile?: null | string
   /**
    * Whether this runtime belongs to the session the MAIN pane is showing.
    * Foreground (the default) mirrors into the composer atoms every main-pane
@@ -1601,8 +1603,10 @@ function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
 
 export function applyRuntimeInfo(
   info: SessionRuntimeInfo | undefined,
-  { foreground = true }: ApplyRuntimeInfoOptions = {}
+  options: ApplyRuntimeInfoOptions = {}
 ): SessionRuntimeStatePatch | null {
+  const { foreground = true } = options
+
   if (!info) {
     return null
   }
@@ -1612,7 +1616,11 @@ export function applyRuntimeInfo(
   reportBackendContract(info.desktop_contract)
 
   if (info.approval_mode !== undefined) {
-    reconcileApprovalModeForProfile($activeGatewayProfile.get(), info.approval_mode)
+    const approvalProfile = Object.hasOwn(options, 'profile')
+      ? normalizeProfileKey(options.profile)
+      : normalizeProfileKey($activeGatewayProfile.get())
+
+    reconcileApprovalModeForProfile(approvalProfile, info.approval_mode)
   }
 
   requestDesktopOnboardingForCredentialWarning(info.credential_warning)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1245,6 +1245,7 @@ export function selectBranchMessages(
 interface OptimisticSessionContext {
   connectionId?: string
   cwd?: null | string
+  mode?: 'local' | 'remote'
   profile?: null | string
   targetProfile?: string
 }
@@ -1293,7 +1294,12 @@ export function upsertOptimisticSession(
   }
 
   if (connectionId && context?.profile) {
-    setSessionOwnerHint(id, context as SessionProfileRoute)
+    setSessionOwnerHint(id, {
+      connectionId,
+      profile: context.profile,
+      ...(context.mode ? { mode: context.mode } : {}),
+      ...(context.targetProfile ? { targetProfile: context.targetProfile } : {})
+    })
   }
 
   setSessions(prev => [session, ...prev.filter(s => s.id !== id)])

--- a/apps/desktop/src/lib/json-rpc-gateway-recovery.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-recovery.test.ts
@@ -132,7 +132,7 @@ describe('hermes-ws-recovery-v1 silent blackhole', () => {
     vi.useRealTimers()
   })
 
-  it('keeps a replacement socket open when a superseded connect times out', async () => {
+  it('keeps a replacement socket open after closing a superseded connect', async () => {
     vi.useFakeTimers()
     vi.stubGlobal('WebSocket', { OPEN: LoopbackSocket.OPEN })
     const backend = new RecoveryBackend()
@@ -154,7 +154,9 @@ describe('hermes-ws-recovery-v1 silent blackhole', () => {
     client.onState(state => states.push(state))
 
     const staleConnect = client.connect('ws://gateway.test/a')
-    const staleRejection = expect(staleConnect).rejects.toThrow('WebSocket connection failed')
+    // close() now settles the superseded connect immediately; advancing the
+    // old timeout below must still leave the replacement generation untouched.
+    const staleRejection = expect(staleConnect).rejects.toThrow('WebSocket closed')
 
     client.close()
 

--- a/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
@@ -92,6 +92,7 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
     }
 
     const sockets: ControlledSocket[] = []
+
     const client = new JsonRpcGatewayClient({
       connectTimeoutMs: 50,
       socketFactory: () => {

--- a/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
@@ -62,6 +62,64 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
       expect(client.connectionState).toBe('open')
     }
   })
+
+  it('settles a closed connect and cannot poison a newer socket after its old timeout', async () => {
+    vi.useFakeTimers()
+
+    class ControlledSocket {
+      static OPEN = 1
+      readyState = 0
+      private readonly listeners = new Map<string, Set<() => void>>()
+
+      addEventListener = vi.fn((type: string, handler: () => void) => {
+        const handlers = this.listeners.get(type) ?? new Set<() => void>()
+        handlers.add(handler)
+        this.listeners.set(type, handlers)
+      })
+      removeEventListener = vi.fn((type: string, handler: () => void) => {
+        this.listeners.get(type)?.delete(handler)
+      })
+      close = vi.fn()
+      send = vi.fn()
+
+      open(): void {
+        this.readyState = ControlledSocket.OPEN
+
+        for (const handler of this.listeners.get('open') ?? []) {
+          handler()
+        }
+      }
+    }
+
+    const sockets: ControlledSocket[] = []
+    const client = new JsonRpcGatewayClient({
+      connectTimeoutMs: 50,
+      socketFactory: () => {
+        const socket = new ControlledSocket()
+        sockets.push(socket)
+
+        return socket as unknown as WebSocket
+      }
+    })
+
+    try {
+      const stale = client.connect('ws://127.0.0.1:1234/stale')
+      expect(client.connectionState).toBe('connecting')
+      client.close()
+      await expect(stale).rejects.toThrow('WebSocket closed')
+
+      const current = client.connect('ws://127.0.0.1:1234/current')
+      sockets[1].open()
+      await expect(current).resolves.toBeUndefined()
+      expect(client.connectionState).toBe('open')
+
+      await vi.advanceTimersByTimeAsync(50)
+      expect(client.connectionState).toBe('open')
+    } finally {
+      client.close()
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('JsonRpcGatewayClient structured errors', () => {

--- a/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
+++ b/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
@@ -120,6 +120,7 @@ describe('activation lease vs. the live-work pruner (#89622)', () => {
 
     const lease = acquireGatewayRequestLeaseForAgent('source-b', 'default')
 
+    expect(lease.ownerRoute).toEqual({ connectionId: 'source-b', profile: 'default' })
     await expect(lease.request('session.branch', { session_id: 'runtime-b' })).resolves.toEqual({
       method: 'session.branch',
       params: { session_id: 'runtime-b' }

--- a/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
+++ b/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { RECONNECT_ATTEMPT_TIMEOUT_MS } from '@/lib/with-timeout'
+
 // Regression suite for #89622: clicking a profile in the rail did nothing.
 // The live-work pruner (pruneSecondaryGateways) disposed the switch target's
 // secondary entry while its socket was still dialing — the target is not yet
@@ -61,7 +63,9 @@ const {
 function installDesktop(): void {
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
     getConnection: vi.fn(async (profile: null | string) =>
-      profile ? { port: 5151, profile, token: 'secondary-token' } : { port: 4242, token: 'primary-token' }
+      profile
+        ? { port: 5151, profile, token: 'secondary-token', wsUrl: 'ws://127.0.0.1:5151/ws' }
+        : { port: 4242, token: 'primary-token', wsUrl: 'ws://127.0.0.1:4242/ws' }
     ),
     getConnectionFor: vi.fn(async ({ profile }: { connectionId: string; profile: string }) => ({
       port: 6161,
@@ -75,6 +79,9 @@ function installDesktop(): void {
 
 function makePrimary() {
   return {
+    connect: vi.fn(async function (this: { connectionState: string }) {
+      this.connectionState = 'open'
+    }),
     connectionState: 'open',
     request: vi.fn(async (method: string, params: Record<string, unknown>) => ({ method, params }))
   }
@@ -151,6 +158,53 @@ describe('activation lease vs. the live-work pruner (#89622)', () => {
     await expect(lease.request('session.branch', { session_id: 'runtime-bot' })).rejects.toBe(outcomeUnknown)
     expect(gateway.request).toHaveBeenCalledOnce()
     expect(gateway.connect).toHaveBeenCalledOnce()
+    lease.release()
+  })
+
+  it('bounds a wedged primary descriptor lookup and permits a later recovery attempt', async () => {
+    vi.useFakeTimers()
+    const primary = makePrimary()
+    const desktop = window.hermesDesktop
+    vi.mocked(desktop.getConnection).mockImplementationOnce(() => new Promise(() => undefined))
+    primary.connectionState = 'closed'
+    setPrimaryGateway(primary as never, 'default')
+    const firstLease = acquireGatewayRequestLease(primary as never, 'default')
+    const firstRequest = firstLease.request('session.branch', { session_id: 'runtime-primary' })
+    const firstRejection = expect(firstRequest).rejects.toThrow('Timed out reconnecting to Hermes backend')
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_ATTEMPT_TIMEOUT_MS)
+    await firstRejection
+    firstLease.release()
+
+    const secondLease = acquireGatewayRequestLease(primary as never, 'default')
+    await expect(secondLease.request('session.branch', { session_id: 'runtime-primary' })).resolves.toEqual({
+      method: 'session.branch',
+      params: { session_id: 'runtime-primary' }
+    })
+    expect(desktop.getConnection).toHaveBeenCalledTimes(2)
+    secondLease.release()
+  })
+
+  it('bounds a wedged primary WebSocket URL refresh before dispatch', async () => {
+    vi.useFakeTimers()
+    const primary = makePrimary()
+    const desktop = window.hermesDesktop
+    vi.mocked(desktop.getConnection).mockResolvedValue({
+      authMode: 'oauth',
+      profile: 'default',
+      wsUrl: 'wss://gateway.invalid/ws'
+    } as never)
+    desktop.getGatewayWsUrl = vi.fn(() => new Promise<string>(() => undefined))
+    primary.connectionState = 'closed'
+    setPrimaryGateway(primary as never, 'default')
+    const lease = acquireGatewayRequestLease(primary as never, 'default')
+    const request = lease.request('session.branch', { session_id: 'runtime-primary' })
+    const rejection = expect(request).rejects.toThrow('Timed out re-minting the gateway WebSocket URL')
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_ATTEMPT_TIMEOUT_MS)
+    await rejection
+    expect(primary.connect).not.toHaveBeenCalled()
+    expect(primary.request).not.toHaveBeenCalled()
     lease.release()
   })
 

--- a/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
+++ b/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
@@ -48,6 +48,7 @@ vi.mock('@/store/session', () => ({ setConnection: vi.fn(), setGatewayState: vi.
 vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
 
 const {
+  acquireGatewayRequestLease,
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForAgent,
@@ -143,6 +144,30 @@ describe('activation lease vs. the live-work pruner (#89622)', () => {
 
     releaseConnect()
     await expect(switching).resolves.toBe(true)
+  })
+
+  it('releasing a command lease cannot consume a prune deferred by an in-flight activation', async () => {
+    let releaseConnect: () => void = () => undefined
+    connectGate = new Promise<void>(resolve => {
+      releaseConnect = resolve
+    })
+
+    const switching = ensureGatewayForProfile('bot')
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(secondaryGateways).toHaveLength(1)
+
+    const commandLease = acquireGatewayRequestLease(secondaryGateways[0] as never, 'bot')
+
+    pruneSecondaryGateways(new Set())
+    commandLease.release()
+
+    expect(secondaryGateways[0].close).not.toHaveBeenCalled()
+
+    releaseConnect()
+    await switching
+
+    expect(secondaryGateways[0].connectionState).toBe('open')
   })
 
   it('the lease is released once the switch settles — a later prune reclaims the idle entry', async () => {

--- a/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
+++ b/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
@@ -49,6 +49,7 @@ vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() })
 
 const {
   acquireGatewayRequestLease,
+  acquireGatewayRequestLeaseForAgent,
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForAgent,
@@ -105,6 +106,54 @@ async function flushUntilSecondaryRegistered(max = 20): Promise<void> {
 }
 
 describe('activation lease vs. the live-work pruner (#89622)', () => {
+  it('leases the exact connection when two sources expose the same profile', async () => {
+    await ensureGatewayForAgent('source-a', 'default')
+    await ensureGatewayForAgent('source-b', 'default')
+    expect(secondaryGateways).toHaveLength(2)
+
+    const lease = acquireGatewayRequestLeaseForAgent('source-b', 'default')
+
+    await expect(lease.request('session.branch', { session_id: 'runtime-b' })).resolves.toEqual({
+      method: 'session.branch',
+      params: { session_id: 'runtime-b' }
+    })
+    expect(secondaryGateways[0].request).not.toHaveBeenCalled()
+    expect(secondaryGateways[1].request).toHaveBeenCalledOnce()
+    lease.release()
+  })
+
+  it('recovers a leased owner only when the socket is closed before dispatch', async () => {
+    await ensureGatewayForProfile('bot')
+    const gateway = secondaryGateways[0]
+    const lease = acquireGatewayRequestLease(gateway as never, 'bot')
+    gateway.connectionState = 'closed'
+
+    await expect(lease.request('session.branch', { session_id: 'runtime-bot' })).resolves.toEqual({
+      method: 'session.branch',
+      params: { session_id: 'runtime-bot' }
+    })
+    expect(gateway.connect).toHaveBeenCalledTimes(2)
+    expect(gateway.request).toHaveBeenCalledOnce()
+    lease.release()
+  })
+
+  it('does not replay a leased mutation after a post-send connection close', async () => {
+    await ensureGatewayForProfile('bot')
+    const gateway = secondaryGateways[0]
+    const lease = acquireGatewayRequestLease(gateway as never, 'bot')
+    const outcomeUnknown = new Error('connection closed')
+
+    gateway.request.mockImplementationOnce(async () => {
+      gateway.connectionState = 'closed'
+      throw outcomeUnknown
+    })
+
+    await expect(lease.request('session.branch', { session_id: 'runtime-bot' })).rejects.toBe(outcomeUnknown)
+    expect(gateway.request).toHaveBeenCalledOnce()
+    expect(gateway.connect).toHaveBeenCalledOnce()
+    lease.release()
+  })
+
   it('a prune during the switch dial does not dispose the target and the switch lands', async () => {
     let releaseConnect: () => void = () => undefined
     connectGate = new Promise<void>(resolve => {
@@ -135,8 +184,7 @@ describe('activation lease vs. the live-work pruner (#89622)', () => {
     })
 
     const switching = ensureGatewayForAgent('homelab', 'research')
-    await Promise.resolve()
-    await Promise.resolve()
+    await flushUntilSecondaryRegistered()
     expect(secondaryGateways).toHaveLength(1)
 
     pruneSecondaryGateways(new Set())
@@ -153,8 +201,7 @@ describe('activation lease vs. the live-work pruner (#89622)', () => {
     })
 
     const switching = ensureGatewayForProfile('bot')
-    await Promise.resolve()
-    await Promise.resolve()
+    await flushUntilSecondaryRegistered()
     expect(secondaryGateways).toHaveLength(1)
 
     const commandLease = acquireGatewayRequestLease(secondaryGateways[0] as never, 'bot')

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1520,7 +1520,12 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
   const key = normKey(profile)
   const secondary =
     [...g.secondaries.values()].find(entry => entry.gateway === gateway && normKey(entry.profile) === key) ?? null
-  const ownsPrimary = !secondary && g.primaryGateway === gateway && g.primaryProfile === key
+  // Shared-primary commands may bind a logical profile that differs from the
+  // primary's physical route. Snapshot the physical owner so a later re-home
+  // cannot let this lease reconnect or retry on the wrong backend.
+  const primaryOwnerProfile = g.primaryProfile
+  const primaryOwnerConnectionId = g.primaryConnectionId
+  const ownsPrimary = !secondary && g.primaryGateway === gateway
 
   if (!secondary && !ownsPrimary) {
     throw new Error('Hermes source gateway unavailable')
@@ -1535,7 +1540,9 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
     !released &&
     (secondary
       ? secondary.wantOpen && g.secondaries.get(secondary.scope) === secondary && secondary.gateway === gateway
-      : g.primaryGateway === gateway && g.primaryProfile === key)
+      : g.primaryGateway === gateway &&
+        g.primaryProfile === primaryOwnerProfile &&
+        g.primaryConnectionId === primaryOwnerConnectionId)
 
   const recover = async (): Promise<boolean> => {
     if (!stillRegistered()) {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -565,7 +565,9 @@ async function openSecondary(entry: Secondary): Promise<void> {
       // turn that successful transport recovery into a reported dial failure.
     }
 
-    if (!entry.wantOpen) {
+    // Teardown or replacement can win while connect() itself is pending. Close
+    // the exact orphaned socket rather than publishing a removed registry entry.
+    if (!entry.wantOpen || g.secondaries.get(entry.scope) !== entry) {
       entry.gateway.close()
 
       return

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -34,7 +34,8 @@ export type GatewayRequester = <T>(
   method: string,
   params?: Record<string, unknown>,
   timeoutMs?: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  isStillValid?: () => boolean
 ) => Promise<T>
 
 export interface GatewayRequestLease {
@@ -1576,8 +1577,17 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
         return
       }
 
-      const connection = await desktop.getConnection(key)
-      const wsUrl = await resolveGatewayWsUrl(desktop, connection)
+      const connection = await withTimeout(
+        desktop.getConnection(key),
+        RECONNECT_ATTEMPT_TIMEOUT_MS,
+        'Timed out reconnecting to Hermes backend'
+      )
+
+      const wsUrl = await withTimeout(
+        resolveGatewayWsUrl(desktop, connection),
+        RECONNECT_ATTEMPT_TIMEOUT_MS,
+        'Timed out re-minting the gateway WebSocket URL'
+      )
 
       if (stillRegistered()) {
         await gateway.connect(wsUrl)
@@ -1599,8 +1609,14 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
   }
 
   return {
-    request: async <T>(method: string, params = {}, timeoutMs?: number, signal?: AbortSignal): Promise<T> => {
-      if (!stillRegistered()) {
+    request: async <T>(
+      method: string,
+      params = {},
+      timeoutMs?: number,
+      signal?: AbortSignal,
+      isStillValid?: () => boolean
+    ): Promise<T> => {
+      if (!stillRegistered() || (isStillValid && !isStillValid())) {
         throw new Error('Hermes source gateway unavailable')
       }
 
@@ -1621,6 +1637,14 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
 
           throw reconnectError
         }
+      }
+
+      // Recovery can yield for an IPC descriptor lookup and a fresh OAuth
+      // ticket. The command owner may disappear or rebind during either await;
+      // validate at the last pre-send boundary so a non-idempotent mutation is
+      // never dispatched for a stale runtime.
+      if (!stillRegistered() || (isStillValid && !isStillValid())) {
+        throw new Error('Hermes source gateway unavailable')
       }
 
       return timeoutMs !== undefined || signal !== undefined

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -13,6 +13,7 @@ import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
 import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { markNativeNotifyBaseline } from '@/store/notify-baseline'
 import { setConnection, setGatewayState } from '@/store/session'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
 
 // ── Multi-profile gateway routing ──────────────────────────────────────────
 // Concurrent sessions across profiles need concurrent sockets: the renderer's
@@ -39,6 +40,8 @@ export type GatewayRequester = <T>(
 ) => Promise<T>
 
 export interface GatewayRequestLease {
+  /** Exact registry route of the pinned socket, when the registry names it. */
+  ownerRoute?: SessionOwnerRoute
   request: GatewayRequester
   release(): void
 }
@@ -1608,7 +1611,10 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
     return stillRegistered() && isOpen(gateway)
   }
 
+  const ownerConnectionId = secondary?.connectionId ?? primaryOwnerConnectionId
+
   return {
+    ...(ownerConnectionId ? { ownerRoute: { connectionId: ownerConnectionId, profile: key } } : {}),
     request: async <T>(
       method: string,
       params = {},

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1,4 +1,10 @@
-import { type ConnectionState, type GatewayEvent, registryBackendScopeKey, resolveGatewayWsUrl } from '@hermes/shared'
+import {
+  type ConnectionState,
+  type GatewayEvent,
+  isGatewayReauthRequired,
+  registryBackendScopeKey,
+  resolveGatewayWsUrl
+} from '@hermes/shared'
 import { atom } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
@@ -23,6 +29,18 @@ const normKey = (profile: string | null | undefined): string => (profile ?? '').
 // Read connection state through a call so TS control-flow analysis doesn't
 // narrow the getter to a constant across guards (it genuinely changes).
 const isOpen = (gateway: HermesGateway | null): boolean => gateway?.connectionState === 'open'
+
+export type GatewayRequester = <T>(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number,
+  signal?: AbortSignal
+) => Promise<T>
+
+export interface GatewayRequestLease {
+  request: GatewayRequester
+  release(): void
+}
 
 interface RegistryConfig {
   /** Electron's published descriptor is authoritative for a primary gateway's
@@ -1488,6 +1506,142 @@ export async function ensureActiveGatewayOpen(): Promise<HermesGateway | null> {
 // How long ensureActiveGatewayOpen waits out an in-flight secondary
 // activation before reporting the gateway as unavailable.
 const ACTIVE_GATEWAY_OPEN_WAIT_MS = 8_000
+
+let primaryCommandReconnect: { gateway: HermesGateway; profile: string; promise: Promise<void> } | null = null
+
+/**
+ * Pin the concrete socket that owned a command at invocation time. Secondary
+ * leases reuse the registry's active-request hold, so pruning and connection
+ * edits cannot replace that socket while metadata lookup is pending.
+ */
+export function acquireGatewayRequestLease(gateway: HermesGateway, profile: string): GatewayRequestLease {
+  const key = normKey(profile)
+  const secondary =
+    [...g.secondaries.values()].find(entry => entry.gateway === gateway && normKey(entry.profile) === key) ?? null
+  const ownsPrimary = !secondary && g.primaryGateway === gateway && g.primaryProfile === key
+
+  if (!secondary && !ownsPrimary) {
+    throw new Error('Hermes source gateway unavailable')
+  }
+
+  if (secondary) {
+    secondary.activeRequests += 1
+  }
+
+  let released = false
+  const stillRegistered = () =>
+    !released &&
+    (secondary
+      ? secondary.wantOpen && g.secondaries.get(secondary.scope) === secondary && secondary.gateway === gateway
+      : g.primaryGateway === gateway && g.primaryProfile === key)
+
+  const recover = async (): Promise<boolean> => {
+    if (!stillRegistered()) {
+      return false
+    }
+
+    if (secondary) {
+      clearTimer(secondary)
+      secondary.reconnectAttempt = 0
+      await openSecondary(secondary)
+
+      return stillRegistered() && isOpen(gateway)
+    }
+
+    const current = primaryCommandReconnect
+
+    if (current?.gateway === gateway && current.profile === key) {
+      await current.promise
+
+      return stillRegistered() && isOpen(gateway)
+    }
+
+    const attempt = (async () => {
+      const desktop = window.hermesDesktop
+
+      if (!desktop || !stillRegistered()) {
+        return
+      }
+
+      const connection = await desktop.getConnection(key)
+      const wsUrl = await resolveGatewayWsUrl(desktop, connection)
+
+      if (stillRegistered()) {
+        await gateway.connect(wsUrl)
+      }
+    })()
+    const reconnect = { gateway, profile: key, promise: attempt }
+    primaryCommandReconnect = reconnect
+
+    try {
+      await attempt
+    } finally {
+      if (primaryCommandReconnect === reconnect) {
+        primaryCommandReconnect = null
+      }
+    }
+
+    return stillRegistered() && isOpen(gateway)
+  }
+
+  return {
+    request: async <T>(method: string, params = {}, timeoutMs?: number, signal?: AbortSignal): Promise<T> => {
+      if (!stillRegistered()) {
+        throw new Error('Hermes source gateway unavailable')
+      }
+
+      try {
+        return await gateway.request<T>(method, params, timeoutMs, signal)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+
+        if (!/not connected|connection closed/i.test(message)) {
+          throw error
+        }
+
+        try {
+          if (!(await recover())) {
+            throw error
+          }
+        } catch (reconnectError) {
+          if (isGatewayReauthRequired(reconnectError)) {
+            throw reconnectError
+          }
+
+          throw error
+        }
+
+        return gateway.request<T>(method, params, timeoutMs, signal)
+      }
+    },
+    release: () => {
+      if (released) {
+        return
+      }
+
+      released = true
+
+      if (secondary) {
+        secondary.activeRequests = Math.max(0, secondary.activeRequests - 1)
+
+        if (
+          !drainPendingConnectionRedial(secondary) &&
+          secondary.activeRequests === 0 &&
+          !secondary.retained &&
+          !relayRetained(secondary) &&
+          !foregroundPinned(secondary) &&
+          g.activeKey !== secondary.scope
+        ) {
+          disposeSecondary(secondary)
+
+          if (g.secondaries.get(secondary.scope) === secondary) {
+            g.secondaries.delete(secondary.scope)
+          }
+        }
+      }
+    }
+  }
+}
 
 // Recovery signal: nudge every live secondary back open. Power-resume/network
 // signals can force sockets that still report open to retire before redialing.

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1604,36 +1604,28 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
         throw new Error('Hermes source gateway unavailable')
       }
 
-      try {
-        return await (timeoutMs !== undefined || signal !== undefined
-          ? gateway.request<T>(method, params, timeoutMs, signal)
-          : gateway.request<T>(method, params))
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-
-        // Only transport failures on a socket that actually left `open` are
-        // replay-safe. Domain errors may contain the same words (for example,
-        // "model provider not connected") and must never duplicate a command.
-        if (!/not connected|connection closed/i.test(message) || isOpen(gateway)) {
-          throw error
-        }
-
+      // Recover only before handing the command to request(). Once request()
+      // has been entered, a later close is outcome-unknown: WebSocket.send may
+      // already have delivered a non-idempotent mutation (session.branch) even
+      // though the reply was lost. Blindly replaying that command can create a
+      // second branch. A socket observed closed here is provably pre-send.
+      if (!isOpen(gateway)) {
         try {
           if (!(await recover())) {
-            throw error
+            throw new Error('Hermes source gateway unavailable')
           }
         } catch (reconnectError) {
           if (isGatewayReauthRequired(reconnectError)) {
             throw reconnectError
           }
 
-          throw error
+          throw reconnectError
         }
-
-        return timeoutMs !== undefined || signal !== undefined
-          ? gateway.request<T>(method, params, timeoutMs, signal)
-          : gateway.request<T>(method, params)
       }
+
+      return timeoutMs !== undefined || signal !== undefined
+        ? gateway.request<T>(method, params, timeoutMs, signal)
+        : gateway.request<T>(method, params)
     },
     release: () => {
       if (released) {
@@ -1662,6 +1654,37 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
       }
     }
   }
+}
+
+/**
+ * Lease the exact registry route that owns a runtime. Unlike the profile-only
+ * binder, this lookup cannot confuse two connections exposing the same Desktop
+ * profile name. Foreground tiles keep their owner registered; if it is gone,
+ * fail closed instead of borrowing whichever same-named route is active.
+ */
+export function acquireGatewayRequestLeaseForAgent(connectionId: string, profile: string): GatewayRequestLease {
+  const ownerConnectionId = connectionId.trim()
+  const key = normKey(profile)
+
+  if (!ownerConnectionId) {
+    throw new Error('Hermes source gateway owner is missing connectionId')
+  }
+
+  if (isPrimaryRegistryRoute(ownerConnectionId, key)) {
+    if (!g.primaryGateway) {
+      throw new Error('Hermes source gateway unavailable')
+    }
+
+    return acquireGatewayRequestLease(g.primaryGateway, key)
+  }
+
+  const entry = g.secondaries.get(registryBackendScopeKey(ownerConnectionId, key))
+
+  if (!entry?.wantOpen) {
+    throw new Error('Hermes source gateway unavailable')
+  }
+
+  return acquireGatewayRequestLease(entry.gateway, key)
 }
 
 // Recovery signal: nudge every live secondary back open. Power-resume/network

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1518,11 +1518,14 @@ let primaryCommandReconnect: { gateway: HermesGateway; profile: string; promise:
  */
 export function acquireGatewayRequestLease(gateway: HermesGateway, profile: string): GatewayRequestLease {
   const key = normKey(profile)
+
   const secondary =
     [...g.secondaries.values()].find(entry => entry.gateway === gateway && normKey(entry.profile) === key) ?? null
+
   // Shared-primary commands may bind a logical profile that differs from the
   // primary's physical route. Snapshot the physical owner so a later re-home
   // cannot let this lease reconnect or retry on the wrong backend.
+
   const primaryOwnerProfile = g.primaryProfile
   const primaryOwnerConnectionId = g.primaryConnectionId
   const ownsPrimary = !secondary && g.primaryGateway === gateway
@@ -1536,6 +1539,7 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
   }
 
   let released = false
+
   const stillRegistered = () =>
     !released &&
     (secondary
@@ -1579,6 +1583,7 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
         await gateway.connect(wsUrl)
       }
     })()
+
     const reconnect = { gateway, profile: key, promise: attempt }
     primaryCommandReconnect = reconnect
 
@@ -1600,11 +1605,16 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
       }
 
       try {
-        return await gateway.request<T>(method, params, timeoutMs, signal)
+        return await (timeoutMs !== undefined || signal !== undefined
+          ? gateway.request<T>(method, params, timeoutMs, signal)
+          : gateway.request<T>(method, params))
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
 
-        if (!/not connected|connection closed/i.test(message)) {
+        // Only transport failures on a socket that actually left `open` are
+        // replay-safe. Domain errors may contain the same words (for example,
+        // "model provider not connected") and must never duplicate a command.
+        if (!/not connected|connection closed/i.test(message) || isOpen(gateway)) {
           throw error
         }
 
@@ -1620,7 +1630,9 @@ export function acquireGatewayRequestLease(gateway: HermesGateway, profile: stri
           throw error
         }
 
-        return gateway.request<T>(method, params, timeoutMs, signal)
+        return timeoutMs !== undefined || signal !== undefined
+          ? gateway.request<T>(method, params, timeoutMs, signal)
+          : gateway.request<T>(method, params)
       }
     },
     release: () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1373,20 +1373,35 @@ export function openSessionTileForProfile(
   profile: string,
   dir: TileDock = 'right',
   anchor?: string,
-  before?: null | string
+  before?: null | string,
+  ownerRoute?: SessionOwnerRoute
 ): boolean {
   const targetProfile = normalizeProfileKey(profile)
 
   if (targetProfile === profileKey()) {
     openSessionTile(storedSessionId, dir, anchor, before)
 
+    if (ownerRoute) {
+      patchSessionTile(storedSessionId, { ownerRoute })
+    }
+
     return true
   }
 
   const stored = tilesByProfile[targetProfile] ?? []
 
-  if (!stored.some(tile => tile.storedSessionId === storedSessionId)) {
-    tilesByProfile[targetProfile] = [...stored, { anchor, before: before ?? undefined, dir, storedSessionId }]
+  const existing = stored.find(tile => tile.storedSessionId === storedSessionId)
+
+  if (!existing) {
+    tilesByProfile[targetProfile] = [
+      ...stored,
+      { anchor, before: before ?? undefined, dir, ownerRoute, storedSessionId }
+    ]
+    persistTiles()
+  } else if (ownerRoute) {
+    tilesByProfile[targetProfile] = stored.map(tile =>
+      tile.storedSessionId === storedSessionId ? { ...tile, ownerRoute } : tile
+    )
     persistTiles()
   }
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1361,6 +1361,38 @@ export function openSessionTile(
   }
 }
 
+/**
+ * Persist a tile into an explicit profile namespace without disturbing the
+ * profile currently on screen. Returns true when that namespace is active, in
+ * which case the regular open path also publishes the tile for immediate pane
+ * adoption. An inactive profile receives only durable placement; its runtime is
+ * re-resumed when the user returns to it.
+ */
+export function openSessionTileForProfile(
+  storedSessionId: string,
+  profile: string,
+  dir: TileDock = 'right',
+  anchor?: string,
+  before?: null | string
+): boolean {
+  const targetProfile = normalizeProfileKey(profile)
+
+  if (targetProfile === profileKey()) {
+    openSessionTile(storedSessionId, dir, anchor, before)
+
+    return true
+  }
+
+  const stored = tilesByProfile[targetProfile] ?? []
+
+  if (!stored.some(tile => tile.storedSessionId === storedSessionId)) {
+    tilesByProfile[targetProfile] = [...stored, { anchor, before: before ?? undefined, dir, storedSessionId }]
+    persistTiles()
+  }
+
+  return false
+}
+
 /** ⌘W on the MAIN tab: the next session tab stacked WITH the workspace, to
  *  shift into main. Walks the workspace group's strip from the workspace tab
  *  outward (the tab after it first, then wrapping to the ones before), and

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1614,9 +1614,15 @@ export function reopenLastClosedTile(): void {
 
     if (!$sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
       openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before, {
+        ownerRoute: tile.ownerRoute,
         workspaceMode: tile.workspaceMode ?? 'sessions',
         workspaceOwnerKey: tile.workspaceOwnerKey
       })
+
+      if (tile.ownerRoute) {
+        patchSessionTile(storedSessionId, { ownerRoute: tile.ownerRoute })
+      }
+
       focusOpenSession(storedSessionId)
 
       return

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -154,6 +154,17 @@ export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: n
   const hint = getSessionOwnerHint(sessionId)
 
   if (connectionId) {
+    const hintProfiles = new Set([hint?.profile.trim() || 'default', hint?.targetProfile?.trim() || 'default'])
+
+    // A connection-tagged row persists the backend profile for REST/list
+    // placement, while its exact owner hint retains the Desktop-facing profile
+    // that selects the physical gateway route. Prefer that complete route only
+    // when both the registry source and one of its profile names still agree;
+    // otherwise the row remains authoritative over a stale hint.
+    if (hint && hint.connectionId.trim() === connectionId && hintProfiles.has(profile || 'default')) {
+      return hint
+    }
+
     return { connectionId, profile: profile || 'default' }
   }
 

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -100,6 +100,7 @@ const DEFAULT_HEARTBEAT_DEADLINE_MS = 45_000
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000
 
 export class JsonRpcGatewayClient {
+  private cancelConnect: ((error: Error) => void) | null = null
   private nextId = 0
   private pending = new Map<GatewayRequestId, PendingCall>()
   private socket: WebSocketLike | null = null
@@ -214,6 +215,7 @@ export class JsonRpcGatewayClient {
     await new Promise<void>((resolve, reject) => {
       let settled = false
       let timer: ReturnType<typeof setTimeout> | undefined
+      let cancelConnect: (error: Error) => void = () => undefined
 
       const cleanup = () => {
         if (timer !== undefined) {
@@ -222,7 +224,29 @@ export class JsonRpcGatewayClient {
 
         socket.removeEventListener('open', onOpen)
         socket.removeEventListener('error', onError)
+
+        if (this.cancelConnect === cancelConnect) {
+          this.cancelConnect = null
+        }
       }
+
+      const rejectConnect = (error: Error, state?: ConnectionState) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+        cleanup()
+
+        if (state) {
+          this.setState(state)
+        }
+
+        reject(error)
+      }
+
+      cancelConnect = error => rejectConnect(error)
+      this.cancelConnect = cancelConnect
 
       const onOpen = () => {
         if (settled || this.socket !== socket) {
@@ -244,10 +268,7 @@ export class JsonRpcGatewayClient {
           return
         }
 
-        settled = true
-        cleanup()
-        this.setState('error')
-        reject(new Error(this.options.connectErrorMessage))
+        rejectConnect(new Error(this.options.connectErrorMessage), 'error')
       }
 
       socket.addEventListener('open', onOpen, { once: true })
@@ -259,23 +280,22 @@ export class JsonRpcGatewayClient {
             return
           }
 
-          settled = true
-          cleanup()
-
-          // Drop the half-open socket so the next connect() starts clean
-          // instead of short-circuiting on a zombie 'connecting' state.
-          if (this.socket === socket) {
-            try {
-              socket.close()
-            } catch {
-              // ignore
-            }
-
-            this.socket = null
-            this.setState('error')
+          if (this.socket !== socket) {
+            rejectConnect(new Error(this.options.closedErrorMessage))
+            return
           }
 
-          reject(new Error(this.options.connectErrorMessage))
+          // Invalidate the attempt before closing: a synchronous close event
+          // must not race this timeout into a second state transition.
+          this.socket = null
+
+          try {
+            socket.close()
+          } catch {
+            // ignore
+          }
+
+          rejectConnect(new Error(this.options.connectErrorMessage), 'error')
         }, this.options.connectTimeoutMs)
       }
     })
@@ -288,11 +308,16 @@ export class JsonRpcGatewayClient {
       return
     }
 
+    // Invalidate all socket listeners and settle a pending connect immediately.
+    // A later timeout from the old attempt must not overwrite a newer socket's
+    // open state when callers reuse this client after a soft switch.
+    this.socket = null
+
     try {
       socket.close()
     } finally {
-      this.socket = null
       this.stopHeartbeat()
+      this.cancelConnect?.(new Error(this.options.closedErrorMessage))
       this.setState('closed')
       this.rejectAllPending(new Error(this.options.closedErrorMessage))
     }


### PR DESCRIPTION
## What does this PR do?

Fixes #73207.

Desktop session tiles already pass their runtime ID into the shared slash dispatcher. The native `/branch` action dropped that target and called the foreground-only branch helper with no arguments, so a command entered in a tile created a child from whichever primary chat was in front.

This PR forwards the invocation runtime through the existing branch action and resolves offscreen branch state from that runtime's isolated cache. The target transcript, busy state, stored parent identity, owning profile, and workspace now stay together, including an explicitly detached/empty workspace rather than borrowing the foreground cwd. Live runtime branches synchronously lease the invocation socket before asynchronous profile lookup; production pruning preserves that lease, disconnected requests reconnect once and retry on the exact same transport, concurrent reconnects coalesce by owner generation, and every completion path releases the lease. Domain errors are never replayed. A delayed branch runtime response reconciles profile-scoped approval metadata only into the source profile, even after the foreground switches. Delayed children are persisted in the invocation profile/layout namespace and no longer steal focus or consume the foreground route-resume edge after profile or route intent changes. Their runtime metadata remains isolated from foreground stores. The existing foreground message-action path remains unchanged, and an explicit target that disappears during dispatch fails closed instead of falling through to an unrelated conversation.

This is adjacent to, but not duplicated by:

- #71805, which fixed target routing for exec/skill slash commands but did not cover native actions;
- #71960, which fixed foreground branch persistence/count semantics;
- #71969, which hides the per-message Branch button in tiles but does not cover the whole-session `/branch` command or tile session-menu branching.

## Related Issue

Fixes #73207

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts`
  - forwards the slash invocation's target runtime to the native branch action.
- `apps/desktop/src/app/contrib/wiring.tsx`
  - carries the optional target through the existing branch wrapper and injects the gateway request binder.
- `apps/desktop/src/app/gateway/hooks/use-gateway-request.ts`
  - exposes the production profile-scoped gateway request lease to session actions.
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`
  - branches offscreen runtimes from their own cached transcript, busy state, stored identity, profile, and cwd;
  - acquires a source command lease before async profile resolution and dispatches runtime-scoped `session.branch` through its recovery-aware requester;
  - hydrates the child tile without overwriting foreground model/cwd/control stores;
  - snapshots profile/layout/route intent and suppresses stale focus effects;
  - keeps foreground creation/route-resume ownership out of offscreen branch requests;
  - preserves the existing foreground branch path;
  - fails closed when an explicit target runtime no longer has state.
- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`
  - lets optimistic children carry an explicitly resolved profile/workspace, including explicit detached cwd, without changing the active gateway;
  - applies runtime approval metadata to an explicit owner profile instead of the mutable foreground profile.
- `apps/desktop/src/store/gateway.ts`
  - adds exact-owner command leases that survive activation/prewarm pruning, coalesce primary/secondary reconnects by owner generation, revalidate registry identity after awaits, retry only disconnect failures on the same transport, and defer pruning until the final lease releases.
- `apps/desktop/src/store/gateway.test.ts`
  - exercises the production registry's primary recovery, secondary pruning, concurrent reconnect coalescing, exact request retry, non-disconnect behavior, terminal retry propagation, and teardown invalidation.
- `apps/desktop/src/store/session-states.ts`
  - persists delayed child tiles into an explicit profile namespace without mutating the profile currently on screen.
- Regression tests cover dispatcher forwarding and the full session-action identity boundary, including a busy foreground chat, a differently profiled tile, deferred profile resolution, an in-flight profile switch, source-requester enforcement, approval-cache ownership, lease release, production pruning/reconnect behavior, stale-completion suppression, optimistic child metadata, and foreground-state isolation.

## How to Test

1. Open session A as the primary Desktop chat.
2. Open a different session B in a tile or split pane.
3. Type `/branch` in session B.
4. Confirm the child uses B's transcript and is nested under B, while A remains untouched.

Commands run locally:

```bash
NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-vitest-localstorage-pr73251-final.json' \
  npm --workspace apps/desktop exec -- vitest run --project ui \
  src/app/session/hooks/use-prompt-actions/index.test.tsx \
  src/app/session/hooks/use-session-actions.test.tsx \
  src/app/session/hooks/use-session-actions/utils.test.ts \
  src/app/session/hooks/use-message-stream/utils.test.ts \
  src/app/gateway/hooks/use-gateway-request.test.ts \
  src/app/gateway/hooks/use-gateway-boot.test.tsx \
  src/app/session/hooks/use-route-resume.test.tsx \
  src/store/gateway.test.ts \
  src/store/session-states.test.ts
# 9 files, 292 tests passed

NODE_ENV=test npm --workspace apps/desktop run typecheck
# pass: renderer + electron + e2e TypeScript projects

NODE_ENV=test npm --workspace apps/desktop exec -- eslint \
  src/app/contrib/wiring.tsx \
  src/app/gateway/hooks/use-gateway-request.ts \
  src/app/session/hooks/use-session-actions.test.tsx \
  src/app/session/hooks/use-session-actions/index.ts \
  src/app/session/hooks/use-session-actions/utils.test.ts \
  src/app/session/hooks/use-session-actions/utils.ts \
  src/store/gateway.test.ts \
  src/store/gateway.ts
# pass: 0 errors, 0 warnings

npm --workspace apps/desktop exec -- prettier --check \
  src/app/contrib/wiring.tsx \
  src/app/gateway/hooks/use-gateway-request.ts \
  src/app/session/hooks/use-session-actions.test.tsx \
  src/app/session/hooks/use-session-actions/index.ts \
  src/app/session/hooks/use-session-actions/utils.test.ts \
  src/app/session/hooks/use-session-actions/utils.ts \
  src/store/gateway.test.ts \
  src/store/gateway.ts
# pass: all matched files use Prettier formatting

NODE_ENV=production npm --workspace apps/desktop run build
# pass: production stamp 057a817d6379

git diff --check HEAD^ HEAD
# pass
```

The earlier parent candidate's complete Desktop UI run reported `2771 passed, 5 failed`, while its exact detached `origin/main` baseline reported `2766 passed, 6 failed`; every candidate failure reproduced there with the same assertion (locale-sensitive number/date formatting and unrelated billing tests), and the baseline had one additional floating-pane order flake. The remediation commit was then validated through the expanded 292-test affected lane, renderer/electron/e2e typechecks, changed-file lint and formatting checks, a clean production build, and `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop renderer-only change; the relevant Vitest/typecheck/build gates are documented above, and the full UI baseline is disclosed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux, Node 25.4.0, npm 11.7.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: no user-facing command semantics changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only TypeScript; no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual styling changes. The fail-before behavior was captured by two deterministic hook regressions:

```text
expected session.branch { session_id: "tile-runtime", count: 2 }
received session.branch { session_id: "foreground-runtime", count: 1 }

expected branchCurrentSession(undefined, "tile-runtime")
received branchCurrentSession()
```

Both now pass, along with all 292 tests in the affected hook/helper/store files. The cross-profile regressions also verify that asynchronous profile lookup cannot reroute `session.branch`, a profile switch during the pending RPC cannot mutate/reveal the newer profile's tiles or approval cache, foreground stores remain unchanged, and the child persists under the invocation layout with the target profile/workspace/runtime metadata. Additional exact-seam regressions cover explicit detached cwd, offscreen route-resume ownership, primary generation invalidation, reconnect coalescing, domain-error no-replay, activation/prewarm pruning, and deferred pruning after the final lease release.

Disposable mutation probes demonstrated that both original findings are test-sensitive:

- restoring approval writes through the mutable active profile failed both named ownership regressions (`expected work off, received smart`);
- bypassing the leased requester with `sourceGateway.request.bind(sourceGateway)` failed the source-requester regression because the production lease was never invoked.

Refreshed candidate identity:

- commit: `057a817d6379aaad9a92051dad989ae34ecb9121`
- tree: `7072b73f912f0e2a71fdcf1450ad82e87f12be52`
- parent: `2d5dd972325b83f34a2e24e298a8afd4e7ea1f4f`
- frozen base: `936dd7346fd7fd8107af1ce7fc019c07c001c1bd`

---

### 2026-08-21 current-main refresh

This PR remains necessary: current `main` still drops the targeted runtime for the Desktop native `/branch` path. The series was rebased onto exact upstream `main` `fc9cbc872d8050c22f1192b16bc5ff4aed471e10`; the refreshed candidate is `ec001240f0bb18bf84fae2f193061f4be8b07fce`. The current-main port keeps profile-aware routing and separates bounded activation ownership from command/request leases, with generation plus `routeEpoch` revalidation and orphan-expiry-safe pruning.

The final follow-ups also close three ownership races found during exact-SHA review: a non-default logical profile on a shared physical primary gateway can now acquire and coalesce leases by the physical gateway generation; closing a stale in-flight `JsonRpcGatewayClient.connect()` settles that attempt immediately so its timeout cannot poison a newer socket opened on the reused client; and releasing a command/request lease can no longer consume a deferred prune while a bounded activation lease still owns the secondary transport.

Verified locally on the exact candidate: focused gateway/JSON-RPC/activation-prune regressions (53 tests), full Electron (1574 tests plus 3 platform skips), full Desktop UI under CI-like `en_US.UTF-8` (558 files, 5373 tests), Desktop typecheck, changed-file ESLint (0 errors), changed-file Prettier, Desktop production build stamped `ec001240f0bb`, Web typecheck plus 275 tests, Web lint (0 errors, 26 baseline warnings), Web production build, attribution audit, and `git diff --check`. A host-`pl_PL.UTF-8` run on the parent exposed unrelated locale-sensitive current-main formatting assertions; the CI-like locale run is fully green.
