### PR TITLE
fix(computer-use): allow exact Cua targets for input actions

### DIFF
--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -213,6 +213,68 @@ def test_dispatcher_threads_delivery_mode_to_backend():
         assert clicks and clicks[-1].get("delivery_mode") == "foreground"
 
 
+def test_dispatcher_threads_exact_pid_window_to_input_actions():
+    """Callers that already discovered a native window can target it directly.
+
+    This is the same escape hatch capture() exposes for Linux/X11 windows whose
+    app names are generic or whose discovery context came from list_windows in a
+    previous tool call. Input actions must not force an extra capture/focus_app
+    just to populate backend sticky state.
+    """
+    from tools.computer_use import tool as cu
+
+    with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False):
+        cu.reset_backend_for_tests()
+        be = cu._get_backend()
+
+        cu.handle_computer_use({
+            "action": "click",
+            "coordinate": [10, 20],
+            "pid": 4242,
+            "window_id": 7,
+        })
+        cu.handle_computer_use({
+            "action": "type",
+            "text": "hello",
+            "pid": 4242,
+            "window_id": 7,
+        })
+
+        clicks = [kw for (name, kw) in be.calls if name == "click"]  # type: ignore[attr-defined]
+        types = [kw for (name, kw) in be.calls if name == "type"]  # type: ignore[attr-defined]
+        assert clicks and clicks[-1].get("pid") == 4242
+        assert clicks[-1].get("window_id") == 7
+        assert types and types[-1].get("pid") == 4242
+        assert types[-1].get("window_id") == 7
+
+
+def test_cua_backend_exact_target_allows_input_without_prior_capture():
+    out = {"isError": False, "data": {}, "structuredContent": {"effect": "confirmed"}}
+    sess = _FakeSession(out)
+    be = _make_backend(sess)
+    be._active_pid = None  # type: ignore[attr-defined]
+    be._active_window_id = None  # type: ignore[attr-defined]
+
+    res = be.click(x=10, y=20, pid=111, window_id=222)
+
+    assert res.ok is True
+    assert sess.last_args["pid"] == 111
+    assert sess.last_args["window_id"] == 222
+    assert sess.last_args["x"] == 10
+    assert sess.last_args["y"] == 20
+    assert be._last_target == {"pid": 111, "window_id": 222}  # type: ignore[attr-defined]
+
+
+def test_cua_backend_rejects_partial_exact_target():
+    out = {"isError": False, "data": {}, "structuredContent": {"effect": "confirmed"}}
+    be = _make_backend(_FakeSession(out))
+
+    res = be.type_text("hello", pid=111)
+
+    assert res.ok is False
+    assert "requires both pid and window_id" in res.message
+
+
 # ---------------------------------------------------------------------------
 # Phase C — foreground approval scoping (action + delivery_mode + session)
 # ---------------------------------------------------------------------------

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -147,6 +147,8 @@ class ComputerUseBackend(ABC):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,   # background (default) | foreground
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult: ...
 
     @abstractmethod
@@ -161,6 +163,8 @@ class ComputerUseBackend(ABC):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult: ...
 
     @abstractmethod
@@ -175,16 +179,20 @@ class ComputerUseBackend(ABC):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult: ...
 
     # ── Keyboard ────────────────────────────────────────────────────
     @abstractmethod
     def type_text(self, text: str, *, delivery_mode: Optional[str] = None,
-                  bring_to_front: bool = False) -> ActionResult: ...
+                  bring_to_front: bool = False, pid: Optional[int] = None,
+                  window_id: Optional[int] = None) -> ActionResult: ...
 
     @abstractmethod
     def key(self, keys: str, *, delivery_mode: Optional[str] = None,
-            bring_to_front: bool = False) -> ActionResult:
+            bring_to_front: bool = False, pid: Optional[int] = None,
+            window_id: Optional[int] = None) -> ActionResult:
         """Send a key combo, e.g. 'cmd+s', 'ctrl+alt+t', 'return'."""
 
     # ── Introspection ───────────────────────────────────────────────

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -2199,6 +2199,56 @@ class CuaDriverBackend(ComputerUseBackend):
             args["bring_to_front"] = True
         return None
 
+    def _resolve_input_target(
+        self,
+        action: str,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
+    ) -> tuple[Optional[int], Optional[int], Optional[ActionResult]]:
+        """Return the input target, allowing an exact pid/window override.
+
+        capture() and focus_app() populate sticky target state. When the caller
+        already knows the native target from list_windows or an earlier capture,
+        accepting an explicit pair avoids a redundant capture/focus_app round-trip
+        and keeps coordinate/keyboard actions pointed at the intended X11 window.
+        """
+        if pid is None and window_id is None:
+            target_pid = self._active_pid
+            target_window_id = self._active_window_id
+            if target_pid is None or target_window_id is None:
+                return None, None, ActionResult(
+                    ok=False,
+                    action=action,
+                    message=(
+                        "No active window — call capture() first or pass both "
+                        "pid and window_id."
+                    ),
+                )
+            return target_pid, target_window_id, None
+
+        if pid is None or window_id is None:
+            return None, None, ActionResult(
+                ok=False,
+                action=action,
+                message="Exact input targeting requires both pid and window_id.",
+            )
+
+        target_pid = _positive_int(pid)
+        target_window_id = _positive_int(window_id)
+        if target_pid is None or target_window_id is None:
+            return None, None, ActionResult(
+                ok=False,
+                action=action,
+                message="Exact input targeting requires positive integer pid and window_id.",
+            )
+
+        if self._active_pid != target_pid or self._active_window_id != target_window_id:
+            self._snapshot_tokens = {}
+        self._active_pid = target_pid
+        self._active_window_id = target_window_id
+        self._last_target = {"pid": target_pid, "window_id": target_window_id}
+        return target_pid, target_window_id, None
+
     def click(
         self,
         *,
@@ -2210,11 +2260,14 @@ class CuaDriverBackend(ComputerUseBackend):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult:
-        pid = self._active_pid
-        if pid is None:
-            return ActionResult(ok=False, action="click",
-                                message="No active window — call capture() first.")
+        target_pid, target_window_id, target_error = self._resolve_input_target(
+            "click", pid, window_id
+        )
+        if target_error is not None:
+            return target_error
 
         # Choose tool by click_count only — single-vs-double — and pass the
         # button through to `click`'s `button` enum (Surface 5 of
@@ -2230,20 +2283,14 @@ class CuaDriverBackend(ComputerUseBackend):
                                 message=f"unknown button {button!r} — expected left, right, middle.")
         tool = "double_click" if click_count == 2 else "click"
 
-        args: Dict[str, Any] = {"pid": pid, "button": button_norm}
+        args: Dict[str, Any] = {"pid": target_pid, "button": button_norm}
         if element is not None:
-            if self._active_window_id is None:
-                return ActionResult(ok=False, action=tool,
-                                    message="No active window_id for element_index click.")
             args["element_index"] = element
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         elif x is not None and y is not None:
-            if self._active_window_id is None:
-                return ActionResult(ok=False, action=tool,
-                                    message="No active window_id for coordinate click.")
             args["x"] = x
             args["y"] = y
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         else:
             return ActionResult(ok=False, action=tool,
                                 message="click requires element= or x/y.")
@@ -2266,26 +2313,23 @@ class CuaDriverBackend(ComputerUseBackend):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult:
-        pid = self._active_pid
-        if pid is None:
-            return ActionResult(ok=False, action="drag",
-                                message="No active window — call capture() first.")
-        args: Dict[str, Any] = {"pid": pid}
+        target_pid, target_window_id, target_error = self._resolve_input_target(
+            "drag", pid, window_id
+        )
+        if target_error is not None:
+            return target_error
+        args: Dict[str, Any] = {"pid": target_pid}
         if from_element is not None and to_element is not None:
-            if self._active_window_id is None:
-                return ActionResult(ok=False, action="drag",
-                                    message="No active window_id for element-based drag.")
             args["from_element"] = from_element
             args["to_element"] = to_element
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         elif from_xy is not None and to_xy is not None:
-            if self._active_window_id is None:
-                return ActionResult(ok=False, action="drag",
-                                    message="No active window_id for coordinate drag.")
             args["from_x"], args["from_y"] = int(from_xy[0]), int(from_xy[1])
             args["to_x"], args["to_y"] = int(to_xy[0]), int(to_xy[1])
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         else:
             return ActionResult(ok=False, action="drag",
                                 message="drag requires from_element/to_element or from_coordinate/to_coordinate.")
@@ -2305,23 +2349,26 @@ class CuaDriverBackend(ComputerUseBackend):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult:
-        pid = self._active_pid
-        if pid is None:
-            return ActionResult(ok=False, action="scroll",
-                                message="No active window — call capture() first.")
+        target_pid, target_window_id, target_error = self._resolve_input_target(
+            "scroll", pid, window_id
+        )
+        if target_error is not None:
+            return target_error
         args: Dict[str, Any] = {
-            "pid": pid,
+            "pid": target_pid,
             "direction": direction,
             "amount": max(1, min(50, amount)),
         }
-        if element is not None and self._active_window_id is not None:
+        if pid is not None or window_id is not None:
+            args["window_id"] = target_window_id
+        if element is not None:
             args["element_index"] = element
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         elif x is not None and y is not None:
-            if self._active_window_id is None:
-                return ActionResult(ok=False, action="scroll",
-                                    message="No active window_id for coordinate scroll.")
+            args["window_id"] = target_window_id
             # CUA Driver 0.7.1 Linux schema rejects x/y on scroll. Only
             # include them when the driver explicitly advertises support
             # for coordinate scrolling; otherwise omit and let the driver
@@ -2333,33 +2380,46 @@ class CuaDriverBackend(ComputerUseBackend):
             ):
                 args["x"] = x
                 args["y"] = y
-            args["window_id"] = self._active_window_id
         refusal = self._apply_delivery("scroll", args, delivery_mode, bring_to_front)
         if refusal is not None:
             return refusal
         return self._action("scroll", args)
 
     # ── Keyboard ───────────────────────────────────────────────────
-    def type_text(self, text: str, *, delivery_mode: Optional[str] = None,
-                  bring_to_front: bool = False) -> ActionResult:
-        pid = self._active_pid
-        window_id = self._active_window_id
-        if pid is None or window_id is None:
-            return ActionResult(ok=False, action="type_text",
-                                message="No active window — call capture() first.")
-        args: Dict[str, Any] = {"pid": pid, "window_id": window_id, "text": text}
+    def type_text(
+        self,
+        text: str,
+        *,
+        delivery_mode: Optional[str] = None,
+        bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
+    ) -> ActionResult:
+        target_pid, target_window_id, target_error = self._resolve_input_target(
+            "type_text", pid, window_id
+        )
+        if target_error is not None:
+            return target_error
+        args: Dict[str, Any] = {"pid": target_pid, "window_id": target_window_id, "text": text}
         refusal = self._apply_delivery("type_text", args, delivery_mode, bring_to_front)
         if refusal is not None:
             return refusal
         return self._action("type_text", args)
 
-    def key(self, keys: str, *, delivery_mode: Optional[str] = None,
-            bring_to_front: bool = False) -> ActionResult:
-        pid = self._active_pid
-        window_id = self._active_window_id
-        if pid is None or window_id is None:
-            return ActionResult(ok=False, action="key",
-                                message="No active window — call capture() first.")
+    def key(
+        self,
+        keys: str,
+        *,
+        delivery_mode: Optional[str] = None,
+        bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
+    ) -> ActionResult:
+        target_pid, target_window_id, target_error = self._resolve_input_target(
+            "key", pid, window_id
+        )
+        if target_error is not None:
+            return target_error
 
         key_name, modifiers = _parse_key_combo(keys)
         if not key_name:
@@ -2368,14 +2428,14 @@ class CuaDriverBackend(ComputerUseBackend):
 
         if modifiers:
             # hotkey requires at least one modifier + one key.
-            args: Dict[str, Any] = {"pid": pid, "window_id": window_id,
+            args: Dict[str, Any] = {"pid": target_pid, "window_id": target_window_id,
                                     "keys": modifiers + [key_name]}
             refusal = self._apply_delivery("hotkey", args, delivery_mode, bring_to_front)
             if refusal is not None:
                 return refusal
             return self._action("hotkey", args)
         else:
-            args = {"pid": pid, "window_id": window_id, "key": key_name}
+            args = {"pid": target_pid, "window_id": target_window_id, "key": key_name}
             refusal = self._apply_delivery("press_key", args, delivery_mode, bring_to_front)
             if refusal is not None:
                 return refusal

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -85,16 +85,21 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
             "pid": {
                 "type": "integer",
                 "description": (
-                    "Optional exact process target for action='capture'. Pair "
-                    "with window_id when discovery cannot resolve an X11 app."
+                    "Optional exact process target. For action='capture', pair "
+                    "with window_id when discovery cannot resolve an X11 app. "
+                    "For input actions, pass both pid and window_id to route "
+                    "directly to a known native window without an extra capture "
+                    "or focus_app call."
                 ),
             },
             "window_id": {
                 "type": "integer",
                 "description": (
-                    "Optional exact native window target for action='capture'. "
-                    "Pair with pid when an external cua-driver list_windows "
-                    "lookup has already identified the window."
+                    "Optional exact native window target. For action='capture', "
+                    "pair with pid when an external cua-driver list_windows "
+                    "lookup has already identified the window. For input "
+                    "actions, pass both pid and window_id to bypass sticky "
+                    "target state from the last capture."
                 ),
             },
             "max_elements": {

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -446,6 +446,11 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
     # model can escalate background → foreground per cua-driver's ladder.
     delivery_mode = args.get("delivery_mode")
     bring_to_front = bool(args.get("bring_to_front"))
+    # Optional exact native target discovered via list_windows or another
+    # capture. This lets callers act on a known X11/window target without an
+    # extra focus_app/capture round-trip solely to hydrate backend sticky state.
+    target_pid = args.get("pid")
+    target_window_id = args.get("window_id")
 
     if action in {"click", "double_click", "right_click", "middle_click"}:
         button = args.get("button")
@@ -466,6 +471,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             x=x, y=y, button=button or "left", click_count=click_count,
             modifiers=args.get("modifiers"),
             delivery_mode=delivery_mode, bring_to_front=bring_to_front,
+            pid=target_pid, window_id=target_window_id,
         )
         return _maybe_follow_capture(backend, res, capture_after)
 
@@ -484,6 +490,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             button=args.get("button", "left"),
             modifiers=args.get("modifiers"),
             delivery_mode=delivery_mode, bring_to_front=bring_to_front,
+            pid=target_pid, window_id=target_window_id,
         )
         return _maybe_follow_capture(backend, res, capture_after)
 
@@ -497,17 +504,20 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             y=coord[1] if coord and coord[1] is not None else None,
             modifiers=args.get("modifiers"),
             delivery_mode=delivery_mode, bring_to_front=bring_to_front,
+            pid=target_pid, window_id=target_window_id,
         )
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "type":
         res = backend.type_text(args.get("text", ""),
-                                delivery_mode=delivery_mode, bring_to_front=bring_to_front)
+                                delivery_mode=delivery_mode, bring_to_front=bring_to_front,
+                                pid=target_pid, window_id=target_window_id)
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "key":
         res = backend.key(args.get("keys", ""),
-                          delivery_mode=delivery_mode, bring_to_front=bring_to_front)
+                          delivery_mode=delivery_mode, bring_to_front=bring_to_front,
+                          pid=target_pid, window_id=target_window_id)
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "set_value":


### PR DESCRIPTION
## Summary
- Allow `computer_use` input actions to accept exact `pid` + `window_id` targets, matching the existing exact-target escape hatch on `capture()`.
- Thread the target pair through the generic tool dispatcher and Cua backend for click/drag/scroll/type/key.
- Keep the existing sticky target flow intact: callers can still `capture()` or `focus_app()` first; exact targets are optional and require both positive integers.

## Why
On Linux/X11, `list_windows` can identify the right native window even when app-name matching is generic or ambiguous. Before this change, callers had to perform an extra capture/focus step just to hydrate backend sticky state before input actions. Passing an exact target directly makes the already-known window identity usable for coordinate and keyboard actions, and keeps `capture_after` pinned to that same native target.

## Test plan
- `PYTHONPATH=$PWD uv run --extra dev python -m pytest tests/tools/test_computer_use_delivery_ladder.py::test_dispatcher_threads_exact_pid_window_to_input_actions tests/tools/test_computer_use_delivery_ladder.py::test_cua_backend_exact_target_allows_input_without_prior_capture tests/tools/test_computer_use_delivery_ladder.py::test_cua_backend_rejects_partial_exact_target -q`
- `PYTHONPATH=$PWD uv run --extra dev python -m pytest tests/tools/test_computer_use_delivery_ladder.py tests/tools/test_computer_use_cua_backend_linux.py tests/tools/test_computer_use.py -q`
- `uv run --extra dev ruff check tools/computer_use/backend.py tools/computer_use/cua_backend.py tools/computer_use/tool.py tools/computer_use/schema.py tests/tools/test_computer_use_delivery_ladder.py`

Note: I used `PYTHONPATH=$PWD` for pytest in my local Plana runtime because its Nix wrapper prepends deployed computer-use patch paths ahead of the checkout. That is local-environment isolation, not required in normal CI.