### PR TITLE
fix(kanban): alert on repeated dead pid failures

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -186,6 +186,91 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
         _log.debug("kanban lifecycle hook %s failed: %s", event, exc)
 
 
+def _fire_failure_alert(task_id: str, **fields: Any) -> None:
+    """Fire an observable fleet-level kanban failure alert hook.
+
+    Unlike ordinary kanban lifecycle hooks, this path is intentionally strict:
+    if the relay/plugin raises, the caller sees the failure. That prevents a
+    broken alert channel from hiding worker-stall storms.
+    """
+    from hermes_cli.plugins import invoke_hook_strict
+    from hermes_cli.profiles import get_active_profile_name
+
+    try:
+        profile_name = get_active_profile_name()
+    except Exception:
+        profile_name = "default"
+    invoke_hook_strict(
+        "kanban_failure_alert",
+        task_id=task_id,
+        profile_name=profile_name,
+        **fields,
+    )
+
+
+def _is_dead_pid_fingerprint(fingerprint: str) -> bool:
+    """Return True for worker-death fingerprints normalized by _error_fingerprint."""
+    fp = (fingerprint or "").lower()
+    return (
+        "pid n not alive" in fp
+        or "pid n exited with code" in fp
+        or "pid n killed by signal" in fp
+    )
+
+
+def _maybe_fire_deadpid_fleet_alert(
+    conn: sqlite3.Connection,
+    task_id: str,
+    fingerprint: str,
+    error: str,
+    *,
+    protocol_violation: bool,
+) -> None:
+    """Emit kanban_failure_alert when a dead-PID task reaches cf>=3."""
+    if protocol_violation or not _is_dead_pid_fingerprint(fingerprint):
+        return
+    row = conn.execute(
+        "SELECT assignee, consecutive_failures, current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return
+    failures = int(row["consecutive_failures"] or 0)
+    if failures < 3:
+        return
+
+    payload = {
+        "board": get_current_board(),
+        "assignee": row["assignee"],
+        "run_id": row["current_run_id"],
+        "consecutive_failures": failures,
+        "fingerprint": fingerprint,
+        "error": error[:500],
+    }
+    try:
+        _fire_failure_alert(task_id, **payload)
+    except Exception as exc:
+        # The alert hook is deliberately strict. Persist a dead-letter event so
+        # the failure is inspectable from the board, then re-raise so the
+        # dispatcher/gateway logs and supervisor see the relay breakage.
+        try:
+            with write_txn(conn):
+                _append_event(
+                    conn,
+                    task_id,
+                    "kanban_failure_alert_failed",
+                    {**payload, "hook_error": str(exc)[:500]},
+                    run_id=row["current_run_id"],
+                )
+        except Exception:
+            _log.warning(
+                "failed to persist kanban_failure_alert dead-letter for %s",
+                task_id,
+                exc_info=True,
+            )
+        raise
+
+
 # A running task's claim is valid for 15 minutes by default; after that the
 # next dispatcher tick reclaims it. Workers that outlive this window should
 # call ``heartbeat_claim(task_id)`` periodically. In practice most kanban
@@ -7628,6 +7713,13 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={"pid": pid, "claimer": claimer},
+            )
+            _maybe_fire_deadpid_fleet_alert(
+                conn,
+                tid,
+                fp,
+                error_text,
+                protocol_violation=protocol_violation,
             )
             if tripped:
                 auto_blocked.append(tid)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -209,9 +209,14 @@ VALID_HOOKS: Set[str] = {
     #   run_id: int | None, profile_name: str.
     # kanban_task_completed adds: summary: str | None.
     # kanban_task_blocked adds:   reason: str | None.
+    # kanban_failure_alert adds:  consecutive_failures: int,
+    #   fingerprint: str, error: str. It is a fleet-level alert surface for
+    #   repeated worker failures and is fired through invoke_hook_strict so
+    #   relay/plugin failures are observable instead of silently swallowed.
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    "kanban_failure_alert",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
@@ -1945,6 +1950,33 @@ class PluginManager:
                 )
         return results
 
+    def invoke_hook_strict(self, hook_name: str, **kwargs: Any) -> List[Any]:
+        """Call callbacks for *hook_name*, surfacing callback failures.
+
+        Most Hermes hooks are observers and intentionally isolate callback
+        failures. Operational fleet-alert hooks are different: swallowing a
+        failing relay would hide the incident the hook exists to expose. Use
+        this narrow strict path only when the caller wants plugin failure to be
+        logged and re-raised.
+        """
+        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        callbacks = self._hooks.get(hook_name, [])
+        results: List[Any] = []
+        for cb in callbacks:
+            try:
+                ret = cb(**kwargs)
+                if ret is not None:
+                    results.append(ret)
+            except Exception:
+                logger.warning(
+                    "Strict hook '%s' callback %s raised",
+                    hook_name,
+                    getattr(cb, "__name__", repr(cb)),
+                    exc_info=True,
+                )
+                raise
+        return results
+
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
@@ -2071,6 +2103,11 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+def invoke_hook_strict(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Invoke a lifecycle hook and re-raise the first callback failure."""
+    return get_plugin_manager().invoke_hook_strict(hook_name, **kwargs)
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/plugins/deadpid-fleet-alert/__init__.py
+++ b/plugins/deadpid-fleet-alert/__init__.py
@@ -1,0 +1,110 @@
+"""Dead-PID fleet alert relay plugin.
+
+The kanban dispatcher fires ``kanban_failure_alert`` when a worker-death
+fingerprint reaches ``consecutive_failures >= 3``. This plugin turns that strict
+hook into one compact fleet notification and deduplicates by fingerprint so a
+storm of cards produces one message per window, not one per task.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from typing import Any, Dict
+
+from hermes_cli.config import cfg_get, load_config
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TARGET = "discord:#fleet-reports"
+_DEFAULT_DEDUP_WINDOW_SECONDS = 30 * 60
+_seen_by_fingerprint: Dict[str, float] = {}
+
+
+def _settings() -> tuple[str, int]:
+    try:
+        cfg = load_config()
+    except Exception:
+        cfg = {}
+    target = cfg_get(
+        cfg,
+        "kanban",
+        "failure_alert",
+        "target",
+        default=_DEFAULT_TARGET,
+    )
+    window = cfg_get(
+        cfg,
+        "kanban",
+        "failure_alert",
+        "dedup_window_seconds",
+        default=_DEFAULT_DEDUP_WINDOW_SECONDS,
+    )
+    try:
+        dedup_window = max(1, int(window))
+    except (TypeError, ValueError):
+        dedup_window = _DEFAULT_DEDUP_WINDOW_SECONDS
+    if not isinstance(target, str) or not target.strip():
+        target = _DEFAULT_TARGET
+    return target.strip(), dedup_window
+
+
+def _prune(now: float, window: int) -> None:
+    stale = [fp for fp, ts in _seen_by_fingerprint.items() if now - ts >= window]
+    for fp in stale:
+        _seen_by_fingerprint.pop(fp, None)
+
+
+def _format_message(
+    *,
+    task_id: str,
+    board: str | None,
+    assignee: str | None,
+    consecutive_failures: int,
+    fingerprint: str,
+    error: str,
+    run_id: int | None = None,
+    **_: Any,
+) -> str:
+    board_part = board or "default"
+    assignee_part = assignee or "unassigned"
+    run_part = f" run={run_id}" if run_id is not None else ""
+    return (
+        "KANBAN FAILURE ALERT: dead-PID worker failures reached "
+        f"cf={consecutive_failures} on {board_part}/{task_id}{run_part} "
+        f"assignee={assignee_part} fp={fingerprint!r} error={error[:240]!r}"
+    )
+
+
+def _on_kanban_failure_alert(**kwargs: Any) -> Dict[str, Any] | None:
+    fingerprint = str(kwargs.get("fingerprint") or "").strip()
+    if not fingerprint:
+        return None
+    target, window = _settings()
+    now = time.time()
+    _prune(now, window)
+    if fingerprint in _seen_by_fingerprint:
+        logger.info("deadpid-fleet-alert: deduped fingerprint %s", fingerprint)
+        return {"deduped": True, "fingerprint": fingerprint}
+    _seen_by_fingerprint[fingerprint] = now
+
+    message = _format_message(**kwargs)
+    proc = subprocess.run(
+        ["hermes", "send", "--to", target, "--quiet", message],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        _seen_by_fingerprint.pop(fingerprint, None)
+        raise RuntimeError(
+            "deadpid-fleet-alert delivery failed "
+            f"target={target!r} rc={proc.returncode} stderr={proc.stderr.strip()!r}"
+        )
+    return {"sent": True, "target": target, "fingerprint": fingerprint}
+
+
+def register(ctx) -> None:
+    ctx.register_hook("kanban_failure_alert", _on_kanban_failure_alert)

--- a/plugins/deadpid-fleet-alert/plugin.yaml
+++ b/plugins/deadpid-fleet-alert/plugin.yaml
@@ -1,0 +1,7 @@
+name: deadpid-fleet-alert
+version: "0.1.0"
+description: "Relay deduplicated kanban dead-PID consecutive-failure alerts to a fleet messaging target."
+author: "Hermes Agent"
+kind: backend
+hooks:
+  - kanban_failure_alert

--- a/tests/hermes_cli/test_deadpid_fleet_alert.py
+++ b/tests/hermes_cli/test_deadpid_fleet_alert.py
@@ -1,0 +1,171 @@
+"""Tests for dead-PID kanban fleet failure alerts."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    with kb.connect() as c:
+        yield c
+
+
+@pytest.fixture
+def captured_failure_alerts():
+    mgr = get_plugin_manager()
+    events: list[dict] = []
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    mgr._hooks["kanban_failure_alert"] = [lambda **kw: events.append(kw)]
+    try:
+        yield events
+    finally:
+        mgr._hooks = saved
+
+
+def _crash_task(conn, *, consecutive_failures: int = 2, max_retries: int | None = None) -> str:
+    host = kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(conn, title="dead pid", assignee="worker", max_retries=max_retries)
+    kb.claim_task(conn, tid, claimer=f"{host}:deadpid-test")
+    dead = subprocess.Popen(["true"])
+    dead.wait()
+    kb._set_worker_pid(conn, tid, dead.pid)
+    conn.execute(
+        "UPDATE tasks SET started_at = started_at - 9999, consecutive_failures = ? WHERE id = ?",
+        (consecutive_failures, tid),
+    )
+    conn.execute(
+        "UPDATE task_runs SET started_at = started_at - 9999 WHERE task_id = ?",
+        (tid,),
+    )
+    conn.commit()
+    kb._record_worker_exit(dead.pid, 1 << 8)  # nonzero exit -> "pid N exited with code 1"
+    return tid
+
+
+def test_kanban_failure_alert_is_valid_hook():
+    assert "kanban_failure_alert" in VALID_HOOKS
+
+
+def test_dead_pid_cf3_fires_exactly_one_failure_alert(conn, captured_failure_alerts):
+    tid = _crash_task(conn, consecutive_failures=2, max_retries=10)
+
+    crashed = kb.detect_crashed_workers(conn)
+
+    assert tid in crashed
+    assert len(captured_failure_alerts) == 1
+    event = captured_failure_alerts[0]
+    assert event["task_id"] == tid
+    assert event["assignee"] == "worker"
+    assert event["board"] == "default"
+    assert event["consecutive_failures"] == 3
+    assert event["fingerprint"] == "pid n exited with code 1"
+    # Additive only: max_retries keeps the breaker from blocking at cf=3.
+    row = conn.execute("SELECT status, consecutive_failures FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["status"] == "ready"
+    assert row["consecutive_failures"] == 3
+
+
+def test_no_failure_alert_below_cf3(conn, captured_failure_alerts):
+    tid = _crash_task(conn, consecutive_failures=1, max_retries=10)
+
+    crashed = kb.detect_crashed_workers(conn)
+
+    assert tid in crashed
+    assert captured_failure_alerts == []
+
+
+def test_failure_alert_plugin_error_is_not_swallowed_and_dead_letters(conn):
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+
+    def boom(**_kw):
+        raise RuntimeError("relay down")
+
+    mgr._hooks["kanban_failure_alert"] = [boom]
+    try:
+        tid = _crash_task(conn, consecutive_failures=2, max_retries=10)
+        with pytest.raises(RuntimeError, match="relay down"):
+            kb.detect_crashed_workers(conn)
+    finally:
+        mgr._hooks = saved
+
+    event = conn.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id = ? AND kind = 'kanban_failure_alert_failed'",
+        (tid,),
+    ).fetchone()
+    assert event is not None
+    assert event["kind"] == "kanban_failure_alert_failed"
+    assert "relay down" in event["payload"]
+
+
+def _load_deadpid_plugin():
+    plugin_path = (
+        Path(__file__).resolve().parents[2]
+        / "plugins"
+        / "deadpid-fleet-alert"
+        / "__init__.py"
+    )
+    spec = importlib.util.spec_from_file_location("deadpid_fleet_alert_test", plugin_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_deadpid_plugin_dedups_by_fingerprint(monkeypatch):
+    plugin = _load_deadpid_plugin()
+    plugin._seen_by_fingerprint.clear()
+    sent: list[list[str]] = []
+
+    def fake_run(cmd, **_kwargs):
+        sent.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(plugin.subprocess, "run", fake_run)
+    monkeypatch.setattr(plugin, "_settings", lambda: ("discord:#fleet-reports", 30))
+    now = {"t": 1000.0}
+    monkeypatch.setattr(plugin.time, "time", lambda: now["t"])
+    payload = {
+        "task_id": "t_deadbeef",
+        "board": "jarvis-os",
+        "assignee": "devops",
+        "run_id": 42,
+        "consecutive_failures": 3,
+        "fingerprint": "pid n not alive",
+        "error": "pid 123 not alive",
+    }
+
+    first = plugin._on_kanban_failure_alert(**payload)
+    second = plugin._on_kanban_failure_alert(**payload)
+    now["t"] += 31
+    third = plugin._on_kanban_failure_alert(**payload)
+
+    assert first == {"sent": True, "target": "discord:#fleet-reports", "fingerprint": "pid n not alive"}
+    assert second == {"deduped": True, "fingerprint": "pid n not alive"}
+    assert third == {"sent": True, "target": "discord:#fleet-reports", "fingerprint": "pid n not alive"}
+    assert len(sent) == 2
+    assert sent[0][:5] == ["hermes", "send", "--to", "discord:#fleet-reports", "--quiet"]


### PR DESCRIPTION
Implements jarvis-os/t_9f603089 acceptance #3: emit a strict kanban_failure_alert when dead-PID worker failures reach consecutive_failures >= 3, add a bundled deduplicating deadpid-fleet-alert relay plugin, and cover the path with unit tests.\n\nVerification:\n- python -m pytest tests/hermes_cli/test_deadpid_fleet_alert.py\n- python -m pytest tests/hermes_cli/test_deadpid_fleet_alert.py tests/hermes_cli/test_kanban_lifecycle_hooks.py tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py\n- python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_deadpid_fleet_alert.py\n- plugin discovery proof: deadpid-fleet-alert enabled and has_hook('kanban_failure_alert') true\n\nNo gateway restart or live runtime mutation performed.