### PR TITLE
fix(agent): retry 401 on chat_completions api-key providers before fallback (#73237)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3845,6 +3845,34 @@ def run_conversation(
                     print(f"{agent.log_prefix}     • Legacy cleanup: hermes config set ANTHROPIC_TOKEN \"\"")
                     print(f"{agent.log_prefix}     • Clear stale keys: hermes config set ANTHROPIC_API_KEY \"\"")
 
+                # ── Generic api-key 401 retry ──────────────────────────────
+                # A 401 on a chat_completions custom/api-key provider that
+                # wasn't covered by any of the provider-specific refresh
+                # handlers above.  Retry once (without credential refresh —
+                # there is no refresh helper for a static key) before
+                # falling through to the auth-failure failover path.
+                # Even a 401 on a genuinely invalid key gets a single
+                # retry, which is what every provider with a refresh helper
+                # already gets: the refresh itself is not the retry.  See
+                # issue #73237 (chat_completions 401 on api-key provider
+                # falls back with no retry).
+                if (
+                    agent.api_mode == "chat_completions"
+                    and status_code == 401
+                    and not _retry.generic_auth_retry_attempted
+                ):
+                    _retry.generic_auth_retry_attempted = True
+                    # No refresh helper — just retry once with the same
+                    # credential.  A transient 401 (load balancer, auth
+                    # endpoint blip) gets a second chance; a permanent 401
+                    # falls through to the auth_failover path on the
+                    # second try.
+                    agent._buffer_vprint(
+                        "🔐 API key provider returned 401 — retrying once "
+                        "before fallback..."
+                    )
+                    continue
+
                 # Thinking block signature recovery.
                 #
                 # Anthropic signs thinking blocks against the full turn

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -46,6 +46,11 @@ class TurnRetryState:
     nous_paid_entitlement_refresh_attempted: bool = False
     copilot_auth_retry_attempted: bool = False
     vertex_auth_retry_attempted: bool = False
+    # Generic api-key provider 401 — no refresh helper available, but
+    # still retry once before falling back.  Covers ``custom`` and any
+    # other chat_completions provider without its own credential-refresh
+    # path.  See issue #73237.
+    generic_auth_retry_attempted: bool = False
 
     # ── Format / payload recovery guards ─────────────────────────────────
     thinking_sig_retry_attempted: bool = False

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -20,6 +20,7 @@ EXPECTED_FIELDS = {
     "nous_paid_entitlement_refresh_attempted",
     "copilot_auth_retry_attempted",
     "vertex_auth_retry_attempted",
+    "generic_auth_retry_attempted",
     "thinking_sig_retry_attempted",
     "invalid_encrypted_content_retry_attempted",
     "image_shrink_retry_attempted",


### PR DESCRIPTION
## Problem

A 401 on a `chat_completions` custom/api-key provider triggers immediate fallback without any retry.  The log shows `API call failed (attempt 1/3)` followed by `Fallback activated` with no `attempt 2/3` line in between — the retry counter never advances.

Every existing 401-retry path in the conversation loop is gated on a provider name paired with a provider-specific credential-refresh call (openai-codex, xai-oauth, vertex, nous, copilot, anthropic). A static api-key route (e.g. `custom` provider with `HERMES_API_KEY`) has no refresh helper, so it matches none of the handlers and the error is immediately classified as `is_client_error`, which calls `_try_activate_fallback()` on attempt 1/3.

## Fix

Add a generic 401 retry handler for `chat_completions` mode that fires when no provider-specific handler matched (`generic_auth_retry_attempted` guard).  Retries once (without credential refresh — there is no refresh helper for a static key) before falling through to the existing auth-failure failover path.

This gives a transient 401 (load balancer blip, auth endpoint hiccup) a second chance, while a permanent 401 on a genuinely invalid key still fails on the second attempt and falls back as before.

## Changes

- `agent/turn_retry_state.py`: Add `generic_auth_retry_attempted` one-shot guard
- `agent/conversation_loop.py`: Add handler for `api_mode == "chat_completions" \&\& status_code == 401` that was not covered by a provider-specific handler
- `tests/agent/test_turn_retry_state.py`: Update EXPECTED_FIELDS contract

Fixes #73237