### PR TITLE
fix(plugins/langfuse): skip key prefix validation for custom endpoints (#72484)

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -179,14 +179,22 @@ def _get_langfuse() -> Optional[Langfuse]:
     # to post them, by which point the warning is buried under whatever
     # else the process is logging.  Catch it here, surface it once, and
     # short-circuit via the same _INIT_FAILED path as the empty case.
-    placeholder_issues = [
-        msg
-        for msg in (
-            _validate_langfuse_key("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
-            _validate_langfuse_key("HERMES_LANGFUSE_SECRET_KEY", secret_key),
-        )
-        if msg
-    ]
+    # When a custom HERMES_LANGFUSE_BASE_URL is configured (not the
+    # default cloud.langfuse.com), skip prefix validation — the custom
+    # endpoint may issue credentials with a different key format.
+    # See issue #72484.
+    _base_url = _env("HERMES_LANGFUSE_BASE_URL") or _env("LANGFUSE_BASE_URL") or ""
+    _is_custom_endpoint = bool(_base_url) and "cloud.langfuse.com" not in _base_url
+    placeholder_issues = []
+    if not _is_custom_endpoint:
+        placeholder_issues = [
+            msg
+            for msg in (
+                _validate_langfuse_key("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
+                _validate_langfuse_key("HERMES_LANGFUSE_SECRET_KEY", secret_key),
+            )
+            if msg
+        ]
     if placeholder_issues:
         logger.warning(
             "Langfuse plugin: credentials look like placeholders, traces will "


### PR DESCRIPTION
## Problem

The Langfuse plugin rejects valid credentials for custom Langfuse-compatible endpoints because it checks for hard-coded `pk-lf-` / `sk-lf-` key prefixes.  These prefixes are a Langfuse Cloud convention, not a protocol requirement.

When `HERMES_LANGFUSE_BASE_URL` points to a custom endpoint, operator-issued credentials with a different format (e.g. a company-internal key format) are rejected with the warning: `credentials look like placeholders (expected 'pk-lf-' prefix)`.  The `_INIT_FAILED` cache also permanently disables the plugin until restart.

## Fix

When a custom `HERMES_LANGFUSE_BASE_URL` is configured (one that does not contain `cloud.langfuse.com`), skip the key prefix validation entirely.  Custom endpoints are trusted with their own credential format.

The prefix check still runs for the default `cloud.langfuse.com` endpoint, so the existing placeholder detection (#23823) remains active for Langfuse Cloud users.

## Changes

- `plugins/observability/langfuse/__init__.py`: Gate prefix validation behind `not _is_custom_endpoint`

Fixes #72484