### PR TITLE
fix(tui): 修复 Windows 上 MCP 发现线程中 signal.signal() 引发 ValueError 崩溃

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -185,17 +185,32 @@ def _log_signal(signum: int, frame) -> None:
 # ``hermes --tui``) imports cleanly there.  SIGBREAK (Windows' Ctrl+Break)
 # is installed when available as a weaker equivalent of SIGHUP.
 if hasattr(signal, "SIGPIPE"):
-    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    try:
+        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    except ValueError:
+        pass  # signal.signal() requires the main thread (Windows MCP discovery)
 if hasattr(signal, "SIGTERM"):
-    signal.signal(signal.SIGTERM, _log_signal)
+    try:
+        signal.signal(signal.SIGTERM, _log_signal)
+    except ValueError:
+        pass  # signal.signal() requires the main thread (Windows MCP discovery)
 if hasattr(signal, "SIGHUP"):
-    signal.signal(signal.SIGHUP, _log_signal)
+    try:
+        signal.signal(signal.SIGHUP, _log_signal)
+    except ValueError:
+        pass  # signal.signal() requires the main thread (Windows MCP discovery)
 elif hasattr(signal, "SIGBREAK"):
     # Windows-only: Ctrl+Break in a console window delivers SIGBREAK.
     # Route it through the same handler so kills are diagnosable.
-    signal.signal(signal.SIGBREAK, _log_signal)
+    try:
+        signal.signal(signal.SIGBREAK, _log_signal)
+    except ValueError:
+        pass  # signal.signal() requires the main thread (Windows MCP discovery)
 if hasattr(signal, "SIGINT"):
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    try:
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+    except ValueError:
+        pass  # signal.signal() requires the main thread (Windows MCP discovery)
 
 
 def _log_exit(reason: str) -> None:


### PR DESCRIPTION
## 背景

修复 #73157: Windows 上 TUI gateway 启动时，MCP 发现在后台线程中执行，signal.signal() 抛出 ValueError 导致崩溃。

## 根因分析

tui_gateway/entry.py 中的 signal.signal() 调用（SIGPIPE、SIGTERM、SIGHUP、SIGBREAK、SIGINT）已有 hasattr() 守卫来处理 Windows 上不存在的 POSIX 信号，但未处理从非主线程调用时引发的 ValueError — Python 只允许在主线程中设置信号处理器。

当 MCP 发现在后台线程中执行时，此问题会触发。

## 修复方式

将所有 5 个 signal.signal() 调用包裹在 try/except ValueError: pass 块中，与 hermes_cli/gateway.py 和 tools/environments/file_sync.py 中已有的模式保持一致。

- 不影响现有主线程场景的信号处理
- 当从非主线程调用时优雅跳过，不崩溃
- 注释清晰说明原因（Windows MCP discovery）

## 验证

- [x] 代码变更已在本地验证（pytest tests/tui_gateway/test_entry_sys_path.py tests/test_tui_entry_mcp_owner.py 全部通过，8/8）
- [x] 语法检查通过
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更

Closes #73157