### PR TITLE
fix(mcp): reap orphaned stdio children immediately on connect failure (#72887)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2522,7 +2522,9 @@ class MCPServerTask:
             # If any of the spawned PIDs are still alive, the SDK's
             # teardown failed (common when the task is cancelled mid-way
             # on Linux, where setsid() children escape the parent cgroup).
-            # Mark them as orphans so the next cleanup sweep can reap them.
+            # Mark them as orphans and reap them immediately so they cannot
+            # hold resource locks (e.g. PGLite single-writer) that block
+            # subsequent reconnect attempts (#72887).
             if new_pids:
                 from gateway.status import _pid_exists
                 _killpg = getattr(os, "killpg", None)
@@ -2552,6 +2554,20 @@ class MCPServerTask:
                             # Nothing left to reap — drop the pgid entry so
                             # PID-reuse can't surface stale pgroup state later.
                             _stdio_pgids.pop(pid, None)
+                # Reap orphans immediately instead of deferring to the next
+                # _run_stdio call.  An orphaned child that holds an exclusive
+                # resource lock (e.g. PGLite's single-writer lock) will cause
+                # every subsequent reconnect to fail with "resource busy",
+                # producing a permanent "connecting" loop (#72887).
+                try:
+                    await asyncio.to_thread(
+                        _kill_orphaned_mcp_children,
+                        server_name=self.name,
+                    )
+                except (asyncio.CancelledError, Exception):
+                    # Best-effort: the thread still runs to completion even
+                    # if the await is cancelled.
+                    pass
 
     # Content types a real MCP Streamable-HTTP endpoint may return on the
     # initial POST/GET. Anything else on a 2xx response means the URL is not


### PR DESCRIPTION
## Summary

Fixes #72887. When a stdio MCP connect attempt is cancelled or times out, the spawned child process was only marked as an orphan for deferred cleanup by `_kill_orphaned_mcp_children()` at the start of the **next** `_run_stdio` call.

If the orphaned child held an exclusive resource lock (e.g. PGLite single-writer lock), every subsequent reconnect attempt would fail immediately with "resource busy", producing a permanent "connecting" loop.

## Changes

In `_run_stdio()` `finally` block, call `_kill_orphaned_mcp_children(server_name=self.name)` immediately after marking orphans, so the child is reaped before the reconnect backoff sleep begins. Uses `asyncio.to_thread` to avoid blocking the event loop. Wrapped in `try/except` for best-effort cleanup.

## Root Cause

The `finally` block added PIDs to `_orphan_stdio_pids` for deferred cleanup, but `_kill_orphaned_mcp_children` only ran at the start of the next `_run_stdio` call (line 2439). Between those two points, the orphaned child could hold exclusive resource locks, making all retries fail.

## Test Plan

- [x] `tests/tools/test_mcp_stdio_watchdog.py` 3 passed
- [x] `tests/tools/test_mcp_tool_issue_948.py` 7 passed
- [x] Syntax check via `ast.parse()`