### PR TITLE
fix: gate KANBAN_GUIDANCE on HERMES_KANBAN_TASK with three-way split, preserve orchestrator guidance

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1415,9 +1415,17 @@ def init_agent(
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
+    #
+    # Gate on HERMES_KANBAN_TASK specifically, not just kanban_show tool
+    # presence: profiles with "kanban" in their toolsets config enable the
+    # kanban tool surface for orchestrator mode, but non-dispatched cron
+    # agents should not receive the kanban lifecycle protocol (#68592).
+    import os
     from agent.prompt_builder import KANBAN_GUIDANCE
     agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+        KANBAN_GUIDANCE
+        if os.environ.get("HERMES_KANBAN_TASK") and "kanban_show" in agent.valid_tool_names
+        else ""
     )
 
     # Check tool requirements

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1409,24 +1409,26 @@ def init_agent(
     elif not agent.quiet_mode:
         print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
-    # Kanban worker/orchestrator lifecycle guidance is session-static:
-    # the dispatcher decides at spawn time whether this process is a kanban
-    # worker (kanban_show tool is present iff HERMES_KANBAN_TASK is set).
+    # Kanban WORKER lifecycle guidance is session-static: the dispatcher
+    # decides at spawn time whether this process is a kanban worker by
+    # setting HERMES_KANBAN_TASK. Tool presence alone is NOT the signal —
+    # orchestrator profiles (``kanban`` in the toolsets config) also carry
+    # kanban_show without any task id, and injecting the worker protocol
+    # there makes every cron run on such a profile call ``kanban_show()``
+    # first and record a "task_id is required" error (issue #68592).
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
-    #
-    # Gate on HERMES_KANBAN_TASK specifically, not just kanban_show tool
-    # presence: profiles with "kanban" in their toolsets config enable the
-    # kanban tool surface for orchestrator mode, but non-dispatched cron
-    # agents should not receive the kanban lifecycle protocol (#68592).
     import os
-    from agent.prompt_builder import KANBAN_GUIDANCE
-    agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE
-        if os.environ.get("HERMES_KANBAN_TASK") and "kanban_show" in agent.valid_tool_names
-        else ""
-    )
+    from agent.prompt_builder import KANBAN_GUIDANCE, KANBAN_ORCHESTRATOR_GUIDANCE
+    if "kanban_show" not in agent.valid_tool_names:
+        agent._kanban_worker_guidance = ""
+    elif os.environ.get("HERMES_KANBAN_TASK"):
+        agent._kanban_worker_guidance = KANBAN_GUIDANCE
+    else:
+        # Kanban toolset without a dispatched task: board-routing guidance
+        # only — no worker lifecycle, no mandatory kanban_show() first step.
+        agent._kanban_worker_guidance = KANBAN_ORCHESTRATOR_GUIDANCE
 
     # Check tool requirements
     if agent.tools and not agent.quiet_mode:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -201,6 +201,35 @@ SKILLS_GUIDANCE = (
     "4. **DEDUP** — After reloading a pruned skill, **ignore any remaining `[SKILL_PRUNED]` markers for that same skill** — they are historical artifacts from previous compactions and do not need further action."
 )
 
+# Board-side guidance for profiles that carry the kanban toolset WITHOUT a
+# dispatched task (orchestrator profiles, and cron/scheduled agents on such
+# profiles). Deliberately excludes the worker lifecycle: its mandatory
+# "call `kanban_show()` first" step fails with "task_id is required" when
+# no $HERMES_KANBAN_TASK exists (issue #68592). The routing rules below were
+# folded into the always-injected guidance when the standalone
+# kanban-orchestrator skill was removed, so they must survive the split.
+KANBAN_ORCHESTRATOR_GUIDANCE = (
+    "# Kanban board guidance\n"
+    "This profile carries the `kanban_*` tools for routing work on the "
+    "shared board at `~/.hermes/kanban.db`. You are NOT a dispatched "
+    "worker: no task of your own is assigned, `$HERMES_KANBAN_TASK` is "
+    "unset, and `kanban_show()` requires an explicit `task_id` argument.\n"
+    "- **Route, don't implement.** Use `kanban_create(title=..., "
+    "assignee=<right-profile>, parents=[...])` to fan work out to "
+    "specialist profiles, expressing dependencies via `parents=[...]`, "
+    "not prose.\n"
+    "- **Discover profiles first.** The dispatcher SILENTLY drops a card "
+    "with an unknown assignee (it sits in `ready` forever). Ground every "
+    "assignee in a real profile (`hermes profile list`, or ask the user).\n"
+    "- **Created cards.** Reference task ids only when captured from a "
+    "successful `kanban_create` return — never invent or paste ids.\n"
+    "- **Attachments.** Attach real downloadable artifacts with "
+    "`kanban_attach` / `kanban_attach_url` (25 MB cap) instead of pasting "
+    "links in comments.\n"
+    "- Do not shell out to `hermes kanban <verb>` for board operations. "
+    "Use the `kanban_*` tools — they work across all terminal backends.\n"
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -35,6 +35,7 @@ from agent.prompt_builder import (
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
+    KANBAN_ORCHESTRATOR_GUIDANCE,
     MEMORY_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
@@ -231,16 +232,25 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
-    # Kanban worker/orchestrator lifecycle — only present when the
-    # dispatcher spawned this process (kanban_show check_fn gates on
-    # HERMES_KANBAN_TASK env var). Normal chat sessions never see
-    # this block. Resolved once at __init__ (see _kanban_worker_guidance).
+    # Kanban WORKER lifecycle — only present when the dispatcher spawned
+    # this process (HERMES_KANBAN_TASK set). Tool presence alone is not
+    # enough: orchestrator profiles carry kanban_show without a task id,
+    # and the worker protocol's mandatory ``kanban_show()`` first step
+    # fails there with "task_id is required" (issue #68592). Normal chat
+    # sessions never see this block. Resolved once at __init__ (see
+    # _kanban_worker_guidance).
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
     elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
-        # Fallback for code paths that bypass agent_init (rare).
-        tool_guidance.append(KANBAN_GUIDANCE)
+        # Fallback for code paths that bypass agent_init (rare) — same
+        # three-way split as agent_init: worker protocol only for
+        # dispatcher-spawned processes, board-routing guidance otherwise.
+        tool_guidance.append(
+            KANBAN_GUIDANCE
+            if os.environ.get("HERMES_KANBAN_TASK")
+            else KANBAN_ORCHESTRATOR_GUIDANCE
+        )
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1741,6 +1741,51 @@ def test_kanban_guidance_not_in_normal_prompt(monkeypatch, tmp_path):
     assert "kanban_show()" not in prompt
 
 
+def test_kanban_guidance_not_injected_without_env_var_even_with_kanban_tools(monkeypatch, tmp_path):
+    """Regression for #68592: a profile with kanban tools in its toolsets config
+    enables the kanban tool surface (kanban_show is in valid_tool_names), but
+    without HERMES_KANBAN_TASK set the agent is NOT a dispatched kanban worker
+    and must not receive the kanban lifecycle guidance.
+
+    Before the fix, the guidance was injected based solely on kanban_show
+    presence in valid_tool_names, so orchestrator-mode profiles with kanban
+    tools got the worker protocol injected into their system prompt.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from tools.registry import invalidate_check_fn_cache
+    from model_tools import _clear_tool_defs_cache
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+    from run_agent import AIAgent
+    a = AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    # Simulate a profile that has kanban tools enabled (orchestrator mode)
+    # but is NOT a dispatched kanban worker (no HERMES_KANBAN_TASK).
+    a.valid_tool_names = getattr(a, "valid_tool_names", set()) | {"kanban_show"}
+    agent_kanban_guidance = getattr(a, "_kanban_worker_guidance", None)
+    # The gating in init_agent must have left _kanban_worker_guidance empty
+    # because HERMES_KANBAN_TASK is not set, even though kanban_show is present.
+    assert not agent_kanban_guidance, (
+        "KANBAN_GUIDANCE must not be set when HERMES_KANBAN_TASK is absent, "
+        "even if kanban_show is in valid_tool_names"
+    )
+    prompt = a._build_system_prompt()
+    assert "Kanban task execution protocol" not in prompt
+    assert "kanban_show()" not in prompt
+
+
 def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
     """A worker session (HERMES_KANBAN_TASK set) MUST have the full
     lifecycle guidance in its system prompt."""

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1750,10 +1750,14 @@ def test_kanban_guidance_not_injected_without_env_var_even_with_kanban_tools(mon
     Before the fix, the guidance was injected based solely on kanban_show
     presence in valid_tool_names, so orchestrator-mode profiles with kanban
     tools got the worker protocol injected into their system prompt.
+
+    Now the three-way split injects board-routing guidance (KANBAN_ORCHESTRATOR_GUIDANCE)
+    instead of the worker protocol for tool-only profiles.
     """
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     home = tmp_path / ".hermes"
     home.mkdir()
+    (home / "config.yaml").write_text("toolsets:\n  - kanban\n")
     monkeypatch.setenv("HERMES_HOME", str(home))
     from pathlib import Path as _P
     monkeypatch.setattr(_P, "home", lambda: tmp_path)
@@ -1771,19 +1775,68 @@ def test_kanban_guidance_not_injected_without_env_var_even_with_kanban_tools(mon
         skip_context_files=True,
         skip_memory=True,
     )
-    # Simulate a profile that has kanban tools enabled (orchestrator mode)
-    # but is NOT a dispatched kanban worker (no HERMES_KANBAN_TASK).
-    a.valid_tool_names = getattr(a, "valid_tool_names", set()) | {"kanban_show"}
-    agent_kanban_guidance = getattr(a, "_kanban_worker_guidance", None)
-    # The gating in init_agent must have left _kanban_worker_guidance empty
-    # because HERMES_KANBAN_TASK is not set, even though kanban_show is present.
-    assert not agent_kanban_guidance, (
-        "KANBAN_GUIDANCE must not be set when HERMES_KANBAN_TASK is absent, "
-        "even if kanban_show is in valid_tool_names"
-    )
     prompt = a._build_system_prompt()
+    # The tool surface IS present for orchestrator profiles...
+    assert "kanban_show" in a.valid_tool_names, (
+        "test setup: kanban toolset should expose kanban tools"
+    )
+    # ...but the worker lifecycle protocol must not be injected.
     assert "Kanban task execution protocol" not in prompt
-    assert "kanban_show()" not in prompt
+    assert "kanban_show()` first" not in prompt
+    # The board-routing guidance IS injected instead — the routing rules
+    # (profile discovery, parents deps, no phantom ids) were folded into
+    # the always-injected guidance when the standalone orchestrator skill
+    # was removed, and must survive the worker/orchestrator split.
+    assert "Kanban board guidance" in prompt
+    assert "unknown assignee" in prompt
+
+
+def test_kanban_guidance_fallback_three_way_split(monkeypatch, tmp_path):
+    """The system_prompt fallback (code paths that bypass agent_init leave
+    ``_kanban_worker_guidance`` unset -> None) mirrors the same three-way
+    split as agent_init: worker protocol iff HERMES_KANBAN_TASK, board
+    guidance for tool-only."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("toolsets:\n  - kanban\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from tools.registry import invalidate_check_fn_cache
+    from model_tools import _clear_tool_defs_cache
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+    from run_agent import AIAgent
+    from agent.system_prompt import invalidate_system_prompt
+    a = AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    # Simulate a code path that bypasses agent_init: delete the cached
+    # _kanban_worker_guidance so the fallback in system_prompt runs.
+    if hasattr(a, "_kanban_worker_guidance"):
+        del a._kanban_worker_guidance
+    invalidate_system_prompt()
+    prompt = a._build_system_prompt()
+    # Without HERMES_KANBAN_TASK, the fallback must inject board guidance,
+    # not the worker protocol.
+    assert "Kanban task execution protocol" not in prompt
+    assert "Kanban board guidance" in prompt
+    assert "unknown assignee" in prompt
+
+    # Now set HERMES_KANBAN_TASK and verify the fallback injects the
+    # worker protocol instead.
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fallback_test")
+    invalidate_system_prompt()
+    prompt2 = a._build_system_prompt()
+    assert "Kanban task execution protocol" in prompt2
+    assert "kanban_show()` first" in prompt2
 
 
 def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):


### PR DESCRIPTION
The kanban worker lifecycle protocol (KANBAN_GUIDANCE) was previously injected based solely on `kanban_show` tool presence. This caused two bugs:

1. **Orchestrator profiles** with `kanban` in their toolsets config got the worker protocol injected, making every session call `kanban_show()` first and fail with "task_id is required" (issue #68592).

2. **Board-routing rules** (profile discovery, parents deps, no phantom ids) were folded into KANBAN_GUIDANCE when the standalone orchestrator skill was removed, so a simple tool-presence gate silently dropped them for orchestrator profiles.

### The fix

Implements a **three-way split** at both injection sites:

- **`agent_init.py`**: If `kanban_show` is absent → empty guidance. If `HERMES_KANBAN_TASK` is set → full worker protocol (`KANBAN_GUIDANCE`). Otherwise → board-routing guidance (`KANBAN_ORCHESTRATOR_GUIDANCE`).

- **`system_prompt.py` fallback**: Mirrors the same three-way split for code paths that bypass `agent_init`.

- **`prompt_builder.py`**: New `KANBAN_ORCHESTRATOR_GUIDANCE` constant with board-routing rules but no worker lifecycle.

- **Tests**: Updated existing test to verify board guidance is injected instead of empty string. Added fallback three-way split test covering both the no-task and with-task paths.

Fixes #68592