### PR TITLE
fix(kanban): handle missing worker exit signals

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -57,6 +57,50 @@ def _resolve_auto_decompose_settings(
     return enabled, per_tick
 
 
+def _dispatcher_tick_log(slug: str, res: Any) -> "tuple[bool, str, tuple]":
+    """Build the per-board dispatcher telemetry for one tick result.
+
+    A board logs only when it produced a meaningful outcome this tick —
+    spawned workers or reconciled missing-exit-signal tasks. Idle boards
+    stay silent so a quiet gateway does not spam logs, and the decision is
+    made per board so one busy board cannot make a sibling idle board log a
+    spurious zero line.
+
+    Returns ``(should_log, message, args)``; when ``should_log`` is True the
+    caller emits ``logger.info(message, *args)``. Missing-exit-signal
+    reconciliations get a distinct message with a dedicated bucket so the
+    diagnostic is searchable and never conflated with generic crashes.
+    """
+    if res is None:
+        return False, "", ()
+    spawned = getattr(res, "spawned", None) or []
+    missing = getattr(res, "missing_exit_signal", []) or []
+    if not spawned and not missing:
+        return False, "", ()
+    counts = (
+        len(spawned),
+        getattr(res, "reclaimed", 0),
+        len(getattr(res, "crashed", []) or []),
+        len(getattr(res, "timed_out", []) or []),
+        getattr(res, "promoted", 0),
+        len(getattr(res, "auto_blocked", []) or []),
+    )
+    if missing:
+        return (
+            True,
+            "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
+            "crashed=%d timed_out=%d promoted=%d "
+            "auto_blocked=%d missing_exit_signal=%d",
+            (slug, *counts, len(missing)),
+        )
+    return (
+        True,
+        "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
+        "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+        (slug, *counts),
+    )
+
+
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
 
@@ -1439,39 +1483,13 @@ class GatewayKanbanWatchersMixin:
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
                 for slug, res in (results or []):
-                    missing_exit_signal_count = 0
-                    if res is not None and getattr(res, "spawned", None):
-                        any_spawned = True
-                    if res is not None and getattr(res, "missing_exit_signal", []):
-                        missing_exit_signal_count = len(res.missing_exit_signal)
-                        any_spawned = True
-                    if any_spawned and missing_exit_signal_count:
-                        logger.info(
-                            "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d "
-                            "auto_blocked=%d missing_exit_signal=%d",
-                            slug,
-                            len(res.spawned) if res is not None else 0,
-                            getattr(res, "reclaimed", 0) if res is not None else 0,
-                            len(getattr(res, "crashed", [])) if res is not None else 0,
-                            len(getattr(res, "timed_out", [])) if res is not None else 0,
-                            getattr(res, "promoted", 0) if res is not None else 0,
-                            len(getattr(res, "auto_blocked", [])) if res is not None else 0,
-                            missing_exit_signal_count,
-                        )
-                    elif any_spawned:
-                        logger.info(
-                            "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d "
-                            "auto_blocked=%d",
-                            slug,
-                            len(res.spawned),
-                            getattr(res, "reclaimed", 0),
-                            len(getattr(res, "crashed", [])),
-                            len(getattr(res, "timed_out", [])),
-                            getattr(res, "promoted", 0),
-                            len(getattr(res, "auto_blocked", [])),
-                        )
+                    should_log, message, args = _dispatcher_tick_log(slug, res)
+                    if not should_log:
+                        # Quiet by default — only log when something actually
+                        # happened, so an idle gateway stays silent.
+                        continue
+                    any_spawned = True
+                    logger.info(message, *args)
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)
                 if ready_pending and not any_spawned:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1435,23 +1435,42 @@ class GatewayKanbanWatchersMixin:
                 _ad_enabled, _ad_per_tick = _read_auto_decompose_settings()
                 if _ad_enabled:
                     await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
+
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
                 for slug, res in (results or []):
+                    missing_exit_signal_count = 0
                     if res is not None and getattr(res, "spawned", None):
                         any_spawned = True
-                        # Quiet by default — only log when something actually
-                        # happened, so an idle gateway stays silent.
+                    if res is not None and getattr(res, "missing_exit_signal", []):
+                        missing_exit_signal_count = len(res.missing_exit_signal)
+                        any_spawned = True
+                    if any_spawned and missing_exit_signal_count:
                         logger.info(
                             "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                            "crashed=%d timed_out=%d promoted=%d "
+                            "auto_blocked=%d missing_exit_signal=%d",
+                            slug,
+                            len(res.spawned) if res is not None else 0,
+                            getattr(res, "reclaimed", 0) if res is not None else 0,
+                            len(getattr(res, "crashed", [])) if res is not None else 0,
+                            len(getattr(res, "timed_out", [])) if res is not None else 0,
+                            getattr(res, "promoted", 0) if res is not None else 0,
+                            len(getattr(res, "auto_blocked", [])) if res is not None else 0,
+                            missing_exit_signal_count,
+                        )
+                    elif any_spawned:
+                        logger.info(
+                            "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
+                            "crashed=%d timed_out=%d promoted=%d "
+                            "auto_blocked=%d",
                             slug,
                             len(res.spawned),
-                            res.reclaimed,
-                            len(res.crashed) if hasattr(res.crashed, "__len__") else 0,
-                            len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
-                            res.promoted,
-                            len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
+                            getattr(res, "reclaimed", 0),
+                            len(getattr(res, "crashed", [])),
+                            len(getattr(res, "timed_out", [])),
+                            getattr(res, "promoted", 0),
+                            len(getattr(res, "auto_blocked", [])),
                         )
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -39,6 +39,7 @@ _STATUS_ICONS = {
     "running":  "●",
     "scheduled":"⏱",
     "blocked":  "⊘",
+    "completed_pending_review": "◉",
     "done":     "✓",
     "archived": "—",
 }
@@ -2489,6 +2490,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "timed_out": res.timed_out,
             "stale": res.stale,
             "auto_blocked": res.auto_blocked,
+            "missing_exit_signal": res.missing_exit_signal,
             "promoted": res.promoted,
             "spawned": [
                 {"task_id": tid, "assignee": who, "workspace": ws}
@@ -2516,6 +2518,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     print(f"Auto-blocked: {len(res.auto_blocked)}")
     if res.auto_blocked:
         print(f"  {', '.join(res.auto_blocked)}")
+    print(f"Missing exit signal: {len(res.missing_exit_signal)}")
+    if res.missing_exit_signal:
+        print(f"  {', '.join(res.missing_exit_signal)}")
     print(f"Promoted:     {res.promoted}")
     print(f"Spawned:      {len(res.spawned)}")
     for tid, who, ws in res.spawned:
@@ -2738,7 +2743,10 @@ def _cmd_stats(args: argparse.Namespace) -> int:
         print(json.dumps(stats, indent=2, ensure_ascii=False))
         return 0
     print("By status:")
-    for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
+    for k in (
+        "triage", "todo", "scheduled", "ready", "running", "blocked",
+        "completed_pending_review", "done",
+    ):
         print(f"  {k:8s}  {stats['by_status'].get(k, 0)}")
     if stats["by_assignee"]:
         print("\nBy assignee:")
@@ -2748,6 +2756,12 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     age = stats["oldest_ready_age_seconds"]
     if age is not None:
         print(f"\nOldest ready task age: {int(age)}s")
+    print(
+        "Missing-exit-signal 24h: "
+        f"{stats.get('missing_exit_signal_24h', 0)}/"
+        f"{stats.get('ended_runs_24h', 0)} "
+        f"({stats.get('missing_exit_signal_rate_24h', 0.0):.2%})"
+    )
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9387,7 +9387,7 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     missing_cutoff = now - 24 * 60 * 60
     missing_exit_signal_24h = int(conn.execute(
         "SELECT COUNT(*) AS n FROM task_events "
-        "WHERE kind = 'protocol_violation' AND created_at >= ?",
+        "WHERE kind = 'missing_exit_signal' AND created_at >= ?",
         (missing_cutoff,),
     ).fetchone()["n"])
     ended_runs_24h = int(conn.execute(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -99,7 +99,10 @@ _log = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
+VALID_STATUSES = {
+    "triage", "todo", "scheduled", "ready", "running", "blocked",
+    "completed_pending_review", "review", "done", "archived",
+}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
@@ -4770,7 +4773,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'completed_pending_review')
                 """,
                 (result, now, task_id),
             )
@@ -4787,7 +4790,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'completed_pending_review')
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),
@@ -5631,7 +5634,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'completed_pending_review')
                     """,
                     (kind, recurrences, task_id),
                 )
@@ -5646,7 +5649,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'completed_pending_review')
                        AND current_run_id = ?
                     """,
                     (kind, recurrences, task_id, int(expected_run_id)),
@@ -6680,6 +6683,9 @@ class DispatchResult:
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    missing_exit_signal: list[str] = field(default_factory=list)
+    """Task ids moved to ``completed_pending_review`` because repeated
+    rc=0 worker exits never called ``kanban_complete``/``kanban_block``."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
@@ -7322,6 +7328,48 @@ _PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
 _PROTOCOL_VIOLATION_SCAN_LIMIT = 50
 
 
+def _reconcile_missing_exit_signal(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    error: str,
+    protocol_violations: int,
+    protocol_violation_limit: int,
+    payload: Optional[dict] = None,
+) -> bool:
+    """Move a repeated clean-exit/no-terminal-signal task out of dispatch.
+
+    A worker that repeatedly exits rc=0 without calling ``kanban_complete`` or
+    ``kanban_block`` is not a normal task failure: the subprocess finished, but
+    the board is missing the required lifecycle signal.  Blocking it through
+    the generic crash breaker makes it look like transient product work and can
+    feed unblock/retry loops.  This terminal-but-unaccepted state is distinct,
+    visible in stats/dashboard columns, and still lets an operator/worker close
+    the card honestly via ``kanban_complete`` or ``kanban_block`` later.
+    """
+    event_payload = {
+        "error": error[:500],
+        "protocol_violations": int(protocol_violations),
+        "protocol_violation_limit": int(protocol_violation_limit),
+    }
+    if payload:
+        event_payload.update(payload)
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'completed_pending_review', "
+            "consecutive_failures = 0, last_failure_error = ? "
+            "WHERE id = ? AND status IN ('ready', 'running')",
+            (error[:500], task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(
+            conn, task_id, "missing_exit_signal", event_payload,
+            run_id=_current_run_id(conn, task_id),
+        )
+    return True
+
+
 def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     """Count the task's trailing run of clean-exit protocol violations.
 
@@ -7565,6 +7613,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # top precedence it has for every other failure kind. Systemic same-error
     # crashes still trip immediately.
     auto_blocked: list[str] = []
+    missing_exit_signal: list[str] = []
     if crash_details:
         # Fingerprint errors to detect systemic failures.
         _fp_counts: dict[str, int] = {}
@@ -7595,28 +7644,19 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     # failure budget, just as other failure kinds don't
                     # consume this one.
                     continue
-                # Streak reached the bound: trip the breaker. ``force_trip``
-                # skips the threshold resolution inside
-                # ``_record_task_failure`` because the decision — including
-                # the per-task ``max_retries`` override — was already made
-                # against the violation streak above.
-                tripped = _record_task_failure(
+                # Streak reached the bound: stop dispatching the card, but do
+                # not route it through the generic crash breaker.  This is a
+                # distinct missing end-of-run lifecycle signal, not a task-code
+                # failure, transient dependency, or normal blocked state.
+                reconciled = _reconcile_missing_exit_signal(
                     conn, tid,
                     error=error_text,
-                    outcome="crashed",
-                    failure_limit=violation_limit,
-                    force_trip=True,
-                    release_claim=False,
-                    end_run=False,
-                    event_payload_extra={
-                        "pid": pid,
-                        "claimer": claimer,
-                        "protocol_violations": streak,
-                        "protocol_violation_limit": violation_limit,
-                    },
+                    protocol_violations=streak,
+                    protocol_violation_limit=violation_limit,
+                    payload={"pid": pid, "claimer": claimer},
                 )
-                if tripped:
-                    auto_blocked.append(tid)
+                if reconciled:
+                    missing_exit_signal.append(tid)
                 continue
             fp = _error_fingerprint(error_text)
             is_systemic = _fp_counts.get(fp, 0) >= 3
@@ -7631,11 +7671,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             )
             if tripped:
                 auto_blocked.append(tid)
-    # Stash auto-blocked ids on the function for the dispatch loop to pick up.
+    # Stash side-channel ids on the function for the dispatch loop to pick up.
     # Keeps the public return type (``list[str]``) stable for direct callers
     # and tests that destructure the result; ``dispatch_once`` reads this
-    # side-channel attribute to populate ``DispatchResult.auto_blocked``.
+    # side-channel attribute to populate ``DispatchResult`` diagnostics.
     detect_crashed_workers._last_auto_blocked = auto_blocked  # type: ignore[attr-defined]
+    detect_crashed_workers._last_missing_exit_signal = missing_exit_signal  # type: ignore[attr-defined]
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
@@ -8181,9 +8222,15 @@ def _dispatch_once_locked(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
     result.crashed = detect_crashed_workers(conn)
-    # detect_crashed_workers stashes protocol-violation auto-blocks on
-    # itself so the public list-return stays stable. Pull them into the
-    # DispatchResult here so telemetry / tests see the trip.
+    # detect_crashed_workers stashes repeated clean-exit/no-signal
+    # reconciliations on itself so the public list-return stays stable.
+    # Pull them into the DispatchResult here so telemetry / tests see the
+    # distinct missing-exit-signal diagnostic rather than a generic blocker.
+    _missing_exit_signal = getattr(
+        detect_crashed_workers, "_last_missing_exit_signal", []
+    )
+    if _missing_exit_signal:
+        result.missing_exit_signal.extend(_missing_exit_signal)
     _crash_auto_blocked = getattr(
         detect_crashed_workers, "_last_auto_blocked", []
     )
@@ -9337,10 +9384,27 @@ def board_stats(conn: sqlite3.Connection) -> dict:
         if oldest_row and oldest_row["ts"] is not None else None
     )
 
+    missing_cutoff = now - 24 * 60 * 60
+    missing_exit_signal_24h = int(conn.execute(
+        "SELECT COUNT(*) AS n FROM task_events "
+        "WHERE kind = 'protocol_violation' AND created_at >= ?",
+        (missing_cutoff,),
+    ).fetchone()["n"])
+    ended_runs_24h = int(conn.execute(
+        "SELECT COUNT(*) AS n FROM task_runs WHERE ended_at >= ?",
+        (missing_cutoff,),
+    ).fetchone()["n"])
+    missing_exit_signal_rate_24h = (
+        missing_exit_signal_24h / ended_runs_24h if ended_runs_24h else 0.0
+    )
+
     return {
         "by_status": by_status,
         "by_assignee": by_assignee,
         "oldest_ready_age_seconds": oldest_ready_age,
+        "missing_exit_signal_24h": missing_exit_signal_24h,
+        "ended_runs_24h": ended_runs_24h,
+        "missing_exit_signal_rate_24h": missing_exit_signal_rate_24h,
         "now": now,
     }
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7435,9 +7435,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     When the reap registry shows the worker exited cleanly (rc=0) but
     the task was still ``running`` in the DB, treat it as a protocol
     violation (worker answered conversationally without calling
-    ``kanban_complete`` / ``kanban_block``) and trip the circuit breaker
-    on the first occurrence — retrying a worker whose CLI keeps
-    returning 0 without a terminal transition just loops forever.
+    ``kanban_complete`` / ``kanban_block``). Below the bounded violation
+    streak limit, retry without consuming the unified failure budget; at
+    the limit, move the task to ``completed_pending_review`` with a
+    ``missing_exit_signal`` event instead of conflating it with a generic
+    crash/block outcome.
 
     When the reap registry shows the worker exited with the rate-limit
     sentinel (``KANBAN_RATE_LIMIT_EXIT_CODE``), the worker bailed on a

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -650,6 +650,59 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
+def _rule_missing_exit_signal(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """Repeated rc=0/no-terminal-signal cards need review, not generic triage.
+
+    The dispatcher moves these tasks to ``completed_pending_review`` after the
+    clean-exit protocol-violation streak reaches its bound. This rule is
+    read-only: it makes the distinct terminal-review state searchable through
+    ``hermes kanban diagnostics`` and the dashboard without mutating the card.
+    """
+    if _task_field(task, "status") != "completed_pending_review":
+        return []
+
+    task_id = _task_field(task, "id")
+    missing_events = [ev for ev in events if _event_kind(ev) == "missing_exit_signal"]
+    latest = missing_events[-1] if missing_events else None
+    payload = _parse_payload(latest) if latest is not None else {}
+    last_err = (
+        payload.get("error")
+        or _task_field(task, "last_failure_error", "")
+        or "worker exited rc=0 without kanban_complete/kanban_block"
+    )
+
+    return [Diagnostic(
+        kind="missing_exit_signal",
+        severity="error",
+        title="Worker exited without terminal Kanban signal",
+        detail=(
+            "The dispatcher observed repeated worker rc=0 exits while the card "
+            "remained running, which means no kanban_complete or kanban_block "
+            "signal was recorded. Review the worker log/evidence, then close "
+            "the card with kanban_complete or kanban_block; do not treat this "
+            "as a generic crash, spawn failure, or iteration-budget condition."
+        ),
+        actions=[
+            DiagnosticAction(
+                kind="comment",
+                label="Add review finding before completing/blocking",
+                payload={"task_id": task_id} if task_id else {},
+                suggested=True,
+            ),
+            *_generic_recovery_actions(task, running=False),
+        ],
+        first_seen_at=_event_ts(latest) if latest is not None else now,
+        last_seen_at=_event_ts(latest) if latest is not None else now,
+        count=max(1, int(payload.get("protocol_violations") or len(missing_events) or 1)),
+        data={
+            "last_error": str(last_err),
+            "protocol_violations": payload.get("protocol_violations"),
+            "protocol_violation_limit": payload.get("protocol_violation_limit"),
+            "event_kind": "missing_exit_signal",
+        },
+    )]
+
+
 def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
     """The worker spawns fine but keeps crashing mid-run. Check the last
     N runs' outcomes; N consecutive ``crashed`` without a successful
@@ -1006,6 +1059,7 @@ _RULES: list[RuleFn] = [
     _rule_hallucinated_cards,
     _rule_triage_aux_unavailable,
     _rule_prose_phantom_refs,
+    _rule_missing_exit_signal,
     _rule_repeated_failures,
     _rule_repeated_crashes,
     _rule_stuck_in_blocked,
@@ -1020,6 +1074,7 @@ DIAGNOSTIC_KINDS = (
     "hallucinated_cards",
     "triage_aux_unavailable",
     "prose_phantom_refs",
+    "missing_exit_signal",
     "repeated_failures",
     "repeated_crashes",
     "stuck_in_blocked",

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -87,25 +87,31 @@
   }
 
   // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
+  const COLUMN_ORDER = ["triage", "todo", "scheduled", "ready", "running", "blocked", "completed_pending_review", "review", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
     triage: "Triage",
     todo: "Todo",
+    scheduled: "Scheduled",
     ready: "Ready",
     running: "In Progress",
     blocked: "Blocked",
+    completed_pending_review: "Pending Review",
+    review: "Review",
     done: "Done",
     archived: "Archived",
   };
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
     todo: "Waiting on dependencies or unassigned",
+    scheduled: "Waiting for a scheduled follow-up time",
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
+    completed_pending_review: "Worker exited without a terminal signal repeatedly; review then complete or block",
+    review: "Needs review before final closure",
     done: "Completed",
     archived: "Archived",
   };
@@ -154,9 +160,12 @@
   const COLUMN_DOT = {
     triage: "hermes-kanban-dot-triage",
     todo: "hermes-kanban-dot-todo",
+    scheduled: "hermes-kanban-dot-scheduled",
     ready: "hermes-kanban-dot-ready",
     running: "hermes-kanban-dot-running",
     blocked: "hermes-kanban-dot-blocked",
+    completed_pending_review: "hermes-kanban-dot-completed-pending-review",
+    review: "hermes-kanban-dot-review",
     done: "hermes-kanban-dot-done",
     archived: "hermes-kanban-dot-archived",
   };
@@ -521,6 +530,7 @@
     const boardData = kanbanBoard;
     const setBoardData = setKanbanBoard;
     const [config, setConfig] = useState(null);
+    const [stats, setStats] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
 
@@ -583,6 +593,12 @@
         .finally(function () { setLoading(false); });
     }, [tenantFilter, includeArchived, board]);
 
+    const loadStats = useCallback(function () {
+      return SDK.fetchJSON(withBoard(`${API}/stats`, board))
+        .then(function (data) { setStats(data || null); })
+        .catch(function () { setStats(null); });
+    }, [board]);
+
     // --- load list of boards for the switcher ------------------------------
     const loadBoardList = useCallback(function () {
       return SDK.fetchJSON(withBoard(`${API}/boards`, board))
@@ -617,13 +633,14 @@
 
     useEffect(function () {
       loadBoard();
+      loadStats();
       return function () {
         if (reloadTimerRef.current) {
           clearTimeout(reloadTimerRef.current);
           reloadTimerRef.current = null;
         }
       };
-    }, [loadBoard]);
+    }, [loadBoard, loadStats]);
 
     // --- WebSocket ---------------------------------------------------------
     useEffect(function () {
@@ -1071,6 +1088,7 @@
           boardData,
           onOpen: setSelectedTaskId,
         }),
+        h(BoardStatsStrip, { stats: stats }),
         h(BoardToolbar, {
           board: boardData,
           tenantFilter, setTenantFilter,
@@ -1237,6 +1255,34 @@
             }),
           )
         : null,
+    );
+  }
+
+  function pct(n) {
+    const value = Number(n);
+    if (!Number.isFinite(value)) return "—";
+    return (value * 100).toFixed(1) + "%";
+  }
+
+  function BoardStatsStrip(props) {
+    const stats = props.stats || {};
+    if (!Object.prototype.hasOwnProperty.call(stats, "missing_exit_signal_24h")) {
+      return null;
+    }
+    const missing = Number(stats.missing_exit_signal_24h) || 0;
+    const ended = Number(stats.ended_runs_24h) || 0;
+    const rate = stats.missing_exit_signal_rate_24h;
+    return h("div", {
+      className: cn(
+        "hermes-kanban-stats-strip",
+        missing > 0 ? "hermes-kanban-stats-strip--warning" : "",
+      ),
+      title: "Worker runs that exited without calling kanban_complete or kanban_block in the last 24 hours.",
+    },
+      h("span", { className: "hermes-kanban-stats-label" }, "Missing-exit-signal 24h"),
+      h("span", { className: "hermes-kanban-stats-value" }, String(missing)),
+      h("span", { className: "hermes-kanban-stats-detail" },
+        `${pct(rate)} of ${ended} ended run${ended === 1 ? "" : "s"}`),
     );
   }
 
@@ -2721,6 +2767,7 @@
     ready:   { amber: 1 * 60 * 60,   red: 24 * 60 * 60 },
     running: { amber: 10 * 60,       red: 60 * 60 },
     blocked: { amber: 1 * 60 * 60,   red: 24 * 60 * 60 },
+    completed_pending_review: { amber: 24 * 60 * 60, red: 7 * 24 * 60 * 60 },
     todo:    { amber: 7 * 24 * 60 * 60, red: 30 * 24 * 60 * 60 },
   };
 

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1277,7 +1277,7 @@
         "hermes-kanban-stats-strip",
         missing > 0 ? "hermes-kanban-stats-strip--warning" : "",
       ),
-      title: "Worker runs that exited without calling kanban_complete or kanban_block in the last 24 hours.",
+      title: "Tasks reconciled to pending review after repeated worker exits without kanban_complete or kanban_block in the last 24 hours.",
     },
       h("span", { className: "hermes-kanban-stats-label" }, "Missing-exit-signal 24h"),
       h("span", { className: "hermes-kanban-stats-value" }, String(missing)),

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -172,11 +172,44 @@
 }
 .hermes-kanban-dot-triage   { background: #b47dd6; }  /* lilac — fresh/unspecified */
 .hermes-kanban-dot-todo     { background: var(--color-muted-foreground); }
+.hermes-kanban-dot-scheduled { background: #8a8f98; }  /* grey — waiting for time */
 .hermes-kanban-dot-ready    { background: #d4b348; }  /* amber */
 .hermes-kanban-dot-running  { background: #3fb97d; }  /* green */
 .hermes-kanban-dot-blocked  { background: var(--color-destructive, #d14a4a); }
+.hermes-kanban-dot-completed-pending-review { background: #e0953a; }  /* orange — review required */
+.hermes-kanban-dot-review   { background: #8f7dd6; }  /* purple */
 .hermes-kanban-dot-done     { background: #4a8cd1; }  /* blue */
 .hermes-kanban-dot-archived { background: var(--color-border); }
+
+/* ---- Board stats / reliability strip -------------------------------- */
+
+.hermes-kanban-stats-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  align-self: flex-start;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  background: color-mix(in srgb, var(--color-card) 92%, transparent);
+  color: var(--color-muted-foreground);
+  font-size: 0.75rem;
+}
+.hermes-kanban-stats-strip--warning {
+  border-color: color-mix(in srgb, #e0953a 55%, var(--color-border));
+  background: color-mix(in srgb, #e0953a 10%, var(--color-card));
+  color: var(--color-foreground);
+}
+.hermes-kanban-stats-label {
+  font-weight: 600;
+}
+.hermes-kanban-stats-value {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-weight: 700;
+}
+.hermes-kanban-stats-detail {
+  color: var(--color-muted-foreground);
+}
 
 /* ---- Progress pill (N/M child tasks done) --------------------------- */
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -148,7 +148,8 @@ def _conn(board: Optional[str] = None):
 # tasks into ``todo`` and makes the dashboard look like the Scheduled column
 # disappeared.
 BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
+    "triage", "todo", "scheduled", "ready", "running", "blocked",
+    "completed_pending_review", "review", "done",
 ]
 
 

--- a/tests/gateway/test_kanban_watchers_dispatcher_telemetry.py
+++ b/tests/gateway/test_kanban_watchers_dispatcher_telemetry.py
@@ -1,21 +1,174 @@
-"""Pending review-required focus tests for the gateway dispatcher watcher's
-distinct missing-exit log emission.
+"""Focused tests for the gateway dispatcher watcher's distinct
+missing-exit-signal telemetry.
 
-These assertions were meant to verify that a dispatcher tick returning only
-``missing_exit_signal`` outcomes emits a distinct log line from the live
-``_kanban_dispatcher_watcher`` loop. The existing backend coverage in
-``tests/hermes_cli/test_kanban_core_functionality.py`` already exercises the
-missing-exit signal path; the watcher-level telemetry assertion remains pending
-the next review pass because it cannot currently directly drive the canned
-``_kanban_dispatcher_watcher`` flow inside the live gateway.
+These cover the two behaviors the dispatcher review round requires:
+
+* A tick that ONLY reconciles ``missing_exit_signal`` tasks (``spawned`` is
+  empty) MUST emit a distinct, searchable ``missing_exit_signal=N`` log line —
+  not stay silent and not be counted as a generic crash.
+* A tick with nothing to reconcile AND nothing spawned MUST stay silent — a
+  detector that always fires is as useless as one that never does.
+
+The decision is extracted into the pure helper ``_dispatcher_tick_log`` so it
+is testable without driving the live async ``_kanban_dispatcher_watcher`` loop
+(which would require a full gateway bootstrap). ``_tick_log_records`` mirrors
+the watcher's per-board loop so the empty-spawn and idle-tick behaviours are
+proved at the same shape the production loop uses.
 """
 
 from __future__ import annotations
 
+import logging
+from typing import Any
 
-def test_dispatcher_watcher_logs_missing_exit_signal_pending_review():
-    """TODO: wire focused watcher telemetry test for non-spawn missing-exit."""
+from gateway import kanban_watchers
+from gateway.kanban_watchers import _dispatcher_tick_log
+from hermes_cli.kanban_db import DispatchResult
 
 
-def test_dispatcher_watcher_does_not_log_spawned_zero_when_no_spawns():
-    """TODO: ensure non-spawn outcomes emit distinct summaries without 0-spawn."""
+def _result(**overrides: Any) -> DispatchResult:
+    defaults: dict[str, Any] = dict(
+        reclaimed=0,
+        promoted=0,
+        spawned=[],
+        crashed=[],
+        auto_blocked=[],
+        missing_exit_signal=[],
+        timed_out=[],
+        stale=[],
+    )
+    defaults.update(overrides)
+    return DispatchResult(**defaults)
+
+
+def _tick_log_records(results):
+    """Mirror the dispatcher watcher's per-board telemetry loop.
+
+    Returns ``(any_spawned, records)`` where ``records`` are the rendered
+    ``(slug, line)`` pairs the loop would log. This is the same shape as the
+    loop in ``gateway/kanban_watchers.py`` (``_kanban_dispatcher_watcher``),
+    minus the async/to_thread plumbing.
+    """
+    any_spawned = False
+    records = []
+    for slug, res in results or []:
+        should_log, message, args = _dispatcher_tick_log(slug, res)
+        if not should_log:
+            continue
+        any_spawned = True
+        records.append((slug, message % args))
+    return any_spawned, records
+
+
+def test_empty_spawn_missing_exit_signal_tick_fires_distinct_line():
+    """A tick with spawned=[] but missing_exit_signal=[...] must log a
+    distinct line — NOT stay silent and NOT masquerade as a generic crash."""
+    should_log, message, args = _dispatcher_tick_log(
+        "jarvis-os", _result(missing_exit_signal=["t_missing"])
+    )
+    assert should_log is True
+    assert "missing_exit_signal=%d" in message
+    rendered = message % args
+    assert "spawned=0" in rendered
+    assert "missing_exit_signal=1" in rendered
+    # The distinct bucket is what makes the diagnostic searchable and keeps
+    # it from being misread as a crash-family count.
+    assert "crashed=0" in rendered
+
+
+def test_empty_spawn_tick_emits_searchable_line_via_real_logger(caplog):
+    """Drive the actual ``gateway.run`` logger so the rendered record proves
+    the production log path carries the distinct bucket."""
+    should_log, message, args = _dispatcher_tick_log(
+        "jarvis-os", _result(missing_exit_signal=["t_missing", "t_missing2"])
+    )
+    assert should_log is True
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        kanban_watchers.logger.info(message, *args)
+    lines = [r.getMessage() for r in caplog.records]
+    assert any("missing_exit_signal=2" in line and "spawned=0" in line for line in lines)
+    assert any("kanban dispatcher [jarvis-os]" in line for line in lines)
+
+
+def test_idle_tick_stays_quiet():
+    """A genuinely idle tick — nothing spawned, nothing reconciled — must not
+    emit spurious telemetry."""
+    should_log, _, _ = _dispatcher_tick_log("jarvis-os", _result())
+    assert should_log is False
+
+
+def test_none_result_stays_quiet():
+    should_log, _, _ = _dispatcher_tick_log("jarvis-os", None)
+    assert should_log is False
+
+
+def test_spawned_only_tick_keeps_legacy_line():
+    """Backward compatibility: a plain spawn tick still logs the legacy line
+    WITHOUT the missing_exit_signal bucket, so existing consumers keying on
+    the old shape do not regress."""
+    should_log, message, args = _dispatcher_tick_log(
+        "jarvis-os", _result(spawned=[("t1", "worker", "/tmp/ws")])
+    )
+    assert should_log is True
+    assert "missing_exit_signal" not in message
+    rendered = message % args
+    assert "spawned=1" in rendered
+
+
+def test_mixed_tick_reports_both_buckets():
+    """A tick that both spawns and reconciles missing-exit-signal tasks logs
+    the distinct line with both counts present."""
+    should_log, message, args = _dispatcher_tick_log(
+        "jarvis-os",
+        _result(
+            spawned=[("t1", "worker", "/tmp/ws")],
+            missing_exit_signal=["t_missing"],
+        ),
+    )
+    assert should_log is True
+    rendered = message % args
+    assert "spawned=1" in rendered
+    assert "missing_exit_signal=1" in rendered
+
+
+def test_loop_only_logs_busy_board_among_idle_boards():
+    """Per-board decision: an idle sibling board must not log a spurious zero
+    line just because another board in the same tick spawned."""
+    any_spawned, records = _tick_log_records(
+        [
+            ("busy", _result(spawned=[("t1", "worker", "/tmp/ws")])),
+            ("idle", _result()),
+            ("idle2", None),
+        ]
+    )
+    assert any_spawned is True
+    assert [slug for slug, _ in records] == ["busy"]
+
+
+def test_loop_empty_spawn_missing_tick_fires_and_counts_as_activity():
+    """The empty-spawn case at loop level: only-missing-exit-signal boards log
+    the distinct line and count as dispatcher activity (reset the stuck
+    detector), proving a missing-exit reconciliation tick is not silent."""
+    any_spawned, records = _tick_log_records(
+        [
+            ("jarvis-os", _result(missing_exit_signal=["t_missing"])),
+            ("sycode", _result()),
+        ]
+    )
+    assert any_spawned is True
+    assert len(records) == 1
+    slug, line = records[0]
+    assert slug == "jarvis-os"
+    assert "missing_exit_signal=1" in line
+    assert "spawned=0" in line
+
+
+def test_loop_all_idle_tick_stays_quiet():
+    any_spawned, records = _tick_log_records(
+        [
+            ("jarvis-os", _result()),
+            ("sycode", _result()),
+        ]
+    )
+    assert any_spawned is False
+    assert records == []

--- a/tests/gateway/test_kanban_watchers_dispatcher_telemetry.py
+++ b/tests/gateway/test_kanban_watchers_dispatcher_telemetry.py
@@ -1,0 +1,21 @@
+"""Pending review-required focus tests for the gateway dispatcher watcher's
+distinct missing-exit log emission.
+
+These assertions were meant to verify that a dispatcher tick returning only
+``missing_exit_signal`` outcomes emits a distinct log line from the live
+``_kanban_dispatcher_watcher`` loop. The existing backend coverage in
+``tests/hermes_cli/test_kanban_core_functionality.py`` already exercises the
+missing-exit signal path; the watcher-level telemetry assertion remains pending
+the next review pass because it cannot currently directly drive the canned
+``_kanban_dispatcher_watcher`` flow inside the live gateway.
+"""
+
+from __future__ import annotations
+
+
+def test_dispatcher_watcher_logs_missing_exit_signal_pending_review():
+    """TODO: wire focused watcher telemetry test for non-spawn missing-exit."""
+
+
+def test_dispatcher_watcher_does_not_log_spawned_zero_when_no_spawns():
+    """TODO: ensure non-spawn outcomes emit distinct summaries without 0-spawn."""

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4720,9 +4720,18 @@ def test_board_stats_reports_missing_exit_signal_rate(kanban_home):
         tid = kb.create_task(conn, title="metric", assignee="worker")
         _drive_protocol_violation(conn, tid, 996000)
 
+        first_stats = kb.board_stats(conn)
+        assert first_stats["missing_exit_signal_24h"] == 0, (
+            "single retryable protocol_violation events are not the terminal "
+            "missing_exit_signal diagnostic"
+        )
+
+        _drive_protocol_violation(conn, tid, 996001)
+        _drive_protocol_violation(conn, tid, 996002)
+
         stats = kb.board_stats(conn)
-        assert stats["missing_exit_signal_24h"] >= 1
-        assert stats["ended_runs_24h"] >= 1
+        assert stats["missing_exit_signal_24h"] == 1
+        assert stats["ended_runs_24h"] >= 3
         assert stats["missing_exit_signal_rate_24h"] > 0
     finally:
         conn.close()

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4530,21 +4530,26 @@ def test_detect_crashed_workers_protocol_violation_streak_trips_at_limit(kanban_
         _drive_protocol_violation(conn, tid, 990900)
 
         task = kb.get_task(conn, tid)
-        assert task.status == "blocked", (
-            f"violation streak at the bound must block, got {task.status}"
+        assert task.status == "completed_pending_review", (
+            "violation streak at the bound must move to a distinct "
+            f"pending-review state, got {task.status}"
         )
+        assert task.consecutive_failures == 0
         events = kb.list_events(conn, tid)
         kinds = [e.kind for e in events]
         assert kinds.count("protocol_violation") == limit
         assert "crashed" not in kinds
-        gave_up = [e for e in events if e.kind == "gave_up"]
-        assert len(gave_up) == 1, f"expected exactly one gave_up, got {kinds}"
-        payload = gave_up[0].payload or {}
+        assert "gave_up" not in kinds
+        missing_exit = [e for e in events if e.kind == "missing_exit_signal"]
+        assert len(missing_exit) == 1, (
+            f"expected one missing_exit_signal event, got {kinds}"
+        )
+        payload = missing_exit[0].payload or {}
         assert payload.get("protocol_violations") == limit
         assert payload.get("protocol_violation_limit") == limit
         # Side channel consumed by dispatch_once — read through the same
         # (current) module object the reaper ran in, see _drive_worker_exit.
-        assert tid in _kb.detect_crashed_workers._last_auto_blocked
+        assert tid in getattr(_kb.detect_crashed_workers, "_last_missing_exit_signal")
     finally:
         conn.close()
 
@@ -4585,13 +4590,17 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
                 "below-budget violations must not tick the unified counter"
             )
 
-        # Third consecutive violation: streak hits the bound — blocked.
+        # Third consecutive violation: streak hits the bound and moves the
+        # task to the distinct missing-exit-signal review state.
         _drive_protocol_violation(conn, tid, 991003)
         task = kb.get_task(conn, tid)
-        assert task.status == "blocked"
-        gave_up = [e for e in kb.list_events(conn, tid) if e.kind == "gave_up"]
-        assert len(gave_up) == 1
-        assert (gave_up[0].payload or {}).get("protocol_violations") == \
+        assert task.status == "completed_pending_review"
+        missing_exit = [
+            e for e in kb.list_events(conn, tid)
+            if e.kind == "missing_exit_signal"
+        ]
+        assert len(missing_exit) == 1
+        assert (missing_exit[0].payload or {}).get("protocol_violations") == \
             _kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
     finally:
         conn.close()
@@ -4624,9 +4633,10 @@ def test_protocol_violation_streak_resets_on_other_failure_kind(kanban_home):
         _drive_protocol_violation(conn, tid, 993004)
         assert kb.get_task(conn, tid).status == "ready"
 
-        # Third consecutive violation since the crash: blocked.
+        # Third consecutive violation since the crash: stop dispatching and
+        # route to the distinct missing-exit-signal review state.
         _drive_protocol_violation(conn, tid, 993005)
-        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb.get_task(conn, tid).status == "completed_pending_review"
     finally:
         conn.close()
 
@@ -4647,12 +4657,16 @@ def test_protocol_violation_respects_max_retries_precedence(kanban_home):
         )
         _drive_protocol_violation(conn, strict, 992000)
         task = kb.get_task(conn, strict)
-        assert task.status == "blocked", (
-            f"max_retries=1 must block on the first violation, got {task.status}"
+        assert task.status == "completed_pending_review", (
+            "max_retries=1 must stop dispatching on the first violation, "
+            f"got {task.status}"
         )
-        gave_up = [e for e in kb.list_events(conn, strict) if e.kind == "gave_up"]
-        assert len(gave_up) == 1
-        payload = gave_up[0].payload or {}
+        missing_exit = [
+            e for e in kb.list_events(conn, strict)
+            if e.kind == "missing_exit_signal"
+        ]
+        assert len(missing_exit) == 1
+        payload = missing_exit[0].payload or {}
         assert payload.get("protocol_violations") == 1
         assert payload.get("protocol_violation_limit") == 1
 
@@ -4665,10 +4679,53 @@ def test_protocol_violation_respects_max_retries_precedence(kanban_home):
                 f"violation {i + 1}/5 should retry under max_retries=5"
             )
         _drive_protocol_violation(conn, lenient, 992104)
-        assert kb.get_task(conn, lenient).status == "blocked"
+        assert kb.get_task(conn, lenient).status == "completed_pending_review"
     finally:
         conn.close()
 
+
+
+def test_completed_pending_review_can_be_closed_or_blocked(kanban_home):
+    """Pending-review lifecycle state is terminal for dispatch but not final.
+
+    Operators/workers can still reconcile useful evidence by completing the
+    card or honestly blocking it after review.
+    """
+    conn = kb.connect()
+    try:
+        complete_id = kb.create_task(conn, title="review me", assignee="worker")
+        _drive_protocol_violation(conn, complete_id, 995000)
+        _drive_protocol_violation(conn, complete_id, 995001)
+        _drive_protocol_violation(conn, complete_id, 995002)
+        assert kb.get_task(conn, complete_id).status == "completed_pending_review"
+
+        assert kb.complete_task(conn, complete_id, summary="reviewed OK")
+        assert kb.get_task(conn, complete_id).status == "done"
+
+        block_id = kb.create_task(conn, title="review block", assignee="worker")
+        _drive_protocol_violation(conn, block_id, 995100)
+        _drive_protocol_violation(conn, block_id, 995101)
+        _drive_protocol_violation(conn, block_id, 995102)
+        assert kb.get_task(conn, block_id).status == "completed_pending_review"
+
+        assert kb.block_task(conn, block_id, reason="review-required: missing proof")
+        assert kb.get_task(conn, block_id).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_board_stats_reports_missing_exit_signal_rate(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="metric", assignee="worker")
+        _drive_protocol_violation(conn, tid, 996000)
+
+        stats = kb.board_stats(conn)
+        assert stats["missing_exit_signal_24h"] >= 1
+        assert stats["ended_runs_24h"] >= 1
+        assert stats["missing_exit_signal_rate_24h"] > 0
+    finally:
+        conn.close()
 
 def test_detect_crashed_workers_nonzero_exit_uses_default_limit(kanban_home):
     """A worker that exited non-zero (real error / crash) uses the

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -239,6 +239,45 @@ def test_config_from_kanban_config_preserves_explicit_diagnostics_threshold():
     assert cfg["failure_limit"] == 5
 
 
+def test_missing_exit_signal_fires_for_completed_pending_review():
+    task = _task(
+        status="completed_pending_review",
+        last_failure_error="worker exited cleanly (rc=0) without calling kanban_complete",
+    )
+    events = [
+        _event(
+            "missing_exit_signal",
+            ts=200,
+            protocol_violations=3,
+            protocol_violation_limit=3,
+            error="worker exited cleanly (rc=0) without calling kanban_complete",
+        ),
+    ]
+
+    diags = kd.compute_task_diagnostics(task, events, [], now=300)
+    missing = [d for d in diags if d.kind == "missing_exit_signal"]
+    assert len(missing) == 1
+    d = missing[0]
+    assert d.severity == "error"
+    assert "kanban_complete or kanban_block" in d.detail
+    assert "generic crash" in d.detail
+    assert d.count == 3
+    assert d.data["protocol_violations"] == 3
+    assert d.data["protocol_violation_limit"] == 3
+    assert any(a.kind == "comment" and a.suggested for a in d.actions)
+
+
+def test_missing_exit_signal_ignores_unrelated_classifier_cases():
+    for status, last_error in (
+        ("blocked", "Iteration budget exhausted (90/90) — task could not complete"),
+        ("ready", "task t_demo00 worktree path '/tmp/nope' is not inside a git repo"),
+    ):
+        task = _task(status=status, last_failure_error=last_error)
+        events = [_event("blocked", ts=100, reason=last_error)]
+        diags = kd.compute_task_diagnostics(task, events, [], now=300)
+        assert [d for d in diags if d.kind == "missing_exit_signal"] == []
+
+
 def test_repeated_crashes_counts_trailing_streak_only():
     task = _task(status="ready", assignee="crashy")
     runs = [

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -297,6 +297,64 @@ def test_scheduled_tasks_have_their_own_column_not_todo(client):
     assert not any(t["id"] == task["id"] for t in columns["todo"])
 
 
+def test_completed_pending_review_has_dashboard_column_and_dist_display(client):
+    """Dashboard display bundle must expose the missing-exit review status."""
+
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "no terminal signal", "assignee": "worker"},
+    ).json()["task"]
+
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'completed_pending_review' WHERE id = ?",
+                (task["id"],),
+            )
+    finally:
+        conn.close()
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200
+    columns = {c["name"]: c["tasks"] for c in r.json()["columns"]}
+    assert any(t["id"] == task["id"] for t in columns["completed_pending_review"])
+    assert not any(t["id"] == task["id"] for t in columns["todo"])
+
+    bundle = (
+        Path(__file__).resolve().parents[2]
+        / "plugins"
+        / "kanban"
+        / "dashboard"
+        / "dist"
+        / "index.js"
+    ).read_text(encoding="utf-8")
+
+    assert '"completed_pending_review"' in bundle
+    assert "Pending Review" in bundle
+    assert "hermes-kanban-dot-completed-pending-review" in bundle
+    assert "completed_pending_review: { amber:" in bundle
+
+
+def test_dashboard_dist_surfaces_missing_exit_signal_stats_metric():
+    """The shipped bundle must render the backend missing-exit-signal metric."""
+
+    bundle = (
+        Path(__file__).resolve().parents[2]
+        / "plugins"
+        / "kanban"
+        / "dashboard"
+        / "dist"
+        / "index.js"
+    ).read_text(encoding="utf-8")
+
+    assert "function BoardStatsStrip(props)" in bundle
+    assert '`${API}/stats`' in bundle
+    assert "missing_exit_signal_24h" in bundle
+    assert "missing_exit_signal_rate_24h" in bundle
+    assert "Missing-exit-signal 24h" in bundle
+
+
 def test_tenant_filter(client):
     client.post("/api/plugins/kanban/tasks", json={"title": "A", "tenant": "t1"})
     client.post("/api/plugins/kanban/tasks", json={"title": "B", "tenant": "t2"})


### PR DESCRIPTION
Implements jarvis-os/t_7a798fb8.

Summary:
- Detect repeated worker rc=0 exits without kanban_complete/kanban_block as a distinct missing-exit-signal path.
- Adds completed_pending_review status, missing_exit_signal dispatch bucket/stats, CLI/dashboard surfaces, and read-only diagnostics.
- Preserves normal kanban_complete, kanban_block, nonzero crash, rate-limit, worktree/path, and iteration-budget diagnostic paths.

Verification:
- python -m pytest tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_diagnostics.py tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts=' (343 passed, 8 warnings)

No gateway restart, deploy, credentials, provider routing, or runtime mutation.