### PR TITLE
fix(api): bind approvals to immutable request ids

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1252,6 +1252,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Resolved approval decisions retained with terminal run status so
+        # retries remain idempotent after the agent thread has exited.
+        self._run_approval_decisions: Dict[str, Dict[str, str]] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         # Last-known-good resolved model per session (keyed by gateway_session_key
         # ONLY — never session_id, which rotates/is ephemeral for one-off API
@@ -6216,6 +6219,12 @@ class APIServerAdapter(BasePlatformAdapter):
                         run_id,
                         "waiting_for_approval",
                         last_event="approval.request",
+                        pending_approval={
+                            "approval_id": event.get("approval_id"),
+                            "created_at": event.get("created_at"),
+                            "expires_at": event.get("expires_at"),
+                            "choices": event["choices"],
+                        },
                     )
                     try:
                         loop.call_soon_threadsafe(q.put_nowait, event)
@@ -6522,6 +6531,37 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        expected_approval_id = str(body.get("expected_approval_id", "")).strip()
+        if not expected_approval_id:
+            return web.json_response(
+                _openai_error(
+                    "Missing 'expected_approval_id' for approval compare-and-set",
+                    code="approval_id_required",
+                ),
+                status=409,
+            )
+
+        previous_choice = self._run_approval_decisions.get(run_id, {}).get(
+            expected_approval_id
+        )
+        if previous_choice is not None:
+            if previous_choice != choice:
+                return web.json_response(
+                    _openai_error(
+                        "Approval id was already resolved with a different choice",
+                        code="approval_decision_conflict",
+                    ),
+                    status=409,
+                )
+            return web.json_response({
+                "object": "hermes.run.approval_response",
+                "run_id": run_id,
+                "approval_id": expected_approval_id,
+                "choice": choice,
+                "resolved": 0,
+                "idempotent": True,
+            })
+
         approval_session_key = self._run_approval_sessions.get(run_id)
         if not approval_session_key:
             return web.json_response(
@@ -6536,30 +6576,57 @@ class APIServerAdapter(BasePlatformAdapter):
             _coerce_request_bool(body.get("all"), default=False)
             or _coerce_request_bool(body.get("resolve_all"), default=False)
         )
+        if resolve_all:
+            return web.json_response(
+                _openai_error(
+                    "'resolve_all' is incompatible with an exact approval decision",
+                    code="approval_resolve_all_not_supported",
+                ),
+                status=400,
+            )
         try:
-            from tools.approval import resolve_gateway_approval
+            from tools.approval import resolve_gateway_approval_cas
 
-            resolved = resolve_gateway_approval(
+            resolution = resolve_gateway_approval_cas(
                 approval_session_key,
                 choice,
-                resolve_all=resolve_all,
+                expected_approval_id,
             )
         except Exception as exc:
             logger.exception("[api_server] approval resolution failed for run %s", run_id)
             return web.json_response(_openai_error(str(exc)), status=500)
 
-        if resolved <= 0:
+        resolution_status = resolution["status"]
+        if resolution_status not in {"resolved", "already_resolved"}:
+            error_codes = {
+                "approval_id_required": "approval_id_required",
+                "decision_conflict": "approval_decision_conflict",
+                "expired": "approval_expired",
+                "mismatch": "approval_id_mismatch",
+                "not_pending": "approval_not_pending",
+            }
             return web.json_response(
                 _openai_error(
-                    f"Run has no pending approval: {run_id}",
-                    code="approval_not_pending",
+                    f"Approval compare-and-set failed: {resolution_status}",
+                    code=error_codes.get(resolution_status, "approval_conflict"),
                 ),
                 status=409,
             )
 
-        self._set_run_status(run_id, "running", last_event="approval.responded")
+        resolved = resolution["resolved"]
+        idempotent = resolution["idempotent"]
+        self._run_approval_decisions.setdefault(run_id, {})[
+            expected_approval_id
+        ] = choice
+        if not idempotent:
+            self._set_run_status(
+                run_id,
+                "running",
+                last_event="approval.responded",
+                pending_approval=None,
+            )
         q = self._run_streams.get(run_id)
-        if q is not None:
+        if q is not None and not idempotent:
             try:
                 q.put_nowait({
                     "event": "approval.responded",
@@ -6567,6 +6634,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": time.time(),
                     "choice": choice,
                     "resolved": resolved,
+                    "approval_id": expected_approval_id,
                 })
             except Exception:
                 pass
@@ -6574,8 +6642,10 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({
             "object": "hermes.run.approval_response",
             "run_id": run_id,
+            "approval_id": expected_approval_id,
             "choice": choice,
             "resolved": resolved,
+            "idempotent": idempotent,
         })
 
     async def _handle_stop_run(self, request: "web.Request") -> "web.Response":
@@ -6649,6 +6719,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ]
         for run_id in stale_statuses:
             self._run_statuses.pop(run_id, None)
+            self._run_approval_decisions.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2817,6 +2817,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
+                "run_approval_compare_and_set": {
+                    "version": 1,
+                    "required": True,
+                    "request_id_field": "expected_approval_id",
+                    "event_id_field": "approval_id",
+                },
                 "tool_progress_events": True,
                 "approval_events": True,
                 "session_resources": True,
@@ -5925,6 +5931,9 @@ class APIServerAdapter(BasePlatformAdapter):
         """Update pollable run status without exposing private agent objects."""
         now = time.time()
         current = self._run_statuses.get(run_id, {})
+        if status in {"completed", "failed", "cancelled"}:
+            fields["pending_approval"] = None
+            fields["pending_approvals"] = []
         current.update({
             "object": "hermes.run",
             "run_id": run_id,
@@ -5935,6 +5944,48 @@ class APIServerAdapter(BasePlatformAdapter):
         current.update(fields)
         self._run_statuses[run_id] = current
         return current
+
+    def _refresh_run_approval_status(
+        self,
+        run_id: str,
+        approval_session_key: str,
+        *,
+        last_event: Optional[str] = None,
+    ) -> None:
+        """Rebuild public pending-approval state from the locked core queue."""
+        from tools.approval import list_gateway_approvals
+
+        current = self._run_statuses.get(run_id)
+        if current is None:
+            return
+        pending = []
+        for approval in list_gateway_approvals(approval_session_key):
+            pending.append({
+                "approval_id": approval["approval_id"],
+                "created_at": approval["created_at"],
+                "expires_at": approval["expires_at"],
+                "choices": _approval_event_choices(
+                    smart_denied=bool(approval.get("smart_denied")),
+                    allow_permanent=approval.get("allow_permanent") is not False,
+                ),
+            })
+        current_status = current.get("status", "running")
+        if current_status in {"completed", "failed", "cancelled"}:
+            pending = []
+            next_status = current_status
+        elif pending:
+            next_status = "waiting_for_approval"
+        elif current_status == "waiting_for_approval":
+            next_status = "running"
+        else:
+            next_status = current_status
+        fields = {
+            "pending_approvals": pending,
+            "pending_approval": pending[0] if len(pending) == 1 else None,
+        }
+        if last_event is not None:
+            fields["last_event"] = last_event
+        self._set_run_status(run_id, next_status, **fields)
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
@@ -6215,19 +6266,34 @@ class APIServerAdapter(BasePlatformAdapter):
                             allow_permanent=event.get("allow_permanent") is not False,
                         ),
                     })
-                    self._set_run_status(
-                        run_id,
-                        "waiting_for_approval",
-                        last_event="approval.request",
-                        pending_approval={
-                            "approval_id": event.get("approval_id"),
-                            "created_at": event.get("created_at"),
-                            "expires_at": event.get("expires_at"),
-                            "choices": event["choices"],
-                        },
-                    )
+                    def _publish_request() -> None:
+                        self._refresh_run_approval_status(
+                            run_id,
+                            approval_session_key,
+                            last_event="approval.request",
+                        )
+                        q.put_nowait(event)
+
                     try:
-                        loop.call_soon_threadsafe(q.put_nowait, event)
+                        loop.call_soon_threadsafe(_publish_request)
+                    except Exception:
+                        pass
+
+                def _approval_finalized(approval_data: Dict[str, Any]) -> None:
+                    def _update() -> None:
+                        choice = approval_data.get("_resolution_choice")
+                        approval_id = approval_data.get("approval_id")
+                        if choice is not None and approval_id:
+                            self._run_approval_decisions.setdefault(run_id, {})[
+                                approval_id
+                            ] = choice
+                        self._refresh_run_approval_status(
+                            run_id,
+                            approval_session_key,
+                        )
+
+                    try:
+                        loop.call_soon_threadsafe(_update)
                     except Exception:
                         pass
 
@@ -6262,7 +6328,11 @@ class APIServerAdapter(BasePlatformAdapter):
                                 session_key=approval_session_key,
                                 session_id=session_id or "",
                             )
-                            register_gateway_notify(approval_session_key, _approval_notify)
+                            register_gateway_notify(
+                                approval_session_key,
+                                _approval_notify,
+                                finalized_cb=_approval_finalized,
+                            )
                             r = agent.run_conversation(
                                 user_message=user_message,
                                 conversation_history=conversation_history,
@@ -6598,12 +6668,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
         resolution_status = resolution["status"]
         if resolution_status not in {"resolved", "already_resolved"}:
+            self._refresh_run_approval_status(run_id, approval_session_key)
             error_codes = {
                 "approval_id_required": "approval_id_required",
                 "decision_conflict": "approval_decision_conflict",
                 "expired": "approval_expired",
                 "mismatch": "approval_id_mismatch",
                 "not_pending": "approval_not_pending",
+                "already_finalized": "approval_already_finalized",
             }
             return web.json_response(
                 _openai_error(
@@ -6619,11 +6691,10 @@ class APIServerAdapter(BasePlatformAdapter):
             expected_approval_id
         ] = choice
         if not idempotent:
-            self._set_run_status(
+            self._refresh_run_approval_status(
                 run_id,
-                "running",
+                approval_session_key,
                 last_event="approval.responded",
-                pending_approval=None,
             )
         q = self._run_streams.get(run_id)
         if q is not None and not idempotent:
@@ -6663,6 +6734,20 @@ class APIServerAdapter(BasePlatformAdapter):
 
         self._set_run_status(run_id, "stopping", last_event="run.stopping")
         self._stopping_run_ids.add(run_id)
+
+        approval_session_key = self._run_approval_sessions.get(run_id)
+        if approval_session_key:
+            try:
+                from tools.approval import resolve_gateway_approval
+
+                resolve_gateway_approval(
+                    approval_session_key,
+                    "deny",
+                    resolve_all=True,
+                )
+                self._refresh_run_approval_status(run_id, approval_session_key)
+            except Exception:
+                pass
 
         if agent is not None:
             try:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1337,6 +1337,12 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_approval_compare_and_set"] == {
+                "version": 1,
+                "required": True,
+                "request_id_field": "expected_approval_id",
+                "event_id_field": "approval_id",
+            }
             assert data["features"]["model_options"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -457,7 +457,10 @@ class TestRunEvents:
 
                 approval_resp = await cli.post(
                     f"/v1/runs/{run_id}/approval",
-                    json={"choice": "once"},
+                    json={
+                        "choice": "once",
+                        "expected_approval_id": "approval_not_pending",
+                    },
                 )
                 assert approval_resp.status == 409
                 approval_data = await approval_resp.json()
@@ -467,29 +470,30 @@ class TestRunEvents:
                 }
 
     @pytest.mark.asyncio
-    async def test_approval_string_false_does_not_resolve_all(self, adapter):
-        """Quoted false must not fan out approval resolution across the queue."""
+    async def test_approval_without_expected_id_cannot_resolve_bound_request(self, adapter):
         app = _create_runs_app(adapter)
         run_id = "run_bool_parse"
         adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
         adapter._run_approval_sessions[run_id] = "session-123"
+        pending = approval_mod._ApprovalEntry({"command": "danger"})
+        with approval_mod._lock:
+            approval_mod._gateway_queues["session-123"] = [pending]
 
         async with TestClient(TestServer(app)) as cli:
-            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
-                approval_resp = await cli.post(
-                    f"/v1/runs/{run_id}/approval",
-                    json={"choice": "once", "all": "false"},
-                )
+            approval_resp = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={"choice": "once"},
+            )
+            response = await approval_resp.json()
 
-        assert approval_resp.status == 200
-        mock_resolve.assert_called_once_with(
-            "session-123",
-            "once",
-            resolve_all=False,
-        )
+        assert approval_resp.status == 409
+        assert response["error"]["code"] == "approval_id_required"
+        assert not pending.event.is_set()
+        with approval_mod._lock:
+            approval_mod._gateway_queues.pop("session-123", None)
 
     @pytest.mark.asyncio
-    async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):
+    async def test_exact_approval_is_scoped_to_target_run(self, auth_adapter):
         """Same client session_id must not let one run approve another run's queue."""
         app = _create_runs_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -535,7 +539,10 @@ class TestRunEvents:
 
                 approval_resp = await cli.post(
                     f"/v1/runs/{attacker_run}/approval",
-                    json={"choice": "always", "resolve_all": True},
+                    json={
+                        "choice": "always",
+                        "expected_approval_id": attacker_entry.data["approval_id"],
+                    },
                     headers={"Authorization": "Bearer sk-secret"},
                 )
                 approval_data = await approval_resp.json()
@@ -572,6 +579,221 @@ class TestRunEvents:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/runs/run_any/events")
         assert resp.status == 401
+
+
+class TestRunApprovalCompareAndSet:
+    @staticmethod
+    def _bind_pending(adapter, run_id, *entries):
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_approval"}
+        adapter._run_approval_sessions[run_id] = run_id
+        with approval_mod._lock:
+            approval_mod._gateway_queues[run_id] = list(entries)
+
+    @pytest.mark.asyncio
+    async def test_pause_state_exposes_immutable_approval_id(self, adapter):
+        app = _create_runs_app(adapter)
+        requested = threading.Event()
+
+        def _request_approval(**_kwargs):
+            session_key = approval_mod.get_current_session_key()
+            with approval_mod._lock:
+                notify = approval_mod._gateway_notify_cbs[session_key]
+            requested.set()
+            decision = approval_mod._await_gateway_decision(
+                session_key,
+                notify,
+                {
+                    "command": "bash -c dangerous",
+                    "description": "dangerous command",
+                    "pattern_key": "shell-c",
+                    "pattern_keys": ["shell-c"],
+                },
+            )
+            return {"final_response": decision["choice"] or "denied"}
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.side_effect = _request_approval
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                start = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await start.json())["run_id"]
+                assert requested.wait(timeout=3)
+
+                for _ in range(40):
+                    status_response = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_response.json()
+                    pending = status.get("pending_approval")
+                    if pending:
+                        break
+                    await asyncio.sleep(0.05)
+
+                approval_id = pending["approval_id"]
+                assert approval_id.startswith("approval_")
+                assert pending["created_at"] < pending["expires_at"]
+
+                response = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={
+                        "choice": "once",
+                        "expected_approval_id": approval_id,
+                    },
+                )
+                body = await response.json()
+                for _ in range(40):
+                    terminal_response = await cli.get(f"/v1/runs/{run_id}")
+                    terminal = await terminal_response.json()
+                    if terminal["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+                retry = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={
+                        "choice": "once",
+                        "expected_approval_id": approval_id,
+                    },
+                )
+                retry_body = await retry.json()
+
+        assert response.status == 200
+        assert body["approval_id"] == approval_id
+        assert body["resolved"] == 1
+        assert body["idempotent"] is False
+        assert terminal["status"] == "completed"
+        assert retry.status == 200
+        assert retry_body["resolved"] == 0
+        assert retry_body["idempotent"] is True
+
+    @pytest.mark.asyncio
+    async def test_delayed_duplicate_for_a_never_resolves_replacement_b(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_replacement"
+        approval_a = approval_mod._ApprovalEntry({"command": "danger-a"})
+        self._bind_pending(adapter, run_id, approval_a)
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={
+                    "choice": "once",
+                    "expected_approval_id": approval_a.data["approval_id"],
+                },
+            )
+            approval_b = approval_mod._ApprovalEntry({"command": "danger-b"})
+            with approval_mod._lock:
+                approval_mod._gateway_queues[run_id] = [approval_b]
+
+            duplicate = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={
+                    "choice": "once",
+                    "expected_approval_id": approval_a.data["approval_id"],
+                },
+            )
+            duplicate_body = await duplicate.json()
+            conflicting_duplicate = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={
+                    "choice": "deny",
+                    "expected_approval_id": approval_a.data["approval_id"],
+                },
+            )
+            conflict_body = await conflicting_duplicate.json()
+
+        assert first.status == 200
+        assert duplicate.status == 200
+        assert duplicate_body["idempotent"] is True
+        assert duplicate_body["resolved"] == 0
+        assert conflicting_duplicate.status == 409
+        assert conflict_body["error"]["code"] == "approval_decision_conflict"
+        assert approval_b.result is None
+        assert not approval_b.event.is_set()
+        with approval_mod._lock:
+            assert approval_mod._gateway_queues[run_id] == [approval_b]
+            approval_mod._gateway_queues.pop(run_id, None)
+
+    @pytest.mark.asyncio
+    async def test_mismatched_id_fails_without_action(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_mismatch"
+        current = approval_mod._ApprovalEntry({"command": "current-danger"})
+        self._bind_pending(adapter, run_id, current)
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={
+                    "choice": "once",
+                    "expected_approval_id": "approval_replaced",
+                },
+            )
+            body = await response.json()
+
+        assert response.status == 409
+        assert body["error"]["code"] == "approval_id_mismatch"
+        assert current.result is None
+        assert not current.event.is_set()
+        with approval_mod._lock:
+            approval_mod._gateway_queues.pop(run_id, None)
+
+    def test_concurrent_matching_decisions_resolve_once(self):
+        run_id = "run_concurrent_cas"
+        pending = approval_mod._ApprovalEntry({"command": "danger"})
+        self._bind_pending(_make_adapter(), run_id, pending)
+        approval_id = pending.data["approval_id"]
+        barrier = threading.Barrier(3)
+        results = []
+
+        def _resolve():
+            barrier.wait()
+            results.append(
+                approval_mod.resolve_gateway_approval_cas(
+                    run_id,
+                    "once",
+                    approval_id,
+                )
+            )
+
+        threads = [threading.Thread(target=_resolve) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=3)
+
+        assert {result["status"] for result in results} == {
+            "resolved",
+            "already_resolved",
+        }
+        assert sum(result["resolved"] for result in results) == 1
+        assert pending.result == "once"
+        assert pending.event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_expired_match_fails_closed(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_expired_approval"
+        expired = approval_mod._ApprovalEntry({"command": "old-danger"})
+        expired.deadline = time.monotonic() - 1
+        self._bind_pending(adapter, run_id, expired)
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={
+                    "choice": "once",
+                    "expected_approval_id": expired.data["approval_id"],
+                },
+            )
+            body = await response.json()
+
+        assert response.status == 409
+        assert body["error"]["code"] == "approval_expired"
+        assert expired.result is None
+        assert expired.event.is_set()
 
 
 # ---------------------------------------------------------------------------
@@ -641,7 +863,10 @@ class TestRunLifecycleSweep:
 
                 approval_resp = await cli.post(
                     f"/v1/runs/{run_id}/approval",
-                    json={"choice": "once"},
+                    json={
+                        "choice": "once",
+                        "expected_approval_id": pending.data["approval_id"],
+                    },
                 )
                 assert approval_resp.status == 200
                 assert pending.event.is_set()

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -739,6 +739,101 @@ class TestRunApprovalCompareAndSet:
         with approval_mod._lock:
             approval_mod._gateway_queues.pop(run_id, None)
 
+    @pytest.mark.asyncio
+    async def test_multiple_pending_approvals_remain_visible_until_each_resolves(
+        self, adapter
+    ):
+        app = _create_runs_app(adapter)
+        run_id = "run_multiple_pending"
+        approval_a = approval_mod._ApprovalEntry({"command": "danger-a"})
+        approval_b = approval_mod._ApprovalEntry({"command": "danger-b"})
+        self._bind_pending(adapter, run_id, approval_a, approval_b)
+        adapter._refresh_run_approval_status(run_id, run_id)
+
+        status = adapter._run_statuses[run_id]
+        assert [
+            pending["approval_id"] for pending in status["pending_approvals"]
+        ] == [approval_a.approval_id, approval_b.approval_id]
+        assert status["pending_approval"] is None
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={
+                    "choice": "once",
+                    "expected_approval_id": approval_a.approval_id,
+                },
+            )
+            assert first.status == 200
+            status = adapter._run_statuses[run_id]
+            assert status["status"] == "waiting_for_approval"
+            assert status["pending_approvals"] == [status["pending_approval"]]
+            assert status["pending_approval"]["approval_id"] == approval_b.approval_id
+
+            second = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={
+                    "choice": "deny",
+                    "expected_approval_id": approval_b.approval_id,
+                },
+            )
+
+        assert second.status == 200
+        status = adapter._run_statuses[run_id]
+        assert status["status"] == "running"
+        assert status["pending_approvals"] == []
+        assert status["pending_approval"] is None
+
+    @pytest.mark.parametrize("terminal_status", ["completed", "failed", "cancelled"])
+    def test_terminal_status_clears_stale_pending_approvals(
+        self, adapter, terminal_status
+    ):
+        run_id = "run_terminal_cleanup"
+        adapter._run_statuses[run_id] = {
+            "run_id": run_id,
+            "status": "waiting_for_approval",
+            "pending_approval": {"approval_id": "approval_stale"},
+            "pending_approvals": [{"approval_id": "approval_stale"}],
+        }
+
+        adapter._set_run_status(
+            run_id,
+            terminal_status,
+            last_event=f"run.{terminal_status}",
+        )
+
+        status = adapter._run_statuses[run_id]
+        assert status["pending_approval"] is None
+        assert status["pending_approvals"] == []
+
+    @pytest.mark.asyncio
+    async def test_stop_finalizes_pending_as_deny_before_stale_cas(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_stop_approval_race"
+        pending = approval_mod._ApprovalEntry({"command": "danger"})
+        self._bind_pending(adapter, run_id, pending)
+        adapter._active_run_agents[run_id] = MagicMock()
+
+        async with TestClient(TestServer(app)) as cli:
+            stop = await cli.post(f"/v1/runs/{run_id}/stop")
+            stale = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={
+                    "choice": "once",
+                    "expected_approval_id": pending.approval_id,
+                },
+            )
+            stale_body = await stale.json()
+
+        assert stop.status == 200
+        assert stale.status == 409
+        assert stale_body["error"]["code"] == "approval_decision_conflict"
+        assert pending.result == "deny"
+        assert pending.event.is_set()
+        status = adapter._run_statuses[run_id]
+        assert status["pending_approval"] is None
+        assert status["pending_approvals"] == []
+
     def test_concurrent_matching_decisions_resolve_once(self):
         run_id = "run_concurrent_cas"
         pending = approval_mod._ApprovalEntry({"command": "danger"})
@@ -772,6 +867,64 @@ class TestRunApprovalCompareAndSet:
         assert pending.result == "once"
         assert pending.event.is_set()
 
+    def test_interrupt_finalization_wins_atomic_race_with_cas(self, monkeypatch):
+        session_key = "run_interrupt_cas"
+        approval_requested = threading.Event()
+        interrupt_finalized = threading.Event()
+        release_finalize_callback = threading.Event()
+        approval_id = {}
+        decision = {}
+
+        monkeypatch.setattr(approval_mod, "is_interrupted", lambda: True)
+        original_notify = approval_mod._notify_gateway_entry_finalized
+
+        def _pause_after_atomic_finalize(entry):
+            interrupt_finalized.set()
+            assert release_finalize_callback.wait(timeout=3)
+            original_notify(entry)
+
+        monkeypatch.setattr(
+            approval_mod,
+            "_notify_gateway_entry_finalized",
+            _pause_after_atomic_finalize,
+        )
+
+        def _notify(data):
+            approval_id["value"] = data["approval_id"]
+            approval_requested.set()
+
+        def _wait():
+            decision.update(
+                approval_mod._await_gateway_decision(
+                    session_key,
+                    _notify,
+                    {
+                        "command": "danger",
+                        "description": "danger",
+                        "pattern_key": "danger",
+                        "pattern_keys": ["danger"],
+                    },
+                )
+            )
+
+        waiter = threading.Thread(target=_wait)
+        waiter.start()
+        assert approval_requested.wait(timeout=3)
+        assert interrupt_finalized.wait(timeout=3)
+
+        stale = approval_mod.resolve_gateway_approval_cas(
+            session_key,
+            "once",
+            approval_id["value"],
+        )
+        release_finalize_callback.set()
+        waiter.join(timeout=3)
+
+        assert stale["status"] == "decision_conflict"
+        assert stale["previous_choice"] == "deny"
+        assert decision["resolved"] is True
+        assert decision["choice"] == "deny"
+
     @pytest.mark.asyncio
     async def test_expired_match_fails_closed(self, adapter):
         app = _create_runs_app(adapter)
@@ -794,6 +947,9 @@ class TestRunApprovalCompareAndSet:
         assert body["error"]["code"] == "approval_expired"
         assert expired.result is None
         assert expired.event.is_set()
+        status = adapter._run_statuses[run_id]
+        assert status["pending_approval"] is None
+        assert status["pending_approvals"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -21,6 +21,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -2154,11 +2155,18 @@ def _denial_breaker_addendum(session_key: str) -> str:
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("event", "data", "result", "reason", "approval_id", "deadline")
 
     def __init__(self, data: dict):
         self.event = threading.Event()
-        self.data = data          # command, description, pattern_keys, …
+        self.data = dict(data)    # command, description, pattern_keys, …
+        timeout = max(_get_approval_timeout(), 0)
+        created_at = time.time()
+        self.approval_id = f"approval_{uuid.uuid4().hex}"
+        self.data["approval_id"] = self.approval_id
+        self.data["created_at"] = created_at
+        self.data["expires_at"] = created_at + timeout
+        self.deadline = time.monotonic() + timeout
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
@@ -2168,6 +2176,8 @@ class _ApprovalEntry:
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+_resolved_gateway_approvals: dict[tuple[str, str], dict] = {}
+_RESOLVED_GATEWAY_APPROVALS_MAX = 1024
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -2229,6 +2239,97 @@ def resolve_gateway_approval(session_key: str, choice: str,
             entry.reason = reason
         entry.event.set()
     return len(targets)
+
+
+def resolve_gateway_approval_cas(
+    session_key: str,
+    choice: str,
+    expected_approval_id: str,
+    reason: Optional[str] = None,
+) -> dict:
+    """Atomically resolve exactly the pending approval named by the caller.
+
+    A repeated decision with the same approval id and choice is idempotent.
+    Reusing an approval id with a different choice, or presenting an id that
+    does not name a currently pending request, fails without resolving any
+    other approval in the session.
+    """
+    expected_approval_id = str(expected_approval_id or "").strip()
+    if not expected_approval_id:
+        return {"status": "approval_id_required", "resolved": 0}
+
+    target = None
+    expired = False
+    key = (session_key, expected_approval_id)
+    with _lock:
+        previous = _resolved_gateway_approvals.get(key)
+        if previous is not None:
+            if previous["choice"] == choice:
+                return {
+                    "status": "already_resolved",
+                    "resolved": 0,
+                    "approval_id": expected_approval_id,
+                    "choice": choice,
+                    "idempotent": True,
+                }
+            return {
+                "status": "decision_conflict",
+                "resolved": 0,
+                "approval_id": expected_approval_id,
+                "choice": choice,
+                "previous_choice": previous["choice"],
+            }
+
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return {
+                "status": "not_pending",
+                "resolved": 0,
+                "approval_id": expected_approval_id,
+            }
+
+        for entry in queue:
+            if entry.approval_id == expected_approval_id:
+                target = entry
+                break
+        if target is None:
+            return {
+                "status": "mismatch",
+                "resolved": 0,
+                "approval_id": expected_approval_id,
+            }
+
+        queue.remove(target)
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+
+        if time.monotonic() >= target.deadline:
+            expired = True
+        else:
+            target.result = choice
+            if reason:
+                target.reason = reason
+            _resolved_gateway_approvals[key] = {
+                "choice": choice,
+                "resolved_at": time.time(),
+            }
+            while len(_resolved_gateway_approvals) > _RESOLVED_GATEWAY_APPROVALS_MAX:
+                _resolved_gateway_approvals.pop(next(iter(_resolved_gateway_approvals)))
+        target.event.set()
+
+    if expired:
+        return {
+            "status": "expired",
+            "resolved": 0,
+            "approval_id": expected_approval_id,
+        }
+    return {
+        "status": "resolved",
+        "resolved": 1,
+        "approval_id": expected_approval_id,
+        "choice": choice,
+        "idempotent": False,
+    }
 
 
 def has_blocking_approval(session_key: str) -> bool:
@@ -3263,7 +3364,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     # Notify the user (bridges sync agent thread → async gateway)
     try:
-        notify_cb(approval_data)
+        notify_cb(entry.data)
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
         _drop_entry()
@@ -3274,15 +3375,13 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     # every ~10s to the agent's inactivity tracker — otherwise the gateway
     # watchdog kills the agent while the user is still responding. Mirrors
     # _wait_for_process() cadence.
-    timeout = _get_approval_timeout()
-
     try:
         from tools.environments.base import touch_activity_if_due
     except Exception:  # pragma: no cover
         touch_activity_if_due = None
 
     _now = time.monotonic()
-    _deadline = _now + max(timeout, 0)
+    _deadline = entry.deadline
     _activity_state = {"last_touch": _now, "start": _now}
     resolved = False
     while True:
@@ -3301,6 +3400,9 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
             )
             entry.result = "deny"
             entry.event.set()
+            resolved = True
+            break
+        if entry.event.is_set():
             resolved = True
             break
         _remaining = _deadline - time.monotonic()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2155,7 +2155,10 @@ def _denial_breaker_addendum(session_key: str) -> str:
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason", "approval_id", "deadline")
+    __slots__ = (
+        "event", "data", "result", "reason", "approval_id", "deadline",
+        "finalized_cb",
+    )
 
     def __init__(self, data: dict):
         self.event = threading.Event()
@@ -2167,6 +2170,7 @@ class _ApprovalEntry:
         self.data["created_at"] = created_at
         self.data["expires_at"] = created_at + timeout
         self.deadline = time.monotonic() + timeout
+        self.finalized_cb = None
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
@@ -2176,11 +2180,12 @@ class _ApprovalEntry:
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+_gateway_finalize_cbs: dict[str, object] = {}
 _resolved_gateway_approvals: dict[tuple[str, str], dict] = {}
 _RESOLVED_GATEWAY_APPROVALS_MAX = 1024
 
 
-def register_gateway_notify(session_key: str, cb) -> None:
+def register_gateway_notify(session_key: str, cb, finalized_cb=None) -> None:
     """Register a per-session callback for sending approval requests to the user.
 
     The callback signature is ``cb(approval_data: dict) -> None`` where
@@ -2190,6 +2195,59 @@ def register_gateway_notify(session_key: str, cb) -> None:
     """
     with _lock:
         _gateway_notify_cbs[session_key] = cb
+        if finalized_cb is not None:
+            _gateway_finalize_cbs[session_key] = finalized_cb
+        else:
+            _gateway_finalize_cbs.pop(session_key, None)
+
+
+def _remember_gateway_resolution_locked(
+    session_key: str,
+    entry: _ApprovalEntry,
+    choice: Optional[str],
+    status: str,
+) -> None:
+    _resolved_gateway_approvals[(session_key, entry.approval_id)] = {
+        "choice": choice,
+        "status": status,
+        "resolved_at": time.time(),
+    }
+    while len(_resolved_gateway_approvals) > _RESOLVED_GATEWAY_APPROVALS_MAX:
+        _resolved_gateway_approvals.pop(next(iter(_resolved_gateway_approvals)))
+
+
+def _finalize_gateway_entry_locked(
+    session_key: str,
+    entry: _ApprovalEntry,
+    choice: Optional[str],
+    *,
+    reason: Optional[str] = None,
+    status: str = "resolved",
+) -> bool:
+    """Finalize and dequeue one entry while the caller holds ``_lock``."""
+    queue = _gateway_queues.get(session_key)
+    if not queue or entry not in queue or entry.event.is_set():
+        return False
+    queue.remove(entry)
+    if not queue:
+        _gateway_queues.pop(session_key, None)
+    entry.result = choice
+    if reason:
+        entry.reason = reason
+    _remember_gateway_resolution_locked(session_key, entry, choice, status)
+    entry.event.set()
+    return True
+
+
+def _notify_gateway_entry_finalized(entry: _ApprovalEntry) -> None:
+    if entry.finalized_cb is None:
+        return
+    try:
+        payload = dict(entry.data)
+        payload["_resolution_choice"] = entry.result
+        entry.finalized_cb(payload)
+    except Exception as exc:
+        logger.debug("Gateway approval finalize callback failed: %s", exc)
 
 
 def unregister_gateway_notify(session_key: str) -> None:
@@ -2200,9 +2258,14 @@ def unregister_gateway_notify(session_key: str) -> None:
     """
     with _lock:
         _gateway_notify_cbs.pop(session_key, None)
-        entries = _gateway_queues.pop(session_key, [])
-    for entry in entries:
-        entry.event.set()
+        _gateway_finalize_cbs.pop(session_key, None)
+        entries = list(_gateway_queues.get(session_key, []))
+        finalized = [
+            entry for entry in entries
+            if _finalize_gateway_entry_locked(session_key, entry, "deny")
+        ]
+    for entry in finalized:
+        _notify_gateway_entry_finalized(entry)
 
 
 def resolve_gateway_approval(session_key: str, choice: str,
@@ -2221,24 +2284,24 @@ def resolve_gateway_approval(session_key: str, choice: str,
 
     Returns the number of approvals resolved (0 means nothing was pending).
     """
+    finalized = []
     with _lock:
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
         if resolve_all:
             targets = list(queue)
-            queue.clear()
         else:
-            targets = [queue.pop(0)]
-        if not queue:
-            _gateway_queues.pop(session_key, None)
-
-    for entry in targets:
-        entry.result = choice
-        if reason:
-            entry.reason = reason
-        entry.event.set()
-    return len(targets)
+            targets = [queue[0]]
+        finalized = [
+            entry for entry in targets
+            if _finalize_gateway_entry_locked(
+                session_key, entry, choice, reason=reason
+            )
+        ]
+    for entry in finalized:
+        _notify_gateway_entry_finalized(entry)
+    return len(finalized)
 
 
 def resolve_gateway_approval_cas(
@@ -2264,6 +2327,12 @@ def resolve_gateway_approval_cas(
     with _lock:
         previous = _resolved_gateway_approvals.get(key)
         if previous is not None:
+            if previous.get("status") == "expired":
+                return {
+                    "status": "expired",
+                    "resolved": 0,
+                    "approval_id": expected_approval_id,
+                }
             if previous["choice"] == choice:
                 return {
                     "status": "already_resolved",
@@ -2299,23 +2368,29 @@ def resolve_gateway_approval_cas(
                 "approval_id": expected_approval_id,
             }
 
-        queue.remove(target)
-        if not queue:
-            _gateway_queues.pop(session_key, None)
-
+        if target.event.is_set():
+            return {
+                "status": "already_finalized",
+                "resolved": 0,
+                "approval_id": expected_approval_id,
+            }
         if time.monotonic() >= target.deadline:
             expired = True
+            finalized = _finalize_gateway_entry_locked(
+                session_key, target, None, status="expired"
+            )
         else:
-            target.result = choice
-            if reason:
-                target.reason = reason
-            _resolved_gateway_approvals[key] = {
-                "choice": choice,
-                "resolved_at": time.time(),
-            }
-            while len(_resolved_gateway_approvals) > _RESOLVED_GATEWAY_APPROVALS_MAX:
-                _resolved_gateway_approvals.pop(next(iter(_resolved_gateway_approvals)))
-        target.event.set()
+            finalized = _finalize_gateway_entry_locked(
+                session_key, target, choice, reason=reason
+            )
+
+    if not finalized:
+        return {
+            "status": "already_finalized",
+            "resolved": 0,
+            "approval_id": expected_approval_id,
+        }
+    _notify_gateway_entry_finalized(target)
 
     if expired:
         return {
@@ -2336,6 +2411,16 @@ def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
         return bool(_gateway_queues.get(session_key))
+
+
+def list_gateway_approvals(session_key: str) -> list[dict]:
+    """Return snapshots of the session's currently pending approvals."""
+    with _lock:
+        return [
+            dict(entry.data)
+            for entry in _gateway_queues.get(session_key, [])
+            if not entry.event.is_set()
+        ]
 
 
 def submit_pending(session_key: str, approval: dict):
@@ -3340,6 +3425,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     entry = _ApprovalEntry(approval_data)
     with _lock:
+        entry.finalized_cb = _gateway_finalize_cbs.get(session_key)
         _gateway_queues.setdefault(session_key, []).append(entry)
 
     def _drop_entry() -> None:
@@ -3398,15 +3484,25 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 "returning deny for session %s",
                 session_key,
             )
-            entry.result = "deny"
-            entry.event.set()
-            resolved = True
+            with _lock:
+                finalized = _finalize_gateway_entry_locked(
+                    session_key, entry, "deny"
+                )
+            if finalized:
+                _notify_gateway_entry_finalized(entry)
+            resolved = finalized or entry.event.is_set()
             break
         if entry.event.is_set():
             resolved = True
             break
         _remaining = _deadline - time.monotonic()
         if _remaining <= 0:
+            with _lock:
+                finalized = _finalize_gateway_entry_locked(
+                    session_key, entry, None, status="expired"
+                )
+            if finalized:
+                _notify_gateway_entry_finalized(entry)
             break
         if entry.event.wait(timeout=min(1.0, _remaining)):
             resolved = True

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -250,6 +250,12 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
+    "run_approval_compare_and_set": {
+      "version": 1,
+      "required": true,
+      "request_id_field": "expected_approval_id",
+      "event_id_field": "approval_id"
+    },
     "run_stop": true
   }
 }
@@ -371,9 +377,21 @@ Poll the current run state. This is useful for dashboards that need status witho
 
 Statuses are retained briefly after terminal states (`completed`, `failed`, or `cancelled`) for polling and UI reconciliation.
 
+While a run is waiting for one or more human decisions, status includes
+`pending_approvals`. Each item contains the immutable `approval_id`,
+`created_at`, `expires_at`, and allowed `choices`. For compatibility,
+`pending_approval` contains the same item when exactly one request is pending;
+it is `null` when none or multiple are pending. Both fields are cleared when
+the run completes, fails, is cancelled, stops, or the request expires.
+
 ### GET /v1/runs/\{run_id\}/events
 
 Server-Sent Events stream of the run's tool-call progress, token deltas, and lifecycle events. Designed for dashboards and thick clients that want to attach/detach without losing state.
+
+An `approval.request` event includes the same immutable `approval_id`,
+`created_at`, `expires_at`, and `choices` fields exposed by run status. Clients
+must retain that `approval_id` and return it as `expected_approval_id`; a
+decision must never be inferred from only the run ID.
 
 When the agent delegates work to background subagents, the stream also carries
 `subagent.start` and `subagent.complete` lifecycle events, so clients can
@@ -401,7 +419,55 @@ running.
 
 ### POST /v1/runs/\{run_id\}/approval
 
-Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). The body carries the approval decision; the run resumes once the decision is recorded. This endpoint is advertised in `/v1/capabilities` as the `run_approval` feature so external UIs can detect support before surfacing an approval prompt.
+Resolve exactly one pending approval for a run that is waiting on a human
+decision. This endpoint uses compare-and-set: `expected_approval_id` is
+mandatory and must match the immutable ID from `approval.request` or
+`pending_approvals`.
+
+```json
+{
+  "choice": "once",
+  "expected_approval_id": "approval_abc123"
+}
+```
+
+The first matching decision returns:
+
+```json
+{
+  "object": "hermes.run.approval_response",
+  "run_id": "run_abc123",
+  "approval_id": "approval_abc123",
+  "choice": "once",
+  "resolved": 1,
+  "idempotent": false
+}
+```
+
+Repeating the same ID and choice is safe and returns HTTP 200 with
+`"resolved": 0` and `"idempotent": true`, including after the run reaches a
+terminal state while its retained status is available. Reusing the ID with a
+different choice fails closed.
+
+Errors use the normal OpenAI-style error envelope:
+
+- HTTP 400 `invalid_approval_choice` — unsupported `choice`.
+- HTTP 400 `approval_resolve_all_not_supported` — exact decisions cannot use
+  `all` or `resolve_all`.
+- HTTP 409 `approval_id_required` — `expected_approval_id` was omitted.
+- HTTP 409 `approval_id_mismatch` — the ID does not name a current request.
+- HTTP 409 `approval_expired` — the matching request passed its deadline.
+- HTTP 409 `approval_decision_conflict` — that ID was already finalized with a
+  different decision, including a concurrent stop/interrupt denial.
+- HTTP 409 `approval_not_pending` or `approval_not_active` — the run has no
+  resolvable approval state.
+
+The mandatory contract is discoverable at
+`features.run_approval_compare_and_set` in `/v1/capabilities`. Version `1`
+advertises `required: true`, `event_id_field: "approval_id"`, and
+`request_id_field: "expected_approval_id"`. Clients that do not discover this
+capability must not display an actionable approval control, because legacy
+run-ID-only decisions are unsafe.
 
 ## Jobs API (background scheduled work)
 


### PR DESCRIPTION
## Problem

The runs API currently resolves approvals by run/session plus choice. If approval A is replaced by later approval B before a delayed client response arrives, the stale response can resolve B.

I reproduced this on current `main`: a POST carrying a stale expected ID for A returned 200, set replacement B to `once`, and released B.

## What this changes

- assigns an immutable random `approval_id` when each gateway approval is enqueued
- exposes the ID and expiry in `approval.request` events and run status
- requires `expected_approval_id` on `POST /v1/runs/{run_id}/approval`
- atomically compares and finalizes the exact pending entry under the existing approval lock
- rejects missing, mismatched, expired, or conflicting decisions
- makes same-ID/same-choice retries idempotent
- finalizes interrupt, stop, timeout, legacy resolution, and CAS through one locked transition
- represents multiple pending approvals and clears stale pending state on terminal transitions
- advertises the mandatory v1 CAS contract through `/v1/capabilities`
- documents the event, status, request, response, and error shapes

Legacy non-API gateway resolvers retain their existing behavior. Legacy API requests without an expected ID fail closed because preserving that path would preserve the vulnerability.

## Validation

```text
scripts/run_tests.sh   tests/gateway/test_api_server_runs.py   tests/gateway/test_api_server.py   tests/gateway/test_approve_deny_commands.py   tests/tools/test_approval_interrupt.py -q

335 passed, 0 failed
```

Also passed:

- focused Ruff checks
- `git diff --check`
- independent review of interrupt/CAS races, multi-pending lifecycle, terminal cleanup, and capability discovery

New tests cover delayed A/current B, exact match, missing/mismatched IDs, matching/conflicting retries, expiry, concurrent resolution, cross-run isolation, stop/interrupt races, multi-pending status, terminal cleanup, and capability advertisement.