### PR TITLE
fix(windows): discover S4U gateways from profile PID files

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -603,7 +603,18 @@ def find_gateway_pids(
     """
     _exclude = set(exclude_pids or set())
     pids: list[int] = []
-    if not all_profiles:
+    if all_profiles:
+        # An S4U Scheduled Task runs in session 0 and can hide its command line
+        # from CIM/WMIC/psutil even for the same user.  The process-table scan
+        # below therefore cannot identify it as ``gateway run``.  Validated
+        # profile PID/lock records remain readable, so include them in the
+        # all-profile sweep before falling back to service/process discovery.
+        # This is especially important for ``hermes update``: missing the S4U
+        # gateway here leaves its venv launcher alive, and the later .pyd-holder
+        # guard correctly aborts the update as unsafe.
+        for proc in find_profile_gateway_processes(exclude_pids=_exclude):
+            _append_unique_pid(pids, proc.pid, _exclude)
+    else:
         try:
             from gateway.status import get_running_pid
 

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -452,6 +452,36 @@ def test_quarantine_actionable_warning_when_everything_fails(
 # ---------------------------------------------------------------------------
 
 
+def test_all_profile_gateway_scan_uses_pid_files_when_s4u_hides_command_line(
+    monkeypatch,
+):
+    """S4U hides argv, but its validated gateway.pid record remains readable."""
+    import hermes_cli.gateway as gateway_mod
+
+    profile_proc = SimpleNamespace(profile="default", path="ignored", pid=321)
+    excluded_proc = SimpleNamespace(profile="work", path="ignored", pid=654)
+    seen_exclusions = []
+
+    def fake_profile_processes(exclude_pids=None):
+        seen_exclusions.append(exclude_pids)
+        # Return the excluded PID too: the aggregator must remain defensive
+        # even if a discovery source fails to honor the exclusion itself.
+        return [profile_proc, excluded_proc]
+
+    # Repeating the profile PID through service discovery must not duplicate it.
+    monkeypatch.setattr(gateway_mod, "_get_service_pids", lambda: {321})
+    monkeypatch.setattr(
+        gateway_mod,
+        "find_profile_gateway_processes",
+        fake_profile_processes,
+    )
+    monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_scan_gateway_pids", lambda *_a, **_k: [])
+
+    assert gateway_mod.find_gateway_pids(exclude_pids={654}, all_profiles=True) == [321]
+    assert seen_exclusions == [{654}]
+
+
 @patch.object(cli_main, "_is_windows", return_value=True)
 def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
     _winp,


### PR DESCRIPTION
## Summary

- include validated per-profile PID/lock records in all-profile gateway discovery
- preserve existing service/process-table fallbacks, PID exclusions, and deduplication
- allow `hermes update` to pause Windows S4U/Session 0 gateways whose command lines are inaccessible to CIM, WMIC, or psutil

## Problem

On Windows, an S4U Scheduled Task runs in Session 0 without an interactive logon. The gateway remains visible by PID, and its validated profile `gateway.pid`/runtime lock remains readable, but an unelevated interactive updater may receive no `CommandLine` or `ExecutablePath` from CIM/WMIC/psutil.

`find_gateway_pids(all_profiles=True)` previously skipped the current-profile PID lookup and depended on service/process-table discovery. That meant the updater could miss an S4U gateway during its pause phase, then correctly abort later when the venv-holder guard found the still-running Python process.

This complements the broader Windows update recovery work discussed in #53124: that PR explicitly identified S4U/Session 0 command-line visibility as an uncovered case.

## Fix

When `all_profiles=True`, merge the already-validated records returned by `find_profile_gateway_processes()` before the existing service and process-table scans. `_append_unique_pid()` continues to enforce caller exclusions, self-PID rejection, and deduplication.

The regression test models inaccessible process argv and verifies that:

- the profile PID is still discovered
- `exclude_pids` is propagated and enforced defensively
- a PID repeated by service discovery is returned only once

## Verification

- native Windows isolated per-file runner: `26 passed`
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_update_concurrent_quarantine.py`
- `git diff --check origin/main...HEAD`
- independent pre-commit review: no security concerns or logic errors
- real S4U Scheduled Task validation on Windows 11 IoT Enterprise LTSC 2024 (Session 0):
  - before the fix, all-profile discovery missed the live gateway while profile PID discovery found it
  - after the fix, all-profile discovery returned the profile PID
  - update pause released all Hermes venv holders
  - resume relaunched the gateway with a new validated PID

## Scope

Two files only; no account names, task names, machine paths, or deployment-specific process names are hardcoded.
