### PR TITLE
fix(tests): preserve config module identity in backup tests

### DIFF
--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2296,10 +2296,9 @@ class TestRunPreUpdateBackup:
         monkeypatch.setenv("HERMES_HOME", str(root))
         # Make Path.home() point at tmp_path for anything that uses it
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        # Bust caches for hermes_cli.config + hermes_constants so they pick up HERMES_HOME
-        for mod in list(__import__("sys").modules.keys()):
-            if mod.startswith("hermes_cli.config") or mod == "hermes_constants":
-                del __import__("sys").modules[mod]
+        # Config reads resolve HERMES_HOME dynamically and their caches are
+        # keyed by config path. Do not remove shared modules from sys.modules:
+        # other test modules may retain imports from the existing module object.
         return root
 
     @staticmethod
@@ -2309,10 +2308,6 @@ class TestRunPreUpdateBackup:
             "_config_version": 22,
             "updates": {"pre_update_backup": value},
         }))
-        import sys as _sys
-        for mod in list(_sys.modules.keys()):
-            if mod.startswith("hermes_cli.config"):
-                del _sys.modules[mod]
 
     @staticmethod
     def _zips(hermes_home):


### PR DESCRIPTION
## What does this PR do?

Fixes an order-dependent test-isolation failure in the CLI suite. The pre-update-backup fixture removed `hermes_cli.config` and `hermes_constants` directly from `sys.modules`. Other collected tests retained imports from the old config module, while string-based patches resolved the newly imported module, so the patched sanitizer was not called.

The fixture now relies on Hermes' path/mtime-keyed config caches instead of replacing shared module objects.

## Related Issue

Fixes #73144

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Removed direct `sys.modules` eviction from `TestRunPreUpdateBackup` setup and mode configuration in `tests/hermes_cli/test_backup.py`.
- Kept the backup tests' `HERMES_HOME` and `Path.home()` isolation intact.
- Restored compatibility with `TestSanitizeEnvLines.test_migrate_reports_normalized_line_formatting` when it runs after the backup test.

## How to Test

1. On unmodified current `main`, run:
   ```bash
   pytest \
     tests/hermes_cli/test_backup.py::TestRunPreUpdateBackup::test_default_creates_quick_snapshot_only \
     tests/hermes_cli/test_config.py::TestSanitizeEnvLines::test_migrate_reports_normalized_line_formatting \
     -q -o 'addopts='
   ```
   This produces `1 passed, 1 failed`: the config test captures no normalization message.
2. Apply this change and rerun the same command: `2 passed`.
3. Run the focused suites:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/hermes_cli/test_config.py -q
   ```
   Result: `350 passed`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (the wider CLI suite has unrelated existing failures; targeted canonical suites pass)
- [x] I've added/retained regression coverage through the exact ordering repro
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation N/A — test-isolation-only change
- [x] `cli-config.yaml.example` N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] Cross-platform impact N/A — Python test-process isolation only
- [x] Tool descriptions/schemas N/A

## Screenshots / Logs

Focused validation:

```text
163 passed
350 passed
ruff check: All checks passed
```
