### PR TITLE
fix(desktop): rehydrate persisted native OAuth tokens with a stored-set parser (#73271)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -135,6 +135,7 @@ import {
 import {
   nativeRefreshUrl,
   type NativeTokenSet,
+  parseStoredTokenSet,
   parseTokenResponse,
   resolveLoginStrategy,
   tokenNeedsRefresh
@@ -6098,7 +6099,11 @@ function _loadNativeTokens(baseUrl: string): NativeTokenSet | null {
       return null
     }
 
-    const tokens = parseTokenResponse(JSON.parse(plaintext))
+    // Reload uses the stored-set parser (camelCase), NOT parseTokenResponse
+    // (snake_case, for raw gateway responses) — the persisted blob is a
+    // JSON.stringify'd NativeTokenSet, so the raw parser would reject it and
+    // strand a signed-in user on the sign-in screen after restart (#73271).
+    const tokens = parseStoredTokenSet(JSON.parse(plaintext))
     _nativeTokens.set(baseUrl, tokens)
 
     return tokens

--- a/apps/desktop/electron/native-oauth.test.ts
+++ b/apps/desktop/electron/native-oauth.test.ts
@@ -20,6 +20,7 @@ import {
   nativeRefreshUrl,
   nativeTokenUrl,
   parseLoopbackCallback,
+  parseStoredTokenSet,
   parseTokenResponse,
   resolveLoginStrategy,
   statusSupportsNativeFlow,
@@ -171,6 +172,48 @@ test('parseTokenResponse throws on a missing access token', () => {
 
 test('parseTokenResponse tolerates an absent refresh token / expiry', () => {
   const t = parseTokenResponse({ access_token: 'AT' })
+
+  assert.equal(t.refreshToken, '')
+  assert.equal(t.expiresAt, 0)
+})
+
+// --- stored-token rehydration (#73271) ---
+
+test('parseStoredTokenSet rehydrates a persisted camelCase NativeTokenSet', () => {
+  const original = {
+    accessToken: 'AT-stored',
+    refreshToken: 'RT-stored',
+    expiresAt: 1893456000,
+    provider: 'nous',
+    userId: 'u-9'
+  }
+
+  // Round-trip through the on-disk encoding: _persistNativeTokens writes
+  // JSON.stringify(tokens); _loadNativeTokens decrypts and JSON.parses it.
+  const t = parseStoredTokenSet(JSON.parse(JSON.stringify(original)))
+
+  assert.deepEqual(t, original)
+})
+
+test('parseTokenResponse cannot read a persisted set (the reload bug #73271)', () => {
+  // Guards against regressing to the wrong parser on the reload path: a
+  // persisted camelCase set has no snake_case access_token, so the raw-response
+  // parser throws — which is exactly why the stored path must use
+  // parseStoredTokenSet instead.
+  const persisted = JSON.parse(
+    JSON.stringify({ accessToken: 'AT', refreshToken: 'RT', expiresAt: 1, provider: 'nous', userId: 'u' })
+  )
+
+  assert.throws(() => parseTokenResponse(persisted), /missing access_token/i)
+  assert.equal(parseStoredTokenSet(persisted).accessToken, 'AT')
+})
+
+test('parseStoredTokenSet throws on a missing access token', () => {
+  assert.throws(() => parseStoredTokenSet({ refreshToken: 'RT' }), /missing accessToken/i)
+})
+
+test('parseStoredTokenSet tolerates an absent refresh token / expiry', () => {
+  const t = parseStoredTokenSet({ accessToken: 'AT' })
 
   assert.equal(t.refreshToken, '')
   assert.equal(t.expiresAt, 0)

--- a/apps/desktop/electron/native-oauth.ts
+++ b/apps/desktop/electron/native-oauth.ts
@@ -194,6 +194,37 @@ export function parseTokenResponse(body: any): NativeTokenSet {
 }
 
 /**
+ * Parse a *persisted* NativeTokenSet back into a validated NativeTokenSet.
+ * This is the reload counterpart of `parseTokenResponse`: the on-disk blob is
+ * `JSON.stringify(NativeTokenSet)` (camelCase — `accessToken`, `refreshToken`,
+ * `expiresAt`, …), whereas `parseTokenResponse` reads the raw gateway
+ * `/auth/native/token` response (snake_case — `access_token`, …). The two
+ * payloads use different field names, so a stored set must NOT be run through
+ * the raw-response parser — that path reads `access_token`, finds it absent on
+ * every persisted set, and throws `missing access_token`, stranding a
+ * signed-in user on the sign-in screen after a restart. Throws on a
+ * missing/empty access token so a corrupt store fails loudly rather than
+ * rehydrating junk.
+ */
+export function parseStoredTokenSet(body: any): NativeTokenSet {
+  const accessToken = String(body?.accessToken || '')
+
+  if (!accessToken) {
+    throw new Error('Stored native token set missing accessToken')
+  }
+
+  const expiresAt = Number(body?.expiresAt)
+
+  return {
+    accessToken,
+    refreshToken: String(body?.refreshToken || ''),
+    expiresAt: Number.isFinite(expiresAt) ? expiresAt : 0,
+    provider: String(body?.provider || ''),
+    userId: String(body?.userId || '')
+  }
+}
+
+/**
  * True when a stored token set is at/near expiry and should be refreshed
  * before use. `skewSeconds` refreshes slightly early to avoid a race where
  * the token expires in flight (mirrors the server's 60s cookie floor).


### PR DESCRIPTION
Fixes #73271

## Problem

Desktop native OAuth sign-in works during a process lifetime, but a **cold restart** reports the user as signed out even though a valid, encrypted native token record was persisted. The Desktop log shows `failed to load tokens: Gateway token response missing access_token`.

## Root cause

The persist and reload paths disagree on the token payload shape:

- `_persistNativeTokens` writes `JSON.stringify(tokens)`, where `tokens` is an internal **camelCase** `NativeTokenSet` (`accessToken`, `refreshToken`, `expiresAt`, `provider`, `userId`).
- `_loadNativeTokens` fed that decrypted JSON to `parseTokenResponse`, which parses the **raw gateway response** shape (**snake_case** `access_token`, …).

A persisted set has no `access_token`, so `parseTokenResponse` throws `Gateway token response missing access_token`; the surrounding `catch` swallows it and returns `null`, stranding a signed-in user on the sign-in recovery screen after every restart.

## Fix

Add `parseStoredTokenSet` — the reload counterpart of `parseTokenResponse` — which validates/normalizes a persisted camelCase `NativeTokenSet`, and use it on the load path (`_loadNativeTokens`). The token-response path (`parseTokenResponse`) is unchanged for the live `/auth/native/token` + `/auth/native/refresh` exchanges. Existing on-disk tokens are already camelCase, so they rehydrate without a re-login.

## Tests

`apps/desktop/electron/native-oauth.test.ts`:
- `parseStoredTokenSet` round-trips a persisted set through `JSON.stringify` → `JSON.parse` (the on-disk encoding) and rehydrates it.
- A regression guard asserting `parseTokenResponse` throws on a persisted camelCase set — encoding why the reload path must use `parseStoredTokenSet`.
- Missing-token and absent-refresh/expiry cases, mirroring the existing `parseTokenResponse` coverage.

No token value is exposed to reproduce or fix this; the failure is entirely after safe-storage decryption and before any token use.

`electron` vitest project: 837 passed. `parseStoredTokenSet`/`parseTokenResponse` files lint- and typecheck-clean (`tsconfig.electron.json`).

_The arm64 fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change._