### PR TITLE
fix(desktop): normalise artifact timestamp units and harden regressions

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -17,6 +17,17 @@ export interface ArtifactRecord {
   timestamp: number
 }
 
+function toEpochMs(value: null | number | undefined): null | number {
+  if (!Number.isFinite(value)) {
+    return null
+  }
+
+  const ts = Number(value)
+
+  // Session DB values are often Unix seconds while JS Date expects ms.
+  return ts < 100_000_000_000 ? ts * 1000 : ts
+}
+
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)\s]+)\)/g
 const URL_RE = /https?:\/\/[^\s<>"')]+/g
@@ -273,7 +284,11 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
-        timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
+        timestamp:
+          toEpochMs(message.timestamp) ??
+          toEpochMs(session.last_active) ??
+          toEpochMs(session.started_at) ??
+          Date.now()
       })
     })
   }

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -17,6 +17,12 @@ export interface ArtifactRecord {
   timestamp: number
 }
 
+// Numeric epoch timestamps before 1973 are treated as Unix seconds. This is
+// the supported contract for the ambiguous range: millisecond timestamps that
+// far in the past are not realistic for these use cases. A number alone cannot
+// distinguish them from later second timestamps.
+const EPOCH_MILLISECONDS_CUTOFF = Date.UTC(1973, 0, 1)
+
 function toEpochMs(value: null | number | undefined): null | number {
   if (!Number.isFinite(value)) {
     return null
@@ -25,7 +31,7 @@ function toEpochMs(value: null | number | undefined): null | number {
   const ts = Number(value)
 
   // Session DB values are often Unix seconds while JS Date expects ms.
-  return ts < 100_000_000_000 ? ts * 1000 : ts
+  return ts < EPOCH_MILLISECONDS_CUTOFF ? ts * 1000 : ts
 }
 
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -67,6 +67,45 @@ describe('collectArtifactsForSession', () => {
     })
   })
 
+  it('normalizes session-level unix-second timestamps to epoch milliseconds', () => {
+    const session = makeSession({ last_active: 1_700_000_000, started_at: 1_699_000_000 })
+    const artifacts = collectArtifactsForSession(session, [
+      {
+        content: 'Reference: https://example.com/status',
+        role: 'assistant'
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]?.timestamp).toBe(1_700_000_000_000)
+  })
+
+  it('keeps message timestamps that are already in milliseconds', () => {
+    const artifacts = collectArtifactsForSession(makeSession({ last_active: 1_700_000_000 }), [
+      {
+        content: 'Reference: https://example.com/docs',
+        role: 'assistant',
+        timestamp: 1_700_000_123_456
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]?.timestamp).toBe(1_700_000_123_456)
+  })
+
+  it('converts fractional unix-second message timestamps to milliseconds', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Reference: https://example.com/fractional',
+        role: 'assistant',
+        timestamp: 1_700_000_000.125
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]?.timestamp).toBe(1_700_000_000_125)
+  })
+
   it('resolves remote image artifact thumbnails through the desktop fs bridge', async () => {
     const api = vi.fn(async ({ path }: { path: string }) => {
       if (path.startsWith('/api/fs/read-data-url?')) {

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -106,6 +106,30 @@ describe('collectArtifactsForSession', () => {
     expect(artifacts[0]?.timestamp).toBe(1_700_000_000_125)
   })
 
+  it('treats numeric epochs before 1973 as seconds at the unit boundary', () => {
+    const before1973 = 94_694_399
+    const millisecondsAt1973 = 94_694_400_000
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Reference: https://example.com/boundary',
+        role: 'assistant',
+        timestamp: before1973
+      }
+    ])
+
+    expect(artifacts[0]?.timestamp).toBe(before1973 * 1000)
+
+    const boundaryArtifacts = collectArtifactsForSession(makeSession({ id: 'session-boundary' }), [
+      {
+        content: 'Reference: https://example.com/boundary-ms',
+        role: 'assistant',
+        timestamp: millisecondsAt1973
+      }
+    ])
+
+    expect(boundaryArtifacts[0]?.timestamp).toBe(millisecondsAt1973)
+  })
+
   it('resolves remote image artifact thumbnails through the desktop fs bridge', async () => {
     const api = vi.fn(async ({ path }: { path: string }) => {
       if (path.startsWith('/api/fs/read-data-url?')) {

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -106,6 +106,23 @@ describe('collectArtifactsForSession', () => {
     expect(artifacts[0]?.timestamp).toBe(1_700_000_000_125)
   })
 
+  it('falls back to the session timestamp when a message timestamp is non-finite', () => {
+    const session = makeSession({ last_active: 1_700_000_000 })
+
+    for (const timestamp of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      const artifacts = collectArtifactsForSession(session, [
+        {
+          content: 'Reference: https://example.com/fallback',
+          role: 'assistant',
+          timestamp
+        }
+      ])
+
+      expect(artifacts).toHaveLength(1)
+      expect(artifacts[0]?.timestamp).toBe(1_700_000_000_000)
+    }
+  })
+
   it('treats numeric epochs before 1973 as seconds at the unit boundary', () => {
     const before1973 = 94_694_399
     const millisecondsAt1973 = 94_694_400_000


### PR DESCRIPTION
## Summary
- Normalises artifact timestamps at collection-time so Unix-second values are converted to epoch milliseconds before rendering, while millisecond inputs remain untouched.
- Adds explicit regression coverage for three timestamp classes in `apps/desktop/src/app/artifacts/index.test.ts`: epoch seconds, epoch milliseconds, and fractional epoch seconds.
- Keeps the change narrowly scoped to the Artifacts path, preserving existing behaviour in adjacent Desktop surfaces.

## Why this is not duplicate of existing PRs
- Existing open PRs (#42670, #42221, #42415) focus on the primary conversion fix; this contribution specifically strengthens regression guarantees for mixed timestamp precision, including fractional-second handling at the collection boundary.
- The test suite additions in this branch target precision-preservation semantics that are not asserted together in the listed PRs.
- The implementation remains minimal and can be cleanly reviewed as a salvage-hardening pass rather than a parallel broad refactor.

## Test plan
- `npm run test -- src/app/artifacts/index.test.ts`
  - Expected: all artifact regression tests pass, including new mixed-unit and fractional-unit cases.

## Risks / follow-ups
- End-to-end Desktop coverage for this exact timestamp pathway was attempted locally but proved unstable on this Windows host due Electron test-runtime lifecycle issues; this PR therefore ships deterministic unit-level regression hardening.
- Follow-up: add a Linux CI E2E fixture that injects deterministic timestamped artifact rows and asserts rendered time correctness in the Artifacts table.