### PR TITLE
feat(delegation): enforce read-only boundary and expose handoff trust status

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -504,6 +504,7 @@ def init_agent(
     max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
+    allowed_tool_names: List[str] = None,
     save_trajectories: bool = False,
     verbose_logging: bool = False,
     quiet_mode: bool = False,
@@ -581,6 +582,8 @@ def init_agent(
         max_iterations (int): Maximum number of tool calling iterations (default: 90)
         enabled_toolsets (List[str]): Only enable tools from these toolsets (optional)
         disabled_toolsets (List[str]): Disable tools from these toolsets (optional)
+        allowed_tool_names (List[str]): Exact tool-name allowlist applied after
+            toolset expansion and post-build tool injection (optional)
         save_trajectories (bool): Whether to save conversation trajectories to JSONL files (default: False)
         verbose_logging (bool): Enable verbose logging for debugging (default: False)
         quiet_mode (bool): Suppress progress output for clean CLI experience (default: False)
@@ -885,9 +888,14 @@ def init_agent(
     agent.provider_data_collection = provider_data_collection
     agent.openrouter_min_coding_score = openrouter_min_coding_score
 
-    # Store toolset filtering options
+    # Store toolset and exact-name filtering options.
     agent.enabled_toolsets = enabled_toolsets
     agent.disabled_toolsets = disabled_toolsets
+    agent.allowed_tool_names = (
+        frozenset(str(name) for name in allowed_tool_names)
+        if allowed_tool_names is not None
+        else None
+    )
     
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
@@ -2747,6 +2755,24 @@ def init_agent(
             agent.valid_tool_names.add(_tname)
             agent._context_engine_tool_names.add(_tname)
             _existing_tool_names.add(_tname)
+
+    # Exact-name capability boundary. Apply after registry toolset expansion
+    # and every post-build injection so mixed bundles cannot leak tools that a
+    # security-sensitive caller did not grant.
+    if agent.allowed_tool_names is not None:
+        agent.tools = [
+            tool
+            for tool in (agent.tools or [])
+            if (tool.get("function") or {}).get("name") in agent.allowed_tool_names
+        ]
+        agent.valid_tool_names = {
+            (tool.get("function") or {}).get("name") for tool in agent.tools
+        }
+        agent.valid_tool_names.discard(None)
+        if isinstance(agent._context_engine_tool_names, set):
+            agent._context_engine_tool_names.intersection_update(
+                agent.valid_tool_names
+            )
 
     # Notify context engine of session start
     if hasattr(agent, "context_compressor") and agent.context_compressor:

--- a/run_agent.py
+++ b/run_agent.py
@@ -447,6 +447,7 @@ class AIAgent:
         tool_delay: float = None,  # Deprecated: accepted for compatibility, ignored
         enabled_toolsets: List[str] = None,
         disabled_toolsets: List[str] = None,
+        allowed_tool_names: List[str] = None,
         save_trajectories: bool = False,
         verbose_logging: bool = False,
         quiet_mode: bool = False,
@@ -535,6 +536,7 @@ class AIAgent:
             max_iterations=max_iterations,
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
+            allowed_tool_names=allowed_tool_names,
             save_trajectories=save_trajectories,
             verbose_logging=verbose_logging,
             quiet_mode=quiet_mode,
@@ -8223,6 +8225,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            read_only=function_args.get("read_only"),
             background=(not _is_subagent),
             action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"),

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -65,38 +65,6 @@ def _drain_for(delegation_id, timeout=5.0):
     return None
 
 
-def test_active_for_session_counts_every_live_delegation_state():
-    with ad._records_lock:
-        ad._records.update(
-            {
-                "running": {
-                    "status": "running",
-                    "origin_ui_session_id": "desktop-sid",
-                },
-                "stalling": {
-                    "status": "stalling",
-                    "origin_ui_session_id": "desktop-sid",
-                },
-                "finalizing": {
-                    "status": "finalizing",
-                    "origin_ui_session_id": "desktop-sid",
-                },
-                "completed": {
-                    "status": "completed",
-                    "origin_ui_session_id": "desktop-sid",
-                },
-                "other-session": {
-                    "status": "running",
-                    "origin_ui_session_id": "other-sid",
-                },
-            }
-        )
-
-    assert ad.active_for_session("desktop-sid") == 3
-    assert ad.active_for_session("other-sid") == 1
-    assert ad.active_for_session("") == 0
-
-
 def test_dispatch_returns_immediately_without_blocking():
     gate = threading.Event()
 
@@ -473,6 +441,43 @@ def test_list_async_delegations_exposes_live_activity(monkeypatch):
         gate.set()
 
 
+def test_stalled_batch_is_interrupted_then_finalized(monkeypatch):
+    _fast_stale_monitor(monkeypatch)
+    gate = threading.Event()
+    interrupted = {"count": 0}
+
+    def stuck_batch():
+        gate.wait(timeout=10)
+        return {"results": [{"status": "completed", "summary": "too late"}]}
+
+    def interrupt_fn():
+        interrupted["count"] += 1
+
+    res = ad.dispatch_async_delegation_batch(
+        goals=["a", "b"], context="ctx", toolsets=None, role="leaf",
+        model="m", session_key="", runner=stuck_batch,
+        interrupt_fn=interrupt_fn, max_async_children=1,
+        progress_fn=lambda: (((0, None), (0, None)), False),
+    )
+    assert res["status"] == "dispatched"
+
+    evt = _drain_for(res["delegation_id"], timeout=5.0)
+    try:
+        assert evt is not None
+        assert evt["type"] == "async_delegation"
+        assert evt["status"] == "stalled"
+        assert evt["is_batch"] is True
+        assert evt["goals"] == ["a", "b"]
+        assert evt["results"] == []
+        assert "stalled" in evt["error"]
+        assert interrupted["count"] >= 1
+        assert ad.active_count() == 0
+    finally:
+        gate.set()
+
+    assert _drain_one(timeout=0.5) is None
+
+
 def test_in_tool_stall_uses_higher_threshold(monkeypatch):
     """A frozen child inside a tool gets the in-tool ceiling, not the idle one."""
     _fast_stale_monitor(monkeypatch, idle=0.1, in_tool=10.0, grace=0.1)
@@ -499,6 +504,185 @@ def test_in_tool_stall_uses_higher_threshold(monkeypatch):
     evt = _drain_for(res["delegation_id"], timeout=5.0)
     assert evt is not None
     assert evt["status"] == "completed"
+
+
+def test_stall_stays_finalizing_until_durable_persistence(tmp_path, monkeypatch):
+    _fast_stale_monitor(monkeypatch)
+    gate = threading.Event()
+    persist_entered = threading.Event()
+    allow_persist = threading.Event()
+    real_persist = ad._persist_completion
+
+    def blocking_persist(event, result):
+        persist_entered.set()
+        allow_persist.wait(timeout=5)
+        real_persist(event, result)
+
+    def stuck_runner():
+        gate.wait(timeout=10)
+        return {"status": "completed", "summary": "too late"}
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(ad, "_persist_completion", blocking_persist)
+    dispatched = ad.dispatch_async_delegation(
+        goal="durable stall", context=None, toolsets=None, role="leaf",
+        model="m", session_key="owner", runner=stuck_runner,
+        max_async_children=1, progress_fn=lambda: ((0, None), False),
+    )
+
+    try:
+        assert persist_entered.wait(timeout=5)
+        assert ad.active_count() == 1
+        record = next(
+            item for item in ad.list_async_delegations()
+            if item["delegation_id"] == dispatched["delegation_id"]
+        )
+        assert record["status"] == "finalizing"
+        assert process_registry.completion_queue.empty()
+
+        allow_persist.set()
+        evt = _drain_for(dispatched["delegation_id"])
+        assert evt is not None
+        assert evt["status"] == "stalled"
+        assert ad.active_count() == 0
+        durable = ad.get_durable_delegation(dispatched["delegation_id"])
+        assert durable["state"] == "stalled"
+        assert durable["delivery_state"] == "pending"
+    finally:
+        allow_persist.set()
+        gate.set()
+
+
+def test_stalled_completion_restores_once_after_process_restart(tmp_path):
+    repo = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    env = {**os.environ, "HERMES_HOME": str(tmp_path), "PYTHONPATH": repo}
+    producer = r'''
+import json
+import threading
+import time
+from tools import async_delegation as ad
+ad._STALE_CHECK_INTERVAL = 0.03
+ad._STALE_IDLE_SECONDS = 0.1
+ad._STALL_GRACE_SECONDS = 0.1
+gate = threading.Event()
+r = ad.dispatch_async_delegation(
+    goal="restart stall", context=None, toolsets=None, role="leaf", model="m",
+    session_key="owner-session", parent_session_id="durable-parent",
+    runner=lambda: gate.wait(timeout=60),
+    progress_fn=lambda: ((0, None), False),
+)
+deadline = time.time() + 10
+while ad.active_count() and time.time() < deadline:
+    time.sleep(.01)
+row = ad.get_durable_delegation(r["delegation_id"])
+print(json.dumps({"delegation_id": r["delegation_id"], "row": row}, sort_keys=True))
+'''
+    first = subprocess.run(
+        [sys.executable, "-c", producer], cwd=repo, env=env,
+        text=True, capture_output=True, timeout=30, check=True,
+    )
+    produced = json.loads(first.stdout.strip().splitlines()[-1])
+    delegation_id = produced["delegation_id"]
+    assert produced["row"]["state"] == "stalled"
+    assert produced["row"]["delivery_state"] == "pending"
+
+    consumer = r'''
+import json
+from tools.process_registry import process_registry
+evt = process_registry.completion_queue.get_nowait()
+print(json.dumps({"event": evt, "remaining": process_registry.completion_queue.qsize()}, sort_keys=True))
+'''
+    second = subprocess.run(
+        [sys.executable, "-c", consumer], cwd=repo, env=env,
+        text=True, capture_output=True, timeout=15, check=True,
+    )
+    restored = json.loads(second.stdout.strip().splitlines()[-1])
+    assert restored["remaining"] == 0
+    assert restored["event"]["delegation_id"] == delegation_id
+    assert restored["event"]["status"] == "stalled"
+    assert restored["event"]["restored"] is True
+
+    acker = f'''
+from tools import async_delegation as ad
+assert ad.mark_completion_delivered({delegation_id!r})
+'''
+    subprocess.run(
+        [sys.executable, "-c", acker], cwd=repo, env=env,
+        text=True, capture_output=True, timeout=15, check=True,
+    )
+    probe = subprocess.run(
+        [sys.executable, "-c", "from tools.process_registry import process_registry; print(process_registry.completion_queue.qsize())"],
+        cwd=repo, env=env, text=True, capture_output=True, timeout=15, check=True,
+    )
+    assert probe.stdout.strip().splitlines()[-1] == "0"
+
+
+def test_completed_records_pruned_to_cap():
+    # Run more than the retention cap quickly; ensure list doesn't grow forever.
+    for i in range(ad._MAX_RETAINED_COMPLETED + 10):
+        ad.dispatch_async_delegation(
+            goal=f"t{i}", context=None, toolsets=None, role="leaf", model="m",
+            session_key="", runner=lambda: {"status": "completed", "summary": "ok"},
+            max_async_children=ad._MAX_RETAINED_COMPLETED + 20,
+        )
+    # let workers finish
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and ad.active_count() > 0:
+        time.sleep(0.05)
+    assert len(ad.list_async_delegations()) <= ad._MAX_RETAINED_COMPLETED
+
+
+def test_active_task_count_expands_batches_while_active_count_stays_unit(monkeypatch):
+    """active_count() counts dispatch UNITS (batch=1); active_task_count()
+    expands a batch to its child count. This is the batch-vs-single distinction
+    the background_work metric relies on so a 3-task fan-out isn't undercounted
+    as 1 running subagent.
+    """
+    # Deterministic: install synthetic running records directly, no real spawn.
+    with ad._records_lock:
+        saved = dict(ad._records)
+        ad._records.clear()
+        ad._records["single_a"] = {"status": "running"}  # single subagent
+        ad._records["batch_3"] = {"status": "running", "is_batch": True,
+                                   "goals": ["g1", "g2", "g3"]}  # 3-task batch
+        ad._records["batch_missing"] = {"status": "running", "is_batch": True}  # goals absent -> 1
+        ad._records["done"] = {"status": "completed", "is_batch": True,
+                                "goals": ["x", "y"]}  # not running -> ignored
+    try:
+        # 3 running UNITS (single + 2 batches); the completed one is excluded.
+        assert ad.active_count() == 3
+        # TASKS: single(1) + batch_3(3) + batch_missing(1, fallback) = 5.
+        assert ad.active_task_count() == 5
+    finally:
+        with ad._records_lock:
+            ad._records.clear()
+            ad._records.update(saved)
+
+
+
+def test_completion_is_persisted_and_delivery_can_be_acknowledged(tmp_path, monkeypatch):
+    """A finished child remains pending on disk until its queue consumer acks it."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    dispatched = ad.dispatch_async_delegation(
+        goal="durable", context="ctx", toolsets=["terminal"], role="leaf",
+        model="m", session_key="owner", parent_session_id="parent",
+        runner=lambda: {"status": "completed", "summary": "survived"},
+    )
+    assert _drain_one() is not None
+
+    restored = queue.Queue()
+    assert ad.restore_undelivered_completions(restored) == 1
+    row = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert row["origin_session"] == "owner"
+    assert row["state"] == "completed"
+    assert row["result"]["summary"] == "survived"
+    assert row["delivery_state"] == "pending"
+    # Queue publication/restoration is not a destination delivery attempt.
+    assert row["delivery_attempts"] == 0
+
+    assert ad.mark_completion_delivered(dispatched["delegation_id"])
+    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+    assert ad.get_durable_delegation(dispatched["delegation_id"])["delivery_state"] == "delivered"
 
 
 def test_real_process_restart_restores_owned_completion_once(tmp_path):
@@ -553,6 +737,177 @@ assert ad.mark_completion_delivered({delegation_id!r})
         cwd=repo, env=env, text=True, capture_output=True, timeout=15, check=True,
     )
     assert probe.stdout.strip().splitlines()[-1] == "0"
+
+
+def test_submit_failure_removes_durable_running_record(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class _BrokenExecutor:
+        def submit(self, *_args, **_kwargs):
+            raise RuntimeError("submit failed")
+
+    monkeypatch.setattr(ad, "_get_executor", lambda _max_workers: _BrokenExecutor())
+    result = ad.dispatch_async_delegation(
+        goal="never ran", context=None, toolsets=None, role="leaf", model="m",
+        session_key="owner", runner=lambda: {},
+    )
+
+    assert result["status"] == "rejected"
+    with ad._DB_LOCK, ad._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM async_delegations").fetchone()[0] == 0
+
+
+def test_pending_retention_prunes_delivered_before_undelivered(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(ad, "_MAX_RETAINED_COMPLETED", 2)
+    for index, delivery_state in enumerate(("pending", "delivered", "pending")):
+        delegation_id = f"deleg_{index}"
+        record = {
+            "delegation_id": delegation_id,
+            "session_key": "owner",
+            "origin_ui_session_id": "",
+            "parent_session_id": None,
+            "dispatched_at": float(index + 1),
+        }
+        ad._persist_dispatch(record)
+        ad._persist_completion(
+            {
+                "delegation_id": delegation_id,
+                "status": "completed",
+                "completed_at": float(index + 1),
+            },
+            {"status": "completed", "summary": delegation_id},
+        )
+        if delivery_state == "delivered":
+            ad.mark_completion_delivered(delegation_id)
+
+    ad._prune_durable_records()
+
+    assert ad.get_durable_delegation("deleg_0") is not None
+    assert ad.get_durable_delegation("deleg_1") is None
+    assert ad.get_durable_delegation("deleg_2") is not None
+
+
+def test_recover_marks_abandoned_running_record_unknown(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    record = {
+        "delegation_id": "deleg_abandoned",
+        "session_key": "owner",
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "dispatched_at": 1.0,
+    }
+    ad._persist_dispatch(record)
+    with ad._DB_LOCK, ad._connect() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=?, owner_started_at=NULL WHERE delegation_id=?",
+            (99999999, "deleg_abandoned"),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+    durable = ad.get_durable_delegation("deleg_abandoned")
+    assert durable["state"] == "unknown"
+    assert durable["delivery_state"] == "pending"
+    restored = queue.Queue()
+    assert ad.restore_undelivered_completions(restored) == 1
+    assert restored.get_nowait()["status"] == "unknown"
+
+
+def test_origin_session_id_survives_persistence_round_trip(tmp_path, monkeypatch):
+    """origin_session_id (the api_server wake self-post target) must be
+    persisted with the durable dispatch record and restored on recovery —
+    otherwise completions recovered after a process restart are unroutable
+    to api_server sessions (in-memory record is gone)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    record = {
+        "delegation_id": "deleg_wake_target",
+        "session_key": "owner",
+        "origin_ui_session_id": "",
+        "origin_session_id": "raw-api-sid-42",
+        "parent_session_id": None,
+        "dispatched_at": 1.0,
+    }
+    ad._persist_dispatch(record)
+
+    # Durable record carries the wake target.
+    durable = ad.get_durable_delegation("deleg_wake_target")
+    assert durable["origin_session_id"] == "raw-api-sid-42"
+
+    # Simulate the owning process dying, then recovery after restart: the
+    # regenerated completion event must still carry the wake target.
+    with ad._DB_LOCK, ad._connect() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=?, owner_started_at=NULL WHERE delegation_id=?",
+            (99999999, "deleg_wake_target"),
+        )
+    restored = queue.Queue()
+    assert ad.restore_undelivered_completions(restored) == 1
+    evt = restored.get_nowait()
+    assert evt["delegation_id"] == "deleg_wake_target"
+    assert evt["origin_session_id"] == "raw-api-sid-42"
+    assert evt["restored"] is True
+
+
+def test_origin_session_id_migration_backfills_legacy_rows(tmp_path, monkeypatch):
+    """Rows written by a pre-origin_session_id build must survive the ALTER
+    TABLE migration and read back as an empty wake target."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Create a legacy-schema DB (no origin_session_id column).
+    import sqlite3
+
+    db_path = ad._db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy = sqlite3.connect(str(db_path))
+    legacy.execute(
+        """CREATE TABLE async_delegations (
+            delegation_id TEXT PRIMARY KEY,
+            origin_session TEXT NOT NULL,
+            origin_ui_session_id TEXT NOT NULL DEFAULT '',
+            parent_session_id TEXT,
+            state TEXT NOT NULL,
+            dispatched_at REAL NOT NULL,
+            completed_at REAL,
+            updated_at REAL NOT NULL,
+            event_json TEXT,
+            result_json TEXT,
+            delivery_state TEXT NOT NULL DEFAULT 'pending',
+            delivery_attempts INTEGER NOT NULL DEFAULT 0,
+            delivered_at REAL
+        )"""
+    )
+    legacy.execute(
+        """INSERT INTO async_delegations
+           (delegation_id, origin_session, state, dispatched_at, updated_at)
+           VALUES ('deleg_legacy', 'owner', 'running', 1.0, 1.0)"""
+    )
+    legacy.commit()
+    legacy.close()
+
+    durable = ad.get_durable_delegation("deleg_legacy")
+    assert durable is not None
+    assert durable["origin_session_id"] == ""
+
+
+def test_durable_delivery_claim_is_exclusive_and_retryable(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    record = {
+        "delegation_id": "deleg_claim", "session_key": "owner",
+        "origin_ui_session_id": "", "parent_session_id": None,
+        "dispatched_at": 1.0,
+    }
+    ad._persist_dispatch(record)
+    ad._persist_completion(
+        {"delegation_id": "deleg_claim", "status": "completed", "completed_at": 2.0},
+        {"status": "completed", "summary": "done"},
+    )
+
+    assert ad.claim_completion_delivery("deleg_claim", "consumer-a")
+    assert not ad.claim_completion_delivery("deleg_claim", "consumer-b")
+    assert ad.release_completion_delivery("deleg_claim", "consumer-a")
+    assert ad.claim_completion_delivery("deleg_claim", "consumer-b")
+    assert ad.complete_completion_delivery("deleg_claim", "consumer-b")
+    assert not ad.claim_completion_delivery("deleg_claim", "consumer-c")
+    assert ad.get_durable_delegation("deleg_claim")["delivery_state"] == "delivered"
 
 
 # ---------------------------------------------------------------------------
@@ -623,6 +978,74 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert "the real task" in text
 
 
+def test_delegate_task_background_waits_inside_kanban_worker(monkeypatch):
+    """A dispatcher-spawned Kanban worker is a finite process, so a required
+    delegated result must return in-turn instead of becoming an orphaned
+    background completion after the parent exits."""
+    import json
+    from unittest.mock import MagicMock
+    import tools.delegate_tool as dt
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_review")
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "kanban-worker-session"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def delayed_child(task_index, goal, child=None, parent_agent=None, **kw):
+        started.set()
+        release.wait(timeout=5)
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": "review approved",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
+    monkeypatch.setattr(dt, "_run_single_child", delayed_child)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+
+    captured = {}
+
+    def call_delegate():
+        captured["output"] = dt.delegate_task(
+            goal="independent review",
+            background=True,
+            parent_agent=parent,
+        )
+
+    caller = threading.Thread(target=call_delegate)
+    caller.start()
+    assert started.wait(timeout=2)
+    assert caller.is_alive(), "Kanban delegate_task returned before its child finished"
+    assert ad.active_count() == 0
+
+    release.set()
+    caller.join(timeout=5)
+    assert not caller.is_alive()
+
+    parsed = json.loads(captured["output"])
+    assert parsed["results"][0]["summary"] == "review approved"
+    assert "SYNCHRONOUSLY" in parsed["note"]
+    assert process_registry.completion_queue.empty()
+
+
 def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     """TUI async delegation must route to the live/compressed agent id.
 
@@ -685,6 +1108,264 @@ def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     assert evt["origin_ui_session_id"] == "origin-tab"
 
 
+def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
+    """A multi-item batch with background=True dispatches the WHOLE fan-out as
+    ONE background unit (one handle, one async slot). The children run in
+    parallel and join; the consolidated results come back as a single
+    completion event when ALL of them finish."""
+    import json
+    from unittest.mock import MagicMock, patch
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "sess"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+
+    gate = threading.Event()
+
+    def _blocking_child(task_index, goal, child=None, parent_agent=None, **kw):
+        gate.wait(timeout=60)
+        return {
+            "task_index": task_index, "status": "completed",
+            "summary": f"done: {goal}", "api_calls": 1,
+            "duration_seconds": 0.1, "model": "m", "exit_reason": "completed",
+        }
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+
+    # Use monkeypatch (not a `with` block) so the patches stay active while the
+    # background worker thread runs _execute_and_aggregate AFTER delegate_task
+    # has already returned.
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
+    monkeypatch.setattr(dt, "_run_single_child", _blocking_child)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    out = dt.delegate_task(
+        tasks=[{"goal": "a"}, {"goal": "b"}, {"goal": "c"}],
+        background=True,
+        parent_agent=parent,
+    )
+
+    parsed = json.loads(out)
+    assert parsed["status"] == "dispatched"
+    assert parsed["mode"] == "background"
+    assert parsed["count"] == 3
+    assert parsed["delegation_id"].startswith("deleg_")
+    assert parsed["goals"] == ["a", "b", "c"]
+    # ONE background unit for the whole fan-out (not three), and the call
+    # returned while all children are still blocked → chat not blocked.
+    assert process_registry.completion_queue.empty()
+    assert ad.active_count() == 1
+
+    # Release the children; the whole batch joins and emits ONE event.
+    gate.set()
+    evt = _drain_one()
+    assert evt is not None
+    assert evt["type"] == "async_delegation"
+    assert evt.get("is_batch") is True
+    assert len(evt["results"]) == 3
+    summaries = sorted(r["summary"] for r in evt["results"])
+    assert summaries == ["done: a", "done: b", "done: c"]
+    # The consolidated notification names all three tasks in one block.
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "TASK 1/3" in text and "TASK 2/3" in text and "TASK 3/3" in text
+    assert "done: a" in text and "done: b" in text and "done: c" in text
+    # No more events — it's a single combined completion, not N of them.
+    assert _drain_one() is None
+
+
+def test_delegate_task_background_passes_progress_fn_to_async_registry(monkeypatch):
+    import json
+    from unittest.mock import MagicMock
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "sess"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    fake_child._subagent_id = "s1"
+    fake_child.get_activity_summary.return_value = {
+        "api_call_count": 4,
+        "current_tool": "terminal",
+        "last_activity_ts": 1234.5,
+    }
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    captured = {}
+
+    def fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return {"status": "dispatched", "delegation_id": "deleg_progress"}
+
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    monkeypatch.setattr(ad, "dispatch_async_delegation_batch", fake_dispatch)
+
+    out = dt.delegate_task(goal="background stall guard", background=True, parent_agent=parent)
+
+    parsed = json.loads(out)
+    assert parsed["status"] == "dispatched"
+    assert parsed["delegation_id"] == "deleg_progress"
+    # The dispatch wires a live progress sampler over the child agents so the
+    # async registry's stale monitor can watch the detached batch. The token
+    # includes last_activity_ts so streamed chunks count as liveness (each
+    # chunk ticks _touch_activity), not just completed API calls.
+    progress_fn = captured["progress_fn"]
+    assert callable(progress_fn)
+    token, in_tool = progress_fn()
+    assert token == ((4, "terminal", 1234.5),)
+    assert in_tool is True
+
+
+def test_model_dispatch_forces_background():
+    """The MODEL-facing dispatch path forces background=True for any top-level
+    delegation (single task OR batch), and keeps it off for an orchestrator
+    subagent (depth > 0). Direct delegate_task() callers are unaffected (they
+    keep the synchronous default)."""
+    import tools.delegate_tool as dt
+    from unittest.mock import MagicMock
+
+    top = MagicMock()
+    top._delegate_depth = 0
+    sub = MagicMock()
+    sub._delegate_depth = 1
+
+    # Registry-fallback helper: top-level always background, regardless of
+    # single vs batch; subagent never.
+    assert dt._model_background_value({"goal": "x"}, top) is True
+    assert dt._model_background_value(
+        {"tasks": [{"goal": "a"}, {"goal": "b"}]}, top
+    ) is True
+    assert dt._model_background_value({"tasks": [{"goal": "a"}]}, top) is True
+    assert dt._model_background_value({"goal": "x"}, sub) is False
+    assert dt._model_background_value(
+        {"tasks": [{"goal": "a"}, {"goal": "b"}]}, sub
+    ) is False
+
+
+def test_run_agent_dispatch_forces_background():
+    """run_agent._dispatch_delegate_task — the live model path — forces
+    background on for any top-level delegation (single OR batch) and off for a
+    subagent."""
+    from unittest.mock import patch
+    import run_agent
+
+    class _FakeAgent:
+        _delegate_depth = 0
+
+    captured = {}
+
+    def _fake_delegate(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    with patch("tools.delegate_tool.delegate_task", _fake_delegate):
+        agent = _FakeAgent()
+        run_agent.AIAgent._dispatch_delegate_task(agent, {"goal": "x"})
+        assert captured["background"] is True
+
+        run_agent.AIAgent._dispatch_delegate_task(
+            agent,
+            {
+                "tasks": [{"goal": "a"}, {"goal": "b"}],
+                "read_only": True,
+            },
+        )
+        assert captured["background"] is True
+        assert captured["read_only"] is True
+
+        sub = _FakeAgent()
+        sub._delegate_depth = 1
+        run_agent.AIAgent._dispatch_delegate_task(sub, {"goal": "x"})
+        assert captured["background"] is False
+
+
+def test_dispatch_never_forwards_model_toolsets():
+    """The model has no toolsets argument — subagents always inherit the
+    parent's toolsets. Even if a model smuggles a `toolsets` key into the
+    tool-call args, the live dispatch path must NOT forward it to
+    delegate_task (which no longer accepts it) and must not crash."""
+    from unittest.mock import patch
+    import run_agent
+
+    class _FakeAgent:
+        _delegate_depth = 0
+
+    captured = {}
+
+    def _fake_delegate(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    with patch("tools.delegate_tool.delegate_task", _fake_delegate):
+        run_agent.AIAgent._dispatch_delegate_task(
+            _FakeAgent(), {"goal": "x", "toolsets": ["web", "terminal"]}
+        )
+    assert "toolsets" not in captured
+
+
+def test_delegate_task_background_detaches_child_from_parent(monkeypatch):
+    """A background child must NOT remain in parent._active_children —
+    otherwise parent-turn interrupts / cache evicts / session close would
+    kill the detached subagent mid-run."""
+    from unittest.mock import MagicMock, patch
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "sess"
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    fake_child._subagent_id = "s1"
+
+    gate = threading.Event()
+
+    def slow_child(task_index, goal, child=None, parent_agent=None, **kw):
+        gate.wait(timeout=60)
+        return {"task_index": 0, "status": "completed", "summary": "ok"}
+
+    def build_and_register(**kw):
+        # Mirror what the real _build_child_agent does: register the child
+        # for interrupt propagation.
+        parent._active_children.append(fake_child)
+        return fake_child
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    with patch.object(dt, "_build_child_agent", side_effect=build_and_register), \
+         patch.object(dt, "_run_single_child", side_effect=slow_child), \
+         patch.object(dt, "_resolve_delegation_credentials", return_value=creds):
+        out = dt.delegate_task(goal="bg task", background=True, parent_agent=parent)
+
+    import json
+    assert json.loads(out)["status"] == "dispatched"
+    # Child detached immediately at dispatch, while it is still running.
+    assert fake_child not in parent._active_children
+    gate.set()
+    assert _drain_one() is not None
+
+
 def test_concurrent_dispatch_respects_capacity():
     """Two threads racing dispatch with cap=1 must yield exactly one accept
     (capacity check and record insert are atomic under the records lock)."""
@@ -742,6 +1423,17 @@ def _make_async_evt(**over):
     return evt
 
 
+def test_gateway_enriches_routing_from_session_key():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    evt = _make_async_evt()
+    runner._enrich_async_delegation_routing(evt)
+    assert evt["platform"] == "telegram"
+    assert evt["chat_id"] == "12345"
+    assert evt["thread_id"] == "678"
+
+
 def test_gateway_formatter_renders_async_block():
     from gateway.run import _format_gateway_process_notification
 
@@ -750,6 +1442,40 @@ def test_gateway_formatter_renders_async_block():
     assert "ASYNC DELEGATION COMPLETE" in txt
     assert "Found the bug in test_foo" in txt
     assert "Investigate flaky test" in txt
+
+
+def test_gateway_watch_drain_requeues_async_without_looping():
+    from gateway.run import _drain_gateway_watch_events
+
+    q = queue.Queue()
+    async_evt = _make_async_evt()
+    watch_evt = {
+        "type": "watch_match",
+        "session_id": "proc_1",
+        "command": "pytest",
+        "pattern": "READY",
+        "output": "READY",
+    }
+    q.put(async_evt)
+    q.put(watch_evt)
+
+    watch_events = _drain_gateway_watch_events(q)
+
+    assert watch_events == [watch_evt]
+    assert q.qsize() == 1
+    assert q.get_nowait() == async_evt
+
+
+def test_gateway_builds_routable_source_from_enriched_event():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    evt = _make_async_evt()
+    runner._enrich_async_delegation_routing(evt)
+    src = runner._build_process_event_source(evt)
+    assert src is not None
+    assert src.platform.value == "telegram"
+    assert src.chat_id == "12345"
 
 
 def test_gateway_cli_origin_event_left_unrouted():

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -1148,8 +1148,13 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
     monkeypatch.setattr(dt, "_run_single_child", _blocking_child)
     monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    goals = [
+        "Analyze the authentication flow",
+        "Review the database migration path",
+        "Audit the deployment configuration",
+    ]
     out = dt.delegate_task(
-        tasks=[{"goal": "a"}, {"goal": "b"}, {"goal": "c"}],
+        tasks=[{"goal": item} for item in goals],
         background=True,
         parent_agent=parent,
     )
@@ -1159,7 +1164,7 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     assert parsed["mode"] == "background"
     assert parsed["count"] == 3
     assert parsed["delegation_id"].startswith("deleg_")
-    assert parsed["goals"] == ["a", "b", "c"]
+    assert parsed["goals"] == goals
     # ONE background unit for the whole fan-out (not three), and the call
     # returned while all children are still blocked → chat not blocked.
     assert process_registry.completion_queue.empty()
@@ -1173,12 +1178,12 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     assert evt.get("is_batch") is True
     assert len(evt["results"]) == 3
     summaries = sorted(r["summary"] for r in evt["results"])
-    assert summaries == ["done: a", "done: b", "done: c"]
+    assert summaries == sorted(f"done: {item}" for item in goals)
     # The consolidated notification names all three tasks in one block.
     text = format_process_notification(evt)
     assert text is not None
     assert "TASK 1/3" in text and "TASK 2/3" in text and "TASK 3/3" in text
-    assert "done: a" in text and "done: b" in text and "done: c" in text
+    assert all(f"done: {item}" in text for item in goals)
     # No more events — it's a single combined completion, not N of them.
     assert _drain_one() is None
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -65,6 +65,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("goal", props)
         self.assertIn("tasks", props)
         self.assertIn("context", props)
+        self.assertIn("read_only", props)
+        self.assertIn("read_only", props["tasks"]["items"]["properties"])
         # toolsets is intentionally NOT exposed to the model — subagents always
         # inherit the parent's toolsets. Letting the model name toolsets was a
         # capability-selection surface the model should not control.
@@ -140,6 +142,43 @@ class TestChildSystemPrompt(unittest.TestCase):
         self.assertNotIn("CONTEXT", prompt)
 
 class TestStripBlockedTools(unittest.TestCase):
+    def test_read_only_child_gets_exact_tool_allowlist_and_forces_leaf(self):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["hermes-cli"]
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._get_orchestrator_enabled", return_value=True),
+            patch("tools.delegate_tool._get_max_spawn_depth", return_value=2),
+        ):
+            child = MagicMock()
+            MockAgent.return_value = child
+            _build_child_agent(
+                task_index=0,
+                goal="Audit safely",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                role="orchestrator",
+                read_only=True,
+            )
+
+        _, kwargs = MockAgent.call_args
+        allowed = set(kwargs["allowed_tool_names"])
+        self.assertIn("read_file", allowed)
+        self.assertIn("search_files", allowed)
+        self.assertIn("web_search", allowed)
+        self.assertNotIn("terminal", allowed)
+        self.assertNotIn("execute_code", allowed)
+        self.assertNotIn("write_file", allowed)
+        self.assertNotIn("patch", allowed)
+        self.assertNotIn("tool_call", allowed)
+        self.assertNotIn("browser_click", allowed)
+        self.assertEqual(child._delegate_role, "leaf")
+        self.assertTrue(child._delegate_read_only)
     def test_removes_blocked_toolsets(self):
         result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])
         self.assertEqual(sorted(result), ["code_execution", "file", "terminal"])

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -27,6 +27,7 @@ from tools.delegate_tool import (
     _build_child_agent,
     _build_child_progress_callback,
     _build_child_system_prompt,
+    _normalize_child_result,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -41,6 +42,8 @@ def _make_mock_parent(depth=0):
     parent.api_key="***"
     parent.provider = "openrouter"
     parent.api_mode = "chat_completions"
+    parent.acp_command = None
+    parent.acp_args = []
     parent.model = "anthropic/claude-sonnet-4"
     parent.platform = "cli"
     parent.providers_allowed = None
@@ -142,6 +145,25 @@ class TestChildSystemPrompt(unittest.TestCase):
         self.assertNotIn("CONTEXT", prompt)
 
 class TestStripBlockedTools(unittest.TestCase):
+    def test_read_only_rejects_acp_transport(self):
+        parent = _make_mock_parent()
+        parent.acp_command = "copilot"
+        parent.acp_args = ["--stdio"]
+
+        with self.assertRaisesRegex(ValueError, "read_only delegation.*ACP"):
+            _build_child_agent(
+                task_index=0,
+                goal="Audit safely",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                role="leaf",
+                read_only=True,
+            )
+
     def test_read_only_child_gets_exact_tool_allowlist_and_forces_leaf(self):
         parent = _make_mock_parent()
         parent.enabled_toolsets = ["hermes-cli"]
@@ -182,6 +204,15 @@ class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
         result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])
         self.assertEqual(sorted(result), ["code_execution", "file", "terminal"])
+
+    def test_result_envelope_is_present_on_failure_paths(self):
+        child = MagicMock()
+        child._delegate_read_only = True
+        for status in ("error", "timeout", "interrupted", "failed"):
+            entry = _normalize_child_result({"status": status}, child)
+            self.assertEqual(entry["semantic_status"], "not_applicable")
+            self.assertTrue(entry["read_only"])
+            self.assertEqual(entry["exit_reason"], status)
 
     def test_strips_cronjob_toolset(self):
         """Regression for issue #43466: child subagents must not inherit
@@ -1343,7 +1374,6 @@ class TestDelegateHeartbeat(unittest.TestCase):
             f"Heartbeat stopped too early while child was waiting on the model; "
             f"got {len(touch_calls)} touches",
         )
-
 
 class TestDelegationReasoningEffort(unittest.TestCase):
     """Tests for delegation.reasoning_effort config override."""

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -44,6 +44,87 @@ def test_refresh_adds_late_landing_tools(monkeypatch):
     assert len(agent.tools) == 3
 
 
+def test_refresh_preserves_exact_tool_name_allowlist(monkeypatch):
+    """A registry/MCP refresh must not reintroduce tools denied at build time."""
+    agent = _agent(["read_file"])
+    agent.allowed_tool_names = {"read_file", "web_search"}
+
+    import model_tools
+    monkeypatch.setattr(
+        model_tools,
+        "get_tool_definitions",
+        lambda **kw: [
+            _tool("read_file"),
+            _tool("web_search"),
+            _tool("terminal"),
+            _tool("mcp_remote_write"),
+        ],
+    )
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert added == {"web_search"}
+    assert agent.valid_tool_names == {"read_file", "web_search"}
+    assert {t["function"]["name"] for t in agent.tools} == {
+        "read_file",
+        "web_search",
+    }
+
+
+def test_refresh_no_change_returns_empty_and_leaves_agent_untouched(monkeypatch):
+    """No new tools → empty set, and the snapshot object is not swapped."""
+    agent = _agent(["read_file", "terminal"])
+    original_tools = agent.tools
+
+    import model_tools
+    monkeypatch.setattr(
+        model_tools, "get_tool_definitions",
+        lambda **kw: [_tool("read_file"), _tool("terminal")],
+    )
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert added == set()
+    assert agent.tools is original_tools  # not replaced → no churn / no cache thrash
+
+
+def test_refresh_detects_equal_size_swap(monkeypatch):
+    """Name-based diff catches an add+remove of equal count (count-compare can't)."""
+    agent = _agent(["a", "old_mcp_tool"])  # 2 tools
+
+    import model_tools
+    # Same COUNT (2) but a different membership: old_mcp_tool removed, new added.
+    monkeypatch.setattr(
+        model_tools, "get_tool_definitions",
+        lambda **kw: [_tool("a"), _tool("new_mcp_tool")],
+    )
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert added == {"new_mcp_tool"}
+    assert agent.valid_tool_names == {"a", "new_mcp_tool"}
+    assert "old_mcp_tool" not in agent.valid_tool_names
+
+
+def test_refresh_passes_agent_toolset_filters(monkeypatch):
+    """The rebuild re-derives with the agent's OWN enabled/disabled toolsets."""
+    agent = _agent(["a"], enabled=["coding", "granola"], disabled=["messaging"])
+    seen = {}
+
+    import model_tools
+
+    def _capture(**kw):
+        seen.update(kw)
+        return [_tool("a"), _tool("b")]
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _capture)
+
+    mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert seen["enabled_toolsets"] == ["coding", "granola"]
+    assert seen["disabled_toolsets"] == ["messaging"]
+
+
 def test_refresh_preserves_memory_provider_and_context_engine_tools(monkeypatch):
     """B1 regression: a rebuild must NOT drop post-build-injected tools.
 
@@ -210,6 +291,50 @@ def test_resolve_discovery_timeout_explicit_wins(monkeypatch):
     from hermes_cli import mcp_startup
 
     assert mcp_startup._resolve_discovery_timeout(2.5) == 2.5
+
+
+def test_resolve_discovery_timeout_reads_config(monkeypatch):
+    from hermes_cli import mcp_startup
+    import hermes_cli.config as cfg
+
+    monkeypatch.setattr(cfg, "load_config", lambda: {"mcp_discovery_timeout": 8.0})
+
+    assert mcp_startup._resolve_discovery_timeout(None) == 8.0
+
+
+def test_resolve_discovery_timeout_falls_back_on_bad_value(monkeypatch):
+    from hermes_cli import mcp_startup
+    import hermes_cli.config as cfg
+
+    # Non-positive / unparsable → DEFAULT_CONFIG value, never hang.
+    default = float(cfg.DEFAULT_CONFIG.get("mcp_discovery_timeout", 1.5))
+    monkeypatch.setattr(cfg, "load_config", lambda: {"mcp_discovery_timeout": 0})
+    assert mcp_startup._resolve_discovery_timeout(None) == default
+
+    monkeypatch.setattr(cfg, "load_config", lambda: {"mcp_discovery_timeout": "oops"})
+    assert mcp_startup._resolve_discovery_timeout(None) == default
+
+
+def test_stale_generation_refresh_does_not_clobber_newer(monkeypatch):
+    """A slower refresh that computed an OLDER registry generation must not
+    overwrite a snapshot a newer-generation refresh already published."""
+    from tools import registry as _reg_mod
+
+    agent = _agent(["read_file"])
+    # A newer refresh already published generation = current+5, with two tools.
+    agent._tool_snapshot_generation = _reg_mod.registry._generation + 5
+    agent.tools = [_tool("read_file"), _tool("mcp_new_tool")]
+    agent.valid_tool_names = {"read_file", "mcp_new_tool"}
+
+    import model_tools
+    # This (stale) refresh computes only the old single-tool set.
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: [_tool("read_file")])
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    # Stale write rejected: the newer tool survives.
+    assert added == set()
+    assert "mcp_new_tool" in agent.valid_tool_names
 
 
 def test_wait_returns_instantly_when_no_discovery_thread(monkeypatch):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1748,6 +1748,13 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
+    if read_only and effective_acp_command:
+        raise ValueError(
+            "read_only delegation is unavailable with ACP transports because "
+            "ACP executes outside Hermes' tool allowlist; use a direct API "
+            "provider or disable read_only explicitly"
+        )
+
     # Resolve reasoning config: delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
@@ -2344,6 +2351,22 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
         )
 
 
+def _normalize_child_result(
+    entry: Dict[str, Any], child=None
+) -> Dict[str, Any]:
+    """Apply the public delegation-result envelope on every exit path."""
+    status = str(entry.get("status") or "error")
+    entry.setdefault(
+        "semantic_status",
+        "unverified" if status == "completed" else "not_applicable",
+    )
+    entry.setdefault(
+        "read_only", bool(getattr(child, "_delegate_read_only", False))
+    )
+    entry.setdefault("exit_reason", status)
+    return entry
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -2793,7 +2816,7 @@ def _run_single_child(
                     f"{_late_pending_steer}]"
                 )
             _attach_worktree(_error_entry)
-            return _error_entry
+            return _normalize_child_result(_error_entry, child)
         finally:
             # Shut down executor without waiting — if the child thread
             # is stuck on blocking I/O, wait=True would hang forever.
@@ -3168,7 +3191,7 @@ def _run_single_child(
             )
         # _attach_worktree defaults to a no-op when isolation never engaged.
         _attach_worktree(_error_entry)
-        return _error_entry
+        return _normalize_child_result(_error_entry, child)
 
     finally:
         # Stop the heartbeat thread so it doesn't keep touching parent activity
@@ -3285,8 +3308,12 @@ def _finalize_child_results(
 ) -> None:
     """Apply host-owned summary, memory, hook, and cost contracts once."""
     with _parent_finalization_lock(parent_agent):
-        _apply_summary_budget(results, parent_agent)
         child_by_index = {index: child for index, _task, child in children}
+        for entry in results:
+            _normalize_child_result(
+                entry, child_by_index.get(entry.get("task_index", -1))
+            )
+        _apply_summary_budget(results, parent_agent)
 
         if parent_agent and getattr(parent_agent, "_memory_manager", None):
             for entry in results:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -57,6 +57,30 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
     ]
 )
 
+# Exact-name allowlist for runtime-enforced read-only delegations. Dual-use
+# surfaces (terminal, execute_code, browser_console, process, deferred MCP
+# bridges) are intentionally absent: prompt-only restrictions cannot make
+# those tools read-only.
+READ_ONLY_ALLOWED_TOOLS = frozenset(
+    {
+        "read_file",
+        "search_files",
+        "web_search",
+        "web_extract",
+        "browser_navigate",
+        "browser_snapshot",
+        "browser_back",
+        "browser_scroll",
+        "browser_get_images",
+        "browser_vision",
+        "vision_analyze",
+        "video_analyze",
+        "session_search",
+        "skill_view",
+        "skills_list",
+    }
+)
+
 
 # ---------------------------------------------------------------------------
 # Subagent approval callbacks
@@ -1066,6 +1090,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    read_only: bool = False,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -1087,6 +1112,14 @@ def _build_child_system_prompt(
             "\nWORKSPACE PATH:\n"
             f"{workspace_path}\n"
             "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
+        )
+    if read_only:
+        parts.append(
+            "\n## READ-ONLY MODE (runtime-enforced)\n"
+            "You must not modify local files, repositories, processes, remote "
+            "systems, accounts, or external state. The runtime exposes only an "
+            "exact allowlist of read-only tools; do not claim writes or other "
+            "side effects. Report evidence and proposed changes instead."
         )
     parts.append(
         "\nComplete this task using the tools available to you. "
@@ -1486,6 +1519,8 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Runtime-enforced exact tool allowlist; also forces leaf role.
+    read_only: bool = False,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1508,7 +1543,13 @@ def _build_child_agent(
     child_depth = getattr(parent_agent, "_delegate_depth", 0) + 1
     max_spawn = _get_max_spawn_depth()
     orchestrator_ok = _get_orchestrator_enabled() and child_depth < max_spawn
-    effective_role = role if (role == "orchestrator" and orchestrator_ok) else "leaf"
+    # Read-only children are always leaves. Otherwise an orchestrator could
+    # escape the exact allowlist by spawning an unrestricted descendant.
+    effective_role = (
+        role
+        if (not read_only and role == "orchestrator" and orchestrator_ok)
+        else "leaf"
+    )
 
     # ── Subagent identity (stable across events, 0-indexed for TUI) ─────
     # subagent_id is generated here so the progress callback, the
@@ -1595,6 +1636,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        read_only=read_only,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -1824,6 +1866,9 @@ def _build_child_agent(
                 fallback_model=parent_fallback,
                 enabled_toolsets=child_toolsets,
                 disabled_toolsets=child_disabled_toolsets,
+                allowed_tool_names=(
+                    sorted(READ_ONLY_ALLOWED_TOOLS) if read_only else None
+                ),
                 quiet_mode=True,
                 ephemeral_system_prompt=child_prompt,
                 log_prefix=f"[subagent-{task_index}]",
@@ -1872,8 +1917,9 @@ def _build_child_agent(
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = child_depth
     # Stash the post-degrade role for introspection (leaf if the
-    # kill switch or depth bounded the caller's requested role).
+    # kill switch, depth bound, or read-only mode bounded the caller's role).
     child._delegate_role = effective_role
+    child._delegate_read_only = bool(read_only)
     # Stash subagent identity for nested-delegation event propagation and
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id
@@ -3431,6 +3477,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    read_only: Optional[bool] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
     action: Optional[str] = None,
@@ -3484,8 +3531,10 @@ def delegate_task(
             "(`p` in /agents) or the `delegation.pause` RPC before retrying."
         )
 
-    # Normalise the top-level role once; per-task overrides re-normalise.
+    # Normalise the top-level role and read-only default once; per-task
+    # overrides are resolved below.
     top_role = _normalize_role(role)
+    top_read_only = is_truthy_value(read_only, default=False)
 
     # Background (async) delegation now applies to BOTH single tasks and
     # batches. A batch is dispatched as ONE async unit: the whole fan-out runs
@@ -3561,7 +3610,12 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
+        single_task: Dict[str, Any] = {
+            "goal": goal,
+            "context": context,
+            "role": top_role,
+            "read_only": top_read_only,
+        }
         if output_schema is not None:
             single_task["output_schema"] = output_schema
         task_list = [single_task]
@@ -3657,9 +3711,11 @@ def delegate_task(
     # subagent-lifecycle API).
     children = []
     for i, t in enumerate(task_list):
-        # Per-task role beats top-level; normalise again so unknown
-        # per-task values warn and degrade to leaf uniformly.
+        # Per-task role and read-only values beat top-level defaults.
         effective_role = _normalize_role(t.get("role") or top_role)
+        effective_read_only = is_truthy_value(
+            t.get("read_only"), default=top_read_only
+        )
         # T1-24: schema'd tasks get the contract appended to their context
         # so the child knows the expected output shape before it starts.
         _task_schema = task_schemas[i] if i < len(task_schemas) else None
@@ -3688,6 +3744,7 @@ def delegate_task(
             override_acp_command=creds.get("command"),
             override_acp_args=creds.get("args"),
             role=effective_role,
+            read_only=effective_read_only,
         )
         # Attach the validated schema for the completion-side validation
         # hook in _run_single_child. Absent (None) on schema-less tasks.
@@ -4597,6 +4654,13 @@ DELEGATE_TASK_SCHEMA = {
                                 "require only fields you will actually read."
                             ),
                         },
+                        "read_only": {
+                            "type": "boolean",
+                            "description": (
+                                "Per-task runtime-enforced read-only mode. "
+                                "Overrides the top-level value."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -4616,6 +4680,14 @@ DELEGATE_TASK_SCHEMA = {
                     "Optional JSON Schema for the single-goal form — the "
                     "subagent's final answer must validate against it "
                     "(same semantics as tasks[].output_schema)."
+                ),
+            },
+            "read_only": {
+                "type": "boolean",
+                "description": (
+                    "Runtime-enforced read-only mode. The child receives an "
+                    "exact allowlist of read-only tools and is forced to leaf "
+                    "role. Per-task values override this batch default."
                 ),
             },
             "background": {
@@ -4721,6 +4793,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        read_only=args.get("read_only"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
         action=args.get("action"),

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7360,6 +7360,23 @@ def refresh_agent_mcp_tools(
     # this rebuild actually appended (matching agent_init's dedup-aware add).
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
 
+    # Preserve any exact-name capability boundary established at build time.
+    # Toolset filtering is insufficient for mixed bundles, and a late MCP
+    # registration must never widen a read-only subagent's surface.
+    allowed_names = getattr(agent, "allowed_tool_names", None)
+    if allowed_names is not None:
+        allowed_names = frozenset(str(name) for name in allowed_names)
+        new_defs = [
+            tool
+            for tool in new_defs
+            if (tool.get("function") or {}).get("name") in allowed_names
+        ]
+        new_names = {
+            (tool.get("function") or {}).get("name") for tool in new_defs
+        }
+        new_names.discard(None)
+        staged_engine_names.intersection_update(new_names)
+
     # Single atomic read-diff-publish so the returned ``added`` is consistent
     # with what was actually published, even under concurrent callers, and a
     # stale (older-generation) rebuild can't overwrite a newer published one.


### PR DESCRIPTION
## Summary

Add a host-enforced read-only boundary for delegated subagents and make the result trust boundary explicit.

- `read_only=true` gives the child an exact allowlist of inspection-only tools and forces `role=leaf`.
- Top-level `read_only` applies to a single task or as the batch default; `tasks[].read_only` can override it.
- `status=completed` remains a lifecycle result, while `semantic_status=unverified` makes clear that child claims and artifacts still require parent verification.
- Non-completed terminal paths use `semantic_status=not_applicable`.

## Root cause

Delegation previously inherited resolved toolsets, which could contain mixed read/write capabilities and could be widened again by post-build injection or MCP refresh. A prompt instruction alone is not a security boundary. Separately, the result envelope exposed mechanical completion without an explicit trust-status field.

## Implementation

- Add an optional exact `allowed_tool_names` boundary to `AIAgent`.
- For read-only children, allow only explicit read/search/inspection tools; exclude terminal, code execution, writes, process control, interactive browser actions, deferred MCP dispatch, generation, memory, scheduling, messaging, and delegation.
- Reapply the exact allowlist after registry expansion, post-build injection, and MCP refresh.
- Reject read-only delegation over ACP because ACP executes outside Hermes' tool allowlist and can expose filesystem writes.
- Normalize successful, timeout, exception, interrupted, and batch-fabricated child results through a shared trust envelope.
- Preserve current-main live orchestration, steering authority, structured-output validation, worktree metadata, and failure diagnostics while resolving the rebase.

## Read-only allowlist

```text
read_file, search_files, web_search, web_extract,
browser_navigate, browser_snapshot, browser_back, browser_scroll,
browser_get_images, browser_vision, vision_analyze, video_analyze,
session_search, skill_view, skills_list
```

## Review response

The automated review identified two real gaps in the earlier head:

1. ACP could bypass the Hermes tool allowlist.
2. Timeout/error/interrupted results did not uniformly carry the trust envelope.

Both are fixed in the current head: read-only ACP is rejected before child construction, and every terminal result path is normalized. Regression tests cover the ACP rejection and failure-path envelope.

## Widening audit

- `read_only` omitted/false: normal delegation capabilities are unchanged.
- `read_only=true`: exact inspection-only tool names are enforced at construction and refresh boundaries.
- Read-only orchestrator requests degrade to leaf, preventing unrestricted descendants.
- Batch/background execution uses the same child builder and finalizer.
- Current-main steering, live transcripts, schemas, interruption behavior, and isolated-worktree metadata remain intact.

## Verification

Rebuilt on current `main` (`12b1f0f83d`) rather than replaying obsolete delegation internals.

```text
python -m pytest -q \
  tests/tools/test_delegate.py \
  tests/tools/test_async_delegation.py \
  tests/tools/test_refresh_agent_mcp_tools.py
# 128 passed

python -m ruff check \
  agent/agent_init.py run_agent.py tools/delegate_tool.py tools/mcp_tool.py \
  tests/tools/test_delegate.py tests/tools/test_async_delegation.py \
  tests/tools/test_refresh_agent_mcp_tools.py
# All checks passed

python -m py_compile agent/agent_init.py run_agent.py \
  tools/delegate_tool.py tools/mcp_tool.py \
  tests/tools/test_delegate.py tests/tools/test_async_delegation.py \
  tests/tools/test_refresh_agent_mcp_tools.py

git diff --check
```
