### PR TITLE
fix: add usedforsecurity=False to hashlib.sha1 in tui_gateway/server (FIPS crash)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15006,7 +15006,7 @@ def _compute_mcp_rev() -> str:
             sort_keys=True,
             default=str,
         )
-        return hashlib.sha1(rev_src.encode()).hexdigest()[:12]
+        return hashlib.sha1(rev_src.encode(), usedforsecurity=False).hexdigest()[:12]
     except Exception:
         return ""
 


### PR DESCRIPTION
## Summary

The `_mcp_rev_hash()` function at `tui_gateway/server.py:15009` uses `hashlib.sha1()` without `usedforsecurity=False` to compute a short revision hash for MCP config changes. On FIPS-enabled systems (RHEL 8/9, Ubuntu FIPS), this raises `ValueError: EVP_DigestInit_ex disabled for FIPS`, crashing the TUI gateway's MCP reload path.

## Root Cause

```python
return hashlib.sha1(rev_src.encode()).hexdigest()[:12]
```

This is the same pattern as the FIPS crashes fixed in:
- `agent/context_compressor.py` (PR #56715)
- `agent/codex_responses_adapter.py` (PR #56716)
- `tools/skills_hub.py`, `tools/skills_sync.py` (PR #62654)

This particular site was NOT covered by PR #64808 (which covered context_compressor + codex_responses_adapter hashlib calls, and assert→runtime guards in tui_gateway/server.py but NOT this hashlib call).

## Fix

```python
return hashlib.sha1(rev_src.encode(), usedforsecurity=False).hexdigest()[:12]
```

One line. The function is not security-sensitive — it only computes a config fingerprint for change detection.

## Test Plan

- [ ] Verify syntax: `python3 -c "import ast; ast.parse(open('tui_gateway/server.py').read())"`
- [ ] Existing tests pass