### PR TITLE
fix(mcp): serialise the stdio spawn window so parallel connects cannot misattribute child PIDs

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 import signal
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
@@ -582,6 +582,95 @@ class TestStdioPgroupReaping:
             _time.sleep(0.05)
         assert not psutil.pid_exists(grandchild_pid), (
             "grandchild survived killpg-based reaping (issue #23799 regression)"
+        )
+
+
+class TestStdioSpawnWindowSerialisation:
+    """Concurrent connects must not claim each other's child PIDs."""
+
+    def _make_server(self, name):
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask.__new__(MCPServerTask)
+        server.name = name
+        server._ready = MagicMock()
+        server._shutdown_event = MagicMock()
+        server._shutdown_event.is_set.return_value = True
+        server._reconnect_event = MagicMock()
+        server._sampling = None
+        server._elicitation = None
+        server._registered_tool_names = []
+        return server
+
+    def test_spawn_window_is_held_under_the_spawn_lock(self):
+        """The snapshot/attribution window must run with the spawn lock held.
+
+        _run_stdio derives its spawned PID from a delta over *all* gateway
+        children, and background discovery connects every configured server
+        concurrently on one loop. If that window is not serialised, one
+        server's delta contains a peer's child, and it then orphan-tracks a
+        process it does not own — so a scoped orphan sweep can terminate a
+        healthy peer.
+        """
+        from tools import mcp_tool
+        from tools.mcp_tool import (
+            _lock,
+            _orphan_stdio_pid_servers,
+            _orphan_stdio_pids,
+            _stdio_pgids,
+            _stdio_pids,
+        )
+
+        with _lock:
+            _stdio_pids.clear()
+            _stdio_pgids.clear()
+            _orphan_stdio_pids.clear()
+            _orphan_stdio_pid_servers.clear()
+
+        lock_state_during_window = []
+        server = self._make_server("test-spawn-window")
+
+        async def _run():
+            spawn_lock = mcp_tool._get_stdio_spawn_lock()
+
+            def _snapshot():
+                # Sampled at both ends of the attribution window.
+                lock_state_during_window.append(spawn_lock.locked())
+                return set()
+
+            stdio_cm = MagicMock()
+            stdio_cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+            stdio_cm.__aexit__ = AsyncMock(return_value=False)
+            session_cm = MagicMock()
+            session_cm.__aenter__ = AsyncMock(side_effect=RuntimeError("stop here"))
+            session_cm.__aexit__ = AsyncMock(return_value=False)
+
+            with patch("tools.mcp_tool.ClientSession", return_value=session_cm), \
+                 patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._build_safe_env", return_value={}), \
+                 patch("tools.mcp_tool._resolve_stdio_command", return_value=("echo", {})), \
+                 patch("tools.mcp_tool._write_stderr_log_header"), \
+                 patch("tools.mcp_tool._get_mcp_stderr_log", return_value=None), \
+                 patch("tools.osv_check.check_package_for_malware", return_value=None), \
+                 patch("tools.mcp_tool._kill_orphaned_mcp_children"), \
+                 patch("tools.mcp_tool._snapshot_child_pids", side_effect=_snapshot), \
+                 patch("tools.mcp_tool._filter_mcp_children", side_effect=lambda pids: pids), \
+                 patch("tools.mcp_tool.stdio_client", return_value=stdio_cm):
+                try:
+                    await server._run_stdio({"command": "echo", "args": []})
+                except Exception:
+                    pass
+            # Released before returning, so a later spawn is never blocked by a
+            # peer still inside its (up to connect_timeout) handshake.
+            assert not spawn_lock.locked()
+
+        asyncio.run(_run())
+
+        assert lock_state_during_window, "the PID snapshot was never taken"
+        assert all(lock_state_during_window), (
+            "the spawn/PID-attribution window ran without the spawn lock held, "
+            "so a concurrent connect could be misattributed; observed lock "
+            f"states={lock_state_during_window}"
         )
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2438,6 +2438,23 @@ class MCPServerTask:
         # exist, which would otherwise stall the shared MCP event loop.
         await asyncio.to_thread(_kill_orphaned_mcp_children)
 
+        # Serialise the spawn window. The PID delta below is a difference over
+        # *all* gateway children, and background discovery connects every
+        # configured server in PARALLEL on this single loop — so without this
+        # lock one server's window straddles another's spawn and it claims a
+        # child it did not spawn. Serialising is cheap: the window covers only
+        # the subprocess spawn and is released before the handshake, which can
+        # block for up to connect_timeout.
+        spawn_lock = _get_stdio_spawn_lock()
+        spawn_lock_released = False
+
+        def _release_spawn_lock() -> None:
+            nonlocal spawn_lock_released
+            if not spawn_lock_released:
+                spawn_lock_released = True
+                spawn_lock.release()
+
+        await spawn_lock.acquire()
         # Snapshot child PIDs before spawning so we can track the new one.
         pids_before = _snapshot_child_pids()
         new_pids: set = set()
@@ -2479,6 +2496,10 @@ class MCPServerTask:
                         for _pid in new_pids:
                             _stdio_pids[_pid] = self.name
                         _stdio_pgids.update(new_pgids)
+                # This server's PIDs are attributed now, so let the next spawn
+                # proceed. Holding the lock across the handshake below would
+                # serialise parallel discovery on connect_timeout.
+                _release_spawn_lock()
                 async with ClientSession(
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
@@ -2518,6 +2539,8 @@ class MCPServerTask:
                     # consistency with _run_http.
                     return await self._wait_for_lifecycle_event()
         finally:
+            # Covers paths that raised before the in-band release above.
+            _release_spawn_lock()
             # Runs on clean exit, exceptions, AND asyncio cancellation.
             # If any of the spawned PIDs are still alive, the SDK's
             # teardown failed (common when the task is cancelled mid-way
@@ -4122,6 +4145,21 @@ _orphan_stdio_pid_servers: Dict[int, str] = {}
 # exited and been removed from the active map.  Empty on Windows
 # (``os.getpgid`` is POSIX-only).
 _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
+
+
+# Serialises the stdio spawn window so concurrent _run_stdio calls cannot
+# claim each other's children. Created lazily: every _run_stdio runs on the
+# shared MCP loop, and binding an asyncio primitive at import time would tie
+# it to whichever loop happened to be current then.
+_stdio_spawn_lock: Optional["asyncio.Lock"] = None
+
+
+def _get_stdio_spawn_lock() -> "asyncio.Lock":
+    """Return the process-wide stdio spawn lock, creating it on first use."""
+    global _stdio_spawn_lock
+    if _stdio_spawn_lock is None:
+        _stdio_spawn_lock = asyncio.Lock()
+    return _stdio_spawn_lock
 
 
 def _snapshot_child_pids() -> set:


### PR DESCRIPTION
## Problem

`_run_stdio` identifies the process it just spawned with a set difference over `_snapshot_child_pids()`, which returns **all** gateway children:

```python
pids_before = _snapshot_child_pids()
async with stdio_client(server_params, errlog=_errlog) as (...):
    new_pids = _filter_mcp_children(_snapshot_child_pids() - pids_before)
```

Background discovery connects every configured server **in parallel** on the shared MCP loop, so one server's snapshot window can straddle another's spawn. When it does, the slower server's delta contains the peer's PID, and it records that PID in `_stdio_pids` and `_orphan_stdio_pid_servers` under its own name.

`_filter_mcp_children` does not prevent this — it strips `slash_worker`, `tui_gateway.entry` and LSP servers by cmdline marker, and another MCP stdio child matches none of those.

Today the consequence is deferred and probabilistic: a misattributed PID gets reaped by a later sweep. It becomes **direct** as soon as a cancelled or failed connect reaps its orphans eagerly — a failing server then terminates a healthy peer's process. That surfaces as fewer connected servers rather than as an error, which makes it hard to attribute.

This is worth fixing on its own, and it is a prerequisite for making eager reaping safe. #73261 proposes exactly that eager reap for #72887, scoped with `server_name=self.name` — but scoping cannot help when the peer's PID is *recorded under this server's name*, which is precisely what the race produces.

## Fix

Hold a process-wide lock across the window from the pre-spawn snapshot to PID registration.

The lock is released as soon as the PIDs are attributed and **before** the handshake, so parallel discovery still overlaps on `connect_timeout` and only the subprocess spawns are ordered — those are fast, so the throughput cost is negligible. It is created lazily because binding an asyncio primitive at import time would tie it to whichever loop was current then rather than the shared MCP loop.

## Verification

Added `TestStdioSpawnWindowSerialisation::test_spawn_window_is_held_under_the_spawn_lock`, which asserts the lock is held at both ends of the attribution window and released before return. Confirmed it **fails without** the source change:

```
$ git stash push tools/mcp_tool.py && pytest tests/tools/test_mcp_stability.py -k SpawnWindow
1 failed
$ git stash pop && pytest tests/tools/test_mcp_stability.py -k SpawnWindow
1 passed
```

Full checks:

```
$ ruff check .                                    All checks passed!
$ python scripts/check-windows-footguns.py --all  ✓ No Windows footguns found (830 files)
$ pytest tests/tools/ -k mcp                      787 passed, 2 skipped
```

Two caveats, stated rather than glossed: `tests/tools/test_slack_send_message_media.py` is excluded from that run because it fails to collect on a missing `aiohttp` in my environment — it fails identically on unmodified `main`, so it is unrelated. And my venv resolved ruff 0.12.0 while CI pins 0.15.10, so I can confirm ruff passes locally but not claim CI parity.

The race itself is timing-dependent and I did not find a way to reproduce it deterministically in a unit test, which is why the test asserts the invariant (window is serialised) rather than the symptom.

This change was prepared with AI assistance and reviewed by me before submitting.