### PR TITLE
fix(desktop): bind submits to activated session

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -87,6 +87,7 @@ import { useRouteResume } from '../session/hooks/use-route-resume'
 import { useSessionActions } from '../session/hooks/use-session-actions'
 import { useSessionListActions } from '../session/hooks/use-session-list-actions'
 import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
+import type { SessionActivationRef } from '../session/session-activation'
 import { newSessionOpensTab, startWorkspaceSession } from '../session/workspace-session-target'
 import { useOverlayRouting } from '../shell/hooks/use-overlay-routing'
 import { useWindowControlsOverlayWidth } from '../shell/hooks/use-window-controls-overlay-width'
@@ -127,6 +128,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)
+  const sessionActivationRef: SessionActivationRef = useRef(null)
   // Billing recovery routes to Settings → Billing from surfaces without router
   // context (the sticky toast). The shell owns `navigate`, so it consumes the
   // intent counter here; the ref skips the initial mount value.
@@ -435,6 +437,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     requestGateway,
     resetViewSync,
     runtimeIdByStoredSessionIdRef,
+    sessionActivationRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
     sessionStateByRuntimeIdRef,
@@ -565,6 +568,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     refreshSessions,
     requestGateway,
     resumeStoredSession: resumeSession,
+    sessionActivationRef,
     selectedStoredSessionIdRef,
     startFreshSessionDraft,
     sttEnabled,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -23,6 +23,8 @@ import {
 import { dropSessionState, publishSessionState } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
+import type { SessionActivationRef } from '../../session-activation'
+
 import type { SubmitTextOptions } from './utils'
 
 import { uploadComposerAttachment, usePromptActions } from '.'
@@ -99,6 +101,7 @@ function Harness({
   refreshSessions,
   requestGateway,
   resumeStoredSession,
+  sessionActivationRef,
   seedMessages,
   selectedStoredSessionIdRef: selectedStoredSessionIdRefProp,
   storedSessionId,
@@ -120,6 +123,7 @@ function Harness({
   openMemoryGraph?: () => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+  sessionActivationRef?: SessionActivationRef
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
   seedMessages?: unknown[]
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
@@ -160,6 +164,7 @@ function Harness({
     refreshSessions,
     requestGateway,
     resumeStoredSession: resumeStoredSession ?? (() => undefined),
+    sessionActivationRef,
     selectedStoredSessionIdRef,
     startFreshSessionDraft: () => undefined,
     sttEnabled: false,
@@ -3610,6 +3615,122 @@ describe('usePromptActions new-chat first-send delivery (#63078)', () => {
 
     expect(await submitting).toBe(false)
     expect(calls.some(c => c.method === 'prompt.submit')).toBe(false)
+  })
+})
+
+describe('usePromptActions session activation submit barrier (#72971)', () => {
+  const STORED_SESSION_A = 'stored-activation-a'
+  const STORED_SESSION_B = 'stored-activation-b'
+  const RUNTIME_SESSION_B = 'rt-activation-b'
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    $connection.set(null)
+    $composerAttachments.set([])
+  })
+
+  it('blocks prompt.submit while the selected session activation is unacknowledged', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_B }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_B }
+    const sessionActivationRef: SessionActivationRef = {
+      current: { requestId: 7, storedSessionId: STORED_SESSION_B }
+    }
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={RUNTIME_SESSION_B}
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => STORED_SESSION_B}
+        getRuntimeIdForStoredSession={() => RUNTIME_SESSION_B}
+        getRouteToken={() => `/${STORED_SESSION_B}::`}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        sessionActivationRef={sessionActivationRef}
+        storedSessionId={STORED_SESSION_B}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    expect(await handle!.submitText('do not leak into the previous session')).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+
+    sessionActivationRef.current = null
+
+    expect(await handle!.submitText('send after activate ack')).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      expect.objectContaining({ session_id: RUNTIME_SESSION_B, text: 'send after activate ack' }),
+      expect.anything()
+    )
+  })
+
+  it('re-reads the active runtime immediately before prompt.submit', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl: vi.fn(async () => 'data:application/pdf;base64,JVBERi0=') }
+    })
+
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_A }
+    let releaseAttach: () => void = () => {}
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'file.attach') {
+        await new Promise<void>(resolve => {
+          releaseAttach = resolve
+        })
+
+        return { attached: true, ref_text: '@file:.hermes/desktop-attachments/test.pdf' } as never
+      }
+
+      return {} as never
+    })
+
+    const attachment: ComposerAttachment = {
+      id: 'activation-race-file',
+      kind: 'file',
+      label: 'test.pdf',
+      path: '/abs/test.pdf',
+      refText: '@file:`/abs/test.pdf`'
+    }
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={RUNTIME_SESSION_ID}
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => STORED_SESSION_A}
+        getRuntimeIdForStoredSession={() => activeSessionIdRef.current}
+        getRouteToken={() => `/${STORED_SESSION_A}::`}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_A}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const submitting = handle!.submitText('bind me to the acknowledged runtime', { attachments: [attachment] })
+    await waitFor(() => expect(calls.some(call => call.method === 'file.attach')).toBe(true))
+
+    activeSessionIdRef.current = RUNTIME_SESSION_B
+    releaseAttach()
+
+    expect(await submitting).toBe(true)
+    expect(calls.find(call => call.method === 'prompt.submit')?.params).toMatchObject({
+      session_id: RUNTIME_SESSION_B,
+      text: expect.stringContaining('bind me to the acknowledged runtime')
+    })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -44,6 +44,7 @@ import type {
   ImageAttachResponse,
   SessionRedirectResponse
 } from '../../../types'
+import type { SessionActivationRef } from '../../session-activation'
 import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import {
@@ -182,6 +183,7 @@ interface PromptActionsOptions {
   openMemoryGraph: () => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+  sessionActivationRef?: SessionActivationRef
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: () => void
@@ -214,6 +216,7 @@ export function usePromptActions({
   refreshSessions,
   requestGateway,
   resumeStoredSession,
+  sessionActivationRef,
   selectedStoredSessionIdRef,
   startFreshSessionDraft,
   sttEnabled,
@@ -405,6 +408,7 @@ export function usePromptActions({
     getRouteToken,
     requestGateway,
     resumeStoredSession,
+    sessionActivationRef,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,
     updateSessionState

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -24,6 +24,7 @@ import { $sessions, resolveComposerSessionKey, setAwaitingResponse, setBusy, set
 import { $sessionStates } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../../types'
+import { isSessionActivationPending, type SessionActivationRef } from '../../session-activation'
 import { sessionContextDrift } from '../session-context-drift'
 import { resolveSessionProfile } from '../use-session-actions/utils'
 
@@ -49,6 +50,7 @@ interface SubmitPromptDeps {
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
   getRouteToken: () => string
   requestGateway: GatewayRequest
+  sessionActivationRef?: SessionActivationRef
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   syncAttachmentsForSubmit: (
@@ -95,6 +97,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     getRouteToken,
     requestGateway,
     resumeStoredSession,
+    sessionActivationRef,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,
     updateSessionState,
@@ -175,6 +178,15 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // must never inherit the currently selected session after the user moves
       // to another chat.
       const targetStoredSessionId = options?.storedSessionId ?? selectedStoredSessionIdRef.current
+
+      // A foreground session switch is not ready to accept prompts until the
+      // latest session.activate/session.resume handshake has been acknowledged.
+      // Returning false keeps the composer draft intact (dispatchSubmit restores
+      // rejected sends) instead of letting a closure-captured runtime id route
+      // the text into the previously active chat (#72971).
+      if (isSessionActivationPending(sessionActivationRef, targetStoredSessionId)) {
+        return false
+      }
 
       const targetStartedInCurrentView =
         !targetStoredSessionId || targetStoredSessionId === selectedStoredSessionIdRef.current
@@ -539,6 +551,32 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return abortForSessionSwitch(sessionId)
         }
 
+        if (targetIsCurrentView()) {
+          // The submit pipeline can cross async boundaries (profile swap,
+          // session.activate, attachment upload). Re-read the live foreground
+          // runtime immediately before prompt.submit instead of trusting the
+          // runtime captured when Enter was pressed. A pending activation is a
+          // hard barrier; a mismatched stored->runtime mapping is fail-closed.
+          if (isSessionActivationPending(sessionActivationRef, startingStoredSessionId)) {
+            return abortForSessionSwitch(sessionId)
+          }
+
+          const currentRuntimeId = activeSessionIdRef.current
+          const mappedRuntimeId = startingStoredSessionId
+            ? getRuntimeIdForStoredSession(startingStoredSessionId)
+            : currentRuntimeId
+
+          if (!currentRuntimeId || (mappedRuntimeId && mappedRuntimeId !== currentRuntimeId)) {
+            return abortForSessionSwitch(sessionId)
+          }
+
+          if (currentRuntimeId !== sessionId) {
+            dropOptimistic(sessionId)
+            sessionId = currentRuntimeId
+            seedOptimistic(sessionId)
+          }
+        }
+
         // Rewrite the optimistic message + prompt text with the synced refs so
         // the gateway receives @file: paths that resolve in its workspace.
         // (Images keep their inline base64 preview — see optimisticAttachmentRef.)
@@ -682,6 +720,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       resumeStoredSession,
       scope,
       selectedStoredSessionIdRef,
+      sessionActivationRef,
       syncAttachmentsForSubmit,
       updateSessionState
     ]

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -38,6 +38,7 @@ import { $sessionTiles } from '@/store/session-states'
 
 import { sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
+import type { SessionActivationRef } from '../session-activation'
 
 import { useSessionActions } from './use-session-actions'
 
@@ -575,6 +576,7 @@ function ResumeHarness({
   onReady,
   requestGateway,
   runtimeIdByStoredSessionIdRef,
+  sessionActivationRef,
   selectedStoredSessionId = null,
   sessionStateByRuntimeIdRef
 }: {
@@ -582,6 +584,7 @@ function ResumeHarness({
   onReady: (resume: (storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
+  sessionActivationRef?: SessionActivationRef
   selectedStoredSessionId?: string | null
   sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
 }) {
@@ -599,6 +602,7 @@ function ResumeHarness({
     requestGateway,
     resetViewSync: vi.fn(),
     runtimeIdByStoredSessionIdRef: runtimeIdByStoredSessionIdRef ?? ref(new Map<string, string>()),
+    sessionActivationRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef: ref<string | null>(selectedStoredSessionId),
     sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef ?? ref(new Map<string, ClientSessionState>()),
@@ -1432,6 +1436,63 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(methods).not.toContain('session.resume')
     expect(getSessionMessages).toHaveBeenCalledWith('stored-A', undefined)
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
+  })
+
+  it('keeps the activation barrier pending until warm session.activate is acknowledged', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', clientState('stored-A')]])
+    }
+    const sessionActivationRef: SessionActivationRef = { current: null }
+    const activation = deferred<Record<string, unknown>>()
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return (await activation.promise) as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionActivationRef={sessionActivationRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    let resumePromise!: Promise<unknown>
+    act(() => {
+      resumePromise = resume!('stored-A', true)
+    })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.activate', expect.anything()))
+
+    expect(sessionActivationRef.current?.storedSessionId).toBe('stored-A')
+
+    activation.resolve({
+      session_id: 'rt-A',
+      session_key: 'stored-A',
+      resumed: 'stored-A',
+      message_count: 0,
+      messages: [],
+      running: false,
+      info: {}
+    })
+
+    await act(async () => {
+      await resumePromise
+    })
+
+    expect(sessionActivationRef.current).toBeNull()
   })
 
   it('preserves cached image attachments through an idle persisted transcript refresh', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -71,6 +71,7 @@ import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, Usag
 
 import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
+import { acknowledgeSessionActivation, beginSessionActivation, type SessionActivationRef } from '../../session-activation'
 import { sessionContextDrift } from '../session-context-drift'
 
 import {
@@ -104,6 +105,7 @@ interface SessionActionsOptions {
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   resetViewSync: () => void
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
+  sessionActivationRef?: SessionActivationRef
   selectedStoredSessionId: string | null
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
@@ -208,6 +210,7 @@ export function useSessionActions({
   requestGateway,
   resetViewSync,
   runtimeIdByStoredSessionIdRef,
+  sessionActivationRef,
   selectedStoredSessionId,
   selectedStoredSessionIdRef,
   sessionStateByRuntimeIdRef,
@@ -539,6 +542,7 @@ export function useSessionActions({
     async (storedSessionId: string, replaceRoute = false) => {
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
+      beginSessionActivation(sessionActivationRef, requestId, storedSessionId)
       const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId
       const resumeStartMessages = resumedSameSelectedSession ? $messages.get() : []
 
@@ -716,6 +720,8 @@ export function useSessionActions({
                 setCurrentUsage(current => ({ ...current, ...usage }))
               }
 
+              acknowledgeSessionActivation(sessionActivationRef, requestId)
+
               return
             }
 
@@ -777,6 +783,7 @@ export function useSessionActions({
               setBusy(running)
               setAwaitingResponse(running)
               syncSessionStateToView(cachedRuntimeId, activatedState)
+              acknowledgeSessionActivation(sessionActivationRef, requestId)
 
               return
             }
@@ -971,6 +978,7 @@ export function useSessionActions({
 
         setActiveSessionId(resumed.session_id)
         activeSessionIdRef.current = resumed.session_id
+        acknowledgeSessionActivation(sessionActivationRef, requestId)
         const runtimeInfo = applyRuntimeInfo(resumed.info)
 
         patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
@@ -1102,6 +1110,7 @@ export function useSessionActions({
       resetViewSync,
       runtimeIdByStoredSessionIdRef,
       selectedStoredSessionIdRef,
+      sessionActivationRef,
       sessionStateByRuntimeIdRef,
       startFreshSessionDraft,
       syncSessionStateToView,

--- a/apps/desktop/src/app/session/session-activation.ts
+++ b/apps/desktop/src/app/session/session-activation.ts
@@ -1,0 +1,34 @@
+import type { MutableRefObject } from 'react'
+
+export interface PendingSessionActivation {
+  requestId: number
+  storedSessionId: string
+}
+
+export type SessionActivationRef = MutableRefObject<PendingSessionActivation | null>
+
+export function beginSessionActivation(
+  ref: SessionActivationRef | undefined,
+  requestId: number,
+  storedSessionId: string
+): void {
+  if (ref) {
+    ref.current = { requestId, storedSessionId }
+  }
+}
+
+export function acknowledgeSessionActivation(
+  ref: SessionActivationRef | undefined,
+  requestId: number
+): void {
+  if (ref?.current?.requestId === requestId) {
+    ref.current = null
+  }
+}
+
+export function isSessionActivationPending(
+  ref: SessionActivationRef | undefined,
+  storedSessionId: string | null
+): boolean {
+  return Boolean(storedSessionId && ref?.current?.storedSessionId === storedSessionId)
+}


### PR DESCRIPTION
## What does this PR do?

Prevents Desktop prompt submissions from being routed to a stale runtime session during asynchronous session switches.

The submit path now waits for the latest `session.activate` or `session.resume` acknowledgement and re-reads the active runtime session immediately before `prompt.submit`.

## Related issue

Fixes #72971

Related to #66661, but this PR addresses the stale activation and submit-routing path rather than rejected-submit composer restoration.

## Type of change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Refactor

## Changes made

- add a monotonic session activation barrier shared by session and prompt actions
- block prompt submission while the selected session activation is unacknowledged
- re-read the active runtime session immediately before `prompt.submit`
- fail closed when stored-session and runtime-session mappings disagree
- prevent stale activation responses from clearing a newer pending activation
- restore the composer text when submission is rejected by the session barrier
- add regression coverage for pending activation and runtime changes during asynchronous attachment upload

## How to test

1. Start a response in one Desktop session.
2. Switch to or branch into another session while the response is still active.
3. Submit a message immediately in the newly selected session.
4. Verify that submission is blocked until the latest session activation is acknowledged.
5. Verify that the message is then submitted with the newly active runtime session ID.
6. Run the focused Desktop session-action and prompt-action tests.

## Checklist

- [x] The change is scoped to the Desktop session-switch and prompt-submit paths
- [x] Regression tests were added
- [x] Existing credential, backend, and persistence behavior is unchanged
- [x] No unrelated files were modified