### PR TITLE
fix(auxiliary): use active runtime in final main-agent fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6126,6 +6126,22 @@ def resolve_provider_client(
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = _scoped_key_env(custom_key_env)
+            # Live runtime beats the persisted entry.  The main conversation may
+            # already be serving this named provider from a different endpoint or
+            # credential (rotated key, failover host, session-scoped token); the
+            # auxiliary safety net has to follow the route that actually works.
+            # Only the endpoint/credential are overridden — the entry keeps
+            # owning api_mode, model default, and header handling below.
+            if explicit_base_url:
+                _explicit_base = str(explicit_base_url).strip().rstrip("/")
+                if _explicit_base:
+                    custom_base = _explicit_base
+            if explicit_api_key:
+                if callable(explicit_api_key):
+                    # Azure Entra-style bearer provider — pass the callable through.
+                    custom_key = explicit_api_key
+                else:
+                    custom_key = str(explicit_api_key).strip() or custom_key
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3327,7 +3327,11 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     return CodexAuxiliaryClient(real_client, model), model
 
 
-def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+def _build_codex_client(
+    model: str,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an explicitly-requested model.
 
     There is no auto-selection of the Codex model: the ChatGPT-account
@@ -3336,7 +3340,9 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     is responsible for passing the model (e.g. from the user's own
     ``model.model`` or ``auxiliary.<task>.model`` config).
 
-    Returns (None, None) when no Codex OAuth token is available.
+    Returns (None, None) when no Codex OAuth token is available.  A live
+    runtime credential takes precedence over the pool/auth store so auxiliary
+    fallback stays on the exact account already serving the conversation.
     """
     if not model:
         logger.warning(
@@ -3344,21 +3350,25 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
             "pass model explicitly (auxiliary.<task>.model in config.yaml)."
         )
         return None, None
-    pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        codex_token = _pool_runtime_api_key(entry)
-        if codex_token:
-            base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
+    if explicit_api_key:
+        codex_token = explicit_api_key
+        base_url = explicit_base_url or _CODEX_AUX_BASE_URL
+    else:
+        pool_present, entry = _select_pool_entry("openai-codex")
+        if pool_present:
+            codex_token = _pool_runtime_api_key(entry)
+            if codex_token:
+                base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
+            else:
+                codex_token = _read_codex_access_token()
+                if not codex_token:
+                    return None, None
+                base_url = _CODEX_AUX_BASE_URL
         else:
             codex_token = _read_codex_access_token()
             if not codex_token:
                 return None, None
             base_url = _CODEX_AUX_BASE_URL
-    else:
-        codex_token = _read_codex_access_token()
-        if not codex_token:
-            return None, None
-        base_url = _CODEX_AUX_BASE_URL
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", model)
     real_client = _create_openai_client(
         api_key=codex_token,
@@ -4944,13 +4954,19 @@ def _try_main_agent_model_fallback(
     task: str = None,
     reason: str = "error",
     failed_model: Optional[str] = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
-    """Last-resort fallback to the user's main agent provider + model.
+    """Last-resort fallback to the active main agent provider + model.
 
     Used after the configured fallback_chain is exhausted (or empty) for
     users with an explicit auxiliary provider.  This is the "safety net"
     layer: if nothing the user asked for can serve the request, try the
     main chat model before giving up.
+
+    Prefer the live ``main_runtime`` snapshot over config.yaml.  The main
+    conversation may already have failed over to a different provider/model;
+    re-reading the configured primary here would retry the stale route instead
+    of following the model that is actually serving the conversation.
 
     ``failed_model`` narrows the same-provider skip to the exact
     (provider, model) pair that just failed, mirroring
@@ -4973,8 +4989,45 @@ def _try_main_agent_model_fallback(
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
     """
-    main_provider = (_read_main_provider() or "").strip()
-    main_model = (_read_main_model() or "").strip()
+    if main_runtime is None:
+        # Direct safety-net callers may rely on the session-local binding, but
+        # must not inherit another session through the process-global legacy
+        # mirror. call_llm passes its normalized snapshot explicitly.
+        scoped_runtime = _RUNTIME_MAIN_CONTEXT.get()
+        runtime = _normalize_main_runtime(scoped_runtime) if scoped_runtime else {}
+    else:
+        runtime = _normalize_main_runtime(main_runtime)
+    runtime_provider = str(runtime.get("provider") or "").strip()
+    runtime_model = str(runtime.get("model") or "").strip()
+    using_runtime = bool(runtime_provider and runtime_model)
+    if using_runtime:
+        main_provider, main_model = runtime_provider, runtime_model
+    else:
+        main_provider = (_read_main_provider() or "").strip()
+        main_model = (_read_main_model() or "").strip()
+
+    resolution_kwargs: Dict[str, Any] = {}
+    if using_runtime:
+        resolution_kwargs = {
+            "explicit_base_url": runtime.get("base_url") or None,
+            "explicit_api_key": runtime.get("api_key") or None,
+            "api_mode": runtime.get("api_mode") or None,
+            "main_runtime": runtime,
+        }
+
+    if using_runtime and main_provider.startswith("custom:") and runtime.get("base_url"):
+        # A config-less named custom provider exists only in the live runtime.
+        # Mirror _resolve_auto(): collapse it to the anonymous custom arm so
+        # the runtime endpoint and credential are actually used.
+        try:
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+
+            has_named_entry = _get_named_custom_provider(main_provider) is not None
+        except ImportError:
+            has_named_entry = False
+        if not has_named_entry:
+            main_provider = "custom"
+
     if main_provider.lower() == "moa":
         # MoA virtual provider: fall back to the preset's aggregator — the
         # acting model — instead of the unreachable "moa"/<preset-name> pair.
@@ -4982,6 +5035,9 @@ def _try_main_agent_model_fallback(
         if not _agg_provider or not _agg_model:
             return None, None, ""
         main_provider, main_model = _agg_provider, _agg_model
+        # Runtime endpoint/auth fields belong to the moa:// facade, not the
+        # aggregator's real provider.
+        resolution_kwargs = {}
     if not main_provider or not main_model or main_provider.lower() in {"auto", ""}:
         return None, None, ""
 
@@ -5009,7 +5065,9 @@ def _try_main_agent_model_fallback(
 
     try:
         client, resolved_model = resolve_provider_client(
-            provider=main_provider, model=main_model,
+            provider=main_provider,
+            model=main_model,
+            **resolution_kwargs,
         )
     except Exception:
         client, resolved_model = None, None
@@ -5930,7 +5988,11 @@ def resolve_provider_client(
             )
             return (raw_client, final_model)
         # Standard path: wrap in CodexAuxiliaryClient adapter
-        client, default = _build_codex_client(model)
+        client, default = _build_codex_client(
+            model,
+            explicit_api_key=explicit_api_key,
+            explicit_base_url=explicit_base_url,
+        )
         if client is None:
             logger.warning("resolve_provider_client: openai-codex requested "
                            "but no Codex OAuth token found (run: hermes model)")
@@ -9289,7 +9351,8 @@ def _call_llm_impl(
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason,
-                        failed_model=_chain_failed_model)
+                        failed_model=_chain_failed_model,
+                        main_runtime=main_runtime)
 
             if fb_client is not None:
                 fb_resp = _call_fallback_candidate_sync(
@@ -9926,7 +9989,8 @@ async def _async_call_llm_impl(
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason,
-                        failed_model=_chain_failed_model)
+                        failed_model=_chain_failed_model,
+                        main_runtime=main_runtime)
 
             if fb_client is not None:
                 # Convert sync fallback client to async

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -708,6 +708,33 @@ class TestAnthropicOAuthFlag:
 
 
 class TestBuildCodexClient:
+    def test_live_runtime_credentials_override_persisted_codex_auth(self):
+        """An active fallback route must keep its exact Codex credential."""
+        with (
+            patch(
+                "agent.auxiliary_client._select_pool_entry",
+                side_effect=AssertionError("credential pool should not be read"),
+            ),
+            patch(
+                "agent.auxiliary_client._read_codex_access_token",
+                side_effect=AssertionError("auth store should not be read"),
+            ),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import _build_codex_client
+
+            client, model = _build_codex_client(
+                "gpt-5.6-sol",
+                explicit_api_key="live-runtime-token",
+                explicit_base_url="https://runtime.example/codex",
+            )
+
+        assert client is not None
+        assert model == "gpt-5.6-sol"
+        assert mock_openai.call_args.kwargs["api_key"] == "live-runtime-token"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://runtime.example/codex"
+
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):
         with (
             patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
@@ -1580,6 +1607,142 @@ class TestCallLlmPaymentFallback:
         # Fallback client should have been used
         assert fallback_client.chat.completions.create.called
 
+    def test_explicit_compression_fallback_uses_live_main_runtime(self):
+        """A failed pinned compressor falls back to the active main route.
+
+        The main conversation may already have failed over from its configured
+        Anthropic model to Codex.  The auxiliary safety net must follow that
+        live route instead of re-reading the stale configured main model.
+        """
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = (
+            self._make_429_rate_limit_error()
+        )
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = _DummyResponse(
+            "runtime codex response"
+        )
+        live_runtime = {
+            "provider": "openai-codex",
+            "model": "gpt-5.6-sol",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "runtime-test-token",
+            "api_mode": "codex_responses",
+        }
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "claude-haiku-4-5-20251001"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=(
+                "anthropic",
+                "claude-haiku-4-5-20251001",
+                None,
+                None,
+                None,
+            ),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(None, None, ""),
+        ), patch(
+            "agent.auxiliary_client._recover_provider_pool", return_value=False
+        ), patch(
+            "agent.auxiliary_client._read_main_provider", return_value="anthropic"
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="claude-opus-4-6",
+        ), patch(
+            "agent.auxiliary_client._is_provider_unhealthy", return_value=False
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "gpt-5.6-sol"),
+        ) as mock_resolve:
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                main_runtime=live_runtime,
+            )
+
+        assert result.choices[0].message.content == "runtime codex response"
+        mock_resolve.assert_called_once_with(
+            provider="openai-codex",
+            model="gpt-5.6-sol",
+            explicit_base_url="https://chatgpt.com/backend-api/codex",
+            explicit_api_key="runtime-test-token",
+            api_mode="codex_responses",
+            main_runtime=live_runtime,
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_explicit_compression_fallback_uses_live_main_runtime(self):
+        """The async auxiliary path preserves the same live-route contract."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=self._make_429_rate_limit_error()
+        )
+
+        sync_fallback_client = MagicMock()
+        async_fallback_client = MagicMock()
+        async_fallback_client.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("async runtime codex response")
+        )
+        live_runtime = {
+            "provider": "openai-codex",
+            "model": "gpt-5.6-sol",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "runtime-test-token",
+            "api_mode": "codex_responses",
+        }
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "claude-haiku-4-5-20251001"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=(
+                "anthropic",
+                "claude-haiku-4-5-20251001",
+                None,
+                None,
+                None,
+            ),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(None, None, ""),
+        ), patch(
+            "agent.auxiliary_client._recover_provider_pool", return_value=False
+        ), patch(
+            "agent.auxiliary_client._read_main_provider", return_value="anthropic"
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="claude-opus-4-6",
+        ), patch(
+            "agent.auxiliary_client._is_provider_unhealthy", return_value=False
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(sync_fallback_client, "gpt-5.6-sol"),
+        ) as mock_resolve, patch(
+            "agent.auxiliary_client._to_async_client",
+            return_value=(async_fallback_client, "gpt-5.6-sol"),
+        ):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                main_runtime=live_runtime,
+            )
+
+        assert result.choices[0].message.content == "async runtime codex response"
+        mock_resolve.assert_called_once_with(
+            provider="openai-codex",
+            model="gpt-5.6-sol",
+            explicit_base_url="https://chatgpt.com/backend-api/codex",
+            explicit_api_key="runtime-test-token",
+            api_mode="codex_responses",
+            main_runtime=live_runtime,
+        )
+
     def test_401_auth_error_triggers_fallback_in_auto_mode(self, monkeypatch):
         """401 auth errors should trigger fallback in auto mode (#21165).
 
@@ -1890,6 +2053,88 @@ class TestTryMainAgentModelFallback:
             client, model, label = _try_main_agent_model_fallback("glm", task="vision")
         assert client is None and model is None and label == ""
 
+
+    def test_ignores_legacy_runtime_mirror_without_context_binding(self):
+        """A stale process-global mirror must not cross session boundaries."""
+        from agent.auxiliary_client import (
+            _try_main_agent_model_fallback,
+            clear_runtime_main,
+            reset_runtime_main,
+            set_runtime_main,
+        )
+
+        token = set_runtime_main(
+            "openai-codex",
+            "stale-runtime-model",
+            api_key="stale-runtime-token",
+        )
+        reset_runtime_main(token)  # Clears ContextVar, intentionally leaves mirror.
+        fake_client = MagicMock()
+        try:
+            with patch(
+                "agent.auxiliary_client._read_main_provider", return_value="openrouter"
+            ), patch(
+                "agent.auxiliary_client._read_main_model", return_value="configured-model"
+            ), patch(
+                "agent.auxiliary_client._is_provider_unhealthy", return_value=False
+            ), patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fake_client, "configured-model"),
+            ) as mock_resolve:
+                client, model, label = _try_main_agent_model_fallback(
+                    "anthropic", task="compression", failed_model="haiku"
+                )
+        finally:
+            clear_runtime_main()
+
+        assert client is fake_client
+        assert model == "configured-model"
+        assert label == "main-agent(openrouter)"
+        mock_resolve.assert_called_once_with(
+            provider="openrouter", model="configured-model"
+        )
+
+    def test_live_configless_named_custom_runtime_uses_its_endpoint(self):
+        """A config-less custom runtime must not be re-resolved from config."""
+        from agent.auxiliary_client import (
+            _try_main_agent_model_fallback,
+            scoped_runtime_main,
+        )
+
+        fake_client = MagicMock()
+        live_runtime = {
+            "provider": "custom:ephemeral",
+            "model": "runtime-model",
+            "base_url": "https://live.example/v1",
+            "api_key": "live-runtime-key",
+            "api_mode": "chat_completions",
+        }
+        with scoped_runtime_main(live_runtime), patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            return_value=None,
+        ), patch(
+            "agent.auxiliary_client._is_provider_unhealthy", return_value=False
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fake_client, "runtime-model"),
+        ) as mock_resolve:
+            client, model, label = _try_main_agent_model_fallback(
+                "anthropic",
+                task="compression",
+                failed_model="claude-haiku-4-5-20251001",
+            )
+
+        assert client is fake_client
+        assert model == "runtime-model"
+        assert label == "main-agent(custom)"
+        mock_resolve.assert_called_once_with(
+            provider="custom",
+            model="runtime-model",
+            explicit_base_url="https://live.example/v1",
+            explicit_api_key="live-runtime-key",
+            api_mode="chat_completions",
+            main_runtime=live_runtime,
+        )
 
     def test_resolves_main_provider_client(self):
         from agent.auxiliary_client import _try_main_agent_model_fallback

--- a/tests/agent/test_set_runtime_main_custom_provider.py
+++ b/tests/agent/test_set_runtime_main_custom_provider.py
@@ -229,3 +229,163 @@ class TestResolveAutoCustomEndToEnd:
             assert mock_resolve.call_args.kwargs["explicit_base_url"] is None
         finally:
             mod.clear_runtime_main()
+
+
+class TestConfiguredNamedCustomHonorsActiveRuntime:
+    """A ``custom:<name>`` provider that DOES have a config entry, but whose
+    live runtime endpoint/credential differ from that entry.
+
+    The named-custom arm of ``resolve_provider_client`` reads base_url/api_key
+    from the config entry, so the auxiliary safety net used to resolve against
+    the stale configured endpoint even when the main conversation had already
+    moved to a different host or key (rotated credential, failover endpoint,
+    session-scoped token).  The active runtime must win for endpoint + key,
+    while the entry keeps owning api_mode handling.
+    """
+
+    @staticmethod
+    def _client_base_url(client):
+        for chain in (("base_url",), ("_client", "base_url")):
+            obj = client
+            try:
+                for attr in chain:
+                    obj = getattr(obj, attr)
+                return str(obj)
+            except AttributeError:
+                continue
+        return None
+
+    @staticmethod
+    def _write_home(tmp_path, monkeypatch, extra_entry_lines=""):
+        for var in ("OPENROUTER_API_KEY", "NOUS_API_KEY", "OPENAI_API_KEY",
+                    "OPENAI_BASE_URL", "ANTHROPIC_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: glm-5.1\n"
+            "  provider: 'custom:rotator'\n"
+            "  base_url: ''\n"
+            "custom_providers:\n"
+            "  - name: rotator\n"
+            "    base_url: 'https://stale-config.example/v1'\n"
+            "    model: glm-5.1\n"
+            "    api_key: stale-config-key\n"
+            + extra_entry_lines
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        return hermes_home
+
+    def test_safety_net_uses_runtime_endpoint_over_config_entry(
+            self, tmp_path, monkeypatch):
+        """_try_main_agent_model_fallback on a configured named-custom main
+        provider builds a client at the ACTIVE endpoint/key, not the entry's."""
+        import agent.auxiliary_client as mod
+
+        self._write_home(tmp_path, monkeypatch)
+
+        mod.clear_runtime_main()
+        try:
+            live_runtime = {
+                "provider": "custom:rotator",
+                "model": "glm-5.1-live",
+                "base_url": "https://live-failover.example/v1",
+                "api_key": "sk-live-rotated",
+            }
+            with patch.object(mod, "_is_provider_unhealthy", return_value=False):
+                client, model, label = mod._try_main_agent_model_fallback(
+                    "anthropic",
+                    task="compression",
+                    failed_model="claude-haiku-4-5",
+                    main_runtime=live_runtime,
+                )
+
+            assert client is not None, (
+                "configured named-custom main provider produced no safety-net "
+                "client"
+            )
+            assert model == "glm-5.1-live"
+            assert label == "main-agent(custom:rotator)"
+            base = self._client_base_url(client)
+            assert base and base.rstrip("/") == "https://live-failover.example/v1", (
+                f"safety net resolved to {base!r} — the stale config entry won "
+                "over the active runtime endpoint"
+            )
+            assert getattr(client, "api_key", None) == "sk-live-rotated", (
+                "safety net used the config entry's credential instead of the "
+                "live one already serving the conversation"
+            )
+        finally:
+            mod.clear_runtime_main()
+
+    def test_runtime_override_preserves_entry_api_mode(
+            self, tmp_path, monkeypatch):
+        """Honouring the runtime endpoint must not lose the entry's api_mode.
+
+        ``api_mode: anthropic_messages`` still has to build an
+        AnthropicAuxiliaryClient against the un-rewritten URL — only the host
+        and credential come from the live runtime.
+        """
+        import agent.auxiliary_client as mod
+
+        self._write_home(
+            tmp_path, monkeypatch,
+            extra_entry_lines="    api_mode: anthropic_messages\n",
+        )
+
+        mod.clear_runtime_main()
+        try:
+            live_proxy = "https://live-failover.example/api/v2/llm/proxy/anthropic"
+            with patch.object(mod, "_is_provider_unhealthy", return_value=False):
+                client, model, label = mod._try_main_agent_model_fallback(
+                    "openrouter",
+                    task="vision",
+                    main_runtime={
+                        "provider": "custom:rotator",
+                        "model": "claude-4-6-opus",
+                        "base_url": live_proxy,
+                        "api_key": "sk-live-rotated",
+                        "api_mode": "anthropic_messages",
+                    },
+                )
+
+            assert client is not None
+            assert model == "claude-4-6-opus"
+            assert client.__class__.__name__ == "AnthropicAuxiliaryClient", (
+                f"expected AnthropicAuxiliaryClient, got "
+                f"{client.__class__.__name__} — the entry's api_mode was lost "
+                "while adopting the runtime endpoint"
+            )
+            # No /anthropic → /v1 rewrite, and the live host (not the config
+            # host) is what the client talks to.
+            assert getattr(client, "base_url", "").rstrip("/") == live_proxy
+        finally:
+            mod.clear_runtime_main()
+
+    def test_config_entry_still_used_when_runtime_carries_no_endpoint(
+            self, tmp_path, monkeypatch):
+        """Guard the other direction: a runtime snapshot without base_url/key
+        must leave the configured entry's own endpoint and credential intact."""
+        import agent.auxiliary_client as mod
+
+        self._write_home(tmp_path, monkeypatch)
+
+        mod.clear_runtime_main()
+        try:
+            with patch.object(mod, "_is_provider_unhealthy", return_value=False):
+                client, model, label = mod._try_main_agent_model_fallback(
+                    "anthropic",
+                    task="compression",
+                    main_runtime={
+                        "provider": "custom:rotator",
+                        "model": "glm-5.1",
+                    },
+                )
+
+            assert client is not None
+            base = self._client_base_url(client)
+            assert base and base.rstrip("/") == "https://stale-config.example/v1"
+            assert getattr(client, "api_key", None) == "stale-config-key"
+        finally:
+            mod.clear_runtime_main()


### PR DESCRIPTION
## What does this PR do?

The final auxiliary `main-agent` safety net currently re-reads the statically configured main provider/model after an auxiliary route fails. If the conversation has switched or failed over to a different runtime, the safety net can retry the stale provider instead of the provider already serving the session.

This PR threads the normalized session-local `main_runtime` snapshot through the final synchronous and asynchronous safety-net calls. A complete active runtime takes priority; static main configuration remains the fallback when no runtime snapshot is available.

For `openai-codex`, the resolver now preserves the token and base URL selected by the active runtime instead of selecting a new route from the credential pool or auth store.

This closes a narrow propagation gap between the layered safety net introduced in #27625 and the session-scoped runtime work merged in #63521.

## Related Issue

Fixes #73283

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Pass the normalized active runtime into the final main-agent fallback in both sync and async auxiliary paths.
- Prefer the active provider/model/authentication context/endpoint, while preserving the existing static-config fallback when runtime state is absent.
- Make the Codex auxiliary client builder honor an explicit runtime token and base URL before credential-pool/auth-store resolution.
- Preserve scoped runtime isolation and handle config-less named custom runtimes through their resolved live endpoint.
- Add regressions for sync/async routing, Codex credential/endpoint reuse, scoped runtime behavior, custom runtime resolution, and legacy config fallback.

## How to Test

1. Configure main provider A, then switch or fail over the active conversation to provider B.
2. Make an explicit auxiliary compression route fail with an error handled by the fallback chain.
3. Verify the final `main-agent` fallback resolves provider B and reuses its active authentication context and endpoint, rather than re-reading provider A from static config.

Validation run on current `main`:

```text
Focused runtime/safety-net tests: 12 passed
Auxiliary client suite: 373 passed, 1 deselected
Local dual-endpoint probe: configured auxiliary endpoint received one 429 request; active runtime endpoint received one successful request
Ruff, py_compile, and git diff checks: passed
```

Baseline note: a broader adjacent bundle reports four order-dependent provider-health failures. The same four failures reproduce on a clean current-main worktree, and all four pass in isolation, so they are not introduced by this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Configured auxiliary route -> HTTP 429
Active main runtime route -> valid summary response
Requests observed: auxiliary=1, active-runtime=1
```
