### PR TITLE
feat(agent): add native Ollama /api/chat adapter (#4505)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2014,6 +2014,55 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
                 agent._client_log_context(),
             )
             return client
+    if agent.provider == "custom" or str(agent.provider).startswith("custom:"):
+        # Local Ollama is configured as provider "custom" — either bare ("custom")
+        # or as a named instance ("custom:<name>") when several custom providers are
+        # set up (providers.py forms these as "custom:" + normalized-name; the
+        # "ollama"/"vllm"/"llamacpp" aliases all normalize to "custom"). Match the
+        # provider *type* (before the colon) so a second Ollama instance such as
+        # "custom:ollama-2" still gets the native path instead of silently falling
+        # back to /v1. Route it through Ollama's NATIVE /api/chat — which honors
+        # per-request num_ctx and returns correct streaming tool_calls, unlike the
+        # OpenAI-compat /v1 path — but ONLY when the endpoint is positively
+        # identified as Ollama via an /api/version probe (same detection-based,
+        # always-on selection the Gemini branch above uses), so a non-Ollama
+        # "custom" server (vLLM / llama.cpp / LM Studio) — which has no /api/version
+        # — fails the probe and stays byte-identical to the existing /v1 path.
+        from agent.ollama_native_adapter import OllamaNativeClient, is_native_ollama_base_url
+
+        base_url = str(client_kwargs.get("base_url", "") or "")
+        # Give the probe the same auth material and TLS trust the real client will
+        # use — an unauthenticated / default-trust probe would 401 or SSLError
+        # behind an authenticated proxy or a private CA and native routing would
+        # silently never engage for exactly those deployments.
+        if is_native_ollama_base_url(
+            base_url,
+            api_key=client_kwargs.get("api_key"),
+            default_headers=client_kwargs.get("default_headers"),
+            default_query=client_kwargs.get("default_query"),
+            verify=httpx_verify,
+        ):
+            safe_kwargs = {
+                k: v for k, v in client_kwargs.items()
+                if k in {
+                    "api_key", "base_url", "default_headers", "default_query",
+                    "timeout", "http_client",
+                }
+            }
+            if "http_client" not in safe_kwargs:
+                keepalive_http = agent._build_keepalive_http_client(
+                    base_url, verify=httpx_verify,
+                )
+                if keepalive_http is not None:
+                    safe_kwargs["http_client"] = keepalive_http
+            client = OllamaNativeClient(**safe_kwargs)
+            _ra().logger.info(
+                "Ollama native client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                agent._client_log_context(),
+            )
+            return client
     # Inject TCP keepalives so the kernel detects dead provider connections
     # instead of letting them sit silently in CLOSE-WAIT (#10324).  Without
     # this, a peer that drops mid-stream leaves the socket in a state where

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1219,6 +1219,43 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     try:
         from providers import get_provider_profile
         _profile = get_provider_profile(agent.provider)
+        if _profile is None and str(agent.provider).startswith("custom:"):
+            # Named custom instances ("custom:<name>") aren't in the registry, but
+            # a named OLLAMA instance needs the "custom" profile so the profile path
+            # runs build_api_kwargs_extras() and injects ollama_num_ctx — without it,
+            # create_openai_client routes the endpoint to the native client but
+            # num_ctx never reaches extra_body and the model loads at Ollama's 4096
+            # default. Gate the fallback on the same /api/version identification the
+            # client selection uses (cache-warm here: the client build just probed
+            # this base_url): a NON-Ollama named instance (vLLM / a corp gateway)
+            # must keep its pre-existing no-profile request shape — the profile
+            # would inject max_tokens=65536 and reasoning_effort/think fields that
+            # such endpoints reject.
+            from agent.ollama_native_adapter import is_native_ollama_base_url
+
+            # Probe the SAME base_url the client was built from (_client_kwargs) —
+            # agent.base_url can be empty (router-resolved providers) or still
+            # carry a query string agent_init stripped into default_query — and
+            # with the SAME TLS verify, so this per-turn caller can't poison the
+            # shared probe cache that client selection reads.
+            _ck = getattr(agent, "_client_kwargs", None) or {}
+            _verify = None
+            try:
+                from agent.ssl_verify import resolve_httpx_verify
+
+                _verify = resolve_httpx_verify(
+                    ca_bundle=_ck.get("ssl_ca_cert"), ssl_verify=_ck.get("ssl_verify")
+                )
+            except Exception:
+                _verify = None
+            if is_native_ollama_base_url(
+                str(_ck.get("base_url") or getattr(agent, "base_url", "") or ""),
+                api_key=_ck.get("api_key"),
+                default_headers=_ck.get("default_headers"),
+                default_query=_ck.get("default_query"),
+                verify=_verify,
+            ):
+                _profile = get_provider_profile("custom")
     except Exception:
         _profile = None
 

--- a/agent/ollama_native_adapter.py
+++ b/agent/ollama_native_adapter.py
@@ -749,6 +749,7 @@ class OllamaNativeClient:
         max_tokens: Optional[int] = None,
         stop: Any = None,
         seed: Optional[int] = None,
+        reasoning_effort: Optional[str] = None,
         extra_body: Optional[Dict[str, Any]] = None,
         timeout: Any = None,
         **_: Any,
@@ -758,6 +759,19 @@ class OllamaNativeClient:
         if isinstance(extra_body, dict):
             options = extra_body.get("options")
             think = extra_body.get("think")
+
+        # The custom profile emits a configured reasoning level as TOP-LEVEL
+        # reasoning_effort (the OpenAI-compatible field Ollama's /v1 honors),
+        # not extra_body.think — translate it so the level survives the native
+        # path instead of silently falling back to the server default. An
+        # explicit extra_body.think always wins (the profile's disabled case
+        # already pairs reasoning_effort="none" with think=False); "none" alone
+        # maps to think=False. Level strings pass through unchanged — Ollama
+        # accepts them as native think values exactly as /v1's reasoning_effort
+        # mapping does, so /v1 and native stay behavior-identical per level.
+        if think is None and isinstance(reasoning_effort, str) and reasoning_effort.strip():
+            effort = reasoning_effort.strip().lower()
+            think = False if effort == "none" else effort
 
         # Newer Ollama 400s on a truthy `think` (true or a "low"/"high" level)
         # for models without the "thinking" capability; `think: false` is

--- a/agent/ollama_native_adapter.py
+++ b/agent/ollama_native_adapter.py
@@ -1,0 +1,841 @@
+"""Native Ollama (/api/chat) adapter for the Hermes Agent.
+
+Ollama's OpenAI-compatible /v1 endpoint IGNORES per-request `num_ctx` (verified
+live on Ollama 0.22.0 and 0.32.5, and in the /v1 handler source: it maps only a
+fixed OpenAI allowlist to model options, not `num_ctx`), so a Hermes agent talking
+to Ollama via /v1 always loads models at Ollama's default context. Ollama's NATIVE
+/api/chat endpoint honors `options.num_ctx` and returns correct streaming tool-call
+deltas.
+
+This module provides a drop-in, OpenAI-SDK-shaped client (`OllamaNativeClient`)
+that POSTs to /api/chat and translates requests/responses/streams back to the
+OpenAI shape the agent already consumes — modeled directly on the sibling
+`agent/gemini_native_adapter.py`, so `api_mode` stays "chat_completions" and the
+rest of the agent loop is unchanged.
+
+Selected in `agent_runtime_helpers.create_openai_client` for a `custom` provider
+whose `base_url` is positively identified as Ollama via an `/api/version` probe —
+the same always-on, detection-based selection the sibling Gemini adapter uses (no
+feature flag). Depends only on httpx + stdlib plus the shared
+`agent.bounded_response` helper (for bounded streaming-error reads, exactly as the
+Gemini adapter does).
+
+Scope: the MAIN chat loop only. Auxiliary side-tasks (title generation,
+compression, vision) still build their own /v1 clients in `auxiliary_client` —
+wiring those through the native path (the Gemini adapter has hooks at each aux
+construction site) is deliberate follow-up work; note that aux calls therefore
+don't carry `num_ctx`, so on a shared local model an aux call can reload the
+model at the server-default context between main-loop turns.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from types import SimpleNamespace
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+
+import httpx
+
+from agent.bounded_response import read_streaming_error_body
+
+logger = logging.getLogger("hermes_ollama_native")
+
+# Cache of base_url(root) -> (is_ollama, expires_at_monotonic). Both positive and
+# negative results are bounded by the same 1h TTL that model_metadata's endpoint
+# probe uses (`_ENDPOINT_PROBE_TTL_SECONDS`) and for the same reasons: a positive
+# must not be pinned for the process lifetime (a server swap on the same port —
+# stop Ollama, start vLLM — is eventually re-detected instead of hard-404ing every
+# turn until restart), and a bounded negative caps the probe at one round trip per
+# endpoint per hour on the client-build path instead of re-probing every minute.
+_OLLAMA_PROBE_CACHE: Dict[str, Tuple[bool, Optional[float]]] = {}
+_VERSION_PROBE_TTL = 3600.0  # seconds; matches model_metadata._ENDPOINT_PROBE_TTL_SECONDS
+# Failure TTL for the /api/show thinking-capability probe below: short, so a flaky
+# /api/show recovers quickly while never adding a round trip to every chat call.
+_NEG_PROBE_TTL = 60.0  # seconds
+
+
+def native_root(base_url: str) -> str:
+    """Native Ollama root for a base URL — strips a trailing /v1 (and /) so we can
+    POST to {root}/api/chat regardless of whether the caller passed the /v1 form."""
+    b = (base_url or "").strip().rstrip("/")
+    if b.endswith("/v1"):
+        b = b[:-3]
+    return b
+
+
+def _probe_is_ollama(
+    root: str,
+    *,
+    timeout: float = 2.0,
+    headers: Optional[Dict[str, str]] = None,
+    params: Optional[Dict[str, Any]] = None,
+    verify: Any = None,
+) -> bool:
+    """Positively identify Ollama via GET {root}/api/version. Cached per root.
+
+    This is what keeps us from mis-routing other `provider="custom"` endpoints
+    (vLLM / llama.cpp / LM Studio) — which have no /api/chat — to native mode.
+
+    The probe sends the caller's auth headers / query params and honors the
+    caller's TLS ``verify`` — behind an authenticated reverse proxy or a private
+    CA an unconfigured probe would 401 / SSLError and native routing would
+    silently never engage for exactly the deployments that need it.
+
+    Definitive outcomes (positive, or provably-not-Ollama: 404 / wrong 200 shape)
+    are cached with the 1h `_VERSION_PROBE_TTL` (the precedent set by
+    model_metadata's endpoint probe): positives so a server swap on the same port
+    re-detects within the hour, definitive negatives so a non-Ollama endpoint
+    costs at most one probe per hour on the client-build path. Indeterminate
+    failures (transport blip, 401/403, 5xx) keep the short `_NEG_PROBE_TTL` so a
+    restarting Ollama or a fixed credential recovers within a minute.
+    """
+    entry = _OLLAMA_PROBE_CACHE.get(root)
+    if entry is not None:
+        result, expires_at = entry
+        if expires_at is None or time.monotonic() < expires_at:
+            return result
+    ok = False
+    definitive_negative = False
+    try:
+        kwargs: Dict[str, Any] = {"timeout": timeout}
+        if headers:
+            kwargs["headers"] = headers
+        if params:
+            kwargs["params"] = params
+        if verify is not None:
+            kwargs["verify"] = verify
+        resp = httpx.get(f"{root}/api/version", **kwargs)
+        if resp.status_code == 200:
+            # Validate the JSON shape ({"version": "<str>"}) rather than a
+            # substring match, so a non-Ollama server returning 200 text
+            # containing the word "version" can't false-positive into native
+            # routing. A 200 with the wrong shape is a definitive "not Ollama".
+            try:
+                ok = isinstance(resp.json().get("version"), str)
+            except Exception:
+                ok = False
+            definitive_negative = not ok
+        elif resp.status_code == 404:
+            # No /api/version route at all — definitive "not Ollama".
+            definitive_negative = True
+        elif resp.status_code in (401, 403):
+            # Indeterminate: the endpoint may be Ollama behind a misconfigured
+            # credential — keep the short retry TTL so a fixed key recovers fast.
+            logger.warning(
+                "Ollama /api/version probe got HTTP %s from %s — if this is an "
+                "authenticated Ollama endpoint, native routing stays disabled; "
+                "check the provider's api_key / extra_headers.",
+                resp.status_code,
+                root,
+            )
+    except Exception as exc:  # network/timeout — indeterminate
+        logger.debug("Ollama /api/version probe failed for %s: %s", root, exc)
+        ok = False
+    # Definitive answers (Ollama, or provably-not-Ollama) get the long TTL;
+    # indeterminate failures (transport blip, auth error, 5xx) get the short one
+    # so a transient outage or a fixed credential can't cost an hour of native
+    # routing — and a per-turn probe caller can't poison the cache for long.
+    ttl = _VERSION_PROBE_TTL if (ok or definitive_negative) else _NEG_PROBE_TTL
+    _OLLAMA_PROBE_CACHE[root] = (ok, time.monotonic() + ttl)
+    return ok
+
+
+def is_native_ollama_base_url(
+    base_url: str,
+    *,
+    api_key: Optional[str] = None,
+    default_headers: Optional[Dict[str, str]] = None,
+    default_query: Optional[Dict[str, Any]] = None,
+    verify: Any = None,
+) -> bool:
+    """True when we should route this endpoint through native /api/chat.
+
+    Detection-only, no feature flag: a `custom` endpoint routes to native mode iff
+    it positively identifies as Ollama via /api/version — mirroring how the sibling
+    Gemini adapter selects on `is_native_gemini_base_url` alone. The probe is what
+    keeps other `custom` endpoints (vLLM / llama.cpp / LM Studio), which have no
+    /api/version, on the stock /v1 path. Works whether the URL carries /v1 or not.
+
+    Pass the endpoint's auth material (``api_key`` / ``default_headers`` /
+    ``default_query``) and TLS ``verify`` so the probe can reach Ollama behind an
+    authenticated proxy or a private CA.
+    """
+    if not (base_url or "").strip():
+        return False
+    headers: Dict[str, Any] = {}
+    if api_key and api_key != "ollama":
+        headers["Authorization"] = f"Bearer {api_key}"
+    if isinstance(default_headers, dict):
+        for k, v in default_headers.items():
+            # Same str/bytes filter as the client's _headers(): forward exactly
+            # the header values the real requests would carry (SDK Omit()/NotGiven
+            # sentinels are dropped). default_headers OVERRIDE the api_key-derived
+            # Authorization, matching _headers() precedence — so a placeholder
+            # api_key plus real gateway auth in extra_headers probes with the
+            # same credentials the real requests will send.
+            if isinstance(k, str) and isinstance(v, (str, bytes)):
+                headers[k] = v
+    return _probe_is_ollama(
+        native_root(base_url),
+        headers=headers or None,
+        params=dict(default_query) if isinstance(default_query, dict) else None,
+        verify=verify,
+    )
+
+
+# Cache of (root, model) -> (supports_thinking, expires_at_monotonic_or_None).
+# Definitive answers (any 200 from /api/show) are memoized for the process; probe
+# failures are cached with the short `_NEG_PROBE_TTL` (same pattern as the version
+# probe above) so a flaky /api/show can't add a round trip to every chat call,
+# while a recovered server is re-probed shortly after.
+_THINKING_CAP_CACHE: Dict[Tuple[str, str], Tuple[bool, Optional[float]]] = {}
+
+
+# ── Request construction ────────────────────────────────────────────────────
+
+
+def _coerce_text(content: Any) -> Tuple[str, List[str]]:
+    """Return (text, images[]) from OpenAI message content (str or parts list).
+
+    Images are returned as raw base64 (Ollama's `images` field), best-effort.
+    """
+    if content is None:
+        return "", []
+    if isinstance(content, str):
+        return content, []
+    if isinstance(content, list):
+        texts: List[str] = []
+        images: List[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            ptype = part.get("type")
+            if ptype == "text" and isinstance(part.get("text"), str):
+                texts.append(part["text"])
+            elif ptype == "image_url":
+                url = (
+                    ((part.get("image_url") or {}).get("url"))
+                    if isinstance(part.get("image_url"), dict)
+                    else None
+                )
+                # RFC 2397 scheme matching is case-insensitive; compare a bounded
+                # lowered prefix so a multi-MB base64 URL isn't copied to lower it.
+                if isinstance(url, str) and url[:5].lower() == "data:" and "," in url:
+                    images.append(url.split(",", 1)[1])  # strip data:...;base64,
+                elif isinstance(url, str) and url[:5].lower() == "data:":
+                    # Malformed data: URL (no comma separator) — never splice the
+                    # potentially multi-MB base64 blob into the message text.
+                    logger.warning("Dropping malformed data: image URL (no comma separator)")
+                elif isinstance(url, str) and url:
+                    # Native /api/chat only accepts base64 images; a remote
+                    # http(s) URL can't be forwarded. Keep a visible marker in the
+                    # text (the Bedrock adapter's degradation pattern) and log, so
+                    # the model isn't silently asked about an image it never got.
+                    texts.append(f"[Image: {url[:200]}]")
+                    logger.warning(
+                        "Dropping non-base64 image_url for native Ollama "
+                        "(/api/chat requires base64 data: URLs): %s",
+                        url[:120],
+                    )
+        return "".join(texts), images
+    return str(content), []
+
+
+def _to_ollama_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert OpenAI-format messages to Ollama /api/chat format.
+
+    Key differences handled:
+      - assistant tool_calls: arguments are a JSON *string* in OpenAI, an *object*
+        in Ollama → parse.
+      - tool results (role="tool"): Ollama uses {role:"tool", content[, tool_name]};
+        OpenAI's tool_call_id is dropped (Ollama matches positionally).
+      - multimodal content list → text + images[].
+    """
+    out: List[Dict[str, Any]] = []
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role") or "user"
+        text, images = _coerce_text(msg.get("content"))
+        om: Dict[str, Any] = {"role": role, "content": text}
+        if images:
+            om["images"] = images
+
+        if role == "tool":
+            name = msg.get("name") or msg.get("tool_name")
+            if name:
+                om["tool_name"] = name
+
+        tcs = msg.get("tool_calls")
+        if role == "assistant" and isinstance(tcs, list) and tcs:
+            conv: List[Dict[str, Any]] = []
+            for tc in tcs:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function") or {}
+                args = fn.get("arguments")
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args) if args.strip() else {}
+                    except (TypeError, ValueError):
+                        args = {}
+                # Coerce anything that isn't an object (bad parse, or a JSON null /
+                # array / scalar) to {} — Ollama expects tool-call args as an object.
+                if not isinstance(args, dict):
+                    args = {}
+                conv.append({
+                    "function": {"name": fn.get("name") or "", "arguments": args}
+                })
+            if conv:
+                om["tool_calls"] = conv
+        out.append(om)
+    return out
+
+
+def _to_ollama_tools(tools: Any) -> Optional[List[Dict[str, Any]]]:
+    """OpenAI tool defs are already Ollama-compatible ({type:function, function:{...}})."""
+    if not tools or not isinstance(tools, list):
+        return None
+    cleaned = [
+        t
+        for t in tools
+        if isinstance(t, dict) and t.get("type") == "function" and t.get("function")
+    ]
+    return cleaned or None
+
+
+def build_ollama_request(
+    *,
+    model: str,
+    messages: List[Dict[str, Any]],
+    tools: Any = None,
+    stream: bool = False,
+    temperature: Optional[float] = None,
+    top_p: Optional[float] = None,
+    max_tokens: Optional[int] = None,
+    stop: Any = None,
+    seed: Optional[int] = None,
+    options: Optional[Dict[str, Any]] = None,
+    think: Any = None,
+) -> Dict[str, Any]:
+    """Assemble the native /api/chat payload. `options` (incl. num_ctx) come from
+    the caller's extra_body.options; sampling params merge in without clobbering it."""
+    opts: Dict[str, Any] = dict(options or {})  # num_ctx, etc. (authoritative)
+    if temperature is not None and "temperature" not in opts:
+        opts["temperature"] = temperature
+    if top_p is not None and "top_p" not in opts:
+        opts["top_p"] = top_p
+    if max_tokens is not None and "num_predict" not in opts:
+        opts["num_predict"] = max_tokens
+    if seed is not None and "seed" not in opts:
+        opts["seed"] = seed
+    if stop is not None and "stop" not in opts:
+        opts["stop"] = [stop] if isinstance(stop, str) else stop
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": _to_ollama_messages(messages),
+        "stream": bool(stream),
+    }
+    tl = _to_ollama_tools(tools)
+    if tl:
+        payload["tools"] = tl
+    if opts:
+        payload["options"] = opts
+    if think is not None:
+        payload["think"] = think
+    return payload
+
+
+# ── Response / stream translation (output shapes mirror gemini_native_adapter) ─
+
+
+def _new_id() -> str:
+    return f"chatcmpl-{uuid.uuid4().hex[:12]}"
+
+
+def _translate_tool_calls(raw: Any) -> Optional[List[SimpleNamespace]]:
+    if not isinstance(raw, list) or not raw:
+        return None
+    calls: List[SimpleNamespace] = []
+    for index, tc in enumerate(raw):
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function") or {}
+        args = fn.get("arguments")
+        if isinstance(args, (dict, list)):
+            try:
+                args_str = json.dumps(args, ensure_ascii=False)
+            except (TypeError, ValueError):
+                args_str = "{}"
+        elif isinstance(args, str):
+            args_str = args
+        else:
+            args_str = "{}"
+        calls.append(
+            SimpleNamespace(
+                id=tc.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                type="function",
+                index=index,
+                function=SimpleNamespace(
+                    name=str(fn.get("name") or ""), arguments=args_str
+                ),
+            )
+        )
+    return calls or None
+
+
+def _usage_from(payload: Dict[str, Any]) -> SimpleNamespace:
+    prompt = int(payload.get("prompt_eval_count") or 0)
+    completion = int(payload.get("eval_count") or 0)
+    return SimpleNamespace(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=prompt + completion,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+    )
+
+
+def _map_finish_reason(done_reason: Any, has_tool_calls: bool) -> str:
+    if has_tool_calls:
+        return "tool_calls"
+    dr = str(done_reason or "stop")
+    if dr == "length":
+        return "length"
+    return "stop"
+
+
+def translate_ollama_response(payload: Dict[str, Any], model: str) -> SimpleNamespace:
+    msg = payload.get("message") or {}
+    tool_calls = _translate_tool_calls(msg.get("tool_calls"))
+    content = msg.get("content")
+    thinking = msg.get("thinking") or None  # Ollama returns reasoning under "thinking"
+    message = SimpleNamespace(
+        role=msg.get("role") or "assistant",
+        content=(
+            content if (content not in (None, "")) else (None if tool_calls else "")
+        ),
+        tool_calls=tool_calls,
+        reasoning=thinking,
+        reasoning_content=thinking,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(
+        index=0,
+        message=message,
+        finish_reason=_map_finish_reason(payload.get("done_reason"), bool(tool_calls)),
+    )
+    return SimpleNamespace(
+        id=_new_id(),
+        object="chat.completion",
+        created=int(payload.get("created_at_epoch") or time.time()),
+        model=payload.get("model") or model,
+        choices=[choice],
+        usage=_usage_from(payload),
+    )
+
+
+class _OllamaStreamChunk(SimpleNamespace):
+    pass
+
+
+def _make_stream_chunk(
+    *,
+    model: str,
+    content: str = "",
+    reasoning: str = "",
+    tool_call_delta: Optional[Dict[str, Any]] = None,
+    finish_reason: Optional[str] = None,
+    usage: Optional[SimpleNamespace] = None,
+) -> _OllamaStreamChunk:
+    delta_kwargs: Dict[str, Any] = {
+        "role": "assistant",
+        "content": content or None,
+        "tool_calls": None,
+        "reasoning": reasoning or None,
+        "reasoning_content": reasoning or None,
+    }
+    if tool_call_delta is not None:
+        delta_kwargs["tool_calls"] = [
+            SimpleNamespace(
+                index=tool_call_delta.get("index", 0),
+                id=tool_call_delta.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                type="function",
+                function=SimpleNamespace(
+                    name=tool_call_delta.get("name") or "",
+                    arguments=tool_call_delta.get("arguments") or "",
+                ),
+            )
+        ]
+    delta = SimpleNamespace(**delta_kwargs)
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return _OllamaStreamChunk(
+        id=_new_id(),
+        object="chat.completion.chunk",
+        created=int(time.time()),
+        model=model,
+        choices=[choice],
+        usage=usage,
+    )
+
+
+def translate_stream_line(
+    line: Dict[str, Any], model: str, tool_idx: Dict[str, int]
+) -> List[_OllamaStreamChunk]:
+    """Translate one Ollama NDJSON object into zero+ OpenAI-style chunks."""
+    # Ollama reports mid-stream failures (runner OOM, model crash) as an in-band
+    # {"error": "<str>"} frame on the already-200 stream. Surface the message —
+    # silently dropping the frame would end the stream looking like a clean close
+    # and lose the actual reason.
+    err = line.get("error")
+    if err:
+        raise OllamaAPIError(f"Ollama stream error: {str(err)[:500]}")
+    chunks: List[_OllamaStreamChunk] = []
+    msg = line.get("message") or {}
+
+    reasoning = msg.get("thinking")
+    if isinstance(reasoning, str) and reasoning:
+        chunks.append(_make_stream_chunk(model=model, reasoning=reasoning))
+
+    content = msg.get("content")
+    if isinstance(content, str) and content:
+        chunks.append(_make_stream_chunk(model=model, content=content))
+
+    raw_tcs = msg.get("tool_calls")
+    if isinstance(raw_tcs, list):
+        for tc in raw_tcs:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") or {}
+            name = str(fn.get("name") or "")
+            args = fn.get("arguments")
+            if isinstance(args, (dict, list)):
+                try:
+                    args = json.dumps(args, ensure_ascii=False)
+                except (TypeError, ValueError):
+                    args = "{}"
+            elif not isinstance(args, str):
+                args = "{}"
+            # Ollama streams a whole tool call per object; give each a fresh index.
+            idx = tool_idx.get("n", 0)
+            tool_idx["n"] = idx + 1
+            chunks.append(
+                _make_stream_chunk(
+                    model=model,
+                    tool_call_delta={
+                        "index": idx,
+                        "id": tc.get("id"),
+                        "name": name,
+                        "arguments": args,
+                    },
+                )
+            )
+
+    if line.get("done") is True:
+        has_tc = isinstance(raw_tcs, list) and len(raw_tcs) > 0
+        chunks.append(
+            _make_stream_chunk(
+                model=model,
+                finish_reason=_map_finish_reason(
+                    line.get("done_reason"), has_tc or tool_idx.get("n", 0) > 0
+                ),
+                usage=_usage_from(line),
+            )
+        )
+    return chunks
+
+
+# ── Client facade (OpenAI-SDK-shaped, drop-in) ───────────────────────────────
+
+
+class OllamaAPIError(Exception):
+    def __init__(
+        self, message: str, *, status_code: Optional[int] = None, response: Any = None
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = response
+
+
+def ollama_http_error(
+    response: httpx.Response, *, body_text: Optional[str] = None
+) -> OllamaAPIError:
+    # Ollama's native API reports failures as {"error": "<str>"} — surface that
+    # message directly instead of the raw JSON blob; fall back to raw body text.
+    # On a streaming request the caller passes a bounded `body_text` (see
+    # read_streaming_error_body); otherwise the already-buffered body is read here.
+    if body_text is None:
+        try:
+            body_text = response.text
+        except Exception:
+            body_text = ""
+    body_text = body_text or ""
+    body = body_text[:500] or "<unreadable>"
+    try:
+        parsed = json.loads(body_text) if body_text else None
+        if isinstance(parsed, dict) and isinstance(parsed.get("error"), str):
+            # An empty error string would produce a bare trailing colon — keep
+            # the raw body (e.g. '{"error": ""}') as the more useful diagnostic.
+            body = parsed["error"][:500] or body
+    except (ValueError, TypeError):
+        pass  # non-JSON body: keep the raw text captured above
+    return OllamaAPIError(
+        f"Ollama native API error {response.status_code}: {body}",
+        status_code=response.status_code,
+        response=response,
+    )
+
+
+class _ChatCompletions:
+    def __init__(self, client: "OllamaNativeClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ChatNamespace:
+    def __init__(self, client: "OllamaNativeClient"):
+        self.completions = _ChatCompletions(client)
+
+
+class OllamaNativeClient:
+    """Minimal OpenAI-SDK-compatible facade over Ollama's native REST API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        default_headers: Optional[Dict[str, str]] = None,
+        default_query: Optional[Dict[str, Any]] = None,
+        timeout: Any = None,
+        http_client: Optional[httpx.Client] = None,
+        **_: Any,
+    ) -> None:
+        self.api_key = api_key or "ollama"
+        self.base_url = native_root(base_url or "http://127.0.0.1:11434")
+        self._default_headers = dict(default_headers or {})
+        # Query params agent_init extracted from a query-bearing base_url (URL-token
+        # auth, api-version params). The stock OpenAI client appends them to every
+        # request; mirror that or such gateways 401 on the native path.
+        self._default_query = dict(default_query or {})
+        self.chat = _ChatNamespace(self)
+        self.is_closed = False
+        # Per-request default timeout. Applied both to a self-made client AND, below,
+        # as the explicit per-request timeout — so an injected http_client that only
+        # carries httpx's short 5s default never governs a long local-model call.
+        self._default_timeout = (
+            timeout
+            if timeout is not None
+            else httpx.Timeout(connect=15.0, read=600.0, write=30.0, pool=30.0)
+        )
+        self._http = http_client or httpx.Client(timeout=self._default_timeout)
+        # Also expose the httpx client as `_client`: the agent's socket-abort path
+        # (force_close_tcp_sockets -> _iter_pool_sockets) resolves the pool via
+        # getattr(client, "_client"), the OpenAI-SDK convention. Without this alias
+        # interrupt / stale-kill can't shut a long native stream's socket.
+        self._client = self._http
+
+    # lifecycle / SDK-compat surface
+    def close(self) -> None:
+        self.is_closed = True
+        try:
+            self._http.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def _headers(self) -> Dict[str, Union[str, bytes]]:
+        h: Dict[str, Union[str, bytes]] = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "hermes-agent (ollama-native)",
+        }
+        # Ollama ignores auth locally, but a reverse proxy may want it.
+        if self.api_key and self.api_key != "ollama":
+            h["Authorization"] = f"Bearer {self.api_key}"
+        # Only forward headers with real str/bytes values. default_headers copied
+        # from an OpenAI SDK client (the aux Hook-2 path mirrors the client's
+        # timeout + default_headers) can contain the SDK's `Omit()` / `NotGiven`
+        # sentinels for UNSET headers (e.g. OpenAI-Organization / OpenAI-Project).
+        # httpx rejects those ("Header value must be str or bytes"), which would
+        # fail every aux side-task (title/compression/vision). Drop non-string values.
+        for k, v in (self._default_headers or {}).items():
+            if isinstance(v, (str, bytes)):
+                h[k] = v
+        return h
+
+    def _timeout_kwargs(self, timeout: Any) -> Dict[str, Any]:
+        """httpx request kwargs. Always pass a concrete timeout — the caller's when
+        given, else our long default — so a request never silently falls back to
+        httpx's 5s default (which applies when an external http_client was injected
+        without one). Passing ``timeout=None`` to httpx DISABLES the timeout, which
+        we never want. Also carries the client's default_query so URL-param auth
+        reaches every native request (the stock OpenAI client's behavior)."""
+        kwargs: Dict[str, Any] = {
+            "timeout": timeout if timeout is not None else self._default_timeout
+        }
+        if self._default_query:
+            kwargs["params"] = self._default_query
+        return kwargs
+
+    def _model_supports_thinking(self, model: str) -> bool:
+        """Whether the model advertises the "thinking" capability via /api/show.
+
+        Returns True on any uncertainty — a missing capabilities list (older
+        Ollama accepts `think` for every model) or a failed probe — so the gate
+        only ever suppresses `think` on a positive "not supported" signal.
+        Cached per (base_url, model) for the process.
+        """
+        key = (self.base_url, model)
+        entry = _THINKING_CAP_CACHE.get(key)
+        if entry is not None:
+            cached_supports, expires_at = entry
+            if expires_at is None or time.monotonic() < expires_at:
+                return cached_supports
+        supports = True
+        definitive = False
+        try:
+            # Send the same headers as real requests — behind an authenticated
+            # reverse proxy an unauthenticated probe would 401 and the gate
+            # would silently never engage.
+            resp = self._http.post(
+                f"{self.base_url}/api/show",
+                json={"model": model},
+                headers=self._headers(),
+                params=self._default_query or None,
+                timeout=2.0,
+            )
+            if resp.status_code == 200:
+                caps = resp.json().get("capabilities")
+                if isinstance(caps, list):
+                    supports = "thinking" in caps
+                # A 200 is definitive (capabilities absent = pre-capability
+                # server, which accepts `think` for every model).
+                definitive = True
+            else:
+                logger.debug(
+                    "thinking-capability probe got HTTP %s for %s", resp.status_code, model
+                )
+        except Exception as exc:
+            logger.debug("thinking-capability probe failed for %s: %s", model, exc)
+        # Definitive answers are memoized; failures forward `think` (fail-open)
+        # and are TTL-cached so a persistently failing /api/show doesn't add a
+        # round trip to every chat call.
+        _THINKING_CAP_CACHE[key] = (
+            (supports, None) if definitive else (supports, time.monotonic() + _NEG_PROBE_TTL)
+        )
+        return supports
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str,
+        messages: Optional[List[Dict[str, Any]]] = None,
+        stream: bool = False,
+        tools: Any = None,
+        tool_choice: Any = None,  # Ollama has no tool_choice; accepted + ignored
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stop: Any = None,
+        seed: Optional[int] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
+        timeout: Any = None,
+        **_: Any,
+    ) -> Any:
+        options = None
+        think = None
+        if isinstance(extra_body, dict):
+            options = extra_body.get("options")
+            think = extra_body.get("think")
+
+        # Newer Ollama 400s on a truthy `think` (true or a "low"/"high" level)
+        # for models without the "thinking" capability; `think: false` is
+        # tolerated everywhere. Drop `think` entirely for non-thinking models
+        # (mirrors Ollama's own relax_thinking path, and a false/None think is
+        # equivalent for a model that cannot think anyway). Unknown capability
+        # (older Ollama, probe failure) forwards `think` unchanged.
+        if think is not None and not self._model_supports_thinking(model):
+            logger.debug("model %s lacks 'thinking' capability; dropping think=%r", model, think)
+            think = None
+
+        request = build_ollama_request(
+            model=model,
+            messages=messages or [],
+            tools=tools,
+            stream=stream,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            stop=stop,
+            seed=seed,
+            options=options if isinstance(options, dict) else None,
+            think=think,
+        )
+
+        if stream:
+            return self._stream_completion(
+                model=model, request=request, timeout=timeout
+            )
+
+        url = f"{self.base_url}/api/chat"
+        resp = self._http.post(
+            url, json=request, headers=self._headers(), **self._timeout_kwargs(timeout)
+        )
+        if resp.status_code != 200:
+            raise ollama_http_error(resp)
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise OllamaAPIError(
+                f"Invalid JSON from Ollama /api/chat: {exc}",
+                status_code=resp.status_code,
+            ) from exc
+        return translate_ollama_response(payload, model=model)
+
+    def _stream_completion(
+        self, *, model: str, request: Dict[str, Any], timeout: Any = None
+    ) -> Iterator[_OllamaStreamChunk]:
+        url = f"{self.base_url}/api/chat"
+
+        def _generator() -> Iterator[_OllamaStreamChunk]:
+            # Transport errors (ReadTimeout, ConnectError, RemoteProtocolError, ...)
+            # deliberately propagate with their concrete httpx types: the streaming
+            # worker's mid-stream reconnect and the transport-recovery layer classify
+            # on isinstance checks against those exact types, so wrapping them in
+            # OllamaAPIError would silently disable reconnects and misclassify a
+            # dropped peer as a non-retryable API error.
+            tool_idx: Dict[str, int] = {"n": 0}
+            with self._http.stream(
+                "POST",
+                url,
+                json=request,
+                headers=self._headers(),
+                **self._timeout_kwargs(timeout),
+            ) as resp:
+                if resp.status_code != 200:
+                    body_text = read_streaming_error_body(resp)
+                    raise ollama_http_error(resp, body_text=body_text)
+                for raw_line in resp.iter_lines():
+                    if not raw_line:
+                        continue
+                    try:
+                        obj = json.loads(raw_line)
+                    except (json.JSONDecodeError, TypeError):
+                        logger.debug("Non-JSON Ollama stream line: %s", str(raw_line)[:200])
+                        continue
+                    if isinstance(obj, dict):
+                        for chunk in translate_stream_line(obj, model, tool_idx):
+                            yield chunk
+
+        return _generator()

--- a/tests/agent/test_ollama_native_adapter.py
+++ b/tests/agent/test_ollama_native_adapter.py
@@ -454,6 +454,79 @@ def test_http_error_empty_error_string_keeps_raw_body():
     assert '{"error": ""}' in msg
 
 
+def _custom_profile():
+    """Resolve the registered "custom" provider profile (the one create_openai_client's
+    routing pairs with this adapter), via the same discovery path production uses."""
+    import model_tools  # noqa: F401  (import triggers plugin discovery/registration)
+    import providers
+
+    profile = providers.get_provider_profile("custom")
+    assert profile is not None, "custom provider profile must be registered"
+    return profile
+
+
+def _capture_client(capture, *, thinking_capable=True):
+    caps = ["completion", "thinking"] if thinking_capable else ["completion"]
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            return httpx.Response(200, json={"capabilities": caps})
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    return OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+
+
+def test_profile_reasoning_level_reaches_native_think():
+    # The custom profile emits an enabled reasoning level as TOP-LEVEL
+    # reasoning_effort (the field /v1 honors), not extra_body.think. Feed the
+    # profile's actual output through the native client and assert the level
+    # reaches the wire as `think` — the full profile-to-request path, not a
+    # hand-built extra_body.
+    profile = _custom_profile()
+    extra_body, top_level = profile.build_api_kwargs_extras(
+        reasoning_config={"enabled": True, "effort": "high"}, ollama_num_ctx=8192
+    )
+    assert top_level.get("reasoning_effort") == "high"  # the profile's contract
+    assert "think" not in extra_body
+
+    capture = {}
+    client = _capture_client(capture)
+    client.chat.completions.create(
+        model="m", messages=[{"role": "user", "content": "x"}], extra_body=extra_body, **top_level
+    )
+    assert capture["body"]["think"] == "high"
+    assert capture["body"]["options"]["num_ctx"] == 8192
+
+
+def test_profile_reasoning_disabled_reaches_native_think_false():
+    # Disabled reasoning: the profile pairs reasoning_effort="none" with
+    # extra_body.think=False — the wire request must carry think=False.
+    profile = _custom_profile()
+    extra_body, top_level = profile.build_api_kwargs_extras(reasoning_config={"effort": "none"})
+    capture = {}
+    client = _capture_client(capture)
+    client.chat.completions.create(
+        model="m", messages=[{"role": "user", "content": "x"}], extra_body=extra_body, **top_level
+    )
+    assert capture["body"]["think"] is False
+
+
+def test_explicit_think_wins_over_reasoning_effort():
+    # An explicit extra_body.think takes precedence over the top-level field.
+    capture = {}
+    client = _capture_client(capture)
+    client.chat.completions.create(
+        model="m",
+        messages=[{"role": "user", "content": "x"}],
+        reasoning_effort="high",
+        extra_body={"think": "low"},
+    )
+    assert capture["body"]["think"] == "low"
+
+
 def test_version_probe_positive_expires_and_redetects(monkeypatch):
     """Positives are bounded by _VERSION_PROBE_TTL (the model_metadata precedent):
     a server swap on the same port re-detects within the TTL instead of hard-404ing

--- a/tests/agent/test_ollama_native_adapter.py
+++ b/tests/agent/test_ollama_native_adapter.py
@@ -1,0 +1,756 @@
+"""Tests for agent/ollama_native_adapter.py — the native Ollama /api/chat adapter.
+
+Covers request/response/stream translation, the probe-based Ollama detection,
+and the OpenAI-SDK-shaped client facade. Network is faked with
+httpx.MockTransport + unittest.mock (no extra test dependency).
+"""
+
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from agent.ollama_native_adapter import (
+    _OLLAMA_PROBE_CACHE,
+    OllamaAPIError,
+    OllamaNativeClient,
+    build_ollama_request,
+    is_native_ollama_base_url,
+    native_root,
+    translate_ollama_response,
+    translate_stream_line,
+)
+
+
+def _mock_client(handler):
+    """A real OllamaNativeClient wired to an httpx.MockTransport request handler."""
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe_caches():
+    """Both probes memoize process-globally (endpoint detection per root, thinking
+    capability per (base_url, model)); clear them around every test so cases don't
+    leak cached verdicts into each other — including when an assertion fails
+    mid-test (an inline trailing clear() would be skipped)."""
+    from agent.ollama_native_adapter import _THINKING_CAP_CACHE
+
+    _OLLAMA_PROBE_CACHE.clear()
+    _THINKING_CAP_CACHE.clear()
+    yield
+    _OLLAMA_PROBE_CACHE.clear()
+    _THINKING_CAP_CACHE.clear()
+
+
+# ── request construction ──────────────────────────────────────────────────────
+
+
+def test_num_ctx_preserved_in_native_payload():
+    req = build_ollama_request(
+        model="gemma4:e2b",
+        messages=[{"role": "user", "content": "hi"}],
+        options={"num_ctx": 64000},
+    )
+    assert req["options"]["num_ctx"] == 64000
+    assert req["stream"] is False
+
+
+def test_sampling_merges_without_clobbering_options():
+    req = build_ollama_request(
+        model="m",
+        messages=[{"role": "user", "content": "x"}],
+        temperature=0.5,
+        top_p=0.9,
+        max_tokens=128,
+        seed=7,
+        stop="STOP",
+        options={"num_ctx": 8192, "temperature": 0.1},
+    )
+    opts = req["options"]
+    assert opts["num_ctx"] == 8192
+    assert opts["temperature"] == 0.1  # explicit option wins over the 0.5 arg
+    assert opts["top_p"] == 0.9
+    assert opts["num_predict"] == 128  # max_tokens -> num_predict
+    assert opts["seed"] == 7
+    assert opts["stop"] == ["STOP"]
+
+
+def test_assistant_tool_call_args_string_to_object_and_tool_role():
+    req = build_ollama_request(
+        model="m",
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "function": {"name": "lookup", "arguments": '{"q": "cats"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "name": "lookup", "content": "result"},
+        ],
+    )
+    assert req["messages"][0]["tool_calls"][0]["function"]["arguments"] == {"q": "cats"}
+    assert req["messages"][1]["tool_name"] == "lookup"
+
+
+def test_multimodal_image_data_url_extracted():
+    req = build_ollama_request(
+        model="m",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,QUJD"},
+                    },
+                ],
+            }
+        ],
+    )
+    assert req["messages"][0]["content"] == "what is this"
+    assert req["messages"][0]["images"] == ["QUJD"]
+
+
+# ── response + stream + embeddings translation ────────────────────────────────
+
+
+def test_response_content_usage_and_finish_reason():
+    resp = translate_ollama_response(
+        {
+            "model": "m",
+            "message": {"role": "assistant", "content": "hello"},
+            "done_reason": "stop",
+            "prompt_eval_count": 10,
+            "eval_count": 5,
+        },
+        model="m",
+    )
+    assert resp.choices[0].message.content == "hello"
+    assert resp.choices[0].finish_reason == "stop"
+    assert resp.usage.prompt_tokens == 10
+    assert resp.usage.completion_tokens == 5
+    assert resp.usage.total_tokens == 15
+
+
+def test_response_tool_calls_object_to_string():
+    resp = translate_ollama_response(
+        {
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"function": {"name": "f", "arguments": {"a": 1}}}],
+            }
+        },
+        model="m",
+    )
+    msg = resp.choices[0].message
+    assert resp.choices[0].finish_reason == "tool_calls"
+    assert msg.content is None
+    assert msg.tool_calls[0].function.name == "f"
+    assert json.loads(msg.tool_calls[0].function.arguments) == {"a": 1}
+
+
+def test_stream_content_tool_call_and_done():
+    tool_idx = {"n": 0}
+    c1 = translate_stream_line({"message": {"content": "hi"}}, "m", tool_idx)
+    assert c1[0].choices[0].delta.content == "hi"
+
+    c2 = translate_stream_line(
+        {
+            "message": {
+                "tool_calls": [{"function": {"name": "f", "arguments": {"x": 1}}}]
+            }
+        },
+        "m",
+        tool_idx,
+    )
+    tc = c2[0].choices[0].delta.tool_calls[0]
+    assert tc.function.name == "f"
+    assert json.loads(tc.function.arguments) == {"x": 1}
+    assert tc.index == 0
+    assert tool_idx["n"] == 1
+
+    # A tool call was streamed, so the terminal chunk's finish_reason must be
+    # "tool_calls" even though Ollama reports done_reason="stop".
+    c3 = translate_stream_line(
+        {"done": True, "done_reason": "stop", "prompt_eval_count": 3, "eval_count": 2},
+        "m",
+        tool_idx,
+    )
+    assert c3[-1].choices[0].finish_reason == "tool_calls"
+    assert c3[-1].usage.prompt_tokens == 3
+
+
+def test_stream_done_without_tool_calls_is_stop():
+    # Pure content stream (fresh counter, no tool calls) → finish_reason "stop".
+    chunks = translate_stream_line(
+        {"done": True, "done_reason": "stop", "prompt_eval_count": 4, "eval_count": 1},
+        "m",
+        {"n": 0},
+    )
+    assert chunks[-1].choices[0].finish_reason == "stop"
+    assert chunks[-1].usage.completion_tokens == 1
+
+
+def test_stream_error_frame_raises_with_message():
+    # Ollama reports mid-stream failures (runner OOM) as an in-band
+    # {"error": "<str>"} frame on the already-200 stream — it must surface the
+    # actual message, not silently end the stream looking like a clean close.
+    with pytest.raises(OllamaAPIError) as exc_info:
+        translate_stream_line(
+            {"error": "an error was encountered while running the model: CUDA out of memory"},
+            "m",
+            {"n": 0},
+        )
+    assert "CUDA out of memory" in str(exc_info.value)
+
+
+def test_stream_transport_errors_propagate_unwrapped():
+    # Transport failures must keep their concrete httpx types: the streaming
+    # worker's mid-stream reconnect classifies on isinstance(e, httpx.ConnectError/
+    # RemoteProtocolError/...) — a wrapped OllamaAPIError would disable reconnects.
+    def handler(request):
+        raise httpx.ConnectError("peer went away")
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    with pytest.raises(httpx.ConnectError):
+        stream = client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "x"}], stream=True
+        )
+        list(stream)
+
+
+def test_remote_image_url_degrades_to_text_marker():
+    # Native /api/chat only accepts base64 images; a remote http(s) URL can't be
+    # forwarded. It must degrade visibly (text marker), never vanish silently.
+    body = build_ollama_request(
+        model="m",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this? "},
+                    {"type": "image_url", "image_url": {"url": "https://x.test/cat.png"}},
+                ],
+            }
+        ],
+    )
+    msg = body["messages"][0]
+    assert "[Image: https://x.test/cat.png]" in msg["content"]
+    assert not msg.get("images")
+
+
+def test_default_query_attached_to_requests():
+    # agent_init moves a query-bearing base_url's params into default_query (URL-token
+    # auth, api-version); the native client must send them on every request like the
+    # stock OpenAI client does.
+    captured = {}
+
+    def handler(request):
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(
+        base_url="http://h:11434",
+        default_query={"access_token": "sekrit"},
+        http_client=_mock_client(handler),
+    )
+    client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+    assert captured["params"] == {"access_token": "sekrit"}
+
+
+# ── detection ─────────────────────────────────────────────────────────────────
+
+
+def test_native_root_strips_v1():
+    assert native_root("http://h:11434/v1") == "http://h:11434"
+    assert native_root("http://h:11434/v1/") == "http://h:11434"
+    assert native_root("http://h:11434/") == "http://h:11434"
+
+
+def test_detection_is_noop_for_empty_base_url():
+    _OLLAMA_PROBE_CACHE.clear()
+    # An empty base_url short-circuits to False without touching the network.
+    with patch("agent.ollama_native_adapter.httpx.get") as get:
+        assert is_native_ollama_base_url("") is False
+        assert get.call_count == 0
+
+
+def test_detection_positive_for_ollama():
+    # Detection is probe-only (no feature flag): a positive /api/version identifies
+    # Ollama and routes it to native mode, mirroring the Gemini adapter's always-on
+    # selection.
+    _OLLAMA_PROBE_CACHE.clear()
+    resp = httpx.Response(200, json={"version": "0.30.0"})
+    with patch("agent.ollama_native_adapter.httpx.get", return_value=resp):
+        assert is_native_ollama_base_url("http://h:11434/v1") is True
+
+
+def test_detection_negative_for_non_ollama():
+    _OLLAMA_PROBE_CACHE.clear()
+    resp = httpx.Response(404)
+    with patch("agent.ollama_native_adapter.httpx.get", return_value=resp):
+        # A non-Ollama "custom" endpoint (vLLM/llama.cpp/LM Studio) is left on /v1.
+        assert is_native_ollama_base_url("http://other:8000/v1") is False
+
+
+def test_detection_rejects_200_without_version_field():
+    _OLLAMA_PROBE_CACHE.clear()
+    resp = httpx.Response(200, json={"status": "ok"})
+    with patch("agent.ollama_native_adapter.httpx.get", return_value=resp):
+        assert is_native_ollama_base_url("http://h:11434") is False
+
+
+# ── client facade (httpx.MockTransport) ───────────────────────────────────────
+
+
+def test_chat_completion_posts_num_ctx_to_api_chat():
+    captured = {}
+
+    def handler(request):
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": "gemma4:e2b",
+                "message": {"role": "assistant", "content": "hello"},
+                "done_reason": "stop",
+                "prompt_eval_count": 11,
+                "eval_count": 3,
+            },
+        )
+
+    client = OllamaNativeClient(
+        base_url="http://h:11434/v1", http_client=_mock_client(handler)
+    )
+    result = client.chat.completions.create(
+        model="gemma4:e2b",
+        messages=[{"role": "user", "content": "hi"}],
+        extra_body={"options": {"num_ctx": 64000}},
+    )
+    assert captured["url"].endswith("/api/chat")
+    assert captured["body"]["options"]["num_ctx"] == 64000
+    assert result.choices[0].message.content == "hello"
+    assert result.usage.prompt_tokens == 11
+
+
+def test_streaming_yields_openai_chunks():
+    ndjson = (
+        '{"message":{"content":"he"}}\n'
+        '{"message":{"content":"llo"}}\n'
+        '{"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":2}\n'
+    )
+    client = OllamaNativeClient(
+        base_url="http://h:11434",
+        http_client=_mock_client(lambda request: httpx.Response(200, text=ndjson)),
+    )
+    chunks = list(
+        client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "hi"}], stream=True
+        )
+    )
+    assert "".join(c.choices[0].delta.content or "" for c in chunks) == "hello"
+    assert chunks[-1].choices[0].finish_reason == "stop"
+
+
+def test_headers_drop_non_string_sentinels():
+    class _Sentinel:
+        pass
+
+    headers = OllamaNativeClient(
+        base_url="http://h:11434",
+        default_headers={
+            "X-Real": "keep",
+            "OpenAI-Organization": _Sentinel(),
+            "X-None": None,
+        },
+    )._headers()
+    assert headers["X-Real"] == "keep"
+    assert "OpenAI-Organization" not in headers
+    assert "X-None" not in headers
+    assert all(isinstance(v, (str, bytes)) for v in headers.values())
+
+
+def test_version_probe_sends_auth_headers_and_verify():
+    # Behind an authenticated reverse proxy / private CA, an unconfigured probe
+    # would 401 or SSLError and native routing would silently never engage — the
+    # probe must carry the caller's auth material and TLS trust.
+    _OLLAMA_PROBE_CACHE.clear()
+    resp = httpx.Response(200, json={"version": "0.32.5"})
+    with patch("agent.ollama_native_adapter.httpx.get", return_value=resp) as get:
+        assert (
+            is_native_ollama_base_url(
+                "http://h:11434/v1",
+                api_key="proxy-secret",
+                default_headers={"CF-Access-Client-Id": "cid"},
+                default_query={"access_token": "tok"},
+                verify="/etc/ssl/corp-ca.pem",
+            )
+            is True
+        )
+    kwargs = get.call_args.kwargs
+    assert kwargs["headers"]["Authorization"] == "Bearer proxy-secret"
+    assert kwargs["headers"]["CF-Access-Client-Id"] == "cid"
+    assert kwargs["params"] == {"access_token": "tok"}
+    assert kwargs["verify"] == "/etc/ssl/corp-ca.pem"
+    _OLLAMA_PROBE_CACHE.clear()
+
+
+def test_probe_default_headers_override_api_key_authorization():
+    # _headers() lets default_headers override the api_key-derived Authorization,
+    # so the probe must too — a placeholder api_key with real gateway auth in
+    # extra_headers must probe with the credentials real requests will send.
+    resp = httpx.Response(200, json={"version": "0.32.5"})
+    with patch("agent.ollama_native_adapter.httpx.get", return_value=resp) as get:
+        assert (
+            is_native_ollama_base_url(
+                "http://h:11434/v1",
+                api_key="not-needed",
+                default_headers={"Authorization": "Bearer real-gateway-token"},
+            )
+            is True
+        )
+    assert get.call_args.kwargs["headers"]["Authorization"] == "Bearer real-gateway-token"
+
+
+def test_uppercase_data_scheme_still_decodes():
+    # RFC 2397 scheme names are case-insensitive: an uppercase DATA: URL must be
+    # decoded as an image (and a malformed uppercase one dropped), never routed
+    # to the remote-URL marker path where its base64 would leak into the prompt.
+    body = build_ollama_request(
+        model="m",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,QUJD"}},
+                    {"type": "image_url", "image_url": {"url": "Data:image/png;base64" + "A" * 500}},
+                ],
+            }
+        ],
+    )
+    msg = body["messages"][0]
+    assert msg.get("images") == ["QUJD"]
+    assert "[Image:" not in msg["content"] and "A" * 100 not in msg["content"]
+
+
+def test_http_error_empty_error_string_keeps_raw_body():
+    # {"error": ""} must not produce a bare-trailing-colon message — keep the
+    # raw body as the diagnostic.
+    from agent.ollama_native_adapter import ollama_http_error
+
+    resp = httpx.Response(500, content=b'{"error": ""}')
+    msg = str(ollama_http_error(resp))
+    assert not msg.rstrip().endswith(":")
+    assert '{"error": ""}' in msg
+
+
+def test_version_probe_positive_expires_and_redetects(monkeypatch):
+    """Positives are bounded by _VERSION_PROBE_TTL (the model_metadata precedent):
+    a server swap on the same port re-detects within the TTL instead of hard-404ing
+    every turn until process restart."""
+    import time as real_time
+    from types import SimpleNamespace
+
+    from agent import ollama_native_adapter as adapter
+
+    _OLLAMA_PROBE_CACHE.clear()
+    now = {"t": 5000.0}
+    monkeypatch.setattr(
+        adapter, "time", SimpleNamespace(monotonic=lambda: now["t"], time=real_time.time)
+    )
+    calls = {"n": 0}
+
+    def fake_get(url, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(200, json={"version": "0.32.5"})  # Ollama
+        return httpx.Response(404)  # server swapped (vLLM on the same port)
+
+    with patch("agent.ollama_native_adapter.httpx.get", side_effect=fake_get):
+        assert is_native_ollama_base_url("http://h:11434/v1") is True
+        assert is_native_ollama_base_url("http://h:11434/v1") is True  # cached
+        assert calls["n"] == 1
+        now["t"] += adapter._VERSION_PROBE_TTL + 1
+        assert is_native_ollama_base_url("http://h:11434/v1") is False  # re-detected
+        assert calls["n"] == 2
+    _OLLAMA_PROBE_CACHE.clear()
+
+
+# ── thinking-capability gate (/api/show) ──────────────────────────────────────
+
+
+def _cap_handler(caps, capture):
+    """Route /api/show (returns given capabilities) and /api/chat (captures body)."""
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            body = {"capabilities": caps} if caps is not None else {}
+            return httpx.Response(200, json=body)
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    return handler
+
+
+def _fresh_cap_client(caps, capture):
+    return OllamaNativeClient(
+        base_url="http://h:11434", http_client=_mock_client(_cap_handler(caps, capture))
+    )
+
+
+def test_think_dropped_for_non_thinking_model():
+    """Newer Ollama 400s on `think` for models without the capability — never send it."""
+    capture = {}
+    client = _fresh_cap_client(["completion", "tools"], capture)
+    client.chat.completions.create(
+        model="llama3.2", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+    )
+    assert "think" not in capture["body"]
+
+
+def test_think_kept_for_thinking_model():
+    capture = {}
+    client = _fresh_cap_client(["completion", "tools", "thinking"], capture)
+    client.chat.completions.create(
+        model="qwen3.5", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+    )
+    assert capture["body"]["think"] is False
+
+
+def test_think_string_level_passes_through():
+    """Newer Ollama accepts think as a string level ("low"/"medium"/"high"/"max");
+    the adapter forwards the value verbatim (no bool coercion)."""
+    capture = {}
+    client = _fresh_cap_client(["completion", "thinking"], capture)
+    client.chat.completions.create(
+        model="gpt-oss", messages=[{"role": "user", "content": "x"}], extra_body={"think": "high"}
+    )
+    assert capture["body"]["think"] == "high"
+
+
+def test_think_kept_when_capabilities_absent():
+    """Pre-capability Ollama (no `capabilities` key) accepts think for every model."""
+    capture = {}
+    client = _fresh_cap_client(None, capture)
+    client.chat.completions.create(
+        model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": True}
+    )
+    assert capture["body"]["think"] is True
+
+
+def test_no_probe_when_think_not_requested():
+    seen = {"show": 0}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            return httpx.Response(200, json={"capabilities": []})
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+    assert seen["show"] == 0  # zero overhead unless `think` is present
+
+
+def test_think_kept_when_probe_fails_and_failure_is_ttl_cached():
+    """Fail-open: uncertainty never suppresses think — and the failure is TTL-cached
+    so a flaky /api/show can't add a round trip to every chat call."""
+    seen = {"show": 0}
+    capture = {}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            raise httpx.ConnectError("down")
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    for _ in range(3):
+        client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+        )
+    assert capture["body"]["think"] is False
+    assert seen["show"] == 1
+
+
+def test_probe_result_is_cached_per_model():
+    seen = {"show": 0}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            return httpx.Response(200, json={"capabilities": ["completion"]})
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    for _ in range(3):
+        client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+        )
+    assert seen["show"] == 1  # definitive answer memoized
+
+
+# ── error-body parsing + parallel-frame tool calls ────────────────────────────
+
+
+def test_error_body_message_is_parsed():
+    """Ollama reports failures as {"error": "<str>"} — surface the message itself."""
+
+    def handler(request):
+        return httpx.Response(400, json={"error": "model does not support thinking"})
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    try:
+        client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+        raise AssertionError("expected OllamaAPIError")
+    except OllamaAPIError as e:
+        assert e.status_code == 400
+        assert "model does not support thinking" in str(e)
+        assert '{"error"' not in str(e)  # message, not the raw JSON blob
+
+
+def test_parallel_tool_calls_in_separate_frames_get_distinct_indices():
+    """Ollama can emit parallel calls in separate NDJSON frames with no ids; a
+    per-frame index would merge them into one unparseable call. The counter is
+    stream-global, so each call gets a distinct index and synthesized id."""
+    tool_idx = {"n": 0}
+    f1 = translate_stream_line(
+        {"message": {"tool_calls": [{"function": {"name": "a", "arguments": {}}}]}}, "m", tool_idx
+    )
+    f2 = translate_stream_line(
+        {"message": {"tool_calls": [{"function": {"name": "b", "arguments": {}}}]}}, "m", tool_idx
+    )
+    tc1 = f1[0].choices[0].delta.tool_calls[0]
+    tc2 = f2[0].choices[0].delta.tool_calls[0]
+    assert (tc1.index, tc2.index) == (0, 1)
+    assert tc1.id and tc2.id and tc1.id != tc2.id
+
+
+def test_error_body_non_json_falls_back_to_raw_text():
+    """A plain-text error (overloaded proxy, HTML gateway page) must surface its
+    raw text, not "<unreadable>"."""
+
+    def handler(request):
+        return httpx.Response(502, text="upstream proxy exploded")
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    try:
+        client.chat.completions.create(model="m", messages=[{"role": "user", "content": "x"}])
+        raise AssertionError("expected OllamaAPIError")
+    except OllamaAPIError as e:
+        assert e.status_code == 502
+        assert "upstream proxy exploded" in str(e)
+        assert "<unreadable>" not in str(e)
+
+
+def test_probe_sends_auth_headers():
+    """Behind an authenticated reverse proxy an unauthenticated probe would 401
+    and silently disable the gate — the probe must send the client's headers."""
+    seen = {}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["auth"] = request.headers.get("Authorization")
+            return httpx.Response(200, json={"capabilities": ["completion"]})
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(
+        base_url="http://h:11434", api_key="proxy-secret", http_client=_mock_client(handler)
+    )
+    client.chat.completions.create(
+        model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": False}
+    )
+    assert seen["auth"] == "Bearer proxy-secret"
+
+
+def test_think_kept_on_non_200_probe_and_bounded():
+    """A proxy that 404s /api/show while /api/chat works must not disable chat —
+    think is forwarded (fail-open) and the failure is TTL-cached, not re-probed
+    on every request."""
+    seen = {"show": 0}
+    capture = {}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            return httpx.Response(404)
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    for _ in range(3):
+        client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": True}
+        )
+    assert capture["body"]["think"] is True
+    assert seen["show"] == 1
+
+
+def test_failure_ttl_expires_then_recovers_to_definitive(monkeypatch):
+    """The load-bearing TTL contract: a cached failure is re-probed after the TTL
+    lapses, and a now-healthy server yields a definitive answer that is memoized
+    (and, for a non-thinking model, finally suppresses `think`)."""
+    from types import SimpleNamespace
+
+    from agent import ollama_native_adapter as adapter
+
+    import time as real_time
+
+    now = {"t": 1000.0}
+    monkeypatch.setattr(
+        adapter, "time", SimpleNamespace(monotonic=lambda: now["t"], time=real_time.time)
+    )
+
+    seen = {"show": 0}
+    capture = {}
+
+    def handler(request):
+        if request.url.path == "/api/show":
+            seen["show"] += 1
+            if seen["show"] == 1:
+                raise httpx.ConnectError("down")
+            return httpx.Response(200, json={"capabilities": ["completion"]})
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"message": {"role": "assistant", "content": "ok"}, "done_reason": "stop"}
+        )
+
+    client = OllamaNativeClient(base_url="http://h:11434", http_client=_mock_client(handler))
+    kw = dict(model="m", messages=[{"role": "user", "content": "x"}], extra_body={"think": False})
+
+    client.chat.completions.create(**kw)  # probe fails -> fail-open, TTL-cached
+    assert capture["body"]["think"] is False
+    client.chat.completions.create(**kw)  # within TTL -> cached, no re-probe
+    assert seen["show"] == 1
+
+    now["t"] += adapter._NEG_PROBE_TTL + 1  # TTL lapses
+    client.chat.completions.create(**kw)  # re-probe -> definitive: no thinking cap
+    assert seen["show"] == 2
+    assert "think" not in capture["body"]
+    assert adapter._THINKING_CAP_CACHE[("http://h:11434", "m")] == (False, None)
+
+    client.chat.completions.create(**kw)  # memoized -> no further probes
+    assert seen["show"] == 2

--- a/tests/run_agent/test_create_openai_client_ollama_native.py
+++ b/tests/run_agent/test_create_openai_client_ollama_native.py
@@ -1,0 +1,104 @@
+"""Regression: the native-Ollama branch in ``create_openai_client`` must match the
+provider *type*, so a named custom instance (``custom:<name>``) is still routed to
+the native ``/api/chat`` client instead of silently falling back to ``/v1``.
+
+Multiple Ollama providers are named ``custom`` (bare) and ``custom:<name>`` (see
+``hermes_cli/providers.py``). An exact ``== "custom"`` gate would route only the
+bare instance native and drop every ``custom:<name>`` instance to ``/v1`` — losing
+per-request ``num_ctx`` and correct streaming ``tool_calls`` for delegated
+sub-agents. The routing itself stays gated on the per-endpoint Ollama probe, so a
+non-Ollama ``custom:<name>`` (vLLM / llama.cpp / LM Studio) is never mis-routed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.chat_completion_helpers import build_api_kwargs
+from agent.ollama_native_adapter import OllamaNativeClient
+from run_agent import AIAgent
+
+_BASE_URL = "http://localhost:11434/v1"
+
+
+def _make_agent(provider: str) -> AIAgent:
+    agent = AIAgent(
+        api_key="ollama",
+        base_url=_BASE_URL,
+        model="gemma4:e2b",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.provider = provider
+    return agent
+
+
+@patch("run_agent.OpenAI")
+def test_bare_custom_routes_native(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent("custom")
+    with patch("agent.ollama_native_adapter.is_native_ollama_base_url", return_value=True):
+        client = agent._create_openai_client(
+            {"api_key": "ollama", "base_url": _BASE_URL}, reason="test", shared=False
+        )
+    assert isinstance(client, OllamaNativeClient)
+
+
+@patch("run_agent.OpenAI")
+def test_suffixed_custom_instance_still_routes_native(mock_openai):
+    """Client selection: 'custom:ollama-2' must get the native client (previously it
+    fell through to /v1). NOTE: this only asserts the client TYPE — that num_ctx
+    actually reaches the payload is covered separately by
+    test_suffixed_custom_instance_injects_num_ctx."""
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent("custom:ollama-2")
+    with patch("agent.ollama_native_adapter.is_native_ollama_base_url", return_value=True):
+        client = agent._create_openai_client(
+            {"api_key": "ollama", "base_url": _BASE_URL}, reason="test", shared=False
+        )
+    assert isinstance(client, OllamaNativeClient)
+
+
+@patch("run_agent.OpenAI")
+def test_suffixed_custom_instance_injects_num_ctx(mock_openai):
+    """Routing the native client is not enough — num_ctx must reach extra_body, which
+    only happens on the provider-profile path. A named OLLAMA instance (probe says
+    yes) must resolve to the 'custom' profile so ollama_num_ctx is injected;
+    otherwise the model loads at Ollama's 4096 default despite the native client."""
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent("custom:ollama-2")
+    agent._ollama_num_ctx = 64000
+    with patch("agent.ollama_native_adapter.is_native_ollama_base_url", return_value=True):
+        kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+    assert kwargs["extra_body"]["options"]["num_ctx"] == 64000
+
+
+@patch("run_agent.OpenAI")
+def test_suffixed_non_ollama_custom_keeps_legacy_kwargs(mock_openai):
+    """The profile fallback is gated on the SAME Ollama identification as client
+    selection: a non-Ollama named instance (vLLM / corp gateway; probe says no)
+    must keep its pre-existing no-profile request shape. The custom profile would
+    inject max_tokens=65536 (CustomProfile.default_max_tokens) and
+    reasoning_effort/think fields that /v1-only servers reject with HTTP 400."""
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent("custom:vllm-prod")
+    agent.base_url = "http://localhost:8000/v1"
+    with patch("agent.ollama_native_adapter.is_native_ollama_base_url", return_value=False):
+        kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+    # Legacy path: no profile default max_tokens, no profile reasoning fields.
+    assert "max_tokens" not in kwargs
+    assert "reasoning_effort" not in kwargs
+    assert "think" not in (kwargs.get("extra_body") or {})
+
+
+@patch("run_agent.OpenAI")
+def test_suffixed_non_ollama_custom_stays_on_v1(mock_openai):
+    """A non-Ollama custom instance (probe says no) is never mis-routed to native."""
+    sentinel = MagicMock()
+    mock_openai.return_value = sentinel
+    agent = _make_agent("custom:vllm")
+    with patch("agent.ollama_native_adapter.is_native_ollama_base_url", return_value=False):
+        client = agent._create_openai_client(
+            {"api_key": "x", "base_url": "http://localhost:8000/v1"}, reason="test", shared=False
+        )
+    assert not isinstance(client, OllamaNativeClient)
+    assert client is sentinel  # fell through to the stock OpenAI client


### PR DESCRIPTION
## Description

Adds a native Ollama `/api/chat` adapter so local-Ollama users get **honored per-request `num_ctx`** and **correct tool calling**, neither of which the current OpenAI-compatible `/v1` path delivers.

> **Supersedes #55606.** That PR was auto-closed under the `env-var-for-config` policy because it gated on a `HERMES_OLLAMA_NATIVE` env var. That's fixed here — **the env var is gone**; selection is now probe-only, the same detection-based pattern the in-tree `agent/gemini_native_adapter.py` already uses. I couldn't reopen #55606 (the API refuses once a branch gets commits after close, and its branch was ~5k commits behind `main`), so this is a fresh branch rebased onto current `main` with the same work. @laurinaitis reviewed the original end-to-end, confirmed the design, and dropped their competing transport adapter to consolidate on this one.

Local Ollama is configured as `provider: custom` with `base_url: …:11434/v1`. That `/v1` surface:

1. **Silently drops per-request `num_ctx`.** Hermes already does the right thing on its side — `agent_init` detects the model's context via `query_ollama_num_ctx` (`/api/show`) and the `custom` provider profile injects it as `extra_body.options.num_ctx`. But Ollama's `/v1` maps only a fixed allowlist of OpenAI params and ignores the `options` object, so that value never reaches the model — it loads at the **4096** default anyway. The detection/injection machinery is effectively inert over `/v1`; native `/api/chat` is the endpoint that honors `options.num_ctx`. Verified live on Ollama 0.22.0 **and 0.32.5 (latest)**, and confirmed in the v0.32.5 `/v1` handler source (it maps only a fixed OpenAI allowlist to model options — no `num_ctx`); tracked in ollama/ollama#11409 (still open).
2. **Can corrupt streamed `tool_calls` deltas** for local models — the recurring complaint in #4505, and untouched by the num_ctx work. Several users confirm the *same* model returns correct tool calls via native `/api/chat` but broken ones via `/v1`, which leaves an agentic assistant unable to act locally.

This PR adds `agent/ollama_native_adapter.py` — a drop-in, OpenAI-SDK-shaped client over Ollama's native `/api/chat`, **modeled directly on the existing `agent/gemini_native_adapter.py`** so `api_mode` stays `chat_completions` and the rest of the agent loop is unchanged.

### Selection is detection-based, exactly like the Gemini adapter — no feature flag

Native routing engages iff the endpoint answers `GET /api/version` as Ollama — mirroring how the Gemini branch selects on `is_native_gemini_base_url(base_url)` alone, no flag, nothing in `.env` or `config.yaml`.

- **Never mis-routes.** `custom` also covers vLLM / llama.cpp / LM Studio, which have no `/api/version`; they fail the probe and stay byte-identical on `/v1`. Negatives are TTL-cached, positives memoized, so it's one probe per endpoint per process.
- **Ollama endpoints are transparently upgraded** to the native path — same as a Gemini endpoint gets the Gemini-native client — with no user config change (the adapter accepts the `/v1` URL and targets the native root itself).
- **Named instances too.** `chat_completion_helpers` resolves a `custom:<name>` instance to the `custom` profile so per-request `num_ctx` is injected for it as well.
- **Zero new dependencies** — uses `httpx`, already a core pin. No new dispatch in `run_agent.py`; `api_mode` untouched.

### Thinking + error handling

- Top-level `reasoning_effort` — the format the `custom` profile emits for configured reasoning levels — is translated to the native `think` value: an explicit `extra_body.think` wins, `"none"` maps to `think=false` (preserving the profile's disabled pairing), and level strings pass through unchanged, exactly as Ollama's own `/v1` `reasoning_effort` mapping does — so `/v1` and native stay behavior-identical per level.
- `think` is only sent when the model advertises the `thinking` capability (probed via `/api/show` with the client's auth headers; definitive answers memoized per endpoint+model, failures TTL-cached and fail-open). String think levels (`"low"`/`"high"`/…) pass through untouched.
- Ollama's `{"error": "<str>"}` bodies are surfaced directly instead of the raw JSON blob.

*(Capability probe + error-body parsing suggested by @laurinaitis during review of #55606.)*

## Related issue

Refs #4505. **Fixes #43900** — the open, multi-user-confirmed bug "Ollama local models silently capped at 4096-token context → `finish_reason=length` and garbled retries." Its root cause is exactly this: Hermes detects the real context (`query_ollama_num_ctx`) and the `custom` profile injects `extra_body.options.num_ctx`, but `/v1` ignores it. #43995 targets the same bug by sending `num_ctx` *top-level* over `/v1`; the `/v1` handler has no field to receive it either (it maps only a fixed OpenAI allowlist — see the source note above), which is why the fix has to happen at the transport. This PR routes positively-identified Ollama endpoints through native `/api/chat`, where `options.num_ctx` is honored — verified live on 0.22.0 and 0.32.5.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

- `tests/agent/test_ollama_native_adapter.py` (new, 41 tests): profile-to-request integration (the registered `custom` profile's `reasoning_effort`/`num_ctx` output driven through the client to the wire), request construction (`num_ctx` preserved, sampling merge, tool-call string↔object mapping, multimodal images incl. remote-URL degradation and case-insensitive `data:` schemes), non-streaming + NDJSON-stream translation (incl. in-band error frames and raw transport-error propagation), usage/finish-reason mapping, probe-based `/api/version` detection (auth headers/query/TLS verify with `_headers()`-matching precedence, dual-TTL expiry), the `/api/show` thinking-capability gate, error-body parsing (incl. empty error strings), and `default_query` forwarding — via `httpx.MockTransport`. No new test deps.
- `tests/run_agent/test_create_openai_client_ollama_native.py` (new): the `create_openai_client` routing branch (incl. `custom:<name>` num_ctx injection).
- `ruff check` clean on all changed files; rebased onto current `main`.
- Live (Ollama 0.22.0 **and 0.32.5, latest**), same `options.num_ctx=16384` on the same model:
  - `POST /v1/chat/completions` → `/api/ps` shows the model loaded at **4096** (dropped).
  - `POST /api/chat` → `/api/ps` shows **16384** (honored).
  - Through this adapter (passing the `/v1` URL + `extra_body.options.num_ctx`, exactly as `create_openai_client` + the `custom` profile do) → **honored** end-to-end.
- Manual: a non-Ollama `custom` endpoint (vLLM) fails the `/api/version` probe and is unchanged on `/v1`.

## Checklist

- [x] Conventional Commits in history (`feat(agent): …`)
- [x] No new dependencies
- [x] No new `HERMES_*` env var; selection is detection-based like the Gemini adapter
- [x] Non-Ollama `custom` endpoints unchanged (fail the probe, stay on `/v1`)

