### PR TITLE
fix(web-server): absorb _warm_gateway_module import before lifespan yield (#73083)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -195,13 +195,13 @@ async def _lifespan(app: "FastAPI"):
     # event loop during lifespan startup — see _get_event_state's docstring.
     app.state.chat_argv_lock = asyncio.Lock()
 
-    # Fire hermes_cli.gateway import into a background thread so the event
-    # loop is not blocked and HERMES_DASHBOARD_READY fires without delay.
-    # On a cold Windows install the module chain triggers .pyc compilation
-    # and Defender real-time scans that can stall the event loop for 15-30s.
-    # Running in an executor means the cost is paid in a worker thread while
-    # the server socket is already open and accepting probes.
-    asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
+    # Import hermes_cli.gateway eagerly *before* the lifespan yield so the
+    # GIL-heavy .pyc compilation and Defender scan cost is absorbed during
+    # backend initialisation — before the server socket accepts probes.
+    # On Windows + Python 3.11 the import does not release the GIL, so
+    # run_in_executor still froze the event loop for 15-22 s, causing the
+    # Desktop's 10-second WebSocket ready-probe to time out (GH-73083).
+    _warm_gateway_module()
 
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes


### PR DESCRIPTION
## Summary

On Windows + Python 3.11, the `_warm_gateway_module()` call in `hermes_cli/web_server.py` uses `run_in_executor` to import `hermes_cli.gateway` in a background thread. The intent was to avoid blocking the event loop during .pyc compilation and Defender real-time scans.

However, the heavy .pyc file reads do not release the GIL, so the event loop still freezes for 15–22 seconds. The Desktop Electron app's 10-second WebSocket ready-probe times out during this stall, causing a "Could not connect to Hermes gateway" error on startup.

## Fix

Move `_warm_gateway_module()` from `run_in_executor` to a synchronous call before the lifespan yield. The GIL block is now absorbed during backend initialisation — before the server socket accepts probes — so the Desktop's probe timeout is never triggered.

## Changes

- `hermes_cli/web_server.py`: Replace `asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)` with `_warm_gateway_module()`, update comment to explain the GIL-related rationale.

## Test Plan

- [ ] Desktop on Windows: startup no longer shows "Could not connect" error
- [ ] CLI `hermes dashboard` still works (the warm import is simply synchronous now)
- [ ] No regressions in existing tests

Fixes #73083