### PR TITLE
fix: locale-agnostic desktop tests and proxy env injection in systemd units

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,6 +5,7 @@
   "version": "0.17.0",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
+  "homepage": "https://github.com/NousResearch/hermes-agent",
   "type": "module",
   "main": "dist/electron-main.mjs",
   "engines": {
@@ -265,8 +266,7 @@
       "synopsis": "Native desktop shell for Hermes Agent.",
       "target": [
         "AppImage",
-        "deb",
-        "rpm"
+        "deb"
       ]
     },
     "nsis": {

--- a/apps/desktop/src/app/settings/billing/index.test.tsx
+++ b/apps/desktop/src/app/settings/billing/index.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { formatMoney } from './billing-amounts'
 import {
   billingDevFixtures,
   loggedOutBillingState,
@@ -168,7 +169,7 @@ describe('BillingSettings', () => {
       target: { value: '7.50' }
     })
 
-    expect(screen.getByText('Threshold: minimum is $10.')).toBeTruthy()
+    expect(screen.getByText(`Threshold: minimum is ${formatMoney(10)}.`)).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
@@ -219,7 +220,7 @@ describe('BillingSettings', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Manage' }))
 
     expect(screen.getByRole('spinbutton', { name: 'Auto-refill threshold' })).toBeTruthy()
-    expect(screen.queryByText('Threshold: minimum is $10.')).toBeNull()
+    expect(screen.queryByText(`Threshold: minimum is ${formatMoney(10)}.`)).toBeNull()
     // Save is disabled because the prefilled config is invalid — but no error yet.
     expect(screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true)
   })
@@ -592,7 +593,7 @@ describe('BillingSettings', () => {
       ok: true
     })
 
-    await waitFor(() => expect(screen.getByText('$25 added. Balance is refreshing.')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(`${formatMoney(25)} added. Balance is refreshing.`)).toBeTruthy())
   })
 
   it('renders logged-out as a connect card without normal account rows', async () => {

--- a/apps/desktop/src/lib/time.test.ts
+++ b/apps/desktop/src/lib/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { calendarBucket, DAY, formatAgo, HOUR, MINUTE, nominalDayStart, SECOND, sessionBucketLabel } from './time'
+import { calendarBucket, DAY, fmtMonth, fmtMonthYear, formatAgo, HOUR, MINUTE, nominalDayStart, SECOND, sessionBucketLabel } from './time'
 
 const labels = {
   ageNow: 'now',
@@ -117,8 +117,18 @@ describe('sessionBucketLabel', () => {
   })
 
   it('formats month (same year) and month + year (prior year) via Intl', () => {
-    // en-US default in the test env: month name, plus year for the prior year.
-    expect(labelAt(2026, 2, 3)).toBe('March')
-    expect(labelAt(2025, 11, 3)).toBe('December 2025')
+    // Locale-agnostic contract: same-year month buckets render via fmtMonth,
+    // prior-year buckets via fmtMonthYear. Assert against the shared
+    // formatters instead of frozen en-US strings so the test passes under
+    // any host locale (the formatters intentionally use the runtime locale).
+    const monthBucket = calendarBucket(secondsAt(2026, 2, 3), THU_NOON, 1)
+
+    if (monthBucket.kind !== 'month') {throw new Error(`expected month bucket, got ${monthBucket.kind}`)}
+    expect(sessionBucketLabel(monthBucket, labels)).toBe(fmtMonth.format(monthBucket.at))
+
+    const monthYearBucket = calendarBucket(secondsAt(2025, 11, 3), THU_NOON, 1)
+
+    if (monthYearBucket.kind !== 'monthYear') {throw new Error(`expected monthYear bucket, got ${monthYearBucket.kind}`)}
+    expect(sessionBucketLabel(monthYearBucket, labels)).toBe(fmtMonthYear.format(monthYearBucket.at))
   })
 })

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2750,6 +2750,16 @@ def _systemd_watchdog_service_fields(
     return "notify", f"NotifyAccess=main\nWatchdogSec={seconds}s\n"
 
 
+def _collect_systemd_proxy_env() -> list[str]:
+    """Add HTTP_PROXY / HTTPS_PROXY to the systemd unit if available."""
+    result: list[str] = []
+    for var in ("HTTP_PROXY", "HTTPS_PROXY"):
+        val = os.environ.get(var, "")
+        if val:
+            result.append(f'Environment="{var}={val}"')
+    return result
+
+
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
     python_path = get_python_path()
     working_dir = _stable_service_working_dir()
@@ -2793,6 +2803,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
             hermes_home
         )
         profile_arg = _profile_arg_for_target_user(hermes_home, home_dir)
+        proxy_env = _collect_systemd_proxy_env()
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
         # actually access them.
@@ -2825,6 +2836,7 @@ Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
+""" + "\n".join(proxy_env) + f"""
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
@@ -2846,6 +2858,7 @@ WantedBy=multi-user.target
         hermes_home
     )
     profile_arg = _profile_arg(hermes_home)
+    proxy_env = _collect_systemd_proxy_env()
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))
     path_entries.extend(common_bin_paths)
@@ -2863,6 +2876,7 @@ WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
+""" + "\n".join(proxy_env) + f"""
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -238,6 +238,14 @@ class TestSystemdServiceRefresh:
             return True
 
         monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
+        # ``run_gateway()`` routes every exit path through
+        # ``_exit_after_graceful_shutdown`` which hard-kills the process with
+        # ``os._exit`` (by design, see #53107). Stub it or the test runner
+        # itself dies mid-suite. Same pattern as test_gateway.py's
+        # ``_install_fake_gateway_run``.
+        monkeypatch.setattr(
+            "gateway.run._exit_after_graceful_shutdown", lambda code: None
+        )
 
         gateway_cli.run_gateway()
 


### PR DESCRIPTION
## Summary

### Locale-agnostic desktop tests
- `billing/index.test.tsx`: Use `formatMoney()` formatter instead of hardcoded `$10`/`$25`
- `lib/time.test.ts`: Use `fmtMonth`/`fmtMonthYear` instead of hardcoded month strings

### Gateway proxy env injection
- `hermes_cli/gateway.py`: Collect HTTP_PROXY / HTTPS_PROXY and inject as Environment= in systemd units

### Test fix
- `tests/hermes_cli/test_gateway_service.py`: Monkeypatch `_exit_after_graceful_shutdown` to prevent hard-kill

### Desktop build config
- `apps/desktop/package.json`: Add homepage URL, drop unused RPM target

## Test Plan
- [ ] `npm run test` in desktop package
- [ ] Gateway systemd unit generation with/without proxy env vars