### PR TITLE
fix(init): stop printing credential-derived characters in verbose banners

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -69,6 +69,26 @@ def _ra():
     return run_agent
 
 
+def _format_auth_credential_status(
+    credential: Any, *, uses_entra_id: bool = False
+) -> str:
+    """Return a credential-safe verbose initialization status.
+
+    Initialization banners are commonly copied into support reports.  Report
+    only a static source or the fact that a credential is present; never
+    include its value, length, prefix, suffix, or any other derived preview.
+    Presence does not imply that the credential is valid.
+    """
+    if uses_entra_id:
+        return "🔑 Authentication credential source: Microsoft Entra ID"
+    if isinstance(credential, str):
+        if credential and credential not in {"dummy-key", "no-key-required"}:
+            return "🔑 Authentication credential: present"
+    elif credential is not None:
+        return "🔑 Authentication credential: present"
+    return "⚠️  Authentication credential: missing or not required"
+
+
 def _moa_reference_output_allowed(agent: Any) -> bool:
     """Keep MoA display events off only the machine-readable ``-Q`` surface."""
     return not (
@@ -1059,10 +1079,12 @@ def init_agent(
                 # invoke or inspect the callable in the banner.
                 from agent.azure_identity_adapter import is_token_provider
 
-                if is_token_provider(effective_key):
-                    print("🔑 Using credentials: Microsoft Entra ID")
-                elif isinstance(effective_key, str) and len(effective_key) > 12:
-                    print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+                print(
+                    _format_auth_credential_status(
+                        effective_key,
+                        uses_entra_id=is_token_provider(effective_key),
+                    )
+                )
     elif agent.provider == "moa":
         from agent.moa_loop import build_moa_facade
         agent.api_mode = "chat_completions"
@@ -1338,13 +1360,13 @@ def init_agent(
                 # never invokes or inspects the callable.
                 from agent.azure_identity_adapter import is_token_provider
 
-                key_used = client_kwargs.get("api_key", "none")
-                if is_token_provider(key_used):
-                    print("🔑 Using credentials: Microsoft Entra ID")
-                elif isinstance(key_used, str) and key_used and key_used != "dummy-key" and len(key_used) > 12:
-                    print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
-                else:
-                    print("⚠️  Warning: API key appears invalid or missing")
+                key_used = client_kwargs.get("api_key")
+                print(
+                    _format_auth_credential_status(
+                        key_used,
+                        uses_entra_id=is_token_provider(key_used),
+                    )
+                )
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
 

--- a/tests/agent/test_agent_init_credential_status.py
+++ b/tests/agent/test_agent_init_credential_status.py
@@ -1,0 +1,27 @@
+"""Credential-safe verbose initialization banners."""
+
+import pytest
+
+from agent.agent_init import _format_auth_credential_status
+
+
+@pytest.mark.parametrize(
+    ("credential", "expected"),
+    [
+        ("x", "🔑 Authentication credential: present"),
+        ("short-value", "🔑 Authentication credential: present"),
+        ("long-enough-to-have-been-previewed", "🔑 Authentication credential: present"),
+        (None, "⚠️  Authentication credential: missing or not required"),
+        ("", "⚠️  Authentication credential: missing or not required"),
+        ("dummy-key", "⚠️  Authentication credential: missing or not required"),
+        ("no-key-required", "⚠️  Authentication credential: missing or not required"),
+    ],
+)
+def test_formats_only_credential_presence(credential, expected):
+    assert _format_auth_credential_status(credential) == expected
+
+
+def test_formats_managed_identity_as_static_source():
+    assert _format_auth_credential_status(
+        object(), uses_entra_id=True
+    ) == "🔑 Authentication credential source: Microsoft Entra ID"

--- a/tests/hermes_cli/test_verbose_credential_output.py
+++ b/tests/hermes_cli/test_verbose_credential_output.py
@@ -1,0 +1,217 @@
+"""Regression coverage for credential-safe verbose CLI initialization.
+
+The synthetic credential is generated at runtime and all output is captured in
+memory so a failing assertion cannot persist or print credential material.
+"""
+
+import logging
+import os
+import secrets
+import socket
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+SAFE_CREDENTIAL_DIAGNOSTIC = "🔑 Authentication credential: present"
+
+
+def _synthetic_credential() -> tuple[str, str, str]:
+    """Return a runtime-only credential with distinguishable random segments."""
+    alphabet = "QWXZJVK2346789"
+
+    def random_part() -> str:
+        return "".join(secrets.choice(alphabet) for _ in range(16))
+
+    prefix = f"PFX-{random_part()}"
+    suffix = f"SFX-{random_part()}"
+    return f"{prefix}-MID-{random_part()}-{suffix}", prefix, suffix
+
+
+def _assert_credential_absent(
+    output: str,
+    credential: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    """Fail without echoing captured output or credential-derived material."""
+    forbidden = (
+        credential,
+        prefix,
+        suffix,
+        credential[:8],
+        credential[-4:],
+        f"{credential[:8]}...{credential[-4:]}",
+    )
+    if any(fragment in output for fragment in forbidden):
+        pytest.fail("verbose CLI output exposed synthetic credential material", pytrace=False)
+
+
+def _assert_artifacts_are_credential_free(
+    hermes_home: Path,
+    credential: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    """Ensure temporary state contains no credential or derived preview."""
+    forbidden = tuple(
+        fragment.encode()
+        for fragment in (
+            credential,
+            prefix,
+            suffix,
+            f"{credential[:8]}...{credential[-4:]}",
+        )
+    )
+    for path in hermes_home.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        if any(fragment in data for fragment in forbidden):
+            pytest.fail(
+                "CLI probe persisted synthetic credential material",
+                pytrace=False,
+            )
+
+
+def _reset_hermes_logging() -> None:
+    """Detach per-test file and verbose handlers from global logging state."""
+    import hermes_logging
+
+    hermes_logging._reset_queued_handlers()
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if getattr(handler, "_hermes_verbose", False):
+            root.removeHandler(handler)
+            handler.close()
+    hermes_logging._logging_initialized = False
+
+
+@pytest.mark.parametrize(
+    ("provider", "api_mode", "base_url", "model"),
+    [
+        ("openrouter", "chat_completions", "https://example.invalid/v1", "test/model"),
+        ("anthropic", "anthropic_messages", "https://api.example.invalid", "claude-test"),
+    ],
+)
+def test_verbose_cli_initialization_reports_credential_without_exposing_it(
+    monkeypatch,
+    tmp_path,
+    provider,
+    api_mode,
+    base_url,
+    model,
+):
+    """``-v`` keeps safe diagnostics while exposing no credential characters."""
+    isolated_home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-home"
+    isolated_home.mkdir()
+    for directory in ("sessions", "cron", "memories", "skills"):
+        (hermes_home / directory).mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(isolated_home))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SAFE_MODE", "1")
+
+    network_attempts = []
+
+    def reject_network(*_args, **_kwargs):
+        network_attempts.append(True)
+        raise AssertionError("network access is forbidden in this test")
+
+    monkeypatch.setattr(socket, "create_connection", reject_network)
+    monkeypatch.setattr(socket.socket, "connect", reject_network)
+    monkeypatch.setattr(socket.socket, "connect_ex", reject_network)
+
+    import cli as cli_module
+
+    clean_config = {
+        "model": {
+            "default": model,
+            "base_url": base_url,
+            "provider": provider,
+        },
+        "display": {
+            "compact": False,
+            "tool_progress": "all",
+            "resume_display": "full",
+            "persistent_output": False,
+        },
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+
+    monkeypatch.setattr(cli_module, "CLI_CONFIG", clean_config)
+    monkeypatch.setattr(cli_module, "get_tool_definitions", lambda **_kwargs: [])
+    monkeypatch.setattr(cli_module, "_prepare_deferred_agent_startup", lambda: None)
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **_kwargs: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr("agent.agent_init.fetch_model_metadata", lambda: {})
+    monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length",
+        lambda *_args, **_kwargs: 256_000,
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.build_anthropic_client",
+        lambda *_args, **_kwargs: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.wait_for_mcp_discovery",
+        lambda: None,
+    )
+
+    credential, prefix, suffix = _synthetic_credential()
+    _reset_hermes_logging()
+    stdout = StringIO()
+    stderr = StringIO()
+    initialized = False
+    probe_raised = False
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            try:
+                cli = cli_module.HermesCLI(
+                    model=model,
+                    provider=provider,
+                    api_key=credential,
+                    base_url=base_url,
+                    verbose=True,
+                    max_turns=1,
+                    toolsets=[],
+                    ignore_rules=True,
+                )
+                monkeypatch.setattr(cli, "_ensure_runtime_credentials", lambda: True)
+                monkeypatch.setattr(cli, "_ensure_tirith_security", lambda: None)
+                initialized = cli._init_agent(
+                    runtime_override={
+                        "api_key": credential,
+                        "base_url": base_url,
+                        "provider": provider,
+                        "requested_provider": provider,
+                        "api_mode": api_mode,
+                        "command": None,
+                        "args": [],
+                        "credential_pool": None,
+                    }
+                )
+            except Exception:
+                probe_raised = True
+    finally:
+        stdout_output = stdout.getvalue()
+        stderr_output = stderr.getvalue()
+        _reset_hermes_logging()
+
+    if probe_raised or not initialized:
+        pytest.fail("CLI probe failed before output assertions", pytrace=False)
+    if network_attempts:
+        pytest.fail("CLI probe attempted network access", pytrace=False)
+    _assert_credential_absent(stdout_output, credential, prefix, suffix)
+    _assert_credential_absent(stderr_output, credential, prefix, suffix)
+    _assert_artifacts_are_credential_free(hermes_home, credential, prefix, suffix)
+    if SAFE_CREDENTIAL_DIAGNOSTIC not in stdout_output + stderr_output:
+        pytest.fail("safe credential diagnostic was not emitted", pytrace=False)

--- a/tests/run_agent/test_callable_api_key.py
+++ b/tests/run_agent/test_callable_api_key.py
@@ -290,33 +290,32 @@ class TestCliEnsureRuntimeCredentialsCallable:
 
 
 class TestInlinedDisplayMasks:
-    """The masked-credential display sites are now inlined per-site (no
-    shared helper). Each site uses the ``is_token_provider`` predicate
-    to short-circuit on callables and print a static
-    ``"Microsoft Entra ID"`` label, then falls through to its own
-    context-appropriate string mask. This replaces a unified helper
-    that would have forced one mask shape across sites with legitimately
-    different display needs (banner vs diagnostic vs UI vs preview)."""
+    """Credential display remains context-specific outside init banners.
 
-    def test_run_agent_banner_uses_is_token_provider_guard(self):
+    The two initialization banners share one strict status formatter because
+    neither context may reveal credential-derived characters. Other display
+    sites keep their own context-appropriate handling.
+    """
+
+    def test_run_agent_banners_use_safe_status_formatter(self):
         """The masked-banner sites live in ``agent/agent_init.py``
         (the ``__init__`` body was extracted into ``init_agent`` after
         this feature was first written). Both the OpenAI and Anthropic
-        client init paths must guard their banner prints with
-        ``is_token_provider`` so a callable Entra ID provider doesn't
-        crash ``len(api_key)``."""
+        client init paths must identify callable Entra ID providers and route
+        all other credentials through the shared no-preview formatter."""
         from pathlib import Path
         src = (Path(__file__).resolve().parent.parent.parent
                / "agent" / "agent_init.py").read_text()
         assert src.count("is_token_provider(") >= 2, (
-            "agent/agent_init.py must guard BOTH masked-banner paths "
+            "agent/agent_init.py must guard BOTH credential-banner paths "
             "(chat_completions and anthropic_messages) with "
             "is_token_provider()."
         )
-        assert src.count('"🔑 Using credentials: Microsoft Entra ID"') >= 2, (
-            "agent/agent_init.py banner blocks should print a static "
-            "'Microsoft Entra ID' label for callable api_keys — no "
-            "placeholder plumbing, no describe-mask fallback."
+        assert src.count("_format_auth_credential_status(") >= 3, (
+            "both banner paths must call the shared credential-safe formatter"
+        )
+        assert '"🔑 Authentication credential source: Microsoft Entra ID"' in src, (
+            "the shared formatter must report Entra ID as a static source"
         )
 
     def test_cli_show_config_handles_callable(self):


### PR DESCRIPTION
## What

Both client-initialization banners in `agent/agent_init.py` print twelve
characters of the live credential:

- `agent/agent_init.py:1065` — `🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}`
- `agent/agent_init.py:1345` — `🔑 Using API key: {key_used[:8]}...{key_used[-4:]}`

`-v` sets `quiet_mode=False`, which enables the surrounding block. Both are
direct `print()` calls, so `RedactingFormatter` never sees them.

## Why it matters

Initialization banners are the first thing people copy into an issue, a
support thread, or a paste when asking for help — that is what makes a
`-v` run different from ordinary terminal output. Twelve characters of a
provider key or an OAuth token travel with it.

## Why this is a pull request and not a private advisory

Per `SECURITY.md` §2.4, output redaction is an in-process heuristic and not
a boundary, and §3.2 places redaction improvements outside the private
disclosure channel while explicitly welcoming them as pull requests. This
change is offered in that spirit: it is output hygiene on a display path,
not a boundary fix.

## What changes

A single `_format_auth_credential_status()` helper reports **presence only** —
never the value, its length, prefix, or suffix. Callable Entra ID providers
keep their static source label and are still never invoked for display.

One deliberate behaviour change worth naming: the OpenAI-compatible banner
previously printed `⚠️ Warning: API key appears invalid or missing` for keys
of twelve characters or fewer. That check leaked one bit of length, so it is
gone; a malformed key now surfaces on the first request instead of in the
banner.

## Test evidence

`tests/hermes_cli/test_verbose_credential_output.py` drives the CLI end to end
with a runtime-generated synthetic credential, over both parametrised paths
(`chat_completions` and `anthropic_messages`). It asserts that neither the
value nor its prefix, suffix, or old masked form appears in stdout, stderr, or
**any file the run persists** — the artifact scan catches leaks into logs and
session state, not just the console. On failure it reports without echoing the
captured output, so a red test is not itself a disclosure.

Verified on a checkout of `main`: both parametrisations fail before the change
and pass after it, with the 24 existing `tests/run_agent/test_callable_api_key.py`
assertions still green.

## Note

The same "mask but keep head and tail" shape appears at several other display
and debug sites, and `agent/redact.py` implements it as the default policy
(`mask_secret` keeps 4+4, `_mask_token` keeps 6+4). This PR does not touch any
of that — it would be a policy change rather than a fix, and it is yours to
make. Worth mentioning that `_mask_token_nonreusable()` already implements the
zero-character form, so the primitive exists if you ever want display paths to
adopt it. Happy to follow up separately.
