### PR TITLE
feat(email): Markdown-to-HTML rendering for all 4 send paths

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -17,6 +17,8 @@ Environment variables:
 
 import asyncio
 import email as email_lib
+import html
+import html.parser
 import imaplib
 import logging
 import os
@@ -50,7 +52,6 @@ from gateway.config import Platform, PlatformConfig
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
-
 
 def _get_esecret(name: str, default: str = "") -> str:
     """Scope-aware ``EMAIL_*`` read with the default-profile startup fallback.
@@ -89,6 +90,208 @@ def _esecret_int(name: str, default: int) -> int:
 def _esecret_bool(name: str, default: bool = False) -> bool:
     """Scope-aware boolean read (``env_bool`` variant of ``_get_esecret``)."""
     return is_truthy_value(_get_esecret(name, ""), default=default)
+
+
+# ── HTML Email Formatting ───────────────────────────────────────────────
+# Converts Markdown to styled HTML for rich email rendering.
+# Config: platforms.email.html_format (default: true)
+
+_HERMES_EMAIL_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f4f4f7;">
+<div style="max-width:680px;margin:0 auto;background:#ffffff;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  font-size:15px;line-height:1.6;color:#2d3748;padding:32px;">
+{body}
+<div style="margin-top:32px;padding-top:16px;border-top:1px solid #e2e8f0;
+  font-size:12px;color:#a0aec0;">
+  Sent by <strong>Hermes Agent</strong>
+</div>
+</div>
+</body>
+</html>
+"""
+
+# Inline CSS per-element for email client compat (Gmail strips <style> tags).
+# Note: Python-Markdown generates <pre><code>...</code></pre> for fenced code.
+# The <pre> styling provides the dark background; <code> inside inherits it.
+# We use a two-pass approach: first style all <code> (inline code gets light bg),
+# then override <code> inside <pre> blocks to be transparent.
+_HERMES_EMAIL_STYLES = [
+    ("h1", 'style="font-size:24px;font-weight:700;color:#1a202c;margin:24px 0 12px;border-bottom:2px solid #667eea;padding-bottom:8px;"'),
+    ("h2", 'style="font-size:20px;font-weight:700;color:#2d3748;margin:24px 0 10px;border-bottom:1px solid #e2e8f0;padding-bottom:6px;"'),
+    ("h3", 'style="font-size:17px;font-weight:600;color:#4a5568;margin:18px 0 8px;"'),
+    ("h4", 'style="font-size:15px;font-weight:600;color:#718096;margin:14px 0 6px;"'),
+    ("p", 'style="margin:0 0 12px;"'),
+    ("ul", 'style="margin:0 0 12px;padding-left:24px;"'),
+    ("ol", 'style="margin:0 0 12px;padding-left:24px;"'),
+    ("li", 'style="margin-bottom:4px;"'),
+    ("blockquote", 'style="margin:12px 0;padding:12px 16px;border-left:4px solid #667eea;background:#f7fafc;color:#4a5568;font-style:italic;"'),
+    ("table", 'style="border-collapse:collapse;width:100%;margin:12px 0;font-size:14px;"'),
+    ("th", 'style="background:#667eea;color:#fff;padding:8px 12px;text-align:left;font-weight:600;"'),
+    ("td", 'style="padding:8px 12px;border-bottom:1px solid #e2e8f0;"'),
+    ("code", 'style="background:#edf2f7;padding:2px 5px;border-radius:3px;font-size:13px;font-family:Menlo,Monaco,Consolas,monospace;"'),
+    ("pre", 'style="background:#2d3748;color:#e2e8f0;padding:16px;border-radius:6px;overflow-x:auto;font-size:13px;line-height:1.5;"'),
+    ("a", 'style="color:#667eea;text-decoration:none;"'),
+    ("hr", 'style="border:none;border-top:1px solid #e2e8f0;margin:20px 0;"'),
+]
+
+# Regex to match <pre><code>...</code></pre> blocks — protect from style injection.
+# Strategy: temporarily replace these with placeholders BEFORE injecting inline
+# styles, then restore with custom styling. This avoids duplicate style=
+# attributes from two-pass injection (Copilot #73294).
+_PRE_CODE_BLOCK_RE = re.compile(r"<pre><code>(.*?)</code></pre>", re.DOTALL)
+_PRE_CODE_PLACEHOLDER = "\x00PRE_CODE_BLOCK_{}\x00"
+
+# Styled <pre><code> replacement — dark background, transparent code
+_PRE_CODE_STYLED = (
+    '<pre style="background:#2d3748;color:#e2e8f0;padding:16px;border-radius:6px;'
+    'overflow-x:auto;font-size:13px;line-height:1.5;">'
+    '<code style="background:transparent;padding:0;color:inherit;font-size:13px;'
+    'font-family:Menlo,Monaco,Consolas,monospace;">{}</code></pre>'
+)
+
+
+# ── HTML Sanitization ─────────────────────────────────────────────────
+# Allowlist-based sanitizer for outbound email HTML.
+# Mirrors the Matrix adapter pattern (html.parser-based, no bleach dependency).
+# Policy: only safe structural tags pass; event attributes, unsafe URLs,
+# and script/style blocks are stripped (Tecnium #73294).
+
+_EMAIL_ALLOWED_TAGS = {
+    "a", "b", "blockquote", "br", "code", "em", "h1", "h2", "h3", "h4", "h5", "h6",
+    "hr", "i", "li", "ol", "p", "pre", "strong", "table", "tbody", "td", "th",
+    "thead", "tr", "ul", "img",
+}
+_EMAIL_VOID_TAGS = {"br", "hr", "img"}
+
+
+class _EmailHtmlSanitizer(html.parser.HTMLParser):
+    """Allowlist sanitizer for email-compatible HTML."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self._parts: list[str] = []
+        self._skip_depth = 0
+
+    @staticmethod
+    def _safe_url(value: str) -> str:
+        stripped = re.sub(r"[\x00-\x1f\x7f]+", "", value or "").strip()
+        match = re.match(r"^([A-Za-z][A-Za-z0-9+.-]*):", stripped)
+        scheme = match.group(1).lower() if match else ""
+        if scheme and scheme not in {"http", "https", "mailto"}:
+            return ""
+        return stripped
+
+    def _safe_attrs(self, tag: str, attrs: list[tuple[str, str | None]]) -> str:
+        safe: list[str] = []
+        for key, value in attrs:
+            attr = str(key or "").lower()
+            raw_value = "" if value is None else str(value)
+            # Strip all event handlers
+            if attr.startswith("on"):
+                continue
+            if tag == "a" and attr == "href":
+                href = self._safe_url(raw_value)
+                if href:
+                    safe.append(f' href="{html.escape(href, quote=True)}"')
+            elif tag == "img" and attr == "src":
+                src = self._safe_url(raw_value)
+                if src:
+                    safe.append(f' src="{html.escape(src, quote=True)}"')
+            elif tag == "code" and attr == "class":
+                if re.fullmatch(r"language-[A-Za-z0-9_+.-]{1,64}", raw_value):
+                    safe.append(f' class="{html.escape(raw_value, quote=True)}"')
+            elif attr == "style":
+                # Allow inline styles (email clients need them)
+                safe.append(f' style="{html.escape(raw_value, quote=True)}"')
+        return "".join(safe)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+            return
+        if self._skip_depth:
+            return
+        if tag not in _EMAIL_ALLOWED_TAGS:
+            return
+        if tag in _EMAIL_VOID_TAGS:
+            self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
+            return
+        self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style"} and self._skip_depth:
+            self._skip_depth -= 1
+            return
+        if self._skip_depth or tag not in _EMAIL_ALLOWED_TAGS or tag in _EMAIL_VOID_TAGS:
+            return
+        self._parts.append(f"</{tag}>")
+
+    def handle_data(self, data: str) -> None:
+        if not self._skip_depth:
+            self._parts.append(html.escape(data))
+
+    def handle_entityref(self, name: str) -> None:
+        if not self._skip_depth:
+            self._parts.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        if not self._skip_depth:
+            self._parts.append(f"&#{name};")
+
+    def get_html(self) -> str:
+        return "".join(self._parts)
+
+
+def _sanitize_email_html(html_str: str) -> str:
+    """Sanitize HTML for email using allowlist policy."""
+    sanitizer = _EmailHtmlSanitizer()
+    try:
+        sanitizer.feed(html_str or "")
+        sanitizer.close()
+        return sanitizer.get_html()
+    except Exception:
+        return html.escape(html_str or "")
+
+
+def _is_html(text: str) -> bool:
+    """Detect if text already contains HTML markup."""
+    return bool(re.search(r"<(?:p|div|h[1-6]|table|ul|ol|blockquote|pre|br)\b", text, re.I))
+
+
+def _markdown_to_html_email(body: str) -> str:
+    """Convert Markdown body to styled HTML email content.
+
+    If the body already contains HTML (detected by block-level tags),
+    sanitize it directly instead of re-rendering through Markdown.
+    """
+    if _is_html(body):
+        # Body is already HTML — sanitize and wrap, don't re-render
+        sanitized = _sanitize_email_html(body)
+        return _HERMES_EMAIL_HTML_TEMPLATE.replace("{body}", sanitized)
+    import markdown as _md_mod
+    html = _md_mod.markdown(body, extensions=["tables", "fenced_code", "nl2br"])
+    # Protect <pre><code> blocks from style injection (replace with placeholders)
+    pre_code_blocks = []
+    def _save_block(m):
+        pre_code_blocks.append(m.group(1))
+        return _PRE_CODE_PLACEHOLDER.format(len(pre_code_blocks) - 1)
+    html = _PRE_CODE_BLOCK_RE.sub(_save_block, html)
+    # Inject inline styles per element (Gmail strips <style> blocks)
+    for tag, style in _HERMES_EMAIL_STYLES:
+        html = re.sub(rf"<{tag}(\s|>)", rf"<{tag} {style}\1", html)
+    # Restore <pre><code> blocks with proper styling (no duplicate style=)
+    for i, content in enumerate(pre_code_blocks):
+        html = html.replace(_PRE_CODE_PLACEHOLDER.format(i), _PRE_CODE_STYLED.format(content))
+    # Sanitize to enforce allowlist policy (event handlers, unsafe URLs, script/style)
+    html = _sanitize_email_html(html)
+    # Use .replace() instead of .format() — body may contain { } braces
+    return _HERMES_EMAIL_HTML_TEMPLATE.replace("{body}", html)
 
 
 # Automated sender patterns — emails from these are silently ignored
@@ -492,6 +695,9 @@ class EmailAdapter(BasePlatformAdapter):
         #     email:
         #       skip_attachments: true
         self._skip_attachments = extra.get("skip_attachments", False)
+
+        # HTML email formatting — config: platforms.email.html_format (default: true)
+        self._html_format = extra.get("html_format", True)
 
         # Require the sender's From: domain to be authenticated (SPF/DKIM/DMARC)
         # before trusting it for authorization. The From: header is
@@ -963,6 +1169,36 @@ class EmailAdapter(BasePlatformAdapter):
             return self._address.rsplit("@", 1)[-1] or "localhost"
         return "localhost"
 
+    # ── HTML email helpers ──────────────────────────────────────────────────
+
+    def _attach_body(self, msg: MIMEMultipart, body: str) -> None:
+        """Attach body as plain text + optional HTML to a message."""
+        self._attach_parts(msg, body)
+
+    def _create_body_part(self, body: str):
+        """Create a body part for use inside multipart/mixed.
+
+        Returns MIMEMultipart("alternative") when HTML is enabled,
+        or a simple MIMEText when html_format is disabled.
+        """
+        if self._html_format:
+            alt = MIMEMultipart("alternative")
+            self._attach_parts(alt, body)
+            return alt
+        return MIMEText(body, "plain", "utf-8")
+
+    def _attach_parts(self, container: MIMEMultipart, body: str) -> None:
+        """Attach plain + optional HTML parts to a multipart container."""
+        container.attach(MIMEText(body, "plain", "utf-8"))
+        if self._html_format:
+            try:
+                html = _markdown_to_html_email(body)
+                container.attach(MIMEText(html, "html", "utf-8"))
+            except ImportError:
+                logger.debug("[Email] markdown not installed, sending plain text only")
+            except Exception as e:
+                logger.warning("[Email] HTML conversion failed, sending plain only: %s", e, exc_info=True)
+
     def _send_email(
         self,
         to_addr: str,
@@ -970,7 +1206,7 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
-        msg = MIMEMultipart()
+        msg = MIMEMultipart("alternative")
         msg["From"] = self._address
         msg["To"] = to_addr
 
@@ -991,7 +1227,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
         msg["Message-ID"] = msg_id
 
-        msg.attach(MIMEText(body, "plain", "utf-8"))
+        self._attach_body(msg, body)
 
         smtp = self._connect_smtp()
         try:
@@ -1105,7 +1341,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Message-ID"] = msg_id
 
         if body:
-            msg.attach(MIMEText(body, "plain", "utf-8"))
+            msg.attach(self._create_body_part(body))
 
         for file_path in file_paths:
             p = Path(file_path)
@@ -1185,7 +1421,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Message-ID"] = msg_id
 
         if body:
-            msg.attach(MIMEText(body, "plain", "utf-8"))
+            msg.attach(self._create_body_part(body))
 
         # Attach file
         p = Path(file_path)
@@ -1246,12 +1482,14 @@ async def _standalone_send(
     import smtplib
     import ssl as _ssl
     from email.mime.text import MIMEText
+    from email.mime.multipart import MIMEMultipart as _MIMEMultipart
     from email.utils import formatdate
 
     extra = getattr(pconfig, "extra", {}) or {}
     address = extra.get("address") or _get_secret("EMAIL_ADDRESS", "")
     password = _get_secret("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", "")
+    html_format = extra.get("html_format", True)
     try:
         smtp_port = int(_get_secret("EMAIL_SMTP_PORT", "587") or "587")
     except (ValueError, TypeError):
@@ -1261,7 +1499,16 @@ async def _standalone_send(
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
 
     try:
-        msg = MIMEText(message, "plain", "utf-8")
+        if html_format:
+            msg = _MIMEMultipart("alternative")
+            msg.attach(MIMEText(message, "plain", "utf-8"))
+            try:
+                html = _markdown_to_html_email(message)
+                msg.attach(MIMEText(html, "html", "utf-8"))
+            except Exception as e:
+                logger.warning("[Email] Standalone HTML conversion failed, sending plain only: %s", e, exc_info=True)
+        else:
+            msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
         msg["Subject"] = "Hermes Agent"

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -264,6 +264,44 @@ def _is_html(text: str) -> bool:
     return bool(re.search(r"<(?:p|div|h[1-6]|table|ul|ol|blockquote|pre|br)\b", text, re.I))
 
 
+_HTML_START_RE = re.compile(
+    r"(?:<!DOCTYPE\s+html|<html[\s>]|<(?:div|table|h[1-6]|section|article|main|header|footer|style)\b)",
+    re.IGNORECASE | re.DOTALL,
+)
+_BLOCK_CLOSE_RE = re.compile(
+    r"</(?:div|table|section|article|main|header|footer|body|ul|ol|p|h[1-6])>",
+    re.IGNORECASE,
+)
+
+
+def _trim_html_preamble_postamble(body: str) -> str:
+    """Strip non-HTML preamble (cron wrappers, model commentary) before the
+    first HTML tag and trailing prose after the last block-level tag.
+
+    Ported from PR #36853 (chtse53) — the HTML-body send path needs the
+    same trimming so cron wrappers like ``Cronjob Response: <name>`` do not
+    render as broken text inside an HTML email.
+    """
+    m = _HTML_START_RE.search(body)
+    if not m:
+        return body
+    body = body[m.start():]
+    html_end = body.lower().find("</html>")
+    if html_end >= 0:
+        return body[: html_end + len("</html>")]
+    # HTML fragment without </html>: strip trailing model commentary / cron
+    # footers that follow the last closing block-level tag as pure prose.
+    for cm in reversed(list(_BLOCK_CLOSE_RE.finditer(body))):
+        after_tag = body[cm.end():]
+        after_stripped = after_tag.strip()
+        if not after_stripped:
+            break  # clean end — nothing to strip
+        if re.search(r"<[a-zA-Z/!]", after_stripped):
+            continue  # still HTML — keep looking
+        return body[: cm.end()]  # pure prose = model commentary
+    return body
+
+
 def _markdown_to_html_email(body: str) -> str:
     """Convert Markdown body to styled HTML email content.
 
@@ -271,7 +309,8 @@ def _markdown_to_html_email(body: str) -> str:
     sanitize it directly instead of re-rendering through Markdown.
     """
     if _is_html(body):
-        # Body is already HTML — sanitize and wrap, don't re-render
+        # Body is already HTML — trim preamble/postamble, sanitize, don't re-render
+        body = _trim_html_preamble_postamble(body)
         sanitized = _sanitize_email_html(body)
         return _HERMES_EMAIL_HTML_TEMPLATE.replace("{body}", sanitized)
     import markdown as _md_mod

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1514,8 +1514,9 @@ async def _standalone_send(
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
-        server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=_ssl.create_default_context())
+        server = smtplib.SMTP_SSL(smtp_host, smtp_port, context=_ssl.create_default_context()) if smtp_port == 465 else smtplib.SMTP(smtp_host, smtp_port, timeout=30)
+        if smtp_port != 465:
+            server.starttls(context=_ssl.create_default_context())
         server.login(address, password)
         server.send_message(msg)
         server.quit()

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -8,6 +8,8 @@ import imaplib
 import logging
 import os
 import re
+import html
+import html.parser
 import smtplib
 import socket
 import ssl
@@ -52,6 +54,208 @@ _HTML_SUBS = ((re.compile(r"<br\s*/?>", re.IGNORECASE), "\n"), (re.compile(r"<p[
 # "method=result" tokens (``dmarc=pass``) and property values (``header.from=x``) in Authentication-Results.
 _AUTH_METHOD_RE = re.compile(r"\b(dmarc|dkim|spf)\s*=\s*([a-z]+)", re.IGNORECASE)
 _AUTH_PROP_RE = re.compile(r"\b(header\.from|header\.d|smtp\.mailfrom|smtp\.from|envelope-from)\s*=\s*([^\s;]+)", re.IGNORECASE)
+
+
+# ── HTML Email Formatting ───────────────────────────────────────────────
+# Converts Markdown to styled HTML for rich email rendering.
+# Config: platforms.email.html_format (default: true)
+
+_HERMES_EMAIL_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f4f4f7;">
+<div style="max-width:680px;margin:0 auto;background:#ffffff;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  font-size:15px;line-height:1.6;color:#2d3748;padding:32px;">
+{body}
+<div style="margin-top:32px;padding-top:16px;border-top:1px solid #e2e8f0;
+  font-size:12px;color:#a0aec0;">
+  Sent by <strong>Hermes Agent</strong>
+</div>
+</div>
+</body>
+</html>
+"""
+
+# Inline CSS per-element for email client compat (Gmail strips <style> tags).
+# Note: Python-Markdown generates <pre><code>...</code></pre> for fenced code.
+# The <pre> styling provides the dark background; <code> inside inherits it.
+# We use a two-pass approach: first style all <code> (inline code gets light bg),
+# then override <code> inside <pre> blocks to be transparent.
+_HERMES_EMAIL_STYLES = [
+    ("h1", 'style="font-size:24px;font-weight:700;color:#1a202c;margin:24px 0 12px;border-bottom:2px solid #667eea;padding-bottom:8px;"'),
+    ("h2", 'style="font-size:20px;font-weight:700;color:#2d3748;margin:24px 0 10px;border-bottom:1px solid #e2e8f0;padding-bottom:6px;"'),
+    ("h3", 'style="font-size:17px;font-weight:600;color:#4a5568;margin:18px 0 8px;"'),
+    ("h4", 'style="font-size:15px;font-weight:600;color:#718096;margin:14px 0 6px;"'),
+    ("p", 'style="margin:0 0 12px;"'),
+    ("ul", 'style="margin:0 0 12px;padding-left:24px;"'),
+    ("ol", 'style="margin:0 0 12px;padding-left:24px;"'),
+    ("li", 'style="margin-bottom:4px;"'),
+    ("blockquote", 'style="margin:12px 0;padding:12px 16px;border-left:4px solid #667eea;background:#f7fafc;color:#4a5568;font-style:italic;"'),
+    ("table", 'style="border-collapse:collapse;width:100%;margin:12px 0;font-size:14px;"'),
+    ("th", 'style="background:#667eea;color:#fff;padding:8px 12px;text-align:left;font-weight:600;"'),
+    ("td", 'style="padding:8px 12px;border-bottom:1px solid #e2e8f0;"'),
+    ("code", 'style="background:#edf2f7;padding:2px 5px;border-radius:3px;font-size:13px;font-family:Menlo,Monaco,Consolas,monospace;"'),
+    ("pre", 'style="background:#2d3748;color:#e2e8f0;padding:16px;border-radius:6px;overflow-x:auto;font-size:13px;line-height:1.5;"'),
+    ("a", 'style="color:#667eea;text-decoration:none;"'),
+    ("hr", 'style="border:none;border-top:1px solid #e2e8f0;margin:20px 0;"'),
+]
+
+# Regex to match <pre><code>...</code></pre> blocks — protect from style injection.
+# Strategy: temporarily replace these with placeholders BEFORE injecting inline
+# styles, then restore with custom styling. This avoids duplicate style=
+# attributes from two-pass injection (Copilot #73294).
+_PRE_CODE_BLOCK_RE = re.compile(r"<pre><code>(.*?)</code></pre>", re.DOTALL)
+_PRE_CODE_PLACEHOLDER = "\x00PRE_CODE_BLOCK_{}\x00"
+
+# Styled <pre><code> replacement — dark background, transparent code
+_PRE_CODE_STYLED = (
+    '<pre style="background:#2d3748;color:#e2e8f0;padding:16px;border-radius:6px;'
+    'overflow-x:auto;font-size:13px;line-height:1.5;">'
+    '<code style="background:transparent;padding:0;color:inherit;font-size:13px;'
+    'font-family:Menlo,Monaco,Consolas,monospace;">{}</code></pre>'
+)
+
+
+# ── HTML Sanitization ─────────────────────────────────────────────────
+# Allowlist-based sanitizer for outbound email HTML.
+# Mirrors the Matrix adapter pattern (html.parser-based, no bleach dependency).
+# Policy: only safe structural tags pass; event attributes, unsafe URLs,
+# and script/style blocks are stripped (Tecnium #73294).
+
+_EMAIL_ALLOWED_TAGS = {
+    "a", "b", "blockquote", "br", "code", "em", "h1", "h2", "h3", "h4", "h5", "h6",
+    "hr", "i", "li", "ol", "p", "pre", "strong", "table", "tbody", "td", "th",
+    "thead", "tr", "ul", "img",
+}
+_EMAIL_VOID_TAGS = {"br", "hr", "img"}
+
+
+class _EmailHtmlSanitizer(html.parser.HTMLParser):
+    """Allowlist sanitizer for email-compatible HTML."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self._parts: list[str] = []
+        self._skip_depth = 0
+
+    @staticmethod
+    def _safe_url(value: str) -> str:
+        stripped = re.sub(r"[\x00-\x1f\x7f]+", "", value or "").strip()
+        match = re.match(r"^([A-Za-z][A-Za-z0-9+.-]*):", stripped)
+        scheme = match.group(1).lower() if match else ""
+        if scheme and scheme not in {"http", "https", "mailto"}:
+            return ""
+        return stripped
+
+    def _safe_attrs(self, tag: str, attrs: list[tuple[str, str | None]]) -> str:
+        safe: list[str] = []
+        for key, value in attrs:
+            attr = str(key or "").lower()
+            raw_value = "" if value is None else str(value)
+            # Strip all event handlers
+            if attr.startswith("on"):
+                continue
+            if tag == "a" and attr == "href":
+                href = self._safe_url(raw_value)
+                if href:
+                    safe.append(f' href="{html.escape(href, quote=True)}"')
+            elif tag == "img" and attr == "src":
+                src = self._safe_url(raw_value)
+                if src:
+                    safe.append(f' src="{html.escape(src, quote=True)}"')
+            elif tag == "code" and attr == "class":
+                if re.fullmatch(r"language-[A-Za-z0-9_+.-]{1,64}", raw_value):
+                    safe.append(f' class="{html.escape(raw_value, quote=True)}"')
+            elif attr == "style":
+                # Allow inline styles (email clients need them)
+                safe.append(f' style="{html.escape(raw_value, quote=True)}"')
+        return "".join(safe)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+            return
+        if self._skip_depth:
+            return
+        if tag not in _EMAIL_ALLOWED_TAGS:
+            return
+        if tag in _EMAIL_VOID_TAGS:
+            self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
+            return
+        self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style"} and self._skip_depth:
+            self._skip_depth -= 1
+            return
+        if self._skip_depth or tag not in _EMAIL_ALLOWED_TAGS or tag in _EMAIL_VOID_TAGS:
+            return
+        self._parts.append(f"</{tag}>")
+
+    def handle_data(self, data: str) -> None:
+        if not self._skip_depth:
+            self._parts.append(html.escape(data))
+
+    def handle_entityref(self, name: str) -> None:
+        if not self._skip_depth:
+            self._parts.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        if not self._skip_depth:
+            self._parts.append(f"&#{name};")
+
+    def get_html(self) -> str:
+        return "".join(self._parts)
+
+
+def _sanitize_email_html(html_str: str) -> str:
+    """Sanitize HTML for email using allowlist policy."""
+    sanitizer = _EmailHtmlSanitizer()
+    try:
+        sanitizer.feed(html_str or "")
+        sanitizer.close()
+        return sanitizer.get_html()
+    except Exception:
+        return html.escape(html_str or "")
+
+
+def _is_html(text: str) -> bool:
+    """Detect if text already contains HTML markup."""
+    return bool(re.search(r"<(?:p|div|h[1-6]|table|ul|ol|blockquote|pre|br)\b", text, re.I))
+
+
+def _markdown_to_html_email(body: str) -> str:
+    """Convert Markdown body to styled HTML email content.
+
+    If the body already contains HTML (detected by block-level tags),
+    sanitize it directly instead of re-rendering through Markdown.
+    """
+    if _is_html(body):
+        # Body is already HTML — sanitize and wrap, don't re-render
+        sanitized = _sanitize_email_html(body)
+        return _HERMES_EMAIL_HTML_TEMPLATE.replace("{body}", sanitized)
+    import markdown as _md_mod
+    html = _md_mod.markdown(body, extensions=["tables", "fenced_code", "nl2br"])
+    # Protect <pre><code> blocks from style injection (replace with placeholders)
+    pre_code_blocks = []
+    def _save_block(m):
+        pre_code_blocks.append(m.group(1))
+        return _PRE_CODE_PLACEHOLDER.format(len(pre_code_blocks) - 1)
+    html = _PRE_CODE_BLOCK_RE.sub(_save_block, html)
+    # Inject inline styles per element (Gmail strips <style> blocks)
+    for tag, style in _HERMES_EMAIL_STYLES:
+        html = re.sub(rf"<{tag}(\s|>)", rf"<{tag} {style}\1", html)
+    # Restore <pre><code> blocks with proper styling (no duplicate style=)
+    for i, content in enumerate(pre_code_blocks):
+        html = html.replace(_PRE_CODE_PLACEHOLDER.format(i), _PRE_CODE_STYLED.format(content))
+    # Sanitize to enforce allowlist policy (event handlers, unsafe URLs, script/style)
+    html = _sanitize_email_html(html)
+    # Use .replace() instead of .format() — body may contain { } braces
+    return _HERMES_EMAIL_HTML_TEMPLATE.replace("{body}", html)
 
 
 def _esecret_int(name: str, default: int) -> int:
@@ -338,6 +542,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_tls_verify = tls_verify("EMAIL_SMTP_TLS_VERIFY", "smtp_tls_verify")
         self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
         self._skip_attachments = extra.get("skip_attachments", False)  # platforms.email.skip_attachments
+        self._html_format = extra.get("html_format", True)  # platforms.email.html_format (Markdown→HTML rendering)
         # Require an authenticated From: domain (SPF/DKIM/DMARC) before trusting it for authorization
         # (GHSA-rxqh-5572-8m77). Default ON; opt out via require_authenticated_sender: false / EMAIL_TRUST_FROM_HEADER=true.
         if "require_authenticated_sender" in extra:
@@ -662,8 +867,39 @@ class EmailAdapter(BasePlatformAdapter):
                            ("Date", formatdate(localtime=True)), ("Message-ID", msg_id)):
             msg[key] = value
         if body or attach_empty_body:
-            msg.attach(MIMEText(body, "plain", "utf-8"))
+            self._attach_parts(msg, body)
         return msg, msg_id, subject
+
+    def _create_body_part(self, body: str):
+        """Create a body part for use inside multipart/mixed.
+
+        Returns ``MIMEMultipart("alternative")`` when HTML is enabled (the
+        plain/text + HTML pair), or a simple ``MIMEText`` when html_format is
+        disabled — the pre-feature behavior.
+        """
+        if self._html_format:
+            alt = MIMEMultipart("alternative")
+            self._attach_parts(alt, body)
+            return alt
+        return MIMEText(body, "plain", "utf-8")
+
+    def _attach_parts(self, container: MIMEMultipart, body: str) -> None:
+        """Attach plain + optional HTML parts to a multipart container.
+
+        Honors ``html_format`` (platforms.email.html_format, default true): attach
+        a ``text/plain`` part always, plus a ``text/html`` part rendered from the
+        Markdown body when enabled. HTML rendering is defensive — on failure we
+        fall back to plain text only, never breaking the send.
+        """
+        container.attach(MIMEText(body, "plain", "utf-8"))
+        if self._html_format:
+            try:
+                html = _markdown_to_html_email(body)
+                container.attach(MIMEText(html, "html", "utf-8"))
+            except ImportError:
+                logger.debug("[Email] markdown not installed, sending plain text only")
+            except Exception as e:
+                logger.warning("[Email] HTML conversion failed, sending plain only: %s", e, exc_info=True)
 
     def _smtp_send(self, msg: MIMEMultipart) -> None:
         """Login, send, and always release the SMTP connection (quit, else close)."""

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -228,6 +228,44 @@ def _is_html(text: str) -> bool:
     return bool(re.search(r"<(?:p|div|h[1-6]|table|ul|ol|blockquote|pre|br)\b", text, re.I))
 
 
+_HTML_START_RE = re.compile(
+    r"(?:<!DOCTYPE\s+html|<html[\s>]|<(?:div|table|h[1-6]|section|article|main|header|footer|style)\b)",
+    re.IGNORECASE | re.DOTALL,
+)
+_BLOCK_CLOSE_RE = re.compile(
+    r"</(?:div|table|section|article|main|header|footer|body|ul|ol|p|h[1-6])>",
+    re.IGNORECASE,
+)
+
+
+def _trim_html_preamble_postamble(body: str) -> str:
+    """Strip non-HTML preamble (cron wrappers, model commentary) before the
+    first HTML tag and trailing prose after the last block-level tag.
+
+    Ported from PR #36853 (chtse53) — the HTML-body send path needs the
+    same trimming so cron wrappers like ``Cronjob Response: <name>`` do not
+    render as broken text inside an HTML email.
+    """
+    m = _HTML_START_RE.search(body)
+    if not m:
+        return body
+    body = body[m.start():]
+    html_end = body.lower().find("</html>")
+    if html_end >= 0:
+        return body[: html_end + len("</html>")]
+    # HTML fragment without </html>: strip trailing model commentary / cron
+    # footers that follow the last closing block-level tag as pure prose.
+    for cm in reversed(list(_BLOCK_CLOSE_RE.finditer(body))):
+        after_tag = body[cm.end():]
+        after_stripped = after_tag.strip()
+        if not after_stripped:
+            break  # clean end — nothing to strip
+        if re.search(r"<[a-zA-Z/!]", after_stripped):
+            continue  # still HTML — keep looking
+        return body[: cm.end()]  # pure prose = model commentary
+    return body
+
+
 def _markdown_to_html_email(body: str) -> str:
     """Convert Markdown body to styled HTML email content.
 
@@ -235,7 +273,8 @@ def _markdown_to_html_email(body: str) -> str:
     sanitize it directly instead of re-rendering through Markdown.
     """
     if _is_html(body):
-        # Body is already HTML — sanitize and wrap, don't re-render
+        # Body is already HTML — trim preamble/postamble, sanitize, don't re-render
+        body = _trim_html_preamble_postamble(body)
         sanitized = _sanitize_email_html(body)
         return _HERMES_EMAIL_HTML_TEMPLATE.replace("{body}", sanitized)
     import markdown as _md_mod

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -990,10 +990,20 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
     smtp_host, smtp_port = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", ""), _esecret_int("EMAIL_SMTP_PORT", 587)
     smtp_security = _normalize_security(_get_secret("EMAIL_SMTP_SECURITY", "") or extra.get("smtp_security"), default="tls" if smtp_port == 465 else "starttls")
     smtp_tls_verify = _esecret_bool("EMAIL_SMTP_TLS_VERIFY", is_truthy_value(extra.get("smtp_tls_verify"), default=True))
+    html_format = extra.get("html_format", True)  # platforms.email.html_format
     if not all([address, password, smtp_host]):
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
     try:
-        msg = MIMEText(message, "plain", "utf-8")
+        if html_format:
+            msg = MIMEMultipart("alternative")
+            msg.attach(MIMEText(message, "plain", "utf-8"))
+            try:
+                html = _markdown_to_html_email(message)
+                msg.attach(MIMEText(html, "html", "utf-8"))
+            except Exception as e:
+                logger.warning("[Email] Standalone HTML conversion failed, sending plain only: %s", e, exc_info=True)
+        else:
+            msg = MIMEText(message, "plain", "utf-8")
         for key, value in (("From", address), ("To", chat_id), ("Subject", "Hermes Agent"), ("Date", formatdate(localtime=True))):
             msg[key] = value
         server = _open_smtp(smtp_host, smtp_port, smtp_security, _tls_context(smtp_tls_verify, smtp_host), smtplib.SMTP, smtplib.SMTP_SSL)

--- a/tests/gateway/test_email_html.py
+++ b/tests/gateway/test_email_html.py
@@ -1,0 +1,196 @@
+"""Tests for email adapter HTML rendering (PR #73294)."""
+import pytest
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+
+class TestMarkdownToHtmlEmail:
+    """Test _markdown_to_html_email conversion."""
+
+    def test_basic_markdown(self):
+        from plugins.platforms.email.adapter import _markdown_to_html_email
+        html = _markdown_to_html_email("**bold** and *italic*")
+        assert "<strong>bold</strong>" in html
+        assert "<em>italic</em>" in html
+
+    def test_heading_styled(self):
+        from plugins.platforms.email.adapter import _markdown_to_html_email
+        html = _markdown_to_html_email("# Hello")
+        assert '<h1 style=' in html
+        assert "Hello" in html
+
+    def test_fenced_code_no_duplicate_style(self):
+        """<pre><code> blocks must NOT have duplicate style= attributes."""
+        from plugins.platforms.email.adapter import _markdown_to_html_email
+        md = "```python\nprint('hello')\n```"
+        html = _markdown_to_html_email(md)
+        # <pre> should have exactly one style=
+        import re
+        pre_tags = re.findall(r"<pre[^>]*>", html)
+        for tag in pre_tags:
+            assert tag.count("style=") == 1, f"Duplicate style= in: {tag}"
+        # <code> should have exactly one style=
+        code_tags = re.findall(r"<code[^>]*>", html)
+        for tag in code_tags:
+            assert tag.count("style=") == 1, f"Duplicate style= in: {tag}"
+
+    def test_table_rendering(self):
+        from plugins.platforms.email.adapter import _markdown_to_html_email
+        md = "| A | B |\n|---|---|\n| 1 | 2 |"
+        html = _markdown_to_html_email(md)
+        assert "<table" in html
+        assert "<td" in html
+
+    def test_braces_not_escaped(self):
+        """Body with { } braces must not break template substitution."""
+        from plugins.platforms.email.adapter import _markdown_to_html_email
+        html = _markdown_to_html_email("Use `{code}` here")
+        # Verify the code span is rendered with inline code styling
+        assert '<code style=' in html
+        assert "code" in html
+        # Verify no raw {body} placeholder remains
+        assert "{body}" not in html
+
+
+class TestAttachParts:
+    """Test _attach_parts MIME structure."""
+
+    def _make_adapter(self, html_format=True):
+        """Create a minimal adapter mock for testing."""
+        from unittest.mock import MagicMock
+        adapter = MagicMock()
+        adapter._html_format = html_format
+        # Bind the real method
+        from plugins.platforms.email.adapter import EmailAdapter
+        adapter._attach_parts = EmailAdapter._attach_parts.__get__(adapter)
+        return adapter
+
+    def test_html_enabled_creates_two_parts(self):
+        adapter = self._make_adapter(html_format=True)
+        msg = MIMEMultipart("alternative")
+        adapter._attach_parts(msg, "**bold**")
+        parts = msg.get_payload()
+        assert len(parts) == 2
+        assert parts[0].get_content_type() == "text/plain"
+        assert parts[1].get_content_type() == "text/html"
+
+    def test_html_disabled_creates_one_part(self):
+        adapter = self._make_adapter(html_format=False)
+        msg = MIMEMultipart("alternative")
+        adapter._attach_parts(msg, "**bold**")
+        parts = msg.get_payload()
+        assert len(parts) == 1
+        assert parts[0].get_content_type() == "text/plain"
+
+    def test_importerror_falls_back_gracefully(self):
+        """When markdown is not installed, should fall back to plain text."""
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "markdown":
+                raise ImportError("No module named 'markdown'")
+            return real_import(name, *args, **kwargs)
+
+        adapter = self._make_adapter(html_format=True)
+        msg = MIMEMultipart("alternative")
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(builtins, "__import__", mock_import)
+            # Should not raise — falls back to plain text only
+            adapter._attach_parts(msg, "**bold**")
+        parts = msg.get_payload()
+        assert len(parts) == 1  # only plain text
+
+
+class TestCreateBodyPart:
+    """Test _create_body_part return type based on html_format."""
+
+    def _make_adapter(self, html_format=True):
+        from unittest.mock import MagicMock
+        from plugins.platforms.email.adapter import EmailAdapter
+        adapter = MagicMock()
+        adapter._html_format = html_format
+        adapter._create_body_part = EmailAdapter._create_body_part.__get__(adapter)
+        adapter._attach_parts = EmailAdapter._attach_parts.__get__(adapter)
+        return adapter
+
+    def test_html_enabled_returns_alternative(self):
+        adapter = self._make_adapter(html_format=True)
+        part = adapter._create_body_part("**bold**")
+        assert isinstance(part, MIMEMultipart)
+        assert part.get_content_subtype() == "alternative"
+
+    def test_html_disabled_returns_plain_text(self):
+        adapter = self._make_adapter(html_format=False)
+        part = adapter._create_body_part("**bold**")
+        assert isinstance(part, MIMEText)
+        assert part.get_content_type() == "text/plain"
+
+
+class TestHtmlSanitization:
+    """Test _sanitize_email_html security policy."""
+
+    def test_script_tags_stripped(self):
+        from plugins.platforms.email.adapter import _sanitize_email_html
+        result = _sanitize_email_html('<p>Hello</p><script>alert("xss")</script>')
+        assert "script" not in result
+        assert "alert" not in result
+        assert "Hello" in result
+
+    def test_event_handlers_stripped(self):
+        from plugins.platforms.email.adapter import _sanitize_email_html
+        result = _sanitize_email_html('<p onclick="evil()">Click</p>')
+        assert "onclick" not in result
+        assert "Click" in result
+
+    def test_javascript_urls_stripped(self):
+        from plugins.platforms.email.adapter import _sanitize_email_html
+        result = _sanitize_email_html('<a href="javascript:alert(1)">link</a>')
+        assert "javascript:" not in result
+
+    def test_safe_urls_preserved(self):
+        from plugins.platforms.email.adapter import _sanitize_email_html
+        result = _sanitize_email_html('<a href="https://example.com">link</a>')
+        assert "https://example.com" in result
+
+    def test_style_tags_stripped(self):
+        from plugins.platforms.email.adapter import _sanitize_email_html
+        result = _sanitize_email_html('<p>Text</p><style>body{display:none}</style>')
+        assert "style" not in result
+        assert "display:none" not in result
+        assert "Text" in result
+
+    def test_inline_styles_preserved(self):
+        """Inline styles are needed for email client compatibility."""
+        from plugins.platforms.email.adapter import _sanitize_email_html
+        result = _sanitize_email_html('<p style="margin:0;">Text</p>')
+        assert 'style="margin:0;"' in result
+
+    def test_disallowed_tags_stripped(self):
+        from plugins.platforms.email.adapter import _sanitize_email_html
+        result = _sanitize_email_html('<p>OK</p><iframe src="evil"></iframe><embed>')
+        assert "iframe" not in result
+        assert "embed" not in result
+        assert "OK" in result
+
+    def test_allowed_tags_preserved(self):
+        from plugins.platforms.email.adapter import _sanitize_email_html
+        result = _sanitize_email_html("<p><strong>bold</strong> and <em>italic</em></p>")
+        assert "<strong>" in result
+        assert "<em>" in result
+
+
+class TestHtmlDetection:
+    """Test _is_html detection."""
+
+    def test_html_detected(self):
+        from plugins.platforms.email.adapter import _is_html
+        assert _is_html("<p>Hello</p>") is True
+        assert _is_html("<div>content</div>") is True
+        assert _is_html("<h1>Title</h1>") is True
+
+    def test_markdown_not_detected_as_html(self):
+        from plugins.platforms.email.adapter import _is_html
+        assert _is_html("**bold** and *italic*") is False
+        assert _is_html("# Heading\n\nParagraph") is False
+        assert _is_html("Just plain text.") is False

--- a/tests/gateway/test_email_html.py
+++ b/tests/gateway/test_email_html.py
@@ -194,3 +194,101 @@ class TestHtmlDetection:
         assert _is_html("**bold** and *italic*") is False
         assert _is_html("# Heading\n\nParagraph") is False
         assert _is_html("Just plain text.") is False
+
+
+class TestStandaloneSendSMTPPort:
+    """_standalone_send must select SMTP_SSL for port 465 (implicit TLS)."""
+
+    def test_port_465_uses_smtp_ssl(self):
+        import asyncio
+        from types import SimpleNamespace
+        from plugins.platforms.email.adapter import _standalone_send
+        from unittest.mock import patch
+
+        captured = {}
+
+        class FakeSSL:
+            def __init__(self, *a, **k):
+                captured["cls"] = "SMTP_SSL"
+                captured["port"] = k.get("port") or (a[1] if len(a) > 1 else None)
+
+            def login(self, *a, **k):
+                return None
+
+            def send_message(self, msg):
+                return None
+
+            def quit(self):
+                return None
+
+        class FakeSMTP:
+            def __init__(self, *a, **k):
+                captured["cls"] = "SMTP"
+                captured["port"] = k.get("port") or (a[1] if len(a) > 1 else None)
+
+            def starttls(self, context=None):
+                return None
+
+            def login(self, *a, **k):
+                return None
+
+            def send_message(self, msg):
+                return None
+
+            def quit(self):
+                return None
+
+        import os
+        os.environ["EMAIL_ADDRESS"] = "a@b.ch"
+        os.environ["EMAIL_PASSWORD"] = "x"
+        os.environ["EMAIL_SMTP_HOST"] = "smtp.test.com"
+        os.environ["EMAIL_SMTP_PORT"] = "465"
+
+        pconfig = SimpleNamespace(token=None, api_key=None, extra={"address": "a@b.ch", "smtp_host": "smtp.test.com"})
+
+        with patch("smtplib.SMTP_SSL", FakeSSL), patch("smtplib.SMTP", FakeSMTP):
+            result = asyncio.run(_standalone_send(pconfig, "c@d.ch", "hello"))
+
+        assert captured.get("cls") == "SMTP_SSL", f"port 465 must use SMTP_SSL, got {captured.get('cls')}"
+        assert result.get("success") is True
+
+    def test_port_587_uses_starttls(self):
+        import asyncio
+        from types import SimpleNamespace
+        from plugins.platforms.email.adapter import _standalone_send
+        from unittest.mock import patch
+
+        captured = {}
+
+        class FakeSMTP:
+            def __init__(self, *a, **k):
+                captured["cls"] = "SMTP"
+                captured["starttls"] = False
+
+            def starttls(self, context=None):
+                captured["starttls"] = True
+                return None
+
+            def login(self, *a, **k):
+                return None
+
+            def send_message(self, msg):
+                return None
+
+            def quit(self):
+                return None
+
+        import os
+        os.environ["EMAIL_ADDRESS"] = "a@b.ch"
+        os.environ["EMAIL_PASSWORD"] = "x"
+        os.environ["EMAIL_SMTP_HOST"] = "smtp.test.com"
+        os.environ["EMAIL_SMTP_PORT"] = "587"
+
+        pconfig = SimpleNamespace(token=None, api_key=None, extra={"address": "a@b.ch", "smtp_host": "smtp.test.com"})
+
+        with patch("smtplib.SMTP", FakeSMTP):
+            result = asyncio.run(_standalone_send(pconfig, "c@d.ch", "hello"))
+
+        assert captured.get("cls") == "SMTP"
+        assert captured.get("starttls") is True
+        assert result.get("success") is True

--- a/tests/gateway/test_email_html.py
+++ b/tests/gateway/test_email_html.py
@@ -292,3 +292,41 @@ class TestStandaloneSendSMTPPort:
         assert captured.get("cls") == "SMTP"
         assert captured.get("starttls") is True
         assert result.get("success") is True
+
+
+class TestTrimHtmlPreamblePostamble:
+    """HTML-body trimming ported from PR #36853 (chtse53)."""
+
+    def test_strips_cron_wrapper_preamble(self):
+        from plugins.platforms.email.adapter import _trim_html_preamble_postamble
+        body = "Cronjob Response: Test\n-------------\n<div><b>Hi</b></div>"
+        result = _trim_html_preamble_postamble(body)
+        assert result.startswith("<div>")
+        assert "Cronjob Response" not in result
+
+    def test_strips_trailing_commentary_after_html_doc(self):
+        from plugins.platforms.email.adapter import _trim_html_preamble_postamble
+        body = "<html><body><p>x</p></body></html>\n\nModel commentary after"
+        result = _trim_html_preamble_postamble(body)
+        assert result.endswith("</html>")
+        assert "commentary" not in result
+
+    def test_strips_trailing_prose_after_fragment(self):
+        from plugins.platforms.email.adapter import _trim_html_preamble_postamble
+        body = "<div><p>Body</p></div>\n\nDas war mein Bericht."
+        result = _trim_html_preamble_postamble(body)
+        assert result == "<div><p>Body</p></div>"
+
+    def test_plain_text_unchanged(self):
+        from plugins.platforms.email.adapter import _trim_html_preamble_postamble
+        body = "Nur Text, kein HTML hier"
+        result = _trim_html_preamble_postamble(body)
+        assert result == body
+
+    def test_html_detection_path_applies_trim(self):
+        from plugins.platforms.email.adapter import _markdown_to_html_email
+        result = _markdown_to_html_email(
+            "Cronjob Response: X\n-------------\n<div><b>Hi</b></div>"
+        )
+        assert "<b>Hi</b>" in result
+        assert "Cronjob Response" not in result


### PR DESCRIPTION
## What does this PR do?

Adds automatic Markdown-to-HTML rendering for all outbound emails. Sends emails as `multipart/alternative` with both `text/plain` (raw body) and `text/html` (styled HTML with inline CSS), so HTML-capable clients render rich formatting while plain-text clients fall back gracefully.

**Addresses:** Closes #11941

## How it works

1. `_markdown_to_html_email(body)` converts Markdown to HTML using the `markdown` library (tables, fenced code, nl2br), then injects **inline CSS** per element (because Gmail strips `<style>` blocks).

2. **All 4 send paths** are updated:
   - `_send_email` → `MIMEMultipart("alternative")` + `_attach_body(msg, body)`
   - `_send_email_with_attachment` → `_create_body_part(body)` inside `multipart/mixed`
   - `_send_email_with_attachments` → `_create_body_part(body)` inside `multipart/mixed`
   - `_standalone_send` → `MIMEMultipart("alternative")` with `html_format` config check

3. Config opt-out: `platforms.email.html_format: false` disables HTML (default: `true`).

4. Graceful fallback: if `markdown` is not installed or conversion fails, plain text is sent as before.

5. **Security:** allowlist sanitizer (`_EmailHtmlSanitizer`) strips event handlers, `javascript:`/`data:` URLs, and `<script>`/`<style>` blocks on all outbound HTML.

6. **Already-HTML bodies:** `_is_html()` detects them, `_trim_html_preamble_postamble()` strips cron-wrapper/model commentary before the first HTML tag and trailing prose after `</html>` or the last block-level tag (ported from #36853, commit `592c9b2f`), then the sanitizer applies.

7. **Standalone SMTP fix:** `_standalone_send` uses `SMTP_SSL` on port 465 (implicit TLS) instead of `SMTP`+`STARTTLS`, matching `_connect_smtp` (found by live E2E against smtp.breitband.ch:465).

## Supersedes / Overlapping PRs

- **#46619** — verify-selected best fix, stale branch targeting retired `gateway/platforms/email.py`
- **#54107** — bundled with unrelated changes
- **#46642**, **#46626** — partial fixes, wrong path
- **#36853** — same topic; **feature ported** (preamble/postamble trimming) into this PR with attribution; original targets retired `gateway/platforms/email.py` (bundled-plugin migration 5600105478)
- **#34603** — closed by author (overlap); **#68707** — complementary receive-path fix (decode `&amp;` last), independently mergeable

## Rebase note (2026-08-03)

Branch was 3714 files behind main. Rebuilt fresh from `main` (commit `9529ee30`), carrying the full review history (Copilot + Tecnium rounds on the prior base). Rebased again onto current main (2026-08-03, +149 commits) — only the 4 email commits are in this branch. Test suite: `tests/gateway/test_email_html.py` (25 tests) + `tests/gateway/test_email.py` all pass (61 total).
