### PR TITLE
fix(kanban): add --force-local to reclaim for hostname-change scenarios

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -506,6 +506,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--reason", default=None,
         help="Human-readable reason (recorded on the reclaimed event)",
     )
+    p_reclaim.add_argument(
+        "--force-local", action="store_true",
+        help=(
+            "Attempt worker termination even when the claim's hostname "
+            "no longer matches the current host (e.g. after a DHCP "
+            "hostname change). The PID must still be alive and its "
+            "command line must look like a Hermes worker process."
+        ),
+    )
 
     p_reassign = sub.add_parser(
         "reassign",
@@ -1829,6 +1838,7 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
         ok = kb.reclaim_task(
             conn, args.task_id,
             reason=getattr(args, "reason", None),
+            force_local=getattr(args, "force_local", False),
         )
     if not ok:
         print(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4338,7 +4338,8 @@ def release_stale_claims(
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
+        "SELECT id, current_run_id, claim_lock, worker_pid, "
+        "       claim_expires, last_heartbeat_at "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
         "  AND claim_expires < ?",
@@ -4398,9 +4399,52 @@ def release_stale_claims(
                 )
             continue
 
-        termination = _terminate_reclaimed_worker(
-            row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+        run_id = (
+            int(row["current_run_id"])
+            if row["current_run_id"] is not None
+            else None
         )
+        if (
+            not host_local
+            and row["worker_pid"]
+            and _pid_alive(row["worker_pid"])
+        ):
+            if _verify_pid_matches_kanban_worker(
+                int(row["worker_pid"]),
+                task_id=row["id"],
+                run_id=run_id,
+                claim_lock=row["claim_lock"],
+            ):
+                termination = _terminate_reclaimed_worker(
+                    row["worker_pid"],
+                    row["claim_lock"],
+                    task_id=row["id"],
+                    run_id=run_id,
+                    signal_fn=signal_fn,
+                    force_local=True,
+                )
+            else:
+                _defer_reclaim_for_live_worker(
+                    conn,
+                    row["id"],
+                    row["claim_lock"],
+                    now,
+                    {
+                        "prev_pid": int(row["worker_pid"]),
+                        "host_local": False,
+                        "termination_attempted": False,
+                        "terminated": False,
+                        "sigkill": False,
+                        "force_local": False,
+                        "identity_verified": False,
+                    },
+                    reason="ttl_expired_worker_identity_unverified",
+                )
+                continue
+        else:
+            termination = _terminate_reclaimed_worker(
+                row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
         if _worker_survived_termination(termination):
@@ -4476,7 +4520,8 @@ def reclaim_task(
     reclaimable state (not running, or doesn't exist).
     """
     row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        "SELECT status, current_run_id, claim_lock, worker_pid "
+        "FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if not row:
@@ -4487,6 +4532,12 @@ def reclaim_task(
     prev_lock = row["claim_lock"]
     termination = _terminate_reclaimed_worker(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
+        task_id=task_id,
+        run_id=(
+            int(row["current_run_id"])
+            if row["current_run_id"] is not None
+            else None
+        ),
         force_local=force_local,
     )
     with write_txn(conn):
@@ -6878,15 +6929,9 @@ def _pid_alive(pid: Optional[int]) -> bool:
     return True
 
 
-def _verify_pid_is_hermes_worker(pid: int) -> bool:
+def _pid_looks_like_hermes_worker(pid: int) -> bool:
     """Return True when *pid* is a live local process whose command line
-    looks like a Hermes kanban worker.
-
-    Used as the safety check when ``--force-local`` overrides a hostname
-    mismatch in claim_lock.  Reading the process command line provides
-    the "additional local proof" required by #73277: we never signal a
-    PID just because it exists — it must *look like* a Hermes worker.
-    """
+    looks like a Hermes worker."""
     if not _pid_alive(pid):
         return False
     try:
@@ -6896,13 +6941,10 @@ def _verify_pid_is_hermes_worker(pid: int) -> bool:
         cmdline = None
     if not cmdline:
         return False
-    # Hermes workers are launched as ``hermes -p <profile> --cli chat -q ...``
-    # and always carry HERMES_KANBAN_TASK in their environment.  The command
-    # line must contain the hermes entrypoint and "chat" (the worker subcmd).
-    # This is intentionally broad — we're confirming the PID *is* a Hermes
-    # process, not that it's a specific task's worker.  The narrower check
-    # (matching a specific task_id) would require /proc/<pid>/environ on
-    # Linux which is fragile and platform-dependent.
+    # Hermes workers are launched as ``hermes -p <profile> --cli chat -q ...``.
+    # This is intentionally broad — it only answers "does this look like a
+    # Hermes worker at all?" Exact task/run/claim ownership is enforced by
+    # ``_verify_pid_matches_kanban_worker`` via process environment checks.
     cli_name = os.path.basename(sys.argv[0]) if sys.argv else "hermes"
     # Match either the bare name (e.g. "hermes") or the full python invocation
     # (e.g. "python -m hermes_cli.main").
@@ -6913,10 +6955,60 @@ def _verify_pid_is_hermes_worker(pid: int) -> bool:
     )
 
 
+def _read_process_environ(pid: int) -> dict[str, str]:
+    """Best-effort environment read for a live local process."""
+    environ_path = Path(f"/proc/{pid}/environ")
+    try:
+        raw = environ_path.read_bytes()
+    except (FileNotFoundError, PermissionError, OSError):
+        raw = b""
+    if raw:
+        env: dict[str, str] = {}
+        for item in raw.split(b"\x00"):
+            if not item or b"=" not in item:
+                continue
+            key, value = item.split(b"=", 1)
+            env[key.decode("utf-8", errors="ignore")] = value.decode(
+                "utf-8", errors="ignore",
+            )
+        if env:
+            return env
+
+    try:
+        import psutil  # type: ignore
+
+        proc = psutil.Process(pid)
+        return dict(proc.environ() or {})
+    except Exception:
+        return {}
+
+
+def _verify_pid_matches_kanban_worker(
+    pid: int,
+    *,
+    task_id: str,
+    run_id: Optional[int],
+    claim_lock: Optional[str],
+) -> bool:
+    """Return True only for the exact kanban worker that owns this claim."""
+    if run_id is None or not claim_lock:
+        return False
+    if not _pid_looks_like_hermes_worker(pid):
+        return False
+    env = _read_process_environ(pid)
+    return (
+        env.get("HERMES_KANBAN_TASK") == task_id
+        and env.get("HERMES_KANBAN_RUN_ID") == str(int(run_id))
+        and env.get("HERMES_KANBAN_CLAIM_LOCK") == str(claim_lock)
+    )
+
+
 def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
+    task_id: Optional[str] = None,
+    run_id: Optional[int] = None,
     signal_fn=None,
     force_local: bool = False,
 ) -> dict[str, Any]:
@@ -6925,12 +7017,14 @@ def _terminate_reclaimed_worker(
     When *force_local* is True and the hostname in *claim_lock* no longer
     matches the current host (e.g. after a macOS hostname change between
     network contexts), the function still attempts termination **iff**
-    the PID is alive and its command line looks like a Hermes worker.
+    the PID is alive and its kanban identity matches this exact
+    ``task_id`` / ``run_id`` / ``claim_lock``.
     This closes the #73277 gap where a hostname change silently skips
     termination of a proven-local worker.
 
     Safety: ``force_local`` never signals a PID without additional proof
-    that it belongs to Hermes — see :func:`_verify_pid_is_hermes_worker`.
+    that it belongs to this exact worker — see
+    :func:`_verify_pid_matches_kanban_worker`.
     """
     import signal
 
@@ -6941,6 +7035,7 @@ def _terminate_reclaimed_worker(
         "terminated": False,
         "sigkill": False,
         "force_local": False,
+        "identity_verified": False,
     }
     if not pid or pid <= 0 or not claim_lock:
         return info
@@ -6948,11 +7043,21 @@ def _terminate_reclaimed_worker(
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     if str(claim_lock).startswith(host_prefix):
         info["host_local"] = True
-    elif force_local and _verify_pid_is_hermes_worker(int(pid)):
-        # Hostname changed since claim creation, but PID is alive and
-        # its command line matches a Hermes worker — treat as local.
+    elif (
+        force_local
+        and task_id is not None
+        and _verify_pid_matches_kanban_worker(
+            int(pid),
+            task_id=task_id,
+            run_id=run_id,
+            claim_lock=claim_lock,
+        )
+    ):
+        # Hostname changed since claim creation, but the live PID still
+        # proves it is the exact worker that owns this claim.
         info["host_local"] = True
         info["force_local"] = True
+        info["identity_verified"] = True
 
     if not info["host_local"]:
         return info
@@ -7261,7 +7366,8 @@ def detect_stale_running(
     reclaimed: list[str] = []
 
     rows = conn.execute(
-        "SELECT t.id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
+        "SELECT t.id, t.current_run_id, t.worker_pid, "
+        "       t.last_heartbeat_at, t.claim_lock, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
@@ -7285,11 +7391,50 @@ def detect_stale_running(
         pid = row["worker_pid"]
         tid = row["id"]
         lock = row["claim_lock"] or ""
+        run_id = (
+            int(row["current_run_id"])
+            if row["current_run_id"] is not None
+            else None
+        )
 
         # Terminate the worker if it's still host-local.
-        termination = _terminate_reclaimed_worker(
-            pid, lock, signal_fn=signal_fn,
-        )
+        if pid and not lock.startswith(host_prefix) and _pid_alive(pid):
+            if _verify_pid_matches_kanban_worker(
+                int(pid),
+                task_id=tid,
+                run_id=run_id,
+                claim_lock=row["claim_lock"],
+            ):
+                termination = _terminate_reclaimed_worker(
+                    pid,
+                    lock,
+                    task_id=tid,
+                    run_id=run_id,
+                    signal_fn=signal_fn,
+                    force_local=True,
+                )
+            else:
+                _defer_reclaim_for_live_worker(
+                    conn,
+                    tid,
+                    lock,
+                    now,
+                    {
+                        "prev_pid": int(pid),
+                        "host_local": False,
+                        "termination_attempted": False,
+                        "terminated": False,
+                        "sigkill": False,
+                        "force_local": False,
+                        "identity_verified": False,
+                    },
+                    reason="heartbeat_stale_worker_identity_unverified",
+                )
+                continue
+        else:
+            termination = _terminate_reclaimed_worker(
+                pid, lock, signal_fn=signal_fn,
+            )
 
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4456,6 +4456,7 @@ def reclaim_task(
     *,
     reason: Optional[str] = None,
     signal_fn=None,
+    force_local: bool = False,
 ) -> bool:
     """Operator-driven reclaim: release the claim and reset to ``ready``.
 
@@ -4464,6 +4465,12 @@ def reclaim_task(
     regardless of TTL. Intended for the dashboard/CLI recovery flow
     when an operator wants to abort a running worker without waiting
     for the TTL to expire (e.g. after seeing a hallucination warning).
+
+    When *force_local* is True and the hostname in the claim lock no
+    longer matches the current host (e.g. after a DHCP hostname change
+    on macOS), the function still attempts to terminate the worker if
+    the PID is alive and its command line looks like a Hermes process.
+    See :func:`_terminate_reclaimed_worker` for the safety check.
 
     Returns True if a reclaim happened, False if the task isn't in a
     reclaimable state (not running, or doesn't exist).
@@ -4480,6 +4487,7 @@ def reclaim_task(
     prev_lock = row["claim_lock"]
     termination = _terminate_reclaimed_worker(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
+        force_local=force_local,
     )
     with write_txn(conn):
         cur = conn.execute(
@@ -6870,13 +6878,60 @@ def _pid_alive(pid: Optional[int]) -> bool:
     return True
 
 
+def _verify_pid_is_hermes_worker(pid: int) -> bool:
+    """Return True when *pid* is a live local process whose command line
+    looks like a Hermes kanban worker.
+
+    Used as the safety check when ``--force-local`` overrides a hostname
+    mismatch in claim_lock.  Reading the process command line provides
+    the "additional local proof" required by #73277: we never signal a
+    PID just because it exists — it must *look like* a Hermes worker.
+    """
+    if not _pid_alive(pid):
+        return False
+    try:
+        from gateway.status import _read_process_cmdline
+        cmdline = _read_process_cmdline(pid)
+    except Exception:
+        cmdline = None
+    if not cmdline:
+        return False
+    # Hermes workers are launched as ``hermes -p <profile> --cli chat -q ...``
+    # and always carry HERMES_KANBAN_TASK in their environment.  The command
+    # line must contain the hermes entrypoint and "chat" (the worker subcmd).
+    # This is intentionally broad — we're confirming the PID *is* a Hermes
+    # process, not that it's a specific task's worker.  The narrower check
+    # (matching a specific task_id) would require /proc/<pid>/environ on
+    # Linux which is fragile and platform-dependent.
+    cli_name = os.path.basename(sys.argv[0]) if sys.argv else "hermes"
+    # Match either the bare name (e.g. "hermes") or the full python invocation
+    # (e.g. "python -m hermes_cli.main").
+    return (
+        cli_name in cmdline
+        or "hermes_cli" in cmdline
+        or "hermes_cli.main" in cmdline
+    )
+
+
 def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
     signal_fn=None,
+    force_local: bool = False,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
+    """Best-effort host-local worker termination for reclaim paths.
+
+    When *force_local* is True and the hostname in *claim_lock* no longer
+    matches the current host (e.g. after a macOS hostname change between
+    network contexts), the function still attempts termination **iff**
+    the PID is alive and its command line looks like a Hermes worker.
+    This closes the #73277 gap where a hostname change silently skips
+    termination of a proven-local worker.
+
+    Safety: ``force_local`` never signals a PID without additional proof
+    that it belongs to Hermes — see :func:`_verify_pid_is_hermes_worker`.
+    """
     import signal
 
     info: dict[str, Any] = {
@@ -6885,14 +6940,22 @@ def _terminate_reclaimed_worker(
         "termination_attempted": False,
         "terminated": False,
         "sigkill": False,
+        "force_local": False,
     }
     if not pid or pid <= 0 or not claim_lock:
         return info
 
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
-    if not str(claim_lock).startswith(host_prefix):
+    if str(claim_lock).startswith(host_prefix):
+        info["host_local"] = True
+    elif force_local and _verify_pid_is_hermes_worker(int(pid)):
+        # Hostname changed since claim creation, but PID is alive and
+        # its command line matches a Hermes worker — treat as local.
+        info["host_local"] = True
+        info["force_local"] = True
+
+    if not info["host_local"]:
         return info
-    info["host_local"] = True
 
     kill = signal_fn if signal_fn is not None else (
         os.kill if hasattr(os, "kill") else None

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1554,6 +1554,7 @@ def inspect_run_endpoint(
 
 class TerminateRunBody(BaseModel):
     reason: Optional[str] = None
+    force_local: bool = False
 
 
 @router.post("/runs/{run_id}/terminate")
@@ -1590,7 +1591,10 @@ def terminate_run_endpoint(
                 status_code=409,
                 detail=f"run {run_id} already ended",
             )
-        ok = kanban_db.reclaim_task(conn, r.task_id, reason=payload.reason)
+        ok = kanban_db.reclaim_task(
+            conn, r.task_id, reason=payload.reason,
+            force_local=payload.force_local,
+        )
         if not ok:
             raise HTTPException(
                 status_code=409,
@@ -1610,6 +1614,7 @@ def terminate_run_endpoint(
 
 class ReclaimBody(BaseModel):
     reason: Optional[str] = None
+    force_local: bool = False
 
 
 @router.post("/tasks/{task_id}/reclaim")
@@ -1624,11 +1629,19 @@ def reclaim_task_endpoint(
     abort a stuck worker (e.g. one that keeps hallucinating card ids)
     without waiting for the claim TTL. Maps 1:1 to
     ``hermes kanban reclaim <task_id> --reason ...``.
+
+    When *force_local* is True, the endpoint attempts worker termination
+    even if the claim's hostname no longer matches the current host.
+    The PID must be alive and its command line must look like a Hermes
+    worker — see ``_terminate_reclaimed_worker`` for the safety check.
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.reclaim_task(conn, task_id, reason=payload.reason)
+        ok = kanban_db.reclaim_task(
+            conn, task_id, reason=payload.reason,
+            force_local=payload.force_local,
+        )
         if not ok:
             raise HTTPException(
                 status_code=409,

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -688,6 +688,61 @@ def test_detect_stale_defers_when_live_worker_survives(kanban_home, monkeypatch)
         assert "reclaim_deferred" in kinds
 
 
+def test_detect_stale_holds_when_hostname_changed_and_identity_unverified(
+    kanban_home, monkeypatch,
+):
+    """Heartbeat-stale reclaim must also hold on hostname mismatch unless the
+    live PID proves it is the exact worker."""
+    import json
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="hostname changed", assignee="worker")
+        old_claim_lock = "host-a:12345"
+        conn.execute(
+            "UPDATE tasks SET status='running', claim_lock=?, worker_pid=?, "
+            "started_at=?, last_heartbeat_at=? WHERE id=?",
+            (
+                old_claim_lock,
+                12345,
+                int(time.time()) - 20000,
+                None,
+                t,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, claim_lock, worker_pid, started_at) "
+            "VALUES (?, 'running', ?, ?, ?)",
+            (t, old_claim_lock, 12345, int(time.time()) - 20000),
+        )
+        rid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute("UPDATE tasks SET current_run_id=? WHERE id=?", (rid, t))
+        conn.commit()
+
+    monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        _kb, "_verify_pid_matches_kanban_worker",
+        lambda _pid, **_kwargs: False,
+    )
+
+    with kb.connect() as conn:
+        stale = kb.detect_stale_running(
+            conn, stale_timeout_seconds=14400, signal_fn=lambda _p, _s: None,
+        )
+        assert stale == []
+        assert kb.get_task(conn, t).status == "running"
+
+        ev = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id=? AND kind='reclaim_deferred'",
+            (t,),
+        ).fetchone()
+        payload = json.loads(ev["payload"])
+        assert payload["reason"] == "heartbeat_stale_worker_identity_unverified"
+        assert payload["identity_verified"] is False
+
+
 def test_stale_claim_reclaim_event_records_diagnostic_payload(
     kanban_home, monkeypatch,
 ):
@@ -5013,9 +5068,9 @@ class TestHostnameChangeReclaimBug:
     remote and left alive after reclaim, creating duplicate-spawn risk.
 
     The fix adds ``force_local`` to ``reclaim_task`` /
-    ``_terminate_reclaimed_worker`` and a PID command-line safety check
-    (``_verify_pid_is_hermes_worker``) so that hostname-mismatched claims
-    can still be terminated when the PID proves to be a Hermes worker.
+    ``_terminate_reclaimed_worker`` and exact kanban identity checks so
+    hostname-mismatched claims can still be terminated when the PID proves
+    to be the same worker via env + claim metadata.
     """
 
     def test_terminate_reclaimed_worker_skips_on_hostname_mismatch(self, kanban_home, monkeypatch):
@@ -5034,49 +5089,93 @@ class TestHostnameChangeReclaimBug:
         assert result["termination_attempted"] is False
         assert result["terminated"] is False
 
+    def test_verify_pid_matches_kanban_worker_rejects_unrelated_hermes_pid(self, kanban_home, monkeypatch):
+        """A Hermes-looking PID is still rejected unless task/run/claim all
+        match the target worker identity."""
+        import hermes_cli.kanban_db as _kb
+
+        monkeypatch.setattr(_kb, "_pid_looks_like_hermes_worker", lambda _pid: True)
+        monkeypatch.setattr(
+            _kb,
+            "_read_process_environ",
+            lambda _pid: {
+                "HERMES_KANBAN_TASK": "t_other",
+                "HERMES_KANBAN_RUN_ID": "42",
+                "HERMES_KANBAN_CLAIM_LOCK": "host-a:other",
+            },
+        )
+
+        assert _kb._verify_pid_matches_kanban_worker(
+            12345,
+            task_id="t_target",
+            run_id=7,
+            claim_lock="host-a:12345",
+        ) is False
+
+    def test_verify_pid_matches_kanban_worker_accepts_exact_identity(self, kanban_home, monkeypatch):
+        import hermes_cli.kanban_db as _kb
+
+        monkeypatch.setattr(_kb, "_pid_looks_like_hermes_worker", lambda _pid: True)
+        monkeypatch.setattr(
+            _kb,
+            "_read_process_environ",
+            lambda _pid: {
+                "HERMES_KANBAN_TASK": "t_target",
+                "HERMES_KANBAN_RUN_ID": "7",
+                "HERMES_KANBAN_CLAIM_LOCK": "host-a:12345",
+            },
+        )
+
+        assert _kb._verify_pid_matches_kanban_worker(
+            12345,
+            task_id="t_target",
+            run_id=7,
+            claim_lock="host-a:12345",
+        ) is True
+
     def test_terminate_reclaimed_worker_force_local_uses_pid_verification(self, kanban_home, monkeypatch):
         """With force_local=True, _terminate_reclaimed_worker checks PID
-        command line when hostname doesn't match, and treats the worker as
-        local if the PID looks like a Hermes process."""
+        identity when hostname doesn't match, and treats the worker as
+        local only if the PID matches the exact kanban worker."""
         import hermes_cli.kanban_db as _kb
 
         old_claim_lock = "host-a:12345"
         monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
 
-        # PID doesn't exist → _verify_pid_is_hermes_worker returns False
-        # → still treated as remote
-        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        # Missing run identity → still treated as remote.
         result = _kb._terminate_reclaimed_worker(
-            12345, old_claim_lock, force_local=True,
+            12345, old_claim_lock, task_id="t1", run_id=None, force_local=True,
         )
         assert result["host_local"] is False
         assert result["force_local"] is False
 
-        # PID exists but _read_process_cmdline says it's not a Hermes process
-        # → still treated as remote (safety: never signal non-Hermes PIDs)
-        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        # PID exists but exact identity does not match.
         monkeypatch.setattr(
-            _kb, "_verify_pid_is_hermes_worker", lambda _pid: False,
+            _kb, "_verify_pid_matches_kanban_worker",
+            lambda _pid, **_kwargs: False,
         )
         result = _kb._terminate_reclaimed_worker(
-            12345, old_claim_lock, force_local=True,
+            12345, old_claim_lock, task_id="t1", run_id=7, force_local=True,
         )
         assert result["host_local"] is False
         assert result["force_local"] is False
 
-        # PID exists AND looks like Hermes → treated as local via force_local
-        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        # Exact PID/task/run/claim match → treated as local via force_local.
         monkeypatch.setattr(
-            _kb, "_verify_pid_is_hermes_worker", lambda _pid: True,
+            _kb, "_verify_pid_matches_kanban_worker",
+            lambda _pid, **_kwargs: True,
         )
         # Need signal_fn since the PID isn't real
         result = _kb._terminate_reclaimed_worker(
             12345, old_claim_lock,
+            task_id="t1",
+            run_id=7,
             signal_fn=lambda _pid, _sig: None,
             force_local=True,
         )
         assert result["host_local"] is True
         assert result["force_local"] is True
+        assert result["identity_verified"] is True
         assert result["termination_attempted"] is True
 
     def test_terminate_reclaimed_worker_force_local_noop_when_hostname_matches(self, kanban_home, monkeypatch):
@@ -5162,7 +5261,8 @@ class TestHostnameChangeReclaimBug:
         monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
         monkeypatch.setattr(
-            _kb, "_verify_pid_is_hermes_worker", lambda _pid: True,
+            _kb, "_verify_pid_matches_kanban_worker",
+            lambda _pid, **_kwargs: True,
         )
 
         with kb.connect() as conn:
@@ -5179,15 +5279,14 @@ class TestHostnameChangeReclaimBug:
             payload = json.loads(ev["payload"])
             assert payload["host_local"] is True
             assert payload["force_local"] is True
+            assert payload["identity_verified"] is True
             assert payload["termination_attempted"] is True
 
-    def test_release_stale_claims_misidentifies_local_after_hostname_change(self, kanban_home, monkeypatch):
-        """release_stale_claims treats a local worker as remote after hostname
-        change, so it releases the claim instead of extending it — creating
-        duplicate-spawn risk. This is the unfixable path: release_stale_claims
-        is an automated dispatcher path and does not get a force_local flag
-        (operator intervention is required via explicit reclaim)."""
+    def test_release_stale_claims_holds_when_hostname_changed_and_identity_unverified(self, kanban_home, monkeypatch):
+        """Automated stale reclaim must hold when a live PID cannot be proven
+        to be the exact worker after a hostname mismatch."""
         import hermes_cli.kanban_db as _kb
+        import json
 
         with kb.connect() as conn:
             t = kb.create_task(conn, title="stale-hostname task", assignee="a")
@@ -5201,13 +5300,80 @@ class TestHostnameChangeReclaimBug:
 
         monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(
+            _kb, "_verify_pid_matches_kanban_worker",
+            lambda _pid, **_kwargs: False,
+        )
 
         with kb.connect() as conn:
             reclaimed = kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
-            # BUG: because host_local is False, the claim is released even
-            # though the worker is still alive on this machine.
+            assert reclaimed == 0
+            task = kb.get_task(conn, t)
+            assert task.status == "running"
+
+            ev = conn.execute(
+                "SELECT payload FROM task_events "
+                "WHERE task_id=? AND kind='reclaim_deferred'",
+                (t,),
+            ).fetchone()
+            payload = json.loads(ev["payload"])
+            assert payload["reason"] == "ttl_expired_worker_identity_unverified"
+            assert payload["identity_verified"] is False
+
+    def test_release_stale_claims_force_local_exact_match_after_hostname_change(self, kanban_home, monkeypatch):
+        """Automated stale reclaim may still terminate a hostname-mismatched
+        worker when the PID proves it owns the exact task/run/claim."""
+        import hermes_cli.kanban_db as _kb
+        import json
+
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="stale-hostname exact", assignee="a")
+            old_claim_lock = "host-a:12345"
+            conn.execute(
+                "UPDATE tasks SET status='running', claim_lock=?, "
+                "claim_expires=?, worker_pid=? WHERE id=?",
+                (old_claim_lock, int(time.time()) - 60, 12345, t),
+            )
+            conn.execute(
+                "INSERT INTO task_runs (task_id, status, claim_lock, "
+                "claim_expires, worker_pid, started_at) "
+                "VALUES (?, 'running', ?, ?, ?, ?)",
+                (t, old_claim_lock, int(time.time()) - 60, 12345, int(time.time()) - 600),
+            )
+            rid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute("UPDATE tasks SET current_run_id=? WHERE id=?", (rid, t))
+            conn.commit()
+
+        monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
+        monkeypatch.setattr(
+            _kb, "_verify_pid_matches_kanban_worker",
+            lambda _pid, **_kwargs: True,
+        )
+        monkeypatch.setattr(
+            _kb, "_terminate_reclaimed_worker",
+            lambda *args, **kwargs: {
+                "prev_pid": 12345,
+                "host_local": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "sigkill": False,
+                "force_local": True,
+                "identity_verified": True,
+            },
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        with kb.connect() as conn:
+            reclaimed = kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
             assert reclaimed == 1
             task = kb.get_task(conn, t)
-            # Task goes back to "ready" while PID 12345 is still "alive" —
-            # next dispatch tick will spawn a duplicate worker.
             assert task.status == "ready"
+
+            ev = conn.execute(
+                "SELECT payload FROM task_events "
+                "WHERE task_id=? AND kind='reclaimed'",
+                (t,),
+            ).fetchone()
+            payload = json.loads(ev["payload"])
+            assert payload["force_local"] is True
+            assert payload["identity_verified"] is True

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4999,3 +4999,215 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Issue #73277: hostname-change causes reclaim to skip worker termination
+# ---------------------------------------------------------------------------
+
+class TestHostnameChangeReclaimBug:
+    """Reproduce #73277: claim_lock stores <hostname>:<pid>, and
+    _terminate_reclaimed_worker skips termination when the current hostname
+    no longer matches the stored prefix.  After a hostname change (common on
+    macOS between network contexts), a local worker is misidentified as
+    remote and left alive after reclaim, creating duplicate-spawn risk.
+
+    The fix adds ``force_local`` to ``reclaim_task`` /
+    ``_terminate_reclaimed_worker`` and a PID command-line safety check
+    (``_verify_pid_is_hermes_worker``) so that hostname-mismatched claims
+    can still be terminated when the PID proves to be a Hermes worker.
+    """
+
+    def test_terminate_reclaimed_worker_skips_on_hostname_mismatch(self, kanban_home, monkeypatch):
+        """Without force_local, _terminate_reclaimed_worker returns
+        host_local=False when hostname changed since claim creation."""
+        import hermes_cli.kanban_db as _kb
+
+        # Claim was created under hostname "host-a"
+        old_claim_lock = "host-a:12345"
+
+        # Current hostname is now "host-b"
+        monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
+
+        result = _kb._terminate_reclaimed_worker(12345, old_claim_lock)
+        assert result["host_local"] is False
+        assert result["termination_attempted"] is False
+        assert result["terminated"] is False
+
+    def test_terminate_reclaimed_worker_force_local_uses_pid_verification(self, kanban_home, monkeypatch):
+        """With force_local=True, _terminate_reclaimed_worker checks PID
+        command line when hostname doesn't match, and treats the worker as
+        local if the PID looks like a Hermes process."""
+        import hermes_cli.kanban_db as _kb
+
+        old_claim_lock = "host-a:12345"
+        monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
+
+        # PID doesn't exist → _verify_pid_is_hermes_worker returns False
+        # → still treated as remote
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        result = _kb._terminate_reclaimed_worker(
+            12345, old_claim_lock, force_local=True,
+        )
+        assert result["host_local"] is False
+        assert result["force_local"] is False
+
+        # PID exists but _read_process_cmdline says it's not a Hermes process
+        # → still treated as remote (safety: never signal non-Hermes PIDs)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(
+            _kb, "_verify_pid_is_hermes_worker", lambda _pid: False,
+        )
+        result = _kb._terminate_reclaimed_worker(
+            12345, old_claim_lock, force_local=True,
+        )
+        assert result["host_local"] is False
+        assert result["force_local"] is False
+
+        # PID exists AND looks like Hermes → treated as local via force_local
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(
+            _kb, "_verify_pid_is_hermes_worker", lambda _pid: True,
+        )
+        # Need signal_fn since the PID isn't real
+        result = _kb._terminate_reclaimed_worker(
+            12345, old_claim_lock,
+            signal_fn=lambda _pid, _sig: None,
+            force_local=True,
+        )
+        assert result["host_local"] is True
+        assert result["force_local"] is True
+        assert result["termination_attempted"] is True
+
+    def test_terminate_reclaimed_worker_force_local_noop_when_hostname_matches(self, kanban_home, monkeypatch):
+        """force_local has no effect when the hostname still matches — that
+        path was already working correctly."""
+        import hermes_cli.kanban_db as _kb
+
+        monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-a:99999")
+        result = _kb._terminate_reclaimed_worker(
+            12345, "host-a:12345",
+            signal_fn=lambda _pid, _sig: None,
+            force_local=True,
+        )
+        # Host matches → host_local=True regardless of force_local
+        assert result["host_local"] is True
+        assert result["force_local"] is False  # not needed
+        assert result["termination_attempted"] is True
+
+    def test_reclaim_task_emits_host_local_false_on_hostname_change(self, kanban_home, monkeypatch):
+        """reclaim_task without force_local emits a reclaimed event with
+        host_local=False when the claim's hostname no longer matches."""
+        import hermes_cli.kanban_db as _kb
+        import json
+
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="hostname-change task", assignee="a")
+            old_claim_lock = "host-a:12345"
+            conn.execute(
+                "UPDATE tasks SET status='running', claim_lock=?, "
+                "claim_expires=?, worker_pid=? WHERE id=?",
+                (old_claim_lock, int(time.time()) + 3600, 12345, t),
+            )
+            conn.execute(
+                "INSERT INTO task_runs (task_id, status, claim_lock, "
+                "claim_expires, worker_pid, started_at) "
+                "VALUES (?, 'running', ?, ?, ?, ?)",
+                (t, old_claim_lock, int(time.time()) + 3600, 12345, int(time.time())),
+            )
+            rid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute("UPDATE tasks SET current_run_id=? WHERE id=?", (rid, t))
+            conn.commit()
+
+        monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        with kb.connect() as conn:
+            ok = kb.reclaim_task(conn, t, reason="hostname changed")
+            assert ok
+
+            ev = conn.execute(
+                "SELECT payload FROM task_events "
+                "WHERE task_id=? AND kind='reclaimed'",
+                (t,),
+            ).fetchone()
+            payload = json.loads(ev["payload"])
+            assert payload["host_local"] is False
+            assert payload["termination_attempted"] is False
+
+    def test_reclaim_task_force_local_succeeds_on_hostname_change(self, kanban_home, monkeypatch):
+        """reclaim_task with force_local=True terminates the worker even
+        after a hostname change, as long as the PID proves to be Hermes."""
+        import hermes_cli.kanban_db as _kb
+        import json
+
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="force-local task", assignee="a")
+            old_claim_lock = "host-a:12345"
+            conn.execute(
+                "UPDATE tasks SET status='running', claim_lock=?, "
+                "claim_expires=?, worker_pid=? WHERE id=?",
+                (old_claim_lock, int(time.time()) + 3600, 12345, t),
+            )
+            conn.execute(
+                "INSERT INTO task_runs (task_id, status, claim_lock, "
+                "claim_expires, worker_pid, started_at) "
+                "VALUES (?, 'running', ?, ?, ?, ?)",
+                (t, old_claim_lock, int(time.time()) + 3600, 12345, int(time.time())),
+            )
+            rid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            conn.execute("UPDATE tasks SET current_run_id=? WHERE id=?", (rid, t))
+            conn.commit()
+
+        monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(
+            _kb, "_verify_pid_is_hermes_worker", lambda _pid: True,
+        )
+
+        with kb.connect() as conn:
+            ok = kb.reclaim_task(
+                conn, t, reason="hostname changed", force_local=True,
+            )
+            assert ok
+
+            ev = conn.execute(
+                "SELECT payload FROM task_events "
+                "WHERE task_id=? AND kind='reclaimed'",
+                (t,),
+            ).fetchone()
+            payload = json.loads(ev["payload"])
+            assert payload["host_local"] is True
+            assert payload["force_local"] is True
+            assert payload["termination_attempted"] is True
+
+    def test_release_stale_claims_misidentifies_local_after_hostname_change(self, kanban_home, monkeypatch):
+        """release_stale_claims treats a local worker as remote after hostname
+        change, so it releases the claim instead of extending it — creating
+        duplicate-spawn risk. This is the unfixable path: release_stale_claims
+        is an automated dispatcher path and does not get a force_local flag
+        (operator intervention is required via explicit reclaim)."""
+        import hermes_cli.kanban_db as _kb
+
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="stale-hostname task", assignee="a")
+            old_claim_lock = "host-a:12345"
+            conn.execute(
+                "UPDATE tasks SET status='running', claim_lock=?, "
+                "claim_expires=?, worker_pid=? WHERE id=?",
+                (old_claim_lock, int(time.time()) - 60, 12345, t),
+            )
+            conn.commit()
+
+        monkeypatch.setattr(_kb, "_claimer_id", lambda: "host-b:99999")
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        with kb.connect() as conn:
+            reclaimed = kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
+            # BUG: because host_local is False, the claim is released even
+            # though the worker is still alive on this machine.
+            assert reclaimed == 1
+            task = kb.get_task(conn, t)
+            # Task goes back to "ready" while PID 12345 is still "alive" —
+            # next dispatch tick will spawn a duplicate worker.
+            assert task.status == "ready"

--- a/tests/plugins/test_kanban_worker_runs.py
+++ b/tests/plugins/test_kanban_worker_runs.py
@@ -373,7 +373,7 @@ def test_terminate_run_ok(client, monkeypatch):
     # Capture signal calls so we don't actually SIGTERM a random PID.
     sent = []
 
-    def _fake_terminate(pid, prev_lock, *, signal_fn=None):
+    def _fake_terminate(pid, prev_lock, *, signal_fn=None, force_local=False):
         sent.append((pid, prev_lock))
         return {"signal": "SIGTERM", "delivered": True}
 


### PR DESCRIPTION
## Summary

Fixes #73277

When a hostname changes (common on macOS between network contexts, e.g. DHCP reconfig), `claim_lock`'s `<hostname>:<pid>` prefix no longer matches the current host. This causes `_terminate_reclaimed_worker` to skip termination and `reclaim_task` to release the claim while the worker process is still alive — creating duplicate-spawn risk on the next dispatch tick.

## Root Cause

`_claimer_id()` returns `"<hostname>:<pid>"`, and `_terminate_reclaimed_worker` uses `claim_lock.startswith(host_prefix)` to determine if a worker is local. After a hostname change, the prefix check fails → the worker is misidentified as remote → termination is skipped → claim is released → duplicate worker spawned.

The same issue affects `release_stale_claims` (automated path), but that path is not addressed in this PR since it lacks operator intent — see Notes below.

## Changes

### Core fix (`kanban_db.py`)
- **New `_verify_pid_is_hermes_worker(pid)`**: reads the PID's command line via `gateway.status._read_process_cmdline` and confirms it contains Hermes entrypoints (`hermes`, `hermes_cli`, `hermes_cli.main`). This is the safety check — we never signal a PID just because it exists; it must *look like* a Hermes worker.
- **`_terminate_reclaimed_worker` gains `force_local` param**: when `force_local=True` and hostname doesn't match, the function still attempts termination **iff** the PID is alive and its command line matches a Hermes process. Returns `force_local=True` in the result dict when this path is taken.
- **`reclaim_task` gains `force_local` param**: passed through to `_terminate_reclaimed_worker`.

### CLI (`kanban.py`)
- `hermes kanban reclaim <task_id> --force-local`: new flag to override hostname check. Help text explains the DHCP hostname-change scenario.

### Dashboard API (`plugin_api.py`)
- `ReclaimBody` and `TerminateRunBody` both gain `force_local: bool = False` field.
- Both the `/tasks/{id}/reclaim` and `/tasks/{id}/runs/{run_id}/terminate` endpoints pass `force_local` through to `reclaim_task`.

### Tests (`test_kanban_db.py`, `test_kanban_worker_runs.py`)
- **`TestHostnameChangeReclaimBug`** class with 6 tests:
  - `test_terminate_reclaimed_worker_skips_on_hostname_mismatch` — confirms the bug exists without `force_local`
  - `test_terminate_reclaimed_worker_force_local_uses_pid_verification` — validates all three branches (PID dead, PID alive but not Hermes, PID alive and Hermes)
  - `test_terminate_reclaimed_worker_force_local_noop_when_hostname_matches` — `force_local` has no effect when hostname already matches
  - `test_reclaim_task_emits_host_local_false_on_hostname_change` — event payload records `host_local=False` without `force_local`
  - `test_reclaim_task_force_local_succeeds_on_hostname_change` — event payload records `host_local=True, force_local=True` with `force_local`
  - `test_release_stale_claims_misidentifies_local_after_hostname_change` — documents that `release_stale_claims` still has the issue (automated path)
- Fixed `_fake_terminate` mock signature to accept `force_local` kwarg.

## Safety Model

`force_local` is **opt-in** and **two-factor**:
1. Operator must explicitly pass `--force-local` / `force_local: true`
2. PID must pass `_verify_pid_is_hermes_worker` (alive + command line matches Hermes)

This ensures we never signal an arbitrary PID that merely happens to exist — it must be a Hermes process.

## Notes

- **`release_stale_claims` / `detect_stale_running` / `enforce_max_runtime` / `detect_crashed_workers`**: These automated dispatcher paths also use the hostname-prefix check but do NOT get `force_local`. These are background operations without operator intent; the correct operator response to a hostname-change scenario is to run `hermes kanban reclaim <task> --force-local` explicitly.
- **Future improvement**: A more robust approach would be to also verify the PID's `HERMES_KANBAN_TASK` environment variable matches the specific task, but that's platform-dependent (`/proc/<pid>/environ` on Linux, `ps -E` on macOS) and adds complexity. The command-line check is intentionally broad as a first step.

## Testing

```
python -m pytest tests/hermes_cli/test_kanban_db.py -x --timeout=120 -q   # 236 passed
python -m pytest tests/plugins/test_kanban_worker_runs.py -x --timeout=120 -q  # 16 passed
python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -x --timeout=120 -q  # 114 passed
```
