### PR TITLE
fix: preserve gateway routing handoffs atomically

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1292,11 +1292,9 @@ class SessionStore:
     def _snapshot_routing_locked(self) -> tuple[Dict[str, Any], int, float]:
         """Capture immutable routing data, generation, and snapshot time."""
         self._routing_generation = getattr(self, "_routing_generation", 0) + 1
-        return (
-            {key: entry.to_dict() for key, entry in self._entries.items()},
-            self._routing_generation,
-            time.time(),
-        )
+        snapshot_at = time.time()
+        data = {key: entry.to_dict() for key, entry in self._entries.items()}
+        return data, self._routing_generation, snapshot_at
 
     def _persist_routing_data(
         self, data: Dict[str, Any], generation: int, snapshot_at: float

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -14,6 +14,7 @@ import logging
 import os
 import json
 import threading
+import time
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -1285,19 +1286,22 @@ class SessionStore:
 
     def _save(self) -> None:
         """Persist the routing index while the caller holds ``_lock``."""
-        data, generation = self._snapshot_routing_locked()
-        self._persist_routing_data(data, generation)
+        data, generation, snapshot_at = self._snapshot_routing_locked()
+        self._persist_routing_data(data, generation, snapshot_at)
 
-    def _snapshot_routing_locked(self) -> tuple[Dict[str, Any], int]:
-        """Capture immutable routing data and a monotonic generation."""
+    def _snapshot_routing_locked(self) -> tuple[Dict[str, Any], int, float]:
+        """Capture immutable routing data, generation, and snapshot time."""
         self._routing_generation = getattr(self, "_routing_generation", 0) + 1
         return (
             {key: entry.to_dict() for key, entry in self._entries.items()},
             self._routing_generation,
+            time.time(),
         )
 
-    def _persist_routing_data(self, data: Dict[str, Any], generation: int) -> None:
-        """Serialize all whole-index writers through one durable write lock."""
+    def _persist_routing_data(
+        self, data: Dict[str, Any], generation: int, snapshot_at: float
+    ) -> None:
+        """Serialize whole-index writers without clobbering newer handoffs."""
         save_lock = getattr(self, "_save_lock", None)
         if save_lock is None:
             save_lock = threading.Lock()
@@ -1308,13 +1312,24 @@ class SessionStore:
             db_saved = False
             _db = getattr(self, "_db", None)
             if _db:
-                replacer = getattr(_db, "replace_gateway_routing_entries", None)
+                replacer = getattr(
+                    _db, "replace_gateway_routing_entries_preserving_newer", None
+                )
+                if not callable(replacer):
+                    replacer = getattr(_db, "replace_gateway_routing_entries", None)
                 if callable(replacer):
                     try:
-                        replacer(
-                            {k: json.dumps(v) for k, v in data.items()},
-                            scope=self._routing_scope(),
-                        )
+                        entries_json = {k: json.dumps(v) for k, v in data.items()}
+                        try:
+                            replacer(
+                                entries_json,
+                                scope=self._routing_scope(),
+                                snapshot_at=snapshot_at,
+                            )
+                        except TypeError:
+                            # Compatibility for mocked/older SessionDB objects in tests
+                            # and downgraded installs.
+                            replacer(entries_json, scope=self._routing_scope())
                         db_saved = True
                     except Exception as exc:
                         logger.warning(
@@ -1367,8 +1382,8 @@ class SessionStore:
     def _save_entries(self) -> None:
         """Snapshot latest state under ``_lock`` and persist after releasing it."""
         with self._lock:
-            data, generation = self._snapshot_routing_locked()
-        self._persist_routing_data(data, generation)
+            data, generation, snapshot_at = self._snapshot_routing_locked()
+        self._persist_routing_data(data, generation, snapshot_at)
     def _resolve_profile_for_key(self, source: Optional[SessionSource] = None) -> Optional[str]:
         """Return the profile namespace for session keys, or None when off.
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1312,11 +1312,7 @@ class SessionStore:
             db_saved = False
             _db = getattr(self, "_db", None)
             if _db:
-                replacer = getattr(
-                    _db, "replace_gateway_routing_entries_preserving_newer", None
-                )
-                if not callable(replacer):
-                    replacer = getattr(_db, "replace_gateway_routing_entries", None)
+                replacer = getattr(_db, "replace_gateway_routing_entries", None)
                 if callable(replacer):
                     try:
                         entries_json = {k: json.dumps(v) for k, v in data.items()}

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1252,17 +1252,19 @@ def _recover_pending_systemd_restart(
 
 
 def _parse_launchd_pid_from_list_output(output: str) -> int | None:
-    """Extract the PID from ``launchctl list <label>`` output.
+    """Extract the PID from ``launchctl list/print`` output.
 
-    When launchd is actively supervising a process, the output includes a
-    ``"PID" = <number>;`` line.  When the service definition is only *registered*
-    but not running (macOS 26+ with an unmanageable domain, fallback active),
-    the output lacks a PID field entirely.  Returns ``None`` when no PID is
-    found or the PID is non-positive (e.g. ``-1`` for a recently-crashed service).
+    When launchd is actively supervising a process, ``launchctl list`` includes
+    a ``"PID" = <number>;`` line. ``launchctl print system/<label>`` instead
+    uses lower-case plist-style keys such as ``pid = <number>``. When the
+    service definition is only *registered* but not running (macOS 26+ with an
+    unmanageable domain, fallback active), the output lacks a PID field
+    entirely. Returns ``None`` when no PID is found or the PID is non-positive
+    (e.g. ``-1`` for a recently-crashed service).
     """
     for line in output.splitlines():
         stripped = line.strip()
-        if stripped.startswith('"PID"') or stripped.startswith("PID"):
+        if stripped.startswith('"PID"') or stripped.startswith("PID") or stripped.startswith("pid ="):
             parts = stripped.split("=", 1)
             if len(parts) == 2:
                 val = parts[1].strip().rstrip(";").strip('"')
@@ -1274,15 +1276,52 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
     return None
 
 
+def _launchd_system_gateway_plist_path() -> Path:
+    """Return the optional system LaunchDaemon plist path for the gateway."""
+    return Path("/Library/LaunchDaemons") / f"{get_launchd_label()}.plist"
+
+
+def _probe_system_launchd_gateway() -> tuple[bool, int | None, str]:
+    """Probe a system LaunchDaemon gateway installed outside Hermes' default.
+
+    Hermes' built-in macOS installer manages a per-user LaunchAgent under
+    ``~/Library/LaunchAgents``. Some deployments intentionally use a system
+    LaunchDaemon under ``/Library/LaunchDaemons`` instead (for boot-time
+    startup, external disk readiness wrappers, etc.). ``launchctl list`` from a
+    user shell does not report that daemon, so explicitly inspect the system
+    domain before declaring the gateway detached.
+    """
+    plist_path = _launchd_system_gateway_plist_path()
+    if not plist_path.exists():
+        return False, None, ""
+    label = get_launchd_label()
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"system/{label}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False, None, ""
+    output = (result.stdout or "") + (result.stderr or "")
+    if result.returncode != 0:
+        return False, None, output
+    return True, _parse_launchd_pid_from_list_output(output), output
+
+
 def _probe_launchd_service_running() -> bool:
     """Return True when launchd is actively supervising the gateway process.
 
-    ``launchctl list <label>`` returns exit 0 whenever the service definition is
-    registered with launchd — even when ``state = not running`` (macOS 26+).
-    We additionally require a PID in the output to confirm launchd is actually
-    managing a live process, not just holding a static definition.
+    ``launchctl list <label>`` returns exit 0 whenever a user LaunchAgent
+    definition is registered with launchd — even when ``state = not running``
+    (macOS 26+). We additionally require a PID in the output to confirm launchd
+    is actually managing a live process, not just holding a static definition.
+
+    If the user LaunchAgent is absent or not running, also recognise Techsafe's
+    system LaunchDaemon deployment in ``/Library/LaunchDaemons``.
     """
-    if not get_launchd_plist_path().exists():
+    if not get_launchd_plist_path().exists() and not _launchd_system_gateway_plist_path().exists():
         return False
     try:
         result = subprocess.run(
@@ -1292,10 +1331,12 @@ def _probe_launchd_service_running() -> bool:
             timeout=10,
         )
     except subprocess.TimeoutExpired:
-        return False
-    if result.returncode != 0:
-        return False
-    return _parse_launchd_pid_from_list_output(result.stdout) is not None
+        result = None
+    if result is not None and result.returncode == 0:
+        if _parse_launchd_pid_from_list_output(result.stdout) is not None:
+            return True
+    system_loaded, system_pid, _ = _probe_system_launchd_gateway()
+    return bool(system_loaded and system_pid is not None)
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -1360,7 +1401,7 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
     if is_macos():
         return GatewayRuntimeSnapshot(
             manager="launchd",
-            service_installed=get_launchd_plist_path().exists(),
+            service_installed=get_launchd_plist_path().exists() or _launchd_system_gateway_plist_path().exists(),
             service_running=_probe_launchd_service_running(),
             gateway_pids=gateway_pids,
             service_scope="launchd",
@@ -4510,6 +4551,13 @@ def launchd_status(deep: bool = False):
     # even when no fallback process is currently running.
     launchd_unsupported = _launchd_unsupported_marker_exists()
 
+    system_service_listed, system_launchd_pid, _system_launchd_output = _probe_system_launchd_gateway()
+    if launchd_pid is None and system_launchd_pid is not None:
+        launchd_pid = system_launchd_pid
+        service_listed = True
+        if fallback_pid == launchd_pid:
+            fallback_pid = None
+
     # ── Report ──
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():
@@ -4520,8 +4568,13 @@ def launchd_status(deep: bool = False):
 
     if service_listed:
         if launchd_pid is not None:
-            print(f"✓ Gateway is supervised by launchd (PID {launchd_pid})")
-            print("  Auto-start at login and auto-restart on crash are available.")
+            if system_service_listed and launchd_pid == system_launchd_pid:
+                print(f"✓ Gateway is supervised by system launchd LaunchDaemon (PID {launchd_pid})")
+                print(f"  System plist: {_launchd_system_gateway_plist_path()}")
+                print("  Auto-start at boot and auto-restart on crash are available.")
+            else:
+                print(f"✓ Gateway is supervised by launchd (PID {launchd_pid})")
+                print("  Auto-start at login and auto-restart on crash are available.")
             if launchd_unsupported:
                 print("  (launchd domain was previously unavailable but is now working)")
         elif launchd_unsupported:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3419,15 +3419,56 @@ class SessionDB:
         index).  Runs as a single write transaction.  Other scopes are
         untouched.
         """
+        self.replace_gateway_routing_entries_preserving_newer(
+            entries, scope=scope, snapshot_at=None
+        )
+
+    def replace_gateway_routing_entries_preserving_newer(
+        self,
+        entries: Dict[str, str],
+        *,
+        scope: str = "",
+        snapshot_at: Optional[float] = None,
+    ) -> None:
+        """Replace routing rows while preserving concurrent newer handoffs.
+
+        ``SessionStore`` whole-index saves are based on an in-memory snapshot.
+        Out-of-band handoffs can commit newer durable routes between that
+        snapshot and this write.  Keep any existing row whose ``updated_at`` is
+        newer than the snapshot timestamp, so a stale whole-index writer cannot
+        delete or rewind routes it did not observe.  When ``snapshot_at`` is
+        ``None`` this is an ordinary full replacement for compatibility.
+        """
         now = time.time()
+        clean_entries = {k: v for k, v in entries.items() if k and v}
 
         def _do(conn):
-            conn.execute("DELETE FROM gateway_routing WHERE scope = ?", (scope,))
-            if entries:
+            if snapshot_at is None:
+                conn.execute("DELETE FROM gateway_routing WHERE scope = ?", (scope,))
+            else:
+                conn.execute(
+                    "DELETE FROM gateway_routing WHERE scope = ? AND updated_at <= ?",
+                    (scope, snapshot_at),
+                )
+            if clean_entries:
                 conn.executemany(
-                    "INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at) "
-                    "VALUES (?, ?, ?, ?)",
-                    [(scope, k, v, now) for k, v in entries.items() if k and v],
+                    """INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at)
+                       VALUES (?, ?, ?, ?)
+                       ON CONFLICT(scope, session_key) DO UPDATE SET
+                           entry_json = CASE
+                               WHEN ? IS NULL OR gateway_routing.updated_at <= ?
+                               THEN excluded.entry_json
+                               ELSE gateway_routing.entry_json
+                           END,
+                           updated_at = CASE
+                               WHEN ? IS NULL OR gateway_routing.updated_at <= ?
+                               THEN excluded.updated_at
+                               ELSE gateway_routing.updated_at
+                           END""",
+                    [
+                        (scope, k, v, now, snapshot_at, snapshot_at, snapshot_at, snapshot_at)
+                        for k, v in clean_entries.items()
+                    ],
                 )
 
         self._execute_write(_do)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3410,33 +3410,24 @@ class SessionDB:
         self._execute_write(_do)
 
     def replace_gateway_routing_entries(
-        self, entries: Dict[str, str], *, scope: str = ""
-    ) -> None:
-        """Atomically replace the routing index for *scope* with *entries*.
-
-        Mirrors the sessions.json full-rewrite semantics: keys absent from
-        *entries* are removed (pruned/reset sessions disappear from the
-        index).  Runs as a single write transaction.  Other scopes are
-        untouched.
-        """
-        self.replace_gateway_routing_entries_preserving_newer(
-            entries, scope=scope, snapshot_at=None
-        )
-
-    def replace_gateway_routing_entries_preserving_newer(
         self,
         entries: Dict[str, str],
         *,
         scope: str = "",
         snapshot_at: Optional[float] = None,
     ) -> None:
-        """Replace routing rows while preserving concurrent newer handoffs.
+        """Atomically replace routing rows while preserving newer handoffs.
+
+        Mirrors the sessions.json full-rewrite semantics: keys absent from
+        *entries* are removed (pruned/reset sessions disappear from the
+        index).  Runs as a single write transaction.  Other scopes are
+        untouched.
 
         ``SessionStore`` whole-index saves are based on an in-memory snapshot.
         Out-of-band handoffs can commit newer durable routes between that
-        snapshot and this write.  Keep any existing row whose ``updated_at`` is
+        snapshot and this write. Keep any existing row whose ``updated_at`` is
         newer than the snapshot timestamp, so a stale whole-index writer cannot
-        delete or rewind routes it did not observe.  When ``snapshot_at`` is
+        delete or rewind routes it did not observe. When ``snapshot_at`` is
         ``None`` this is an ordinary full replacement for compatibility.
         """
         now = time.time()

--- a/tests/gateway/test_session_store_lock_io.py
+++ b/tests/gateway/test_session_store_lock_io.py
@@ -440,3 +440,39 @@ def test_atomic_routing_replace_receives_snapshot_timestamp(tmp_path):
     kwargs = db.replace_gateway_routing_entries.call_args.kwargs
     assert kwargs["scope"] == store._routing_scope()
     assert isinstance(kwargs["snapshot_at"], float)
+
+
+def test_snapshot_timestamp_is_captured_before_routing_copy(tmp_path, monkeypatch):
+    """The preserve-newer boundary must start before routing serialization.
+
+    If ``snapshot_at`` is captured after copying ``_entries``, a handoff that
+    lands during the copy can be absent from the stale snapshot while still
+    having ``updated_at <= snapshot_at``. The DB guarded replace would then be
+    allowed to delete the newer handoff. Capturing time first makes every
+    handoff committed during snapshot construction strictly newer than the
+    snapshot boundary.
+    """
+    db = _db_with_rows({})
+    store = _make_store(tmp_path, db)
+    key = store._generate_session_key(_source())
+    entry = _seed_entry(store, key, "sid-a")
+    timestamp_captured = False
+    original_to_dict = entry.to_dict
+
+    def fake_time():
+        nonlocal timestamp_captured
+        timestamp_captured = True
+        return 123.456
+
+    def asserting_to_dict():
+        assert timestamp_captured, "snapshot_at must be captured before copying entries"
+        return original_to_dict()
+
+    monkeypatch.setattr("gateway.session.time.time", fake_time)
+    monkeypatch.setattr(entry, "to_dict", asserting_to_dict)
+
+    data, generation, snapshot_at = store._snapshot_routing_locked()
+
+    assert key in data
+    assert generation == 1
+    assert snapshot_at == 123.456

--- a/tests/gateway/test_session_store_lock_io.py
+++ b/tests/gateway/test_session_store_lock_io.py
@@ -299,7 +299,7 @@ def test_legacy_and_off_lock_saves_share_one_serialization_lock(tmp_path):
             assert release_first_write.wait(timeout=10)
         persisted = dict(entries)
 
-    db.replace_gateway_routing_entries_preserving_newer.side_effect = replace
+    db.replace_gateway_routing_entries.side_effect = replace
     store = _make_store(tmp_path, db)
     source_a = _source()
     source_b = SessionSource(
@@ -343,7 +343,7 @@ def test_save_serialization_snapshots_latest_routing_index(tmp_path):
             assert release_first_write.wait(timeout=10)
         persisted = dict(entries)
 
-    db.replace_gateway_routing_entries_preserving_newer.side_effect = replace
+    db.replace_gateway_routing_entries.side_effect = replace
     store = _make_store(tmp_path, db)
     source_a = _source()
     source_b = SessionSource(
@@ -400,7 +400,7 @@ def test_atomic_routing_replace_preserves_external_handoff_after_snapshot(tmp_pa
         persisted.setdefault(key_b, json.dumps(entry_b.to_dict()))
         persisted.update(entries)
 
-    db.replace_gateway_routing_entries_preserving_newer.side_effect = replace_preserving
+    db.replace_gateway_routing_entries.side_effect = replace_preserving
     store = _make_store(tmp_path, db)
     source_a = _source()
     source_b = SessionSource(
@@ -426,7 +426,6 @@ def test_atomic_routing_replace_preserves_external_handoff_after_snapshot(tmp_pa
     assert set(persisted) == {key_a, key_b}
     assert json.loads(persisted[key_a])["session_id"] == entry_a.session_id
     assert json.loads(persisted[key_b])["session_id"] == entry_b.session_id
-    db.replace_gateway_routing_entries.assert_not_called()
 
 
 def test_atomic_routing_replace_receives_snapshot_timestamp(tmp_path):
@@ -438,6 +437,6 @@ def test_atomic_routing_replace_receives_snapshot_timestamp(tmp_path):
 
     store._save_entries()
 
-    kwargs = db.replace_gateway_routing_entries_preserving_newer.call_args.kwargs
+    kwargs = db.replace_gateway_routing_entries.call_args.kwargs
     assert kwargs["scope"] == store._routing_scope()
     assert isinstance(kwargs["snapshot_at"], float)

--- a/tests/gateway/test_session_store_lock_io.py
+++ b/tests/gateway/test_session_store_lock_io.py
@@ -289,7 +289,7 @@ def test_legacy_and_off_lock_saves_share_one_serialization_lock(tmp_path):
     write_count = 0
     count_lock = threading.Lock()
 
-    def replace(entries, *, scope):
+    def replace(entries, *, scope, snapshot_at=None):
         nonlocal write_count, persisted
         with count_lock:
             write_count += 1
@@ -299,7 +299,7 @@ def test_legacy_and_off_lock_saves_share_one_serialization_lock(tmp_path):
             assert release_first_write.wait(timeout=10)
         persisted = dict(entries)
 
-    db.replace_gateway_routing_entries.side_effect = replace
+    db.replace_gateway_routing_entries_preserving_newer.side_effect = replace
     store = _make_store(tmp_path, db)
     source_a = _source()
     source_b = SessionSource(
@@ -333,7 +333,7 @@ def test_save_serialization_snapshots_latest_routing_index(tmp_path):
     write_count = 0
     count_lock = threading.Lock()
 
-    def replace(entries, *, scope):
+    def replace(entries, *, scope, snapshot_at=None):
         nonlocal write_count, persisted
         with count_lock:
             write_count += 1
@@ -343,7 +343,7 @@ def test_save_serialization_snapshots_latest_routing_index(tmp_path):
             assert release_first_write.wait(timeout=10)
         persisted = dict(entries)
 
-    db.replace_gateway_routing_entries.side_effect = replace
+    db.replace_gateway_routing_entries_preserving_newer.side_effect = replace
     store = _make_store(tmp_path, db)
     source_a = _source()
     source_b = SessionSource(
@@ -387,3 +387,57 @@ def test_recovery_rejects_other_profile_row(tmp_path, monkeypatch):
 
     assert entry.session_id != "foreign-session"
     db.reopen_session.assert_not_called()
+
+def test_atomic_routing_replace_preserves_external_handoff_after_snapshot(tmp_path):
+    """A durable handoff committed after snapshot must survive replacement."""
+    db = _db_with_rows({})
+    persisted: dict[str, str] = {}
+
+    def replace_preserving(entries, *, scope, snapshot_at):
+        # Simulate SessionDB's durable write boundary. An external watchdog
+        # commits key_b after SessionStore took its stale snapshot and before
+        # replace reaches SQLite. The atomic DB operation must not delete it.
+        persisted.setdefault(key_b, json.dumps(entry_b.to_dict()))
+        persisted.update(entries)
+
+    db.replace_gateway_routing_entries_preserving_newer.side_effect = replace_preserving
+    store = _make_store(tmp_path, db)
+    source_a = _source()
+    source_b = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="67890",
+        chat_type="dm",
+        user_id="67890",
+    )
+    key_a = store._generate_session_key(source_a)
+    key_b = store._generate_session_key(source_b)
+    entry_a = _seed_entry(store, key_a, "sid-a")
+    entry_b = SessionEntry(
+        session_key=key_b,
+        session_id="sid-b-external",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+
+    store._save_entries()
+
+    assert set(persisted) == {key_a, key_b}
+    assert json.loads(persisted[key_a])["session_id"] == entry_a.session_id
+    assert json.loads(persisted[key_b])["session_id"] == entry_b.session_id
+    db.replace_gateway_routing_entries.assert_not_called()
+
+
+def test_atomic_routing_replace_receives_snapshot_timestamp(tmp_path):
+    """SessionStore passes snapshot time to the DB atomic replace boundary."""
+    db = _db_with_rows({})
+    store = _make_store(tmp_path, db)
+    key = store._generate_session_key(_source())
+    _seed_entry(store, key, "sid-a")
+
+    store._save_entries()
+
+    kwargs = db.replace_gateway_routing_entries_preserving_newer.call_args.kwargs
+    assert kwargs["scope"] == store._routing_scope()
+    assert isinstance(kwargs["snapshot_at"], float)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7156,3 +7156,48 @@ class TestLoneSurrogatePersistence:
         assert db.set_session_title("s1", "title \ud835 bad") is True
         assert db.get_session("s1")["title"] == "title \ufffd bad"
 
+def test_gateway_routing_replace_preserves_rows_newer_than_snapshot(db):
+    snapshot_at = 1000.0
+    scope = "gateway-scope"
+
+    def seed_rows(conn):
+        # old-key existed before the SessionStore snapshot and should be
+        # replaced by the snapshot contents.
+        conn.execute(
+            """INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at)
+               VALUES (?, ?, ?, ?)""",
+            (scope, "old-key", '{"session_id":"old"}', snapshot_at - 1),
+        )
+        # These rows simulate handoffs committed after the snapshot but before
+        # the whole-index replace reaches SQLite. They must survive, including
+        # the same-key case where a stale snapshot would otherwise rewind the
+        # route to an ended session.
+        conn.execute(
+            """INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at)
+               VALUES (?, ?, ?, ?)""",
+            (scope, "external-key", '{"session_id":"external"}', snapshot_at + 1),
+        )
+        conn.execute(
+            """INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at)
+               VALUES (?, ?, ?, ?)""",
+            (scope, "same-key", '{"session_id":"external-new"}', snapshot_at + 1),
+        )
+
+    db._execute_write(seed_rows)
+
+    db.replace_gateway_routing_entries_preserving_newer(
+        {
+            "old-key": '{"session_id":"replacement"}',
+            "same-key": '{"session_id":"stale-snapshot"}',
+        },
+        scope=scope,
+        snapshot_at=snapshot_at,
+    )
+
+    rows = db.load_gateway_routing_entries(scope=scope)
+    assert rows == {
+        "old-key": '{"session_id":"replacement"}',
+        "external-key": '{"session_id":"external"}',
+        "same-key": '{"session_id":"external-new"}',
+    }
+

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7185,7 +7185,7 @@ def test_gateway_routing_replace_preserves_rows_newer_than_snapshot(db):
 
     db._execute_write(seed_rows)
 
-    db.replace_gateway_routing_entries_preserving_newer(
+    db.replace_gateway_routing_entries(
         {
             "old-key": '{"session_id":"replacement"}',
             "same-key": '{"session_id":"stale-snapshot"}',


### PR DESCRIPTION
## Summary
- Preserve newer gateway routing handoffs when stale whole-index saves persist after a snapshot
- Add a snapshot timestamp path through `SessionStore` to `SessionDB`
- Recognize system launchd LaunchDaemon gateway deployments in runtime/status probes
- Add regression coverage for preserving newer routing rows and related state behavior

## Test Plan
- `./scripts/run_tests.sh tests/gateway/test_session_store_lock_io.py tests/test_hermes_state.py -q` → 421 tests passed, 0 failed