### PR TITLE
fix(gateway): preserve explicit platform disables

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1887,16 +1887,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # WhatsApp (typically uses different auth mechanism)
     whatsapp_enabled = is_truthy_value(getenv("WHATSAPP_ENABLED", ""))
     whatsapp_disabled_explicitly = getenv("WHATSAPP_ENABLED", "").lower() in {"false", "0", "no"}
-    if Platform.WHATSAPP in config.platforms:
-        # YAML config exists — respect explicit disable
-        wa_cfg = config.platforms[Platform.WHATSAPP]
-        if whatsapp_disabled_explicitly:
-            wa_cfg.enabled = False
-        elif whatsapp_enabled:
-            wa_cfg.enabled = True
-        # else: keep whatever the YAML set
+    if whatsapp_disabled_explicitly and Platform.WHATSAPP in config.platforms:
+        config.platforms[Platform.WHATSAPP].enabled = False
     elif whatsapp_enabled:
-        config.platforms[Platform.WHATSAPP] = PlatformConfig(enabled=True)
+        _enable_from_env(Platform.WHATSAPP)
     whatsapp_home = getenv("WHATSAPP_HOME_CHANNEL")
     if whatsapp_home and Platform.WHATSAPP in config.platforms:
         config.platforms[Platform.WHATSAPP].home_channel = HomeChannel(
@@ -1913,45 +1907,43 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     whatsapp_cloud_phone_id = getenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
     whatsapp_cloud_token = getenv("WHATSAPP_CLOUD_ACCESS_TOKEN")
     if whatsapp_cloud_phone_id and whatsapp_cloud_token:
-        if Platform.WHATSAPP_CLOUD not in config.platforms:
-            config.platforms[Platform.WHATSAPP_CLOUD] = PlatformConfig()
-        config.platforms[Platform.WHATSAPP_CLOUD].enabled = True
-        config.platforms[Platform.WHATSAPP_CLOUD].extra.update({
+        whatsapp_cloud_config = _enable_from_env(Platform.WHATSAPP_CLOUD)
+        whatsapp_cloud_config.extra.update({
             "phone_number_id": whatsapp_cloud_phone_id,
             "access_token": whatsapp_cloud_token,
         })
         # Optional: app_id / app_secret (signature verification)
         wa_cloud_app_id = getenv("WHATSAPP_CLOUD_APP_ID")
         if wa_cloud_app_id:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["app_id"] = wa_cloud_app_id
+            whatsapp_cloud_config.extra["app_id"] = wa_cloud_app_id
         wa_cloud_app_secret = getenv("WHATSAPP_CLOUD_APP_SECRET")
         if wa_cloud_app_secret:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["app_secret"] = wa_cloud_app_secret
+            whatsapp_cloud_config.extra["app_secret"] = wa_cloud_app_secret
         # Optional: WABA id (analytics, future use)
         wa_cloud_waba_id = getenv("WHATSAPP_CLOUD_WABA_ID")
         if wa_cloud_waba_id:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["waba_id"] = wa_cloud_waba_id
+            whatsapp_cloud_config.extra["waba_id"] = wa_cloud_waba_id
         # Webhook verify token — Meta hub.verify_token shared secret
         wa_cloud_verify_token = getenv("WHATSAPP_CLOUD_VERIFY_TOKEN")
         if wa_cloud_verify_token:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["verify_token"] = wa_cloud_verify_token
+            whatsapp_cloud_config.extra["verify_token"] = wa_cloud_verify_token
         # Webhook server bind config (defaults baked into the adapter)
         wa_cloud_host = getenv("WHATSAPP_CLOUD_WEBHOOK_HOST")
         if wa_cloud_host:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_host"] = wa_cloud_host
+            whatsapp_cloud_config.extra["webhook_host"] = wa_cloud_host
         wa_cloud_port = getenv("WHATSAPP_CLOUD_WEBHOOK_PORT")
         if wa_cloud_port:
             try:
-                config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_port"] = int(wa_cloud_port)
+                whatsapp_cloud_config.extra["webhook_port"] = int(wa_cloud_port)
             except ValueError:
                 pass
         wa_cloud_path = getenv("WHATSAPP_CLOUD_WEBHOOK_PATH")
         if wa_cloud_path:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_path"] = wa_cloud_path
+            whatsapp_cloud_config.extra["webhook_path"] = wa_cloud_path
         # Graph API version override (rarely needed)
         wa_cloud_api_version = getenv("WHATSAPP_CLOUD_API_VERSION")
         if wa_cloud_api_version:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["api_version"] = wa_cloud_api_version
+            whatsapp_cloud_config.extra["api_version"] = wa_cloud_api_version
     whatsapp_cloud_home = getenv("WHATSAPP_CLOUD_HOME_CHANNEL")
     if whatsapp_cloud_home and Platform.WHATSAPP_CLOUD in config.platforms:
         config.platforms[Platform.WHATSAPP_CLOUD].home_channel = HomeChannel(
@@ -1964,27 +1956,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Slack
     slack_token = getenv("SLACK_BOT_TOKEN")
     if slack_token:
-        if Platform.SLACK not in config.platforms:
-            # No yaml config for Slack — env-only setup, enable it
-            config.platforms[Platform.SLACK] = PlatformConfig()
-            config.platforms[Platform.SLACK].enabled = True
-        else:
-            slack_config = config.platforms[Platform.SLACK]
-            # Read (don't pop) the explicit-enable marker: the registry-driven
-            # plugin-enable pass below also needs it to avoid re-enabling a
-            # platform the user explicitly disabled (Slack is now a plugin
-            # entry — #41112). The flag is cleared once for all platforms in
-            # the final cleanup at the end of _apply_env_overrides.
-            enabled_was_explicit = bool(slack_config.extra.get("_enabled_explicit", False))
-            if not slack_config.enabled and not enabled_was_explicit:
-                # Top-level Slack settings such as channel prompts should not
-                # turn an env-token setup into a disabled platform. Only an
-                # explicit slack.enabled/platforms.slack.enabled false should.
-                slack_config.enabled = True
-        # If yaml config exists, respect its enabled flag (don't override
-        # explicit enabled: false). Token is still stored so skills that
-        # send Slack messages can use it without activating the gateway adapter.
-        config.platforms[Platform.SLACK].token = slack_token
+        # Keep the token available to skills even when the gateway adapter was
+        # explicitly disabled in YAML.
+        slack_config = _enable_from_env(Platform.SLACK)
+        slack_config.token = slack_token
     slack_home = getenv("SLACK_HOME_CHANNEL")
     if slack_home:
         slack_config = config.platforms.setdefault(
@@ -2078,13 +2053,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Home Assistant
     hass_token = getenv("HASS_TOKEN")
     if hass_token:
-        if Platform.HOMEASSISTANT not in config.platforms:
-            config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        homeassistant_config = _enable_from_env(Platform.HOMEASSISTANT)
+        homeassistant_config.token = hass_token
         hass_url = getenv("HASS_URL")
         if hass_url:
-            config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
+            homeassistant_config.extra["url"] = hass_url
 
     # Email
     email_addr = getenv("EMAIL_ADDRESS")
@@ -2092,10 +2065,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_imap = getenv("EMAIL_IMAP_HOST")
     email_smtp = getenv("EMAIL_SMTP_HOST")
     if all([email_addr, email_pwd, email_imap, email_smtp]):
-        if Platform.EMAIL not in config.platforms:
-            config.platforms[Platform.EMAIL] = PlatformConfig()
-        config.platforms[Platform.EMAIL].enabled = True
-        config.platforms[Platform.EMAIL].extra.update({
+        email_config = _enable_from_env(Platform.EMAIL)
+        email_config.extra.update({
             "address": email_addr,
             "imap_host": email_imap,
             "smtp_host": email_smtp,
@@ -2112,10 +2083,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # SMS (Twilio)
     twilio_sid = getenv("TWILIO_ACCOUNT_SID")
     if twilio_sid:
-        if Platform.SMS not in config.platforms:
-            config.platforms[Platform.SMS] = PlatformConfig()
-        config.platforms[Platform.SMS].enabled = True
-        config.platforms[Platform.SMS].api_key = getenv("TWILIO_AUTH_TOKEN", "")
+        sms_config = _enable_from_env(Platform.SMS)
+        sms_config.api_key = getenv("TWILIO_AUTH_TOKEN", "")
     sms_home = getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
         config.platforms[Platform.SMS].home_channel = HomeChannel(
@@ -2137,53 +2106,37 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # reconnect watcher spinning and logging errors forever. Same strength
     # bar as the startup guard (has_usable_secret, min_length=16).
     if _has_usable_api_server_key(api_server_key):
-        if Platform.API_SERVER not in config.platforms:
-            config.platforms[Platform.API_SERVER] = PlatformConfig()
-        # Respect an explicit ``enabled: false`` in config.yaml (flagged by
-        # ``_enabled_explicit``). In multiplex mode a secondary profile's
-        # config.yaml pins ``platforms.api_server.enabled: false`` so it shares
-        # the default profile's listener instead of binding its own port. That
-        # profile still inherits the process-level env (including
-        # ``API_SERVER_KEY``); without this guard the env-var presence would
-        # force-enable the listener and trip the MultiplexConfigError check.
-        # Pop (don't read) the marker — the api_server branch is terminal (no
-        # later registry pass re-enables it), so this both consumes the flag and
-        # avoids reading it twice, matching the pop convention used elsewhere.
-        api_server_explicit = config.platforms[Platform.API_SERVER].extra.pop("_enabled_explicit", False)
-        if not api_server_explicit or config.platforms[Platform.API_SERVER].enabled:
-            config.platforms[Platform.API_SERVER].enabled = True
+        api_server_config = _enable_from_env(Platform.API_SERVER)
         if api_server_key:
-            config.platforms[Platform.API_SERVER].extra["key"] = api_server_key
+            api_server_config.extra["key"] = api_server_key
         if api_server_cors_origins:
             origins = [origin.strip() for origin in api_server_cors_origins.split(",") if origin.strip()]
             if origins:
-                config.platforms[Platform.API_SERVER].extra["cors_origins"] = origins
+                api_server_config.extra["cors_origins"] = origins
         if api_server_port:
             try:
-                config.platforms[Platform.API_SERVER].extra["port"] = int(api_server_port)
+                api_server_config.extra["port"] = int(api_server_port)
             except ValueError:
                 pass
         if api_server_host:
-            config.platforms[Platform.API_SERVER].extra["host"] = api_server_host
+            api_server_config.extra["host"] = api_server_host
         api_server_model_name = getenv("API_SERVER_MODEL_NAME", "")
         if api_server_model_name:
-            config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name
+            api_server_config.extra["model_name"] = api_server_model_name
 
     # Webhook platform
     webhook_enabled = is_truthy_value(getenv("WEBHOOK_ENABLED", ""))
     webhook_port = getenv("WEBHOOK_PORT")
     webhook_secret = getenv("WEBHOOK_SECRET", "")
     if webhook_enabled:
-        if Platform.WEBHOOK not in config.platforms:
-            config.platforms[Platform.WEBHOOK] = PlatformConfig()
-        config.platforms[Platform.WEBHOOK].enabled = True
+        webhook_config = _enable_from_env(Platform.WEBHOOK)
         if webhook_port:
             try:
-                config.platforms[Platform.WEBHOOK].extra["port"] = int(webhook_port)
+                webhook_config.extra["port"] = int(webhook_port)
             except ValueError:
                 pass
         if webhook_secret:
-            config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
+            webhook_config.extra["secret"] = webhook_secret
 
     # Microsoft Graph webhook platform
     msgraph_webhook_enabled = is_truthy_value(getenv("MSGRAPH_WEBHOOK_ENABLED", ""))
@@ -2201,19 +2154,21 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         or msgraph_webhook_resources
         or msgraph_webhook_allowed_cidrs
     ):
-        if Platform.MSGRAPH_WEBHOOK not in config.platforms:
-            config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
         if msgraph_webhook_enabled:
-            config.platforms[Platform.MSGRAPH_WEBHOOK].enabled = True
+            msgraph_webhook_config = _enable_from_env(Platform.MSGRAPH_WEBHOOK)
+        else:
+            msgraph_webhook_config = config.platforms.setdefault(
+                Platform.MSGRAPH_WEBHOOK, PlatformConfig()
+            )
         if msgraph_webhook_port:
             try:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra["port"] = int(
+                msgraph_webhook_config.extra["port"] = int(
                     msgraph_webhook_port
                 )
             except ValueError:
                 pass
         if msgraph_webhook_client_state:
-            config.platforms[Platform.MSGRAPH_WEBHOOK].extra["client_state"] = (
+            msgraph_webhook_config.extra["client_state"] = (
                 msgraph_webhook_client_state
             )
         if msgraph_webhook_resources:
@@ -2223,9 +2178,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 if resource.strip()
             ]
             if resources:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
-                    "accepted_resources"
-                ] = resources
+                msgraph_webhook_config.extra["accepted_resources"] = resources
         if msgraph_webhook_allowed_cidrs:
             cidrs = [
                 cidr.strip()
@@ -2233,17 +2186,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 if cidr.strip()
             ]
             if cidrs:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
-                    "allowed_source_cidrs"
-                ] = cidrs
+                msgraph_webhook_config.extra["allowed_source_cidrs"] = cidrs
 
     # DingTalk
     dingtalk_client_id = getenv("DINGTALK_CLIENT_ID")
     dingtalk_client_secret = getenv("DINGTALK_CLIENT_SECRET")
     if dingtalk_client_id and dingtalk_client_secret:
-        if Platform.DINGTALK not in config.platforms:
-            config.platforms[Platform.DINGTALK] = PlatformConfig()
-        config.platforms[Platform.DINGTALK].enabled = True
+        _enable_from_env(Platform.DINGTALK)
         config.platforms[Platform.DINGTALK].extra.update({
             "client_id": dingtalk_client_id,
             "client_secret": dingtalk_client_secret,
@@ -2261,9 +2210,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = getenv("FEISHU_APP_ID")
     feishu_app_secret = getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
-            config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
+        _enable_from_env(Platform.FEISHU)
         config.platforms[Platform.FEISHU].extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
@@ -2289,9 +2236,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_bot_id = getenv("WECOM_BOT_ID")
     wecom_secret = getenv("WECOM_SECRET")
     if wecom_bot_id and wecom_secret:
-        if Platform.WECOM not in config.platforms:
-            config.platforms[Platform.WECOM] = PlatformConfig()
-        config.platforms[Platform.WECOM].enabled = True
+        _enable_from_env(Platform.WECOM)
         config.platforms[Platform.WECOM].extra.update({
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,
@@ -2312,9 +2257,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_callback_corp_id = getenv("WECOM_CALLBACK_CORP_ID")
     wecom_callback_corp_secret = getenv("WECOM_CALLBACK_CORP_SECRET")
     if wecom_callback_corp_id and wecom_callback_corp_secret:
-        if Platform.WECOM_CALLBACK not in config.platforms:
-            config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
-        config.platforms[Platform.WECOM_CALLBACK].enabled = True
+        _enable_from_env(Platform.WECOM_CALLBACK)
         config.platforms[Platform.WECOM_CALLBACK].extra.update({
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
@@ -2329,9 +2272,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     weixin_token = getenv("WEIXIN_TOKEN")
     weixin_account_id = getenv("WEIXIN_ACCOUNT_ID")
     if weixin_token or weixin_account_id:
-        if Platform.WEIXIN not in config.platforms:
-            config.platforms[Platform.WEIXIN] = PlatformConfig()
-        config.platforms[Platform.WEIXIN].enabled = True
+        _enable_from_env(Platform.WEIXIN)
         if weixin_token:
             config.platforms[Platform.WEIXIN].token = weixin_token
         extra = config.platforms[Platform.WEIXIN].extra
@@ -2371,9 +2312,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     bluebubbles_server_url = getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = getenv("BLUEBUBBLES_PASSWORD")
     if bluebubbles_server_url and bluebubbles_password:
-        if Platform.BLUEBUBBLES not in config.platforms:
-            config.platforms[Platform.BLUEBUBBLES] = PlatformConfig()
-        config.platforms[Platform.BLUEBUBBLES].enabled = True
+        _enable_from_env(Platform.BLUEBUBBLES)
         config.platforms[Platform.BLUEBUBBLES].extra.update({
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
@@ -2411,9 +2350,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     qq_app_id = getenv("QQ_APP_ID")
     qq_client_secret = getenv("QQ_CLIENT_SECRET")
     if qq_app_id or qq_client_secret:
-        if Platform.QQBOT not in config.platforms:
-            config.platforms[Platform.QQBOT] = PlatformConfig()
-        config.platforms[Platform.QQBOT].enabled = True
+        _enable_from_env(Platform.QQBOT)
         extra = config.platforms[Platform.QQBOT].extra
         if qq_app_id:
             extra["app_id"] = qq_app_id
@@ -2453,9 +2390,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     yuanbao_app_id = getenv("YUANBAO_APP_ID") or getenv("YUANBAO_APP_KEY")
     yuanbao_app_secret = getenv("YUANBAO_APP_SECRET")
     if yuanbao_app_id and yuanbao_app_secret:
-        if Platform.YUANBAO not in config.platforms:
-            config.platforms[Platform.YUANBAO] = PlatformConfig()
-        config.platforms[Platform.YUANBAO].enabled = True
+        _enable_from_env(Platform.YUANBAO)
         extra = config.platforms[Platform.YUANBAO].extra
         extra["app_id"] = yuanbao_app_id
         extra["app_secret"] = yuanbao_app_secret

--- a/tests/gateway/test_platform_env_enablement_precedence.py
+++ b/tests/gateway/test_platform_env_enablement_precedence.py
@@ -1,0 +1,316 @@
+"""Regression coverage for platform env auto-enablement precedence (#73289)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from gateway.config import Platform, load_gateway_config
+from gateway.platform_registry import PlatformEntry, platform_registry
+
+
+_PLATFORM_CASES: tuple[
+    tuple[str, dict[str, str], tuple[tuple[str, str, Any], ...]], ...
+] = (
+    (
+        "whatsapp",
+        {"WHATSAPP_ENABLED": "true"},
+        (),
+    ),
+    (
+        "whatsapp_cloud",
+        {
+            "WHATSAPP_CLOUD_PHONE_NUMBER_ID": "phone-123",
+            "WHATSAPP_CLOUD_ACCESS_TOKEN": "cloud-token",
+        },
+        (
+            ("extra", "phone_number_id", "phone-123"),
+            ("extra", "access_token", "cloud-token"),
+        ),
+    ),
+    (
+        "homeassistant",
+        {"HASS_TOKEN": "hass-token", "HASS_URL": "http://ha.local:8123"},
+        (
+            ("attr", "token", "hass-token"),
+            ("extra", "url", "http://ha.local:8123"),
+        ),
+    ),
+    (
+        "email",
+        {
+            "EMAIL_ADDRESS": "hermes@example.com",
+            "EMAIL_PASSWORD": "email-password",
+            "EMAIL_IMAP_HOST": "imap.example.com",
+            "EMAIL_SMTP_HOST": "smtp.example.com",
+        },
+        (
+            ("extra", "address", "hermes@example.com"),
+            ("extra", "imap_host", "imap.example.com"),
+            ("extra", "smtp_host", "smtp.example.com"),
+        ),
+    ),
+    (
+        "sms",
+        {
+            "TWILIO_ACCOUNT_SID": "AC123",
+            "TWILIO_AUTH_TOKEN": "twilio-token",
+        },
+        (("attr", "api_key", "twilio-token"),),
+    ),
+    (
+        "api_server",
+        {"API_SERVER_ENABLED": "true", "API_SERVER_KEY": "a" * 32},
+        (("extra", "key", "a" * 32),),
+    ),
+    (
+        "webhook",
+        {"WEBHOOK_ENABLED": "true", "WEBHOOK_SECRET": "webhook-secret"},
+        (("extra", "secret", "webhook-secret"),),
+    ),
+    (
+        "msgraph_webhook",
+        {
+            "MSGRAPH_WEBHOOK_ENABLED": "true",
+            "MSGRAPH_WEBHOOK_CLIENT_STATE": "client-state",
+        },
+        (("extra", "client_state", "client-state"),),
+    ),
+    (
+        "dingtalk",
+        {
+            "DINGTALK_CLIENT_ID": "ding-id",
+            "DINGTALK_CLIENT_SECRET": "ding-secret",
+        },
+        (
+            ("extra", "client_id", "ding-id"),
+            ("extra", "client_secret", "ding-secret"),
+        ),
+    ),
+    (
+        "feishu",
+        {"FEISHU_APP_ID": "feishu-id", "FEISHU_APP_SECRET": "feishu-secret"},
+        (
+            ("extra", "app_id", "feishu-id"),
+            ("extra", "app_secret", "feishu-secret"),
+        ),
+    ),
+    (
+        "wecom",
+        {"WECOM_BOT_ID": "wecom-id", "WECOM_SECRET": "wecom-secret"},
+        (
+            ("extra", "bot_id", "wecom-id"),
+            ("extra", "secret", "wecom-secret"),
+        ),
+    ),
+    (
+        "wecom_callback",
+        {
+            "WECOM_CALLBACK_CORP_ID": "corp-id",
+            "WECOM_CALLBACK_CORP_SECRET": "corp-secret",
+        },
+        (
+            ("extra", "corp_id", "corp-id"),
+            ("extra", "corp_secret", "corp-secret"),
+        ),
+    ),
+    (
+        "weixin",
+        {"WEIXIN_TOKEN": "weixin-token", "WEIXIN_ACCOUNT_ID": "wx-account"},
+        (
+            ("attr", "token", "weixin-token"),
+            ("extra", "account_id", "wx-account"),
+        ),
+    ),
+    (
+        "bluebubbles",
+        {
+            "BLUEBUBBLES_SERVER_URL": "https://bluebubbles.local/",
+            "BLUEBUBBLES_PASSWORD": "blue-password",
+        },
+        (
+            ("extra", "server_url", "https://bluebubbles.local"),
+            ("extra", "password", "blue-password"),
+        ),
+    ),
+    (
+        "qqbot",
+        {"QQ_APP_ID": "qq-id", "QQ_CLIENT_SECRET": "qq-secret"},
+        (
+            ("extra", "app_id", "qq-id"),
+            ("extra", "client_secret", "qq-secret"),
+        ),
+    ),
+    (
+        "yuanbao",
+        {"YUANBAO_APP_ID": "yuanbao-id", "YUANBAO_APP_SECRET": "yuanbao-secret"},
+        (
+            ("extra", "app_id", "yuanbao-id"),
+            ("extra", "app_secret", "yuanbao-secret"),
+        ),
+    ),
+)
+
+
+def _write_platform_config(tmp_path, body: str) -> None:
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def _assert_seeded(config, platform: Platform, expected) -> None:
+    platform_config = config.platforms[platform]
+    for source, key, value in expected:
+        actual = (
+            getattr(platform_config, key)
+            if source == "attr"
+            else platform_config.extra.get(key)
+        )
+        assert actual == value
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "env", "expected"),
+    _PLATFORM_CASES,
+    ids=[case[0] for case in _PLATFORM_CASES],
+)
+def test_explicit_platform_disable_wins_over_env_auto_enable(
+    tmp_path,
+    monkeypatch,
+    platform_name: str,
+    env: dict[str, str],
+    expected: tuple[tuple[str, str, Any], ...],
+):
+    """Credentials may be seeded, but an explicit disable stays authoritative."""
+    _write_platform_config(
+        tmp_path,
+        f"platforms:\n  {platform_name}:\n    enabled: false\n",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    config = load_gateway_config()
+
+    platform = Platform(platform_name)
+    platform_config = config.platforms[platform]
+    assert platform_config.enabled is False
+    assert "_enabled_explicit" not in platform_config.extra
+    _assert_seeded(config, platform, expected)
+
+
+@pytest.mark.parametrize(
+    "yaml_body",
+    (
+        "weixin:\n  enabled: false\n",
+        "gateway:\n  platforms:\n    weixin:\n      enabled: false\n",
+    ),
+    ids=("top-level-platform-block", "nested-gateway-platforms"),
+)
+def test_explicit_disable_is_preserved_across_supported_yaml_shapes(
+    tmp_path, monkeypatch, yaml_body: str
+):
+    _write_platform_config(tmp_path, yaml_body)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("WEIXIN_TOKEN", "weixin-token")
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.WEIXIN].enabled is False
+    assert config.platforms[Platform.WEIXIN].token == "weixin-token"
+
+
+def test_env_only_platform_still_auto_enables(tmp_path, monkeypatch):
+    _write_platform_config(tmp_path, "{}\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("WEIXIN_TOKEN", "weixin-token")
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.WEIXIN].enabled is True
+    assert config.platforms[Platform.WEIXIN].token == "weixin-token"
+
+
+def test_platform_with_unspecified_enabled_still_auto_enables(tmp_path, monkeypatch):
+    _write_platform_config(
+        tmp_path,
+        "platforms:\n  weixin:\n    extra:\n      dm_policy: allowlist\n",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("WEIXIN_TOKEN", "weixin-token")
+
+    config = load_gateway_config()
+
+    weixin = config.platforms[Platform.WEIXIN]
+    assert weixin.enabled is True
+    assert weixin.token == "weixin-token"
+    assert weixin.extra["dm_policy"] == "allowlist"
+
+
+def test_plugin_registry_does_not_probe_or_enable_explicitly_disabled_platform(
+    tmp_path, monkeypatch
+):
+    calls = {"check": 0, "connected": 0, "seed": 0}
+    name = "precedence-test-plugin"
+    entry = PlatformEntry(
+        name=name,
+        label="Precedence Test Plugin",
+        adapter_factory=lambda cfg: object(),
+        check_fn=lambda: calls.__setitem__("check", calls["check"] + 1) or True,
+        is_connected=lambda cfg: calls.__setitem__("connected", calls["connected"] + 1) or True,
+        env_enablement_fn=lambda: (
+            calls.__setitem__("seed", calls["seed"] + 1)
+            or {"credential": "seeded"}
+        ),
+        source="plugin",
+    )
+    platform_registry.register(entry)
+    try:
+        _write_platform_config(
+            tmp_path,
+            f"platforms:\n  {name}:\n    enabled: false\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        config = load_gateway_config()
+
+        platform = Platform(name)
+        assert config.platforms[platform].enabled is False
+        assert calls == {"check": 0, "connected": 0, "seed": 0}
+        assert "_enabled_explicit" not in config.platforms[platform].extra
+    finally:
+        platform_registry.unregister(name)
+
+
+def test_plugin_registry_env_only_auto_enable_is_unchanged(tmp_path, monkeypatch):
+    calls = {"check": 0, "connected": 0, "seed": 0}
+    name = "precedence-test-plugin-env-only"
+    entry = PlatformEntry(
+        name=name,
+        label="Precedence Test Plugin Env Only",
+        adapter_factory=lambda cfg: object(),
+        check_fn=lambda: calls.__setitem__("check", calls["check"] + 1) or True,
+        is_connected=lambda cfg: calls.__setitem__("connected", calls["connected"] + 1) or bool(
+            cfg.extra.get("credential")
+        ),
+        env_enablement_fn=lambda: (
+            calls.__setitem__("seed", calls["seed"] + 1)
+            or {"credential": "seeded"}
+        ),
+        source="plugin",
+    )
+    platform_registry.register(entry)
+    try:
+        _write_platform_config(tmp_path, "{}\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        config = load_gateway_config()
+
+        platform = Platform(name)
+        platform_config = config.platforms[platform]
+        assert platform_config.enabled is True
+        assert platform_config.extra["credential"] == "seeded"
+        assert calls == {"check": 1, "connected": 1, "seed": 1}
+    finally:
+        platform_registry.unregister(name)


### PR DESCRIPTION
## What does this PR do?

Preserves explicit `platforms.<name>.enabled: false` settings during environment credential bootstrap.

Environment variables may still populate credentials and defaults, but they no longer re-enable a platform that the operator explicitly disabled in `config.yaml`.

## Related issue

Fixes #73289

Related to #55447, which covers a narrower subset of the same configuration-precedence problem.

## Type of change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Refactor

## Changes made

- add a shared helper for applying environment-driven platform enablement
- preserve explicit `enabled: false` values from YAML
- retain existing auto-enable behavior when a platform is absent or `enabled` is unspecified
- apply the same precedence rule to built-in and plugin-registry platform paths
- add cross-platform regression coverage for explicit disables and env-only configuration

## Testing

- focused precedence regression tests: 22 passed
- related Gateway test suite: 348 passed
- Python syntax validation passed

## Checklist

- [x] Explicit operator configuration remains authoritative
- [x] Env-only platform configuration still auto-enables
- [x] Built-in and plugin platform paths are covered
- [x] Regression tests were added
- [x] No unrelated files were modified