### PR TITLE
fix: exclude reasoning_details from preflight token estimate (#73298)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2785,7 +2785,7 @@ def _estimate_message_chars(msg: Dict[str, Any]) -> int:
         return len(str(msg))
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
-        if k == "_anthropic_content_blocks":
+        if k in ("_anthropic_content_blocks", "reasoning_details"):
             continue
         if k == "content":
             if isinstance(v, list):
@@ -2814,7 +2814,7 @@ def _estimate_message_tokens_without_images(msg: Dict[str, Any]) -> int:
         return estimate_tokens_rough(str(msg))
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
-        if k == "_anthropic_content_blocks":
+        if k in ("_anthropic_content_blocks", "reasoning_details"):
             continue
         if k == "content":
             if isinstance(v, list):


### PR DESCRIPTION
## Summary

The `reasoning_details` field (OpenRouter/Anthropic thinking blocks + opaque cryptographic signature blobs) inflates the rough preflight token estimate by ~4x, causing premature compression on thinking models.

Providers do not bill these envelope bytes as prompt tokens — in a measured Kimi K3 session, `reasoning_details` held 2,124K chars vs 281K chars of actual thinking text. The estimator reported ~533K tokens when real `prompt_tokens` was ~140K, triggering compression at ~27% of the configured threshold.

## Fix

Skip `reasoning_details` in both `_estimate_message_chars` and `_estimate_message_tokens_without_images`, alongside the existing `_anthropic_content_blocks` exclusion. This is the same treatment already applied to Anthropic content blocks (which also contain opaque metadata not billed as tokens).

## Changes

- `agent/model_metadata.py`: Add `reasoning_details` to the skip set in both `_estimate_message_chars()` (L2788) and `_estimate_message_tokens_without_images()` (L2817)

## Test Plan

- [x] All 132 tests in `tests/agent/test_model_metadata.py` pass
- [x] Syntax check passes

Fixes #73298