### PR TITLE
fix(update): preserve activated extras across runtime rebuilds

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9651,10 +9651,22 @@ def _repair_venv_via_import_probes(
     return "failed"
 
 
+def _capture_active_lazy_features() -> list[str]:
+    """Snapshot active lazy backends before a managed runtime is replaced."""
+    try:
+        from tools import lazy_deps
+
+        return lazy_deps.active_features()
+    except Exception as exc:
+        logger.debug("Could not snapshot active lazy features: %s", exc)
+        return []
+
+
 def _refresh_active_lazy_features(
     install_cmd_prefix: list[str] | None = None,
     *,
     env: dict[str, str] | None = None,
+    features: list[str] | None = None,
 ) -> bool:
     """Refresh lazy-installed backends after a code update.
 
@@ -9682,11 +9694,14 @@ def _refresh_active_lazy_features(
         logger.debug("Lazy refresh skipped (import failed): %s", exc)
         return True
 
-    try:
-        active = lazy_deps.active_features()
-    except Exception as exc:
-        logger.debug("Lazy refresh skipped (active_features failed): %s", exc)
-        return True
+    if features is None:
+        try:
+            active = lazy_deps.active_features()
+        except Exception as exc:
+            logger.debug("Lazy refresh skipped (active_features failed): %s", exc)
+            return True
+    else:
+        active = features
 
     if not active:
         return True
@@ -9696,7 +9711,10 @@ def _refresh_active_lazy_features(
 
     unexpected_failure = False
     try:
-        results = lazy_deps.refresh_active_features(prompt=False)
+        if features is None:
+            results = lazy_deps.refresh_active_features(prompt=False)
+        else:
+            results = lazy_deps.restore_features(active)
     except Exception as exc:
         # refresh_active_features is documented as never-raise, but defend
         # the update flow against future regressions.
@@ -9704,7 +9722,7 @@ def _refresh_active_lazy_features(
         results = {}
         unexpected_failure = True
 
-    refreshed = [f for f, s in results.items() if s == "refreshed"]
+    refreshed = [f for f, s in results.items() if s in {"refreshed", "restored"}]
     current = [f for f, s in results.items() if s == "current"]
     failed = [(f, s) for f, s in results.items() if s.startswith("failed:")]
     skipped = [(f, s) for f, s in results.items() if s.startswith("skipped:")]
@@ -11901,6 +11919,11 @@ def cmd_update(args):
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
+    # A managed-runtime refresh can replace site-packages before the normal
+    # ``.[all]`` install runs. Snapshot while the old environment can still
+    # prove which optional backends the user had activated.
+    active_lazy_features = _capture_active_lazy_features()
+
     # In gateway mode, use file-based IPC for prompts instead of stdin
     gw_input_fn = (
         (lambda prompt, default="": _gateway_prompt(prompt, default))
@@ -12228,9 +12251,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     _install_python_dependencies_with_optional_fallback(
                         [repair_uv, "pip"], env=repair_env, group="all"
                     )
+                    _refresh_active_lazy_features(
+                        [repair_uv, "pip"], env=repair_env,
+                        features=active_lazy_features,
+                    )
                 else:
                     _install_python_dependencies_with_optional_fallback(
                         [sys.executable, "-m", "pip"], group="all"
+                    )
+                    _refresh_active_lazy_features(
+                        [sys.executable, "-m", "pip"],
+                        features=active_lazy_features,
                     )
                 _clear_update_incomplete_marker()
                 healthy_after, detail_after = _venv_core_imports_healthy()
@@ -12478,7 +12509,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         # Lazy refresh can corrupt the venv when a backend install fails.
         # Clear the lazy marker only when refresh/repair is confirmed healthy.
-        lazy_ok = _refresh_active_lazy_features(install_prefix, env=lazy_env)
+        lazy_ok = _refresh_active_lazy_features(
+            install_prefix, env=lazy_env, features=active_lazy_features
+        )
         if lazy_ok:
             _clear_lazy_refresh_incomplete_marker()
         else:

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import hermes_cli.main as m
+import pytest
 
 
 def test_detect_broken_imports_returns_repair_package_names(
@@ -163,6 +164,28 @@ def test_refresh_repairs_venv_after_lazy_failure(tmp_path, monkeypatch, capsys):
     assert "Venv repair succeeded" in out
     assert "import probes" in out
     assert "Backends keep their previously-installed version" not in out
+
+
+def test_refresh_uses_pre_rebuild_snapshot_when_provided(monkeypatch):
+    """Replacement runtimes must not re-detect features after packages vanish."""
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "active_features",
+        lambda: pytest.fail("post-rebuild detection must not run"),
+    )
+    restored = []
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "restore_features",
+        lambda features: restored.append(features) or {"platform.telegram": "restored"},
+    )
+
+    assert m._refresh_active_lazy_features(
+        ["uv", "pip"], features=["platform.telegram"]
+    ) is True
+    assert restored == [["platform.telegram"]]
 
 
 def test_refresh_returns_false_when_repair_fails(tmp_path, monkeypatch, capsys):

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -455,6 +455,42 @@ class TestRefreshActiveFeatures:
         assert "test.feat" in result
         assert result["test.feat"].startswith("skipped:")
 
+    def test_restore_snapshot_reinstalls_telegram_with_lazy_installs_disabled(
+        self, monkeypatch
+    ):
+        """An update may restore a captured feature without opening runtime installs."""
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: False)
+        satisfied = iter([False, True])
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: next(satisfied))
+        installs = []
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda specs, **kw: installs.append(specs) or ld._InstallResult(True, "", ""),
+        )
+
+        result = ld.restore_features(["platform.telegram"])
+
+        assert result == {"platform.telegram": "restored"}
+        assert installs == [("python-telegram-bot[webhooks]==22.6",)]
+        assert ld._allow_lazy_installs() is False
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        with pytest.raises(ld.FeatureUnavailable, match="lazy installs disabled"):
+            ld.ensure("platform.telegram", prompt=False)
+
+    def test_restore_snapshot_does_not_install_never_activated_features(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *args, **kwargs: pytest.fail(
+                "cold features must stay uninstalled"
+            ),
+        )
+
+        assert ld.restore_features([]) == {}
+
     def test_mixed_results_returns_per_feature_status(self, monkeypatch):
         monkeypatch.setattr(ld, "active_features", lambda: ["a.ok", "b.fail"])
         monkeypatch.setitem(ld.LAZY_DEPS, "a.ok", ("pkga==1.0",))

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -908,8 +908,32 @@ def refresh_active_features(*, prompt: bool = False) -> dict[str, str]:
     Intended for ``hermes update``. Never raises; lazy-install failures
     here must not block the rest of the update flow.
     """
+    return _refresh_features(active_features(), prompt=prompt, restoring=False)
+
+
+def restore_features(features: list[str]) -> dict[str, str]:
+    """Restore features captured before an explicit managed-runtime rebuild.
+
+    ``security.allow_lazy_installs`` gates installs initiated at feature-use
+    time.  A runtime rebuild is different: the updater is deliberately
+    recreating the environment and may restore only features that were
+    already present before that rebuild.  The feature names are still checked
+    against :data:`LAZY_DEPS`, so this never accepts arbitrary package specs.
+
+    This does not change the security setting.  Subsequent runtime calls to
+    :func:`ensure` remain subject to the normal lazy-install gate.
+    """
+    return _refresh_features(features, prompt=False, restoring=True)
+
+
+def _refresh_features(
+    features: list[str], *, prompt: bool, restoring: bool
+) -> dict[str, str]:
+    """Refresh or restore a known set of allowlisted lazy features."""
     results: dict[str, str] = {}
-    for feature in active_features():
+    for feature in features:
+        if feature not in LAZY_DEPS:
+            continue
         missing = feature_missing(feature)
         if not missing:
             results[feature] = "current"
@@ -921,8 +945,24 @@ def refresh_active_features(*, prompt: bool = False) -> dict[str, str]:
             continue
 
         try:
-            ensure(feature, prompt=prompt)
-            results[feature] = "refreshed"
+            if restoring:
+                result = _venv_pip_install(missing)
+                if not result.success:
+                    snippet = (result.stderr or result.stdout or "").strip()
+                    raise FeatureUnavailable(
+                        feature, missing,
+                        f"pip install failed: {snippet or 'no error output'}",
+                    )
+                if feature_missing(feature):
+                    raise FeatureUnavailable(
+                        feature, missing,
+                        "install reported success but packages are still missing "
+                        "(may require Python restart)",
+                    )
+                results[feature] = "restored"
+            else:
+                ensure(feature, prompt=prompt)
+                results[feature] = "refreshed"
         except FeatureUnavailable as e:
             # Distinguish "user opted out" or platform-incompatible features
             # from install failures so the update command can render the


### PR DESCRIPTION
## Root cause

`hermes update` rebuilt the managed environment with `.[all]`, then called `active_features()` to decide what to refresh. That detector infers activation from packages *currently installed* in the environment. A replacement runtime has already removed a lazy backend's anchor package, so the updater cannot recover the previously active feature.

## Reproduction

1. Activate Telegram (`python-telegram-bot[webhooks]==22.6`).
2. Set `security.allow_lazy_installs: false`.
3. Run an update that replaces the managed runtime.
4. The core `.[all]` install omits Telegram, and post-rebuild `active_features()` returns no Telegram feature.

## Why active-feature detection fails after removal

It is intentionally presence-based and does not persist history. Once the replacement runtime has dropped the package, its anchor is gone; probing after the rebuild cannot distinguish “previously activated then removed” from “never activated.”

## Fix design

Snapshot the allowlisted active lazy features before the update can replace site-packages, then restore that exact snapshot after the core dependency install. The restore path only accepts names in `LAZY_DEPS` and its pinned specs, so it is general across declared lazy backends without accepting arbitrary packages. Cold features remain absent.

## Security behavior

This does not modify `security.allow_lazy_installs`. Runtime `ensure()` remains blocked when it is false. The explicit updater may restore only dependencies already captured before its own managed-runtime rebuild.

## Tests executed

- Added regression test: failed before the fix with `AttributeError: module 'tools.lazy_deps' has no attribute 'restore_features'`.
- `python -m pytest tests/tools/test_lazy_deps.py tests/hermes_cli/test_lazy_refresh_venv_repair.py -q`: **84 passed**.
- `ruff check tools/lazy_deps.py hermes_cli/main.py tests/tools/test_lazy_deps.py tests/hermes_cli/test_lazy_refresh_venv_repair.py`: **passed**.
- `py_compile tools/lazy_deps.py hermes_cli/main.py`: **passed**.
- Canonical `scripts/run_tests.sh` could not run on the Windows author host because it invokes WSL and no WSL distribution is installed. Direct broader collection is also blocked by Linux-only test prerequisites; CI is required for platform-parity validation.
- `ty check tools/lazy_deps.py hermes_cli/main.py` reports existing diagnostics across `hermes_cli/main.py` outside this diff.

Fixes #72924
