### PR TITLE
feat(usage): add Kimi for Coding account usage windows to /usage

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -881,6 +881,129 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+KIMI_CODING_PROVIDERS = {"kimi-coding", "kimi-code", "kimi", "moonshot", "moonshot-cn"}
+KIMI_DEFAULT_BASE_URL = "https://api.kimi.com/coding/v1"
+
+
+def _kimi_window_label(window: dict[str, Any]) -> str:
+    duration = window.get("duration")
+    unit = str(window.get("timeUnit") or "").strip().upper()
+    try:
+        value = int(str(duration))
+    except (TypeError, ValueError):
+        return "Rate limit window"
+    if unit.endswith("MINUTE"):
+        if value % (7 * 24 * 60) == 0:
+            return f"Current {value // (7 * 24 * 60)}w"
+        if value % (24 * 60) == 0:
+            return f"Current {value // (24 * 60)}d"
+        if value % 60 == 0:
+            return f"Current {value // 60}h"
+        return f"Current {value}m"
+    if unit.endswith("HOUR"):
+        if value % (7 * 24) == 0:
+            return f"Current {value // (7 * 24)}w"
+        if value % 24 == 0:
+            return f"Current {value // 24}d"
+        return f"Current {value}h"
+    if unit.endswith("DAY"):
+        if value % 7 == 0:
+            return f"Current {value // 7}w"
+        return f"Current {value}d"
+    return "Rate limit window"
+
+
+def _kimi_usage_percent(bucket: dict[str, Any]) -> Optional[float]:
+    try:
+        limit = float(str(bucket.get("limit")))
+        used = float(str(bucket.get("used")))
+    except (TypeError, ValueError):
+        return None
+    if limit <= 0 or used < 0:
+        return None
+    return (used / limit) * 100
+
+
+def _fetch_kimi_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
+    runtime = resolve_runtime_provider(
+        requested="kimi-coding",
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
+    )
+    token = str(runtime.get("api_key", "") or "").strip()
+    if not token:
+        return None
+    normalized = str(runtime.get("base_url", "") or "").rstrip("/") or KIMI_DEFAULT_BASE_URL
+    if not normalized.endswith("/v1"):
+        normalized = f"{normalized}/v1"
+    usages_url = f"{normalized}/usages"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    with httpx.Client(timeout=10.0) as client:
+        response = client.get(usages_url, headers=headers)
+        response.raise_for_status()
+    payload = response.json() or {}
+
+    windows: list[AccountUsageWindow] = []
+    top = payload.get("usage") or {}
+    if isinstance(top, dict) and top:
+        percent = _kimi_usage_percent(top)
+        if percent is not None:
+            windows.append(
+                AccountUsageWindow(
+                    label="Current week",
+                    used_percent=percent,
+                    reset_at=_parse_dt(top.get("resetTime")),
+                )
+            )
+    limits = payload.get("limits") or []
+    if isinstance(limits, list):
+        for entry in limits:
+            if not isinstance(entry, dict):
+                continue
+            window = entry.get("window") or {}
+            detail = entry.get("detail") or {}
+            if not isinstance(detail, dict) or not detail:
+                continue
+            percent = _kimi_usage_percent(detail)
+            if percent is None:
+                continue
+            windows.append(
+                AccountUsageWindow(
+                    label=_kimi_window_label(window if isinstance(window, dict) else {}),
+                    used_percent=percent,
+                    reset_at=_parse_dt(detail.get("resetTime")),
+                )
+            )
+
+    details: list[str] = []
+    parallel = payload.get("parallel") or {}
+    if isinstance(parallel, dict):
+        limit = parallel.get("limit")
+        if _is_finite_num(limit) or (isinstance(limit, str) and limit.strip().isdigit()):
+            details.append(f"Parallel requests: up to {limit}")
+
+    plan: Optional[str] = None
+    user = payload.get("user") or {}
+    if isinstance(user, dict):
+        membership = user.get("membership") or {}
+        if isinstance(membership, dict):
+            level = str(membership.get("level") or "").strip()
+            if level:
+                plan = _title_case_slug(level.removeprefix("LEVEL_").lower())
+
+    return AccountUsageSnapshot(
+        provider="kimi-coding",
+        source="usages_api",
+        fetched_at=_utc_now(),
+        plan=plan,
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
@@ -897,6 +1020,8 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized in KIMI_CODING_PROVIDERS:
+            return _fetch_kimi_account_usage(base_url, api_key)
     except Exception:
         return None
     return None

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -201,3 +201,105 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+_KIMI_USAGES_PAYLOAD = {
+    "user": {"userId": "u1", "membership": {"level": "LEVEL_STANDARD"}},
+    "usage": {
+        "limit": "100",
+        "used": "40",
+        "remaining": "60",
+        "resetTime": "2026-08-04T11:05:18Z",
+    },
+    "limits": [
+        {
+            "window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+            "detail": {
+                "limit": "100",
+                "used": "25",
+                "remaining": "75",
+                "resetTime": "2026-07-28T16:05:18Z",
+            },
+        }
+    ],
+    "parallel": {"limit": "30"},
+}
+
+
+def _patch_kimi(monkeypatch, payload=_KIMI_USAGES_PAYLOAD):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda requested, explicit_base_url=None, explicit_api_key=None: {
+            "provider": "kimi-coding",
+            "base_url": "https://api.kimi.com/coding/v1",
+            "api_key": "sk-test",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=10.0: _RoutingClient(
+            {"https://api.kimi.com/coding/v1/usages": payload}
+        ),
+    )
+
+
+def test_fetch_account_usage_kimi_renders_weekly_and_five_hour_windows(monkeypatch):
+    _patch_kimi(monkeypatch)
+
+    snapshot = fetch_account_usage("kimi-coding")
+
+    assert snapshot is not None
+    assert snapshot.provider == "kimi-coding"
+    assert snapshot.plan == "Standard"
+    labels = [w.label for w in snapshot.windows]
+    assert labels == ["Current week", "Current 5h"]
+    weekly, five_hour = snapshot.windows
+    assert weekly.used_percent == 40.0
+    assert weekly.reset_at == datetime(2026, 8, 4, 11, 5, 18, tzinfo=timezone.utc)
+    assert five_hour.used_percent == 25.0
+    assert five_hour.reset_at == datetime(2026, 7, 28, 16, 5, 18, tzinfo=timezone.utc)
+    assert "Parallel requests: up to 30" in snapshot.details
+    rendered = render_account_usage_lines(snapshot)
+    assert any("Current week: 60% remaining (40% used)" in line for line in rendered)
+    assert any("Current 5h: 75% remaining (25% used)" in line for line in rendered)
+
+
+def test_fetch_account_usage_kimi_provider_aliases(monkeypatch):
+    for alias in ("kimi", "kimi-code", "moonshot"):
+        _patch_kimi(monkeypatch)
+        snapshot = fetch_account_usage(alias)
+        assert snapshot is not None, alias
+        assert snapshot.provider == "kimi-coding"
+
+
+def test_fetch_account_usage_kimi_without_token_returns_none(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda requested, explicit_base_url=None, explicit_api_key=None: {
+            "provider": "kimi-coding",
+            "base_url": "https://api.kimi.com/coding/v1",
+            "api_key": "",
+        },
+    )
+
+    assert fetch_account_usage("kimi-coding") is None
+
+
+def test_fetch_account_usage_kimi_handles_malformed_numbers(monkeypatch):
+    _patch_kimi(
+        monkeypatch,
+        payload={
+            "usage": {"limit": "nope", "used": "1", "resetTime": None},
+            "limits": [
+                {
+                    "window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+                    "detail": {"limit": "100", "used": "10", "resetTime": "2026-07-28T16:05:18Z"},
+                }
+            ],
+        },
+    )
+
+    snapshot = fetch_account_usage("kimi-coding")
+
+    assert snapshot is not None
+    assert [w.label for w in snapshot.windows] == ["Current 5h"]


### PR DESCRIPTION
## Problem

`/usage` had no account-usage support for the `kimi-coding` provider — `fetch_account_usage()` only handled `openai-codex`, `anthropic`, and `openrouter`, so Kimi Coding Plan users saw no weekly or 5-hour window information.

## Fix

The official `kimi-cli` (PyPI) exposes this data via its `/usage` command, which calls `GET {base_url}/v1/usages` with the account API key. This PR adds a `_fetch_kimi_account_usage()` fetcher that probes the same endpoint and renders:

- **Weekly usage window** — used % and reset time (from the top-level `usage` bucket)
- **Per-window rate limits** — e.g. the 5-hour window from `limits[]`, labeled generically from `window.duration`/`window.timeUnit` so other window sizes render correctly (`Current 5h`, `Current 1d`, etc.)
- **Parallel request cap** (`parallel.limit`)
- **Membership plan level** (`user.membership.level` → e.g. `Standard`)

Details:

- Provider aliases `kimi`, `kimi-code`, `moonshot`, `moonshot-cn` resolve to the same fetcher.
- Runtime base URLs without a `/v1` suffix are normalized before appending `/usages` (the provider's configured `base_url` is `https://api.kimi.com/coding` while the endpoint lives under `/v1`).
- Numeric fields arrive as JSON strings (`"limit": "100"`) and are parsed defensively; unparseable buckets are skipped instead of failing the whole snapshot, matching the existing fail-open style of the other fetchers.

Example render (from the test fixture):

```
📈 Account limits
Provider: kimi-coding (Standard)
Current week: 60% remaining (40% used) • resets in 8d 11h
Current 5h: 75% remaining (25% used) • resets in 4h 35m
Parallel requests: up to 30
```

## Tests

- 4 new tests in `tests/test_account_usage.py`: weekly+5h window parsing/rendering, provider aliases, missing-token `None`, malformed-number resilience.
- `pytest tests/test_account_usage.py` → 8 passed; full account-usage suite (including `tests/agent/test_account_usage.py`) → 21 passed.