### PR TITLE
fix(desktop): hold the quit while the "still working" confirmation is unanswered

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -147,7 +147,7 @@ import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
-import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitGuardAction, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   RemoteLivenessTracker,
@@ -2539,8 +2539,9 @@ let updateInFlight = false
 // actually dies and the hand-off script can proceed immediately.
 let isQuittingForHandoff = false
 
-// Quit-guard latches: one while the confirmation is on screen (a second
-// Cmd-Q must not stack dialogs), one after the user has said "quit anyway"
+// Quit-guard latches: one while the confirmation is on screen (a second Cmd-Q
+// must not stack dialogs, and must not quit out from under the unanswered one
+// either — see quitGuardAction), one after the user has said "quit anyway"
 // (the app.quit() that follows re-enters before-quit and must pass through).
 let quitPromptOpen = false
 let quitConfirmedWithActiveWork = false
@@ -11454,15 +11455,35 @@ function configureSpellChecker() {
 }
 
 // Ask before a quit kills a turn in flight. True when the quit was intercepted
-// and the confirmation is on screen; "Quit Anyway" re-enters before-quit with
-// the latch set and falls straight through to the teardown below.
+// — either because the confirmation was just raised, or because one is already
+// on screen; "Quit Anyway" re-enters before-quit with the latch set and falls
+// straight through to the teardown below.
 function heldQuitForActiveWork(event: Electron.Event): boolean {
-  if (SKIP_QUIT_CONFIRM || quitConfirmedWithActiveWork || quitPromptOpen) {
+  const action = quitGuardAction({
+    confirmed: quitConfirmedWithActiveWork,
+    promptOpen: quitPromptOpen,
+    skipConfirm: SKIP_QUIT_CONFIRM
+  })
+
+  if (action === 'proceed') {
     return false
   }
 
-  const prompt = quitPromptFor(mergeActiveWork(activeWorkByWebContents.values()), isQuittingForHandoff)
   const parent = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
+
+  if (action === 'hold') {
+    // A confirmation is already up and unanswered. Hold this quit and put the
+    // sheet back in front instead of quitting behind it.
+    event.preventDefault()
+
+    if (parent && !parent.isDestroyed()) {
+      parent.focus()
+    }
+
+    return true
+  }
+
+  const prompt = quitPromptFor(mergeActiveWork(activeWorkByWebContents.values()), isQuittingForHandoff)
 
   if (!prompt || !parent || parent.isDestroyed()) {
     return false

--- a/apps/desktop/electron/quit-guard.test.ts
+++ b/apps/desktop/electron/quit-guard.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { mergeActiveWork, normalizeActiveWork, quitGuardAction, quitPromptFor } from './quit-guard'
 
 test('normalizeActiveWork drops junk and keeps the count at least the title count', () => {
   assert.deepEqual(normalizeActiveWork(null), { count: 0, titles: [] })
@@ -59,4 +59,24 @@ test('quitPromptFor speaks singular for one chat', () => {
   assert.ok(prompt)
   assert.equal(prompt.message, 'Hermes is still working on 1 chat.')
   assert.ok(prompt.detail.includes('mid-turn'))
+})
+
+test('quitGuardAction asks on the first quit gesture', () => {
+  assert.equal(quitGuardAction({ confirmed: false, promptOpen: false, skipConfirm: false }), 'prompt')
+})
+
+test('quitGuardAction holds a second quit while the confirmation is unanswered', () => {
+  assert.equal(quitGuardAction({ confirmed: false, promptOpen: true, skipConfirm: false }), 'hold')
+})
+
+test('quitGuardAction lets the answered quit and automated teardown through', () => {
+  assert.equal(quitGuardAction({ confirmed: true, promptOpen: false, skipConfirm: false }), 'proceed')
+  assert.equal(quitGuardAction({ confirmed: false, promptOpen: false, skipConfirm: true }), 'proceed')
+})
+
+test('quitGuardAction keeps the fall-through latches ahead of the hold', () => {
+  // Both latches are cleared before app.quit() re-enters before-quit, but a
+  // hold that outranked them would deadlock the quit with no dialog to answer.
+  assert.equal(quitGuardAction({ confirmed: true, promptOpen: true, skipConfirm: false }), 'proceed')
+  assert.equal(quitGuardAction({ confirmed: false, promptOpen: true, skipConfirm: true }), 'proceed')
 })

--- a/apps/desktop/electron/quit-guard.ts
+++ b/apps/desktop/electron/quit-guard.ts
@@ -90,3 +90,36 @@ export function quitPromptFor(work: ActiveWork, quittingForHandoff: boolean): nu
     message: work.count === 1 ? 'Hermes is still working on 1 chat.' : `Hermes is still working on ${work.count} chats.`
   }
 }
+
+/** What `before-quit` should do with a quit request. */
+export type QuitGuardAction = 'hold' | 'proceed' | 'prompt'
+
+export interface QuitGuardState {
+  /** The user answered "Quit Anyway"; the `app.quit()` that follows must pass. */
+  confirmed: boolean
+  /** The confirmation is on screen and still unanswered. */
+  promptOpen: boolean
+  /** Automated teardown asked for no modal at all. */
+  skipConfirm: boolean
+}
+
+/**
+ * Route a quit request past, into, or away from the confirmation.
+ *
+ * `skipConfirm` and `confirmed` are deliberate fall-throughs: automated
+ * teardown has nobody to answer a modal, and "Quit Anyway" re-enters
+ * `before-quit` with the latch set and must not be caught a second time.
+ *
+ * `promptOpen` is not a fall-through. The dialog is window-modal and leaves
+ * the app menu and the Dock menu live, so a second quit gesture can arrive
+ * while it is still on screen. Letting that one through would tear the backend
+ * down mid-turn behind a confirmation the user never answered — the exact loss
+ * this guard exists to prevent — so it is held instead.
+ */
+export function quitGuardAction(state: QuitGuardState): QuitGuardAction {
+  if (state.skipConfirm || state.confirmed) {
+    return 'proceed'
+  }
+
+  return state.promptOpen ? 'hold' : 'prompt'
+}


### PR DESCRIPTION
## This is a sibling follow-up to commit 9ae3bd7

- **What the parent covered** — `9ae3bd7 feat(desktop): confirm before quitting with a turn in flight` added the active-work quit guard: `before-quit` intercepts the quit, `quit-guard.ts` decides the copy, and a modal asks "Keep Running / Quit Anyway" before the backend is torn down.
- **What the parent did NOT touch** — what happens to a **second** quit gesture that arrives while that confirmation is still on screen. `quitPromptOpen` was added to stop a second Cmd-Q from stacking dialogs, and it bought that by letting the quit through.
- **What this adds** — that second gesture is now *held* instead of let through, so the app cannot quit behind a confirmation the user never answered.

## What does this PR do?

**The bug is a data loss, not a cosmetic one.** With a turn in flight:

1. Cmd-Q → "Hermes is still working on 2 chats. Quitting stops the agent mid-turn. Any work it has not finished writing is lost."
2. While deciding, press Cmd-Q again (or Dock → Quit, or Hermes → Quit).
3. Hermes exits immediately. The backend is killed mid-tool-call, half-written files stay half-written, and the dialog is never answered.

That is precisely the loss the parent feature exists to prevent, and it is easy to hit: the dialog is window-modal (`dialog.showMessageBox(parent, …)`), so it does **not** disable the app menu or the Dock menu — every quit affordance stays live behind it.

Root cause, `apps/desktop/electron/main.ts`:

```ts
function heldQuitForActiveWork(event: Electron.Event): boolean {
  if (SKIP_QUIT_CONFIRM || quitConfirmedWithActiveWork || quitPromptOpen) {
    return false
  }
```

`return false` means `event.preventDefault()` is never called, so `before-quit` falls past

```ts
if (heldQuitForActiveWork(event)) {
  return
}
```

straight into the ssh teardown, backend stop and PTY disposal below it.

`SKIP_QUIT_CONFIRM` and `quitConfirmedWithActiveWork` belong in that condition — automated teardown (`579b6633`) has nobody to answer a modal, and the `app.quit()` after "Quit Anyway" re-enters `before-quit` and must pass through. Only `quitPromptOpen` is wrong.

The fix moves the decision into `apps/desktop/electron/quit-guard.ts`, whose header already declares that contract — *"The decision + copy live here (pure, testable) so main.ts only owns the IPC and the dialog call."* `quitPromptOpen` was the one piece of that decision that had leaked into `main.ts`, and putting it back makes the branch unit-testable with no Electron app running.

**Scope — every site of this root cause is covered.** `before-quit` is the only caller of `heldQuitForActiveWork` on `main`, and `dialog.showMessageBox` has exactly one call site in `main.ts` (the quit prompt itself), so there is no second guard of this shape to widen into. This composes cleanly with #73046, which adds a *second entry point* into the same guard for the Windows/Linux window-close gesture — that entry point is in fact another way to reach this bug, and it needs no change here.

## Related Issue

No filed issue — found while reading the quit path added by `9ae3bd7` (#72897).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/quit-guard.ts` — new pure `quitGuardAction(state): 'hold' | 'proceed' | 'prompt'`. `skipConfirm`/`confirmed` → `'proceed'` (checked first, so the fall-through latches always win); `promptOpen` → `'hold'`; otherwise → `'prompt'`.
- `apps/desktop/electron/main.ts` — `heldQuitForActiveWork` routes through `quitGuardAction`. `'hold'` calls `event.preventDefault()`, re-focuses the parent window so the pending sheet comes back to the user rather than the gesture being silently swallowed, and returns `true`. `'prompt'` keeps the existing `showMessageBox` path byte-for-byte; `parent` is just resolved a few lines earlier so both branches can share it. Also refreshed the two now-stale comments describing the latch.
- `apps/desktop/electron/quit-guard.test.ts` — four cases: first gesture prompts, a gesture during an unanswered prompt holds, the answered quit and automated teardown proceed, and both fall-through latches still outrank the hold (a `'hold'` that outranked them would deadlock a quit with no dialog left to answer).

## How to Test

**Reproduce on `main`:** start a turn, Cmd-Q, then press Cmd-Q again while the "still working" dialog is up — the app quits with the dialog unanswered. With this branch the second Cmd-Q does nothing except bring the sheet back to the front, and only "Quit Anyway" quits.

**Automated, no Electron required:**

```
cd apps/desktop && npx vitest run electron/quit-guard.test.ts
```

Fails-before / passes-after was verified explicitly. Reverting `quitGuardAction` to the old semantics (`promptOpen` folded into the `'proceed'` branch) turns exactly the new hold case red and leaves the other 11 green:

```
FAIL  quitGuardAction holds a second quit while the confirmation is unanswered
AssertionError: Expected values to be strictly equal:
  Expected: "hold"
  Received: "proceed"

Test Files  1 failed (1)
     Tests  1 failed | 11 passed (12)
```

With the fix restored: `12 passed (12)`.

Whole desktop electron suite, and typecheck/lint/format on the touched files:

```
cd apps/desktop
npx vitest run --project electron   # 837 passed | 2 skipped (839), 72 files passed | 1 skipped
npx tsc -p tsconfig.electron.json --noEmit   # clean
npx eslint electron/quit-guard.ts electron/quit-guard.test.ts   # clean
npx prettier --check electron/quit-guard.ts electron/quit-guard.test.ts   # clean
```

(`main.ts` carries one pre-existing `padding-line-between-statements` warning and one pre-existing Prettier deviation at line ~9270; both reproduce unchanged on clean `main` and are untouched here.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is desktop TypeScript; the vitest runs above are the equivalent gate
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the two stale `main.ts` comments describing the latch are updated; no user-facing docs describe this path
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the changed code is platform-independent and the new decision function is pure; only macOS was exercised by hand, the rest by the unit tests
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
