### PR TITLE
fix(kanban): keep Codex missions atomic

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -138,6 +138,128 @@ _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
 
 
+def is_atomic_codex_mission(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> bool:
+    """Return whether a task is or was owned by the atomic Codex lane."""
+    row = conn.execute(
+        """
+        SELECT EXISTS(
+            SELECT 1
+              FROM tasks
+             WHERE id = ?
+               AND lower(trim(COALESCE(assignee, ''))) = 'codex'
+        ) OR EXISTS(
+            SELECT 1
+              FROM task_runs
+             WHERE task_id = ?
+               AND lower(trim(COALESCE(profile, ''))) = 'codex'
+        )
+        """,
+        (task_id, task_id),
+    ).fetchone()
+    if row and row[0]:
+        return True
+    historical_assignments = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('created', 'assigned') "
+        "ORDER BY id DESC",
+        (task_id,),
+    ).fetchall()
+    for event in historical_assignments:
+        try:
+            payload = json.loads(event["payload"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        assignee = payload.get("assignee")
+        if isinstance(assignee, str) and assignee.strip().casefold() == "codex":
+            return True
+    return False
+
+
+def is_terminal_atomic_codex_mission(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> bool:
+    """Return whether an atomic Codex mission was delivered or remains blocked."""
+    if not is_atomic_codex_mission(conn, task_id):
+        return False
+    row = conn.execute(
+        """
+        SELECT EXISTS(
+                   SELECT 1
+                     FROM task_events
+                    WHERE task_id = ?
+                      AND kind = 'completed'
+               ) AS delivered,
+               (
+                   SELECT kind
+                     FROM task_events
+                    WHERE task_id = ?
+                      AND kind IN (
+                          'blocked',
+                          'dependency_wait',
+                          'block_loop_detected',
+                          'unblocked'
+                      )
+                    ORDER BY id DESC
+                    LIMIT 1
+               ) AS latest_block_kind
+        """,
+        (task_id, task_id),
+    ).fetchone()
+    return bool(
+        row
+        and (
+            row["delivered"]
+            or (
+                row["latest_block_kind"]
+                and row["latest_block_kind"] != "unblocked"
+            )
+        )
+    )
+
+
+def _generated_from_task_id(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> Optional[str]:
+    rows = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'created' ORDER BY id DESC",
+        (task_id,),
+    ).fetchall()
+    for row in rows:
+        try:
+            payload = json.loads(row["payload"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        source = payload.get("from_decompose_of")
+        if isinstance(source, str) and source:
+            return source
+    return None
+
+
+def is_terminal_atomic_codex_work(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> bool:
+    """Cover a terminal Codex root and all generated descendants."""
+    current_id: Optional[str] = task_id
+    visited: set[str] = set()
+    while current_id and current_id not in visited:
+        visited.add(current_id)
+        if is_terminal_atomic_codex_mission(conn, current_id):
+            return True
+        current_id = _generated_from_task_id(conn, current_id)
+    return False
+
+
 def _assert_not_delegated_child_mutation() -> None:
     """Reject Kanban state mutations from ``delegate_task`` child contexts.
 
@@ -4027,6 +4149,8 @@ def recompute_ready(
         for row in todo_rows:
             task_id = row["id"]
             cur_status = row["status"]
+            if is_terminal_atomic_codex_work(conn, task_id):
+                continue
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
                 # Worker / operator asked for human review — do not
                 # silently auto-recover.  ``unblock_task`` is the only
@@ -4092,6 +4216,14 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        if is_terminal_atomic_codex_work(conn, task_id):
+            _append_event(
+                conn,
+                task_id,
+                "claim_rejected",
+                {"reason": "terminal_atomic_codex_mission"},
+            )
+            return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -5511,11 +5643,13 @@ def block_task(
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, assignee, block_kind, block_recurrences "
+            "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
             return False
+        atomic_codex_mission = is_atomic_codex_mission(conn, task_id)
         prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
         prev_recurrences = (
             int(cur_row["block_recurrences"])
@@ -5528,7 +5662,7 @@ def block_task(
         # wait in ``todo`` and let ``recompute_ready`` gate on parents. Routing
         # here (rather than ``blocked``) is what keeps a cron from ever seeing
         # a dependency-wait as something to "unblock".
-        if kind == "dependency":
+        if kind == "dependency" and not atomic_codex_mission:
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -5579,7 +5713,7 @@ def block_task(
         same_cause = prev_kind == kind
         recurrences = prev_recurrences + 1 if same_cause else 1
 
-        if recurrences >= BLOCK_RECURRENCE_LIMIT:
+        if recurrences >= BLOCK_RECURRENCE_LIMIT and not atomic_codex_mission:
             # Loop detected — stop letting the unblocker spin this task. Route
             # to triage for a human-in-the-loop decision instead of blocked.
             cur = conn.execute(
@@ -5715,6 +5849,8 @@ def promote_task(
             f"task {task_id} is {cur_status!r}; promote only applies to "
             f"'todo' or 'blocked'"
         )
+    if is_terminal_atomic_codex_mission(conn, task_id):
+        return False, "terminal Codex missions cannot be promoted"
 
     if not force:
         parents = conn.execute(
@@ -5766,6 +5902,8 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     now = int(time.time())
     with write_txn(conn):
+        if is_terminal_atomic_codex_mission(conn, task_id):
+            return False
         stale = conn.execute(
             "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (task_id,),
@@ -5854,6 +5992,8 @@ def specify_triage_task(
             (task_id,),
         ).fetchone()
         if existing is None:
+            return False
+        if is_terminal_atomic_codex_mission(conn, task_id):
             return False
         sets: list[str] = ["status = 'todo'"]
         params: list[Any] = []
@@ -6011,6 +6151,8 @@ def decompose_triage_task(
         if root_row is None:
             return None
         if root_row["status"] != "triage":
+            return None
+        if is_atomic_codex_mission(conn, task_id):
             return None
         tenant = root_row["tenant"]
         # Children inherit the root's workspace by default so a fan-out
@@ -8274,6 +8416,8 @@ def _dispatch_once_locked(
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        if is_terminal_atomic_codex_work(conn, row["id"]):
+            continue
         row_assignee = row["assignee"]
         if not row_assignee:
             # Honour kanban.default_assignee: when the dispatcher hits an

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -283,8 +283,18 @@ def decompose_task(
     """
     with kb.connect_closing() as conn:
         task = kb.get_task(conn, task_id)
+        atomic_codex_mission = (
+            task is not None
+            and kb.is_atomic_codex_mission(conn, task_id)
+        )
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
+    if atomic_codex_mission:
+        return DecomposeOutcome(
+            task_id,
+            False,
+            "Codex missions are atomic and cannot be decomposed",
+        )
     if task.status != "triage":
         return DecomposeOutcome(
             task_id, False, f"task is not in triage (status={task.status!r})"
@@ -465,4 +475,8 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
             tenant=tenant,
             limit=1000,
         )
-    return [row.id for row in rows]
+        return [
+            row.id
+            for row in rows
+            if not kb.is_atomic_codex_mission(conn, row.id)
+        ]

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -145,6 +145,48 @@ def test_dependency_block_routes_to_todo(kanban_home: Path) -> None:
         assert t.block_kind == "dependency"
 
 
+def test_codex_dependency_block_stays_terminal(kanban_home: Path) -> None:
+    """An explicit Codex block never returns an atomic mission to the queue."""
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="atomic mission", assignee="codex")
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        assert kb.block_task(
+            conn,
+            tid,
+            reason="superseded dependency",
+            kind="dependency",
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.unblock_task(conn, tid) is False
+        promoted, reason = kb.promote_task(
+            conn,
+            tid,
+            actor="operator",
+            force=True,
+        )
+        assert promoted is False
+        assert reason == "terminal Codex missions cannot be promoted"
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_reassigned_unstarted_codex_block_stays_terminal(
+    kanban_home: Path,
+) -> None:
+    """The created event preserves Codex identity when no run exists yet."""
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="unstarted atomic mission",
+            assignee="codex",
+        )
+        assert kb.block_task(conn, task_id)
+        assert kb.assign_task(conn, task_id, "orchestrator")
+
+        assert kb.unblock_task(conn, task_id) is False
+        assert kb.get_task(conn, task_id).status == "blocked"
+
+
 def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
     """A dependency-parked child becomes ready once its parent completes."""
     with kb.connect_closing() as conn:

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -77,7 +77,12 @@ def _patch_list_profiles(names: list[str]):
 
 def test_decompose_with_fanout_creates_children(kanban_home):
     with kb.connect() as conn:
-        tid = kb.create_task(conn, title="ship a feature", triage=True)
+        tid = kb.create_task(
+            conn,
+            title="plan a multi-step feature",
+            assignee="planner",
+            triage=True,
+        )
 
     llm_payload = jsonlib.dumps({
         "fanout": True,
@@ -88,12 +93,16 @@ def test_decompose_with_fanout_creates_children(kanban_home):
         ],
     })
 
-    patches = _patch_list_profiles(["orchestrator", "researcher", "engineer"])
+    patches = _patch_list_profiles(
+        ["orchestrator", "planner", "researcher", "engineer"]
+    )
     for p in patches:
         p.start()
     try:
         with _patch_aux_client(llm_payload), _patch_extra_body():
             outcome = decomp.decompose_task(tid, author="me")
+        with kb.connect() as conn:
+            dispatch = kb.dispatch_once(conn, dry_run=True)
     finally:
         for p in patches:
             p.stop()
@@ -111,6 +120,218 @@ def test_decompose_with_fanout_creates_children(kanban_home):
     assert c1.status == "todo"
     assert c0.assignee == "researcher"
     assert c1.assignee == "engineer"
+    assert any(task_id == c0.id for task_id, _, _ in dispatch.spawned)
+
+
+def test_historical_codex_mission_cannot_be_decomposed(kanban_home):
+    """The guard survives stale triage status and later reassignment."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="already delivered",
+            assignee="codex",
+        )
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        assert kb.block_task(conn, tid, reason="superseded")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='triage', assignee='orchestrator' "
+                "WHERE id=?",
+                (tid,),
+            )
+
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = decomp.decompose_task(tid, author="auto-decomposer")
+
+    assert outcome.ok is False
+    assert "atomic" in outcome.reason
+    call_llm.assert_not_called()
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_links WHERE child_id=?",
+            (tid,),
+        ).fetchone()[0] == 0
+
+
+def test_blocked_codex_mission_is_not_redecomposed_or_dispatched(kanban_home):
+    """A delivered Codex mission stays atomic after a repeated block.
+
+    This reproduces the production loop: worker block, external unblock,
+    same-cause re-block, auto-decompose, then duplicate child dispatch.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="deliver the existing PR",
+            assignee="codex",
+        )
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        assert kb.block_task(
+            conn,
+            tid,
+            reason="PR already delivered",
+            kind="needs_input",
+        )
+        if kb.unblock_task(conn, tid):
+            assert kb.claim_task(conn, tid, claimer="worker") is not None
+            assert kb.block_task(
+                conn,
+                tid,
+                reason="PR already delivered",
+                kind="needs_input",
+            )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "obsolete split",
+        "tasks": [
+            {
+                "title": "Repeat research",
+                "body": "Re-open work that was already delivered.",
+                "assignee": "research",
+                "parents": [],
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator", "codex", "research"])
+    for p in patches:
+        p.start()
+    try:
+        outcomes = []
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            for triage_id in decomp.list_triage_ids():
+                outcomes.append(
+                    decomp.decompose_task(
+                        triage_id,
+                        author="auto-decomposer",
+                    )
+                )
+        with kb.connect() as conn:
+            dispatch = kb.dispatch_once(conn, dry_run=True)
+            root = kb.get_task(conn, tid)
+            children = conn.execute(
+                "SELECT id FROM tasks WHERE id != ?",
+                (tid,),
+            ).fetchall()
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert root is not None
+    assert root.status == "blocked"
+    assert outcomes == []
+    assert children == []
+    assert dispatch.spawned == []
+
+
+def test_existing_generated_child_of_terminal_codex_mission_is_not_claimed(
+    kanban_home,
+):
+    """Legacy duplicate children are inert even if they are already ready."""
+    with kb.connect() as conn:
+        root_id = kb.create_task(
+            conn,
+            title="delivered Codex mission",
+            assignee="codex",
+        )
+        assert kb.claim_task(conn, root_id, claimer="worker") is not None
+        assert kb.block_task(conn, root_id, reason="delivered")
+
+        child_id = kb.create_task(
+            conn,
+            title="obsolete Research duplicate",
+            assignee="research",
+            created_by="auto-decomposer",
+        )
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='todo', assignee='orchestrator' "
+                "WHERE id=?",
+                (root_id,),
+            )
+            conn.execute(
+                "INSERT INTO task_events "
+                "(task_id, kind, payload, created_at) "
+                "VALUES (?, 'created', ?, 1)",
+                (
+                    child_id,
+                    jsonlib.dumps({"from_decompose_of": root_id}),
+                ),
+            )
+
+        dispatch = kb.dispatch_once(conn, dry_run=True)
+        claim = kb.claim_task(conn, child_id, claimer="worker")
+
+    assert dispatch.spawned == []
+    assert claim is None
+
+
+def test_legacy_reviewer_descendant_of_terminal_codex_mission_is_inert(
+    kanban_home,
+):
+    """The terminal guard follows obsolete Coding to Reviewer chains."""
+    with kb.connect() as conn:
+        root_id = kb.create_task(
+            conn,
+            title="delivered Codex mission",
+            assignee="codex",
+        )
+        assert kb.block_task(conn, root_id, reason="PR already delivered")
+
+        coding_id = kb.create_task(
+            conn,
+            title="obsolete Coding child",
+            assignee="coding",
+            created_by="auto-decomposer",
+        )
+        reviewer_id = kb.create_task(
+            conn,
+            title="obsolete Reviewer grandchild",
+            assignee="reviewer",
+            created_by="legacy-recovery",
+        )
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events "
+                "(task_id, kind, payload, created_at) "
+                "VALUES (?, 'created', ?, 1), (?, 'created', ?, 2)",
+                (
+                    coding_id,
+                    jsonlib.dumps({"from_decompose_of": root_id}),
+                    reviewer_id,
+                    jsonlib.dumps({"from_decompose_of": coding_id}),
+                ),
+            )
+
+        claim = kb.claim_task(conn, reviewer_id, claimer="worker")
+
+    assert claim is None
+
+
+def test_completed_codex_mission_cannot_be_claimed_after_stale_requeue(
+    kanban_home,
+):
+    """A delivered Codex mission stays terminal even if its status regresses."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="already delivered Codex mission",
+            assignee="codex",
+        )
+        assert kb.claim_task(conn, task_id, claimer="worker") is not None
+        assert kb.complete_task(conn, task_id, summary="PR delivered")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='ready', completed_at=NULL WHERE id=?",
+                (task_id,),
+            )
+
+        dispatch = kb.dispatch_once(conn, dry_run=True)
+        claim = kb.claim_task(conn, task_id, claimer="worker")
+
+    assert dispatch.spawned == []
+    assert claim is None
 
 
 def test_decompose_fanout_false_assigns_default_when_unassigned(kanban_home):

--- a/tests/hermes_cli/test_kanban_specify_db.py
+++ b/tests/hermes_cli/test_kanban_specify_db.py
@@ -52,6 +52,28 @@ def test_specify_promotes_triage_to_todo(kanban_home):
     assert "**Goal**" in (task.body or "")
 
 
+def test_specify_fresh_codex_triage_task_preserves_atomic_assignee(
+    kanban_home,
+):
+    with kb.connect() as conn:
+        task_id = _create_triage(
+            conn,
+            title="rough Codex mission",
+            assignee="codex",
+        )
+        ok = kb.specify_triage_task(
+            conn,
+            task_id,
+            body="Implement and self-review this mission.",
+            author="operator",
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert ok is True
+    assert task.status == "ready"
+    assert task.assignee == "codex"
+
+
 def test_specify_with_open_parent_lands_in_todo_not_ready(kanban_home):
     # Parent-gated specified tasks must not jump the dispatcher — they go
     # to todo and wait for parent completion like any other gated task.


### PR DESCRIPTION
## Summary
- keep blocked or delivered Codex missions terminal across recompute, manual promotion, claims, dispatch, and auto-decomposition
- preserve historical Codex identity and stop transitive legacy Coding → Reviewer descendants
- preserve fresh Planner decomposition and fresh Codex specification without adding a Reviewer path

## Root cause
Generic block routing moved dependency blocks to `todo` and recurring blocks to `triage`. The auto-decomposer then reassigned the stale root and created dispatchable duplicate children.

## Tests
- RED reproduced for blocked Codex → requeue → decomposition/dispatch
- RED reproduced for delivered stale requeue, reassigned unstarted Codex work, and transitive Reviewer descendants
- `python -m pytest -q tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py tests/hermes_cli/test_kanban_specify_db.py tests/hermes_cli/test_kanban_promote.py tests/hermes_cli/test_kanban_blocked_sticky.py` — 71 passed
- broad Kanban/dispatcher run — 481 passed, 1 skipped, with unrelated order-dependent lifecycle-hook cache failures documented locally
- `git diff --check` — clean

## Self-review
Independent review found and fixed two in-scope gaps: historical Codex identity after reassignment and transitive legacy child ancestry. No independent Reviewer mission is introduced.

DO NOT MERGE automatically.