### PR TITLE
fix(dashboard): preserve launch profile in deep links

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18812,12 +18812,27 @@ def mount_spa(application: FastAPI):
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
         gated_js = "true" if gated else "false"
+        # ``--open-profile`` historically lived only in the one URL opened by
+        # _maybe_open_browser().  A direct SPA deep link (notably
+        # /chat?resume=...) therefore lost the launch profile and silently
+        # fell back to the machine/default scope.  Preserve it in the same
+        # no-cache bootstrap as the session/auth flags so every entry route
+        # can initialize the same management/chat scope.  Escape ``<`` to
+        # prevent a profile name containing ``</script>`` from terminating
+        # the inline script.
+        initial_profile = str(
+            getattr(application.state, "initial_profile", "") or ""
+        )
+        initial_profile_js = json.dumps(
+            initial_profile, ensure_ascii=False
+        ).replace("<", "\\u003c")
         if gated:
             bootstrap_script = (
                 f"<script>"
                 f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
                 f'window.__HERMES_BASE_PATH__="{prefix}";'
                 f"window.__HERMES_AUTH_REQUIRED__={gated_js};"
+                f"window.__HERMES_INITIAL_PROFILE__={initial_profile_js};"
                 f"</script>"
             )
         else:
@@ -18826,6 +18841,7 @@ def mount_spa(application: FastAPI):
                 f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
                 f'window.__HERMES_BASE_PATH__="{prefix}";'
                 f"window.__HERMES_AUTH_REQUIRED__={gated_js};"
+                f"window.__HERMES_INITIAL_PROFILE__={initial_profile_js};"
                 f"</script>"
             )
         if prefix:
@@ -20080,6 +20096,9 @@ def start_server(
     # uses this to decide whether to refuse the bind, log the gate-on
     # banner, and enable uvicorn proxy_headers.
     app.state.auth_required = should_require_auth(host)
+    # The SPA is mounted at import time, so expose this launch-time value
+    # through app.state for _serve_index() to read per request.
+    app.state.initial_profile = initial_profile
 
     # ``--insecure`` no longer disables the auth gate (June 2026 hardening:
     # the hermes-0day MCP-persistence campaign abused unauthenticated public

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -10171,6 +10171,58 @@ class TestServeIndexMissingIndex:
         assert "SPA-rebuilt" in resp.text
 
 
+class TestServeIndexInitialProfile:
+    """Direct SPA routes retain the profile passed to dashboard launch."""
+
+    def test_injects_initial_profile_for_direct_chat_deep_links(
+        self, tmp_path, monkeypatch
+    ):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        dist = tmp_path / "web_dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            "<html><head></head><body>SPA</body></html>", encoding="utf-8"
+        )
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+        monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
+
+        spa_app = FastAPI()
+        spa_app.state.initial_profile = "research"
+        ws.mount_spa(spa_app)
+
+        response = TestClient(spa_app).get("/chat?resume=session-1")
+
+        assert response.status_code == 200
+        assert 'window.__HERMES_INITIAL_PROFILE__="research";' in response.text
+
+    def test_escapes_initial_profile_in_inline_bootstrap(
+        self, tmp_path, monkeypatch
+    ):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        dist = tmp_path / "web_dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            "<html><head></head><body>SPA</body></html>", encoding="utf-8"
+        )
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+        monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
+
+        spa_app = FastAPI()
+        spa_app.state.initial_profile = "</script><script>alert(1)</script>"
+        ws.mount_spa(spa_app)
+
+        response = TestClient(spa_app).get("/")
+
+        assert "</script><script>alert(1)</script>" not in response.text
+        assert "\\u003c/script>" in response.text
+
+
 class TestDashboardComponentHealth:
     """Component-health rollup: error middleware, /api/status components, self-test."""
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -85,6 +85,19 @@ def test_start_server_applies_process_local_ssh_bootstrap_state(monkeypatch):
     assert captured["port"] == 0
 
 
+def test_start_server_preserves_initial_profile_for_spa_deep_links(monkeypatch):
+    _stub_uvicorn(monkeypatch)
+
+    web_server.start_server(
+        host="127.0.0.1",
+        port=0,
+        open_browser=False,
+        initial_profile="research",
+    )
+
+    assert web_server.app.state.initial_profile == "research"
+
+
 def test_start_server_disables_ws_ping_on_loopback(monkeypatch):
     """Loopback binds (the Desktop case) MUST disable uvicorn's protocol-level
     keepalive ping so an event-loop stall can never trigger a false disconnect.

--- a/web/src/contexts/ProfileProvider.test.ts
+++ b/web/src/contexts/ProfileProvider.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { initialProfileScope } from "@/contexts/profile-scope";
+
+describe("initialProfileScope", () => {
+  it("uses the dashboard launch profile when a deep link omits profile", () => {
+    expect(initialProfileScope(null, "research")).toBe("research");
+  });
+
+  it("keeps an explicit URL profile ahead of the launch profile", () => {
+    expect(initialProfileScope("coding", "research")).toBe("coding");
+  });
+
+  it("preserves an explicit empty profile scope", () => {
+    expect(initialProfileScope("", "research")).toBe("");
+  });
+
+  it("uses the dashboard process scope when neither source is present", () => {
+    expect(initialProfileScope(null, undefined)).toBe("");
+  });
+});

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -8,6 +8,15 @@ import {
 import { useLocation, useSearchParams } from "react-router-dom";
 import { api, setManagementProfile } from "@/lib/api";
 import { ProfileContext } from "@/contexts/profile-context";
+import { initialProfileScope } from "@/contexts/profile-scope";
+
+declare global {
+  interface Window {
+    /** Profile passed to `hermes dashboard --open-profile`, injected by the
+     * server so direct SPA deep links retain the launch scope. */
+    __HERMES_INITIAL_PROFILE__?: string;
+  }
+}
 
 /**
  * Machine-level management-profile scope.
@@ -38,11 +47,14 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   const { pathname } = useLocation();
   const [profiles, setProfiles] = useState<string[]>([]);
   const [currentProfile, setCurrentProfile] = useState("default");
+  const launchProfile =
+    typeof window === "undefined" ? "" : window.__HERMES_INITIAL_PROFILE__;
 
-  // Initial value comes from the URL (deep link / refresh / unified-launch
-  // preselect); afterwards state leads and the URL follows.
+  // Initial value comes from an explicit URL first, then the unified-launch
+  // profile injected by the server. Afterwards state leads and the URL
+  // follows.
   const [profile, setProfileState] = useState(
-    () => searchParams.get("profile") ?? "",
+    () => initialProfileScope(searchParams.get("profile"), launchProfile),
   );
 
   // Mirror into the api module synchronously on every render where it
@@ -96,7 +108,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
         // sticky active profile so Chat and management pages match what the
         // Profiles page shows as "active" (machine dashboard runs as
         // `current`, usually default).
-        if (urlProfile === null && active !== current) {
+        if (urlProfile === null && !launchProfile && active !== current) {
           setManagementProfile(active);
           setProfileState(active);
         }

--- a/web/src/contexts/profile-scope.ts
+++ b/web/src/contexts/profile-scope.ts
@@ -1,0 +1,12 @@
+/**
+ * Resolve the dashboard's first profile scope.
+ *
+ * An explicit deep-link scope always wins. The launch profile is only the
+ * default for routes such as `/chat?resume=...` that omit `?profile=`.
+ */
+export function initialProfileScope(
+  urlProfile: string | null,
+  launchProfile: string | undefined,
+): string {
+  return urlProfile ?? launchProfile ?? "";
+}


### PR DESCRIPTION
## Summary

- preserve `--open-profile` in the server-rendered SPA bootstrap instead of only the auto-opened browser URL
- initialize the dashboard profile scope from that launch profile when a direct route omits `?profile=`
- keep an explicit URL profile authoritative
- escape the injected value for safe inline-script embedding

Closes #73085.

## Root cause

Unified dashboard launch passes the selected profile to `start_server(initial_profile=...)`, but that value was only consumed by `_maybe_open_browser()`. A fresh direct route such as `/chat?resume=<id>` therefore had no profile in its URL or bootstrap state. `ProfileProvider` initialized an empty scope and could align to the machine active/default profile, while the UI had originally been launched for another profile.

## Validation

- `python scripts/run_tests_parallel.py tests/test_web_server.py tests/hermes_cli/test_web_server.py -k "start_server or ServeIndex"` (10 passed)
- `npm --workspace web test -- --run src/contexts/ProfileProvider.test.ts` (4 passed)
- `npm --workspace web run typecheck`
- `npm --workspace web run build`
- `ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`

## Behavior

A direct `/chat?resume=...` deep link now inherits the profile supplied by unified dashboard launch. `?profile=other` still wins when explicitly present, and dashboards launched without `--open-profile` retain the existing active-profile fallback behavior.