### PR TITLE
fix(gateway): flush pending messages to disk before shutdown clear (#72680)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6073,6 +6073,12 @@ class BasePlatformAdapter(ABC):
         self._background_tasks.clear()
         self._expected_cancelled_tasks.clear()
         self._session_tasks.clear()
+        # Flush pending messages to disk before clearing (#72680).
+        try:
+            from gateway.shutdown_flush import flush_pending_to_file
+            flush_pending_to_file(self._pending_messages, reason="adapter_shutdown")
+        except Exception:
+            pass
         self._pending_messages.clear()
         self._active_sessions.clear()
         for state in list(self._text_debounce_store().values()):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9968,6 +9968,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._running_agents_ts.clear()
             if hasattr(self, "_active_session_leases"):
                 self._active_session_leases.clear()
+            # Flush pending messages to disk before clearing (#72680).
+            # When FTS5 corruption prevents message persistence, the
+            # in-memory _pending_messages dict holds the only surviving
+            # copy.  Clearing without flushing causes permanent data loss.
+            try:
+                from gateway.shutdown_flush import flush_pending_to_file
+                flush_pending_to_file(self._pending_messages, reason="shutdown")
+            except Exception:
+                pass
             self._pending_messages.clear()
             self._pending_approvals.clear()
             if hasattr(self, '_busy_ack_ts'):
@@ -24490,6 +24499,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     success = await runner.start()
     if not success:
         return False
+    # Recover any pending messages flushed during a previous shutdown (#72680).
+    try:
+        from gateway.shutdown_flush import recover_pending_to_db
+        recovered = recover_pending_to_db()
+        if recovered:
+            logger.info(
+                "Recovered %d pending message(s) from shutdown flush", recovered,
+            )
+    except Exception:
+        pass
     if runner.should_exit_cleanly:
         if runner.exit_reason:
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -8,11 +8,12 @@ This module provides two hooks:
 
 1. ``flush_pending_to_file()`` — called BEFORE ``_pending_messages.clear()``
    during shutdown.  Serialises any non-empty pending slots to a JSON file
-   under ``~/.hermes/pending_messages/``.
+   under ``<hermes_home>/pending_messages/``.
 
 2. ``recover_pending_to_db()`` — called AFTER ``runner.start()`` on startup.
-   Reads flush files, inserts messages directly into state.db, then deletes
-   the flush file on success.
+   Reads flush files, inserts messages into state.db via ``SessionDB.append_message``
+   (so FTS indexing, session metadata, and display_kind are handled correctly),
+   then deletes the flush file on success.
 
 See issue #72680 for the full incident report.
 """
@@ -22,17 +23,19 @@ from __future__ import annotations
 import json
 import logging
 import time
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-_FLUSH_DIR = Path.home() / ".hermes" / "pending_messages"
 
+def _get_flush_dir():
+    """Return the pending-messages flush directory under the active HERMES_HOME."""
+    from hermes_constants import get_hermes_home
+    from pathlib import Path
 
-def _get_flush_dir() -> Path:
-    _FLUSH_DIR.mkdir(parents=True, exist_ok=True)
-    return _FLUSH_DIR
+    flush_dir = get_hermes_home() / "pending_messages"
+    flush_dir.mkdir(parents=True, exist_ok=True)
+    return flush_dir
 
 
 def flush_pending_to_file(
@@ -125,35 +128,39 @@ def _serialise_value(value: Any) -> Optional[dict]:
 
 
 def recover_pending_to_db(
-    db_path: Optional[Path] = None,
+    session_db=None,
 ) -> int:
-    """Recover flushed pending messages into state.db.
+    """Recover flushed pending messages into state.db via SessionDB.
 
     Reads all ``*.json`` files from the flush directory, inserts messages
-    into the ``messages`` table, and deletes the file on success.
+    using ``SessionDB.append_message`` (so FTS indexing, session metadata
+    updates, and all required columns are handled correctly), and deletes
+    the flush file on success.
 
     Parameters
     ----------
-    db_path:
-        Path to state.db.  Defaults to ``~/.hermes/state.db``.
+    session_db:
+        An existing ``SessionDB`` instance.  If ``None``, a new one is
+        opened on the default ``state.db`` path.
 
     Returns
     -------
     int
         Number of messages recovered.
     """
-    import sqlite3
+    from pathlib import Path
 
     flush_dir = _get_flush_dir()
     flush_files = sorted(flush_dir.glob("*.json"))
     if not flush_files:
         return 0
 
-    if db_path is None:
-        db_path = Path.home() / ".hermes" / "state.db"
-    if not db_path.exists():
-        logger.warning("state.db not found at %s — skipping recovery", db_path)
-        return 0
+    # Use the provided SessionDB or open one on the default path.
+    own_db = False
+    if session_db is None:
+        from hermes_state import SessionDB
+        session_db = SessionDB()
+        own_db = True
 
     recovered = 0
     for path in flush_files:
@@ -166,27 +173,48 @@ def recover_pending_to_db(
                 path.unlink(missing_ok=True)
                 continue
 
-            conn = sqlite3.connect(str(db_path))
-            try:
-                conn.execute(
-                    "INSERT INTO messages (session_key, role, content, created_at) "
-                    "VALUES (?, ?, ?, ?)",
-                    (session_key, "user", text, payload.get("ts", int(time.time()))),
-                )
-                conn.commit()
-                recovered += 1
-                path.unlink(missing_ok=True)
-            except Exception as exc:
+            # The session_key is a gateway routing key (e.g.
+            # "agent:main:telegram:supergroup:...").  We need the actual
+            # session_id (e.g. "20260728_120000_abc123") to append a
+            # message row.  Try the session_id field from the serialised
+            # data first; fall back to scanning sessions for a matching
+            # session_key in the source column.
+            session_id = data.get("session_id", "")
+
+            if not session_id:
+                # Try to extract from the session_key itself — gateway
+                # session keys contain the session_id as the last segment
+                # in some formats, but that's not guaranteed.  Log and
+                # skip if we can't resolve it.
                 logger.warning(
-                    "Failed to recover pending message for %s: %s",
-                    session_key, exc,
+                    "Cannot recover pending message for %s: no session_id "
+                    "in flush file and session_key-to-id resolution is not "
+                    "available at this recovery stage. The message text is "
+                    "preserved in %s",
+                    session_key, path,
                 )
-                # Re-save so next startup can retry
-            finally:
-                conn.close()
-        except Exception as exc:
-            logger.debug("Failed to read flush file %s: %s", path, exc)
+                continue
+
+            session_db.append_message(
+                session_id=session_id,
+                role="user",
+                content=text,
+                timestamp=payload.get("ts", int(time.time())),
+            )
+            recovered += 1
             path.unlink(missing_ok=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to recover pending message from %s: %s",
+                path, exc,
+            )
+            # Leave the file for next startup retry.
+
+    if own_db:
+        try:
+            session_db.close()
+        except Exception:
+            pass
 
     if recovered:
         logger.info(

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -1,0 +1,195 @@
+"""Flush pending messages to disk before shutdown to prevent data loss.
+
+When FTS5 index corruption prevents ``INSERT INTO messages``, the gateway
+accumulates messages in ``_pending_messages`` (memory-only).  On shutdown,
+``.clear()`` discards the only surviving copy — permanent user data loss.
+
+This module provides two hooks:
+
+1. ``flush_pending_to_file()`` — called BEFORE ``_pending_messages.clear()``
+   during shutdown.  Serialises any non-empty pending slots to a JSON file
+   under ``~/.hermes/pending_messages/``.
+
+2. ``recover_pending_to_db()`` — called AFTER ``runner.start()`` on startup.
+   Reads flush files, inserts messages directly into state.db, then deletes
+   the flush file on success.
+
+See issue #72680 for the full incident report.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_FLUSH_DIR = Path.home() / ".hermes" / "pending_messages"
+
+
+def _get_flush_dir() -> Path:
+    _FLUSH_DIR.mkdir(parents=True, exist_ok=True)
+    return _FLUSH_DIR
+
+
+def flush_pending_to_file(
+    pending: Dict[str, Any],
+    *,
+    reason: str = "shutdown",
+) -> int:
+    """Serialise non-empty ``_pending_messages`` slots to disk.
+
+    Parameters
+    ----------
+    pending:
+        The adapter or runner ``_pending_messages`` dict.  Values may be
+        ``MessageEvent`` objects (adapter) or plain strings (runner).
+    reason:
+        Logged context (``shutdown``, ``restart``, etc.).
+
+    Returns
+    -------
+    int
+        Number of sessions flushed.
+    """
+    if not pending:
+        return 0
+
+    flush_dir = _get_flush_dir()
+    ts = int(time.time())
+    flushed = 0
+
+    for session_key, value in list(pending.items()):
+        if value is None:
+            continue
+        try:
+            serialised = _serialise_value(value)
+            if serialised is None:
+                continue
+            safe_key = session_key.replace("/", "_").replace("\\", "_")
+            path = flush_dir / f"{safe_key}_{ts}.json"
+            path.write_text(
+                json.dumps({
+                    "session_key": session_key,
+                    "reason": reason,
+                    "ts": ts,
+                    "data": serialised,
+                }, ensure_ascii=False, default=str),
+                encoding="utf-8",
+            )
+            flushed += 1
+        except Exception as exc:
+            logger.debug(
+                "Failed to flush pending message for %s: %s",
+                session_key, exc,
+            )
+
+    if flushed:
+        logger.info(
+            "Flushed %d pending message(s) to %s (reason=%s)",
+            flushed, flush_dir, reason,
+        )
+    return flushed
+
+
+def _serialise_value(value: Any) -> Optional[dict]:
+    """Convert a pending message value to a JSON-serialisable dict."""
+    # MessageEvent objects have a .text attribute and other fields
+    if hasattr(value, "text"):
+        result: Dict[str, Any] = {"text": getattr(value, "text", "")}
+        # Preserve additional fields if present
+        for attr in ("session_id", "platform", "sender_id", "sender_name",
+                      "reply_to", "media", "raw_event"):
+            val = getattr(value, attr, None)
+            if val is not None:
+                try:
+                    json.dumps(val)
+                    result[attr] = val
+                except (TypeError, ValueError):
+                    result[attr] = str(val)
+        return result
+    # Plain string (runner-level _pending_messages)
+    if isinstance(value, str):
+        return {"text": value}
+    # Dict — try direct serialisation
+    if isinstance(value, dict):
+        try:
+            json.dumps(value)
+            return value
+        except (TypeError, ValueError):
+            return {"text": str(value)}
+    return {"text": str(value)}
+
+
+def recover_pending_to_db(
+    db_path: Optional[Path] = None,
+) -> int:
+    """Recover flushed pending messages into state.db.
+
+    Reads all ``*.json`` files from the flush directory, inserts messages
+    into the ``messages`` table, and deletes the file on success.
+
+    Parameters
+    ----------
+    db_path:
+        Path to state.db.  Defaults to ``~/.hermes/state.db``.
+
+    Returns
+    -------
+    int
+        Number of messages recovered.
+    """
+    import sqlite3
+
+    flush_dir = _get_flush_dir()
+    flush_files = sorted(flush_dir.glob("*.json"))
+    if not flush_files:
+        return 0
+
+    if db_path is None:
+        db_path = Path.home() / ".hermes" / "state.db"
+    if not db_path.exists():
+        logger.warning("state.db not found at %s — skipping recovery", db_path)
+        return 0
+
+    recovered = 0
+    for path in flush_files:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            session_key = payload.get("session_key", "")
+            data = payload.get("data", {})
+            text = data.get("text", "")
+            if not text or not session_key:
+                path.unlink(missing_ok=True)
+                continue
+
+            conn = sqlite3.connect(str(db_path))
+            try:
+                conn.execute(
+                    "INSERT INTO messages (session_key, role, content, created_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (session_key, "user", text, payload.get("ts", int(time.time()))),
+                )
+                conn.commit()
+                recovered += 1
+                path.unlink(missing_ok=True)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to recover pending message for %s: %s",
+                    session_key, exc,
+                )
+                # Re-save so next startup can retry
+            finally:
+                conn.close()
+        except Exception as exc:
+            logger.debug("Failed to read flush file %s: %s", path, exc)
+            path.unlink(missing_ok=True)
+
+    if recovered:
+        logger.info(
+            "Recovered %d pending message(s) from shutdown flush", recovered,
+        )
+    return recovered

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -1,0 +1,199 @@
+"""Tests for gateway/shutdown_flush.py — pending message durability (#72680)."""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.shutdown_flush import (
+    _serialise_value,
+    flush_pending_to_file,
+    recover_pending_to_db,
+)
+
+
+def _make_flush_dir(tmp_path: Path) -> Path:
+    """Create a temp flush dir and monkeypatch _get_flush_dir to use it."""
+    flush_dir = tmp_path / "pending_messages"
+    flush_dir.mkdir(parents=True, exist_ok=True)
+    return flush_dir
+
+
+def test_flush_empty_pending_is_noop(tmp_path, monkeypatch):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    assert flush_pending_to_file({}, reason="test") == 0
+    assert list(flush_dir.glob("*.json")) == []
+
+
+def test_flush_writes_string_pending_to_file(tmp_path, monkeypatch):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    pending = {"agent:main:telegram:supergroup:123": "hello world"}
+    count = flush_pending_to_file(pending, reason="shutdown")
+    assert count == 1
+    files = list(flush_dir.glob("*.json"))
+    assert len(files) == 1
+    payload = json.loads(files[0].read_text(encoding="utf-8"))
+    assert payload["session_key"] == "agent:main:telegram:supergroup:123"
+    assert payload["reason"] == "shutdown"
+    assert payload["data"]["text"] == "hello world"
+
+
+def test_flush_writes_message_event_to_file(tmp_path, monkeypatch):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    event = MagicMock()
+    event.text = "user message"
+    event.session_id = "20260728_120000_abc"
+    event.platform = "telegram"
+    event.sender_id = "456"
+    event.sender_name = "Alice"
+    event.reply_to = None
+    event.media = None
+    event.raw_event = None
+
+    count = flush_pending_to_file({"session_key_1": event}, reason="adapter_shutdown")
+    assert count == 1
+    files = list(flush_dir.glob("*.json"))
+    assert len(files) == 1
+    payload = json.loads(files[0].read_text(encoding="utf-8"))
+    assert payload["data"]["text"] == "user message"
+    assert payload["data"]["session_id"] == "20260728_120000_abc"
+
+
+def test_recover_no_flush_files_is_noop(tmp_path, monkeypatch):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    mock_db = MagicMock()
+    assert recover_pending_to_db(mock_db) == 0
+    mock_db.append_message.assert_not_called()
+
+
+def test_recover_inserts_via_append_message_and_deletes_file(tmp_path, monkeypatch):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    ts = int(time.time())
+    # Write a flush file with session_id
+    payload = {
+        "session_key": "agent:main:telegram:supergroup:123",
+        "reason": "shutdown",
+        "ts": ts,
+        "data": {
+            "text": "lost message",
+            "session_id": "20260728_120000_abc",
+        },
+    }
+    flush_file = flush_dir / "test_session_123.json"
+    flush_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    mock_db = MagicMock()
+    count = recover_pending_to_db(mock_db)
+
+    assert count == 1
+    mock_db.append_message.assert_called_once_with(
+        session_id="20260728_120000_abc",
+        role="user",
+        content="lost message",
+        timestamp=ts,
+    )
+    assert not flush_file.exists()
+
+
+def test_recover_skips_file_without_session_id(tmp_path, monkeypatch):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    payload = {
+        "session_key": "some_key",
+        "reason": "shutdown",
+        "ts": int(time.time()),
+        "data": {"text": "no session id"},
+    }
+    flush_file = flush_dir / "no_sid.json"
+    flush_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    mock_db = MagicMock()
+    count = recover_pending_to_db(mock_db)
+
+    assert count == 0
+    mock_db.append_message.assert_not_called()
+    # File preserved for manual recovery
+    assert flush_file.exists()
+
+
+def test_recover_deletes_empty_text_file(tmp_path, monkeypatch):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    payload = {
+        "session_key": "some_key",
+        "reason": "shutdown",
+        "ts": int(time.time()),
+        "data": {"text": "", "session_id": "sid"},
+    }
+    flush_file = flush_dir / "empty.json"
+    flush_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    mock_db = MagicMock()
+    count = recover_pending_to_db(mock_db)
+
+    assert count == 0
+    assert not flush_file.exists()
+
+
+def test_serialise_string():
+    assert _serialise_value("hello") == {"text": "hello"}
+
+
+def test_serialise_dict():
+    assert _serialise_value({"text": "hi"}) == {"text": "hi"}
+
+
+def test_serialise_object_with_text():
+    obj = MagicMock()
+    obj.text = "msg"
+    obj.session_id = "sid"
+    obj.platform = None
+    obj.sender_id = None
+    obj.sender_name = None
+    obj.reply_to = None
+    obj.media = None
+    obj.raw_event = None
+    result = _serialise_value(obj)
+    assert result is not None
+    assert result["text"] == "msg"
+    assert result["session_id"] == "sid"
+
+
+def test_get_flush_dir_uses_get_hermes_home(tmp_path, monkeypatch):
+    """Flush dir must use get_hermes_home(), not hardcoded Path.home()."""
+    import gateway.shutdown_flush as mod
+
+    captured = {}
+
+    def fake_get_hermes_home():
+        from pathlib import Path
+        captured["called"] = True
+        return tmp_path
+
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home", fake_get_hermes_home
+    )
+    result = mod._get_flush_dir()
+    assert captured.get("called") is True
+    assert result == tmp_path / "pending_messages"


### PR DESCRIPTION
## Summary
Pending gateway messages that couldn't be persisted (FTS5 corruption) are now flushed to disk before shutdown clear() and recovered on next startup via SessionDB.append_message — preventing permanent user data loss. Salvage of #73020 by @JonthanaHanh (cherry-picked, authorship preserved).

Root cause: when FTS5 index corruption prevents `INSERT INTO messages`, the gateway accumulates messages in `_pending_messages` (memory-only). On shutdown, `.clear()` discards the only surviving copy.

## Changes
- `gateway/shutdown_flush.py` (new): `flush_pending_to_file()` serialises non-empty pending slots to JSON files under `<hermes_home>/pending_messages/`; `recover_pending_to_db()` reads them back and inserts via `SessionDB.append_message` (handles FTS indexing, session metadata, all required columns)
- `gateway/run.py`: flush runner `_pending_messages` before `clear()` in `_stop_impl_body`; recover on startup after `runner.start()`
- `gateway/platforms/base.py`: flush adapter `_pending_messages` before `clear()` in adapter shutdown path

## Salvage fixes (ours)
The original PR's `recover_pending_to_db` had three critical defects, all fixed:
1. **Wrong schema**: used `INSERT INTO messages (session_key, role, content, created_at)` — actual columns are `(session_id, role, content, timestamp)`. Would have crashed on every recovery.
2. **Bypassed SessionDB.append_message**: raw sqlite3 INSERT skipped FTS indexing, session metadata updates (message_count), display_kind, and all other columns. Recovered messages would be invisible to session_search.
3. **Hardcoded `Path.home() / ".hermes"`**: replaced with `get_hermes_home()` for profile-aware path resolution.

## Validation
| Check | Result |
|---|---|
| 11 new tests (flush, recovery, serialisation, edge cases) | all pass |
| ruff on changed files | clean |
| py_compile | clean |

Closes #73020

Based on #73020 by @JonthanaHanh — commit cherry-picked to preserve authorship.
