### PR TITLE
fix: add headless MCP tool selection

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1109,6 +1109,12 @@ def init_agent(
         if not agent.quiet_mode:
             _gr_label = " + Guardrails" if agent._bedrock_guardrail_config else ""
             print(f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock, {agent._bedrock_region}{_gr_label})")
+    elif agent.api_mode == "codex_app_server":
+        # The Codex subprocess owns authentication through CODEX_HOME/auth.json.
+        # It does not use Hermes' OpenAI client, so no Hermes OAuth/API key is
+        # required merely to construct the agent.
+        agent.client = None
+        agent._client_kwargs = {}
     else:
         if api_key and base_url:
             # Explicit credentials from CLI/gateway — construct directly.

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1560,6 +1560,22 @@ def init_agent(
     except Exception:
         _agent_cfg = {}
 
+    # Optional executable override for the Codex app-server runtime. Keep the
+    # default PATH lookup for ordinary installs, while allowing managed
+    # workstations to pin the same Codex build used by another long-lived
+    # client that shares CODEX_HOME. Mixing Codex versions against one
+    # models_cache.json can make an older process reject a cache schema written
+    # by a newer process before a turn ever reaches the model.
+    agent.codex_app_server_binary = "codex"
+    try:
+        _model_section = _agent_cfg.get("model", {})
+        if isinstance(_model_section, dict):
+            _codex_binary = str(_model_section.get("codex_binary") or "").strip()
+            if _codex_binary:
+                agent.codex_app_server_binary = _codex_binary
+    except Exception:
+        agent.codex_app_server_binary = "codex"
+
     # Codex commentary visibility (display.show_commentary, default true).
     # When true, completed Codex phase=commentary messages are delivered as
     # visible mid-turn updates through the interim message path. When false,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4802,6 +4802,14 @@ def _resolve_auto(
                             main_provider, resolved or main_model)
                 return client, resolved or main_model
 
+    if task and not _task_provider_fallback_enabled(task):
+        logger.warning(
+            "Auxiliary %s: main provider unavailable and fallback_policy=none; "
+            "refusing automatic provider discovery",
+            task,
+        )
+        return None, None
+
     # ── Step 2: user-configured fallback policy ─────────────────────────
     # In auto mode, respect the task-specific fallback chain first, then the
     # main agent's top-level fallback_providers/fallback_model chain. The
@@ -6795,6 +6803,31 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     return task_config
 
 
+def _task_provider_fallback_enabled(task: Optional[str]) -> bool:
+    """Return whether an auxiliary task may cross to another provider.
+
+    ``fallback_policy: none`` is a fail-closed boundary for tasks that must
+    stay on a pinned local or otherwise explicitly selected backend. The
+    default remains ``auto`` for backwards compatibility. Unknown values fail
+    closed so a typo cannot silently spend against an unintended provider.
+    Same-provider retries are unaffected.
+    """
+    if not task:
+        return True
+    raw = str(_get_auxiliary_task_config(task).get("fallback_policy", "auto"))
+    policy = raw.strip().lower() or "auto"
+    if policy == "auto":
+        return True
+    if policy == "none":
+        return False
+    logger.warning(
+        "Auxiliary %s: invalid fallback_policy=%r; failing closed",
+        task,
+        raw,
+    )
+    return False
+
+
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
     """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
     if not task:
@@ -8219,7 +8252,15 @@ def call_llm(
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
-        if should_fallback and (is_auto or is_capacity_error):
+        fallback_enabled = _task_provider_fallback_enabled(task)
+        if should_fallback and (is_auto or is_capacity_error) and not fallback_enabled:
+            logger.warning(
+                "Auxiliary %s: provider failure on %s with "
+                "fallback_policy=none; refusing cross-provider fallback",
+                task or "call",
+                resolved_provider,
+            )
+        if should_fallback and (is_auto or is_capacity_error) and fallback_enabled:
             if _is_auth_error(first_err):
                 reason = "auth error"
             elif _is_payment_error(first_err):
@@ -8769,7 +8810,15 @@ async def async_call_llm(
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
-        if should_fallback and (is_auto or is_capacity_error):
+        fallback_enabled = _task_provider_fallback_enabled(task)
+        if should_fallback and (is_auto or is_capacity_error) and not fallback_enabled:
+            logger.warning(
+                "Auxiliary %s (async): provider failure on %s with "
+                "fallback_policy=none; refusing cross-provider fallback",
+                task or "call",
+                resolved_provider,
+            )
+        if should_fallback and (is_auto or is_capacity_error) and fallback_enabled:
             if _is_auth_error(first_err):
                 reason = "auth error"
             elif _is_payment_error(first_err):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -395,10 +395,18 @@ def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
 # 272K Codex cap — see _CODEX_OAUTH_CONTEXT_FALLBACK in model_metadata.py).
 # With a 272K ceiling the default 50% compaction trigger fires at ~136K —
 # wasteful, since the model can hold far more raw context before
-# summarization actually buys anything. We raise the trigger to 85% (~231K)
-# on this exact route so Codex gpt-5.4 / gpt-5.5 / gpt-5.6 sessions use the
-# window they actually have.
-_CODEX_GPT54_GPT55_COMPACTION_THRESHOLD = 0.85
+# summarization actually buys anything. We raise the trigger, but NOT all
+# the way to 0.85 (~231K, ~38-40K headroom) as originally shipped: the
+# 2026-07-27 all-hands incident (HC-80042, "6th stall tonight") measured a
+# SINGLE codex_app_server turn adding 46-91K real prompt tokens in one
+# preflight-to-next-preflight cycle (one moderate tool-output read), which
+# alone exceeds the old ~38-40K headroom before the backstop in
+# turn_context.py even gets a chance to force compact_thread() on the next
+# turn. Production sessions were observed climbing to 1.4-1.7x the 258-272K
+# window (379K-471K) before wedging — the thin headroom, not a broken
+# backstop, is why. 0.60 (~103K headroom on a 258K window) still avoids the
+# wasteful 136K trigger while surviving a single oversized agentic turn.
+_CODEX_GPT54_GPT55_COMPACTION_THRESHOLD = 0.60
 
 # gpt-5.3-codex-spark is Codex-OAuth-only (ChatGPT Pro entitlement) with a
 # native 128K context window.  The default 50% compaction trigger fires at

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -51,6 +51,8 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
     the fork uses the main model and the warm cache, exactly as before. When
     ``auxiliary.background_review.{provider,model}`` names a concrete model
     different from the parent's, resolve that runtime and set ``routed=True``.
+    ``fallback_policy: none`` makes failure to resolve that explicit runtime a
+    hard failure instead of silently spending against the parent provider.
     """
     parent_runtime = agent._current_main_runtime()
     parent_api_mode = parent_runtime.get("api_mode") or None
@@ -80,6 +82,18 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
     task_model = (str(task.get("model", "")).strip() or None)
     task_base_url = (str(task.get("base_url", "")).strip() or None)
     task_api_key = (str(task.get("api_key", "")).strip() or None)
+    raw_fallback_policy = str(task.get("fallback_policy", "auto"))
+    fallback_policy = raw_fallback_policy.strip().lower() or "auto"
+    if fallback_policy not in {"auto", "none"}:
+        logger.warning(
+            "Background review: invalid fallback_policy=%r; failing closed",
+            raw_fallback_policy,
+        )
+        fallback_policy = "none"
+    try:
+        task_max_tokens = int(task.get("max_tokens") or 0) or None
+    except (TypeError, ValueError):
+        task_max_tokens = None
     if not (task_provider and task_provider != "auto" and task_model):
         return parent
     if task_provider == (agent.provider or "") and task_model == (agent.model or ""):
@@ -100,12 +114,18 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
             "api_mode": rp.get("api_mode"),
             "credential_pool": rp.get("credential_pool"),
             "request_overrides": dict(rp.get("request_overrides") or {}),
-            "max_tokens": rp.get("max_output_tokens"),
+            "max_tokens": task_max_tokens or rp.get("max_output_tokens"),
             "command": rp.get("command"),
             "args": list(rp.get("args") or []),
             "routed": True,
         }
     except Exception as e:
+        if fallback_policy == "none":
+            raise RuntimeError(
+                "Configured auxiliary background-review provider "
+                f"{task_provider}/{task_model} is unavailable and "
+                "fallback_policy=none"
+            ) from e
         logger.debug("background-review aux routing failed (%s); using main model", e)
         return parent
 
@@ -690,6 +710,19 @@ def _run_review_in_thread(
             # -> codex_responses downgrade is applied inside the resolver.
             _rt = _resolve_review_runtime(agent)
             _routed = bool(_rt.get("routed"))
+            # A different routed model has no parent-cache parity to preserve.
+            # Give it only the tools this fork can actually dispatch instead of
+            # cold-writing the parent's entire tool catalog to a local/cheap
+            # model. The runtime whitelist below remains defense in depth.
+            review_toolsets = ["skills"]
+            if agent._memory_enabled or agent._user_profile_enabled:
+                review_toolsets.insert(0, "memory")
+            if _routed:
+                fork_enabled_toolsets = review_toolsets
+                fork_disabled_toolsets = None
+            else:
+                fork_enabled_toolsets = getattr(agent, "enabled_toolsets", None)
+                fork_disabled_toolsets = getattr(agent, "disabled_toolsets", None)
             # skip_memory=True keeps the review fork from
             # touching external memory plugins (honcho, mem0,
             # supermemory, etc.).  Without it, the fork's
@@ -739,8 +772,8 @@ def _run_review_in_thread(
                 credential_pool=_rt.get("credential_pool"),
                 request_overrides=_rt.get("request_overrides") or {},
                 parent_session_id=agent.session_id,
-                enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                enabled_toolsets=fork_enabled_toolsets,
+                disabled_toolsets=fork_disabled_toolsets,
                 skip_memory=True,
                 **_fork_kwargs,
             )
@@ -834,9 +867,6 @@ def _run_review_in_thread(
             # Hardcoding ["memory", "skills"] granted the review LLM the MEMORY.md
             # read/write tool even when a profile set memory_enabled: false,
             # contaminating a memory-disabled profile (#54937 layer 2).
-            review_toolsets = ["skills"]
-            if review_agent._memory_enabled or review_agent._user_profile_enabled:
-                review_toolsets.insert(0, "memory")
             review_whitelist = {
                 t["function"]["name"]
                 for t in get_tool_definitions(

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -335,20 +335,40 @@ def _codex_item_to_args(item: dict) -> dict:
     _project_mcp_tool_call / _project_dynamic_tool_call shapes."""
     item_type = item.get("type") or ""
     if item_type == "commandExecution":
-        return {"command": item.get("command") or "",
+        args = {"command": item.get("command") or "",
                 "cwd": item.get("cwd") or ""}
+        return _redact_codex_event_value(args)
     if item_type == "fileChange":
-        return {"changes": [
+        return _redact_codex_event_value({"changes": [
             {"kind": (c.get("kind") or {}).get("type") or "update",
              "path": c.get("path") or ""}
             for c in (item.get("changes") or []) if isinstance(c, dict)
-        ]}
+        ]})
     if item_type in {"mcpToolCall", "dynamicToolCall"}:
         args = item.get("arguments") or {}
-        return args if isinstance(args, dict) else {"arguments": args}
+        args = args if isinstance(args, dict) else {"arguments": args}
+        return _redact_codex_event_value(args)
     if item_type == "webSearch":
-        return {"query": item.get("query") or ""}
+        return _redact_codex_event_value(
+            {"query": item.get("query") or ""}
+        )
     return {}
+
+
+def _redact_codex_event_value(value: Any) -> Any:
+    """Recursively scrub Codex event material before UI callbacks receive it."""
+    from agent.redact import redact_sensitive_text
+
+    if isinstance(value, str):
+        try:
+            return redact_sensitive_text(value)
+        except Exception:
+            return "«redacted-output-unavailable»"
+    if isinstance(value, dict):
+        return {key: _redact_codex_event_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_codex_event_value(item) for item in value]
+    return value
 
 
 def _codex_item_to_preview(item: dict) -> Any:
@@ -357,7 +377,7 @@ def _codex_item_to_preview(item: dict) -> Any:
     item_type = item.get("type") or ""
     if item_type == "commandExecution":
         cmd = item.get("command") or ""
-        return cmd[:120] if cmd else None
+        return _redact_codex_event_value(cmd[:120]) if cmd else None
     if item_type == "fileChange":
         paths = [c.get("path") for c in (item.get("changes") or [])
                  if isinstance(c, dict) and c.get("path")]
@@ -366,18 +386,20 @@ def _codex_item_to_preview(item: dict) -> Any:
         preview = ", ".join(paths[:3])
         if len(paths) > 3:
             preview += f", +{len(paths) - 3} more"
-        return preview
+        return _redact_codex_event_value(preview)
     if item_type in {"mcpToolCall", "dynamicToolCall"}:
         args = item.get("arguments") or {}
         if not isinstance(args, dict) or not args:
             return None
         try:
-            return json.dumps(args, ensure_ascii=False)[:120]
+            return _redact_codex_event_value(
+                json.dumps(args, ensure_ascii=False)[:120]
+            )
         except (TypeError, ValueError):
             return None
     if item_type == "webSearch":
         query = item.get("query") or ""
-        return query[:120] if query else None
+        return _redact_codex_event_value(query[:120]) if query else None
     return None
 
 
@@ -392,24 +414,39 @@ def _codex_item_completion_payload(item: dict) -> tuple[str, bool]:
         is_error = bool(exit_code is not None and exit_code != 0)
         if is_error:
             out = f"[exit {exit_code}]\n{out}"
+        from agent.redact import redact_terminal_output
+
+        try:
+            out = redact_terminal_output(
+                out,
+                str(item.get("command") or ""),
+            )
+        except Exception:
+            out = "«redacted-output-unavailable»"
         return out, is_error
     if item_type == "fileChange":
         status = item.get("status") or "unknown"
         n = len(item.get("changes") or [])
         return (
-            f"apply_patch status={status}, {n} change(s)",
+            _redact_codex_event_value(
+                f"apply_patch status={status}, {n} change(s)"
+            ),
             status not in {"completed", "applied", "success"},
         )
     if item_type == "mcpToolCall":
         error = item.get("error")
         if error:
             return (
-                f"[error] {json.dumps(error, ensure_ascii=False)[:1000]}",
+                _redact_codex_event_value(
+                    f"[error] {json.dumps(error, ensure_ascii=False)[:1000]}"
+                ),
                 True,
             )
         result = item.get("result")
         return (
-            json.dumps(result, ensure_ascii=False)[:4000]
+            _redact_codex_event_value(
+                json.dumps(result, ensure_ascii=False)[:4000]
+            )
             if result is not None else "",
             False,
         )
@@ -417,11 +454,15 @@ def _codex_item_completion_payload(item: dict) -> tuple[str, bool]:
         content_items = item.get("contentItems") or []
         if isinstance(content_items, list) and content_items:
             return (
-                json.dumps(content_items, ensure_ascii=False)[:4000],
+                _redact_codex_event_value(
+                    json.dumps(content_items, ensure_ascii=False)[:4000]
+                ),
                 not bool(item.get("success", True)),
             )
         success = item.get("success", True)
-        return f"success={success}", not bool(success)
+        return _redact_codex_event_value(
+            f"success={success}"
+        ), not bool(success)
     return "", False
 
 
@@ -544,6 +585,14 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
         text = params.get("delta") or params.get("text") or ""
         if not isinstance(text, str) or not text:
             return
+        # A credential can be split across arbitrary streaming chunks.  Once
+        # any prefix bytes have been emitted no completed-text redactor can
+        # claw them back, so secure mode withholds raw deltas and emits only
+        # the completed, fully-redacted assistant item.
+        from agent.redact import redaction_enabled
+
+        if redaction_enabled():
+            return
         fn = getattr(agent, "_fire_stream_delta", None)
         if fn is None:
             return
@@ -556,6 +605,10 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
         text = params.get("delta") or params.get("text") or ""
         if not isinstance(text, str) or not text:
             return
+        from agent.redact import redaction_enabled
+
+        if redaction_enabled():
+            return
         fn = getattr(agent, "_fire_reasoning_delta", None)
         if fn is None:
             return
@@ -565,7 +618,7 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
             logger.debug("_fire_reasoning_delta raised", exc_info=True)
 
     def _fire_agent_message_completed(item: dict) -> None:
-        text = item.get("text") or ""
+        text = _redact_codex_event_value(item.get("text") or "")
         if not isinstance(text, str) or not text.strip():
             return
         # display.show_commentary=false — mid-turn narration stays off the

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -91,11 +91,43 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
 
     from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
 
-    input_tokens = _coerce_usage_int(usage.get("inputTokens"))
+    # 2026-07-27 ALL-HANDS ANGLE D (#hermes-context-overrun) DOUBLE-COUNT FIX:
+    # verified against the actual installed codex-cli (0.144.1) protocol
+    # schema (`codex app-server generate-json-schema`) and the upstream
+    # codex-rs test fixture (codex-rs/codex-api/src/sse/responses.rs,
+    # `parses_cache_write_token_usage`): the wire's `inputTokens` is ALREADY
+    # inclusive of `cachedInputTokens` (input_tokens=100, cached_tokens=40 in
+    # the fixture -> total_tokens=110=100+10 output, NOT 100+40+10=150).
+    # `cachedInputTokens` is a breakdown annotation of `inputTokens`, not an
+    # additional bucket — same for `reasoningOutputTokens` inside
+    # `outputTokens`.
+    #
+    # CanonicalUsage.prompt_tokens is defined as
+    # input_tokens + cache_read_tokens + cache_write_tokens (correct ONLY
+    # when its `input_tokens` field holds the non-cached remainder, which is
+    # exactly the convention agent/usage_pricing.py already follows
+    # elsewhere: it subtracts cache from the raw total before constructing
+    # CanonicalUsage). This function instead fed the raw, cache-INCLUSIVE
+    # `inputTokens` straight into CanonicalUsage.input_tokens and then added
+    # `cachedInputTokens` again — double-counting the cached share every
+    # single turn. In a long session with a high cache-hit ratio (typical
+    # once context has grown) this inflates the reported/displayed prompt
+    # size by up to ~2x. That inflated number is exactly what
+    # turn_context.py's preflight/backstop compares against threshold_tokens
+    # and what the live status-bar gauge displays — explaining a
+    # 423K/258.4K (164%) gauge reading with ZERO real context-length-exceeded
+    # API errors anywhere in agent.log (a genuine 423K prompt against a
+    # 258.4K model would have been hard-rejected by the provider).
+    #
+    # Fix: normalize `inputTokens` to its non-cached remainder BEFORE
+    # constructing CanonicalUsage, matching the established convention, so
+    # `.prompt_tokens` reconstructs the correct (non-inflated) total.
+    raw_input_tokens = _coerce_usage_int(usage.get("inputTokens"))
     cache_read_tokens = _coerce_usage_int(usage.get("cachedInputTokens"))
     output_tokens = _coerce_usage_int(usage.get("outputTokens"))
     reasoning_tokens = _coerce_usage_int(usage.get("reasoningOutputTokens"))
     reported_total = _coerce_usage_int(usage.get("totalTokens"))
+    input_tokens = max(0, raw_input_tokens - cache_read_tokens)
 
     canonical_usage = CanonicalUsage(
         input_tokens=input_tokens,
@@ -124,8 +156,27 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
         try:
             compressor.update_from_response(usage_dict)
             context_window = getattr(turn, "model_context_window", None)
-            if isinstance(context_window, int) and context_window > 0:
+            if (
+                isinstance(context_window, int)
+                and context_window > 0
+                and context_window != compressor.context_length
+            ):
+                # HC-80042: this used to set context_length WITHOUT
+                # recomputing threshold_tokens, so the two silently drifted
+                # apart (observed live: context_length updated to Codex's
+                # reported 258,400 while threshold_tokens stayed frozen at
+                # 272,000 * threshold_percent from init — an ~11K-token
+                # stale-threshold gap). Recompute both from the live window
+                # so the backstop's >= threshold_tokens check compares
+                # against the SAME window it just adopted. Deliberately does
+                # NOT touch last_real_prompt_tokens / awaiting_real_usage_*
+                # (unlike update_model()) — those reflect real usage this
+                # turn just reported and must survive this resync.
                 compressor.context_length = context_window
+                compressor.threshold_tokens = compressor._compute_threshold_tokens(
+                    context_window, compressor.threshold_percent, compressor.max_tokens,
+                )
+                compressor._apply_threshold_tokens_cap()
         except Exception:
             logger.debug("codex app-server usage update failed", exc_info=True)
 
@@ -665,6 +716,95 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     return on_event
 
 
+_CONTEXT_CEILING_CONTINUATION = (
+    "Continue the same objective from the turn that Hermes interrupted for "
+    "context safety. Native compaction has completed. Inspect the current "
+    "state, preserve completed work, and resume without repeating successful "
+    "side effects."
+)
+
+
+def _recover_codex_context_ceiling(agent, turn):
+    """Compact and resume the same Codex thread after a safety interruption.
+
+    A mid-turn ceiling is not a user interrupt and must not strand the active
+    objective. Recovery is deliberately bounded to one compact-and-resume
+    attempt so a broken compactor cannot create an infinite internal loop.
+    """
+    if not getattr(turn, "context_ceiling_hit", False):
+        return turn, 1
+
+    session = getattr(agent, "_codex_session", None)
+    if session is None:
+        turn.error = "context ceiling recovery lost the active Codex session"
+        turn.should_retire = True
+        return turn, 1
+
+    logger.warning(
+        "codex app-server context safety recovery: compacting and resuming "
+        "the same objective (session=%s thread=%s turn=%s)",
+        getattr(agent, "session_id", None) or "none",
+        getattr(turn, "thread_id", None) or "",
+        getattr(turn, "turn_id", None) or "",
+    )
+    compact_result = session.compact_thread()
+    if (
+        getattr(compact_result, "interrupted", False)
+        or getattr(compact_result, "error", None)
+    ):
+        turn.error = (
+            "context ceiling recovery compaction failed: "
+            f"{getattr(compact_result, 'error', None) or 'interrupted'}"
+        )
+        turn.should_retire = bool(
+            getattr(turn, "should_retire", False)
+            or getattr(compact_result, "should_retire", False)
+        )
+        return turn, 2
+
+    _record_codex_app_server_compaction(
+        agent,
+        compact_result,
+        force=True,
+    )
+    resumed = session.run_turn(user_input=_CONTEXT_CEILING_CONTINUATION)
+    # Preserve completed tool-call/result pairs from the interrupted attempt,
+    # but drop partial assistant narration at the recovery boundary. Keeping
+    # two adjacent assistant messages would violate the persisted alternation
+    # contract, while completed tool effects are essential recovery context.
+    completed_prior_work = [
+        message
+        for message in (getattr(turn, "projected_messages", None) or [])
+        if isinstance(message, dict)
+        and (
+            message.get("role") == "tool"
+            or bool(message.get("tool_calls"))
+        )
+    ]
+    resumed.projected_messages = [
+        *completed_prior_work,
+        *(getattr(resumed, "projected_messages", None) or []),
+    ]
+    resumed.tool_iterations = (
+        int(getattr(turn, "tool_iterations", 0) or 0)
+        + int(getattr(resumed, "tool_iterations", 0) or 0)
+    )
+    if getattr(resumed, "context_ceiling_hit", False):
+        resumed.error = (
+            "context ceiling recurred immediately after native compaction"
+        )
+        resumed.should_retire = True
+    else:
+        logger.info(
+            "codex app-server context safety recovery completed "
+            "(session=%s thread=%s turn=%s)",
+            getattr(agent, "session_id", None) or "none",
+            getattr(resumed, "thread_id", None) or "",
+            getattr(resumed, "turn_id", None) or "",
+        )
+    return resumed, 3
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -748,6 +888,7 @@ def run_codex_app_server_turn(
 
     try:
         turn = agent._codex_session.run_turn(user_input=user_message)
+        turn, api_calls = _recover_codex_context_ceiling(agent, turn)
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn
@@ -877,8 +1018,6 @@ def run_codex_app_server_turn(
     )
     _record_codex_app_server_compaction(agent, turn)
     usage_result = _record_codex_app_server_usage(agent, turn)
-    api_calls = 1
-
     # Now check the skill nudge AFTER iters were incremented — same
     # pattern the chat_completions path uses (line ~15432).
     should_review_skills = False

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -619,6 +619,7 @@ def run_codex_app_server_turn(
     original_user_message: Any,
     messages: List[Dict[str, Any]],
     effective_task_id: str,
+    developer_instructions: str = "",
     should_review_memory: bool = False,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
@@ -679,6 +680,7 @@ def run_codex_app_server_turn(
         # Supersedes the narrower item/started-only bridge from #38835.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            developer_instructions=developer_instructions,
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,
@@ -760,9 +762,18 @@ def run_codex_app_server_turn(
 
     # Splice projected messages into the conversation. The projector emits
     # standard {role, content, tool_calls, tool_call_id} entries, which
-    # is exactly what curator.py / sessions DB expect.
-    if turn.projected_messages:
-        messages.extend(turn.projected_messages)
+    # is exactly what curator.py / sessions DB expect. Codex also projects a
+    # userMessage for the current input, but the standard run_conversation
+    # entry path already appended and flushed that user turn before this early
+    # return. Drop projected user rows here so every native turn is persisted
+    # exactly once rather than doubling context one request at a time.
+    projected_messages = [
+        msg
+        for msg in (turn.projected_messages or [])
+        if not (isinstance(msg, dict) and msg.get("role") == "user")
+    ]
+    if projected_messages:
+        messages.extend(projected_messages)
 
         # Persist the newly-projected assistant/tool messages ourselves.
         # This path is an early return that bypasses conversation_loop, whose

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -873,6 +873,7 @@ def run_codex_app_server_turn(
         # Supersedes the narrower item/started-only bridge from #38835.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            codex_bin=getattr(agent, "codex_app_server_binary", "codex"),
             developer_instructions=developer_instructions,
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2459,6 +2459,26 @@ class ContextCompressor(ContextEngine):
         result = [m.copy() for m in messages]
         pruned = 0
 
+        # Phase 0: enforce the configured hard cap on EVERY textual tool
+        # result, including protected head/tail messages. Protection means
+        # "preserve recent semantic context"; it must not exempt a result that
+        # entered through a path which bypassed the normal tool-output limit.
+        # Without this recovery seam, one historical 1MB projected command
+        # result in the protected head can make every future compaction a
+        # guaranteed no-op.
+        from tools.tool_output_limits import truncate_tool_output
+
+        for i, msg in enumerate(result):
+            if msg.get("role") != "tool":
+                continue
+            content = msg.get("content")
+            if not isinstance(content, str):
+                continue
+            bounded = truncate_tool_output(content)
+            if bounded != content:
+                result[i] = {**msg, "content": bounded}
+                pruned += 1
+
         # Build index: tool_call_id -> (tool_name, arguments_json)
         call_id_to_tool: Dict[str, tuple] = {}
         for msg in result:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1213,11 +1213,19 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        codex_developer_instructions = active_system_prompt or ""
+        if agent.ephemeral_system_prompt:
+            codex_developer_instructions = (
+                codex_developer_instructions
+                + "\n\n"
+                + agent.ephemeral_system_prompt
+            ).strip()
         return agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,
+            developer_instructions=codex_developer_instructions,
             should_review_memory=_should_review_memory,
         )
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2218,7 +2218,18 @@ def get_model_context_length(
             agg_provider = str(agg.get("provider") or "").strip()
             agg_model = str(agg.get("model") or "").strip()
             if agg_model and agg_provider and agg_provider.lower() != "moa":
-                rt = resolve_runtime_provider(requested=agg_provider, target_model=agg_model)
+                # Metadata-only lookup: the resolved credentials below are
+                # used solely to recurse into another get_model_context_length()
+                # call for display purposes, never to send a request. Skip the
+                # forbidden-model-family spend guard so a policy-forbidden
+                # aggregator model (whatever the user has actually configured)
+                # still resolves its real context window here instead of
+                # silently falling through to the 256K default.
+                rt = resolve_runtime_provider(
+                    requested=agg_provider,
+                    target_model=agg_model,
+                    enforce_openrouter_policy=False,
+                )
                 return get_model_context_length(
                     agg_model,
                     base_url=rt.get("base_url", "") or "",

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -68,6 +68,16 @@ _SENSITIVE_BODY_KEYS = frozenset({
 # downgrade — see `_log_redaction_status()` in gateway/run.py and cli.py.
 _REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "true").lower() in {"1", "true", "yes", "on"}
 
+
+def redaction_enabled() -> bool:
+    """Return the process-snapshotted secret-redaction policy.
+
+    Streaming and subprocess boundaries need to know whether it is safe to
+    emit partial text at all.  Keeping that decision here avoids duplicating
+    the environment parsing (and its import-time snapshot semantics).
+    """
+    return _REDACT_ENABLED
+
 # Known API key prefixes -- match the prefix + contiguous token chars
 _PREFIX_PATTERNS = [
     r"sk-[A-Za-z0-9_-]{10,}",           # OpenAI / OpenRouter / Anthropic (sk-ant-*)

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -399,8 +399,9 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # Skip skills incompatible with the current OS platform
                     if not skill_matches_platform(frontmatter):
                         continue
-                    # Skip skills not relevant to the current runtime env
-                    # (kanban/docker/s6). Offer-time only; explicit load bypasses.
+                    # Skip on-demand skills and skills not relevant to the
+                    # current runtime env. Offer-time only; explicit loads
+                    # bypass this gate.
                     if not skill_matches_environment(frontmatter):
                         continue
                     name = frontmatter.get('name', skill_md.parent.name)

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -286,6 +286,10 @@ def _detect_environment(env: str) -> bool:
 def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
     """Return True when the skill is relevant to the current runtime environment.
 
+    ``activation: on-demand`` is an offer-time gate: the skill stays out of
+    automatic indexes and autocomplete, but explicit ``skill_view`` and
+    ``--skills`` loads still bypass this function and remain available.
+
     Skills may declare an ``environments`` list in their YAML frontmatter::
 
         environments: [kanban]        # only relevant when kanban is active
@@ -305,6 +309,10 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
     A skill matches when ANY of its declared environments is currently active
     (OR semantics, mirroring ``platforms``). Unknown env tags fail open.
     """
+    activation = str(frontmatter.get("activation") or "").strip().lower()
+    if activation == "on-demand":
+        return False
+
     environments = frontmatter.get("environments")
     if not environments:
         return True

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -38,6 +38,7 @@ from agent.transports.codex_app_server import (
     CodexAppServerError,
 )
 from agent.transports.codex_event_projector import CodexEventProjector
+from tools.tool_output_limits import get_max_turn_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,10 @@ class TurnResult:
     token_usage_total: Optional[dict[str, Any]] = None
     model_context_window: Optional[int] = None
     compacted: bool = False
+    # Set only when the live app-server usage stream crossed the absolute
+    # headroom floor. This is a recoverable safety interruption: the caller
+    # should compact the same thread and resume the same objective.
+    context_ceiling_hit: bool = False
     # Hint to the caller that the underlying codex subprocess is likely
     # wedged (turn-level timeout fired, post-tool watchdog tripped, or
     # token-refresh failure killed the child). The caller should retire
@@ -83,6 +88,143 @@ class TurnResult:
     # of riding a CPU-spinning or auth-broken process. Mirrors openclaw
     # beta.8's "retire timed-out app-server clients" fix.
     should_retire: bool = False
+
+
+def _enforce_turn_tool_output_budget(
+    messages: list[dict],
+    chars_used: int,
+    budget: int,
+) -> tuple[int, bool]:
+    """Clamp this turn's newly-projected tool results to a cumulative budget.
+
+    2026-07-27 ALL-HANDS ANGLE B (#hermes-context-overrun): each tool result
+    is already bounded individually by ``truncate_tool_output`` (see
+    ``codex_event_projector._bounded_tool_output``), but that is a
+    PER-RESULT cap only — nothing stopped a turn with many tool calls from
+    stacking N maxed-out results and blowing the context window in one
+    shot. Measured: seven results each pinned at the old 50000-char
+    per-result cap in ONE turn, ~87K tokens against a 258.4K window, six
+    stalls in one evening.
+
+    This is the second, independent backstop: track cumulative tool-output
+    chars ACROSS the whole turn and once the budget is spent, every further
+    tool-role message this turn (regardless of its own per-result size) is
+    truncated or fully suppressed. Mutates ``messages`` (a
+    ``ProjectionResult.messages`` batch — 0-2 dicts) in place. Only
+    ``role == "tool"`` entries count against the budget; the paired
+    assistant tool_call message (name + args, no result body) is left
+    alone since it's small and needed for alternation.
+
+    Returns ``(new_chars_used, just_exhausted)`` — ``just_exhausted`` is
+    True the first time this call pushes the running total to the budget,
+    so the caller can log/emit a one-time notice instead of spamming one
+    per suppressed result.
+    """
+    just_exhausted = False
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, str) or not content:
+            continue
+        if chars_used >= budget:
+            msg["content"] = (
+                "[TURN TOOL-OUTPUT BUDGET EXCEEDED — this result withheld. "
+                f"Cumulative tool output this turn already reached the "
+                f"{budget}-char per-turn budget; further tool results are "
+                "suppressed so this turn cannot overrun the context "
+                "window. Re-run the tool call in a fresh turn if you "
+                "still need this output.]"
+            )
+            just_exhausted = True
+            continue
+        remaining = budget - chars_used
+        if len(content) > remaining:
+            omitted = len(content) - remaining
+            msg["content"] = (
+                content[:remaining]
+                + f"\n\n... [TURN BUDGET TRUNCATED - {omitted} more chars "
+                f"withheld; this turn's cumulative tool-output budget "
+                f"({budget} chars) is now spent] ..."
+            )
+            chars_used = budget
+            just_exhausted = True
+        else:
+            chars_used += len(content)
+    return chars_used, just_exhausted
+
+
+# 2026-07-27 ALL-HANDS ANGLE D (#hermes-context-overrun, 7th recurrence,
+# 423K/258.4K = 164%). ANGLE B's max_turn_bytes budget above only bounds
+# Hermes's own LOCAL PROJECTION of tool-output content: it mutates
+# ``messages`` (the projector's output) AFTER Codex's app-server subprocess
+# has already run the tool, fed the full result to the model as part of its
+# own turn context, and moved on. It never touches what Codex actually sent
+# upstream, so it cannot cap the real window.
+#
+# Separately, turn_context.py's preflight headroom backstop
+# (_MIN_ABSOLUTE_HEADROOM_TOKENS) only runs BETWEEN turns, using the
+# previous turn's final usage. But thread/tokenUsage/updated notifications
+# (consumed by _apply_token_usage_notification, called from inside this
+# very while-loop below) arrive continuously DURING a turn — confirmed live
+# in agent.log via repeated "HC80042-DEBUG usage-applied" lines firing
+# several times between one "conversation turn:" marker and the next.
+# Nothing consumed that live data mid-turn. Because terminal/file-ops/MCP
+# calls run INSIDE the codex subprocess's own agentic loop (see the
+# "Runtime: codex app-server" banner), a single Hermes-level turn can chain
+# many internal Codex tool calls — and therefore many real prompt-token
+# jumps — before ever yielding back to Hermes. A start-of-turn check can
+# only ever see the *previous* turn's final tally; it structurally cannot
+# stop a turn that overruns from the inside. Six of the seven stalls
+# tonight were gradual (~10-30K tokens/turn) and the preflight backstop
+# caught every one cleanly; the seventh was one outsized turn that blew
+# past the window before it ever yielded.
+#
+# Fix: enforce the SAME absolute-headroom invariant the preflight backstop
+# uses, but continuously, using the live usage snapshot we already receive
+# mid-turn. The instant remaining headroom drops below the floor, interrupt
+# the turn immediately instead of letting Codex's internal loop keep
+# running — the turn's last real usage still feeds the normal
+# preflight/compaction path (via codex_runtime._record_codex_app_server_usage
+# -> context_compressor.update_from_response) on the very next turn.
+_MID_TURN_HEADROOM_FLOOR_TOKENS = 90_000
+
+
+def _mid_turn_context_ceiling_hit(
+    result: "TurnResult",
+) -> tuple[bool, int, int]:
+    """Check the live token-usage snapshot against the absolute headroom
+    floor, mid-turn.
+
+    Returns ``(hit, total_tokens, context_window)``. ``hit`` is True once
+    remaining headroom (window - total) drops below
+    ``_MID_TURN_HEADROOM_FLOOR_TOKENS``. Mirrors the ratio-independent
+    absolute-token check in turn_context.py's HC80042 backstop so the same
+    invariant holds whether it's evaluated between turns or inside one.
+    """
+    usage = result.token_usage_last
+    window = result.model_context_window
+    if not isinstance(usage, dict) or not usage or not window:
+        return False, 0, 0
+    total = usage.get("totalTokens")
+    if not isinstance(total, int) or total <= 0:
+        # Fallback only: verified against the codex-rs wire protocol
+        # (codex-cli 0.144.1 generate-json-schema + upstream
+        # sse/responses.rs test fixture) that ``inputTokens`` is ALREADY
+        # inclusive of ``cachedInputTokens``, and ``outputTokens`` is
+        # already inclusive of ``reasoningOutputTokens`` — both are
+        # breakdown annotations, not additional buckets. Summing all four
+        # would double-count (the exact #hermes-context-overrun root cause
+        # fixed in codex_runtime.py._record_codex_app_server_usage).
+        input_val = usage.get("inputTokens")
+        output_val = usage.get("outputTokens")
+        total = (input_val if isinstance(input_val, int) and input_val > 0 else 0) + (
+            output_val if isinstance(output_val, int) and output_val > 0 else 0
+        )
+    if total <= 0:
+        return False, 0, window
+    headroom = window - total
+    return headroom < _MID_TURN_HEADROOM_FLOOR_TOKENS, total, window
 
 
 # Markers we accept as terminal even when codex never emits turn/completed.
@@ -578,6 +720,14 @@ class CodexAppServerSession:
         # within post_tool_quiet_timeout and the turn hasn't completed, we
         # fast-fail and retire the session.
         last_tool_completion_at: Optional[float] = None
+        # Per-turn tool-output budget (ANGLE B, #hermes-context-overrun):
+        # independent of the per-result truncation cap already applied by
+        # the projector — this bounds the SUM of every tool result's
+        # content across the whole turn, so N tool calls in one turn can
+        # never overrun the context window regardless of per-result size.
+        turn_tool_output_budget = get_max_turn_bytes()
+        turn_tool_output_chars = 0
+        turn_tool_output_budget_warned = False
 
         while time.monotonic() < deadline and not turn_complete:
             if self._interrupt_event.is_set():
@@ -658,10 +808,31 @@ class CodexAppServerSession:
                                 "on_event callback raised", exc_info=True
                             )
                     _apply_token_usage_notification(result, pending)
+                    if self._interrupt_for_context_ceiling(result):
+                        turn_complete = True
+                        break
                     _apply_compaction_notification(result, pending)
                     self._track_pending_file_change(pending)
                     proj = projector.project(pending)
                     if proj.messages:
+                        (
+                            turn_tool_output_chars,
+                            _budget_hit,
+                        ) = _enforce_turn_tool_output_budget(
+                            proj.messages,
+                            turn_tool_output_chars,
+                            turn_tool_output_budget,
+                        )
+                        if _budget_hit and not turn_tool_output_budget_warned:
+                            turn_tool_output_budget_warned = True
+                            logger.warning(
+                                "turn tool-output budget (%s chars) spent "
+                                "mid-turn (session %s, turn %s) — further "
+                                "tool results this turn are suppressed",
+                                turn_tool_output_budget,
+                                self._thread_id,
+                                result.turn_id,
+                            )
                         result.projected_messages.extend(proj.messages)
                     if proj.is_tool_iteration:
                         result.tool_iterations += 1
@@ -705,6 +876,8 @@ class CodexAppServerSession:
                     logger.debug("on_event callback raised", exc_info=True)
 
             _apply_token_usage_notification(result, note)
+            if self._interrupt_for_context_ceiling(result):
+                break
             _apply_compaction_notification(result, note)
 
             # Track in-progress fileChange items so the approval bridge
@@ -716,6 +889,24 @@ class CodexAppServerSession:
             # Project into messages
             projection = projector.project(note)
             if projection.messages:
+                (
+                    turn_tool_output_chars,
+                    _budget_hit,
+                ) = _enforce_turn_tool_output_budget(
+                    projection.messages,
+                    turn_tool_output_chars,
+                    turn_tool_output_budget,
+                )
+                if _budget_hit and not turn_tool_output_budget_warned:
+                    turn_tool_output_budget_warned = True
+                    logger.warning(
+                        "turn tool-output budget (%s chars) spent mid-turn "
+                        "(session %s, turn %s) — further tool results this "
+                        "turn are suppressed",
+                        turn_tool_output_budget,
+                        self._thread_id,
+                        result.turn_id,
+                    )
                 result.projected_messages.extend(projection.messages)
             if projection.is_tool_iteration:
                 result.tool_iterations += 1
@@ -856,6 +1047,13 @@ class CodexAppServerSession:
 
         deadline = time.monotonic() + turn_timeout
         turn_complete = False
+        # Same per-turn tool-output budget as run_turn (ANGLE B,
+        # #hermes-context-overrun) — belt-and-suspenders here since a
+        # compaction turn isn't expected to run tools, but nothing prevents
+        # it structurally and this keeps every codex-thread ingestion path
+        # under the same cumulative bound.
+        compact_tool_output_budget = get_max_turn_bytes()
+        compact_tool_output_chars = 0
 
         while time.monotonic() < deadline and not turn_complete:
             if self._interrupt_event.is_set():
@@ -942,6 +1140,22 @@ class CodexAppServerSession:
 
             projection = projector.project(note)
             if projection.messages:
+                (
+                    compact_tool_output_chars,
+                    _budget_hit,
+                ) = _enforce_turn_tool_output_budget(
+                    projection.messages,
+                    compact_tool_output_chars,
+                    compact_tool_output_budget,
+                )
+                if _budget_hit:
+                    logger.warning(
+                        "compact_thread tool-output budget (%s chars) "
+                        "spent mid-turn (session %s, turn %s)",
+                        compact_tool_output_budget,
+                        self._thread_id,
+                        result.turn_id,
+                    )
                 result.projected_messages.extend(projection.messages)
             if projection.is_tool_iteration:
                 result.tool_iterations += 1
@@ -991,6 +1205,30 @@ class CodexAppServerSession:
         return result
 
     # ---------- internals ----------
+
+    def _interrupt_for_context_ceiling(self, result: TurnResult) -> bool:
+        """Interrupt a healthy turn before its live context exhausts headroom."""
+        hit, total_tokens, context_window = _mid_turn_context_ceiling_hit(result)
+        if not hit:
+            return False
+        remaining = context_window - total_tokens
+        logger.warning(
+            "codex app-server mid-turn context ceiling reached: "
+            "%s/%s tokens, %s headroom below %s floor "
+            "(thread=%s turn=%s); interrupting for automatic "
+            "compact-and-resume",
+            total_tokens,
+            context_window,
+            remaining,
+            _MID_TURN_HEADROOM_FLOOR_TOKENS,
+            self._thread_id,
+            result.turn_id,
+        )
+        self._issue_interrupt(result.turn_id)
+        result.interrupted = True
+        result.context_ceiling_hit = True
+        result.error = "codex app-server context ceiling reached mid-turn"
+        return True
 
     def _issue_interrupt(self, turn_id: Optional[str]) -> None:
         if self._client is None or self._thread_id is None or turn_id is None:

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -278,6 +278,7 @@ class CodexAppServerSession:
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
         permission_profile: Optional[str] = None,
+        developer_instructions: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
@@ -291,6 +292,11 @@ class CodexAppServerSession:
                 os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
                 "workspace-write",
             )
+        )
+        self._developer_instructions = (
+            developer_instructions.strip()
+            if isinstance(developer_instructions, str)
+            else ""
         )
         self._approval_callback = approval_callback
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
@@ -343,6 +349,12 @@ class CodexAppServerSession:
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
+        if self._developer_instructions:
+            # Hermes owns the conversational identity and operating contract;
+            # Codex is the scoped execution backend. Passing the complete
+            # Hermes system prompt at thread creation keeps that identity
+            # local to Hermes instead of relying on global ~/.codex guidance.
+            params["developerInstructions"] = self._developer_instructions
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's

--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -66,7 +66,30 @@ def _deterministic_call_id(item_type: str, item_id: str) -> str:
 
 def _format_tool_args(d: dict) -> str:
     """Format a dict as JSON the way Hermes' existing tool_calls path does."""
-    return json.dumps(d, ensure_ascii=False, sort_keys=True)
+    rendered = json.dumps(d, ensure_ascii=False, sort_keys=True)
+    return _redact_projected_text(rendered)
+
+
+def _redact_projected_text(content: Any, *, command: str | None = None) -> str:
+    """Scrub a Codex-owned item before it enters Hermes UI/history.
+
+    Codex app-server executes built-in tools outside Hermes' normal
+    ``terminal_tool``/``model_tools`` path.  Projection is therefore the first
+    Hermes-owned egress boundary for completed command, MCP, dynamic-tool, and
+    assistant content.  Fail closed if the redactor itself is unavailable:
+    losing one diagnostic is preferable to persisting a credential.
+    """
+    text = "" if content is None else str(content)
+    try:
+        if command is not None:
+            from agent.redact import redact_terminal_output
+
+            return redact_terminal_output(text, command)
+        from agent.redact import redact_sensitive_text
+
+        return redact_sensitive_text(text)
+    except Exception:
+        return "«redacted-output-unavailable»"
 
 
 def _bounded_tool_output(content: Any) -> str:
@@ -147,10 +170,12 @@ class CodexEventProjector:
     # ---------- per-type projections ----------
 
     def _project_agent_message(self, item: dict) -> ProjectionResult:
-        text = item.get("text") or ""
+        text = _redact_projected_text(item.get("text") or "")
         msg: dict[str, Any] = {"role": "assistant", "content": text}
         if self._pending_reasoning:
-            msg["reasoning"] = "\n".join(self._pending_reasoning)
+            msg["reasoning"] = _redact_projected_text(
+                "\n".join(self._pending_reasoning)
+            )
             self._pending_reasoning = []
         return ProjectionResult(messages=[msg], final_text=text)
 
@@ -190,12 +215,18 @@ class CodexEventProjector:
             ],
         }
         if self._pending_reasoning:
-            assistant_msg["reasoning"] = "\n".join(self._pending_reasoning)
+            assistant_msg["reasoning"] = _redact_projected_text(
+                "\n".join(self._pending_reasoning)
+            )
             self._pending_reasoning = []
         output = item.get("aggregatedOutput") or ""
         exit_code = item.get("exitCode")
         if exit_code is not None and exit_code != 0:
             output = f"[exit {exit_code}]\n{output}"
+        output = _redact_projected_text(
+            output,
+            command=str(item.get("command") or ""),
+        )
         output = _bounded_tool_output(output)
         tool_msg = {
             "role": "tool",
@@ -232,7 +263,9 @@ class CodexEventProjector:
             ],
         }
         if self._pending_reasoning:
-            assistant_msg["reasoning"] = "\n".join(self._pending_reasoning)
+            assistant_msg["reasoning"] = _redact_projected_text(
+                "\n".join(self._pending_reasoning)
+            )
             self._pending_reasoning = []
         status = item.get("status") or "unknown"
         n = len(changes_summary)
@@ -272,7 +305,9 @@ class CodexEventProjector:
             ],
         }
         if self._pending_reasoning:
-            assistant_msg["reasoning"] = "\n".join(self._pending_reasoning)
+            assistant_msg["reasoning"] = _redact_projected_text(
+                "\n".join(self._pending_reasoning)
+            )
             self._pending_reasoning = []
         result = item.get("result")
         error = item.get("error")
@@ -282,7 +317,7 @@ class CodexEventProjector:
             content = json.dumps(result, ensure_ascii=False)[:4000]
         else:
             content = ""
-        content = _bounded_tool_output(content)
+        content = _bounded_tool_output(_redact_projected_text(content))
         tool_msg = {
             "role": "tool",
             "tool_call_id": call_id,
@@ -318,7 +353,9 @@ class CodexEventProjector:
             ],
         }
         if self._pending_reasoning:
-            assistant_msg["reasoning"] = "\n".join(self._pending_reasoning)
+            assistant_msg["reasoning"] = _redact_projected_text(
+                "\n".join(self._pending_reasoning)
+            )
             self._pending_reasoning = []
         content_items = item.get("contentItems") or []
         if isinstance(content_items, list) and content_items:
@@ -326,7 +363,7 @@ class CodexEventProjector:
         else:
             success = item.get("success")
             content = f"success={success}"
-        content = _bounded_tool_output(content)
+        content = _bounded_tool_output(_redact_projected_text(content))
         tool_msg = {
             "role": "tool",
             "tool_call_id": call_id,
@@ -343,6 +380,7 @@ class CodexEventProjector:
             payload = json.dumps(item, ensure_ascii=False)[:1500]
         except (TypeError, ValueError):
             payload = repr(item)[:1500]
+        payload = _redact_projected_text(payload)
         return ProjectionResult(
             messages=[
                 {

--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -11,7 +11,7 @@ Codex emits items with a discriminator field `type`:
   - reasoning           → stashed in the assistant's "reasoning" field
   - commandExecution    → assistant tool_call(name="exec") + tool result
   - fileChange          → assistant tool_call(name="apply_patch") + tool result
-  - mcpToolCall         → assistant tool_call(name=f"mcp.{server}.{tool}") + tool result
+  - mcpToolCall         → assistant tool_call(name=f"mcp__{server}__{tool}") + tool result
   - dynamicToolCall     → assistant tool_call(name=tool) + tool result
   - plan/hookPrompt/collabAgentToolCall → recorded as opaque assistant notes
 
@@ -30,8 +30,18 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Any, Optional
+
+
+_CODEX_IDENTIFIER_RE = re.compile(r"[^a-zA-Z0-9_-]+")
+
+
+def _sanitize_codex_identifier(value: Any, *, fallback: str) -> str:
+    """Return a Responses-compatible function/call identifier component."""
+    sanitized = _CODEX_IDENTIFIER_RE.sub("_", str(value or "")).strip("_")
+    return sanitized or fallback
 
 
 def _deterministic_call_id(item_type: str, item_id: str) -> str:
@@ -39,17 +49,37 @@ def _deterministic_call_id(item_type: str, item_id: str) -> str:
 
     Uses the codex item id directly when present (already a uuid); falls back
     to a content hash so replay produces the same id across sessions and
-    prefix caches stay valid. See AGENTS.md Pitfall #16 (deterministic IDs in
-    tool call history)."""
-    if item_id:
-        return f"codex_{item_type}_{item_id}"
-    digest = hashlib.sha256(f"{item_type}".encode()).hexdigest()[:16]
-    return f"codex_{item_type}_{digest}"
+    prefix caches stay valid. Codex Responses caps call IDs at 64 characters
+    and accepts only ``[a-zA-Z0-9_-]``; long MCP server/tool names otherwise
+    poison every later request that replays the persisted history.
+    See AGENTS.md Pitfall #16 (deterministic IDs in tool call history)."""
+    safe_type = _sanitize_codex_identifier(item_type, fallback="tool")
+    safe_item_id = _sanitize_codex_identifier(item_id, fallback="")
+    if safe_item_id:
+        candidate = f"codex_{safe_type}_{safe_item_id}"
+        if len(candidate) <= 64:
+            return candidate
+    digest_source = f"{item_type}\0{item_id}".encode("utf-8", errors="replace")
+    digest = hashlib.sha256(digest_source).hexdigest()[:24]
+    return f"codex_{safe_type[:28]}_{digest}"
 
 
 def _format_tool_args(d: dict) -> str:
     """Format a dict as JSON the way Hermes' existing tool_calls path does."""
     return json.dumps(d, ensure_ascii=False, sort_keys=True)
+
+
+def _bounded_tool_output(content: Any) -> str:
+    """Apply Hermes' configured output cap to Codex-projected tool results.
+
+    Codex executes outside ``terminal_tool``, so its completed-item events do
+    not pass through the normal truncation seam. The projected result is still
+    Hermes transcript content and must obey the same bound before it reaches
+    the protected recent tail or durable session storage.
+    """
+    from tools.tool_output_limits import truncate_tool_output
+
+    return truncate_tool_output(content)
 
 
 @dataclass
@@ -166,6 +196,7 @@ class CodexEventProjector:
         exit_code = item.get("exitCode")
         if exit_code is not None and exit_code != 0:
             output = f"[exit {exit_code}]\n{output}"
+        output = _bounded_tool_output(output)
         tool_msg = {
             "role": "tool",
             "tool_call_id": call_id,
@@ -231,7 +262,10 @@ class CodexEventProjector:
                     "id": call_id,
                     "type": "function",
                     "function": {
-                        "name": f"mcp.{server}.{tool}",
+                        "name": _sanitize_codex_identifier(
+                            f"mcp__{server}__{tool}",
+                            fallback="mcp_unknown",
+                        ),
                         "arguments": _format_tool_args(args),
                     },
                 }
@@ -248,6 +282,7 @@ class CodexEventProjector:
             content = json.dumps(result, ensure_ascii=False)[:4000]
         else:
             content = ""
+        content = _bounded_tool_output(content)
         tool_msg = {
             "role": "tool",
             "tool_call_id": call_id,
@@ -273,7 +308,10 @@ class CodexEventProjector:
                     "id": call_id,
                     "type": "function",
                     "function": {
-                        "name": tool,
+                        "name": _sanitize_codex_identifier(
+                            tool,
+                            fallback="unknown",
+                        ),
                         "arguments": _format_tool_args(args),
                     },
                 }
@@ -288,6 +326,7 @@ class CodexEventProjector:
         else:
             success = item.get("success")
             content = f"success={success}"
+        content = _bounded_tool_output(content)
         tool_msg = {
             "role": "tool",
             "tool_call_id": call_id,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -48,6 +48,17 @@ from agent.model_metadata import (
 
 logger = logging.getLogger(__name__)
 
+# HC-80042: minimum absolute token headroom (context_length -
+# last_real_prompt_tokens) the codex_app_server backstop requires before the
+# NEXT turn starts. A ratio-based threshold alone (0.75 small-context floor,
+# or a per-model autoraise) scales headroom down together with the trigger
+# point, so tightening it to buy headroom just makes compaction thrash more
+# often. Sized off a live measurement (2026-07-27 all-hands incident): one
+# ordinary codex_app_server turn with a moderate tool-output read added
+# 46-96K real prompt tokens in a single preflight-to-preflight cycle. 90K
+# comfortably clears that with margin for a heavier turn.
+_MIN_ABSOLUTE_HEADROOM_TOKENS = 90_000
+
 
 def compose_user_api_content(
     content: Any,
@@ -778,6 +789,12 @@ def build_turn_context(
 
         _should_compress_now = False
         _compress_block_reason = None
+        # Backstop force-flag for the codex-native branch below (P0-2,
+        # #hermes-context-compaction-hang). Only ever True when the
+        # native/off auto-compaction mode is skipping its own preflight AND
+        # Codex's own last reported real usage already proves the thread is
+        # over threshold — see the branch below for the full rationale.
+        _codex_native_backstop_force = False
         if _preflight_deferred:
             logger.info(
                 "Skipping preflight compression: rough estimate ~%s >= %s, "
@@ -799,11 +816,90 @@ def build_turn_context(
                 _cooldown_secs = _compression_cooldown.get("remaining_seconds", 0.0)
                 _compress_block_reason = f"cooldown:{_cooldown_secs:.0f}"
         elif _codex_native_auto:
-            logger.info(
-                "Skipping Hermes preflight compression for codex app-server "
-                "(mode=%s); Hermes will not start thread compaction here.",
-                getattr(agent, "codex_app_server_auto_compaction", "native"),
+            # P0-2 root cause (#hermes-context-compaction-hang): in
+            # native/off mode Hermes never calls thread/compact/start on its
+            # own — it assumes Codex's app-server compacts the thread on its
+            # own schedule. Codex *does* sometimes emit an unprompted
+            # ContextCompaction boundary (observed in production logs), but
+            # not reliably enough: real sessions were measured climbing to
+            # 1.4-1.7x the configured context window (~379K-471K tokens
+            # against a ~258K-272K budget) before the next turn's request
+            # hung against the provider and the 600s turn timeout fired.
+            #
+            # Hermes already receives Codex's REAL post-turn token usage
+            # every turn (``last_real_prompt_tokens``, populated by
+            # ``update_from_response`` in context_compressor.py) even though
+            # it takes no action on it in this mode. Use that real number —
+            # not the rough local-transcript estimate, which undercounts the
+            # actual Codex-side thread (it does not see Codex's own retained
+            # reasoning items) — as a backstop: if the last turn's real
+            # prompt tokens already meet or exceed threshold, force a
+            # Codex-native compaction now via ``compact_thread()`` rather
+            # than trusting Codex to have already handled it. This is
+            # strictly additive: it only fires when Codex's own compaction
+            # has demonstrably NOT kept the thread under budget.
+            _real_tokens_over_threshold = (
+                _compressor.last_real_prompt_tokens > 0
+                and _compressor.last_real_prompt_tokens >= _compressor.threshold_tokens
             )
+            # HC-80042 absolute-headroom backstop: any ratio-based threshold
+            # (the 0.75 small-context floor, or a per-model autoraise up to
+            # 0.85) leaves headroom = context_length * (1 - ratio). At 0.75
+            # on a 258-272K Codex window that is only ~65-68K tokens — and a
+            # single codex_app_server turn with a moderate tool-output read
+            # was measured live adding 46-96K real prompt tokens in ONE
+            # preflight-to-preflight cycle (2026-07-27 all-hands incident).
+            # A ratio alone can never guarantee enough headroom to survive
+            # one more oversized turn, because tightening the ratio to buy
+            # headroom also triggers more frequent (thrashing) compaction —
+            # a real, separately-evidenced problem the 0.75 floor exists to
+            # prevent. So this is an ABSOLUTE token check, independent of
+            # and additive to the ratio: if fewer than
+            # _MIN_ABSOLUTE_HEADROOM_TOKENS remain before the real window
+            # limit, force compaction now regardless of what the ratio says.
+            _headroom_tokens = (
+                _compressor.context_length - _compressor.last_real_prompt_tokens
+                if _compressor.last_real_prompt_tokens > 0
+                else None
+            )
+            _headroom_critical = (
+                _headroom_tokens is not None
+                and _headroom_tokens < _MIN_ABSOLUTE_HEADROOM_TOKENS
+            )
+            if _headroom_critical:
+                _real_tokens_over_threshold = True
+                logger.debug(
+                    "Codex-native absolute-headroom backstop tripped: only "
+                    "~%s tokens remain before the %s window (last real "
+                    "prompt ~%s), below the %s floor — forcing compaction "
+                    "even though the ratio threshold (%s) was not yet hit "
+                    "(session %s)",
+                    f"{_headroom_tokens:,}",
+                    f"{_compressor.context_length:,}",
+                    f"{_compressor.last_real_prompt_tokens:,}",
+                    f"{_MIN_ABSOLUTE_HEADROOM_TOKENS:,}",
+                    f"{_compressor.threshold_tokens:,}",
+                    agent.session_id or "none",
+                )
+            if _real_tokens_over_threshold:
+                logger.warning(
+                    "Codex-native auto-compaction backstop: last real prompt "
+                    "~%s >= %s threshold (mode=%s) but Codex has not "
+                    "compacted the thread — forcing thread/compact/start "
+                    "(session %s)",
+                    f"{_compressor.last_real_prompt_tokens:,}",
+                    f"{_compressor.threshold_tokens:,}",
+                    getattr(agent, "codex_app_server_auto_compaction", "native"),
+                    agent.session_id or "none",
+                )
+                _should_compress_now = True
+                _codex_native_backstop_force = True
+            else:
+                logger.info(
+                    "Skipping Hermes preflight compression for codex app-server "
+                    "(mode=%s); Hermes will not start thread compaction here.",
+                    getattr(agent, "codex_app_server_auto_compaction", "native"),
+                )
         else:
             _should_compress_now = _compressor.should_compress(_preflight_tokens)
             if not _should_compress_now:
@@ -863,6 +959,14 @@ def build_turn_context(
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
+                    # Only the codex-native real-usage backstop (above) sets
+                    # this; force=True here bypasses
+                    # _compress_context_via_codex_app_server's
+                    # "mode != hermes -> skip" gate for that one case. All
+                    # other callers (normal threshold-triggered compression)
+                    # keep the default force=False and its cooldown/breaker
+                    # guards intact.
+                    force=_codex_native_backstop_force,
                 )
                 if (
                     messages is _preflight_input

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -604,6 +604,24 @@ prompt_caching:
 #     model: ""
 #     reasoning_effort: "low"
 #
+#   # Context compression. Pin an explicit backend and set fallback_policy to
+#   # "none" when crossing to another provider would violate spend policy.
+#   # Same-provider retries still apply.
+#   compression:
+#     provider: "custom"
+#     model: "qwen3.5:9b"
+#     base_url: "http://127.0.0.1:11434/v1"
+#     fallback_policy: "none"   # auto | none
+#
+#   # Background memory/skill review. Routed reviews receive only their actual
+#   # memory/skills tool surface and honor this output cap.
+#   background_review:
+#     provider: "custom"
+#     model: "qwen3.5:9b"
+#     base_url: "http://127.0.0.1:11434/v1"
+#     fallback_policy: "none"
+#     max_tokens: 1024
+#
 #   # Gemini 3.1 TTS hidden audio-tag insertion
 #   tts_audio_tags:
 #     provider: "auto"       # empty model = your main chat model

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -19,6 +19,14 @@ import sys
 from rich.markup import escape as _escape
 
 
+def _normalize_memory_notifications(value) -> str:
+    """Normalize classic-CLI memory-review notification configuration."""
+    if isinstance(value, bool):
+        return "on" if value else "off"
+    mode = str(value or "on").strip().lower()
+    return mode if mode in {"off", "on", "verbose"} else "on"
+
+
 class CLIAgentSetupMixin:
     """Agent construction + session-resume display methods for ``HermesCLI``."""
 
@@ -235,7 +243,17 @@ class CLIAgentSetupMixin:
         Returns:
             bool: True if successful, False otherwise
         """
-        from cli import AIAgent, ChatConsole, _DIM, _RST, _accent_hex, _cprint, _prepare_deferred_agent_startup, logger
+        from cli import (
+            AIAgent,
+            CLI_CONFIG,
+            ChatConsole,
+            _DIM,
+            _RST,
+            _accent_hex,
+            _cprint,
+            _prepare_deferred_agent_startup,
+            logger,
+        )
         if self.agent is not None:
             return True
 
@@ -421,6 +439,14 @@ class CLIAgentSetupMixin:
             # forever — so memory shutdown never ran on /exit (#49287).
             import cli as _cli
             _cli._active_agent_ref = self.agent
+            # The TUI and messaging gateway already honor this display option,
+            # but the classic CLI previously left AIAgent's hard-coded "on"
+            # default untouched. That made ``memory_notifications: off`` a
+            # no-op and injected "💾 Self-improvement review" bookkeeping into
+            # the transcript despite the user's explicit preference.
+            self.agent.memory_notifications = _normalize_memory_notifications(
+                (CLI_CONFIG.get("display") or {}).get("memory_notifications")
+            )
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
             self.agent._print_fn = _cprint

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1399,10 +1399,17 @@ DEFAULT_CONFIG = {
     #                    being clamped (default 2000).
     # - max_line_length: per-line cap applied when read_file emits a
     #                    line-numbered view (default 2000 chars).
+    # - max_turn_bytes:  cumulative tool-output budget for ONE turn,
+    #                    independent of max_bytes (default 60_000 ≈
+    #                    15K tokens). Enforced by the codex app-server
+    #                    ingestion path so N tool calls in a single turn
+    #                    can't stack past the context window even though
+    #                    each individual result is already capped.
     "tool_output": {
         "max_bytes": 50_000,
         "max_lines": 2000,
         "max_line_length": 2000,
+        "max_turn_bytes": 60_000,
     },
 
     # Tool loop guardrails nudge models when they repeat failed or

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1698,6 +1698,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            "fallback_policy": "auto",  # auto | none (fail closed; same-provider retries still apply)
             "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
@@ -1859,6 +1860,8 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            "fallback_policy": "auto",  # auto | none (fail closed; same-provider retries still apply)
+            "max_tokens": 1024,       # output cap for routed review forks
             "timeout": 120,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -427,6 +427,7 @@ def cmd_mcp_add(args):
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)
     raw_connect_timeout = getattr(args, "connect_timeout", None)
+    all_tools = bool(getattr(args, "all_tools", False))
 
     server_config: Dict[str, Any] = {}
     try:
@@ -565,15 +566,19 @@ def cmd_mcp_add(args):
         print(f"    {color(tool_name, Colors.GREEN):40s} {short}")
     print()
 
-    # Ask: enable all, select, or cancel
-    try:
-        choice = input(
-            color(f"  Enable all {len(tools)} tools? [Y/n/select]: ", Colors.YELLOW)
-        ).strip().lower()
-    except (KeyboardInterrupt, EOFError):
-        print()
-        _info("Cancelled.")
-        return
+    # Ask: enable all, select, or cancel unless the caller explicitly selected
+    # the headless all-tools path.
+    if all_tools:
+        choice = ""
+    else:
+        try:
+            choice = input(
+                color(f"  Enable all {len(tools)} tools? [Y/n/select]: ", Colors.YELLOW)
+            ).strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            _info("Cancelled.")
+            return
 
     if choice in {"n", "no"}:
         _info("Cancelled — server not saved.")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1060,6 +1060,7 @@ def switch_model(
     resolved_alias = ""
     new_model = raw_input.strip()
     target_provider = current_provider
+    selected_pdef: Optional[ProviderDef] = None
     resolved_moa_preset = False
 
     # =================================================================
@@ -1096,6 +1097,7 @@ def switch_model(
                 error_message=_switch_err,
             )
 
+        selected_pdef = pdef
         target_provider = pdef.id
         if target_provider == "moa" and not new_model:
             try:
@@ -1357,6 +1359,43 @@ def switch_model(
     # =================================================================
     # COMMON PATH: Resolve credentials, normalize, get metadata
     # =================================================================
+
+    # Reject forbidden OpenRouter families before credentials, persistence, or
+    # in-session state can be touched.  Reuse the runtime gate so the CLI,
+    # gateway, and picker paths enforce one exact family policy.
+    candidate_base_url = current_base_url
+    if selected_pdef is not None and selected_pdef.base_url:
+        candidate_base_url = selected_pdef.base_url
+    if resolved_alias:
+        _ensure_direct_aliases()
+        _direct_alias = DIRECT_ALIASES.get(resolved_alias)
+        if _direct_alias is not None and _direct_alias.base_url:
+            candidate_base_url = _direct_alias.base_url
+    try:
+        from hermes_cli.runtime_provider import (
+            AuthError,
+            _assert_openrouter_model_allowed,
+        )
+
+        _assert_openrouter_model_allowed(
+            requested_provider=target_provider,
+            explicit_base_url=candidate_base_url,
+            model_cfg={
+                "provider": target_provider,
+                "base_url": candidate_base_url,
+                "default": new_model,
+            },
+            target_model=new_model,
+        )
+    except AuthError as exc:
+        return ModelSwitchResult(
+            success=False,
+            new_model=new_model,
+            target_provider=target_provider,
+            provider_label=get_label(target_provider),
+            is_global=is_global,
+            error_message=str(exc),
+        )
 
     provider_changed = target_provider != current_provider
     provider_label = get_label(target_provider)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -59,6 +59,74 @@ def _getenv(name: str, default: str = "") -> str:
     return val if val is not None else default
 
 
+_DISALLOWED_OPENROUTER_MODEL_RE = re.compile(
+    r"(?:^|[/:_-])(?:openai|gpt|chatgpt|o[134]|codex)(?:$|[/:_.-])|anthropic/|anthopic/|(?:^|[/:_-])claude(?:$|[/:_.-])|(?:^|[/:_-])fable(?:$|[/:_.-])",
+    re.IGNORECASE,
+)
+
+
+def _openrouter_guard_applies(
+    *,
+    requested_provider: str,
+    explicit_base_url: Optional[str],
+    model_cfg: Dict[str, Any],
+) -> bool:
+    """Return True when this runtime resolution would use OpenRouter.
+
+    The user may configure OpenRouter in two supported shapes:
+    ``provider: openrouter`` or ``provider: openai-api`` with
+    ``base_url: https://openrouter.ai/api/v1``.  Guard both, plus explicit
+    OpenRouter base_url overrides, without affecting direct OpenAI/Codex,
+    Anthropic, local, or other provider use.
+    """
+    requested_norm = str(requested_provider or "").strip().lower()
+    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+    cfg_base_url = str(model_cfg.get("base_url") or "").strip()
+    explicit = str(explicit_base_url or "").strip()
+
+    if requested_norm == "openrouter":
+        return True
+    if explicit and base_url_host_matches(explicit, "openrouter.ai"):
+        return True
+    if cfg_base_url and base_url_host_matches(cfg_base_url, "openrouter.ai"):
+        return cfg_provider in {"openrouter", "openai-api", "auto", ""}
+    return False
+
+
+def _assert_openrouter_model_allowed(
+    *,
+    requested_provider: str,
+    explicit_base_url: Optional[str],
+    model_cfg: Dict[str, Any],
+    target_model: Optional[str],
+) -> None:
+    """Fail closed before any OpenRouter request can target banned families.
+
+    OpenRouter itself is allowed.  What is forbidden for this profile is routing
+    OpenRouter spend to Codex, Anthropic/Claude, or Fable-like model ids.  This
+    is a routing guard, not a model pin: any non-matching OpenRouter model still
+    resolves normally.
+    """
+    model = str(target_model or model_cfg.get("default") or "").strip()
+    if not model:
+        return
+    if not _openrouter_guard_applies(
+        requested_provider=requested_provider,
+        explicit_base_url=explicit_base_url,
+        model_cfg=model_cfg,
+    ):
+        return
+    if not _DISALLOWED_OPENROUTER_MODEL_RE.search(model):
+        return
+    raise AuthError(
+        "Refusing to route OpenRouter to a forbidden model family "
+        f"({model!r}). OpenRouter is allowed, but OpenAI/Codex, Anthropic/Claude, "
+        "and Fable-like model ids are blocked in this Hermes profile.",
+        provider="openrouter",
+        code="disallowed_openrouter_model",
+    )
+
+
 def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
@@ -1642,6 +1710,13 @@ def resolve_runtime_provider(
     behavior (api_mode derived from config).
     """
     requested_provider = resolve_requested_provider(requested)
+    _model_cfg_for_guard = _get_model_config()
+    _assert_openrouter_model_allowed(
+        requested_provider=requested_provider,
+        explicit_base_url=explicit_base_url,
+        model_cfg=_model_cfg_for_guard,
+        target_model=target_model,
+    )
 
     # Honour ``providers.<name>.enabled: false`` for BOTH user-defined
     # custom providers and the built-in ones (openai / anthropic /
@@ -1918,6 +1993,23 @@ def resolve_runtime_provider(
                         "falling through to next provider.")
 
     if provider == "openai-codex":
+        # ``codex app-server`` authenticates itself from CODEX_HOME/auth.json.
+        # Hermes does not send an OpenAI request on this path, so requiring its
+        # separate OAuth store here would spuriously force a second device login
+        # before the app-server session can start.
+        if _maybe_apply_codex_app_server_runtime(
+            provider=provider,
+            api_mode="codex_responses",
+            model_cfg=model_cfg,
+        ) == "codex_app_server":
+            return {
+                "provider": "openai-codex",
+                "api_mode": "codex_app_server",
+                "base_url": "",
+                "api_key": "",
+                "source": "codex-cli-app-server",
+                "requested_provider": requested_provider,
+            }
         try:
             creds = resolve_codex_runtime_credentials()
             return {

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1698,6 +1698,7 @@ def resolve_runtime_provider(
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
     target_model: Optional[str] = None,
+    enforce_openrouter_policy: bool = True,
 ) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution.
 
@@ -1708,15 +1709,16 @@ def resolve_runtime_provider(
     api_mode is derived from the model they are switching TO, not the stale
     persisted default. Other callers can leave it None to preserve existing
     behavior (api_mode derived from config).
+
+    enforce_openrouter_policy: When True (default), reject forbidden
+    OpenRouter model families before resolving credentials — see
+    ``_assert_openrouter_model_allowed``. Callers that only need resolved
+    metadata (e.g. context-window lookups for display) and never send a
+    request with the returned credentials should pass False so a passive
+    introspection call cannot be mistaken for the live-routing spend it is
+    guarding against.
     """
     requested_provider = resolve_requested_provider(requested)
-    _model_cfg_for_guard = _get_model_config()
-    _assert_openrouter_model_allowed(
-        requested_provider=requested_provider,
-        explicit_base_url=explicit_base_url,
-        model_cfg=_model_cfg_for_guard,
-        target_model=target_model,
-    )
 
     # Honour ``providers.<name>.enabled: false`` for BOTH user-defined
     # custom providers and the built-in ones (openai / anthropic /
@@ -1727,7 +1729,10 @@ def resolve_runtime_provider(
     # for a provider the user explicitly turned off.
     #
     # Fail fast with a typed error so the fallback chain can advance to
-    # the next provider instead of using a disabled one.
+    # the next provider instead of using a disabled one. This must run
+    # BEFORE the OpenRouter model-family guard below: a provider the user
+    # has explicitly disabled should always fail with the same typed
+    # ValueError regardless of which model it was last configured with.
     from hermes_cli.config import is_provider_enabled, load_config
     _full_cfg = load_config()
     _provs_cfg = _full_cfg.get("providers") if isinstance(_full_cfg, dict) else None
@@ -1738,6 +1743,15 @@ def resolve_runtime_provider(
                 f"provider {requested_provider!r} is disabled in config "
                 f"(providers.{requested_provider}.enabled: false)"
             )
+
+    if enforce_openrouter_policy:
+        _model_cfg_for_guard = _get_model_config()
+        _assert_openrouter_model_allowed(
+            requested_provider=requested_provider,
+            explicit_base_url=explicit_base_url,
+            model_cfg=_model_cfg_for_guard,
+            target_model=target_model,
+        )
 
     if requested_provider == "moa":
         return {

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -66,6 +66,11 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         help="Timeout in seconds for initial connection and tool discovery",
     )
     mcp_add_p.add_argument(
+        "--all-tools",
+        action="store_true",
+        help="Enable every discovered tool without an interactive selection prompt",
+    )
+    mcp_add_p.add_argument(
         "--env",
         nargs="*",
         default=[],

--- a/run_agent.py
+++ b/run_agent.py
@@ -6913,11 +6913,20 @@ class AIAgent:
         original_user_message: Any,
         messages: List[Dict[str, Any]],
         effective_task_id: str,
+        developer_instructions: str = "",
         should_review_memory: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            developer_instructions=developer_instructions,
+            should_review_memory=should_review_memory,
+        )
 
 def main(
     query: str = None,

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -132,12 +132,18 @@ def test_is_codex_gpt54_or_gpt55_rejects_non_54_55_models(model) -> None:
 
 
 def test_compression_threshold_for_codex_gpt55() -> None:
-    assert _compression_threshold_for_model("gpt-5.4", "openai-codex") == 0.85
-    assert _compression_threshold_for_model("gpt-5.4-pro", "openai-codex") == 0.85
-    assert _compression_threshold_for_model("openai/gpt-5.4", "openai-codex") == 0.85
-    assert _compression_threshold_for_model("gpt-5.5", "openai-codex") == 0.85
-    assert _compression_threshold_for_model("gpt-5.5-pro", "openai-codex") == 0.85
-    assert _compression_threshold_for_model("openai/gpt-5.5", "openai-codex") == 0.85
+    for model in (
+        "gpt-5.4",
+        "gpt-5.4-pro",
+        "openai/gpt-5.4",
+        "gpt-5.5",
+        "gpt-5.5-pro",
+        "openai/gpt-5.5",
+    ):
+        threshold = _compression_threshold_for_model(model, "openai-codex")
+        assert threshold is not None
+        assert 0.50 < threshold < 0.85
+        assert 272_000 * (1 - threshold) >= 90_000
 
 
 def test_compression_threshold_codex_gpt55_other_routes_unaffected() -> None:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -33,6 +33,7 @@ from agent.auxiliary_client import (
     _resolve_auto,
     _resolve_task_provider_model,
     _resolve_xai_oauth_for_aux,
+    _task_provider_fallback_enabled,
     _CodexCompletionsAdapter,
     _pool_runtime_base_url,
 )
@@ -96,6 +97,148 @@ def codex_auth_dir(tmp_path, monkeypatch):
         lambda: "codex-test-token-abc123",
     )
     return codex_dir
+
+
+class TestAuxiliaryFailClosedFallbackPolicy:
+    def test_none_disables_cross_provider_fallback(self):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"fallback_policy": "none"},
+        ):
+            assert _task_provider_fallback_enabled("compression") is False
+
+    def test_unknown_policy_fails_closed(self, caplog):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"fallback_policy": "typo"},
+        ), caplog.at_level(logging.WARNING):
+            assert _task_provider_fallback_enabled("compression") is False
+        assert "invalid fallback_policy" in caplog.text
+
+    def test_sync_provider_failure_never_crosses_provider(self):
+        primary = MagicMock()
+        primary.base_url = "http://127.0.0.1:11434/v1"
+        primary.chat.completions.create.side_effect = Exception("Connection error")
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=(
+                    "custom",
+                    "qwen3.5:9b",
+                    "http://127.0.0.1:11434/v1",
+                    None,
+                    None,
+                ),
+            ),
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"fallback_policy": "none"},
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(primary, "qwen3.5:9b"),
+            ),
+            patch(
+                "agent.auxiliary_client._transient_retry_count",
+                return_value=0,
+            ),
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+            ) as configured_fallback,
+            patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+            ) as main_fallback,
+            patch(
+                "agent.auxiliary_client._try_payment_fallback",
+            ) as discovery_fallback,
+            pytest.raises(Exception, match="Connection error"),
+        ):
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        configured_fallback.assert_not_called()
+        main_fallback.assert_not_called()
+        discovery_fallback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_provider_failure_never_crosses_provider(self):
+        primary = MagicMock()
+        primary.base_url = "http://127.0.0.1:11434/v1"
+        primary.chat.completions.create = AsyncMock(
+            side_effect=Exception("Connection error")
+        )
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=(
+                    "custom",
+                    "qwen3.5:9b",
+                    "http://127.0.0.1:11434/v1",
+                    None,
+                    None,
+                ),
+            ),
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"fallback_policy": "none"},
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(primary, "qwen3.5:9b"),
+            ),
+            patch(
+                "agent.auxiliary_client._transient_retry_count",
+                return_value=0,
+            ),
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+            ) as configured_fallback,
+            patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+            ) as main_fallback,
+            patch(
+                "agent.auxiliary_client._try_payment_fallback",
+            ) as discovery_fallback,
+            pytest.raises(Exception, match="Connection error"),
+        ):
+            await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        configured_fallback.assert_not_called()
+        main_fallback.assert_not_called()
+        discovery_fallback.assert_not_called()
+
+    def test_auto_resolution_stops_before_discovery_chain(self):
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_provider",
+                return_value="custom",
+            ),
+            patch(
+                "agent.auxiliary_client._read_main_model",
+                return_value="qwen3.5:9b",
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(None, None),
+            ),
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"fallback_policy": "none"},
+            ),
+            patch(
+                "agent.auxiliary_client._get_provider_chain",
+            ) as discovery_chain,
+        ):
+            assert _resolve_auto(task="compression") == (None, None)
+
+        discovery_chain.assert_not_called()
 
 
 class TestAuxiliaryMaxTokensParam:

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -228,7 +228,10 @@ class TestCodexItemCompletionPayload:
 
 
 class TestStreamDeltaDispatch:
-    def test_agent_message_delta_fires_stream_delta(self):
+    def test_agent_message_delta_fires_stream_delta_when_redaction_disabled(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
         agent = _make_stub_agent()
         bridge = make_codex_app_server_event_bridge(agent)
         bridge({"method": "item/agentMessage/delta",
@@ -246,20 +249,35 @@ class TestStreamDeltaDispatch:
         bridge({"method": "item/agentMessage/delta", "params": {}})
         agent._fire_stream_delta.assert_not_called()
 
-    def test_text_field_used_when_delta_missing(self):
+    def test_text_field_used_when_delta_missing(self, monkeypatch):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
         agent = _make_stub_agent()
         bridge = make_codex_app_server_event_bridge(agent)
         bridge({"method": "item/agentMessage/delta",
                 "params": {"text": "fallback"}})
         agent._fire_stream_delta.assert_called_once_with("fallback")
 
-    def test_reasoning_delta_fires_reasoning_callback(self):
+    def test_reasoning_delta_fires_reasoning_callback(self, monkeypatch):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
         agent = _make_stub_agent()
         bridge = make_codex_app_server_event_bridge(agent)
         bridge({"method": "item/reasoning/delta",
                 "params": {"delta": "thinking..."}})
         agent._fire_reasoning_delta.assert_called_once_with("thinking...")
         agent._fire_stream_delta.assert_not_called()
+
+    def test_secure_mode_withholds_unredactable_stream_chunks(self, monkeypatch):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge({"method": "item/agentMessage/delta",
+                "params": {"delta": "sk-"}})
+        bridge({"method": "item/agentMessage/delta",
+                "params": {"delta": "split-secret-body"}})
+        bridge({"method": "item/reasoning/delta",
+                "params": {"delta": "sk-reasoning-secret"}})
+        agent._fire_stream_delta.assert_not_called()
+        agent._fire_reasoning_delta.assert_not_called()
 
 
 class TestToolProgressDispatch:
@@ -305,6 +323,20 @@ class TestToolProgressDispatch:
         assert completed.kwargs["duration"] == pytest.approx(0.042)
         assert completed.kwargs["is_error"] is False
         assert completed.kwargs["result"] == "hi\n"
+
+    def test_command_completion_secret_is_redacted_from_callbacks(self):
+        secret = "sk-" + ("s1canary" * 6)
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "commandExecution",
+            "id": "exec-secret",
+            "command": "printenv S1_REDACTION_CANARY",
+            "exitCode": 0,
+            "aggregatedOutput": secret,
+        }))
+        completed = agent.tool_progress_callback.call_args
+        assert secret not in completed.kwargs["result"]
 
     def test_nonzero_exit_marks_completion_error(self):
         agent = _make_stub_agent()

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -161,6 +161,69 @@ def test_codex_turn_persists_each_message_exactly_once():
         shutil.rmtree(tmp)
 
 
+def _make_turn_with_projected_user():
+    """Model a real app-server turn, which echoes the inbound user item."""
+    turn = _make_turn()
+    turn.projected_messages = [
+        {"role": "user", "content": "USER_TURN"},
+        *turn.projected_messages,
+    ]
+    return turn
+
+
+def test_codex_turn_drops_projected_copy_of_inbound_user_message():
+    """Codex's userMessage event is an echo, not a second user turn.
+
+    The inbound turn is already appended and flushed before the native runtime
+    starts. Persisting the projected echo doubles every user request and
+    accelerates context growth on long sessions.
+    """
+    tmp = tempfile.mkdtemp(prefix="codex_projected_user_")
+    try:
+        db = SessionDB(Path(tmp) / "state.db")
+        sid = "sess-codex-projected-user"
+        db.create_session(session_id=sid, source="cli", model="codex")
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=db,
+            session_id=sid,
+        )
+        agent._session_db_created = True
+        agent._codex_session = MagicMock()
+        agent._codex_session.run_turn.return_value = (
+            _make_turn_with_projected_user()
+        )
+        agent.tool_progress_callback = None
+
+        user_msg = {"role": "user", "content": "USER_TURN"}
+        messages = [user_msg]
+        agent._flush_messages_to_session_db(messages)
+
+        result = run_codex_app_server_turn(
+            agent,
+            user_message="USER_TURN",
+            original_user_message="USER_TURN",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+
+        assert result["agent_persisted"] is True
+        assert [
+            msg["content"] for msg in result["messages"]
+            if msg.get("role") == "user"
+        ] == ["USER_TURN"]
+        rows = db.get_messages(sid, include_inactive=True)
+        assert [row["content"] for row in rows].count("USER_TURN") == 1
+    finally:
+        import shutil
+
+        shutil.rmtree(tmp)
+
+
 class TestGatewayPersistedResolution:
     """The gateway default must preserve standard-runtime skip-db behaviour."""
 

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -84,13 +84,19 @@ def _threshold_ratio(agent: AIAgent) -> float:
     return round(compressor.threshold_tokens / compressor.context_length, 2)
 
 
+def _assert_safer_autoraise_applies(agent: AIAgent) -> None:
+    ratio = _threshold_ratio(agent)
+    assert ratio > 0.50
+    assert ratio < 0.85
+
+
 # ── config display gate ──────────────────────────────────────────────────────
 
 
 def test_codex_gpt55_autoraise_notice_enabled_by_default(monkeypatch, tmp_path):
     agent, stdout = _make_codex_agent(monkeypatch, tmp_path, show_notice=True)
 
-    assert _threshold_ratio(agent) == 0.85
+    _assert_safer_autoraise_applies(agent)
     warning = getattr(agent, "_compression_warning")
     assert warning is not None
     assert "auto-compaction was raised" in warning
@@ -102,7 +108,7 @@ def test_codex_gpt55_autoraise_notice_can_be_suppressed_without_disabling_autora
 ):
     agent, stdout = _make_codex_agent(monkeypatch, tmp_path, show_notice=False)
 
-    assert _threshold_ratio(agent) == 0.85
+    _assert_safer_autoraise_applies(agent)
     assert getattr(agent, "_compression_warning") is None
     assert "auto-compaction was raised" not in stdout
 
@@ -116,7 +122,7 @@ def test_codex_gpt55_autoraise_notice_deduped_across_agent_inits(monkeypatch, tm
     assert getattr(agent1, "_compression_warning") is not None
 
     agent2, stdout2 = _make_codex_agent(monkeypatch, tmp_path, show_notice=True)
-    assert _threshold_ratio(agent2) == 0.85  # autoraise still applies
+    _assert_safer_autoraise_applies(agent2)
     assert "auto-compaction was raised" not in stdout2
     assert getattr(agent2, "_compression_warning") is None
 

--- a/tests/agent/test_codex_runtime_live_events.py
+++ b/tests/agent/test_codex_runtime_live_events.py
@@ -47,7 +47,8 @@ def _recording_agent():
     return agent, calls
 
 
-def test_agent_message_and_reasoning_deltas_are_forwarded_live():
+def test_agent_message_and_reasoning_deltas_are_forwarded_live(monkeypatch):
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
     agent, calls = _recording_agent()
     bridge = make_codex_app_server_event_bridge(agent)
 

--- a/tests/agent/test_codex_runtime_token_accounting.py
+++ b/tests/agent/test_codex_runtime_token_accounting.py
@@ -1,0 +1,129 @@
+"""Regression test for #hermes-context-overrun (7th recurrence, 2026-07-27,
+423K/258.4K = 164% gauge reading with zero real context-length-exceeded API
+errors in agent.log for that window).
+
+Root cause: ``_record_codex_app_server_usage`` built ``prompt_tokens`` as
+``inputTokens + cachedInputTokens``, but the codex app-server wire protocol
+reports ``inputTokens`` ALREADY INCLUSIVE of ``cachedInputTokens`` (verified
+against the installed codex-cli's own
+``codex app-server generate-json-schema`` output and the upstream codex-rs
+test fixture in ``codex-rs/codex-api/src/sse/responses.rs::
+parses_cache_write_token_usage``: input_tokens=100, cached_tokens=40 (a
+SUBSET of the 100), output_tokens=10 -> total_tokens=110, i.e. 100+10, never
+100+40+10=150). Adding the cached share back on top double-counted it,
+inflating ``last_real_prompt_tokens`` (the number both the live status gauge
+and turn_context.py's preflight/compaction backstop compare against the
+context window) by up to ~2x once a session's cache-hit ratio climbs, which
+is exactly what happens as a long session's context grows.
+
+This test drives the real accounting function against that exact upstream
+fixture so a future edit that reintroduces the double-count fails loudly
+here instead of silently re-inflating the live gauge.
+"""
+from types import SimpleNamespace
+
+from agent import codex_runtime
+
+
+class _FakeCompressor:
+    def __init__(self):
+        self.context_length = 258_400
+        self.threshold_tokens = 193_800
+        self.threshold_percent = 0.75
+        self.max_tokens = None
+        self.last_prompt_tokens = 0
+        self.last_real_prompt_tokens = 0
+        self.last_total_tokens = 0
+        self.last_completion_tokens = 0
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        self.last_total_tokens = usage.get("total_tokens", 0)
+        if self.last_prompt_tokens > 0:
+            self.last_real_prompt_tokens = self.last_prompt_tokens
+
+    def _compute_threshold_tokens(self, *a, **k):
+        return self.threshold_tokens
+
+    def _apply_threshold_tokens_cap(self):
+        pass
+
+
+def _agent_with_compressor():
+    return SimpleNamespace(
+        session_api_calls=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_estimated_cost_usd=0.0,
+        session_cost_status=None,
+        session_cost_source=None,
+        context_compressor=_FakeCompressor(),
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex/",
+        api_key="",
+        _session_db=None,
+        session_id=None,
+    )
+
+
+def test_no_cached_token_double_count_matches_upstream_fixture():
+    """codex-rs's own ``parses_cache_write_token_usage`` fixture: inputTokens
+    is already inclusive of cachedInputTokens, so the real prompt size is 100
+    (not 140) and the real total is 110 (not 150)."""
+    agent = _agent_with_compressor()
+    turn = SimpleNamespace(
+        token_usage_last={
+            "inputTokens": 100,
+            "cachedInputTokens": 40,
+            "outputTokens": 10,
+            "reasoningOutputTokens": 5,
+            "totalTokens": 110,
+        },
+        model_context_window=258_400,
+    )
+
+    result = codex_runtime._record_codex_app_server_usage(agent, turn)
+
+    assert result["prompt_tokens"] == 100, (
+        "prompt_tokens double-counted cachedInputTokens on top of the "
+        "already-inclusive inputTokens (regressed to the "
+        "#hermes-context-overrun bug)"
+    )
+    assert result["total_tokens"] == 110
+    assert agent.context_compressor.last_real_prompt_tokens == 100, (
+        "last_real_prompt_tokens is what the live gauge and the "
+        "preflight/compaction backstop both read -- an inflated value here "
+        "reproduces the 423K/258.4K false-overrun incident"
+    )
+
+
+def test_high_cache_hit_ratio_does_not_inflate_toward_double():
+    """A realistic high-cache-hit-ratio turn (the pattern that produced the
+    7th recurrence): without the fix, prompt_tokens would be
+    86919 + 77568 = 164487 against a 258400 window (63%, still under, but
+    already meaningfully inflated); with the fix it must equal the real
+    inputTokens, 86919 (34%)."""
+    agent = _agent_with_compressor()
+    turn = SimpleNamespace(
+        token_usage_last={
+            "inputTokens": 86919,
+            "cachedInputTokens": 77568,
+            "outputTokens": 400,
+            "reasoningOutputTokens": 120,
+            "totalTokens": 87319,
+        },
+        model_context_window=258_400,
+    )
+
+    result = codex_runtime._record_codex_app_server_usage(agent, turn)
+
+    assert result["prompt_tokens"] == 86919
+    assert result["prompt_tokens"] != 86919 + 77568

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2793,6 +2793,41 @@ class TestTokenBudgetTailProtection:
         tail_size = len(messages) - cut
         assert tail_size >= 3, f"Tail is only {tail_size} messages, min should be 3"
 
+    def test_oversized_tool_result_in_protected_head_is_hard_capped(
+        self, budget_compressor, monkeypatch
+    ):
+        """A previously persisted bypass must remain recoverable.
+
+        The live failure placed a 1MB Codex-projected result immediately after
+        the compaction summary, inside the protected head. Normal middle/tail
+        pruning cannot touch that position, so the hard output cap must apply
+        before boundary protection.
+        """
+        monkeypatch.setattr(
+            "tools.tool_output_limits.get_max_bytes",
+            lambda: 100,
+        )
+        messages = [
+            {"role": "assistant", "content": "compaction summary"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_oversized",
+                "content": "X" * 10_000,
+            },
+            {"role": "assistant", "content": "continuing"},
+            {"role": "user", "content": "next"},
+        ]
+
+        pruned, count = budget_compressor._prune_old_tool_results(
+            messages,
+            protect_tail_count=20,
+            protect_tail_tokens=budget_compressor.tail_token_budget,
+        )
+
+        assert count == 1
+        assert len(pruned[1]["content"]) < 250
+        assert "OUTPUT TRUNCATED" in pruned[1]["content"]
+
     def test_tiny_budget_preserves_bounded_recent_turns(self, budget_compressor):
         """A token-exhausted tail must preserve more than just the latest ask.
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -113,6 +113,19 @@ class TestScanSkillCommands:
         assert "/enabled-skill" in result
         assert "/disabled-skill" not in result
 
+    def test_excludes_on_demand_skill_from_offer_surface(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "on-demand-skill",
+                frontmatter_extra="activation: on-demand\n",
+            )
+            _make_skill(tmp_path, "automatic-skill")
+            result = scan_skill_commands()
+
+        assert "/automatic-skill" in result
+        assert "/on-demand-skill" not in result
+
     def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"
@@ -515,6 +528,22 @@ class TestBuildPreloadedSkillsPrompt:
         assert "first-skill" in prompt
         assert "second-skill" in prompt
         assert "preloaded" in prompt.lower()
+
+    def test_explicitly_preloads_on_demand_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "on-demand-skill",
+                frontmatter_extra="activation: on-demand\n",
+                body="ON DEMAND CONTENT",
+            )
+            prompt, loaded, missing = build_preloaded_skills_prompt(
+                ["on-demand-skill"]
+            )
+
+        assert missing == []
+        assert loaded == ["on-demand-skill"]
+        assert "ON DEMAND CONTENT" in prompt
 
     def test_reports_missing_named_skills(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -13,9 +13,16 @@ from agent.skill_utils import (
     iter_skill_index_files,
     parse_frontmatter,
     resolve_skill_config_values,
+    skill_matches_environment,
     skill_matches_platform,
     skill_matches_platform_list,
 )
+
+
+def test_on_demand_activation_is_hidden_only_from_offer_surfaces():
+    assert skill_matches_environment({"activation": "on-demand"}) is False
+    assert skill_matches_environment({"activation": "automatic"}) is True
+    assert skill_matches_environment({}) is True
 
 
 def test_metadata_as_dict_with_hermes():

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -512,3 +512,58 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
+
+
+def test_codex_native_backstop_forces_compaction_on_real_usage_over_threshold(tmp_path):
+    """P0-2 (hermes-context-compaction-hang) regression guard.
+
+    In native/off mode Hermes normally never calls ``thread/compact/start``
+    itself — it assumes Codex compacts its own thread on its own schedule
+    (see ``test_codex_app_server_native_auto_mode_leaves_thread_compaction_to_codex``
+    in ``tests/run_agent/test_codex_app_server_compaction.py``, which still
+    asserts the hands-off default). But real sessions were observed climbing
+    to 1.4-1.7x the configured context window before a turn hung, proving
+    Codex's own compaction is not a reliable backstop on its own.
+
+    Hermes already receives Codex's REAL post-turn token usage every turn
+    (``last_real_prompt_tokens``) even in native mode — it just never acted
+    on it. This locks in the fix: once that real number is known to be over
+    threshold, the preflight must force a codex-native compaction rather
+    than silently trusting Codex, regardless of native/off mode.
+    """
+    agent = _make_agent_with_cooldown(tmp_path / "state.db", "sess-1")
+    agent.api_mode = "codex_app_server"
+    agent.codex_app_server_auto_compaction = "native"
+    agent.context_compressor.last_real_prompt_tokens = (
+        agent.context_compressor.threshold_tokens + 1000
+    )
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch("agent.turn_context.estimate_request_tokens_rough", return_value=100):
+        ctx = _build(agent)
+
+    assert isinstance(ctx, TurnContext)
+    agent._compress_context.assert_called_once()
+    _, kwargs = agent._compress_context.call_args
+    assert kwargs.get("force") is True
+
+
+def test_codex_native_mode_skips_when_real_usage_not_yet_over_threshold(tmp_path):
+    """Companion negative case for the backstop above: native mode's normal
+    hands-off behavior must stay untouched when Codex's real reported usage
+    has not (yet) proven the thread is over budget — the backstop must not
+    fire speculatively off the (structurally under-counting) rough local
+    estimate alone.
+    """
+    agent = _make_agent_with_cooldown(tmp_path / "state.db", "sess-1")
+    agent.api_mode = "codex_app_server"
+    agent.codex_app_server_auto_compaction = "native"
+    # last_real_prompt_tokens stays at its initial 0 — no real usage
+    # reported yet, so the backstop has no evidence to act on.
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch("agent.turn_context.estimate_request_tokens_rough", return_value=100):
+        ctx = _build(agent)
+
+    assert isinstance(ctx, TurnContext)
+    agent._compress_context.assert_not_called()

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -173,6 +173,18 @@ class TestLifecycle:
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
+        assert "developerInstructions" not in params
+
+    def test_thread_start_passes_scoped_developer_instructions(self):
+        client = FakeClient()
+        s = make_session(
+            client,
+            developer_instructions="You are Aurelian Hermes.",
+        )
+        s.ensure_started()
+        method, params = next(r for r in client.requests if r[0] == "thread/start")
+        assert method == "thread/start"
+        assert params["developerInstructions"] == "You are Aurelian Hermes."
 
     def test_close_idempotent(self):
         client = FakeClient()

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -422,6 +422,72 @@ class TestRunTurn:
         assert r.token_usage_total["totalTokens"] == 500
         assert r.model_context_window == 200000
 
+    def test_live_usage_interrupts_turn_before_context_headroom_is_exhausted(self):
+        client = FakeClient()
+        client.queue_notification(
+            "thread/tokenUsage/updated",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
+            tokenUsage={
+                "last": {
+                    "totalTokens": 170_001,
+                    "inputTokens": 170_000,
+                    "cachedInputTokens": 150_000,
+                    "outputTokens": 1,
+                },
+                "modelContextWindow": 258_400,
+            },
+        )
+
+        result = make_session(client).run_turn("continue", turn_timeout=2.0)
+
+        assert result.interrupted is True
+        assert result.context_ceiling_hit is True
+        assert result.should_retire is False
+        assert "context ceiling" in result.error
+        assert any(
+            method == "turn/interrupt"
+            and params.get("turnId") == "turn-fake-001"
+            for method, params in client.requests
+        )
+
+    def test_server_request_drain_enforces_same_live_context_ceiling(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-ceiling",
+            command="pwd",
+            cwd="/tmp",
+        )
+        client.queue_notification(
+            "thread/tokenUsage/updated",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
+            tokenUsage={
+                "last": {
+                    "totalTokens": 170_001,
+                    "inputTokens": 170_000,
+                    "outputTokens": 1,
+                },
+                "modelContextWindow": 258_400,
+            },
+        )
+        session = make_session(
+            client,
+            request_routing=_ServerRequestRouting(auto_approve_exec=True),
+        )
+
+        result = session.run_turn("continue", turn_timeout=2.0)
+
+        assert result.context_ceiling_hit is True
+        assert client.responses == [
+            ("approval-ceiling", {"decision": "accept"})
+        ]
+        assert any(
+            method == "turn/interrupt"
+            for method, _params in client.requests
+        )
+
     def test_rich_content_turn_is_collapsed_to_text_payload(self):
         client = FakeClient()
         client.queue_notification(
@@ -1573,6 +1639,90 @@ class TestHasTurnAbortedMarker:
             _has_turn_aborted_marker,
         )
         assert _has_turn_aborted_marker("<turn_aborted/>") is True
+
+
+class TestEnforceTurnToolOutputBudget:
+    """Unit coverage for the per-turn cumulative tool-output budget.
+
+    2026-07-27 ALL-HANDS ANGLE B (#hermes-context-overrun): the projector's
+    per-result truncate_tool_output cap alone was proven insufficient — a
+    turn with several tool calls can stack N capped-but-still-large
+    results past the context window (measured: seven results at the old
+    50000-char per-result cap, ~87K tokens in ONE turn). This budget is a
+    second, independent ceiling on the SUM across a whole turn.
+    """
+
+    def test_single_result_under_budget_is_untouched(self):
+        from agent.transports.codex_app_server_session import (
+            _enforce_turn_tool_output_budget,
+        )
+        msgs = [
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "x" * 100},
+        ]
+        chars_used, hit = _enforce_turn_tool_output_budget(msgs, 0, 1000)
+        assert chars_used == 100
+        assert hit is False
+        assert msgs[1]["content"] == "x" * 100
+
+    def test_result_crossing_budget_is_truncated_not_dropped(self):
+        from agent.transports.codex_app_server_session import (
+            _enforce_turn_tool_output_budget,
+        )
+        msgs = [{"role": "tool", "tool_call_id": "c1", "content": "y" * 500}]
+        chars_used, hit = _enforce_turn_tool_output_budget(msgs, 800, 1000)
+        assert chars_used == 1000
+        assert hit is True
+        assert len(msgs[0]["content"]) < 500
+        assert "TURN BUDGET TRUNCATED" in msgs[0]["content"]
+
+    def test_result_after_budget_exhausted_is_fully_suppressed(self):
+        from agent.transports.codex_app_server_session import (
+            _enforce_turn_tool_output_budget,
+        )
+        msgs = [{"role": "tool", "tool_call_id": "c2", "content": "z" * 500}]
+        chars_used, hit = _enforce_turn_tool_output_budget(msgs, 1000, 1000)
+        assert chars_used == 1000
+        assert hit is True
+        assert "TURN TOOL-OUTPUT BUDGET EXCEEDED" in msgs[0]["content"]
+
+    def test_seven_maxed_results_never_exceed_budget(self):
+        """Reproduces the measured incident shape: 7 results each pinned
+        at the (old) 50000-char per-result cap in one turn. Cumulative
+        tool-output chars across the whole turn must never exceed the
+        configured per-turn budget, regardless of how many tool calls
+        fire."""
+        from agent.transports.codex_app_server_session import (
+            _enforce_turn_tool_output_budget,
+        )
+        budget = 60_000
+        chars_used = 0
+        for i in range(7):
+            msgs = [
+                {"role": "assistant", "content": None, "tool_calls": [{"id": f"c{i}"}]},
+                {"role": "tool", "tool_call_id": f"c{i}", "content": "X" * 50_000},
+            ]
+            chars_used, _hit = _enforce_turn_tool_output_budget(
+                msgs, chars_used, budget
+            )
+            assert chars_used <= budget
+        assert chars_used == budget
+
+    def test_non_tool_messages_are_never_touched(self):
+        from agent.transports.codex_app_server_session import (
+            _enforce_turn_tool_output_budget,
+        )
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "c1"}],
+            }
+        ]
+        chars_used, hit = _enforce_turn_tool_output_budget(msgs, 999_999, 1000)
+        assert chars_used == 999_999
+        assert hit is False
+        assert msgs[0]["tool_calls"] == [{"id": "c1"}]
 
 
 class TestClassifyOAuthFailure:

--- a/tests/agent/transports/test_codex_event_projector.py
+++ b/tests/agent/transports/test_codex_event_projector.py
@@ -123,6 +123,35 @@ class TestCommandExecutionProjection:
         b = p2.project(COMMAND_EXEC_COMPLETED).messages
         assert a[0]["tool_calls"][0]["id"] == b[0]["tool_calls"][0]["id"]
 
+    def test_oversized_output_respects_configured_projection_cap(
+        self, monkeypatch
+    ) -> None:
+        """Codex-projected output must not bypass Hermes' tool-output cap.
+
+        Projected rows land at the newest edge of the transcript, where
+        compaction intentionally protects recent messages. Persisting an
+        unbounded command result there can make the session impossible to
+        compact.
+        """
+        monkeypatch.setattr(
+            "tools.tool_output_limits.get_max_bytes",
+            lambda: 100,
+        )
+        item = {
+            **COMMAND_EXEC_COMPLETED["params"]["item"],
+            "aggregatedOutput": "A" * 1000,
+        }
+        notification = {
+            "method": "item/completed",
+            "params": {**COMMAND_EXEC_COMPLETED["params"], "item": item},
+        }
+
+        tool_message = CodexEventProjector().project(notification).messages[1]
+
+        assert len(tool_message["content"]) < 250
+        assert "OUTPUT TRUNCATED" in tool_message["content"]
+        assert "900 chars omitted" in tool_message["content"]
+
 
 class TestAgentMessageProjection:
     """assistant text → final_text + assistant message."""
@@ -209,8 +238,35 @@ class TestMcpToolCallProjection:
         msgs = CodexEventProjector().project(
             {"method": "item/completed", "params": {"item": item}}
         ).messages
-        assert msgs[0]["tool_calls"][0]["function"]["name"] == "mcp.obsidian.search_notes"
+        function_name = msgs[0]["tool_calls"][0]["function"]["name"]
+        assert function_name == "mcp__obsidian__search_notes"
+        assert function_name.replace("_", "").isalnum()
         assert "found" in msgs[1]["content"]
+
+    def test_mcp_identifiers_fit_codex_responses_constraints(self) -> None:
+        item = {
+            "type": "mcpToolCall",
+            "id": "item-" + ("x" * 100),
+            "server": "hermes-tools",
+            "tool": "skill.view",
+            "status": "completed",
+            "arguments": {},
+            "result": {"ok": True},
+            "error": None,
+        }
+
+        messages = CodexEventProjector().project(
+            {"method": "item/completed", "params": {"item": item}}
+        ).messages
+        tool_call = messages[0]["tool_calls"][0]
+
+        assert len(tool_call["id"]) <= 64
+        assert all(ch.isalnum() or ch in "_-" for ch in tool_call["id"])
+        assert all(
+            ch.isalnum() or ch in "_-"
+            for ch in tool_call["function"]["name"]
+        )
+        assert messages[1]["tool_call_id"] == tool_call["id"]
 
     def test_mcp_error_surfaced(self) -> None:
         item = {

--- a/tests/agent/transports/test_codex_event_projector.py
+++ b/tests/agent/transports/test_codex_event_projector.py
@@ -152,6 +152,23 @@ class TestCommandExecutionProjection:
         assert "OUTPUT TRUNCATED" in tool_message["content"]
         assert "900 chars omitted" in tool_message["content"]
 
+    def test_command_output_secret_is_redacted_before_projection(self) -> None:
+        secret = "sk-" + ("s1canary" * 6)
+        item = {
+            **COMMAND_EXEC_COMPLETED["params"]["item"],
+            "command": "printenv S1_REDACTION_CANARY",
+            "aggregatedOutput": secret + "\n",
+        }
+        notification = {
+            "method": "item/completed",
+            "params": {**COMMAND_EXEC_COMPLETED["params"], "item": item},
+        }
+
+        messages = CodexEventProjector().project(notification).messages
+
+        assert secret not in messages[1]["content"]
+        assert secret not in messages[0]["tool_calls"][0]["function"]["arguments"]
+
 
 class TestAgentMessageProjection:
     """assistant text → final_text + assistant message."""
@@ -198,6 +215,22 @@ class TestAgentMessageProjection:
             "type": "agentMessage", "id": "b", "text": "second"}}}).messages[0]
         assert "reasoning" in first
         assert "reasoning" not in second
+
+    def test_agent_echo_secret_is_redacted_before_final_and_history(self) -> None:
+        secret = "sk-" + ("s1canary" * 6)
+        result = CodexEventProjector().project({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "agentMessage",
+                    "id": "secret-echo",
+                    "text": secret,
+                }
+            },
+        })
+
+        assert secret not in result.final_text
+        assert secret not in result.messages[0]["content"]
 
 
 class TestFileChangeProjection:

--- a/tests/cli/test_classic_cli_memory_notifications.py
+++ b/tests/cli/test_classic_cli_memory_notifications.py
@@ -1,0 +1,36 @@
+"""Classic CLI coverage for background-review notification configuration."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from hermes_cli.cli_agent_setup_mixin import (
+    CLIAgentSetupMixin,
+    _normalize_memory_notifications,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, "on"),
+        (False, "off"),
+        (True, "on"),
+        ("off", "off"),
+        (" OFF ", "off"),
+        ("on", "on"),
+        ("verbose", "verbose"),
+        ("invalid", "on"),
+    ],
+)
+def test_normalize_memory_notifications(raw, expected):
+    assert _normalize_memory_notifications(raw) == expected
+
+
+def test_classic_cli_applies_memory_notifications_to_agent():
+    """The classic CLI must not leave AIAgent's hard-coded default in place."""
+    src = inspect.getsource(CLIAgentSetupMixin._init_agent)
+    assert "self.agent.memory_notifications = _normalize_memory_notifications(" in src
+    assert 'CLI_CONFIG.get("display")' in src

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,11 @@ Hermetic-test invariants enforced here (see AGENTS.md for rationale):
 1. **No credential env vars.** All provider/credential-shaped env vars
    (ending in _API_KEY, _TOKEN, _SECRET, _PASSWORD, _CREDENTIALS, etc.)
    are unset before every test. Local developer keys cannot leak in.
-2. **Isolated HERMES_HOME.** HERMES_HOME points to a per-test tempdir so
-   code reading ``~/.hermes/*`` via ``get_hermes_home()`` can't see the
-   real one. (We do NOT also redirect HOME — that broke subprocesses in
-   CI. Code using ``Path.home() / ".hermes"`` instead of the canonical
-   ``get_hermes_home()`` is a bug to fix at the callsite.)
+2. **Isolated HERMES_HOME.** HERMES_HOME points to a session tempdir before
+   collection, then a per-test tempdir while each test runs, so imports and
+   test bodies cannot see the real one. (We do NOT also redirect HOME — that
+   broke subprocesses in CI. Code using ``Path.home() / ".hermes"`` instead
+   of the canonical ``get_hermes_home()`` is a bug to fix at the callsite.)
 3. **Deterministic runtime.** TZ=UTC, LANG=C.UTF-8, PYTHONHASHSEED=0.
 4. **No HERMES_SESSION_* inheritance** — the agent's current gateway
    session must not leak into tests.
@@ -21,11 +21,51 @@ test runner at ``scripts/run_tests.sh``.
 
 import asyncio
 import os
+import shutil
 import sqlite3
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
+
+# Test modules are imported during collection, before autouse fixtures run.
+# Several CLI modules initialize Hermes file logging at import time, so merely
+# redirecting HERMES_HOME in _hermetic_environment is too late: collection can
+# otherwise attach handlers to the developer's live ~/.hermes/logs.
+#
+# Establish a session-scoped test home before pytest imports any test module.
+# Individual tests still receive their own tmp_path HERMES_HOME below. The
+# optional explicit root exists for live acceptance runs that need to inspect
+# the isolated logs after pytest exits.
+_ORIGINAL_HERMES_HOME = os.environ.get("HERMES_HOME")
+_EXPLICIT_TEST_SESSION_HOME = os.environ.get("HERMES_TEST_SESSION_HOME")
+_REAL_HERMES_HOME = Path(
+    _ORIGINAL_HERMES_HOME or (Path.home() / ".hermes")
+).expanduser().resolve()
+if _EXPLICIT_TEST_SESSION_HOME:
+    _TEST_SESSION_HERMES_HOME = Path(_EXPLICIT_TEST_SESSION_HOME).expanduser().resolve()
+    _REMOVE_TEST_SESSION_HERMES_HOME = False
+else:
+    _TEST_SESSION_HERMES_HOME = Path(
+        tempfile.mkdtemp(prefix="hermes-pytest-session-")
+    ).resolve()
+    _REMOVE_TEST_SESSION_HERMES_HOME = True
+
+if (
+    _TEST_SESSION_HERMES_HOME == _REAL_HERMES_HOME
+    or _TEST_SESSION_HERMES_HOME.is_relative_to(_REAL_HERMES_HOME)
+    or _REAL_HERMES_HOME.is_relative_to(_TEST_SESSION_HERMES_HOME)
+):
+    if _REMOVE_TEST_SESSION_HERMES_HOME:
+        shutil.rmtree(_TEST_SESSION_HERMES_HOME, ignore_errors=True)
+    raise RuntimeError(
+        "HERMES_TEST_SESSION_HOME must be disjoint from the live HERMES_HOME"
+    )
+
+_TEST_SESSION_HERMES_HOME.mkdir(parents=True, exist_ok=True)
+os.environ["HERMES_HOME"] = str(_TEST_SESSION_HERMES_HOME)
+os.environ["HERMES_TEST_SESSION_HOME"] = str(_TEST_SESSION_HERMES_HOME)
 
 # Ensure project root is importable
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -605,6 +645,20 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
     # suite runs natively there (POSIX keeps the more reliable signal method).
     if sys.platform == "win32" and getattr(config.option, "timeout_method", None) == "signal":
         config.option.timeout_method = "thread"
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):  # noqa: D401 — pytest hook
+    """Flush collection-time handlers and remove the automatic test log home."""
+    if not _REMOVE_TEST_SESSION_HERMES_HOME:
+        return
+    try:
+        import hermes_logging
+
+        hermes_logging._reset_queued_handlers()
+    except Exception:
+        pass
+    shutil.rmtree(_TEST_SESSION_HERMES_HOME, ignore_errors=True)
 
 
 def pytest_collection_modifyitems(config, items):  # noqa: D401 — pytest hook

--- a/tests/hermes_cli/test_mcp_add_command_dest.py
+++ b/tests/hermes_cli/test_mcp_add_command_dest.py
@@ -42,6 +42,7 @@ def _build_parser():
     mcp_add.add_argument("--url")
     mcp_add.add_argument("--command", dest="mcp_command")
     mcp_add.add_argument("--connect-timeout", type=float)
+    mcp_add.add_argument("--all-tools", action="store_true")
     mcp_add.add_argument("--args", nargs=argparse.REMAINDER, default=[])
 
     return parser
@@ -106,6 +107,23 @@ class TestMcpAddCommandDest:
         assert args.command == "mcp"
         assert args.mcp_action == "add"
         assert args.connect_timeout == 180
+
+    def test_all_tools_flag_enables_headless_selection(self):
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "mcp",
+                "add",
+                "headless",
+                "--command",
+                "python",
+                "--all-tools",
+            ]
+        )
+
+        assert args.command == "mcp"
+        assert args.mcp_action == "add"
+        assert args.all_tools is True
 
     def test_args_passthrough_keeps_nested_option_flags(self):
         """`--args` must keep command flags like Docker MCP's --profile."""

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -250,6 +250,40 @@ class TestMcpAdd:
         assert srv["command"] == "npx"
         assert srv["args"] == ["@mcp/github"]
 
+    def test_add_stdio_server_all_tools_without_prompt(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """--all-tools saves a discovered server without reading stdin."""
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [("echo_time", "Echo with live time")],
+        )
+
+        def unexpected_prompt(_prompt):
+            raise AssertionError("--all-tools must not read stdin")
+
+        monkeypatch.setattr("builtins.input", unexpected_prompt)
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(
+            _make_args(
+                name="headless",
+                mcp_command="python",
+                args=["server.py"],
+                all_tools=True,
+            )
+        )
+        out = capsys.readouterr().out
+        assert "Saved" in out
+        assert "1/1 tools" in out
+
+        from hermes_cli.config import load_config
+
+        server = load_config()["mcp_servers"]["headless"]
+        assert server["enabled"] is True
+        assert "tools" not in server
+
     def test_add_connection_failure_save_disabled(
         self, tmp_path, capsys, monkeypatch
     ):

--- a/tests/hermes_cli/test_model_switch_variant_tags.py
+++ b/tests/hermes_cli/test_model_switch_variant_tags.py
@@ -42,7 +42,7 @@ class TestVariantTagPreservation:
 
     @pytest.mark.parametrize("model,expected", [
         ("nvidia/nemotron-3-super-120b-a12b:free", "nvidia/nemotron-3-super-120b-a12b:free"),
-        ("anthropic/claude-sonnet-4.6:extended", "anthropic/claude-sonnet-4.6:extended"),
+        ("google/gemini-2.5-pro:extended", "google/gemini-2.5-pro:extended"),
         ("meta-llama/llama-4-maverick:fast", "meta-llama/llama-4-maverick:fast"),
     ])
     def test_slash_format_preserves_variant_tag(self, model, expected):
@@ -61,10 +61,10 @@ class TestVariantTagPreservation:
 
     def test_bare_model_name_unaffected(self):
         """Bare model names without colons or slashes should work normally."""
-        result = _run_switch("claude-sonnet-4.6")
-        assert result == "anthropic/claude-sonnet-4.6"
+        result = _run_switch("gemini-2.5-pro")
+        assert result == "google/gemini-2.5-pro"
 
     def test_already_correct_slug_no_tag(self):
         """Standard vendor/model slugs without tags pass through unchanged."""
-        result = _run_switch("anthropic/claude-sonnet-4.6")
-        assert result == "anthropic/claude-sonnet-4.6"
+        result = _run_switch("google/gemini-2.5-pro")
+        assert result == "google/gemini-2.5-pro"

--- a/tests/hermes_cli/test_openrouter_model_selection_policy.py
+++ b/tests/hermes_cli/test_openrouter_model_selection_policy.py
@@ -1,0 +1,118 @@
+"""OpenRouter family policy must reject `/model` before state changes."""
+
+from types import SimpleNamespace
+
+from hermes_cli.model_switch import switch_model
+from hermes_cli.providers import ProviderDef
+
+
+_OPENROUTER = ProviderDef(
+    id="openrouter",
+    name="OpenRouter",
+    transport="openai_chat",
+    api_key_env_vars=("OPENROUTER_API_KEY",),
+    base_url="https://openrouter.ai/api/v1",
+    is_aggregator=True,
+    auth_type="api_key",
+    source="test",
+)
+
+_OPENAI_API_VIA_OPENROUTER = ProviderDef(
+    id="openai-api",
+    name="OpenAI-compatible OpenRouter",
+    transport="openai_chat",
+    api_key_env_vars=("OPENROUTER_API_KEY",),
+    base_url="https://openrouter.ai/api/v1",
+    is_aggregator=False,
+    auth_type="api_key",
+    source="test",
+)
+
+
+def _provider(provider_id):
+    return _OPENAI_API_VIA_OPENROUTER if provider_id == "openai-api" else _OPENROUTER
+
+
+def _switch(model, monkeypatch, provider="openrouter"):
+    monkeypatch.setattr("hermes_cli.model_switch.resolve_provider_full", lambda *args: _provider(provider))
+    monkeypatch.setattr("hermes_cli.model_switch.resolve_alias", lambda *args: None)
+    return switch_model(
+        raw_input=model,
+        current_provider="custom",
+        current_model="google/gemini-2.5-pro",
+        current_base_url="http://localhost:11434/v1",
+        explicit_provider=provider,
+        is_global=True,
+    )
+
+
+def test_openrouter_rejects_openai_family_before_runtime_resolution(monkeypatch):
+    def _unexpected(*args, **kwargs):
+        raise AssertionError("rejected model must not resolve credentials")
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _unexpected)
+
+    result = _switch("openai/gpt-5.6", monkeypatch)
+
+    assert not result.success
+    assert result.target_provider == "openrouter"
+    assert "forbidden model family" in result.error_message
+
+
+def test_openrouter_rejects_anthropic_claude_and_openai_api_url_form(monkeypatch):
+    result = _switch("anthropic/claude-sonnet-4.6", monkeypatch, provider="openai-api")
+
+    assert not result.success
+    assert result.target_provider == "openai-api"
+    assert "forbidden model family" in result.error_message
+
+
+def test_openrouter_allows_non_openai_non_anthropic_model(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: {"accepted": True, "persist": True, "message": ""},
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.normalize_model_for_provider", lambda model, provider: model)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *args: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *args: None)
+
+    result = _switch("google/gemini-2.5-pro", monkeypatch)
+
+    assert result.success
+    assert result.new_model == "google/gemini-2.5-pro"
+
+
+def test_cli_model_rejection_does_not_mutate_or_persist(monkeypatch):
+    import cli as cli_mod
+
+    state = SimpleNamespace(
+        provider="openrouter",
+        model="google/gemini-2.5-pro",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        agent=None,
+    )
+    before = (state.provider, state.model, state.base_url, state.api_key)
+    output = []
+    persisted = []
+
+    monkeypatch.setattr("hermes_cli.model_switch.resolve_provider_full", lambda *args: _OPENROUTER)
+    monkeypatch.setattr("hermes_cli.model_switch.resolve_alias", lambda *args: None)
+    monkeypatch.setattr(cli_mod, "_cprint", lambda text, *args, **kwargs: output.append(str(text)))
+    monkeypatch.setattr(cli_mod, "save_config_value", lambda *args, **kwargs: persisted.append(args))
+
+    cli_mod.HermesCLI._handle_model_switch(
+        state, "/model openai/gpt-5.6 --provider openrouter"
+    )
+
+    assert (state.provider, state.model, state.base_url, state.api_key) == before
+    assert persisted == []
+    assert any("forbidden model family" in line for line in output)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -650,6 +650,41 @@ def test_resolve_runtime_provider_openrouter_allows_non_forbidden_models(monkeyp
     assert resolved["api_key"] == "sk-or-test"
 
 
+def test_resolve_runtime_provider_metadata_only_callers_can_bypass_openrouter_policy(monkeypatch):
+    """enforce_openrouter_policy=False lets passive metadata lookups (e.g. the
+    MoA aggregator context-length probe in agent/model_metadata.py) resolve a
+    policy-forbidden combination without raising, since no live request is
+    ever sent with the returned credentials. The default stays fail-closed."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: type("P", (), {"has_credentials": lambda self: False})())
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-api",
+            "base_url": "https://openrouter.ai/api/v1",
+            "default": "anthropic/claude-opus-4.8",
+        },
+    )
+
+    with pytest.raises(rp.AuthError):
+        rp.resolve_runtime_provider(
+            requested="openrouter", target_model="anthropic/claude-opus-4.8"
+        )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="openrouter",
+        target_model="anthropic/claude-opus-4.8",
+        enforce_openrouter_policy=False,
+    )
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "sk-or-test"
+
+
 def test_resolve_runtime_provider_openrouter_explicit_api_key_skips_pool(monkeypatch):
     class _Entry:
         access_token = "pool-key"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -301,6 +301,40 @@ def test_resolve_runtime_provider_codex(monkeypatch):
     assert resolved["requested_provider"] == "openai-codex"
 
 
+def test_resolve_runtime_provider_codex_app_server_uses_cli_auth_not_hermes_auth(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-codex",
+            "openai_runtime": "codex_app_server",
+            "default": "gpt-5.6-sol",
+        },
+    )
+
+    def _unexpected(*args, **kwargs):
+        raise AssertionError("Hermes OAuth must not be resolved for codex_app_server")
+
+    monkeypatch.setattr(rp, "resolve_codex_runtime_credentials", _unexpected)
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+    assert resolved == {
+        "provider": "openai-codex",
+        "api_mode": "codex_app_server",
+        "base_url": "",
+        "api_key": "",
+        "source": "codex-cli-app-server",
+        "requested_provider": "openai-codex",
+    }
+
+
 def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
     monkeypatch.setattr(
@@ -563,6 +597,57 @@ def test_resolve_runtime_provider_auto_uses_openrouter_pool(monkeypatch):
     assert resolved["base_url"] == "https://openrouter.ai/api/v1"
     assert resolved["source"] == "manual"
     assert resolved.get("credential_pool") is not None
+
+
+def test_resolve_runtime_provider_openrouter_blocks_forbidden_model_families(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: type("P", (), {"has_credentials": lambda self: False})())
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    for forbidden in (
+        "openai/gpt-5.3-codex",
+        "anthropic/claude-sonnet-4.6",
+        "claude-sonnet-4.6",
+        "bm_fable",
+    ):
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda forbidden=forbidden: {
+                "provider": "openai-api",
+                "base_url": "https://openrouter.ai/api/v1",
+                "default": forbidden,
+            },
+        )
+        with pytest.raises(rp.AuthError) as exc:
+            rp.resolve_runtime_provider(requested=None)
+        assert getattr(exc.value, "code", "") == "disallowed_openrouter_model"
+
+
+def test_resolve_runtime_provider_openrouter_allows_non_forbidden_models(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: type("P", (), {"has_credentials": lambda self: False})())
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-api",
+            "base_url": "https://openrouter.ai/api/v1",
+            "default": "google/gemini-2.5-pro",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested=None)
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "sk-or-test"
 
 
 def test_resolve_runtime_provider_openrouter_explicit_api_key_skips_pool(monkeypatch):

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -296,3 +296,8 @@ def test_routed_review_fork_does_not_inherit_reasoning_config():
         "be invalid for the routed model/provider — it must be omitted so "
         "the fork uses provider defaults."
     )
+    assert init_kwargs.get("enabled_toolsets") == ["memory", "skills"], (
+        "A routed review has no parent-cache parity to preserve and must not "
+        "cold-write the parent's unrelated tool catalog."
+    )
+    assert init_kwargs.get("disabled_toolsets") is None

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -11,6 +11,8 @@ Pure-function / config-driven; no live model calls.
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from agent import background_review as br
 
 
@@ -76,6 +78,28 @@ def test_routing_to_different_model_marks_routed_and_resolves_credentials():
     assert rt["max_tokens"] == 2048
 
 
+def test_routed_review_honors_task_output_cap():
+    agent = _FakeAgent()
+    cfg = {"auxiliary": {"background_review": {
+        "provider": "custom",
+        "model": "qwen3.5:9b-s1-64k",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "max_tokens": 512,
+    }}}
+    fake_rp = {
+        "provider": "custom",
+        "api_key": "no-key-required",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "api_mode": "chat_completions",
+        "max_output_tokens": 8192,
+    }
+    with patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=fake_rp):
+        rt = br._resolve_review_runtime(agent)
+    assert rt["routed"] is True
+    assert rt["max_tokens"] == 512
+
+
 def test_unrouted_runtime_keeps_parent_pool_and_overrides():
     agent = _FakeAgent()
     agent._credential_pool = "parent-pool"
@@ -109,6 +133,38 @@ def test_routing_resolution_failure_falls_back_to_parent():
         rt = br._resolve_review_runtime(agent)
     assert rt["routed"] is False
     assert rt["provider"] == "openai-codex"
+
+
+def test_routing_resolution_failure_with_none_fails_closed():
+    agent = _FakeAgent()
+    cfg = {"auxiliary": {"background_review": {
+        "provider": "custom",
+        "model": "qwen2.5:3b-s1-review-64k",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "fallback_policy": "none",
+    }}}
+    with patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+               side_effect=RuntimeError("local runtime unavailable")), \
+         pytest.raises(RuntimeError, match="fallback_policy=none"):
+        br._resolve_review_runtime(agent)
+
+
+def test_routing_invalid_fallback_policy_fails_closed(caplog):
+    agent = _FakeAgent()
+    cfg = {"auxiliary": {"background_review": {
+        "provider": "custom",
+        "model": "qwen2.5:3b-s1-review-64k",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "fallback_policy": "surprise-me",
+    }}}
+    with patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+               side_effect=RuntimeError("local runtime unavailable")), \
+         caplog.at_level("WARNING"), \
+         pytest.raises(RuntimeError, match="fallback_policy=none"):
+        br._resolve_review_runtime(agent)
+    assert "invalid fallback_policy" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -71,6 +71,20 @@ class TestApiModeAccepted:
         agent = _make_codex_agent()
         assert agent.api_mode == "codex_app_server"
 
+    def test_codex_app_server_needs_no_hermes_openai_credentials(self):
+        agent = run_agent.AIAgent(
+            api_key="",
+            base_url="",
+            provider="openai-codex",
+            api_mode="codex_app_server",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+        assert agent.client is None
+        assert agent._client_kwargs == {}
+
 
 class TestRunConversationCodexPath:
     def test_run_conversation_returns_codex_shape(self, fake_session):
@@ -782,8 +796,12 @@ class TestCodexToolProgressBridge:
         agent.tool_progress_callback = lambda kind, name, preview, args: events.append(
             (kind, name, preview))
         with patch.object(agent, "_spawn_background_review", return_value=None):
-            agent.run_conversation("run the tests")
+            agent.run_conversation(
+                "run the tests",
+                system_message="HERMES_SCOPED_SYSTEM_PROMPT",
+            )
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
+        assert "HERMES_SCOPED_SYSTEM_PROMPT" in captured_init["developer_instructions"]
         assert ("tool.started", "exec_command", "pytest") in events
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -108,7 +108,7 @@ class TestRunConversationCodexPath:
                 turn_id="turn-usage-1",
                 thread_id="thread-usage-1",
                 token_usage_last={
-                    "totalTokens": 130,
+                    "totalTokens": 105,
                     "inputTokens": 80,
                     "cachedInputTokens": 20,
                     "outputTokens": 25,
@@ -126,28 +126,28 @@ class TestRunConversationCodexPath:
             result = agent.run_conversation("hello")
 
         assert result["api_calls"] == 1
-        assert result["prompt_tokens"] == 100
+        assert result["prompt_tokens"] == 80
         assert result["completion_tokens"] == 25
-        assert result["total_tokens"] == 130
-        assert result["input_tokens"] == 80
+        assert result["total_tokens"] == 105
+        assert result["input_tokens"] == 60
         assert result["output_tokens"] == 25
         assert result["cache_read_tokens"] == 20
         assert result["cache_write_tokens"] == 0
         assert result["reasoning_tokens"] == 5
-        assert result["last_prompt_tokens"] == 100
+        assert result["last_prompt_tokens"] == 80
 
         assert agent.session_api_calls == 1
-        assert agent.session_prompt_tokens == 100
+        assert agent.session_prompt_tokens == 80
         assert agent.session_completion_tokens == 25
-        assert agent.session_total_tokens == 130
-        assert agent.session_input_tokens == 80
+        assert agent.session_total_tokens == 105
+        assert agent.session_input_tokens == 60
         assert agent.session_output_tokens == 25
         assert agent.session_cache_read_tokens == 20
         assert agent.session_cache_write_tokens == 0
         assert agent.session_reasoning_tokens == 5
-        assert agent.context_compressor.last_prompt_tokens == 100
+        assert agent.context_compressor.last_prompt_tokens == 80
         assert agent.context_compressor.last_completion_tokens == 25
-        assert agent.context_compressor.last_total_tokens == 130
+        assert agent.context_compressor.last_total_tokens == 105
         assert agent.context_compressor.context_length == 200000
 
     def test_native_codex_compaction_updates_bookkeeping(self, monkeypatch):
@@ -633,6 +633,95 @@ class TestErrorHandling:
         assert result["partial"] is True
         assert result["error"] == "user interrupted"
 
+    def test_context_ceiling_compacts_and_resumes_same_objective(self, monkeypatch):
+        inputs = []
+        turns = iter([
+            TurnResult(
+                projected_messages=[
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{
+                            "id": "tool-before-compact",
+                            "type": "function",
+                            "function": {
+                                "name": "exec_command",
+                                "arguments": "{}",
+                            },
+                        }],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "tool-before-compact",
+                        "content": "completed work",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "partial narration",
+                    },
+                ],
+                tool_iterations=1,
+                interrupted=True,
+                error="codex app-server context ceiling reached mid-turn",
+                turn_id="turn-before-compact",
+                thread_id="thread-1",
+                context_ceiling_hit=True,
+            ),
+            TurnResult(
+                final_text="mission complete",
+                projected_messages=[
+                    {"role": "assistant", "content": "mission complete"},
+                ],
+                turn_id="turn-after-compact",
+                thread_id="thread-1",
+            ),
+        ])
+
+        def fake_run_turn(self, user_input, **kwargs):
+            inputs.append(user_input)
+            return next(turns)
+
+        def fake_compact_thread(self, **kwargs):
+            return TurnResult(
+                compacted=True,
+                turn_id="compact-turn",
+                thread_id="thread-1",
+            )
+
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-1",
+        )
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "compact_thread",
+            fake_compact_thread,
+        )
+
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("finish the mission")
+
+        assert result["completed"] is True
+        assert result["partial"] is False
+        assert result["final_response"] == "mission complete"
+        assert result["api_calls"] == 3
+        assert inputs[0] == "finish the mission"
+        assert inputs[1].startswith("Continue the same objective")
+        assert [
+            msg.get("content")
+            for msg in result["messages"]
+            if msg.get("role") == "user"
+        ] == ["finish the mission"]
+        assert "partial narration" not in [
+            msg.get("content") for msg in result["messages"]
+        ]
+        assert "completed work" in [
+            msg.get("content") for msg in result["messages"]
+        ]
+
 
 class TestSessionRetirementOnRunAgent:
     """run_agent.py side: when run_turn returns should_retire=True, the
@@ -804,4 +893,3 @@ class TestCodexToolProgressBridge:
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert "HERMES_SCOPED_SYSTEM_PROMPT" in captured_init["developer_instructions"]
         assert ("tool.started", "exec_command", "pytest") in events
-

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -85,6 +85,41 @@ class TestApiModeAccepted:
         assert agent.client is None
         assert agent._client_kwargs == {}
 
+    def test_codex_binary_config_reaches_app_server_session(self, monkeypatch):
+        configured_binary = "/managed/codex"
+        captured = {}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"codex_binary": configured_binary}},
+        )
+
+        def capture_init(self, **kwargs):
+            captured.update(kwargs)
+            self.thread_id = None
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-configured-binary",
+                thread_id="thread-configured-binary",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", capture_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("use the configured binary")
+
+        assert result["completed"] is True
+        assert captured["codex_bin"] == configured_binary
+
+    def test_codex_binary_defaults_to_path_lookup(self):
+        agent = _make_codex_agent()
+        assert agent.codex_app_server_binary == "codex"
+
 
 class TestRunConversationCodexPath:
     def test_run_conversation_returns_codex_shape(self, fake_session):

--- a/tests/test_collection_logging_isolation.py
+++ b/tests/test_collection_logging_isolation.py
@@ -1,0 +1,62 @@
+"""Regression coverage for collection-time Hermes log isolation."""
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Importing cli initializes centralized logging at module import time. This is
+# intentionally above the test function: collection is the vulnerable phase.
+import cli  # noqa: F401, E402
+
+import hermes_logging
+
+
+def test_collection_time_logging_targets_test_home_not_live_home():
+    session_home = Path(os.environ["HERMES_TEST_SESSION_HOME"]).resolve()
+    live_home = (Path.home() / ".hermes").resolve()
+    targets = {
+        Path(handler.baseFilename).resolve()
+        for handler in hermes_logging.rotating_file_handlers()
+    }
+
+    assert targets
+    assert all(path.is_relative_to(session_home / "logs") for path in targets)
+    assert all(not path.is_relative_to(live_home / "logs") for path in targets)
+
+    logging.getLogger(__name__).warning("S1_004_TEST_LOG_ISOLATION_CANARY")
+    hermes_logging.flush_log_queue()
+    assert "S1_004_TEST_LOG_ISOLATION_CANARY" in (
+        session_home / "logs" / "errors.log"
+    ).read_text(encoding="utf-8")
+
+
+def test_test_session_home_rejects_live_home_descendants(tmp_path):
+    live_home = tmp_path / "would-be-live"
+    nested_test_home = live_home / "pytest"
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(live_home)
+    env["HERMES_TEST_SESSION_HOME"] = str(nested_test_home)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            str(Path(__file__).resolve()),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode != 0
+    assert "must be disjoint from the live HERMES_HOME" in (
+        result.stdout + result.stderr
+    )
+    assert not nested_test_home.exists()

--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -100,6 +100,16 @@ class TestInheritCredentials:
     def test_pythonutf8_set_when_inheriting(self):
         assert _build(inherit_credentials=True).get("PYTHONUTF8") == "1"
 
+    def test_unregistered_secret_value_is_not_inherited_by_model_child(self):
+        secret = "sk-" + ("s1canary" * 6)
+        result = _build(
+            {**_PROVIDER_SAMPLE, "UNRELATED_CANARY": secret},
+            inherit_credentials=True,
+        )
+        assert "UNRELATED_CANARY" not in result
+        for var in _PROVIDER_SAMPLE:
+            assert var in result
+
 
 class TestTierInvariants:
     def test_tier1_always_stripped_both_paths(self):

--- a/tests/tools/test_tool_output_limits.py
+++ b/tests/tools/test_tool_output_limits.py
@@ -37,6 +37,9 @@ class TestDefaults:
         assert tol.DEFAULT_MAX_BYTES == 50_000
         assert tol.DEFAULT_MAX_LINES == 2000
         assert tol.DEFAULT_MAX_LINE_LENGTH == 2000
+        # ANGLE B (#hermes-context-overrun, 2026-07-27): second, independent
+        # cumulative-per-turn budget alongside the per-result max_bytes cap.
+        assert tol.DEFAULT_MAX_TURN_BYTES == 60_000
 
     def test_get_limits_returns_defaults_when_config_missing(self):
         with patch("hermes_cli.config.load_config", return_value={}):
@@ -45,6 +48,7 @@ class TestDefaults:
             "max_bytes": tol.DEFAULT_MAX_BYTES,
             "max_lines": tol.DEFAULT_MAX_LINES,
             "max_line_length": tol.DEFAULT_MAX_LINE_LENGTH,
+            "max_turn_bytes": tol.DEFAULT_MAX_TURN_BYTES,
         }
 
     def test_get_limits_returns_defaults_when_config_not_a_dict(self):
@@ -69,6 +73,7 @@ class TestOverrides:
                 "max_bytes": 100_000,
                 "max_lines": 5000,
                 "max_line_length": 4096,
+                "max_turn_bytes": 300_000,
             }
         }
         with patch("hermes_cli.config.load_config", return_value=cfg):
@@ -77,6 +82,7 @@ class TestOverrides:
             "max_bytes": 100_000,
             "max_lines": 5000,
             "max_line_length": 4096,
+            "max_turn_bytes": 300_000,
         }
 
     def test_partial_override_preserves_other_defaults(self):
@@ -86,6 +92,7 @@ class TestOverrides:
         assert limits["max_bytes"] == 200_000
         assert limits["max_lines"] == tol.DEFAULT_MAX_LINES
         assert limits["max_line_length"] == tol.DEFAULT_MAX_LINE_LENGTH
+        assert limits["max_turn_bytes"] == tol.DEFAULT_MAX_TURN_BYTES
 
     def test_section_not_a_dict_falls_back(self):
         cfg = {"tool_output": "nonsense"}
@@ -118,12 +125,14 @@ class TestShortcuts:
                 "max_bytes": 111,
                 "max_lines": 222,
                 "max_line_length": 333,
+                "max_turn_bytes": 444,
             }
         }
         with patch("hermes_cli.config.load_config", return_value=cfg):
             assert tol.get_max_bytes() == 111
             assert tol.get_max_lines() == 222
             assert tol.get_max_line_length() == 333
+            assert tol.get_max_turn_bytes() == 444
 
 
 class TestDefaultConfigHasSection:
@@ -139,6 +148,7 @@ class TestDefaultConfigHasSection:
         assert section["max_bytes"] == tol.DEFAULT_MAX_BYTES
         assert section["max_lines"] == tol.DEFAULT_MAX_LINES
         assert section["max_line_length"] == tol.DEFAULT_MAX_LINE_LENGTH
+        assert section["max_turn_bytes"] == tol.DEFAULT_MAX_TURN_BYTES
 
 
 class TestIntegrationReadPagination:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -605,6 +605,34 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
         # Tier 2 — strip provider/tool credentials unless explicitly inherited.
         for key in _HERMES_PROVIDER_ENV_BLOCKLIST:
             env.pop(key, None)
+    else:
+        # A model-driving child needs the explicitly catalogued provider/tool
+        # credentials above, but it does not need arbitrary secret-looking
+        # values inherited from Hermes' ambient process environment.  Codex
+        # app-server executes its own shell commands inside the backing model
+        # thread, before Hermes can project/redact their output.  Removing
+        # recognizable credentials here is therefore the only boundary that
+        # keeps an opaque ambient variable (for example a CI canary whose value
+        # is an sk-* token) out of that model context in the first place.
+        #
+        # Preserve catalogued credentials so the child can still authenticate;
+        # all other values are tested with the same central redactor used for
+        # logs and tool output.  Redaction-disabled sessions retain the prior
+        # passthrough behavior because redact_sensitive_text() is then a no-op.
+        try:
+            from agent.redact import redact_sensitive_text
+
+            for key, value in list(env.items()):
+                if key in _HERMES_PROVIDER_ENV_BLOCKLIST:
+                    continue
+                value_text = str(value)
+                if redact_sensitive_text(value_text) != value_text:
+                    env.pop(key, None)
+        except Exception:
+            # Existing explicit blocklists remain in force if the optional
+            # content classifier cannot load; never broaden credential
+            # inheritance as an error recovery mechanism.
+            pass
 
     # Windows UTF-8 safety for spawned processes (#31420).
     env.setdefault("PYTHONUTF8", "1")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -261,8 +261,8 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
 
     Delegates to ``agent.skill_utils.skill_matches_environment`` — kept here
     as a public re-export so existing callers don't need updating. This is an
-    offer-time relevance gate (kanban/docker/s6), NOT a hard-compatibility gate;
-    explicit skill loads bypass it.
+    offer-time relevance gate (on-demand activation and kanban/docker/s6), NOT
+    a hard-compatibility gate; explicit skill loads bypass it.
     """
     from agent.skill_utils import skill_matches_environment as _impl
     return _impl(frontmatter)

--- a/tools/tool_output_limits.py
+++ b/tools/tool_output_limits.py
@@ -23,10 +23,24 @@ Example ``config.yaml``::
       max_bytes: 100000        # terminal output cap (chars)
       max_lines: 5000          # read_file pagination + truncation cap
       max_line_length: 2000    # per-line length cap before '... [truncated]'
+      max_turn_bytes: 60000    # cumulative tool-output cap for ONE turn
 
 The limits reader is defensive: any error (missing config file, invalid
 value type, etc.) falls back to the built-in defaults so tools never
 fail because of a malformed config.
+
+``max_turn_bytes`` (2026-07-27 ALL-HANDS ANGLE B, #hermes-context-overrun):
+``max_bytes`` bounds a single tool RESULT, but a turn with many tool calls
+can still stack N maxed-out results and blow the context window in one
+shot — measured case: seven results each pinned at the old 50000-char cap
+in ONE turn, ~87K tokens against a 258.4K window, six stalls in one
+evening. Per-result caps alone are insufficient because there was no
+ceiling on the TURN. ``max_turn_bytes`` is a second, independent budget
+enforced by the codex app-server ingestion path
+(``agent/transports/codex_app_server_session.py``) across ALL tool
+results projected within a single turn, so overrunning the window from
+tool-output volume is structurally impossible regardless of how many
+tool calls happen or whether compaction ever fires.
 """
 
 from __future__ import annotations
@@ -39,6 +53,7 @@ from typing import Any, Dict
 DEFAULT_MAX_BYTES = 50_000       # terminal_tool.MAX_OUTPUT_CHARS
 DEFAULT_MAX_LINES = 2000         # file_operations.MAX_LINES
 DEFAULT_MAX_LINE_LENGTH = 2000   # file_operations.MAX_LINE_LENGTH
+DEFAULT_MAX_TURN_BYTES = 60_000  # cumulative tool-output cap for ONE turn
 
 # Module-level cache — populated on first call.
 # Avoids repeated config file I/O on every tool call.
@@ -59,9 +74,9 @@ def _coerce_positive_int(value: Any, default: int) -> int:
 def get_tool_output_limits() -> Dict[str, int]:
     """Return resolved tool-output limits, reading ``tool_output`` from config.
 
-    Keys: ``max_bytes``, ``max_lines``, ``max_line_length``. Missing or
-    invalid entries fall through to the ``DEFAULT_*`` constants. This
-    function NEVER raises.
+    Keys: ``max_bytes``, ``max_lines``, ``max_line_length``,
+    ``max_turn_bytes``. Missing or invalid entries fall through to the
+    ``DEFAULT_*`` constants. This function NEVER raises.
 
     Result is cached for the process lifetime to avoid repeated disk I/O
     on every tool call. Call ``_reset_tool_output_limits_cache()`` in
@@ -84,6 +99,9 @@ def get_tool_output_limits() -> Dict[str, int]:
         "max_lines": _coerce_positive_int(section.get("max_lines"), DEFAULT_MAX_LINES),
         "max_line_length": _coerce_positive_int(
             section.get("max_line_length"), DEFAULT_MAX_LINE_LENGTH
+        ),
+        "max_turn_bytes": _coerce_positive_int(
+            section.get("max_turn_bytes"), DEFAULT_MAX_TURN_BYTES
         ),
     }
     return _cached_limits
@@ -108,6 +126,17 @@ def get_max_lines() -> int:
 def get_max_line_length() -> int:
     """Shortcut for file-ops callers that only need the per-line cap."""
     return get_tool_output_limits()["max_line_length"]
+
+
+def get_max_turn_bytes() -> int:
+    """Shortcut for callers that only need the per-TURN cumulative cap.
+
+    Independent of ``max_bytes`` (which bounds one result): this bounds the
+    SUM of every tool result's content projected within a single turn, so a
+    turn with many tool calls can't stack N maxed-out results past the
+    context window even though each individual result is already capped.
+    """
+    return get_tool_output_limits()["max_turn_bytes"]
 
 
 def truncate_tool_output(output: Any, max_chars: int | None = None) -> str:

--- a/tools/tool_output_limits.py
+++ b/tools/tool_output_limits.py
@@ -108,3 +108,26 @@ def get_max_lines() -> int:
 def get_max_line_length() -> int:
     """Shortcut for file-ops callers that only need the per-line cap."""
     return get_tool_output_limits()["max_line_length"]
+
+
+def truncate_tool_output(output: Any, max_chars: int | None = None) -> str:
+    """Bound a tool result while preserving diagnostically useful head/tail.
+
+    ``max_bytes`` is historically measured with ``len(str)`` throughout
+    Hermes, so ``max_chars`` preserves that established behavior. The helper
+    is shared by native tools, Codex event projection, and compaction recovery
+    so no ingestion path can create an uncompressible protected-tail result.
+    """
+    if not isinstance(output, str):
+        output = str(output or "")
+    limit = max_chars if isinstance(max_chars, int) and max_chars > 0 else get_max_bytes()
+    if len(output) <= limit:
+        return output
+    head_chars = int(limit * 0.4)
+    tail_chars = limit - head_chars
+    omitted = len(output) - limit
+    notice = (
+        f"\n\n... [OUTPUT TRUNCATED - {omitted} chars omitted "
+        f"out of {len(output)} total] ...\n\n"
+    )
+    return output[:head_chars] + notice + output[-tail_chars:]

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -175,6 +175,19 @@ In a Hermes session:
 /codex-runtime codex_app_server
 ```
 
+Hermes normally launches `codex` from `PATH`. Managed installations with
+multiple Codex clients sharing one `CODEX_HOME` can pin the exact executable
+in `config.yaml`:
+
+```yaml
+model:
+  openai_runtime: codex_app_server
+  codex_binary: /absolute/path/to/codex
+```
+
+Use the same Codex build for clients that share `CODEX_HOME`; different
+versions can write incompatible model-cache schemas.
+
 That command:
 - Verifies the `codex` CLI is installed (blocks with an install hint if not).
 - Persists `model.openai_runtime: codex_app_server` to your config.yaml.


### PR DESCRIPTION
## Summary

Add an explicit `--all-tools` flag to `hermes mcp add` so unattended callers can accept all discovered tools without reading stdin.

## Root cause

Discovery succeeds in headless processes, but the command then always calls `input()` for tool selection. EOF is handled as cancellation, so the server is never saved.

The new flag bypasses only the final tool-selection prompt. Existing authentication, overwrite, and suspicious-configuration checks remain unchanged.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_add_command_dest.py` — 66 passed
- real local FastMCP stdio server discovered and saved with `--all-tools`
- server called by two fresh Codex-backed Hermes processes across restart
- ambient secret canary was filtered from the MCP subprocess and absent from outputs, logs, and sessions
