### PR TITLE
fix(gateway): hide empty-turn model diagnostics in chat

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -580,6 +580,16 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
         return ""
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
+    # ``AIAgent._format_turn_completion_explanation`` is useful on local
+    # surfaces, but its empty-turn diagnostic exposes model/provider mechanics
+    # in ordinary chats. Keep the retry cue while dropping that implementation
+    # detail; the raw message remains available in local diagnostics and logs.
+    if re.match(
+        r"^\s*(?:⚠️\s*)?no reply:\s+the model returned empty content after retries",
+        redacted,
+        re.IGNORECASE,
+    ):
+        return "⚠️ I couldn’t finish that response. Please try again."
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -263,6 +263,20 @@ def test_chat_gateways_drop_interrupt_sentinel(platform):
     assert _sanitize_gateway_final_response("local", sentinel) == sentinel
 
 
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_replace_empty_model_turn_explainer(platform):
+    """A framework-only empty-turn diagnostic is not useful chat prose."""
+    explainer = (
+        "⚠️ No reply: the model returned empty content after retries and any "
+        "fallback providers. Try `continue`, switch model/provider, or retry."
+    )
+
+    assert _sanitize_gateway_final_response(platform, explainer) == (
+        "⚠️ I couldn’t finish that response. Please try again."
+    )
+    assert _sanitize_gateway_final_response("local", explainer) == explainer
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (


### PR DESCRIPTION
## Summary
- replace the framework-only empty-response explainer with one concise retry notice on human chat platforms
- preserve the raw diagnostic on local/programmatic surfaces and in gateway logs
- cover every filtered chat platform plus the raw-surface negative case

## Verification
- `PYTHONPATH=. /Users/jarvis/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_incomplete_gateway_turns.py -q` (636 passed)
- `PYTHONPATH=. /Users/jarvis/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/run.py`
- `git diff --check`