### PR TITLE
fix(gateway): flush pending memory writes before session teardown (#73297)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6999,6 +6999,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
         try:
             if hasattr(agent, "shutdown_memory_provider"):
+                # Drain queued memory writes BEFORE tearing the provider down.
+                # The memory manager persists per-turn sync and end-of-session
+                # extraction on a single serialized background worker.
+                # shutdown_memory_provider() -> shutdown_all() only gives that
+                # worker a ~5s bounded drain and abandons (cancels) anything
+                # still queued past it, so a /reset — or any gateway session
+                # rotation that reaches this cleanup path — could silently drop
+                # writes the session had already handed off. The next session
+                # then loads stale memory (#73297). Give pending work a bounded
+                # head start through the manager's own barrier first, mirroring
+                # the CLI exit path (cli.py). Best-effort: a flush failure must
+                # never block teardown.
+                _mm = getattr(agent, "_memory_manager", None)
+                if _mm is not None and hasattr(_mm, "flush_pending"):
+                    try:
+                        _mm.flush_pending(timeout=10)
+                    except Exception:
+                        pass
                 # Pass the agent's own conversation transcript so memory
                 # providers' ``on_session_end`` hooks see the real messages
                 # instead of the empty default (#15165). ``_session_messages``

--- a/tests/gateway/test_73297_memory_flush_on_reset.py
+++ b/tests/gateway/test_73297_memory_flush_on_reset.py
@@ -1,0 +1,163 @@
+"""Regression tests for #73297: memory rollback after /reset.
+
+The gateway's ``_cleanup_agent_resources`` (the cleanup chokepoint that
+``/reset`` and every other gateway session rotation invokes to tear down the
+cached agent) used to call ``shutdown_memory_provider()`` WITHOUT first
+draining the memory manager's serialized background write worker.
+``shutdown_memory_provider`` -> ``shutdown_all`` only gives that worker a
+bounded (~5s) drain and abandons whatever is still queued past it, so a
+/reset could silently drop writes the session had already handed off — the
+next session then loaded stale memory.
+
+The CLI exit path already drains via ``MemoryManager.flush_pending`` before
+shutdown (cli.py); these tests pin the same contract on the gateway path.
+
+The fix: in ``_cleanup_agent_resources``, call
+``agent._memory_manager.flush_pending(timeout=10)`` BEFORE
+``shutdown_memory_provider``.
+"""
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from agent.memory_manager import MemoryManager
+from agent.memory_provider import MemoryProvider
+import agent.memory_manager as _mm_module
+from gateway.run import GatewayRunner
+
+
+# How long the "gate" write occupies the single background worker. Chosen so a
+# queued write reliably stays PENDING behind it for the duration of the test
+# (the worker is FIFO, single-threaded). Kept small for test speed.
+_GATE_DELAY_S = 0.6
+
+
+class _RecordingProvider(MemoryProvider):
+    """Provider that records completed writes to ``self.recorded`` (the "disk").
+
+    A write whose assistant payload is the sentinel ``__GATE__`` sleeps for
+    ``gate_delay`` first — it occupies the manager's single background worker
+    so a subsequent real write sits PENDING behind it until the gate clears.
+    """
+
+    _name = "recording"
+
+    def __init__(self, gate_delay: float = _GATE_DELAY_S):
+        self._gate_delay = gate_delay
+        self.recorded: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str = "", **kwargs) -> None:
+        pass
+
+    def system_prompt_block(self) -> str:
+        return ""
+
+    def prefetch(self, query, *, session_id: str = "") -> str:
+        return ""
+
+    def get_tool_schemas(self):
+        return []
+
+    def handle_tool_call(self, tool_name, args, **kwargs) -> str:
+        return ""
+
+    def sync_turn(self, user_content, assistant_content, *, session_id: str = "", messages=None) -> None:
+        if assistant_content == "__GATE__":
+            time.sleep(self._gate_delay)
+            return
+        self.recorded.append(assistant_content)
+
+
+def _make_agent(mgr: MemoryManager) -> SimpleNamespace:
+    """Build a minimal agent wired to a real MemoryManager.
+
+    ``shutdown_memory_provider`` mirrors ``AIAgent.shutdown_memory_provider``
+    (run_agent.py): end-of-session notification then ``shutdown_all``. The
+    memory manager is the live one carrying the queued writes, so the gateway
+    cleanup path exercises the real flush -> shutdown ordering.
+    """
+
+    def _shutdown_memory_provider(messages=None):
+        mgr.on_session_end(messages or [])
+        mgr.shutdown_all()
+
+    return SimpleNamespace(
+        _memory_manager=mgr,
+        _session_messages=[{"role": "user", "content": "earlier turn"}],
+        shutdown_memory_provider=_shutdown_memory_provider,
+    )
+
+
+def test_cleanup_flushes_pending_writes_before_shutdown(monkeypatch):
+    """#73297 invariant: ``disk_state_after_reset >= last_known_state_before_reset``.
+
+    A real write ("fact-1") is queued on the memory manager's background
+    worker behind a slow gate write, so it is PENDING when /reset cleanup
+    runs. ``shutdown_all``'s drain is shortened (via ``_SYNC_DRAIN_TIMEOUT_S``)
+    to model the production condition where the bounded drain abandons queued
+    work — the condition the issue reports. Without the pre-shutdown
+    ``flush_pending``, "fact-1" is abandoned and never reaches the provider
+    (the on-disk store). With the fix, ``flush_pending`` drains the queue
+    BEFORE the unreliable shutdown drain, so the write lands.
+    """
+    # Shorten shutdown_all's drain so it abandons the still-pending write,
+    # modelling the bounded-drain abandonment at the heart of #73297. The
+    # fix's flush_pending uses its OWN (longer) barrier, independent of this
+    # timeout, so it still drains the queue.
+    monkeypatch.setattr(_mm_module, "_SYNC_DRAIN_TIMEOUT_S", 0.1)
+
+    mgr = MemoryManager()
+    provider = _RecordingProvider()
+    mgr.add_provider(provider)
+    mgr.initialize_all("sess-old")
+
+    # Occupy the single worker with a slow gate write, then queue the real
+    # write behind it. "fact-1" is now PENDING (FIFO, worker busy with gate).
+    mgr.sync_all("user msg a", "__GATE__", session_id="sess-old")
+    mgr.sync_all("user msg b", "fact-1", session_id="sess-old")
+
+    last_known_state_before_reset = ["fact-1"]
+    assert provider.recorded == [], "precondition: write must still be pending"
+
+    agent = _make_agent(mgr)
+
+    # Run the gateway cleanup path the /reset handler runs. No explicit flush
+    # here — the contract is that cleanup itself flushes before shutdown.
+    GatewayRunner._cleanup_agent_resources(object(), agent)
+
+    disk_state_after_reset = provider.recorded
+    assert set(last_known_state_before_reset) <= set(disk_state_after_reset), (
+        f"#73297 regression: pending memory write lost across reset. "
+        f"expected >= {last_known_state_before_reset}, got {disk_state_after_reset}"
+    )
+
+
+def test_cleanup_calls_flush_pending_before_shutdown_memory_provider():
+    """Structural contract: the gateway cleanup drains the memory manager
+    BEFORE shutting the provider down (ordering matters — shutdown's drain is
+    the unreliable one the fix works around)."""
+    agent = MagicMock()
+    agent._session_messages = [{"role": "user", "content": "hi"}]
+    agent._memory_manager = MagicMock()
+
+    # Track call order across both objects via a parent mock.
+    parent = MagicMock()
+    parent.attach_mock(agent._memory_manager.flush_pending, "flush_pending")
+    parent.attach_mock(agent.shutdown_memory_provider, "shutdown_memory_provider")
+
+    GatewayRunner._cleanup_agent_resources(object(), agent)
+
+    agent._memory_manager.flush_pending.assert_called_once_with(timeout=10)
+    parent.assert_has_calls(
+        [call.flush_pending(timeout=10), call.shutdown_memory_provider([{"role": "user", "content": "hi"}])],
+        any_order=False,
+    )


### PR DESCRIPTION
### Summary

`/reset` was silently dropping memory writes that the session had already handed off to the memory manager's background writer — the next session then loaded stale `MEMORY.md` from disk.

### Root cause

In `_cleanup_agent_resources` (`gateway/run.py`), the gateway calls `shutdown_memory_provider` to tear the memory provider down on session rotation. That path goes through `MemoryManager.shutdown_all`, which has only a bounded (~5s) drain window on the single serialized write worker. Any write still queued past that timeout is **cancelled**, not flushed.

The CLI exit path already calls `MemoryManager.flush_pending` to drain queued writes before the teardown drain (see cli.py), so this is a long-standing gateway/gateway-vs-CLI divergence.

### Fix

Call `agent._memory_manager.flush_pending(timeout=10)` **before** the existing `shutdown_memory_provider` step in the gateway cleanup path. The flush is best-effort (wrapped in try/except) — a flush failure must never block teardown, so the existing shutdown path is the fallback. The flush is independent of the bounded drain inside `shutdown_all`, so it bypasses the abandoned-work condition this issue reproduces.

### Repro (before fix)

```
1. Open a session
2. Use the `memory` tool to record some fact (tool reports success — write is in the manager's queue)
3. Within ~5s, send `/reset` (or any gateway session rotation)
4. New session re-loads MEMORY.md from disk → does NOT include the recent write
```

The logger line `Persisted transcript lagged live cached history (disk=771, memory=773)` is the FTS-write-corruption symptom that follows when flush drops out of sync with the active run, but the underlying root cause is the same — the cleanup path doesn't give the memory manager its own head start before the unreliable drain.

### Test plan

`tests/gateway/test_73297_memory_flush_on_reset.py`:

- `test_cleanup_flushes_pending_writes_before_shutdown` — behavioral contract: a real write queued behind a slow gate write (`time.sleep(0.6)`) is `PENDING` when cleanup runs. The test shortens `shutdown_all`'s drain (`_SYNC_DRAIN_TIMEOUT_S = 0.1`) to reproduce the production abandonment condition, then asserts `set("fact-1") <= set(provider.recorded)` after `GatewayRunner._cleanup_agent_resources` returns. Without the fix the write is abandoned and the assertion fails.
- `test_cleanup_calls_flush_pending_before_shutdown_memory_provider` — structural contract: `flush_pending(timeout=10)` is invoked **before** `shutdown_memory_provider` in the recorded call order.

```
$ ./venv/Scripts/python.exe -m pytest tests/gateway/test_73297_memory_flush_on_reset.py -v
collected 2 items
test_cleanup_flushes_pending_writes_before_shutdown PASSED [ 50%]
test_cleanup_calls_flush_pending_before_shutdown_memory_provider PASSED [100%]
2 passed in 2.33s
```

### Scope

`gateway/run.py` (+18) and one new test file (163). No public API change. The `flush_pending(timeout=...)` method and the `agent._memory_manager` attribute both already exist — this PR only changes the **ordering** inside an existing cleanup block.

### NOT done

- No changes to `MemoryManager.shutdown_all` itself (its bounded-drain behavior is unchanged — the gateway path no longer relies on it).
- No changes to the CLI teardown path — it already had the flush via a different code branch.
- No fsync / atomic-write improvement to the underlying MEMORY.md persistence (separate scope; not the root cause of this issue).

Closes #73297
