### PR TITLE
fix(agent): add Kimi K2.x/K3 to reasoning stale-timeout allowlist (#73337)

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -35,6 +35,14 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         # "Ox Alpha" stealth reasoning model (OpenRouter / OpenCode Zen slugs); Thinking
         # Machines Inkling (covers inkling-small and :free SKUs).
         "ox-alpha", "x-preview-f-free", "inkling",
+        # Kimi / Moonshot: K2.x and K3 emit a thinking phase before the first content
+        # token. K3 (1M ctx) can spend 80+s reasoning before the first token at long
+        # context, exceeding the 180s default and surfacing as BrokenPipeError/
+        # RemoteProtocolError mid-think. ``kimi`` matches the slug after aggregator-prefix
+        # strip (e.g. ``accounts/fireworks/models/kimi-k3``, ``kimi-k2p6``); ``k3`` catches
+        # the bare Kimi Coding Plan slug. Both are start-of-slug anchored, so ``k3`` never
+        # over-matches ``k3s`` or an embedded ``...-k3``.
+        "kimi", "k3",
     ),
     # Anthropic Claude 4.x+ thinking variants (anchored so 3.x never matches).
     240: ("claude-opus-4", "claude-opus-5"),

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -123,6 +123,20 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("grok-4.20-reasoning", 300),
     ("grok-4.5", 300),
     ("grok-4-fast-non-reasoning", 180),
+    # Kimi / Moonshot — K2.x and K3 are reasoning models that emit a
+    # thinking phase before the first content token.  K3 has 1M
+    # context; at long context (>40K tokens) the reasoning phase can
+    # take 80+ seconds before the first token and at very long context
+    # (>80K) it can exceed the 180s default stale-timeout floor,
+    # surfacing as ``BrokenPipeError``/``RemoteProtocolError`` mid-think.
+    # The ``kimi`` entry matches ``kimi-k3``, ``kimi-k2p6`` etc. (the
+    # slug after aggregator-prefix strip, e.g.
+    # ``accounts/fireworks/models/kimi-k3``); the ``k3`` entry catches
+    # the bare slug used by the Kimi Coding Plan.  Both are start-of-slug
+    # anchored, so ``k3`` never over-matches ``k3s`` or an embedded
+    # ``...-k3``.  300s matches the QwQ-32B / o3-mini tier.
+    ("kimi", 300),
+    ("k3", 300),
 )
 
 

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -91,6 +91,14 @@ import pytest
     ("thinkingmachines/inkling", 300.0),
     ("thinkingmachines/inkling:free", 300.0),
     ("thinkingmachines/inkling-small:free", 300.0),
+    # Kimi / Moonshot reasoning family. `kimi` matches the slug after
+    # aggregator-prefix strip; `k3` matches the bare Kimi Coding slug.
+    ("accounts/fireworks/models/kimi-k3", 300.0),
+    ("kimi-k3", 300.0),
+    ("kimi-k2p6", 300.0),
+    ("moonshot/kimi-k3", 300.0),
+    ("k3", 300.0),
+    ("k3-code", 300.0),
 ])
 def test_reasoning_stale_timeout_floor_positive_cases(model, expected):
     from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
@@ -101,9 +109,49 @@ def test_reasoning_stale_timeout_floor_positive_cases(model, expected):
     )
 
 
-
-
-
+@pytest.mark.parametrize("model", [
+    # Non-reasoning chat models — no floor.
+    "gpt-4o",
+    "gpt-5",
+    "claude-3-5-sonnet-20240620",
+    "llama-3.3-70b-instruct",
+    "gemini-2.5-pro",
+    # Start-of-slug anchor traps — the slug must be at the START of
+    # the bare model name (after aggregator-prefix strip). Bare
+    # substring matching would over-match these.
+    "olmo-1",
+    "olmo-13b",
+    "llama-4-70b-o1-preview",     # embedded `o1-preview`, NOT start of slug
+    "some-model-o3-mini-fork",    # embedded `o3-mini`, NOT start of slug
+    # Bare "grok" must not over-match non-reasoning Grok SKUs.
+    "x-ai/grok-3",
+    "x-ai/grok-4",
+    "x-ai/grok-4-0709",
+    "x-ai/grok-code-fast-1",
+    # Qwen2 must not match Qwen3 (different family).
+    "qwen2-72b-instruct",
+    # Non-reasoning DeepSeek chat must not match the v4 reasoning entries.
+    "deepseek-chat",
+    "deepseek/deepseek-chat",
+    "some-deepseek-v4-flash",     # embedded v4 slug, NOT start of slug
+    # Kimi `k3` anchor traps — `k3` must be at the START of the slug
+    # with a separator/end after it, so these must NOT match.
+    "k3s",                        # k3 followed by `s`, not a separator
+    "k3s-1.28",                   # Kubernetes distro, not Kimi
+    "some-model-k3",              # embedded `k3`, NOT start of slug
+    "kimix-7b",                   # `kimi` prefix but no separator after
+    # Empty / None / non-string inputs — must return None, not raise.
+    "",
+    None,
+    12345,
+    [],
+])
+def test_reasoning_stale_timeout_floor_negative_cases(model):
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    assert get_reasoning_stale_timeout_floor(model) is None, (
+        f"get_reasoning_stale_timeout_floor({model!r}) must return None "
+        f"for non-reasoning models and start-of-slug-anchor traps."
+    )
 
 
 # ── integration: _resolved_api_call_stale_timeout_base ─────────────────────

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -83,6 +83,14 @@ import pytest
     ("x-ai/grok-4.20-reasoning", 300.0),
     ("x-ai/grok-4.5", 300.0),
     ("x-ai/grok-4-fast-non-reasoning", 180.0),
+    # Kimi / Moonshot reasoning family.  `kimi` matches the slug after
+    # aggregator-prefix strip; `k3` matches the bare Kimi Coding slug.
+    ("accounts/fireworks/models/kimi-k3", 300.0),
+    ("kimi-k3", 300.0),
+    ("kimi-k2p6", 300.0),
+    ("moonshot/kimi-k3", 300.0),
+    ("k3", 300.0),
+    ("k3-code", 300.0),
 ])
 def test_reasoning_stale_timeout_floor_positive_cases(model, expected):
     from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
@@ -93,10 +101,49 @@ def test_reasoning_stale_timeout_floor_positive_cases(model, expected):
     )
 
 
-
-
-
-
+@pytest.mark.parametrize("model", [
+    # Non-reasoning chat models — no floor.
+    "gpt-4o",
+    "gpt-5",
+    "claude-3-5-sonnet-20240620",
+    "llama-3.3-70b-instruct",
+    "gemini-2.5-pro",
+    # Start-of-slug anchor traps — the slug must be at the START of
+    # the bare model name (after aggregator-prefix strip).  Bare
+    # substring matching would over-match these.
+    "olmo-1",
+    "olmo-13b",
+    "llama-4-70b-o1-preview",     # embedded `o1-preview`, NOT start of slug
+    "some-model-o3-mini-fork",    # embedded `o3-mini`, NOT start of slug
+    # Bare "grok" must not over-match non-reasoning Grok SKUs.
+    "x-ai/grok-3",
+    "x-ai/grok-4",
+    "x-ai/grok-4-0709",
+    "x-ai/grok-code-fast-1",
+    # Qwen2 must not match Qwen3 (different family).
+    "qwen2-72b-instruct",
+    # Non-reasoning DeepSeek chat must not match the v4 reasoning entries.
+    "deepseek-chat",
+    "deepseek/deepseek-chat",
+    "some-deepseek-v4-flash",     # embedded v4 slug, NOT start of slug
+    # Kimi `k3` anchor traps — `k3` must be at the START of the slug
+    # with a separator/end after it, so these must NOT match.
+    "k3s",                        # k3 followed by `s`, not a separator
+    "k3s-1.28",                   # Kubernetes distro, not Kimi
+    "some-model-k3",              # embedded `k3`, NOT start of slug
+    "kimix-7b",                   # `kimi` prefix but no separator after
+    # Empty / None / non-string inputs — must return None, not raise.
+    "",
+    None,
+    12345,
+    [],
+])
+def test_reasoning_stale_timeout_floor_negative_cases(model):
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    assert get_reasoning_stale_timeout_floor(model) is None, (
+        f"get_reasoning_stale_timeout_floor({model!r}) must return None "
+        f"for non-reasoning models and start-of-slug-anchor traps."
+    )
 
 # ── integration: _resolved_api_call_stale_timeout_base ─────────────────────
 


### PR DESCRIPTION
## What & why

Fixes #73337.

Kimi K3 (1M context) emits an extended reasoning phase before its first content token. At long context (>40K tokens) that phase can take 80+ seconds, and at very long context (>80K) it exceeds the **180s default stream stale-timeout floor** in `agent/reasoning_timeouts.py`. The stale detector then kills the connection mid-think and it surfaces as `BrokenPipeError` / `RemoteProtocolError` even though the model is still working — the exact failure mode the allowlist exists to prevent for every other cloud reasoning model.

Kimi/Moonshot were simply missing from `_REASONING_STALE_TIMEOUT_FLOORS`.

## Change

Add two start-of-slug-anchored floor entries:

```python
("kimi", 300),
("k3", 300),
```

- `kimi` matches the slug after aggregator-prefix strip — `accounts/fireworks/models/kimi-k3`, `kimi-k2p6`, `moonshot/kimi-k3`.
- `k3` matches the bare slug used by the Kimi Coding Plan.

Both are start-anchored (`^<slug>(?:$|[-._])`), so `k3` never over-matches `k3s` (Kubernetes) or an embedded `...-k3`, and `kimi` never matches `kimix-7b`. `300s` mirrors the QwQ-32B / o3-mini tier.

This is a **floor**: it only ever raises `max(default, floor)`, never lowers a threshold, and never overrides an explicit user-configured `stale_timeout_seconds`. Zero effect on non-reasoning models.

## Tests

Extended `tests/agent/test_reasoning_stale_timeout_floor.py`:
- Positive: `accounts/fireworks/models/kimi-k3`, `kimi-k3`, `kimi-k2p6`, `moonshot/kimi-k3`, `k3`, `k3-code` → `300.0`.
- Negative anchor-traps: `k3s`, `k3s-1.28`, `some-model-k3`, `kimix-7b` → `None`.

```
71 passed
```

Preflight (ruff, windows-footguns, doctests, affected tests) green vs `upstream/main`. The arm64-fork-Docker CI job is expected to fail on fork PRs and is unrelated.
