### PR TITLE
test(plugins): add failing test for pre_tool_call plugin hook block directive

### DIFF
--- a/tests/plugins/test_pre_tool_call_block/__init__.py
+++ b/tests/plugins/test_pre_tool_call_block/__init__.py
@@ -1,0 +1,27 @@
+"""Minimal reproduction plugin for pre_tool_call block directive bug.
+
+This plugin blocks ALL terminal tool calls unconditionally.
+If the block directive is respected, terminal commands will fail with
+"BLOCKED by test-block plugin". If the bug is present, terminal commands
+execute normally and post_tool_call fires with the same tool name.
+
+Related: https://github.com/NousResearch/hermes-agent/issues/73338
+         https://github.com/NousResearch/hermes-agent/issues/41045
+"""
+
+
+def pre_block(tool_name: str, args: dict = None, **kwargs):
+    """Block ALL terminal calls unconditionally — for testing only."""
+    if tool_name == "terminal":
+        return {"action": "block", "message": "BLOCKED by test-block plugin"}
+    return None
+
+
+def post_audit(tool_name: str, args: dict = None, result: str = None, **kwargs):
+    """If this fires after a block, the block was ignored."""
+    pass  # No side effects — test verifies via return value, not log
+
+
+def register(ctx):
+    ctx.register_hook("pre_tool_call", pre_block)
+    ctx.register_hook("post_tool_call", post_audit)

--- a/tests/plugins/test_pre_tool_call_block/plugin.yaml
+++ b/tests/plugins/test_pre_tool_call_block/plugin.yaml
@@ -1,0 +1,3 @@
+name: test-pre-tool-call-block
+version: 0.1.0
+description: Minimal reproduction — blocks all terminal calls via pre_tool_call hook

--- a/tests/run_agent/test_pre_tool_call_block_real.py
+++ b/tests/run_agent/test_pre_tool_call_block_real.py
@@ -1,0 +1,111 @@
+"""Test that pre_tool_call plugin hooks can actually block tool execution.
+
+The existing ``test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block``
+in ``test_tool_call_guardrail_runtime.py`` MOCKS ``resolve_pre_tool_block`` — it
+never exercises the real ``invoke_hook()`` → callbacks → return-values path.
+
+This test loads the ``test_pre_tool_call_block`` plugin, registers its hooks,
+calls ``invoke_hook("pre_tool_call", ...)``, and asserts that a block directive
+is returned when a terminal tool call is attempted.
+
+Related:
+  - https://github.com/NousResearch/hermes-agent/issues/73338
+  - https://github.com/NousResearch/hermes-agent/issues/41045
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Skip if we can't import hermes_cli (CI may not have it)
+hermes_cli = pytest.importorskip("hermes_cli.plugins")
+
+from hermes_cli.plugins import (
+    PluginManager,
+    get_plugin_manager,
+    invoke_hook,
+    get_pre_tool_call_block_message,
+)
+
+
+@pytest.fixture(scope="module")
+def _manager_with_test_plugin():
+    """Discover and load plugins, ensuring test_pre_tool_call_block is loaded."""
+    manager = get_plugin_manager()
+    # Force re-discovery to pick up the test plugin
+    manager.discover_and_load(force=True)
+    return manager
+
+
+def test_pre_tool_call_block_directive_collected_from_real_callback(
+    _manager_with_test_plugin,
+):
+    """invoke_hook('pre_tool_call', ...) collects block directive from plugin callback.
+
+    The test_pre_tool_call_block plugin's pre_block callback returns
+    {"action": "block", "message": "BLOCKED by test-block plugin"} for ALL
+    terminal tool calls. This test verifies that invoke_hook() correctly
+    collects that return value.
+    """
+    # Call invoke_hook for a terminal tool
+    results = invoke_hook(
+        "pre_tool_call",
+        tool_name="terminal",
+        args={"command": "echo test"},
+        task_id="test-task-1",
+        session_id="test-session-1",
+        tool_call_id="test-call-1",
+    )
+
+    # At least one result should be the block directive
+    block_found = False
+    for result in results:
+        if isinstance(result, dict) and result.get("action") == "block":
+            block_found = True
+            assert "BLOCKED" in result.get("message", ""), (
+                f"Expected block message, got: {result}"
+            )
+            break
+
+    assert block_found, (
+        f"invoke_hook('pre_tool_call') returned {len(results)} results, "
+        f"none with action='block'. Results: {results}"
+    )
+
+
+def test_get_pre_tool_call_block_message_returns_block_for_terminal(
+    _manager_with_test_plugin,
+):
+    """get_pre_tool_call_block_message() returns block message for terminal calls.
+
+    This is the higher-level API that the agent runtime calls. It should
+    aggregate invoke_hook results and return the first block message.
+    """
+    message = get_pre_tool_call_block_message(
+        "terminal",
+        {"command": "echo blocked"},
+        task_id="test-task-2",
+        session_id="test-session-2",
+        tool_call_id="test-call-2",
+    )
+
+    assert message is not None, (
+        "get_pre_tool_call_block_message() returned None for terminal call — "
+        "block directive was not collected"
+    )
+    assert "BLOCKED" in message, f"Unexpected block message: {message}"
+
+
+def test_safe_tool_not_blocked(_manager_with_test_plugin):
+    """The test plugin only blocks 'terminal' — other tools pass through."""
+    message = get_pre_tool_call_block_message(
+        "web_search",
+        {"query": "test"},
+        task_id="test-task-3",
+    )
+
+    assert message is None, (
+        f"Expected no block for web_search, got: {message}"
+    )


### PR DESCRIPTION
## What

Adds a minimal reproduction plugin and a test that exercises the **real** `invoke_hook()` → plugin callback path for `pre_tool_call` block directives.

## Why

The existing test (`test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block`) **mocks** `resolve_pre_tool_block`, skipping the actual hook dispatch chain entirely. This means the bug where real plugin callbacks return `{"action": "block"}` but the tool still executes is invisible to the test suite.

## Changes

1. **Reproduction plugin** (`tests/plugins/test_pre_tool_call_block/`) — blocks ALL `terminal` tool calls unconditionally
2. **Test** (`tests/run_agent/test_pre_tool_call_block_real.py`) — loads the real plugin, calls `invoke_hook("pre_tool_call", ...)` without mocking, and asserts the block directive is collected

## Related

- Fixes the test gap behind #73338
- Follow-up to #41045 (which was closed claiming fix shipped, but the existing test mocks past the bug)

## Testing

```bash
pytest tests/run_agent/test_pre_tool_call_block_real.py -v
```

If this test passes, the block directive is being collected correctly. If it fails (as expected in current v0.19.0), it confirms the plugin hook return-value gap.