### PR TITLE
fix(deps): refresh safe web security locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9549,9 +9549,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -15544,9 +15544,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -15563,7 +15563,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -15585,9 +15585,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- refresh the root lockfile from DOMPurify 3.4.11 to 3.4.12
- refresh PostCSS from 8.5.15 to 8.5.24 and its nested NanoID resolution
- leave React Router unchanged because the current audit suggestion is not a safe upgrade path
- keep the change lockfile-only with no application API or manifest changes

Closes #73329.

## Security impact

The updated resolutions clear:

- DOMPurify GHSA-c2j3-45gr-mqc4
- PostCSS GHSA-r28c-9q8g-f849

Post-update audits no longer report `dompurify` or `postcss` in `web`, `ui-tui`, or `apps/desktop`. The React Router advisory remains visible and intentionally requires a separate maintainer decision.

## Validation

- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm audit --workspace web --json`
- `npm audit --workspace ui-tui --json`
- `npm audit --workspace apps/desktop --json`
- `npm --workspace web run build`
- `npm --workspace ui-tui run build`
- `npm --workspace ui-tui run typecheck`
- `npm --workspace apps/desktop run build`
- `npm --workspace apps/desktop run typecheck`
- `git diff --check`

All three workspace builds and type checks completed successfully.