### PR TITLE
fix(slack): preserve explicit mention intent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12631,6 +12631,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             group_sessions_per_user=_group_sessions_per_user,
             thread_sessions_per_user=_thread_sessions_per_user,
         )
+        if (
+            _is_shared_multi_user
+            and source.platform == Platform.SLACK
+            and event.metadata.get("slack_bot_mentioned") is True
+        ):
+            # The Slack adapter strips its own raw ``<@UID>`` before creating
+            # MessageEvent.text so commands and natural-language requests stay
+            # clean. Without carrying the verified mention decision forward,
+            # however, group-chat response policy can mistake the explicitly
+            # addressed request for ambient chatter and emit NO_REPLY even
+            # though Slack already routed and acknowledged it.
+            message_text = (
+                "[Slack routing — verified: the current message explicitly "
+                "mentioned this assistant and is directed at you.]\n"
+                f"{message_text}"
+            )
         if _is_shared_multi_user and source.user_name:
             # source.user_name is the platform display name — attacker-
             # influenceable on any platform that lets participants set their

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6292,6 +6292,11 @@ class SlackAdapter(BasePlatformAdapter):
                 "slack_team_id": team_id,
                 "slack_channel_id": channel_id,
                 "slack_thread_ts": thread_ts,
+                # ``text`` no longer contains the bot's raw ``<@UID>`` at this
+                # point. Preserve the adapter's verified routing decision so
+                # the shared-channel agent turn still knows the current request
+                # was explicitly directed at it.
+                "slack_bot_mentioned": is_mentioned,
             },
         )
 

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -103,6 +103,50 @@ async def test_preprocess_includes_slack_author_mention_for_shared_thread():
 
 
 @pytest.mark.asyncio
+async def test_preprocess_marks_verified_slack_bot_mention_as_directed():
+    """Slack strips the bot's raw ``<@UID>`` before the agent turn.
+
+    Preserve the adapter's verified mention decision in the prepared user
+    message so group-chat response policy cannot mistake an explicitly
+    addressed request for ambient channel chatter.
+    """
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+    )
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_name="team-channel",
+        chat_type="group",
+        user_id="U123",
+        user_name="Alice",
+        thread_id="171.000",
+    )
+    event = MessageEvent(
+        text="please investigate the scheduler timeout",
+        source=source,
+        metadata={"slack_bot_mentioned": True},
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == (
+        "[Alice | Slack user <@U123>] "
+        "[Slack routing — verified: the current message explicitly mentioned "
+        "this assistant and is directed at you.]\n"
+        "please investigate the scheduler timeout"
+    )
+
+
+@pytest.mark.asyncio
 async def test_preprocess_slack_shared_thread_without_user_id_keeps_name_only():
     """No user_id on the source → fall back to the plain name prefix."""
     runner = _make_runner(

--- a/tests/test_slack_thread_require_mention.py
+++ b/tests/test_slack_thread_require_mention.py
@@ -142,6 +142,7 @@ def test_thread_require_mention_allows_mentioned_thread_reply_without_sticky_thr
 
     assert len(handled) == 1
     assert handled[0].text == "update this"
+    assert handled[0].metadata["slack_bot_mentioned"] is True
     assert "100.000" not in adapter._mentioned_threads
 
     run(


### PR DESCRIPTION
## Summary
- preserve Slack's verified direct-mention decision after stripping the raw `<@BOT_UID>` token
- surface a compact routing marker on shared Slack sessions so response policy treats the current turn as explicitly directed
- add adapter and gateway regression coverage for the previous `NO_REPLY` failure mode

## Root cause
Slack correctly routed and acknowledged explicitly mentioned messages, but the adapter stripped the bot mention before constructing `MessageEvent.text`. Shared-channel sender prefixing then exposed only the author identity, so group-chat response policy could mistake the request for ambient chatter and emit `NO_REPLY`.

## Test plan
- `python -m pytest tests/test_slack_thread_require_mention.py tests/gateway/test_slack_mention.py tests/gateway/test_shared_group_sender_prefix.py tests/gateway/test_response_filters.py -q -o 'addopts='` — 94 passed
- `ruff check gateway/run.py plugins/platforms/slack/adapter.py tests/test_slack_thread_require_mention.py tests/gateway/test_shared_group_sender_prefix.py` — passed
- `python -m compileall -q ...` — passed
- `git diff --check` — passed

## Formatting note
`ruff format --check` was not used as a gate because the current upstream files contain extensive pre-existing formatting drift under the repository-pinned Ruff version; formatting these whole files would create unrelated churn.