### PR TITLE
fix(agent): detect thinking-budget exhaustion for reasoning_content-only models (#73336)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2767,12 +2767,43 @@ def run_conversation(
                             re.IGNORECASE,
                         )
                     )
+                    # Some reasoning models emit their thinking in a structured
+                    # ``reasoning`` / ``reasoning_content`` field instead of
+                    # inline ``<think>`` tags — Kimi K2.x/K3 on Fireworks,
+                    # DeepSeek on certain providers.  When such a model spends
+                    # its whole budget on reasoning it returns no content and no
+                    # tool calls, and the ``<think>``-tag check above never
+                    # fires, so Hermes wastes up to 4 continuation retries on
+                    # identical budget-exhausted responses before giving up with
+                    # a misleading "remained truncated" error.  ``normalize_response``
+                    # keeps ``reasoning`` on the message and ``reasoning_content``
+                    # under ``provider_data`` (agent/transports/chat_completions.py),
+                    # so consult both.
+                    _trunc_reasoning = getattr(_trunc_msg, "reasoning", None) if _trunc_msg else None
+                    if not _trunc_reasoning and _trunc_msg:
+                        _pd = getattr(_trunc_msg, "provider_data", None)
+                        if isinstance(_pd, dict):
+                            _trunc_reasoning = _pd.get("reasoning_content")
+                    _has_reasoning_content = bool(
+                        isinstance(_trunc_reasoning, str) and _trunc_reasoning.strip()
+                    )
                     _thinking_exhausted = (
                         not _trunc_has_tool_calls
-                        and _has_think_tags
                         and (
-                            (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
-                            or _trunc_content is None
+                            # Inline ``<think>``-tag exhaustion (unchanged): tags
+                            # present and no visible text after the think block.
+                            (
+                                _has_think_tags
+                                and (
+                                    (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
+                                    or _trunc_content is None
+                                )
+                            )
+                            # Structured-reasoning exhaustion: reasoning was
+                            # produced but there is no content to show for it.
+                            # ``finish_reason == 'length'`` is already guaranteed
+                            # by the enclosing branch.
+                            or (_has_reasoning_content and not _trunc_content)
                         )
                     )
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5745,6 +5745,80 @@ class TestRunConversation:
         assert result["api_calls"] == 4
         assert result["completed"] is False
 
+    def test_length_reasoning_content_exhausted_skips_continuation(self, agent):
+        """finish_reason='length' with structured reasoning_content but no
+        content (Kimi K2.x/K3 on Fireworks, DeepSeek via some providers) must
+        fire thinking-exhaustion — not waste 4 continuation retries.  These
+        models emit thinking in ``reasoning_content`` rather than inline
+        ``<think>`` tags, so the tag-based detector alone misses them."""
+        self._setup_agent(agent)
+        resp = _mock_response(
+            content=None,
+            finish_reason="length",
+            reasoning_content="internal reasoning " * 500,
+        )
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # Detected immediately — single API call, no continuation retries.
+        assert result["api_calls"] == 1
+        assert result["completed"] is False
+        assert "reasoning" in result["error"].lower()
+        assert "output tokens" in result["error"].lower()
+        assert result["final_response"] is not None
+        assert "Thinking Budget Exhausted" in result["final_response"]
+
+    def test_length_reasoning_field_exhausted_skips_continuation(self, agent):
+        """Same exhaustion detection for the ``reasoning`` field (DeepSeek/Qwen
+        shape) that ``normalize_response`` keeps on the message directly."""
+        self._setup_agent(agent)
+        resp = _mock_response(
+            content="",
+            finish_reason="length",
+            reasoning="internal reasoning " * 500,
+        )
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["api_calls"] == 1
+        assert result["completed"] is False
+        assert "Thinking Budget Exhausted" in result["final_response"]
+
+    def test_length_reasoning_content_with_partial_content_retries_normally(self, agent):
+        """Reasoning plus a partial visible answer is a genuine mid-content
+        truncation — the answer is worth continuing, so this must NOT be
+        treated as thinking-budget exhaustion."""
+        self._setup_agent(agent)
+        resp = _mock_response(
+            content="Here is the partial",
+            finish_reason="length",
+            reasoning_content="internal reasoning " * 500,
+        )
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # Visible content present → normal continuation retries, not exhaustion.
+        assert result["api_calls"] == 4
+        assert result["completed"] is False
+
     def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):
         self._setup_agent(agent)
         bad_tc = _mock_tool_call(


### PR DESCRIPTION
## What & why

Fixes #73336.

The `finish_reason='length'` thinking-budget exhaustion detector in `agent/conversation_loop.py` only recognizes **inline `<think>` tags** in `content`. Reasoning models that emit their thinking in a structured `reasoning` / `reasoning_content` field instead — **Kimi K2.x/K3 on Fireworks**, DeepSeek via some providers — return `content=None` and no tool calls when they exhaust their token budget on reasoning.

Because the `<think>`-tag check never fires, Hermes falls through to the continuation-retry path and burns **up to 4 identical budget-exhausted API calls** before giving up with a misleading `"Response remained truncated after 4 continuation attempts"` — when the real cause is reasoning-budget exhaustion, for which the existing `"Thinking Budget Exhausted"` message is already exactly right.

## Change

Add a structured-reasoning branch to the detector. `normalize_response` keeps `reasoning` on the message and `reasoning_content` under `provider_data` (`agent/transports/chat_completions.py`), so the detector consults both:

```python
_trunc_reasoning = getattr(_trunc_msg, "reasoning", None) ...
# fall back to provider_data["reasoning_content"]
_has_reasoning_content = bool(isinstance(_trunc_reasoning, str) and _trunc_reasoning.strip())

_thinking_exhausted = (
    not _trunc_has_tool_calls
    and (
        (_has_think_tags and ...)          # existing inline-tag path, unchanged
        or (_has_reasoning_content and not _trunc_content)   # new
    )
)
```

**Deliberately additive, not a rewrite.** The issue's suggested patch replaced the `<think>`-tag condition with a flat `not _trunc_content` gate — but that would *stop* flagging the existing case where `content == "<think>…</think>"` (a truthy string, so `not content` is `False`), a regression on today's behavior. This PR keeps the inline-tag branch byte-for-byte and only *adds* the structured-reasoning case. The new branch fires only when reasoning was produced **and** there is no visible content, so a partial visible answer still gets normal continuation retries. `finish_reason == 'length'` is already guaranteed by the enclosing block.

## Tests

`tests/run_agent/test_run_agent.py`:
- `test_length_reasoning_content_exhausted_skips_continuation` — `reasoning_content` populated, `content=None` → 1 API call, `Thinking Budget Exhausted`.
- `test_length_reasoning_field_exhausted_skips_continuation` — same for the `reasoning` field shape.
- `test_length_reasoning_content_with_partial_content_retries_normally` — reasoning **plus** partial content → 4 normal continuation retries (no false exhaustion).
- Existing `test_length_thinking_exhausted_skips_continuation` (inline `<think>`) and `test_length_empty_content_without_think_tags_retries_normally` (no reasoning) still pass — proving no regression.

```
72 passed
```

Preflight (ruff, windows-footguns, affected tests) green vs `upstream/main`. The arm64-fork-Docker CI job fails on all fork PRs and is unrelated.
