### PR TITLE
fix(gateway): route plain background live output to its spawn-time UI owner (#61719 residual)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16243,3 +16243,58 @@ def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
         assert cleanup_order == ["trim", "reset_home"]
     finally:
         server._sessions.pop("sid_trim", None)
+
+def test_agent_terminal_output_routes_by_spawn_time_ui_owner(monkeypatch):
+    """#61719 residual: `_owner_sid_for_process` matched only by session_key.
+    A delegated child's process carries the subagent's internal key, which
+    never matches a live TUI session, so its live `agent.terminal.output`
+    chunks were emitted with sid "" and dropped by write_json. The spawn-time
+    `origin_ui_session_id` (captured by terminal_tool for every background
+    spawn) must win when it names a live session; key-equality remains the
+    fallback for processes without a recorded UI origin."""
+    from types import SimpleNamespace
+    from tools.process_registry import process_registry
+
+    monkeypatch.setattr(process_registry, "on_output", None)
+    monkeypatch.setattr(process_registry, "on_close", None)
+    emitted = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload))
+    )
+    server._wire_agent_terminal_output()
+
+    saved = dict(server._sessions)
+    server._sessions.clear()
+    try:
+        server._sessions["parent_sid"] = {"session_key": "parent-key"}
+
+        # Delegated-child shape: internal session_key, recorded UI origin.
+        child_proc = SimpleNamespace(
+            id="proc_child", session_key="subagent-internal-key",
+            origin_ui_session_id="parent_sid",
+        )
+        process_registry.on_output(child_proc, "hello from child")
+        assert emitted[-1][0] == "agent.terminal.output"
+        assert emitted[-1][1] == "parent_sid", (
+            "child process live output must route to the spawn-time UI owner"
+        )
+        assert emitted[-1][2] == {"process_id": "proc_child", "chunk": "hello from child"}
+
+        # No recorded origin: legacy session_key equality still routes.
+        plain_proc = SimpleNamespace(
+            id="proc_plain", session_key="parent-key", origin_ui_session_id="",
+        )
+        process_registry.on_output(plain_proc, "plain")
+        assert emitted[-1][1] == "parent_sid"
+
+        # Stale origin (window closed) with unknown key: falls back to "".
+        stale_proc = SimpleNamespace(
+            id="proc_stale", session_key="unknown-key", origin_ui_session_id="gone_sid",
+        )
+        process_registry.on_output(stale_proc, "stale")
+        assert emitted[-1][1] == ""
+    finally:
+        server._sessions.clear()
+        server._sessions.update(saved)
+        process_registry.on_output = None
+        process_registry.on_close = None

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -435,3 +435,53 @@ def test_non_ci_background_command_does_not_emit_homebrew_hint(monkeypatch, tmp_
     assert "hint" not in result, (
         f"Non-CI command using awk must not be flagged as homebrew CI poller, got: {result.get('hint')!r}"
     )
+
+
+def test_background_spawn_captures_ui_origin_without_notify(monkeypatch, tmp_path):
+    """#61719 residual: live `agent.terminal.output` chunks are emitted for
+    EVERY background process, but the spawn-time UI owner was only captured
+    when notify_on_complete/watch_patterns were set — a plain background=true
+    spawn (a delegated child's, in particular) had no positive owner and its
+    live output was dropped by the desktop router."""
+    import gateway.session_context as session_context
+
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    from types import SimpleNamespace
+    from tools import process_registry as process_registry_module
+
+    spawned = {}
+
+    def capturing_spawn_local(**kwargs):
+        proc = SimpleNamespace(
+            id="proc_ui_origin_test",
+            pid=4243,
+            notify_on_complete=False,
+            watcher_platform="",
+            watcher_chat_id="",
+            watcher_user_id="",
+            watcher_user_name="",
+            watcher_thread_id="",
+            watcher_message_id="",
+            watcher_interval=0,
+        )
+        spawned["proc"] = proc
+        return proc
+
+    monkeypatch.setattr(
+        process_registry_module.process_registry, "spawn_local", capturing_spawn_local
+    )
+    monkeypatch.setattr(
+        session_context,
+        "get_session_env",
+        lambda key, default="": "sid_ui_1" if key == "HERMES_UI_SESSION_ID" else default,
+    )
+    try:
+        tt.terminal_tool(command="sleep 60", background=True)
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert getattr(spawned["proc"], "origin_ui_session_id", "") == "sid_ui_1", (
+        "plain background spawn (no notify/watch) must record the spawn-time "
+        "UI owner so live output chunks can be positively routed"
+    )

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -442,7 +442,11 @@ def test_background_spawn_captures_ui_origin_without_notify(monkeypatch, tmp_pat
     EVERY background process, but the spawn-time UI owner was only captured
     when notify_on_complete/watch_patterns were set — a plain background=true
     spawn (a delegated child's, in particular) had no positive owner and its
-    live output was dropped by the desktop router."""
+    live output was dropped by the desktop router.
+
+    The owner must be passed INTO spawn_local() (sweeper review): the local
+    reader thread starts inside the spawn and can emit output before it
+    returns, so a post-spawn attribute assignment races the first chunks."""
     import gateway.session_context as session_context
 
     tt = _silent_bg_harness(monkeypatch, tmp_path)
@@ -452,7 +456,8 @@ def test_background_spawn_captures_ui_origin_without_notify(monkeypatch, tmp_pat
     spawned = {}
 
     def capturing_spawn_local(**kwargs):
-        proc = SimpleNamespace(
+        spawned["kwargs"] = kwargs
+        return SimpleNamespace(
             id="proc_ui_origin_test",
             pid=4243,
             notify_on_complete=False,
@@ -464,8 +469,6 @@ def test_background_spawn_captures_ui_origin_without_notify(monkeypatch, tmp_pat
             watcher_message_id="",
             watcher_interval=0,
         )
-        spawned["proc"] = proc
-        return proc
 
     monkeypatch.setattr(
         process_registry_module.process_registry, "spawn_local", capturing_spawn_local
@@ -481,7 +484,44 @@ def test_background_spawn_captures_ui_origin_without_notify(monkeypatch, tmp_pat
         tt._active_environments.pop("default", None)
         tt._last_activity.pop("default", None)
 
-    assert getattr(spawned["proc"], "origin_ui_session_id", "") == "sid_ui_1", (
-        "plain background spawn (no notify/watch) must record the spawn-time "
-        "UI owner so live output chunks can be positively routed"
+    assert spawned["kwargs"].get("origin_ui_session_id") == "sid_ui_1", (
+        "plain background spawn (no notify/watch) must hand the spawn-time UI "
+        "owner to spawn_local() so the session owns it before the reader starts"
+    )
+
+
+def test_immediate_output_carries_ui_owner_through_real_registry(tmp_path):
+    """Sweeper ask: real registry lifecycle, not a stubbed spawn. The very
+    first chunk a fast process emits must already see the UI owner on the
+    session — spawn_local() sets it at ProcessSession construction, before
+    the reader thread exists."""
+    from tools.process_registry import process_registry
+
+    recorded = []
+    prev_sink = process_registry.on_output
+    process_registry.on_output = lambda session, chunk: recorded.append(
+        (getattr(session, "origin_ui_session_id", ""), chunk)
+    )
+    try:
+        session = process_registry.spawn_local(
+            command="echo immediate-owner-check",
+            cwd=str(tmp_path),
+            origin_ui_session_id="sid_live_1",
+        )
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not any(
+            "immediate-owner-check" in chunk for _, chunk in recorded
+        ):
+            time.sleep(0.05)
+    finally:
+        process_registry.on_output = prev_sink
+        try:
+            process_registry.kill_process(session.id)
+        except Exception:
+            pass
+
+    matching = [sid for sid, chunk in recorded if "immediate-owner-check" in chunk]
+    assert matching, f"no live output observed; recorded={recorded!r}"
+    assert all(sid == "sid_live_1" for sid in matching), (
+        f"immediate output emitted without its UI owner: {matching}"
     )

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -170,6 +170,8 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "session_key": task_id,
         "env_vars": {},
         "use_pty": False,
+        # Spawn-time UI owner (#61719) — empty outside TUI/desktop contexts.
+        "origin_ui_session_id": "",
     }]
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -117,6 +117,13 @@ class ProcessSession:
     watcher_thread_id: str = ""
     watcher_message_id: str = ""                # Triggering message id — reply anchor for topic routing
     watcher_interval: int = 0                   # 0 = no watcher configured
+    # Spawn-time UI owner (TUI/desktop window session id). Captured for EVERY
+    # background spawn — not just notify/watch ones — because live
+    # ``agent.terminal.output`` chunks are emitted for every background
+    # process and the desktop router needs positive ownership: a delegated
+    # child's ``session_key`` is the subagent's internal key and never matches
+    # a live TUI session (#61719).
+    origin_ui_session_id: str = ""
     notify_on_complete: bool = False             # Queue agent notification on exit
     # Watch patterns — trigger agent notification when output matches any pattern
     watch_patterns: List[str] = field(default_factory=list)
@@ -2082,6 +2089,7 @@ class ProcessRegistry:
                             "watcher_thread_id": s.watcher_thread_id,
                             "watcher_message_id": s.watcher_message_id,
                             "watcher_interval": s.watcher_interval,
+                            "origin_ui_session_id": s.origin_ui_session_id,
                             "notify_on_complete": s.notify_on_complete,
                             "watch_patterns": s.watch_patterns,
                         })
@@ -2160,6 +2168,7 @@ class ProcessRegistry:
                 watcher_thread_id=entry.get("watcher_thread_id", ""),
                 watcher_message_id=entry.get("watcher_message_id", ""),
                 watcher_interval=entry.get("watcher_interval", 0),
+                origin_ui_session_id=entry.get("origin_ui_session_id", ""),
                 notify_on_complete=entry.get("notify_on_complete", False),
                 watch_patterns=entry.get("watch_patterns", []),
             )

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -702,6 +702,7 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        origin_ui_session_id: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -727,6 +728,10 @@ class ProcessRegistry:
             command=command,
             task_id=task_id,
             session_key=session_key,
+            # Set at construction — BEFORE any reader/poller thread starts —
+            # so the very first output chunk already has a routable UI owner
+            # (a post-spawn assignment races the reader, #61719).
+            origin_ui_session_id=origin_ui_session_id,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
         )
@@ -850,6 +855,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        origin_ui_session_id: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -867,6 +873,8 @@ class ProcessRegistry:
             command=command,
             task_id=task_id,
             session_key=session_key,
+            # Before the log poller starts — see spawn_local (#61719).
+            origin_ui_session_id=origin_ui_session_id,
             cwd=cwd,
             started_at=time.time(),
             env_ref=env,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2826,6 +2826,24 @@ def terminal_tool(
                             else canonical_hint
                         )
 
+                # Spawn-time UI owner — captured for EVERY background spawn,
+                # not just notify/watch ones: live ``agent.terminal.output``
+                # chunks are emitted for every background process, and the
+                # desktop router needs positive ownership to deliver them. A
+                # delegated child's session_key is the subagent's internal key
+                # and never matches a live TUI window, so without this its
+                # live output was emitted with sid "" and dropped (#61719).
+                # Empty outside TUI/desktop contexts — harmless no-op.
+                if background:
+                    try:
+                        from gateway.session_context import get_session_env as _gse_ui
+
+                        proc_session.origin_ui_session_id = (
+                            _gse_ui("HERMES_UI_SESSION_ID", "") or ""
+                        )
+                    except Exception:
+                        pass  # best-effort: routing falls back to session_key
+
                 # Populate routing metadata on the session so that
                 # watch-pattern and completion notifications can be
                 # routed back to the correct chat/thread.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2687,6 +2687,24 @@ def terminal_tool(
                 default_cwd=cwd,
                 session_key=session_key,
             )
+            # Spawn-time UI owner — captured for EVERY background spawn, not
+            # just notify/watch ones: live ``agent.terminal.output`` chunks
+            # are emitted for every background process, and the desktop
+            # router needs positive ownership to deliver them. A delegated
+            # child's session_key is the subagent's internal key and never
+            # matches a live TUI window, so without this its live output was
+            # emitted with sid "" and dropped (#61719). Captured BEFORE the
+            # spawn and passed into it: the local reader thread starts inside
+            # spawn_local() and can emit output before it returns, so a
+            # post-spawn assignment would race the first chunks. Empty
+            # outside TUI/desktop contexts — harmless no-op.
+            _origin_ui_sid = ""
+            try:
+                from gateway.session_context import get_session_env as _gse_ui
+
+                _origin_ui_sid = _gse_ui("HERMES_UI_SESSION_ID", "") or ""
+            except Exception:
+                pass  # best-effort: routing falls back to session_key
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
@@ -2696,6 +2714,7 @@ def terminal_tool(
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        origin_ui_session_id=_origin_ui_sid,
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -2704,6 +2723,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        origin_ui_session_id=_origin_ui_sid,
                     )
 
                 result_data = {
@@ -2825,24 +2845,6 @@ def terminal_tool(
                             existing + "\n\n" + canonical_hint if existing
                             else canonical_hint
                         )
-
-                # Spawn-time UI owner — captured for EVERY background spawn,
-                # not just notify/watch ones: live ``agent.terminal.output``
-                # chunks are emitted for every background process, and the
-                # desktop router needs positive ownership to deliver them. A
-                # delegated child's session_key is the subagent's internal key
-                # and never matches a live TUI window, so without this its
-                # live output was emitted with sid "" and dropped (#61719).
-                # Empty outside TUI/desktop contexts — harmless no-op.
-                if background:
-                    try:
-                        from gateway.session_context import get_session_env as _gse_ui
-
-                        proc_session.origin_ui_session_id = (
-                            _gse_ui("HERMES_UI_SESSION_ID", "") or ""
-                        )
-                    except Exception:
-                        pass  # best-effort: routing falls back to session_key
 
                 # Populate routing metadata on the session so that
                 # watch-pattern and completion notifications can be

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9316,6 +9316,17 @@ def _wire_agent_terminal_output() -> None:
         return
 
     def _owner_sid_for_process(session) -> str:
+        # Prefer the spawn-time UI owner recorded by terminal_tool: a
+        # delegated child's session_key is the subagent's internal key and
+        # never matches a live TUI session, which used to route its live
+        # output to sid "" — dropped by write_json (#61719). Only honor the
+        # recorded origin while that window is still live; otherwise fall
+        # back to the legacy session_key match.
+        origin_sid = str(getattr(session, "origin_ui_session_id", "") or "")
+        if origin_sid:
+            with _sessions_lock:
+                if origin_sid in _sessions:
+                    return origin_sid
         session_key = str(getattr(session, "session_key", "") or "")
         if not session_key:
             return ""


### PR DESCRIPTION
## Summary

Live `agent.terminal.output` chunks from a **plain** `background=true` process (no `notify_on_complete`, no `watch_patterns`) — a delegated child's, in particular — are dropped by the desktop router: the process has no positive UI owner. This completes the remaining scope of #61719 after its core landed.

## Root cause

Owner-routing for post-turn completions landed in merged `54d0948d3` ("route post-turn completions by owner"), and `drain_notifications` now requires positive ownership for routed events. But the sweeper's flagged problem on #61719 survived the merge:

- `tools/terminal_tool.py` captured routing metadata **only** inside the `background and (notify_on_complete or watch_patterns)` gate — while live output is emitted for *every* background process (`process_registry.on_output`).
- `_owner_sid_for_process()` (`tui_gateway/server.py`, `_wire_agent_terminal_output`) matched only by `session_key` equality against live TUI sessions. A delegated child's `ProcessSession.session_key` is the subagent's internal key, which never matches a window — so its chunks were emitted with `sid=""`, and a session-less event from a registry reader thread is dropped by `write_json` (documented at the `_live_transports` registry).

## Changes

- `tools/process_registry.py`: `ProcessSession.origin_ui_session_id` — spawn-time UI owner, persisted/restored in the crash checkpoint alongside the existing watcher metadata.
- `tools/terminal_tool.py`: capture `HERMES_UI_SESSION_ID` for **every** background spawn, outside the notify/watch gate — same session-env pattern the codebase already uses for UI routing (`tools/desktop_ui.py:39`, `tools/delegate_tool.py:3191`). Empty outside TUI/desktop contexts; best-effort with fallback.
- `tui_gateway/server.py`: `_owner_sid_for_process()` prefers the recorded origin **while that window is still live**, then falls back to the legacy `session_key` match — so existing routing behavior is byte-identical for processes without a recorded origin or after the owning window closes.

## Validation

| case | before | after |
|---|---|---|
| delegated child, plain `background=true` live output | `sid=""` → dropped | routed to spawn-time owner window |
| plain background, no recorded origin (non-desktop spawn) | `session_key` match | unchanged |
| recorded origin but window closed, unknown key | — | falls back to `""` (no leak to other windows) |

- 2 new tests red on unfixed main, green with fix: `test_background_spawn_captures_ui_origin_without_notify` (capture without notify/watch) and `test_agent_terminal_output_routes_by_spawn_time_ui_owner` (child-shape routing + fallback + stale-origin cases)
- `scripts/run_tests.sh tests/tools/test_notify_on_complete.py tests/test_tui_gateway_server.py tests/tools/test_process_registry.py` — 636 passed, 0 failed

## Scope notes

- Completion/watch notifications are untouched — they already carry watcher metadata and flow through the owner-routing from `54d0948d3`.
- A checkpoint-recovered process keeps its recorded origin; if that window is gone after restart the sid simply no longer matches a live session and routing falls back — no stale delivery.

Salvages the remaining scope of #61719 by @soria-clawd-bot (sweeper review problem: UI origin captured only when notify/watch enabled). Refs #54785, `54d0948d3`.
