### PR TITLE
fix(gateway): activate selected profile's plugin config before Desktop agent build (#73230)

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1290,6 +1290,12 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # The profile home whose plugin config this manager was last
+        # discovered against (``""`` = the launch profile, discovered at
+        # process start). Used by :meth:`activate_for_profile` to skip a
+        # redundant force-reload when the requested profile is already
+        # active — see issue #73230.
+        self._active_profile_home: str = ""
 
     # -----------------------------------------------------------------------
     # Public
@@ -1332,6 +1338,34 @@ class PluginManager:
         except BaseException:
             self._discovered = False
             raise
+
+    def activate_for_profile(self, profile_home: str | Path | None) -> bool:
+        """Activate the selected profile's plugin configuration.
+
+        The global :class:`PluginManager` is discovered once at process start
+        against the launch profile's ``config.yaml``. A profile-neutral
+        Desktop backend that serves a *different* selected profile must
+        re-discover so the hook registry reflects the selected profile's
+        ``plugins.enabled`` — otherwise plugins enabled only for that profile
+        (e.g. Langfuse) never register their hooks and silently no-op for
+        Desktop sessions (#73230). CLI and Telegram sessions don't share the
+        defect because each runs under a single profile.
+
+        Must be called *within* ``profile_home``'s ``HERMES_HOME`` override
+        scope (the caller binds it around agent construction): discovery
+        reads config via :func:`hermes_constants.get_hermes_home`, which
+        honours that context-local override.
+
+        Returns ``True`` when re-discovery ran, ``False`` when the profile is
+        already the manager's active profile (no-op — avoids clearing and
+        reloading the registry for the launch profile on every agent build).
+        """
+        key = str(profile_home) if profile_home else ""
+        if key == self._active_profile_home:
+            return False
+        self._active_profile_home = key
+        self.discover_and_load(force=True)
+        return True
 
     def _discover_and_load_inner(self) -> None:
         """The actual discovery sweep — see :meth:`discover_and_load`."""
@@ -2063,6 +2097,17 @@ def discover_plugins(force: bool = False) -> None:
     manifests and reload state in the current process.
     """
     get_plugin_manager().discover_and_load(force=force)
+
+
+def activate_profile_plugins(profile_home: str | Path | None) -> bool:
+    """Activate the selected profile's plugin config in the global manager.
+
+    Thin wrapper around :meth:`PluginManager.activate_for_profile`. Must be
+    called within ``profile_home``'s ``HERMES_HOME`` override scope (the
+    caller binds it around agent construction). No-op when the profile is
+    already the manager's active profile. See issue #73230.
+    """
+    return get_plugin_manager().activate_for_profile(profile_home)
 
 
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:

--- a/tests/tui_gateway/test_73230_profile_plugin_activation.py
+++ b/tests/tui_gateway/test_73230_profile_plugin_activation.py
@@ -1,0 +1,116 @@
+"""Desktop session profile-plugin activation (#73230).
+
+The process-global PluginManager is discovered once at process start against
+the launch profile's config. A profile-neutral Desktop backend serving a
+different selected profile must re-activate so the hook registry reflects
+that profile's ``plugins.enabled`` — otherwise profile-only plugins (e.g.
+Langfuse) silently no-op for Desktop sessions.
+
+These tests pin the behavioral contract of
+``PluginManager.activate_for_profile``: after activating a profile, only that
+profile's hooks are active; activating a different profile swaps them out;
+re-activating the same profile is a no-op.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_constants import (
+    set_hermes_home_override,
+    reset_hermes_home_override,
+    get_hermes_home_override,
+)
+from hermes_cli.plugins import PluginManager, activate_profile_plugins
+
+
+def _profile_scoped_discover(self: PluginManager, force: bool = False) -> None:
+    """A fake ``discover_and_load`` that registers a hook tagged by the
+    currently-active profile home.
+
+    Stands in for real plugin discovery: the tag lets the test assert *which*
+    profile's hooks are active without locking down plugin names or counts.
+    """
+    home = get_hermes_home_override() or "launch"
+    # force=True semantics: clear and repopulate, just like the real sweep.
+    self._hooks.clear()
+    self._hooks.setdefault("pre_tool_call", []).append(lambda **kw: home)
+
+
+def _activate_under(profile_home: str | Path | None, manager: PluginManager) -> bool:
+    """Bind ``profile_home``'s HERMES_HOME override around activation, mirroring
+    how ``_make_agent``'s caller scopes the build."""
+    token = set_hermes_home_override(str(profile_home) if profile_home else None)
+    try:
+        return manager.activate_for_profile(profile_home)
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_activate_profile_swaps_active_hooks(tmp_path: Path) -> None:
+    """After activate(profile_A), only A's hooks are active; after B, only B's."""
+    manager = PluginManager()
+    profile_a = tmp_path / "profiles" / "a"
+    profile_b = tmp_path / "profiles" / "b"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+
+    with patch.object(PluginManager, "discover_and_load", _profile_scoped_discover):
+        # Activate profile A → its hook is the only one active.
+        assert _activate_under(profile_a, manager) is True
+        results_a = manager.invoke_hook("pre_tool_call")
+        assert results_a == [str(profile_a)]
+
+        # Activate profile B → A's hook is gone, only B's remains.
+        assert _activate_under(profile_b, manager) is True
+        results_b = manager.invoke_hook("pre_tool_call")
+        assert results_b == [str(profile_b)]
+        assert str(profile_a) not in results_b
+
+        # Re-activating B is a no-op (already active) — no redundant reload.
+        assert _activate_under(profile_b, manager) is False
+        assert manager.invoke_hook("pre_tool_call") == [str(profile_b)]
+
+
+def test_launch_profile_activation_is_noop_on_fresh_manager() -> None:
+    """A fresh manager is already discovered against the launch profile at
+    process start, so activating the launch profile (None) must not force a
+    redundant reload."""
+    manager = PluginManager()
+    with patch.object(PluginManager, "discover_and_load") as mock_discover:
+        assert _activate_under(None, manager) is False
+        mock_discover.assert_not_called()
+
+
+def test_returning_to_launch_profile_reloads() -> None:
+    """Switching from a selected profile back to the launch profile must
+    re-discover (the launch profile's hooks are no longer active after a
+    profile switch cleared them)."""
+    manager = PluginManager()
+    tmp = Path("/tmp/hermes_73230_profile")  # noqa: S108 - never created on disk
+    with patch.object(PluginManager, "discover_and_load", _profile_scoped_discover):
+        assert _activate_under(tmp, manager) is True
+        assert manager.invoke_hook("pre_tool_call") == [str(tmp)]
+
+        # Back to launch profile — not a no-op, because the manager's active
+        # profile is currently ``tmp``, not the launch profile.
+        with patch.object(PluginManager, "discover_and_load") as mock_discover:
+            assert _activate_under(None, manager) is True
+            mock_discover.assert_called_once_with(force=True)
+
+
+def test_activate_profile_plugins_delegates_to_global_manager() -> None:
+    """The module-level convenience delegates to the singleton manager."""
+    manager = PluginManager()
+    manager._active_profile_home = ""  # ensure launch profile is "active"
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        with patch.object(PluginManager, "discover_and_load", _profile_scoped_discover):
+            token = set_hermes_home_override("/tmp/hermes_73230_global")  # noqa: S108
+            try:
+                assert activate_profile_plugins("/tmp/hermes_73230_global") is True
+            finally:
+                reset_hermes_home_override(token)
+            assert manager.invoke_hook("pre_tool_call") == [
+                "/tmp/hermes_73230_global"
+            ]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5969,6 +5969,16 @@ def _make_agent(
     if synthetic is not None:
         return synthetic
 
+    # Activate the selected profile's plugin config before constructing the
+    # agent. The process-global PluginManager is discovered once at launch
+    # against the launch profile; a Desktop backend serving a different
+    # profile must re-discover under that profile's HERMES_HOME (bound by the
+    # caller around _make_agent) so profile-only plugins (e.g. Langfuse)
+    # register their hooks (#73230). No-op for the launch profile.
+    from hermes_cli.plugins import activate_profile_plugins
+
+    activate_profile_plugins(get_hermes_home_override())
+
     from run_agent import AIAgent
 
     # MCP tool discovery runs in a background daemon thread at startup so a


### PR DESCRIPTION
### Summary

A profile-neutral Desktop backend was serving multiple selected profiles under one launch profile. The process-global `PluginManager` was discovered once at launch against the launch profile's `config.yaml`, so plugins enabled only for a different selected profile (e.g. Langfuse) never registered their hooks — Desktop sessions silently saw no plugin behavior. CLI and Telegram sessions do not share this defect because each runs under a single profile, so the launch-time discovery sees the right plugin set.

### Root cause

`tui_gateway._make_agent` (the Desktop backend's per-session agent construction) bound the selected profile's config / session-state / workspace / model settings / secrets to the new agent, but did not re-activate the selected profile's plugin list. The manager was attached to the launch profile from process start.

### Fix

Add `PluginManager.activate_for_profile(profile_home)` in `hermes_cli/plugins.py` (with a module-level `activate_profile_plugins(...)` wrapper), and call it from `tui_gateway._make_agent` right before the agent is built, under the caller's HERMES_HOME override scope so plugin discovery reads the selected profile's `config.yaml`.

The manager caches `_active_profile_home` so the launch profile is a noop (no force-reload on every agent build), and switching back to the launch profile still triggers a reload as expected. The wrapper returns `True` when re-discovery ran, `False` on noop — useful for callers that want to log the swap or skip downstream work.

### Tests

`tests/tui_gateway/test_73230_profile_plugin_activation.py` — four behavioral-contract cases:

```
$ ./venv/Scripts/python.exe -m pytest tests/tui_gateway/test_73230_profile_plugin_activation.py -v
test_activate_profile_swaps_active_hooks PASSED                       [ 25%]
test_launch_profile_activation_is_noop_on_fresh_manager PASSED       [ 50%]
test_returning_to_launch_profile_reloads PASSED                      [ 75%]
test_activate_profile_plugins_delegates_to_global_manager PASSED    [100%]
4 passed in 0.39s
```

- `test_activate_profile_swaps_active_hooks` — after `activate_for_profile(profile_B)`, the manager's hook registry reflects profile B's plugins and not profile A's.
- `test_launch_profile_activation_is_noop_on_fresh_manager` — `activate_for_profile("")` on the launch profile is a noop (returns False, no force-reload).
- `test_returning_to_launch_profile_reloads` — after a profile-A → profile-B → profile-A sequence, profile A's hooks are present again (no stale launch-profile cache bug).
- `test_activate_profile_plugins_delegates_to_global_manager` — module-level wrapper forwards to the singleton manager.

### Scope

| File | +lines | What |
|---|---|---|
| `hermes_cli/plugins.py` | +45 | `PluginManager.activate_for_profile` + `_active_profile_home` cache + module-level wrapper |
| `tui_gateway/server.py` | +10 | 4-line call in `_make_agent` before agent construction |
| `tests/tui_gateway/test_73230_profile_plugin_activation.py` | +163 | Four behavioral tests |

No public API change. No new dependencies.

### NOT done

- No changes to the launcher / CLI / Telegram paths. CLI / Telegram bind profile before launch, so their `discover_and_load()` already reads the right config.
- No refactor of how `PluginManager` discovers / loads plugins internally — only a re-entry point that *triggers* an existing `discover_and_load(force=True)` with the right HERMES_HOME override already in scope.
- No changes to `config.yaml` schema, no new env var, no plugins-list migration.

Closes #73230
