### PR TITLE
fix(agent): detect structured reasoning budget exhaustion

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2767,12 +2767,24 @@ def run_conversation(
                             re.IGNORECASE,
                         )
                     )
+                    _has_structured_reasoning = bool(
+                        _trunc_msg
+                        and (agent._extract_reasoning(_trunc_msg) or "").strip()
+                    )
+                    _has_visible_content = bool(
+                        isinstance(_trunc_content, str) and _trunc_content.strip()
+                    )
                     _thinking_exhausted = (
                         not _trunc_has_tool_calls
-                        and _has_think_tags
                         and (
-                            (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
-                            or _trunc_content is None
+                            (
+                                _has_think_tags
+                                and not agent._has_content_after_think_block(_trunc_content)
+                            )
+                            or (
+                                _has_structured_reasoning
+                                and not _has_visible_content
+                            )
                         )
                     )
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5726,6 +5726,50 @@ class TestRunConversation:
         assert "Thinking Budget Exhausted" in result["final_response"]
         assert "/thinkon" in result["final_response"]
 
+    def test_length_reasoning_content_only_skips_continuation(self, agent):
+        """Structured reasoning with no visible answer exhausts the budget."""
+        self._setup_agent(agent)
+        resp = _mock_response(
+            content=None,
+            reasoning_content="internal reasoning",
+            finish_reason="length",
+        )
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert "reasoning" in result["error"].lower()
+        assert "Thinking Budget Exhausted" in result["final_response"]
+
+    def test_length_visible_content_with_structured_reasoning_retries_normally(self, agent):
+        """A partial visible answer must still use the continuation path."""
+        self._setup_agent(agent)
+        first = _mock_response(
+            content="Part 1 ",
+            reasoning_content="internal reasoning",
+            finish_reason="length",
+        )
+        second = _mock_response(content="Part 2", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [first, second]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["final_response"] == "Part 1 Part 2"
+
     def test_length_empty_content_without_think_tags_retries_normally(self, agent):
         """When finish_reason='length' and content is None but no think tags,
         fall through to normal continuation retry (not thinking-exhaustion)."""


### PR DESCRIPTION
## Summary

- detect output-budget exhaustion when providers return structured reasoning with no visible content
- reuse the existing reasoning extractor so `reasoning_content`, `reasoning`, and unified reasoning fields follow the same path
- preserve normal continuation for partial visible answers and empty non-reasoning responses

Fixes #73336.

## Validation

- `python scripts/run_tests_parallel.py tests/run_agent/test_run_agent.py -k 'length_thinking_exhausted or length_reasoning_content_only or length_visible_content_with_structured_reasoning or length_empty_content_without_think_tags' -q` (4 passed)
- `ruff check agent/conversation_loop.py tests/run_agent/test_run_agent.py`
- `python -m py_compile agent/conversation_loop.py tests/run_agent/test_run_agent.py`
- `git diff --check`