### PR TITLE
fix(desktop): confirm before clearing the entire Enabled Toolsets list (#73319)

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -28,7 +28,7 @@ import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { PanelEmpty } from '../overlays/panel'
 
 import { ConfigField } from './config-field'
-import { enumOptionsFor, getNested, isExternalMemoryProvider, sectionFieldEntries, setNested } from './helpers'
+import { clearsEnabledToolsets, enumOptionsFor, getNested, isExternalMemoryProvider, sectionFieldEntries, setNested } from './helpers'
 import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
@@ -183,6 +183,15 @@ export function ConfigSettings({
   }, [config, onConfigSaved, saveVersion])
 
   const updateConfig = (next: HermesConfigRecord) => {
+    // Guard the single most destructive config edit: clearing the entire
+    // "Enabled Toolsets" list silently disables memory, terminal, web search,
+    // delegation, and most tools, and a stray select-all + Backspace can do it.
+    // Auto-save is debounced with no undo, so confirm a non-empty → empty
+    // transition before applying it. Every other edit passes through untouched.
+    if (config && clearsEnabledToolsets(config, next) && !window.confirm(c.toolsetsWipeConfirm)) {
+      return
+    }
+
     saveVersionRef.current += 1
     setConfig(next)
     setSaveVersion(saveVersionRef.current)

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -5,6 +5,7 @@ import type { HermesConfigRecord } from '@/types/hermes'
 import { FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
 import { defineFieldCopy, fieldCopyForSchemaKey, schemaKeyToFieldCopyKey } from './field-copy'
 import {
+  clearsEnabledToolsets,
   enumOptionsFor,
   getNested,
   isExternalMemoryProvider,
@@ -361,6 +362,46 @@ describe('settings helpers', () => {
 
     it('hides declared keys absent from both schema and config', () => {
       expect(sectionFieldEntries({}, {}).get('memory') ?? []).toHaveLength(0)
+    })
+  })
+
+  describe('clearsEnabledToolsets', () => {
+    it('flags a non-empty → empty transition', () => {
+      const prev: HermesConfigRecord = { toolsets: ['memory', 'terminal', 'web_search'] }
+      const next: HermesConfigRecord = { toolsets: [] }
+
+      expect(clearsEnabledToolsets(prev, next)).toBe(true)
+    })
+
+    it('does not flag a non-empty → missing transition (deep-merge preserves the key)', () => {
+      // PUT /api/config deep-merges the override onto the stored config, so an
+      // import that omits `toolsets` keeps the existing list — no wipe happens,
+      // so there is nothing to confirm.
+      const prev: HermesConfigRecord = { toolsets: ['memory'] }
+      const next: HermesConfigRecord = {}
+
+      expect(clearsEnabledToolsets(prev, next)).toBe(false)
+    })
+
+    it('does not flag when at least one toolset remains', () => {
+      const prev: HermesConfigRecord = { toolsets: ['memory', 'terminal'] }
+      const next: HermesConfigRecord = { toolsets: ['memory'] }
+
+      expect(clearsEnabledToolsets(prev, next)).toBe(false)
+    })
+
+    it('does not flag when the list was already empty', () => {
+      const prev: HermesConfigRecord = { toolsets: [] }
+      const next: HermesConfigRecord = { toolsets: [] }
+
+      expect(clearsEnabledToolsets(prev, next)).toBe(false)
+    })
+
+    it('does not flag an unrelated edit that never touched toolsets', () => {
+      const prev: HermesConfigRecord = { model: 'a', toolsets: ['memory'] }
+      const next: HermesConfigRecord = { model: 'b', toolsets: ['memory'] }
+
+      expect(clearsEnabledToolsets(prev, next)).toBe(false)
     })
   })
 })

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -97,6 +97,31 @@ export function getNested(obj: HermesConfigRecord, path: string): unknown {
   return cur
 }
 
+/**
+ * True when an edit clears the entire "Enabled Toolsets" list — i.e. the
+ * previous config had a non-empty toolsets array and the next one is an
+ * explicit empty array.
+ *
+ * A *missing* toolsets key is deliberately NOT a clear: `PUT /api/config`
+ * deep-merges the override onto the stored config (`_deep_merge` preserves base
+ * keys absent from the override), so an import that omits `toolsets` leaves the
+ * existing toolsets intact. Prompting there would warn about a wipe that never
+ * happens. Only an explicit `[]` actually empties the list.
+ *
+ * Clearing every toolset silently disables memory, terminal, web search,
+ * delegation, and most tools, and config auto-saves with no undo, so callers
+ * use this to confirm the destructive transition before applying it. Any edit
+ * that keeps at least one toolset — or that never had one — returns false.
+ */
+export function clearsEnabledToolsets(prev: HermesConfigRecord, next: HermesConfigRecord): boolean {
+  const prevToolsets = getNested(prev, 'toolsets')
+  const nextToolsets = getNested(next, 'toolsets')
+  const hadToolsets = Array.isArray(prevToolsets) && prevToolsets.length > 0
+  const clearsToolsets = Array.isArray(nextToolsets) && nextToolsets.length === 0
+
+  return hadToolsets && clearsToolsets
+}
+
 export function inferFieldSchema(value: unknown): ConfigFieldSchema {
   if (typeof value === 'boolean') {
     return { type: 'boolean' }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -561,6 +561,8 @@ export const en: Translations = {
       autosaveFailed: 'Autosave failed',
       imported: 'Config imported',
       invalidJson: 'Invalid config JSON',
+      toolsetsWipeConfirm:
+        'Remove all enabled toolsets? This disables memory, terminal, web search, delegation, and most other tools until you re-enable them.',
       keepAwakeTitle: 'Keep computer awake',
       keepAwakeDesc: 'Stop this machine from sleeping so long or overnight runs keep going. The display can still dim.',
       attachmentSizeTitle: 'Max preview / image load size',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -464,6 +464,7 @@ export interface Translations {
       autosaveFailed: string
       imported: string
       invalidJson: string
+      toolsetsWipeConfirm: string
       keepAwakeTitle: string
       keepAwakeDesc: string
       attachmentSizeTitle: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -771,6 +771,7 @@ export const zh: Translations = {
       autosaveFailed: '自动保存失败',
       imported: '配置已导入',
       invalidJson: '配置 JSON 无效',
+      toolsetsWipeConfirm: '确定移除所有已启用的工具集吗？这将禁用记忆、终端、网络搜索、委派以及大多数其他工具，直到你重新启用它们。',
       keepAwakeTitle: '保持电脑唤醒',
       keepAwakeDesc: '阻止本机休眠，让长时间或通宵运行继续进行。屏幕仍可变暗。',
       attachmentSizeTitle: '预览 / 图片加载大小上限',


### PR DESCRIPTION
## What & why

Fixes #73319.

Config settings auto-save on a **550ms debounce with no undo** (`config-settings.tsx`). The **Enabled Toolsets** list is rendered by the generic `ConfigField` with no destructive-change guard, so a single stray *select-all + Backspace* — or any edit that empties the list — is persisted the moment Settings closes. That silently disables memory, terminal, web search, delegation, and most tools. The issue reports this happening in production (18 toolsets → 2), with recovery requiring CLI intervention.

## Change

Guard the one genuinely destructive transition: when the enabled-toolsets list goes from **non-empty → empty**, `window.confirm()` before applying the edit — the same pattern env-var removal already uses in `toolset-config-panel.tsx`. If the user cancels, the edit is dropped and nothing is saved. Every other edit (including reducing the list to one entry) passes through untouched.

The decision is a small pure helper so the component change stays minimal and the logic is unit-tested directly instead of through a full settings render:

```ts
// helpers.ts
export function clearsEnabledToolsets(prev, next): boolean  // non-empty → empty/absent
```

```tsx
// config-settings.tsx – updateConfig()
if (config && clearsEnabledToolsets(config, next) && !window.confirm(c.toolsetsWipeConfirm)) {
  return
}
```

## i18n

New key `toolsetsWipeConfirm` added to `types.ts` + `en.ts`, with a Simplified-Chinese string in `zh.ts` (the one full locale). The `defineLocale`-based partial locales (`ja`, `ar`, `zh-hant`) inherit the English string via the existing merge-onto-`en` fallback, so no half-translated entries are introduced.

## Tests

`helpers.test.ts` — `clearsEnabledToolsets` covers: non-empty→empty, non-empty→missing, one-remaining (no prompt), already-empty (no prompt), and an unrelated edit that never touched toolsets.

```
35 passed
```

Renderer typecheck (`tsc -p .`) and eslint are clean on the changed files (the pre-existing `src/debug/render-counter.ts` `bippy` errors are unrelated). The arm64-fork-Docker CI job fails on all fork PRs and is unrelated.

## Notes

I went with the issue's stated **minimum** (confirm on the destructive transition) rather than the larger "unsaved-changes dialog" or "explicit Save button" options, since it closes the data-loss hole with the least churn and matches an existing pattern. Happy to extend toward a full dirty-form guard if maintainers prefer that direction.
