### PR TITLE
fix(cli): wire up hermes import-agent subcommand

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -469,6 +469,7 @@ from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
 from hermes_cli.subcommands.mcp import build_mcp_parser
 from hermes_cli.subcommands.claw import build_claw_parser
+from hermes_cli.subcommands.import_agent import build_import_agent_parser
 
 
 def _require_tty(command_name: str) -> None:
@@ -15639,6 +15640,12 @@ def cmd_claw(args):
     claw_command(args)
 
 
+def cmd_import_agent(args):
+    from hermes_cli.agent_import import import_agent_command
+
+    import_agent_command(args)
+
+
 def main():
     """Main entry point for hermes CLI."""
     # Cosmetic: make the process show up as 'hermes' instead of 'python3.11'
@@ -17898,6 +17905,11 @@ def main():
     # claw command  (parser built in hermes_cli/subcommands/claw.py)
     # =========================================================================
     build_claw_parser(subparsers, cmd_claw=cmd_claw)
+
+    # =========================================================================
+    # import-agent command  (parser built in hermes_cli/subcommands/import_agent.py)
+    # =========================================================================
+    build_import_agent_parser(subparsers, cmd_import_agent=cmd_import_agent)
 
     # =========================================================================
     # version command  (parser built in hermes_cli/subcommands/version.py)


### PR DESCRIPTION
## Problem

`hermes import-agent` (added in 24c3c27ba) fails with:

```
hermes: error: argument command: invalid choice: 'import-agent'
```

The feature itself is fully implemented — `hermes_cli/agent_import.py`, `hermes_cli/subcommands/import_agent.py`, docs, and 52 passing tests in `tests/hermes_cli/test_agent_import.py` — but `build_import_agent_parser()` was never called from `hermes_cli/main.py`'s argparse setup, and there was no `cmd_import_agent` dispatcher function. So the subcommand was never registered with the top-level parser.

## Fix

Wire it up the same way `hermes claw` is wired up:
- Import `build_import_agent_parser` from `hermes_cli.subcommands.import_agent`
- Add a `cmd_import_agent(args)` function that dispatches to `hermes_cli.agent_import.import_agent_command`
- Call `build_import_agent_parser(subparsers, cmd_import_agent=cmd_import_agent)` alongside the other subcommand registrations

## Verification

- `hermes import-agent --help` now shows the full help text instead of erroring
- `hermes import-agent claude-code --dry-run` runs cleanly (correctly reports no `~/.claude` dir on a machine that doesn't have Claude Code CLI set up)
- `hermes --help`, `hermes claw --help`, `hermes version` all still work — no regressions to neighboring subcommands
- Existing test suite: `python -m pytest tests/hermes_cli/test_agent_import.py -q` → 52 passed
