### PR TITLE
fix(cron): deliver each profile's cron via its own adapter in multiplex

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -182,6 +182,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -209,6 +210,7 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                profile_adapters=profile_adapters,
             )
             return
 
@@ -269,6 +271,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        profile_adapters=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -319,13 +322,23 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in profile_homes:
+                        _pname = entry[0] if isinstance(entry, tuple) else None
                         home = entry[1] if isinstance(entry, tuple) else entry
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
+                                # Deliver each profile's cron via ITS OWN bot/adapter.
+                                # Secondary profiles live in profile_adapters[name];
+                                # the default profile has no entry there and owns the
+                                # shared `adapters` set — so fall back to it. Without
+                                # this, every profile's cron output ships through the
+                                # default profile's bot (wrong-bot cross-delivery).
+                                _tick_adapters = adapters
+                                if profile_adapters and _pname and profile_adapters.get(_pname):
+                                    _tick_adapters = profile_adapters[_pname]
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=_tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -183,6 +183,7 @@ class InProcessCronScheduler(CronScheduler):
         can_dispatch=None,
         profile_homes=None,
         profile_adapters=None,
+        default_profile=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -211,6 +212,7 @@ class InProcessCronScheduler(CronScheduler):
                 interval=interval,
                 can_dispatch=can_dispatch,
                 profile_adapters=profile_adapters,
+                default_profile=default_profile,
             )
             return
 
@@ -272,6 +274,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_adapters=None,
+        default_profile=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -327,15 +330,19 @@ class InProcessCronScheduler(CronScheduler):
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
-                                # Deliver each profile's cron via ITS OWN bot/adapter.
-                                # Secondary profiles live in profile_adapters[name];
-                                # the default profile has no entry there and owns the
-                                # shared `adapters` set — so fall back to it. Without
-                                # this, every profile's cron output ships through the
-                                # default profile's bot (wrong-bot cross-delivery).
-                                _tick_adapters = adapters
-                                if profile_adapters and _pname and profile_adapters.get(_pname):
-                                    _tick_adapters = profile_adapters[_pname]
+                                # Deliver each profile's cron via ITS OWN adapters.
+                                # The shared `adapters` set belongs to the default
+                                # profile only. A secondary profile uses its own map
+                                # in profile_adapters[name], which is populated only
+                                # once that profile's bot connects. A secondary must
+                                # NEVER fall back to the default profile's `adapters`
+                                # (that ships its cron output through the wrong bot),
+                                # so before its adapter connects — map absent or empty
+                                # — it simply does not deliver this tick.
+                                if _pname is None or _pname == default_profile:
+                                    _tick_adapters = adapters
+                                else:
+                                    _tick_adapters = (profile_adapters or {}).get(_pname) or {}
                                 cron_tick(
                                     verbose=False,
                                     adapters=_tick_adapters,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25518,6 +25518,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 cron_start_kwargs["profile_adapters"] = getattr(
                     runner, "_profile_adapters", None
                 )
+                # runner.adapters belongs to the default profile, which
+                # profiles_to_serve() names "default" in its multiplex list.
+                # Thread that identity so the ticker reserves the shared adapters
+                # for the default profile alone and never routes a secondary's
+                # cron through the default bot (even before its adapter connects,
+                # when profile_adapters[name] is still absent/empty).
+                cron_start_kwargs["default_profile"] = "default"
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25512,6 +25512,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = list(profiles_to_serve(multiplex=True))
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                # Per-profile adapters so each profile's cron output is
+                # delivered via its own bot/adapter instead of the default
+                # profile's.
+                cron_start_kwargs["profile_adapters"] = getattr(
+                    runner, "_profile_adapters", None
+                )
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -414,3 +414,98 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+
+
+def _run_multiplex_capture(tmp_path, *, profile_adapters, shared_adapters):
+    """Run the multiplex ticker one full cycle and return the ``adapters``
+    object passed to ``tick()`` for the default profile and the secondary
+    profile (in ``profile_homes`` order: default first, secondary second)."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    p_default = tmp_path / "default"
+    p_sec = tmp_path / "home-ops"
+    for d in (p_default, p_sec):
+        (d / "cron").mkdir(parents=True)
+    profile_homes = [("default", p_default), ("home-ops", p_sec)]
+
+    captured: list = []  # adapters seen per tick call; order follows profile_homes
+
+    def _capturing_tick(*args, **kwargs):
+        captured.append(kwargs.get("adapters"))
+        return 0
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+    with patch("cron.scheduler.tick", side_effect=_capturing_tick), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": profile_homes,
+                "adapters": shared_adapters,
+                "profile_adapters": profile_adapters,
+                "default_profile": "default",
+            },
+            daemon=True,
+        )
+        t.start()
+        deadline = time.monotonic() + 10
+        while len(captured) < 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    assert len(captured) >= 2, f"expected >= 2 tick calls, got {len(captured)}"
+    return captured[0], captured[1]  # (default, secondary) of the first cycle
+
+
+def test_multiplex_default_profile_uses_shared_adapters(tmp_path):
+    """The default profile's cron is delivered via the shared ``adapters`` set
+    (which belongs to the default profile)."""
+    shared = {"kind": "shared"}
+    default_ad, _ = _run_multiplex_capture(
+        tmp_path, profile_adapters={"home-ops": {"kind": "secondary"}},
+        shared_adapters=shared,
+    )
+    assert default_ad is shared
+
+
+def test_multiplex_connected_secondary_uses_its_own_adapters(tmp_path):
+    """A connected secondary is delivered via ITS OWN adapters, not the shared
+    default-profile set."""
+    shared = {"kind": "shared"}
+    sec = {"kind": "secondary"}
+    default_ad, sec_ad = _run_multiplex_capture(
+        tmp_path, profile_adapters={"home-ops": sec}, shared_adapters=shared,
+    )
+    assert default_ad is shared
+    assert sec_ad is sec
+
+
+def test_multiplex_empty_secondary_does_not_fall_back_to_shared(tmp_path):
+    """A secondary whose adapter map is present-but-empty (its bot has not
+    connected yet) must NOT fall back to the default profile's shared adapters
+    — otherwise its cron output ships through the wrong bot. It receives an
+    empty adapter set and simply does not deliver this tick."""
+    shared = {"kind": "shared"}
+    default_ad, sec_ad = _run_multiplex_capture(
+        tmp_path, profile_adapters={"home-ops": {}}, shared_adapters=shared,
+    )
+    assert default_ad is shared
+    assert sec_ad is not shared
+    assert not sec_ad  # empty → no delivery, not the default bot
+
+
+def test_multiplex_missing_secondary_does_not_fall_back_to_shared(tmp_path):
+    """A secondary absent from profile_adapters entirely (its adapter map has
+    not been created yet) also must not fall back to the shared adapters."""
+    shared = {"kind": "shared"}
+    default_ad, sec_ad = _run_multiplex_capture(
+        tmp_path, profile_adapters={}, shared_adapters=shared,
+    )
+    assert default_ad is shared
+    assert sec_ad is not shared
+    assert not sec_ad


### PR DESCRIPTION
## Summary
In `multiplex_profiles` mode the in-process cron ticker scopes **execution** per profile (HERMES_HOME, cron store, heartbeat, recovery) but delivered **every** profile's cron output through the **default** profile's platform adapter. So a secondary profile's scheduled-job replies / failure summaries were sent by the *default* bot instead of that profile's own bot (e.g. one Telegram bot per profile).

## Root cause
`cron/scheduler_provider.py::InProcessCronScheduler._start_multiplex` iterates each served profile and calls `cron_tick` with the single default-profile `adapters` set for all profiles:
```python
for entry in profile_homes:
    with use_cron_store(home):
        cron_tick(adapters=adapters, ...)   # same default adapters for every profile
```
`adapters` originates from `runner.adapters` (the default/primary profile) in `gateway/run.py`, while each secondary profile's real adapters live in `GatewayRunner._profile_adapters[name]`. Execution was correctly scoped by a61183b, but delivery was not.

## Fix
Thread a `profile_adapters` map (profile name -> adapters) from the gateway into `InProcessCronScheduler.start`, and select the per-profile adapter set in the multiplex tick loop, falling back to the shared `adapters` for the default profile (which owns them). Single-profile path is unchanged; the new parameter defaults to `None`.

## Verification
- Gateway starts healthy; every per-profile Telegram bot connects.
- A secondary profile's cron now delivers via that profile's own adapter/bot instead of the default bot.
- Non-multiplex behavior unchanged (`profile_adapters=None`).

Builds on a61183b (per-profile HERMES_HOME scoping) - same intent, extended from execution to delivery.

## Related issues
- Addresses #70849 — its Problem section is exactly this bug: multiplex cron delivery always uses the default/active profile's `self.adapters`, ignoring `self._profile_adapters`, so a secondary profile's job is delivered by the wrong bot. This PR routes each job's delivery through its owning profile's adapter. The per-job `deliver_profile` override proposed there could layer on top of this default-correct behavior.
- Related: #70620 — the inbound-reply analog (replies sent via the wrong bot adapter under multiplex); different code path (message handler), not touched here.
- Builds on the ticker fix for #69377 (a61183b), which scoped cron *execution* per profile; this extends the same intent to *delivery*.