### PR TITLE
fix(desktop): unstage all before the first commit instead of failing

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 
 import { afterEach, test } from 'vitest'
 
-import { gitFor, repoStatus, resolveRenamePath } from './git-review-ops'
+import { gitFor, repoStatus, resolveRenamePath, reviewUnstage } from './git-review-ops'
 
 const tempDirs: string[] = []
 
@@ -68,6 +68,65 @@ test('resolveRenamePath: brace rename resolves to the new path', () => {
 
 test('resolveRenamePath: brace rename collapsing a segment', () => {
   assert.equal(resolveRenamePath('src/{lib => }/file.ts'), 'src/file.ts')
+})
+
+// A `git init` repo with work already staged and no commit yet, which is what the
+// review pane sees on a new project the agent has just written files into.
+function makeRepoBeforeFirstCommit() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-git-unborn-'))
+
+  tempDirs.push(dir)
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.mkdirSync(path.join(dir, 'nested'))
+  fs.writeFileSync(path.join(dir, 'new.py'), 'print(1)\n')
+  fs.writeFileSync(path.join(dir, 'nested', 'deep.py'), 'print(2)\n')
+  execFileSync('git', ['add', '-A'], { cwd: dir })
+
+  return dir
+}
+
+// Paths the index carries for the next commit. Also valid on an unborn HEAD, where
+// `diff --cached` compares the index against the empty tree.
+function stagedPaths(dir: string) {
+  return execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: dir, encoding: 'utf8' })
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .sort()
+}
+
+test('reviewUnstage clears the whole index before the first commit', async () => {
+  const repo = makeRepoBeforeFirstCommit()
+
+  assert.deepEqual(stagedPaths(repo), ['nested/deep.py', 'new.py'])
+
+  await reviewUnstage(repo, null, 'git')
+
+  assert.deepEqual(stagedPaths(repo), [])
+  // A mixed reset moves the index only; the work itself has to survive.
+  assert.equal(fs.readFileSync(path.join(repo, 'new.py'), 'utf8'), 'print(1)\n')
+  assert.equal(fs.readFileSync(path.join(repo, 'nested', 'deep.py'), 'utf8'), 'print(2)\n')
+})
+
+test('reviewUnstage clears a single path before the first commit', async () => {
+  const repo = makeRepoBeforeFirstCommit()
+
+  await reviewUnstage(repo, 'new.py', 'git')
+
+  assert.deepEqual(stagedPaths(repo), ['nested/deep.py'])
+})
+
+test('reviewUnstage covers the whole index in a committed repo', async () => {
+  const repo = makeRepo()
+
+  fs.writeFileSync(path.join(repo, 'tracked.txt'), 'changed\n')
+  fs.writeFileSync(path.join(repo, 'added.txt'), 'added\n')
+  execFileSync('git', ['add', '-A'], { cwd: repo })
+  assert.deepEqual(stagedPaths(repo), ['added.txt', 'tracked.txt'])
+
+  await reviewUnstage(repo, null, 'git')
+
+  assert.deepEqual(stagedPaths(repo), [])
+  assert.equal(fs.readFileSync(path.join(repo, 'tracked.txt'), 'utf8'), 'changed\n')
 })
 
 test('repoStatus reports an untracked directory without recursively listing its contents', async () => {

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -402,10 +402,15 @@ async function reviewStage(repoPath, filePath, gitBin) {
   return { ok: true }
 }
 
+// Unstaging everything must not name HEAD: before the first commit it resolves to
+// no revision and `reset HEAD` exits 128, failing the whole operation. Bare `reset`
+// defaults to HEAD where one exists and to the empty tree where none does, resetting
+// the entire index in both cases. The pathspec form is safe as written, since a
+// path-limited reset already treats a missing HEAD as empty.
 async function reviewUnstage(repoPath, filePath, gitBin) {
   const cwd = resolveRequestedPathForIpc(repoPath, { purpose: 'Review unstage' })
 
-  await gitFor(cwd, gitBin).raw(filePath ? ['reset', '-q', 'HEAD', '--', filePath] : ['reset', '-q', 'HEAD'])
+  await gitFor(cwd, gitBin).raw(filePath ? ['reset', '-q', 'HEAD', '--', filePath] : ['reset', '-q'])
 
   return { ok: true }
 }

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -344,7 +344,12 @@ def review_stage(cwd: str, file_path: str | None) -> dict:
 
 
 def review_unstage(cwd: str, file_path: str | None) -> dict:
-    _git_ok(cwd, ["reset", "-q", "HEAD", "--", file_path] if file_path else ["reset", "-q", "HEAD"])
+    # Unstaging everything must not name HEAD: before the first commit it resolves
+    # to no revision and `reset HEAD` exits 128, so the whole operation fails. Bare
+    # `reset` defaults to HEAD where one exists and to the empty tree where none
+    # does, resetting the entire index in both cases. The pathspec form is safe as
+    # written -- a path-limited reset already treats a missing HEAD as empty.
+    _git_ok(cwd, ["reset", "-q", "HEAD", "--", file_path] if file_path else ["reset", "-q"])
     return {"ok": True}
 
 

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -175,3 +175,60 @@ def test_git_endpoints_require_auth(repo):
 
     assert unauth.get("/api/git/status", params={"path": str(repo)}).status_code == 401
     assert unauth.post("/api/git/review/stage", json={"path": str(repo)}).status_code == 401
+
+
+def _staged_paths(repo: Path) -> set[str]:
+    """Paths the index carries for the next commit. Also valid on an unborn HEAD,
+    where `diff --cached` compares the index against the empty tree."""
+    listing = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return {line for line in listing.stdout.splitlines() if line}
+
+
+def _repo_before_first_commit(tmp_path: Path) -> Path:
+    """A `git init` repo with work already staged and no commit yet, which is what
+    the review pane sees on a new project the agent has just written files into."""
+    root = tmp_path / "fresh"
+    (root / "nested").mkdir(parents=True)
+    _git(root, "init", "-q")
+    (root / "new.py").write_text("print(1)\n")
+    (root / "nested" / "deep.py").write_text("print(2)\n")
+    _git(root, "add", "-A")
+    return root
+
+
+def test_unstage_all_before_the_first_commit(client, tmp_path):
+    fresh = _repo_before_first_commit(tmp_path)
+    assert _staged_paths(fresh) == {"new.py", "nested/deep.py"}
+
+    response = client.post("/api/git/review/unstage", json={"path": str(fresh)})
+
+    assert response.status_code == 200
+    assert _staged_paths(fresh) == set()
+    # A mixed reset moves the index only; the work itself has to survive.
+    assert (fresh / "new.py").read_text() == "print(1)\n"
+    assert (fresh / "nested" / "deep.py").read_text() == "print(2)\n"
+
+
+def test_unstage_one_file_before_the_first_commit(client, tmp_path):
+    fresh = _repo_before_first_commit(tmp_path)
+
+    response = client.post("/api/git/review/unstage", json={"path": str(fresh), "file": "new.py"})
+
+    assert response.status_code == 200
+    assert _staged_paths(fresh) == {"nested/deep.py"}
+
+
+def test_unstage_all_covers_the_whole_index(client, repo):
+    _git(repo, "add", "-A")
+    assert _staged_paths(repo) == {"a.txt", "new.py"}
+
+    assert client.post("/api/git/review/unstage", json={"path": str(repo)}).json() == {"ok": True}
+
+    assert _staged_paths(repo) == set()
+    assert (repo / "a.txt").read_text() == "one\ntwo\nthree\n"


### PR DESCRIPTION
## What does this PR do?

"Unstage all" in the desktop review pane fails in a repository that has no commits yet. The user gets an error and nothing is unstaged.

Both desktop transports run a bare `git reset -q HEAD` when no path is given. Before the first commit HEAD names no revision, so git exits 128 with `fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree`:

- `hermes_cli/web_git.py::review_unstage` (gateway, `POST /api/git/review/unstage`) raises through `_git_ok`, which `_git_op` turns into HTTP 400.
- `apps/desktop/electron/git-review-ops.ts::reviewUnstage` (Electron IPC) rejects, and the renderer reports the failure.

The pane itself works in such a repository, because `status --porcelain=v2` lists staged files without needing HEAD. That state is reachable in normal use: `git init` a new project, let the agent write files, open review before the first commit.

The fix drops the explicit `HEAD` from the branch that takes no pathspec. `git reset` resolves to HEAD where one exists and to the empty tree where none does, so it resets the whole index either way. Measured on git 2.53.0:

| command | no commits yet | committed repo, cwd in a subdirectory |
|---|---|---|
| `reset -q HEAD` (before) | exit 128 | resets the whole index |
| `reset -q -- .` | exit 0 | resets only the subdirectory |
| `reset -q` (after) | exit 0 | resets the whole index |

The obvious alternative, adding a `-- .` pathspec, is wrong here. That pathspec is cwd-relative, so unstaging would silently skip everything outside the cwd. A path-limited reset also leaves `MERGE_HEAD` in place, where the current code clears it. Dropping the ref changes neither.

The per-path branch is left alone. A path-limited reset already treats a missing HEAD as the empty tree, so unstaging a single file before the first commit works today. A test pins it.

## Related Issue

No issue filed.

#72947 changes `review_revert` in these same two files. The two changes sit in different functions; the only line they both touch is the import in `apps/desktop/electron/git-review-ops.test.ts`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_git.py`: `review_unstage` unstages everything with `reset -q` instead of `reset -q HEAD`.
- `apps/desktop/electron/git-review-ops.ts`: the same change in `reviewUnstage`.
- `tests/hermes_cli/test_web_server_git.py`: three tests over `POST /api/git/review/unstage`.
- `apps/desktop/electron/git-review-ops.test.ts`: the same three cases against `reviewUnstage`.

## How to Test

The failing command on its own:

```
git init -q demo && cd demo
printf 'x = 1\n' > new.py && git add new.py
git reset -q HEAD
```

That is what both transports run for "Unstage all" with no path. In the app the same state is reached by opening a `git init`ed project that has staged but uncommitted files, then clicking "Unstage all" in the review pane: the gateway answers HTTP 400, the Electron transport rejects, and the file stays staged.

Automated:

- `scripts/run_tests.sh tests/hermes_cli/test_web_server_git.py`
- `vitest run --project electron` in `apps/desktop`

`test_unstage_all_before_the_first_commit` fails on `main` with `assert 400 == 200`. Its vitest counterpart fails with the `ambiguous argument 'HEAD'` error from git. The other four tests pass on `main` and pin what the fix must not change: the whole index gets reset, and the files stay on disk with their contents.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (via `scripts/run_tests.sh`; 48557 pass). The 44 remaining failures on this macOS box reproduce unchanged with this PR reverted and touch none of the code it changes.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Darwin 25.5.0), git 2.53.0, Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ git init -q demo && cd demo
$ printf 'x = 1\n' > new.py && git add new.py
$ git status --porcelain -- new.py
A  new.py
$ git reset -q HEAD
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
$ echo $?
128
$ git reset -q
$ echo $?
0
$ git status --porcelain -- new.py
?? new.py
```
