### PR TITLE
fix(desktop): extract platform-aware app icon resolver

### DIFF
--- a/apps/desktop/electron/app-icon.test.ts
+++ b/apps/desktop/electron/app-icon.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { appIconCandidates, resolveAppIconPath } from './app-icon'
+
+test('windows candidates prefer resources then assets .ico over apple-touch', () => {
+  const candidates = appIconCandidates({
+    appRoot: 'C:\\app',
+    resourcesPath: 'C:\\resources',
+    platform: 'win32'
+  })
+
+  assert.equal(candidates[0], path.join('C:\\resources', 'icon.ico'))
+  assert.equal(candidates[1], path.join('C:\\app', 'assets', 'icon.ico'))
+  assert.ok(candidates.includes(path.join('C:\\app', 'public', 'apple-touch-icon.png')))
+  assert.ok(
+    candidates.indexOf(path.join('C:\\app', 'assets', 'icon.ico')) <
+      candidates.indexOf(path.join('C:\\app', 'public', 'apple-touch-icon.png'))
+  )
+})
+
+test('darwin prefers native icns/.png ahead of the packaged .ico', () => {
+  const candidates = appIconCandidates({
+    appRoot: '/Applications/Hermes.app/Contents/Resources/app.asar',
+    resourcesPath: '/Applications/Hermes.app/Contents/Resources',
+    platform: 'darwin'
+  })
+
+  // extraResources always ships resources/icon.ico (the Windows PE-stamp
+  // source) on every platform, so the macOS-native .icns/.png must be ordered
+  // ahead of it; otherwise .ico would win first-pick on Darwin even when a
+  // proper .icns exists.
+  const packagedIco = path.join('/Applications/Hermes.app/Contents/Resources', 'icon.ico')
+  assert.equal(candidates[0], path.join('/Applications/Hermes.app/Contents/Resources', 'icon.icns'))
+  assert.equal(candidates[1], path.join('/Applications/Hermes.app/Contents/Resources', 'icon.png'))
+  assert.ok(
+    candidates.indexOf(path.join('/Applications/Hermes.app/Contents/Resources/app.asar', 'assets', 'icon.icns')) <
+      candidates.indexOf(packagedIco)
+  )
+  assert.ok(
+    candidates.indexOf(
+      path.join('/Applications/Hermes.app/Contents/Resources/app.asar', 'public', 'apple-touch-icon.png')
+    ) < candidates.indexOf(packagedIco)
+  )
+})
+
+test('resolveAppIconPath prefers icns when Darwin resources include icns and ico', () => {
+  const resourcesPath = '/Applications/Hermes.app/Contents/Resources'
+  const icnsPath = path.join(resourcesPath, 'icon.icns')
+  const icoPath = path.join(resourcesPath, 'icon.ico')
+  const existing = new Set([icnsPath, icoPath])
+
+  const resolved = resolveAppIconPath(
+    { appRoot: '/Applications/Hermes.app/Contents/Resources/app.asar', resourcesPath, platform: 'darwin' },
+    filePath => existing.has(filePath)
+  )
+
+  assert.equal(resolved, icnsPath)
+})
+
+test('resolveAppIconPath returns first existing candidate', () => {
+  const existing = new Set([
+    path.join('C:\\app', 'public', 'apple-touch-icon.png'),
+    path.join('C:\\resources', 'icon.ico')
+  ])
+
+  const resolved = resolveAppIconPath(
+    { appRoot: 'C:\\app', resourcesPath: 'C:\\resources', platform: 'win32' },
+    filePath => existing.has(filePath)
+  )
+
+  assert.equal(resolved, path.join('C:\\resources', 'icon.ico'))
+})
+
+test('resolveAppIconPath falls back to apple-touch when ico missing', () => {
+  const existing = new Set([path.join('/app', 'public', 'apple-touch-icon.png')])
+
+  const resolved = resolveAppIconPath({ appRoot: '/app', resourcesPath: '/resources', platform: 'linux' }, filePath =>
+    existing.has(filePath)
+  )
+
+  assert.equal(resolved, path.join('/app', 'public', 'apple-touch-icon.png'))
+})
+
+test('windows still prefers ico when packaged ico and png both exist', () => {
+  const resourcesPath = 'C:\\resources'
+  const icoPath = path.join(resourcesPath, 'icon.ico')
+  const pngPath = path.join('C:\\app', 'assets', 'icon.png')
+  const existing = new Set([icoPath, pngPath])
+
+  const resolved = resolveAppIconPath({ appRoot: 'C:\\app', resourcesPath, platform: 'win32' }, filePath =>
+    existing.has(filePath)
+  )
+
+  assert.equal(resolved, icoPath)
+})

--- a/apps/desktop/electron/app-icon.test.ts
+++ b/apps/desktop/electron/app-icon.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { appIconCandidates, resolveAppIconPath } from './app-icon'
+
+test('windows candidates prefer resources then assets .ico over apple-touch', () => {
+  const candidates = appIconCandidates({
+    appRoot: 'C:\\app',
+    resourcesPath: 'C:\\resources',
+    platform: 'win32'
+  })
+
+  assert.equal(candidates[0], path.join('C:\\resources', 'icon.ico'))
+  assert.equal(candidates[1], path.join('C:\\app', 'assets', 'icon.ico'))
+  assert.ok(candidates.includes(path.join('C:\\app', 'public', 'apple-touch-icon.png')))
+  assert.ok(
+    candidates.indexOf(path.join('C:\\app', 'assets', 'icon.ico')) <
+      candidates.indexOf(path.join('C:\\app', 'public', 'apple-touch-icon.png'))
+  )
+})
+
+test('darwin prefers native icns/.png ahead of the packaged .ico', () => {
+  const candidates = appIconCandidates({
+    appRoot: '/Applications/Hermes.app/Contents/Resources/app.asar',
+    resourcesPath: '/Applications/Hermes.app/Contents/Resources',
+    platform: 'darwin'
+  })
+
+  // extraResources always ships resources/icon.ico (the Windows PE-stamp
+  // source) on every platform, so the macOS-native .icns/.png must be ordered
+  // ahead of it; otherwise .ico would win first-pick on Darwin even when a
+  // proper .icns exists.
+  assert.equal(candidates[0], path.join('/Applications/Hermes.app/Contents/Resources', 'icon.icns'))
+  assert.equal(candidates[1], path.join('/Applications/Hermes.app/Contents/Resources', 'icon.png'))
+  assert.equal(candidates[2], path.join('/Applications/Hermes.app/Contents/Resources', 'icon.ico'))
+  assert.ok(
+    candidates.indexOf(path.join('/Applications/Hermes.app/Contents/Resources/app.asar', 'assets', 'icon.icns')) <
+      candidates.indexOf(
+        path.join('/Applications/Hermes.app/Contents/Resources/app.asar', 'public', 'apple-touch-icon.png')
+      )
+  )
+})
+
+test('resolveAppIconPath prefers icns when Darwin resources include icns and ico', () => {
+  const resourcesPath = '/Applications/Hermes.app/Contents/Resources'
+  const icnsPath = path.join(resourcesPath, 'icon.icns')
+  const icoPath = path.join(resourcesPath, 'icon.ico')
+  const existing = new Set([icnsPath, icoPath])
+
+  const resolved = resolveAppIconPath(
+    { appRoot: '/Applications/Hermes.app/Contents/Resources/app.asar', resourcesPath, platform: 'darwin' },
+    filePath => existing.has(filePath)
+  )
+
+  assert.equal(resolved, icnsPath)
+})
+
+test('resolveAppIconPath returns first existing candidate', () => {
+  const existing = new Set([
+    path.join('C:\\app', 'public', 'apple-touch-icon.png'),
+    path.join('C:\\resources', 'icon.ico')
+  ])
+
+  const resolved = resolveAppIconPath(
+    { appRoot: 'C:\\app', resourcesPath: 'C:\\resources', platform: 'win32' },
+    filePath => existing.has(filePath)
+  )
+
+  assert.equal(resolved, path.join('C:\\resources', 'icon.ico'))
+})
+
+test('resolveAppIconPath falls back to apple-touch when ico missing', () => {
+  const existing = new Set([path.join('/app', 'public', 'apple-touch-icon.png')])
+
+  const resolved = resolveAppIconPath({ appRoot: '/app', resourcesPath: '/resources', platform: 'linux' }, filePath =>
+    existing.has(filePath)
+  )
+
+  assert.equal(resolved, path.join('/app', 'public', 'apple-touch-icon.png'))
+})
+
+test('windows still prefers ico when packaged ico and png both exist', () => {
+  const resourcesPath = 'C:\\resources'
+  const icoPath = path.join(resourcesPath, 'icon.ico')
+  const pngPath = path.join('C:\\app', 'assets', 'icon.png')
+  const existing = new Set([icoPath, pngPath])
+
+  const resolved = resolveAppIconPath(
+    { appRoot: 'C:\\app', resourcesPath, platform: 'win32' },
+    filePath => existing.has(filePath)
+  )
+
+  assert.equal(resolved, icoPath)
+})

--- a/apps/desktop/electron/app-icon.ts
+++ b/apps/desktop/electron/app-icon.ts
@@ -1,0 +1,104 @@
+import path from 'node:path'
+
+/**
+ * Resolve the native BrowserWindow / dock icon path.
+ *
+ * Why this order matters on Windows: the taskbar / Start Menu / .lnk identity
+ * comes from the PE icon stamped onto Hermes.exe (assets/icon.ico via
+ * set-exe-identity / extraResources). BrowserWindow `{ icon }` must prefer that
+ * same .ico (or resources/icon.ico) — not apple-touch-icon.png — or Alt+Tab /
+ * window grouping can show a different glyph than the taskbar.
+ *
+ * On Darwin, `extraResources` still ships `resources/icon.ico` (the Windows
+ * PE-stamp source) for every target. Prefer `.icns` then PNG ahead of that
+ * `.ico` so the dock keeps a crisp native candidate when both exist.
+ */
+
+export type AppIconPathOptions = {
+  appRoot: string
+  resourcesPath?: string | null
+  /** When APP_ROOT is inside app.asar, Electron still serves sibling files. */
+  unpackedAppRoot?: string | null
+  platform?: NodeJS.Platform
+}
+
+/**
+ * Candidate absolute paths, highest priority first.
+ * Pure: no fs I/O — caller picks the first existing path.
+ *
+ * Aligns with post-80c86c4 main.ts Windows `.ico`-first behaviour while making
+ * Darwin priority platform-aware (`.icns` / PNG before packaged `.ico`).
+ */
+export function appIconCandidates({
+  appRoot,
+  resourcesPath = null,
+  unpackedAppRoot = null,
+  platform = process.platform
+}: AppIconPathOptions): string[] {
+  const roots = [appRoot, unpackedAppRoot].filter((r): r is string => Boolean(r))
+  const out: string[] = []
+
+  // 1) Packaged native format.
+  if (resourcesPath) {
+    if (platform === 'darwin') {
+      out.push(path.join(resourcesPath, 'icon.icns'))
+      out.push(path.join(resourcesPath, 'icon.png'))
+    } else {
+      out.push(path.join(resourcesPath, 'icon.ico'))
+    }
+  }
+
+  // 2) Dev / asar-packaged assets next to the app (files: assets/**).
+  for (const root of roots) {
+    if (platform === 'darwin') {
+      out.push(path.join(root, 'assets', 'icon.icns'))
+      out.push(path.join(root, 'assets', 'icon.png'))
+    } else {
+      out.push(path.join(root, 'assets', 'icon.ico'))
+      out.push(path.join(root, 'assets', 'icon.png'))
+    }
+  }
+
+  // 3) Renderer favicon last — historically used, but can drift from the
+  //    stamped .ico; keep as a soft fallback so windows still get *an* icon.
+  for (const root of roots) {
+    out.push(path.join(root, 'public', 'apple-touch-icon.png'))
+    out.push(path.join(root, 'dist', 'apple-touch-icon.png'))
+  }
+
+  // Every Darwin-native or PNG candidate must stay ahead of the Windows PE
+  // stamp source, even when the native icon lives outside resources/.
+  if (platform === 'darwin') {
+    if (resourcesPath) {
+      out.push(path.join(resourcesPath, 'icon.ico'))
+    }
+
+    for (const root of roots) {
+      out.push(path.join(root, 'assets', 'icon.ico'))
+    }
+  }
+
+  // Dedupe while preserving order.
+  const seen = new Set<string>()
+  const unique: string[] = []
+
+  for (const candidate of out) {
+    const key = platform === 'win32' ? candidate.toLowerCase() : candidate
+
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    unique.push(candidate)
+  }
+
+  return unique
+}
+
+export function resolveAppIconPath(
+  options: AppIconPathOptions,
+  exists: (filePath: string) => boolean
+): string | undefined {
+  return appIconCandidates(options).find(exists)
+}

--- a/apps/desktop/electron/app-icon.ts
+++ b/apps/desktop/electron/app-icon.ts
@@ -1,0 +1,97 @@
+import path from 'node:path'
+
+/**
+ * Resolve the native BrowserWindow / dock icon path.
+ *
+ * Why this order matters on Windows: the taskbar / Start Menu / .lnk identity
+ * comes from the PE icon stamped onto Hermes.exe (assets/icon.ico via
+ * set-exe-identity / extraResources). BrowserWindow `{ icon }` must prefer that
+ * same .ico (or resources/icon.ico) — not apple-touch-icon.png — or Alt+Tab /
+ * window grouping can show a different glyph than the taskbar.
+ *
+ * On Darwin, `extraResources` still ships `resources/icon.ico` (the Windows
+ * PE-stamp source) for every target. Prefer `.icns` then PNG ahead of that
+ * `.ico` so the dock keeps a crisp native candidate when both exist.
+ */
+
+export type AppIconPathOptions = {
+  appRoot: string
+  resourcesPath?: string | null
+  /** When APP_ROOT is inside app.asar, Electron still serves sibling files. */
+  unpackedAppRoot?: string | null
+  platform?: NodeJS.Platform
+}
+
+/**
+ * Candidate absolute paths, highest priority first.
+ * Pure: no fs I/O — caller picks the first existing path.
+ *
+ * Aligns with post-80c86c4 main.ts Windows `.ico`-first behaviour while making
+ * Darwin priority platform-aware (`.icns` / PNG before packaged `.ico`).
+ */
+export function appIconCandidates({
+  appRoot,
+  resourcesPath = null,
+  unpackedAppRoot = null,
+  platform = process.platform
+}: AppIconPathOptions): string[] {
+  const roots = [appRoot, unpackedAppRoot].filter((r): r is string => Boolean(r))
+  const out: string[] = []
+
+  // 1) Packaged extraResources copy — byte-identical to the PE stamp source.
+  if (resourcesPath) {
+    if (platform === 'darwin') {
+      out.push(path.join(resourcesPath, 'icon.icns'))
+      out.push(path.join(resourcesPath, 'icon.png'))
+    }
+
+    // Windows (and shared packaging): prefer the stamped .ico. On Darwin this
+    // stays after native formats so a packaged .ico cannot win first-pick.
+    out.push(path.join(resourcesPath, 'icon.ico'))
+  }
+
+  // 2) Dev / asar-packaged assets next to the app (files: assets/**).
+  for (const root of roots) {
+    if (platform === 'darwin') {
+      out.push(path.join(root, 'assets', 'icon.icns'))
+      out.push(path.join(root, 'assets', 'icon.png'))
+    }
+
+    out.push(path.join(root, 'assets', 'icon.ico'))
+
+    if (platform !== 'darwin') {
+      out.push(path.join(root, 'assets', 'icon.png'))
+    }
+  }
+
+  // 3) Renderer favicon last — historically used, but can drift from the
+  //    stamped .ico; keep as a soft fallback so windows still get *an* icon.
+  for (const root of roots) {
+    out.push(path.join(root, 'public', 'apple-touch-icon.png'))
+    out.push(path.join(root, 'dist', 'apple-touch-icon.png'))
+  }
+
+  // Dedupe while preserving order.
+  const seen = new Set<string>()
+  const unique: string[] = []
+
+  for (const candidate of out) {
+    const key = platform === 'win32' ? candidate.toLowerCase() : candidate
+
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    unique.push(candidate)
+  }
+
+  return unique
+}
+
+export function resolveAppIconPath(
+  options: AppIconPathOptions,
+  exists: (filePath: string) => boolean
+): string | undefined {
+  return appIconCandidates(options).find(exists)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,6 +31,7 @@ import {
 } from 'electron'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { resolveAppIconPath } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -816,19 +817,10 @@ const WINDOW_BUTTON_POSITION = {
 // (pure + unit-testable); computeNativeOverlayWidth() applies it per platform.
 // It's only the pre-layout fallback — the renderer measures the exact overlay
 // width live via the Window Controls Overlay API.
-// The apple-touch PNG bakes in the macOS-style ~10% margin, which is correct
-// for the dock but renders visibly smaller than neighboring taskbar icons on
-// Windows, where icons are full-bleed. Windows prefers the full-bleed
-// assets/icon.ico (shipped to resources/ via extraResources) and only falls
-// back to the padded PNG if the ico is missing.
-const APP_ICON_PATHS = [
-  ...(IS_WINDOWS
-    ? [path.join(process.resourcesPath ?? '', 'icon.ico'), path.join(APP_ROOT, 'assets', 'icon.ico')]
-    : []),
-  path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
-  path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
-  path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')
-]
+// Native window icon candidates live in app-icon.ts (pure + unit-tested).
+// Windows keeps the post-80c86c4 .ico-first PE-stamp preference; Darwin prefers
+// .icns/PNG ahead of the packaged resources/icon.ico that extraResources ships
+// on every target.
 
 let rendererTitleBarTheme = null
 
@@ -6216,7 +6208,15 @@ function registerPowerResumeListeners() {
 }
 
 function getAppIconPath() {
-  return APP_ICON_PATHS.find(fileExists)
+  return resolveAppIconPath(
+    {
+      appRoot: APP_ROOT,
+      resourcesPath: process.resourcesPath || null,
+      unpackedAppRoot: unpackedPathFor(APP_ROOT),
+      platform: process.platform
+    },
+    fileExists
+  )
 }
 
 function sendOpenUpdatesRequested() {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,6 +32,7 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { resolveAppIconPath } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -678,19 +679,10 @@ const WINDOW_BUTTON_POSITION = {
 // (pure + unit-testable); computeNativeOverlayWidth() applies it per platform.
 // It's only the pre-layout fallback — the renderer measures the exact overlay
 // width live via the Window Controls Overlay API.
-// The apple-touch PNG bakes in the macOS-style ~10% margin, which is correct
-// for the dock but renders visibly smaller than neighboring taskbar icons on
-// Windows, where icons are full-bleed. Windows prefers the full-bleed
-// assets/icon.ico (shipped to resources/ via extraResources) and only falls
-// back to the padded PNG if the ico is missing.
-const APP_ICON_PATHS = [
-  ...(IS_WINDOWS
-    ? [path.join(process.resourcesPath ?? '', 'icon.ico'), path.join(APP_ROOT, 'assets', 'icon.ico')]
-    : []),
-  path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
-  path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
-  path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')
-]
+// Native window icon candidates live in app-icon.ts (pure + unit-tested).
+// Windows keeps the post-80c86c4 .ico-first PE-stamp preference; Darwin prefers
+// .icns/PNG ahead of the packaged resources/icon.ico that extraResources ships
+// on every target.
 
 let rendererTitleBarTheme = null
 const terminalSessions = new Map()
@@ -5307,7 +5299,15 @@ function registerPowerResumeListeners() {
 }
 
 function getAppIconPath() {
-  return APP_ICON_PATHS.find(fileExists)
+  return resolveAppIconPath(
+    {
+      appRoot: APP_ROOT,
+      resourcesPath: process.resourcesPath || null,
+      unpackedAppRoot: unpackedPathFor(APP_ROOT),
+      platform: process.platform
+    },
+    fileExists
+  )
 }
 
 function sendOpenUpdatesRequested() {


### PR DESCRIPTION
## Summary
- Extract native BrowserWindow / dock icon resolution into a pure, unit-tested `apps/desktop/electron/app-icon.ts` helper and wire `main.ts` through it.
- Preserve post-80c86c4 Windows behaviour: prefer packaged / assets `.ico` (PE-stamp lineage) ahead of apple-touch fallbacks.
- Make Darwin priority platform-aware: prefer `.icns` then PNG **before** packaged `resources/icon.ico` (extraResources ships `.ico` on every target).

## Why
Reviewers correctly noted that a global `.ico`-first candidate list selects the Windows PE stamp on macOS when both files exist. Splitting stream/markdown UI tweaks out of this PR so the icon resolver can land cleanly on current `main`.

## Test plan
- [x] `cd apps/desktop && npm run test -- electron/app-icon.test.ts` (6 passed)
- [ ] Cold-launch Desktop on Windows and confirm window / taskbar still use the PE-aligned `.ico`
- [ ] On macOS, confirm dock prefers `.icns` when both `.icns` and packaged `.ico` exist

## Follow-up
Stream flush / markdown append-cache tweaks land in a separate PR (no `markdown-text.tsx` rewrite).
