### PR TITLE
fix(status): surface macOS launchd unload state in hermes status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9930,8 +9930,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if getattr(self, "_signal_initiated_shutdown", False) and not self._restart_requested:
                 logger.info(
                     "Gateway stopped by an unexpected signal — persisting "
-                    "gateway_state=running so container_boot auto-starts on "
-                    "the next boot (issue #42675)"
+                    "gateway_state=running so the supervisor (s6 on Linux "
+                    "Docker, macOS launchd KeepAlive on Aqua sessions) can "
+                    "auto-recover. Note: launchd has no equivalent to "
+                    "container_boot — if the LaunchAgent has been unloaded "
+                    "(Aqua restart, OS upgrade, `launchctl bootout`), run "
+                    "`hermes gateway start` or see `hermes status` for the "
+                    "fix command. (related: #42675, #55441, #28632)"
                 )
                 self._update_runtime_status("running", self._exit_reason)
             else:

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -520,7 +520,16 @@ def show_status(args):
                 plist = get_launchd_plist_path()
                 if plist.exists() and not _probe_launchd_service_running():
                     print(f"  {color('⚠', Colors.YELLOW)} launchd:      plist found but service is not loaded into launchd")
-                    print(f"  Fix:          launchctl bootstrap gui/$(id -u) {plist}")
+                    # Route the repair through the CLI: `launchd_start()`
+                    # (hermes_cli/gateway.py:4293) already handles
+                    # domain resolution (`_launchd_domain()` chooses
+                    # gui/<uid> in Aqua, user/<uid> in Background/SSH),
+                    # plist regeneration, stale-already-loaded EIO retry,
+                    # and domain-unsupported fallbacks. Raw
+                    # `launchctl bootstrap gui/<uid>` misleads
+                    # Background/SSH users (issue surfaced by hermes-sweeper
+                    # review on PR #73370).
+                    print(f"  Repair:       hermes gateway start")
     except Exception:
         if _is_termux():
             print(f"  Status:       {color('unknown', Colors.DIM)}")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -490,7 +490,13 @@ def show_status(args):
     print(color("◆ Gateway Service", Colors.CYAN, Colors.BOLD))
 
     try:
-        from hermes_cli.gateway import get_gateway_runtime_snapshot, _format_gateway_pids
+        from hermes_cli.gateway import (
+            get_gateway_runtime_snapshot,
+            _format_gateway_pids,
+            get_launchd_plist_path,
+            _probe_launchd_service_running,
+            get_launchd_label,
+        )
 
         snapshot = get_gateway_runtime_snapshot()
         is_running = snapshot.running
@@ -505,6 +511,16 @@ def show_status(args):
             print("  Note:         Android may stop background jobs when Termux is suspended")
         elif snapshot.service_installed and not snapshot.service_running:
             print("  Service:      installed but stopped")
+            # macOS-specific: plist exists but launchd has unloaded the service.
+            # Common after Aqua session restarts, OS upgrades, or `launchctl
+            # bootout` from another agent. Without this warning, users only
+            # notice when their Telegram bot stops responding (no polling).
+            # See #55441, #28632, and the family around #42675.
+            if sys.platform == "darwin":
+                plist = get_launchd_plist_path()
+                if plist.exists() and not _probe_launchd_service_running():
+                    print(f"  {color('⚠', Colors.YELLOW)} launchd:      plist found but service is not loaded into launchd")
+                    print(f"  Fix:          launchctl bootstrap gui/$(id -u) {plist}")
     except Exception:
         if _is_termux():
             print(f"  Status:       {color('unknown', Colors.DIM)}")

--- a/tests/hermes_cli/test_status_launchd_unload.py
+++ b/tests/hermes_cli/test_status_launchd_unload.py
@@ -158,10 +158,13 @@ class TestStatusLaunchdUnloadWarning:
         assert "plist found but service is not loaded into launchd" in out, (
             f"expected unload warning in status output, got:\n{out}"
         )
-        assert "launchctl bootstrap gui/$(id -u)" in out, (
-            f"expected fix command in status output, got:\n{out}"
+        assert "hermes gateway start" in out, (
+            f"expected repair hint in status output, got:\n{out}"
         )
-        assert str(isolated_status_env.plist) in out
+        assert str(isolated_status_env.plist) not in out, (
+            f"status must not echo raw plist path when routing through the CLI; "
+            f"got:\n{out}"
+        )
 
     def test_warning_suppressed_when_launchd_is_running(
         self, monkeypatch, capsys, isolated_status_env
@@ -237,6 +240,38 @@ class TestStatusLaunchdUnloadWarning:
         out = capsys.readouterr().out
         assert "plist found but service is not loaded" not in out, (
             f"warning must not fire on Linux even with plist/unload state; got:\n{out}"
+        )
+
+    def test_warning_does_not_recommend_raw_launchctl_command(
+        self, monkeypatch, capsys, isolated_status_env
+    ):
+        """Regression: status must not suggest a raw ``launchctl bootstrap``
+        command for repair. The launchd domain (gui/<uid> vs user/<uid>) is
+        resolved by ``_launchd_domain()`` and depends on the session (Aqua vs
+        Background/SSH); hardcoding ``gui/<uid>`` misleads Background/SSH
+        users. The CLI (``hermes gateway start``) handles all the cases.
+
+        Surfaced by hermes-sweeper review on PR #73370:
+        https://github.com/NousResearch/hermes-agent/pull/73370
+        """
+        monkeypatch.setattr(sys, "platform", "darwin")
+        isolated_status_env.set_snapshot(
+            running=False,
+            manager="launchd",
+            service_installed=True,
+            service_running=False,
+        ).set_plist(exists=True).set_probe(running=False).install()
+
+        show_status(SimpleNamespace(all=False, deep=False))
+
+        out = capsys.readouterr().out
+        assert "launchctl bootstrap" not in out, (
+            f"status must not print a raw launchctl command — domain resolution "
+            f"is hermes's responsibility (see _launchd_domain()); got:\n{out}"
+        )
+        assert "launchctl bootout" not in out, (
+            f"status must not print a raw bootout command either — sticky domain "
+            f"resolution same reason; got:\n{out}"
         )
 
 

--- a/tests/hermes_cli/test_status_launchd_unload.py
+++ b/tests/hermes_cli/test_status_launchd_unload.py
@@ -1,0 +1,254 @@
+"""Tests for ``hermes status`` surfacing the "plist exists but launchd has
+unloaded the service" state on macOS.
+
+Reproduction:
+- ``~/Library/LaunchAgents/ai.hermes.gateway.plist`` is intact
+- ``launchctl list | grep ai.hermes.gateway`` returns nothing
+- ``hermes status`` previously reported the gateway as running because the
+  ``serve`` (dashboard API) process was still alive — users only noticed
+  the outage when their Telegram bot stopped responding.
+
+Fix: in the macOS branch of the Gateway section, when the plist is present
+but ``_probe_launchd_service_running()`` returns False, print a yellow ⚠
+warning plus the exact ``launchctl bootstrap`` command to repair.
+
+See hermes_cli/status.py (gateway service rendering block). Related upstream
+issues: #55441, #28632, #42675 family.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.status import show_status
+
+
+# ---------------------------------------------------------------------------
+# Snapshot factories
+# ---------------------------------------------------------------------------
+
+
+def _snapshot(
+    *,
+    running: bool = False,
+    manager: str = "launchd",
+    pids: tuple = (),
+    service_installed: bool = True,
+    service_running: bool = False,
+    mismatch: bool = False,
+):
+    return SimpleNamespace(
+        running=running,
+        manager=manager,
+        gateway_pids=pids,
+        service_installed=service_installed,
+        service_running=service_running,
+        has_process_service_mismatch=mismatch,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures — patch all the heavy stuff so status() runs end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_status_env(monkeypatch, tmp_path):
+    """Make ``show_status`` runnable in a unit test without touching real
+    auth, providers, or gateway subprocesses. Returns a context manager
+    the individual tests can use to override gateway state."""
+
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    # HERMES_HOME for any config-loading paths
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "minimax-cn", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "minimax-cn", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "MiniMax", raising=False)
+
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+
+    class _GatewayState:
+        def __init__(self):
+            self.snapshot = _snapshot()
+            self.plist = tmp_path / "ai.hermes.gateway.plist"
+            self.plist_exists = True
+            self.probe_running = False
+
+        def set_snapshot(self, **kwargs):
+            self.snapshot = _snapshot(**kwargs)
+            return self
+
+        def set_plist(self, *, exists: bool):
+            self.plist_exists = exists
+            return self
+
+        def set_probe(self, *, running: bool):
+            self.probe_running = running
+            return self
+
+        def install(self):
+            state = self
+
+            monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None, all_profiles=False: list(state.snapshot.gateway_pids), raising=False)
+            monkeypatch.setattr(gateway_mod, "get_gateway_runtime_snapshot", lambda: state.snapshot, raising=False)
+            monkeypatch.setattr(gateway_mod, "_format_gateway_pids", lambda pids: ",".join(str(p) for p in pids), raising=False)
+            monkeypatch.setattr(gateway_mod, "get_launchd_label", lambda: "ai.hermes.gateway", raising=False)
+            monkeypatch.setattr(gateway_mod, "get_launchd_plist_path", lambda: state.plist, raising=False)
+            monkeypatch.setattr(gateway_mod, "_probe_launchd_service_running", lambda: state.probe_running, raising=False)
+
+            # Make Path.exists honor our toggle for the plist path only.
+            original_exists = Path.exists
+
+            def _exists(self, *a, **kw):
+                if self == state.plist:
+                    return state.plist_exists
+                return original_exists(self, *a, **kw)
+
+            monkeypatch.setattr(Path, "exists", _exists)
+            return state
+
+    return _GatewayState()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStatusLaunchdUnloadWarning:
+    """The macOS warning only fires when ALL of these are true:
+
+    - We're on macOS (``sys.platform == 'darwin'``)
+    - The snapshot reports ``service_installed=True`` and ``service_running=False``
+      — the "installed but stopped" branch in the existing status rendering
+    - The plist file exists on disk
+    - ``_probe_launchd_service_running()`` returns False (launchd has unloaded)
+
+    On Linux/Windows the warning must NOT appear even when the plist path is
+    callable, because no launchd exists to query.
+    """
+
+    def test_warning_shown_on_macos_when_plist_exists_and_unloaded(
+        self, monkeypatch, capsys, isolated_status_env
+    ):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        isolated_status_env.set_snapshot(
+            running=False,
+            manager="launchd",
+            service_installed=True,
+            service_running=False,
+        ).set_plist(exists=True).set_probe(running=False).install()
+
+        show_status(SimpleNamespace(all=False, deep=False))
+
+        out = capsys.readouterr().out
+        assert "plist found but service is not loaded into launchd" in out, (
+            f"expected unload warning in status output, got:\n{out}"
+        )
+        assert "launchctl bootstrap gui/$(id -u)" in out, (
+            f"expected fix command in status output, got:\n{out}"
+        )
+        assert str(isolated_status_env.plist) in out
+
+    def test_warning_suppressed_when_launchd_is_running(
+        self, monkeypatch, capsys, isolated_status_env
+    ):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        isolated_status_env.set_snapshot(
+            running=True,
+            manager="launchd",
+            pids=(12345,),
+            service_installed=True,
+            service_running=True,
+        ).set_plist(exists=True).set_probe(running=True).install()
+
+        show_status(SimpleNamespace(all=False, deep=False))
+
+        out = capsys.readouterr().out
+        assert "plist found but service is not loaded" not in out, (
+            f"warning must not fire when launchd is supervising; got:\n{out}"
+        )
+
+    def test_warning_suppressed_when_plist_missing(
+        self, monkeypatch, capsys, isolated_status_env
+    ):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        isolated_status_env.set_snapshot(
+            running=False,
+            manager="launchd",
+            service_installed=True,
+            service_running=False,
+        ).set_plist(exists=False).set_probe(running=False).install()
+
+        show_status(SimpleNamespace(all=False, deep=False))
+
+        out = capsys.readouterr().out
+        assert "plist found but service is not loaded" not in out, (
+            f"warning must not fire when plist is absent; got:\n{out}"
+        )
+
+    def test_warning_suppressed_when_service_running_per_snapshot(
+        self, monkeypatch, capsys, isolated_status_env
+    ):
+        # Snapshot says service is running → we don't enter the
+        # "installed but stopped" branch at all, so the warning can't fire.
+        monkeypatch.setattr(sys, "platform", "darwin")
+        isolated_status_env.set_snapshot(
+            running=True,
+            manager="launchd",
+            service_installed=True,
+            service_running=True,
+        ).set_plist(exists=True).set_probe(running=False).install()
+
+        show_status(SimpleNamespace(all=False, deep=False))
+
+        out = capsys.readouterr().out
+        assert "plist found but service is not loaded" not in out, (
+            f"warning must not fire when snapshot reports running; got:\n{out}"
+        )
+
+    def test_warning_suppressed_on_linux(
+        self, monkeypatch, capsys, isolated_status_env
+    ):
+        # Force the "not darwin" code path; warning must be silent.
+        monkeypatch.setattr(sys, "platform", "linux")
+        isolated_status_env.set_snapshot(
+            running=False,
+            manager="systemd (user)",
+            service_installed=True,
+            service_running=False,
+        ).set_plist(exists=True).set_probe(running=False).install()
+
+        show_status(SimpleNamespace(all=False, deep=False))
+
+        out = capsys.readouterr().out
+        assert "plist found but service is not loaded" not in out, (
+            f"warning must not fire on Linux even with plist/unload state; got:\n{out}"
+        )
+
+
+class TestStatusSnapshotLoading:
+    """The status function must accept the new symbol imports without crashing.
+
+    If this fails, the new imports added in status.py are wrong.
+    """
+
+    def test_imports_succeed(self):
+        from hermes_cli.gateway import (  # noqa: F401
+            get_launchd_plist_path,
+            _probe_launchd_service_running,
+            get_launchd_label,
+        )


### PR DESCRIPTION
## What does this PR do?

Makes `hermes status` print a yellow warning plus the exact `launchctl bootstrap` command needed when the macOS gateway LaunchAgent has been unloaded from launchd but the plist file is still on disk. Without this, the gateway stops polling Telegram/Discord/WeChat silently and the user only notices when their bot stops responding — observed up to **24 days** of silent outage on at least one user's machine.

The root cause is that `hermes_cli/status.py`'s Gateway section relies on `get_gateway_runtime_snapshot().gateway_pids`, but the `serve` (dashboard API on port 9120) process is always alive, so PIDs look healthy even when no messaging polling is happening. The macOS-specific `_probe_launchd_service_running()` helper (defined at `hermes_cli/gateway.py:1277`) was never called from `hermes status`.

`launchd_start()` and `launchd_restart()` already self-heal (see existing tests `test_launchd_start_reloads_unloaded_job_and_retries` and `test_launchd_restart_boots_out_stale_registration_before_bootstrap`). This PR only closes the *visibility* gap, not the auto-recovery path on macOS.

## Related Issue

Fixes #73368

Related (sibling bugs in the same family): #55441, #28632, #42675 (CLOSED — Docker side).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update (the misleading "container_boot auto-starts on the next boot" log message in `gateway/run.py` is replaced with a platform-aware note)
- [x] ✅ Tests (adding test coverage — 6 new tests in `tests/hermes_cli/test_status_launchd_unload.py`)

## Changes Made

- `hermes_cli/status.py` (+18, −1) — Add macOS-specific branch to the Gateway section. When `snapshot.service_installed and not snapshot.service_running` on `sys.platform == 'darwin'`, additionally probe via `_probe_launchd_service_running()` and `get_launchd_plist_path()`. If plist exists and probe returns False, print a yellow ⚠ warning plus the exact `launchctl bootstrap gui/$UID <plist>` command to repair.

- `gateway/run.py` (+9, −2) — Replace the misleading `"gateway_state=running so container_boot auto-starts on the next boot (issue #42675)"` log message with a platform-aware note that explains the actual macOS behavior (launchd has no equivalent to container_boot; manual bootstrap required when the service is unloaded) and points the user at `hermes status` for the fix command.

- `tests/hermes_cli/test_status_launchd_unload.py` (new, +254) — 6 unit tests covering:
  1. Warning fires on macOS when plist exists + launchd probe returns False
  2. Warning suppressed when launchd is actively supervising
  3. Warning suppressed when plist file is absent
  4. Warning suppressed when snapshot reports service running
  5. Warning suppressed on Linux/Windows regardless of probe state
  6. Import smoke test for the new symbols

## How to Test

**Unit tests** (the standard pipeline):

```bash
pytest tests/hermes_cli/test_status_launchd_unload.py -v
pytest tests/hermes_cli/test_status.py tests/hermes_cli/test_status_provider_label.py -v
pytest tests/hermes_cli/test_gateway_service.py -v
```

Expected: 6 + 22 + 189 passing.

**Manual reproduction (macOS)**:

1. Fresh install: `hermes setup`, confirm gateway polling via `tail -f ~/.hermes/logs/gateway.log`.
2. Trigger unload: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.hermes.gateway.plist`
3. `launchctl list | grep ai.hermes.gateway` → empty
4. `hermes status` → should now show:
   ```
   ⚠ launchd:      plist found but service is not loaded into launchd
     Fix:          launchctl bootstrap gui/$(id -u) /Users/<you>/Library/LaunchAgents/ai.hermes.gateway.plist
   ```
5. Run the suggested fix command → service reloaded, polling resumes, no restart of `serve` needed.

**Linux/Windows**: no behavior change. Verify `hermes status` output is byte-identical before/after.

## Checklist

- [x] I have read [CONTRIBUTING.md](../../CONTRIBUTING.md) and the [AGENTS.md](../../AGENTS.md) contribution rubric.
- [x] My change preserves prompt caching (no system-prompt mutations, no mid-conversation context edits).
- [x] My change is additive on macOS, a strict no-op on Linux/Windows/Docker.
- [x] I have added tests that exercise the new path and at least four regression-guard cases.
- [x] I have not grown the model-tool surface area — no new tool definitions, no new environment variables.
- [x] The behavior contract is "users see a warning when their gateway is silently broken" — not a specific number of log lines or a specific output format, so the implementation has room to evolve without breaking the contract.