### PR TITLE
fix(kanban): bound blocker auth respawn retries

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6688,7 +6688,8 @@ class DispatchResult:
     respawn_guarded: list[tuple[str, str]] = field(default_factory=list)
     """Tasks skipped by the respawn guard, as ``(task_id, reason)`` pairs.
 
-    Reasons: ``"blocker_auth"`` (quota/auth error — also auto-blocked),
+    Reasons: ``"blocker_auth"`` (quota/auth error — deferred once per
+    failed attempt), ``"rate_limit_cooldown"`` (quota retry cooldown),
     ``"recent_success"`` (completed run within guard window),
     ``"active_pr"`` (GitHub PR URL in a recent comment)."""
     rate_limited: list[str] = field(default_factory=list)
@@ -7891,12 +7892,10 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     ``"blocker_auth"``
         The task's last failure error matches a quota / authentication
         pattern. Retrying immediately is unlikely to help (rate limits
-        reset on a timer; auth needs human action), so we defer to the
-        next tick. The existing ``consecutive_failures`` counter still
-        trips the auto-block circuit breaker after ``failure_limit``
-        consecutive failures, so a persistent auth error eventually
-        blocks via the normal path — but a transient 429 gets a few
-        ticks of recovery first.
+        reset on a timer; auth needs human action), so we defer for one
+        tick per failed attempt. The following tick is allowed to probe
+        again so the existing ``consecutive_failures`` counter can trip
+        the auto-block circuit breaker after ``failure_limit`` failures.
 
     ``"recent_success"``
         A completed run exists within ``_RESPAWN_GUARD_SUCCESS_WINDOW``
@@ -7916,7 +7915,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT last_failure_error, consecutive_failures "
+        "FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
@@ -7960,9 +7960,29 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         # crash/completion supersedes it.
         return None
 
-    # 2. Quota / auth blocker: retrying immediately will not help.
+    # 2. Quota / auth blocker: retrying immediately will not help. Defer
+    #    exactly once for each failure-count value, then allow one bounded
+    #    probe. Without that probe the guard runs before claim/spawn, so the
+    #    failure counter never advances and the task remains ready forever.
     err = row["last_failure_error"]
     if err and _RESPAWN_BLOCKER_RE.search(err):
+        latest_guard = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'respawn_guarded' "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        if latest_guard is not None and latest_guard["payload"]:
+            try:
+                guard_payload = json.loads(latest_guard["payload"])
+            except (TypeError, ValueError):
+                guard_payload = {}
+            if (
+                guard_payload.get("reason") == "blocker_auth"
+                and guard_payload.get("failures")
+                == int(row["consecutive_failures"] or 0)
+            ):
+                return None
         return "blocker_auth"
 
     # 3. Completed run within guard window — proof of recent success.
@@ -8216,7 +8236,7 @@ def _dispatch_once_locked(
         )
 
     ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
+        "SELECT id, assignee, consecutive_failures FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -8358,10 +8378,9 @@ def _dispatch_once_locked(
         # in-flight/recent, or when the last failure is a deterministic
         # blocker (quota / auth). The guard defers the spawn this tick so
         # the task gets a chance to clear (rate limits often reset in
-        # seconds-to-minutes); the existing consecutive_failures counter
-        # still trips the auto-block circuit breaker after failure_limit
-        # consecutive failures, so a persistent auth error eventually
-        # blocks via the normal path rather than on first occurrence.
+        # seconds-to-minutes). blocker_auth is deferred once per failed
+        # attempt, then a bounded probe is allowed so consecutive_failures
+        # can reach failure_limit instead of the card staying ready forever.
         guard_reason = check_respawn_guard(conn, row["id"])
         if guard_reason is not None:
             result.respawn_guarded.append((row["id"], guard_reason))
@@ -8370,9 +8389,13 @@ def _dispatch_once_locked(
             # this the task appears stuck in ready with no diagnosis.
             if not dry_run:
                 with write_txn(conn):
+                    payload = {"reason": guard_reason}
+                    if guard_reason == "blocker_auth":
+                        payload["failures"] = int(
+                            row["consecutive_failures"] or 0
+                        )
                     _append_event(
-                        conn, row["id"], "respawn_guarded",
-                        {"reason": guard_reason},
+                        conn, row["id"], "respawn_guarded", payload,
                     )
             continue
         if dry_run:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1989,6 +1989,48 @@ def test_dispatch_respawn_guard_defers_auth_error_without_auto_block(
         assert kb.get_task(conn, t).status == "ready"
 
 
+def test_dispatch_respawn_guard_allows_bounded_retry_after_one_deferred_tick(
+    kanban_home, all_assignees_spawnable
+):
+    """A deterministic blocker must not leave a task ready forever.
+
+    The first failed attempt is deferred for one dispatcher tick.  The next
+    tick must probe again so the normal consecutive-failure circuit breaker
+    can block a task whose underlying failure persists.
+    """
+    attempts = []
+
+    def failing_spawn(task, workspace):
+        attempts.append(task.id)
+        raise PermissionError("Permission denied")
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="persistent-permission", assignee="alice")
+
+        first = kb.dispatch_once(
+            conn, spawn_fn=failing_spawn, failure_limit=2,
+        )
+        assert t not in first.auto_blocked
+        assert kb.get_task(conn, t).status == "ready"
+        assert kb.get_task(conn, t).consecutive_failures == 1
+
+        deferred = kb.dispatch_once(
+            conn, spawn_fn=failing_spawn, failure_limit=2,
+        )
+        assert (t, "blocker_auth") in deferred.respawn_guarded
+        assert kb.get_task(conn, t).status == "ready"
+
+        retried = kb.dispatch_once(
+            conn, spawn_fn=failing_spawn, failure_limit=2,
+        )
+        task = kb.get_task(conn, t)
+
+    assert attempts == [t, t]
+    assert t in retried.auto_blocked
+    assert task.status == "blocked"
+    assert task.consecutive_failures == 2
+
+
 def test_dispatch_respawn_guard_skips_recent_success(
     kanban_home, all_assignees_spawnable
 ):


### PR DESCRIPTION
## What does this PR do?

Bounds the Kanban `blocker_auth` respawn guard so a task cannot remain in `ready` forever after a deterministic spawn failure.

The first matching failure is still deferred for one dispatcher tick. The following tick is allowed to make one probe; if the underlying condition persists, the normal `consecutive_failures` circuit breaker advances and auto-blocks the task at `kanban.failure_limit`.

The dedicated `rate_limit_cooldown` path remains unchanged.

### Root cause

`check_respawn_guard()` returned `blocker_auth` on every pass. `_dispatch_once_locked()` then appended a diagnostic event and continued before claim/spawn, so `_record_task_failure()` was unreachable and `consecutive_failures` could never advance.

## Related Issue

Fixes #73369

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Record the failure-count value on `blocker_auth` guard events.
- Defer once for each failure-count value, then allow a bounded probe.
- Keep rate-limit cooldown handling separate and unchanged.
- Add a regression test covering failure → one deferred tick → retry → auto-block.
- Update respawn-guard documentation to match the bounded behavior.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -q`.
2. Create a ready task whose spawn function raises `PermissionError("Permission denied")` with `failure_limit=2`.
3. Verify the first failure returns the task to ready, the next pass reports `blocker_auth`, and the following pass retries and auto-blocks with `consecutive_failures == 2`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — SQLite/event logic only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Regression on current `main` before the fix:

```text
AssertionError: assert ['task-id'] == ['task-id', 'task-id']
```

Validation after the fix:

```text
tests/hermes_cli/test_kanban_db.py: 231 passed
```
