### PR TITLE
[codex] fix(gateway): 保留 queued dispatch 生命周期归属

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1897,6 +1897,16 @@ class ProcessingOutcome(Enum):
     CANCELLED = "cancelled"
 
 
+class MessageDispatchDisposition(Enum):
+    """Ownership of an inbound message after ``handle_message`` returns."""
+
+    BACKGROUND_STARTED = "background_started"
+    PENDING_QUEUED = "pending_queued"
+    STEERED = "steered"
+    SYNC_HANDLED = "sync_handled"
+    REJECTED = "rejected"
+
+
 @dataclass
 class MessageEvent:
     """
@@ -1970,6 +1980,15 @@ class MessageEvent:
     # consume via ``event.metadata.get(...)`` and must not rely on any
     # particular key existing.
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+    # Set by the gateway branch that actually accepted, queued, steered, or
+    # rejected this event. Platform integrations use it to transfer response
+    # lifecycle ownership without parsing user-visible text.
+    dispatch_disposition: Optional[MessageDispatchDisposition] = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
 
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
@@ -5128,7 +5147,7 @@ class BasePlatformAdapter(ABC):
 
         await self._drain_pending_after_session_command(session_key, command_guard)
 
-    async def handle_message(self, event: MessageEvent) -> None:
+    async def handle_message(self, event: MessageEvent) -> MessageDispatchDisposition:
         """
         Process an incoming message.
         
@@ -5137,7 +5156,9 @@ class BasePlatformAdapter(ABC):
         enabling interruption support.
         """
         if not self._message_handler:
-            return
+            event.metadata.setdefault("dispatch_reject_reason", "transport_unavailable")
+            event.dispatch_disposition = MessageDispatchDisposition.REJECTED
+            return event.dispatch_disposition
 
         coerce_plaintext_gateway_command(event)
 
@@ -5190,7 +5211,14 @@ class BasePlatformAdapter(ABC):
                             "[%s] Command '/%s' dispatch failed: %s",
                             self.name, cmd, e, exc_info=True,
                         )
-                    return
+                        event.metadata.setdefault("dispatch_reject_reason", "dispatch_start_failed")
+                        event.dispatch_disposition = MessageDispatchDisposition.REJECTED
+                        return event.dispatch_disposition
+                    event.dispatch_disposition = (
+                        event.dispatch_disposition
+                        or MessageDispatchDisposition.SYNC_HANDLED
+                    )
+                    return event.dispatch_disposition
 
                 # Other bypass commands (/approve, /deny, /status,
                 # /background, /restart) just need direct dispatch — they
@@ -5218,7 +5246,14 @@ class BasePlatformAdapter(ABC):
                             )
                 except Exception as e:
                     logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
-                return
+                    event.metadata.setdefault("dispatch_reject_reason", "dispatch_start_failed")
+                    event.dispatch_disposition = MessageDispatchDisposition.REJECTED
+                    return event.dispatch_disposition
+                event.dispatch_disposition = (
+                    event.dispatch_disposition
+                    or MessageDispatchDisposition.SYNC_HANDLED
+                )
+                return event.dispatch_disposition
 
             # Clarify reply bypass: if the agent is blocked on a
             # clarify_tool call, the next non-command message in this
@@ -5274,14 +5309,32 @@ class BasePlatformAdapter(ABC):
                             "[%s] Clarify text-intercept dispatch failed: %s",
                             self.name, e, exc_info=True,
                         )
-                    return
+                        event.metadata.setdefault("dispatch_reject_reason", "dispatch_start_failed")
+                        event.dispatch_disposition = MessageDispatchDisposition.REJECTED
+                        return event.dispatch_disposition
+                    event.dispatch_disposition = (
+                        event.dispatch_disposition
+                        or MessageDispatchDisposition.SYNC_HANDLED
+                    )
+                    return event.dispatch_disposition
 
             if self._busy_session_handler is not None:
                 try:
-                    if await self._busy_session_handler(event, session_key):
-                        return
+                    busy_result = await self._busy_session_handler(event, session_key)
+                    if isinstance(busy_result, MessageDispatchDisposition):
+                        event.dispatch_disposition = busy_result
+                        return busy_result
+                    if busy_result:
+                        event.dispatch_disposition = (
+                            event.dispatch_disposition
+                            or MessageDispatchDisposition.SYNC_HANDLED
+                        )
+                        return event.dispatch_disposition
                 except Exception as e:
                     logger.error("[%s] Busy-session handler failed: %s", self.name, e, exc_info=True)
+                    event.metadata.setdefault("dispatch_reject_reason", "dispatch_start_failed")
+                    event.dispatch_disposition = MessageDispatchDisposition.REJECTED
+                    return event.dispatch_disposition
 
             # Special case: photo bursts/albums frequently arrive as multiple near-
             # simultaneous messages. Queue them without interrupting the active run,
@@ -5289,7 +5342,8 @@ class BasePlatformAdapter(ABC):
             if event.message_type == MessageType.PHOTO:
                 logger.debug("[%s] Queuing photo follow-up for session %s without interrupt", self.name, session_key)
                 merge_pending_message_event(self._pending_messages, session_key, event)
-                return  # Don't interrupt now - will run after current task completes
+                event.dispatch_disposition = MessageDispatchDisposition.PENDING_QUEUED
+                return event.dispatch_disposition
 
             if self._is_queue_text_debounce_candidate(event):
                 logger.debug(
@@ -5313,7 +5367,8 @@ class BasePlatformAdapter(ABC):
                     event,
                     merge_text=event.message_type == MessageType.TEXT,
                 )
-            return  # Don't process now - will be handled after current task finishes
+            event.dispatch_disposition = MessageDispatchDisposition.PENDING_QUEUED
+            return event.dispatch_disposition
         
         # Mark session as active BEFORE spawning background task to close
         # the race window where a second message arriving before the task
@@ -5322,7 +5377,15 @@ class BasePlatformAdapter(ABC):
         # pattern — set the guard synchronously, not inside the task.)
         # _start_session_processing installs the guard AND the owner-task
         # mapping atomically so stale-lock detection works.
-        self._start_session_processing(event, session_key)
+        started = self._start_session_processing(event, session_key)
+        event.dispatch_disposition = (
+            MessageDispatchDisposition.BACKGROUND_STARTED
+            if started
+            else MessageDispatchDisposition.REJECTED
+        )
+        if not started:
+            event.metadata.setdefault("dispatch_reject_reason", "dispatch_start_failed")
+        return event.dispatch_disposition
     
     @staticmethod
     def _get_human_delay() -> float:
@@ -5356,6 +5419,8 @@ class BasePlatformAdapter(ABC):
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
         delivery_succeeded = False
+        lifecycle_completed = False
+        lifecycle_transferred = False
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
@@ -5400,10 +5465,15 @@ class BasePlatformAdapter(ABC):
             )
         
         try:
-            await self._run_processing_hook("on_processing_start", event)
+            if not getattr(event, "_processing_lifecycle_started", False):
+                await self._run_processing_hook("on_processing_start", event)
+                setattr(event, "_processing_lifecycle_started", True)
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            lifecycle_transferred = bool(
+                getattr(event, "_processing_lifecycle_transferred", False)
+            )
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
@@ -5806,13 +5876,25 @@ class BasePlatformAdapter(ABC):
                         self.name, len(_response_pre_extract), event.source.chat_id,
                     )
 
-            # Determine overall success for the processing hook
-            processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            # A running GatewayRunner can accept this event into its own
+            # pending queue after the platform task has already started. The
+            # queued turn owns the eventual completion hook and pending drain.
+            if lifecycle_transferred:
+                return
+
+            # A late dispatch rejection is a processing failure even when the
+            # handler had no user-visible response to deliver.
+            processing_ok = (
+                False
+                if event.dispatch_disposition is MessageDispatchDisposition.REJECTED
+                else (delivery_succeeded if delivery_attempted else not bool(response))
+            )
             await self._run_processing_hook(
                 "on_processing_complete",
                 event,
                 ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE,
             )
+            lifecycle_completed = True
 
             # The active drain owns debounce state. If a queue-mode timer has
             # not fired yet, force-flush into _pending_messages here and let
@@ -5863,10 +5945,14 @@ class BasePlatformAdapter(ABC):
             outcome = ProcessingOutcome.CANCELLED
             if current_task is None or current_task not in self._expected_cancelled_tasks:
                 outcome = ProcessingOutcome.FAILURE
-            await self._run_processing_hook("on_processing_complete", event, outcome)
+            if not lifecycle_completed and not lifecycle_transferred:
+                await self._run_processing_hook("on_processing_complete", event, outcome)
             raise
         except Exception as e:
-            await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
+            if not lifecycle_completed and not lifecycle_transferred:
+                await self._run_processing_hook(
+                    "on_processing_complete", event, ProcessingOutcome.FAILURE
+                )
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
             try:
@@ -5908,7 +5994,9 @@ class BasePlatformAdapter(ABC):
                 "_hermes_run_generation",
                 None,
             )
-            if hasattr(self, "pop_post_delivery_callback"):
+            if lifecycle_transferred:
+                _post_cb = None
+            elif hasattr(self, "pop_post_delivery_callback"):
                 _post_cb = self.pop_post_delivery_callback(
                     session_key,
                     generation=_callback_generation,
@@ -5936,7 +6024,8 @@ class BasePlatformAdapter(ABC):
             )
             # Final drain/release boundary: force-flush any timer that missed
             # the in-band drain before deciding whether the guard can clear.
-            await self._flush_text_debounce_now(session_key)
+            if not lifecycle_transferred:
+                await self._flush_text_debounce_now(session_key)
             # Late-arrival drain: a message may have arrived during the
             # cleanup awaits above (typing_task cancel, stop_typing).  Such
             # messages passed the Level-1 guard (entry still live, Event
@@ -5944,8 +6033,32 @@ class BasePlatformAdapter(ABC):
             # busy-handler path.  Without this block, we would delete the
             # active-session entry and the queued message would be silently
             # dropped (user never gets a reply).
-            late_pending = self._pending_messages.pop(session_key, None)
+            requires_adapter_drain = bool(
+                getattr(
+                    event,
+                    "_processing_lifecycle_requires_adapter_drain",
+                    False,
+                )
+            )
+            late_pending = (
+                self._pending_messages.pop(session_key, None)
+                if not lifecycle_transferred or requires_adapter_drain
+                else None
+            )
             if late_pending is not None:
+                if getattr(
+                    late_pending,
+                    "_processing_lifecycle_requires_adapter_drain",
+                    False,
+                ):
+                    delattr(
+                        late_pending,
+                        "_processing_lifecycle_requires_adapter_drain",
+                    )
+                    delattr(
+                        late_pending,
+                        "_processing_lifecycle_transferred",
+                    )
                 current_task = asyncio.current_task()
                 existing_task = self._session_tasks.get(session_key)
                 if (

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -63,6 +63,7 @@ except ImportError:
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    MessageDispatchDisposition,
     MessageEvent,
     MessageType,
     SendResult,
@@ -924,11 +925,11 @@ class QQAdapter(BasePlatformAdapter):
     # Inbound message handling
     # ------------------------------------------------------------------
 
-    async def handle_message(self, event: MessageEvent) -> None:
+    async def handle_message(self, event: MessageEvent) -> MessageDispatchDisposition:
         """Cache the last message ID per chat, then delegate to base."""
         if event.message_id and event.source.chat_id:
             self._last_msg_id[event.source.chat_id] = event.message_id
-        await super().handle_message(event)
+        return await super().handle_message(event)
 
     async def _on_message(self, event_type: str, d: Any) -> None:
         """Process an inbound QQ Bot message event."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2203,8 +2203,10 @@ from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
+    MessageDispatchDisposition,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     merge_pending_message_event,
@@ -3239,6 +3241,17 @@ def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     return True
 
 
+_DIRECT_TURN_OUTCOME_KEY = "_hermes_direct_turn_outcome"
+
+
+def _processing_outcome_for_agent_result(result: dict) -> ProcessingOutcome:
+    if result.get("interrupted"):
+        return ProcessingOutcome.CANCELLED
+    if result.get("failed"):
+        return ProcessingOutcome.FAILURE
+    return ProcessingOutcome.SUCCESS
+
+
 def _preserve_queued_followup_history_offset(
     current_result: dict,
     followup_result: dict,
@@ -3259,15 +3272,19 @@ def _preserve_queued_followup_history_offset(
     if not isinstance(current_result, dict):
         return followup_result
 
+    merged = dict(followup_result)
+    direct_outcome = current_result.get(_DIRECT_TURN_OUTCOME_KEY)
+    if direct_outcome is not None:
+        # The caller needs the direct recursive turn's result, not the
+        # deepest queued descendant's result, to close that event's lifecycle.
+        merged[_DIRECT_TURN_OUTCOME_KEY] = direct_outcome
+
     current_offset = current_result.get("history_offset")
     followup_offset = followup_result.get("history_offset")
-    if not isinstance(current_offset, int):
-        return followup_result
-    if isinstance(followup_offset, int) and followup_offset <= current_offset:
-        return followup_result
-
-    merged = dict(followup_result)
-    merged["history_offset"] = current_offset
+    if isinstance(current_offset, int) and (
+        not isinstance(followup_offset, int) or followup_offset > current_offset
+    ):
+        merged["history_offset"] = current_offset
     return merged
 
 
@@ -5187,13 +5204,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # it up.  Clearing happens on /new and /reset via
     # _handle_reset_command.
 
-    def _enqueue_fifo(self, session_key: str, queued_event: "MessageEvent", adapter: Any) -> None:
+    def _enqueue_fifo(self, session_key: str, queued_event: "MessageEvent", adapter: Any) -> bool:
         """Append a /queue event to the FIFO chain for a session."""
         if adapter is None:
-            return
+            queued_event.metadata.setdefault("dispatch_reject_reason", "transport_unavailable")
+            return False
         pending_slot = getattr(adapter, "_pending_messages", None)
         if pending_slot is None:
-            return
+            queued_event.metadata.setdefault("dispatch_reject_reason", "transport_unavailable")
+            return False
         queued_events = getattr(self, "_queued_events", None)
         if queued_events is None:
             queued_events = {}
@@ -5202,6 +5221,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             queued_events.setdefault(session_key, []).append(queued_event)
         else:
             pending_slot[session_key] = queued_event
+        return True
 
     def _promote_queued_event(
         self,
@@ -6121,10 +6141,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # still small enough to never threaten memory.
     _BUSY_QUEUE_MAX_PENDING = 32
 
-    def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
+    def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> bool:
         adapter = self._adapter_for_source(event.source)
         if not adapter:
-            return
+            event.metadata.setdefault("dispatch_reject_reason", "transport_unavailable")
+            return False
         # #28503 — Previously this called ``merge_pending_message_event``
         # with the default ``merge_text=False``, which silently OVERWROTE
         # the single pending slot when consecutive text messages arrived
@@ -6148,25 +6169,79 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 event,
                 merge_text=event.message_type == MessageType.TEXT,
             )
-            return
+            return True
 
         if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
+            event.metadata.setdefault("dispatch_reject_reason", "queue_full")
             logger.warning(
                 "Dropping busy-mode follow-up for session %s — pending queue at cap (%d).",
                 session_key,
                 self._BUSY_QUEUE_MAX_PENDING,
             )
-            return
+            return False
 
-        self._enqueue_fifo(session_key, event, adapter)
+        return self._enqueue_fifo(session_key, event, adapter)
 
-    async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
+    def _transfer_processing_lifecycle_to_queue(
+        self,
+        session_key: str,
+        event: MessageEvent,
+        *,
+        merge_text: bool = False,
+        adapter_drain: bool = False,
+    ) -> bool:
+        """Queue an already-started platform event without closing its lifecycle.
+
+        This covers the narrow PRIORITY race where the platform adapter did
+        not see an active-session guard, started background processing, and
+        the GatewayRunner then discovered that the same session already had a
+        running agent. The current adapter task has already emitted
+        ``on_processing_start``; the queued turn must emit the single matching
+        completion after it actually runs.
+        """
+        if merge_text:
+            adapter = self._adapter_for_source(event.source)
+            if adapter is None:
+                event.metadata.setdefault(
+                    "dispatch_reject_reason",
+                    "transport_unavailable",
+                )
+                queued = False
+            else:
+                merge_pending_message_event(
+                    adapter._pending_messages,
+                    session_key,
+                    event,
+                    merge_text=True,
+                )
+                queued = True
+        else:
+            queued = self._queue_or_replace_pending_event(session_key, event)
+        if not queued:
+            event.dispatch_disposition = MessageDispatchDisposition.REJECTED
+            return False
+        event.dispatch_disposition = MessageDispatchDisposition.PENDING_QUEUED
+        setattr(event, "_processing_lifecycle_transferred", True)
+        if adapter_drain:
+            setattr(event, "_processing_lifecycle_requires_adapter_drain", True)
+        return True
+
+    async def _handle_active_session_busy_message(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ) -> bool:
+        def handled(disposition: MessageDispatchDisposition) -> bool:
+            event.dispatch_disposition = disposition
+            return True
+
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
         # creating a session.  The busy path must enforce the same check;
         # otherwise unauthorized users in shared threads (Slack/Telegram/Discord)
         # can inject messages into an active session they don't own.
         if not self._is_user_authorized(event.source):
+            event.metadata.setdefault("dispatch_reject_reason", "permission_denied")
             logger.warning(
                 "Dropping message from unauthorized user in active session: "
                 "user=%s (%s), platform=%s, session=%s",
@@ -6175,21 +6250,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 event.source.platform.value if event.source.platform else "unknown",
                 session_key,
             )
-            return True  # handled (silently dropped); do not fall through
+            return handled(MessageDispatchDisposition.REJECTED)
 
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
             adapter = self._adapter_for_source(event.source)
             if not adapter:
-                return True
+                event.metadata.setdefault("dispatch_reject_reason", "transport_unavailable")
+                return handled(MessageDispatchDisposition.REJECTED)
 
             reply_anchor = self._reply_anchor_for_event(event)
             thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
             if self._queue_during_drain_enabled():
-                self._queue_or_replace_pending_event(session_key, event)
+                if not self._queue_or_replace_pending_event(session_key, event):
+                    return handled(MessageDispatchDisposition.REJECTED)
                 message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                disposition = MessageDispatchDisposition.PENDING_QUEUED
             else:
                 message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                disposition = MessageDispatchDisposition.SYNC_HANDLED
 
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -6203,7 +6282,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ),
                 metadata=thread_meta,
             )
-            return True
+            return handled(disposition)
 
         # --- Approval response routing (#46866) ---
         # When the agent is blocked waiting for a dangerous-command approval,
@@ -6272,7 +6351,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 reply_to=_anchor,
                                 metadata=self._thread_metadata_for_source(event.source, _anchor),
                             )
-                    return True
+                    return handled(MessageDispatchDisposition.SYNC_HANDLED)
         except Exception:
             logger.warning(
                 "Plain-text approval routing failed for session %s; "
@@ -6397,12 +6476,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # turn (#43066 sub-bug 2). The FIFO path gives each text its own
         # turn in arrival order while still preserving photo-burst / album
         # merge semantics for media.
-        if not steered and not redirected:
-            self._queue_or_replace_pending_event(session_key, event)
+        if (
+            not steered
+            and not redirected
+            and not self._queue_or_replace_pending_event(session_key, event)
+        ):
+            return handled(MessageDispatchDisposition.REJECTED)
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
         is_redirect_mode = effective_mode == "interrupt" and redirected
+        disposition = (
+            MessageDispatchDisposition.STEERED
+            if steered or redirected
+            else MessageDispatchDisposition.PENDING_QUEUED
+        )
 
         # If not in queue/steer mode, interrupt the running agent immediately.
         # This aborts in-flight tool calls and causes the agent loop to exit
@@ -6436,7 +6524,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         busy_ack_enabled = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true").lower() == "true"
         if not busy_ack_enabled:
             logger.debug("Busy ack suppressed for session %s", session_key)
-            return True  # input still processed, just no ack sent
+            return handled(disposition)
 
         # Debounce before consulting config-heavy display settings. Rapid
         # follow-ups should be processed but should not trigger another config
@@ -6445,7 +6533,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         now = time.time()
         last_ack = self._busy_ack_ts.get(session_key, 0)
         if now - last_ack < _BUSY_ACK_COOLDOWN:
-            return True  # interrupt sent (if not queue), ack already delivered recently
+            return handled(disposition)
 
         from gateway.display_config import resolve_display_setting
         platform_key = _platform_config_key(event.source.platform)
@@ -6469,7 +6557,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             if not steer_ack_enabled:
                 logger.debug("Busy steer ack suppressed for session %s", session_key)
-                return True
+                return handled(disposition)
 
         self._busy_ack_ts[session_key] = now
 
@@ -6569,7 +6657,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to apply busy-input onboarding hint: %s", _onb_err)
 
         reply_anchor = self._reply_anchor_for_event(event)
-        thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+        thread_meta = dict(self._thread_metadata_for_source(event.source, reply_anchor) or {})
+        thread_meta.update(
+            {
+                "gateway_notice_kind": "busy_ack",
+                "busy_input_mode": effective_mode,
+            }
+        )
         try:
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -6586,7 +6680,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.debug("Failed to send busy-ack: %s", e)
 
-        return True
+        return handled(disposition)
 
     async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
@@ -11424,29 +11518,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # fields silently lost the attachment when the queued turn ran.
                 has_media = bool(getattr(event, "media_urls", None))
                 if not queued_text and not has_media:
+                    event.dispatch_disposition = MessageDispatchDisposition.SYNC_HANDLED
                     return "Usage: /queue <prompt>"
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    queued_event = MessageEvent(
+                    queued_event = dataclasses.replace(
+                        event,
                         text=queued_text,
                         message_type=event.message_type if has_media else MessageType.TEXT,
-                        source=event.source,
-                        raw_message=event.raw_message,
-                        message_id=event.message_id,
-                        media_urls=list(getattr(event, "media_urls", []) or []),
-                        media_types=list(getattr(event, "media_types", []) or []),
-                        reply_to_message_id=event.reply_to_message_id,
-                        reply_to_text=event.reply_to_text,
-                        reply_to_author_id=event.reply_to_author_id,
-                        reply_to_author_name=event.reply_to_author_name,
-                        reply_to_is_own_message=event.reply_to_is_own_message,
-                        auto_skill=event.auto_skill,
-                        channel_prompt=event.channel_prompt,
-                        channel_context=event.channel_context,
-                        internal=event.internal,
-                        timestamp=event.timestamp,
+                        dispatch_disposition=None,
                     )
-                    self._enqueue_fifo(_quick_key, queued_event, adapter)
+                    queued = self._enqueue_fifo(_quick_key, queued_event, adapter)
+                else:
+                    event.metadata.setdefault("dispatch_reject_reason", "transport_unavailable")
+                    queued = False
+                if not queued and adapter:
+                    event.metadata.setdefault(
+                        "dispatch_reject_reason",
+                        queued_event.metadata.get(
+                            "dispatch_reject_reason",
+                            "transport_unavailable",
+                        ),
+                    )
+                event.dispatch_disposition = (
+                    MessageDispatchDisposition.PENDING_QUEUED
+                    if queued
+                    else MessageDispatchDisposition.REJECTED
+                )
+                if not queued:
+                    return "Could not queue the next turn."
                 depth = self._queue_depth(_quick_key, adapter=self._adapter_for_source(source))
                 if depth <= 1:
                     return "Queued for the next turn."
@@ -11460,44 +11560,70 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _cmd_def_inner and _cmd_def_inner.name == "steer":
                 steer_text = event.get_command_args().strip()
                 if not steer_text:
+                    event.dispatch_disposition = MessageDispatchDisposition.SYNC_HANDLED
                     return "Usage: /steer <prompt>"
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent is _AGENT_PENDING_SENTINEL:
                     # Agent hasn't started yet — queue as turn-boundary fallback.
-                    adapter = self._adapter_for_source(source)
-                    if adapter:
-                        queued_event = MessageEvent(
-                            text=steer_text,
-                            message_type=MessageType.TEXT,
-                            source=event.source,
-                            message_id=event.message_id,
-                            channel_prompt=event.channel_prompt,
-                            channel_context=event.channel_context,
+                    queued_event = dataclasses.replace(
+                        event,
+                        text=steer_text,
+                        message_type=MessageType.TEXT,
+                        dispatch_disposition=None,
+                    )
+                    queued = self._queue_or_replace_pending_event(_quick_key, queued_event)
+                    if not queued:
+                        event.metadata.setdefault(
+                            "dispatch_reject_reason",
+                            queued_event.metadata.get(
+                                "dispatch_reject_reason",
+                                "transport_unavailable",
+                            ),
                         )
-                        adapter._pending_messages[_quick_key] = queued_event
+                    event.dispatch_disposition = (
+                        MessageDispatchDisposition.PENDING_QUEUED
+                        if queued
+                        else MessageDispatchDisposition.REJECTED
+                    )
+                    if not queued:
+                        return "Could not queue /steer while the agent starts."
                     return "Agent still starting — /steer queued for the next turn."
                 if running_agent and hasattr(running_agent, "steer"):
                     try:
                         accepted = running_agent.steer(steer_text)
                     except Exception as exc:
                         logger.warning("Steer failed for session %s: %s", _quick_key, exc)
+                        event.dispatch_disposition = MessageDispatchDisposition.SYNC_HANDLED
                         return f"⚠️ Steer failed: {exc}"
                     if accepted:
+                        event.dispatch_disposition = MessageDispatchDisposition.STEERED
                         preview = steer_text[:60] + ("..." if len(steer_text) > 60 else "")
                         return f"⏩ Steer queued — arrives after the next tool call: '{preview}'"
+                    event.dispatch_disposition = MessageDispatchDisposition.SYNC_HANDLED
                     return "Steer rejected (empty payload)."
                 # Running agent is missing or lacks steer() — fall back to queue.
-                adapter = self._adapter_for_source(source)
-                if adapter:
-                    queued_event = MessageEvent(
-                        text=steer_text,
-                        message_type=MessageType.TEXT,
-                        source=event.source,
-                        message_id=event.message_id,
-                        channel_prompt=event.channel_prompt,
-                        channel_context=event.channel_context,
+                queued_event = dataclasses.replace(
+                    event,
+                    text=steer_text,
+                    message_type=MessageType.TEXT,
+                    dispatch_disposition=None,
+                )
+                queued = self._queue_or_replace_pending_event(_quick_key, queued_event)
+                if not queued:
+                    event.metadata.setdefault(
+                        "dispatch_reject_reason",
+                        queued_event.metadata.get(
+                            "dispatch_reject_reason",
+                            "transport_unavailable",
+                        ),
                     )
-                    adapter._pending_messages[_quick_key] = queued_event
+                event.dispatch_disposition = (
+                    MessageDispatchDisposition.PENDING_QUEUED
+                    if queued
+                    else MessageDispatchDisposition.REJECTED
+                )
+                if not queued:
+                    return "Could not queue /steer fallback."
                 return "No active agent — /steer queued for the next turn."
 
             # /model must not be used while the agent is running.
@@ -11613,15 +11739,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
-                adapter = self._adapter_for_source(source)
-                if adapter:
-                    merge_pending_message_event(adapter._pending_messages, _quick_key, event)
+                self._transfer_processing_lifecycle_to_queue(_quick_key, event)
                 return None
 
             _telegram_followup_grace = float(
                 os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
             )
             _started_at = self._running_agents_ts.get(_quick_key, 0)
+            running_agent = self._running_agents.get(_quick_key)
+            agent_is_pending = running_agent is _AGENT_PENDING_SENTINEL
             if (
                 source.platform == Platform.TELEGRAM
                 and event.message_type == MessageType.TEXT
@@ -11634,21 +11760,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     time.time() - _started_at,
                     _quick_key,
                 )
-                adapter = self._adapter_for_source(source)
-                if adapter:
-                    if self._busy_input_mode == "queue":
-                        self._enqueue_fifo(_quick_key, event, adapter)
-                    else:
-                        merge_pending_message_event(
-                            adapter._pending_messages,
-                            _quick_key,
-                            event,
-                            merge_text=True,
-                        )
+                self._transfer_processing_lifecycle_to_queue(
+                    _quick_key,
+                    event,
+                    merge_text=(
+                        self._busy_input_mode != "queue"
+                        and not agent_is_pending
+                    ),
+                    adapter_drain=agent_is_pending,
+                )
                 return None
 
-            running_agent = self._running_agents.get(_quick_key)
-            if running_agent is _AGENT_PENDING_SENTINEL:
+            if agent_is_pending:
                 # Agent is being set up but not ready yet.
                 if event.get_command() == "stop":
                     # Force-clean the sentinel so the session is unlocked.
@@ -11657,18 +11780,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return EphemeralReply("⚡ Force-stopped. The agent was still starting — session unlocked.")
                 # Queue the message so it will be picked up after the
                 # agent starts.
-                adapter = self._adapter_for_source(source)
-                if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
-                        _quick_key,
-                        event,
-                        merge_text=True,
-                    )
+                self._transfer_processing_lifecycle_to_queue(
+                    _quick_key,
+                    event,
+                    adapter_drain=True,
+                )
                 return None
             if self._draining:
                 if self._queue_during_drain_enabled():
-                    self._queue_or_replace_pending_event(_quick_key, event)
+                    if not self._transfer_processing_lifecycle_to_queue(_quick_key, event):
+                        return "Could not queue the next turn while the gateway is draining."
                 return (
                     f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
                     if self._queue_during_drain_enabled()
@@ -11676,7 +11797,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             if self._busy_input_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
-                self._queue_or_replace_pending_event(_quick_key, event)
+                self._transfer_processing_lifecycle_to_queue(_quick_key, event)
                 return None
             if self._busy_input_mode == "steer":
                 # Steer mode: inject text into the running agent mid-run via
@@ -11698,9 +11819,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         steered = False
                 if steered:
                     logger.debug("PRIORITY steer for session %s", _quick_key)
+                    event.dispatch_disposition = MessageDispatchDisposition.STEERED
                     return None
                 logger.debug("PRIORITY steer-fallback-to-queue for session %s", _quick_key)
-                self._queue_or_replace_pending_event(_quick_key, event)
+                self._transfer_processing_lifecycle_to_queue(_quick_key, event)
                 return None
             # #30170 — Subagent protection (PRIORITY path). Same rationale
             # as ``_handle_active_session_busy_message``: an interrupt
@@ -11716,7 +11838,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "because the running agent has active subagents (#30170)",
                     _quick_key,
                 )
-                self._queue_or_replace_pending_event(_quick_key, event)
+                self._transfer_processing_lifecycle_to_queue(_quick_key, event)
                 return None
             # #56391 — Compression protection (PRIORITY path). Same
             # rationale as ``_handle_active_session_busy_message``: context
@@ -11732,7 +11854,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "because context compression is in flight (#56391)",
                     _quick_key,
                 )
-                self._queue_or_replace_pending_event(_quick_key, event)
+                self._transfer_processing_lifecycle_to_queue(_quick_key, event)
                 return None
             # Text-only corrections redirect the live turn (preserving
             # displayed context) when the runtime supports it; media/voice and
@@ -11748,6 +11870,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     if running_agent.redirect((event.text or "").strip()):
                         logger.debug("PRIORITY redirect for session %s", _quick_key)
+                        event.dispatch_disposition = MessageDispatchDisposition.STEERED
                         return None
                 except Exception as exc:
                     logger.warning(
@@ -11756,6 +11879,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         exc,
                     )
             logger.debug("PRIORITY interrupt for session %s", _quick_key)
+            if not self._transfer_processing_lifecycle_to_queue(_quick_key, event):
+                return None
             _interrupt_text = event.text
             _media_urls = getattr(event, "media_urls", None) or []
             if self._pending_event_audio_paths(event):
@@ -23324,6 +23449,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Check if we were interrupted OR have a queued message (/queue).
             result = result_holder[0]
+            if isinstance(result, dict):
+                result[_DIRECT_TURN_OUTCOME_KEY] = (
+                    _processing_outcome_for_agent_result(result).value
+                )
             adapter = self._adapter_for_source(source)
             
             # Get pending message from adapter.
@@ -23531,86 +23660,105 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # interrupted." is just noise; the user already knows they sent a
                 # new message).
 
-                updated_history = result.get("messages", history)
-                next_source = source
-                next_message = pending
-                next_message_id = None
-                next_channel_prompt = None
-                next_session_key = session_key
-                if pending_event is not None:
-                    next_source = getattr(pending_event, "source", None) or source
-                    if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
-                        logger.info(
-                            "Discarding stale goal continuation for session %s — goal is no longer active",
-                            session_key or "?",
+                followup_outcome = ProcessingOutcome.FAILURE
+                if pending_event is not None and not getattr(
+                    pending_event, "_processing_lifecycle_started", False
+                ):
+                    await adapter._run_processing_hook("on_processing_start", pending_event)
+                    setattr(pending_event, "_processing_lifecycle_started", True)
+                try:
+                    updated_history = result.get("messages", history)
+                    next_source = source
+                    next_message = pending
+                    next_message_id = None
+                    next_channel_prompt = None
+                    next_session_key = session_key
+                    if pending_event is not None:
+                        next_source = getattr(pending_event, "source", None) or source
+                        if self._is_goal_continuation_event(
+                            pending_event
+                        ) and not self._goal_still_active_for_session(session_id):
+                            logger.info(
+                                "Discarding stale goal continuation for session %s — goal is no longer active",
+                                session_key or "?",
+                            )
+                            followup_outcome = ProcessingOutcome.CANCELLED
+                            return result
+                        # Resolve the follow-up's session key BEFORE preparing
+                        # inbound text so native-image buffering uses the same
+                        # key as the recursive turn that consumes it.
+                        try:
+                            next_session_key = self._session_key_for_source(next_source)
+                        except Exception:
+                            logger.debug(
+                                "Queued follow-up session-key resolution failed; reusing %s",
+                                session_key or "?",
+                                exc_info=True,
+                            )
+                        next_message = await self._prepare_profile_scoped_inbound_message_text(
+                            event=pending_event,
+                            source=next_source,
+                            history=updated_history,
+                            session_key=next_session_key,
                         )
-                        return result
-                    # Resolve the follow-up's session key BEFORE preparing the
-                    # inbound text: _prepare_inbound_message_text buffers native
-                    # image paths under the key it is given, and the recursive
-                    # _run_agent below consumes them under next_session_key.
-                    # The write and consume keys must match or the images drop.
-                    try:
-                        next_session_key = self._session_key_for_source(next_source)
-                    except Exception:
-                        logger.debug(
-                            "Queued follow-up session-key resolution failed; reusing %s",
-                            session_key or "?",
-                            exc_info=True,
+                        if next_message is None:
+                            followup_outcome = ProcessingOutcome.SUCCESS
+                            return result
+                        next_message_id = self._reply_anchor_for_event(pending_event)
+                        next_channel_prompt = getattr(
+                            pending_event, "channel_prompt", None
                         )
-                    next_message = await self._prepare_profile_scoped_inbound_message_text(
-                        event=pending_event,
-                        source=next_source,
-                        history=updated_history,
-                        session_key=next_session_key,
+
+                    # Restart typing indicator so the user sees activity while
+                    # the follow-up turn runs.
+                    _followup_adapter = self._adapter_for_source(source)
+                    if _followup_adapter:
+                        try:
+                            await _followup_adapter.send_typing(
+                                source.chat_id,
+                                metadata=_status_thread_metadata,
+                            )
+                        except Exception:
+                            pass
+
+                    # Re-baseline the cached agent's message_count snapshot
+                    # before recursing into the in-band queued follow-up.
+                    await self._refresh_agent_cache_message_count(
+                        session_key, session_id
                     )
-                    if next_message is None:
-                        return result
-                    next_message_id = self._reply_anchor_for_event(pending_event)
-                    next_channel_prompt = getattr(pending_event, "channel_prompt", None)
 
-                # Restart typing indicator so the user sees activity while
-                # the follow-up turn runs.  The outer _process_message_background
-                # typing task is still alive but may be stale.
-                _followup_adapter = self._adapter_for_source(source)
-                if _followup_adapter:
-                    try:
-                        await _followup_adapter.send_typing(
-                            source.chat_id,
-                            metadata=_status_thread_metadata,
+                    followup_result = await self._run_agent(
+                        message=next_message,
+                        context_prompt=context_prompt,
+                        history=updated_history,
+                        source=next_source,
+                        session_id=session_id,
+                        session_key=next_session_key,
+                        run_generation=run_generation,
+                        _interrupt_depth=_interrupt_depth + 1,
+                        event_message_id=next_message_id,
+                        channel_prompt=next_channel_prompt,
+                    )
+                    direct_outcome = followup_result.get(_DIRECT_TURN_OUTCOME_KEY)
+                    if direct_outcome is not None:
+                        followup_outcome = ProcessingOutcome(direct_outcome)
+                    else:
+                        followup_outcome = _processing_outcome_for_agent_result(
+                            followup_result
                         )
-                    except Exception:
-                        pass
-
-                # Re-baseline the cached agent's message_count snapshot before
-                # recursing into the in-band queued (/queue) follow-up turn.
-                # The first turn has completed and flushed its own user +
-                # assistant rows to the SessionDB, so the cross-process
-                # coherence guard (#45966) — which this recursive _run_agent
-                # call re-enters — would otherwise see the grown on-disk count
-                # against the stale build-time snapshot and rebuild the agent
-                # on THIS process's OWN writes, destroying the prompt-cache
-                # prefix #46237 was merged to preserve.  The existing
-                # re-baseline in _handle_message_with_agent only runs after the
-                # whole _run_agent chain unwinds — too late for the in-band
-                # follow-up.  Use the same (session_key, session_id) the
-                # recursive call runs under so the snapshot matches exactly
-                # what the follow-up's guard will consult.  Fail-safe in helper.
-                await self._refresh_agent_cache_message_count(session_key, session_id)
-
-                followup_result = await self._run_agent(
-                    message=next_message,
-                    context_prompt=context_prompt,
-                    history=updated_history,
-                    source=next_source,
-                    session_id=session_id,
-                    session_key=next_session_key,
-                    run_generation=run_generation,
-                    _interrupt_depth=_interrupt_depth + 1,
-                    event_message_id=next_message_id,
-                    channel_prompt=next_channel_prompt,
-                )
-                return _preserve_queued_followup_history_offset(result, followup_result)
+                    return _preserve_queued_followup_history_offset(
+                        result, followup_result
+                    )
+                except asyncio.CancelledError:
+                    followup_outcome = ProcessingOutcome.CANCELLED
+                    raise
+                finally:
+                    if pending_event is not None:
+                        await adapter._run_processing_hook(
+                            "on_processing_complete",
+                            pending_event,
+                            followup_outcome,
+                        )
         finally:
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -25,6 +25,7 @@ sys.modules.setdefault("telegram.constants", _tg.constants)
 sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
 
 from gateway.platforms.base import (
+    MessageDispatchDisposition,
     MessageEvent,
     MessageType,
     Platform,
@@ -198,9 +199,12 @@ class TestBusySessionAck:
         result = await runner._handle_active_session_busy_message(event, sk)
 
         assert result is True  # handled
+        assert event.dispatch_disposition is MessageDispatchDisposition.PENDING_QUEUED
         # Verify ack was sent
         adapter._send_with_retry.assert_called_once()
         call_kwargs = adapter._send_with_retry.call_args
+        assert call_kwargs.kwargs["metadata"]["gateway_notice_kind"] == "busy_ack"
+        assert call_kwargs.kwargs["metadata"]["busy_input_mode"] == "interrupt"
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         if not content and call_kwargs.args:
             # positional args
@@ -231,6 +235,7 @@ class TestBusySessionAck:
 
         agent.redirect.assert_called_once_with("No, use Postgres")
         agent.interrupt.assert_not_called()
+        assert event.dispatch_disposition is MessageDispatchDisposition.STEERED
         assert sk not in adapter._pending_messages
         content = adapter._send_with_retry.call_args.kwargs.get("content", "")
         assert "Redirected current run" in content
@@ -256,8 +261,50 @@ class TestBusySessionAck:
         assert await runner._handle_active_session_busy_message(event, sk) is True
 
         agent.redirect.assert_not_called()
+        assert event.dispatch_disposition is MessageDispatchDisposition.PENDING_QUEUED
         assert adapter._pending_messages[sk] is event
         assert adapter._pending_messages[sk].media_urls == event.media_urls
+
+    @pytest.mark.asyncio
+    async def test_queue_cap_rejects_without_interrupt_or_busy_ack(self):
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="must not be dropped")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+        adapter._pending_messages[sk] = _make_event(text="head")
+        runner._queued_events = {
+            sk: [
+                _make_event(text=f"queued-{index}")
+                for index in range(runner._BUSY_QUEUE_MAX_PENDING - 1)
+            ]
+        }
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        assert event.dispatch_disposition is MessageDispatchDisposition.REJECTED
+        assert event.metadata["dispatch_reject_reason"] == "queue_full"
+        agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_busy_message_reports_permission_denied(self):
+        runner, _sentinel = _make_runner()
+        runner._is_user_authorized = lambda _source: False
+        event = _make_event(text="not allowed")
+
+        result = await runner._handle_active_session_busy_message(
+            event,
+            build_session_key(event.source),
+        )
+
+        assert result is True
+        assert event.dispatch_disposition is MessageDispatchDisposition.REJECTED
+        assert event.metadata["dispatch_reject_reason"] == "permission_denied"
 
     @pytest.mark.asyncio
     async def test_queue_mode_suppresses_interrupt_and_updates_ack(self):
@@ -276,6 +323,7 @@ class TestBusySessionAck:
         with patch("gateway.run.merge_pending_message_event"):
             await runner._handle_active_session_busy_message(event, sk)
 
+        assert event.dispatch_disposition is MessageDispatchDisposition.PENDING_QUEUED
         # VERIFY: Agent was NOT interrupted
         agent.interrupt.assert_not_called()
 
@@ -335,6 +383,7 @@ class TestBusySessionAck:
         with patch("gateway.run.merge_pending_message_event") as mock_merge:
             await runner._handle_active_session_busy_message(event, sk)
 
+        assert event.dispatch_disposition is MessageDispatchDisposition.STEERED
         # VERIFY: Agent was steered, NOT interrupted
         agent.steer.assert_called_once_with("also check the tests")
         agent.interrupt.assert_not_called()
@@ -346,6 +395,8 @@ class TestBusySessionAck:
         adapter._send_with_retry.assert_called_once()
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+        assert call_kwargs.kwargs["metadata"]["gateway_notice_kind"] == "busy_ack"
+        assert call_kwargs.kwargs["metadata"]["busy_input_mode"] == "steer"
         assert "Steered" in content or "steer" in content.lower()
         assert "Interrupting" not in content
 
@@ -375,6 +426,7 @@ class TestBusySessionAck:
 
         await runner._handle_active_session_busy_message(event, sk)
 
+        assert event.dispatch_disposition is MessageDispatchDisposition.STEERED
         agent.steer.assert_called_once_with("also check the tests")
         agent.interrupt.assert_not_called()
         adapter._send_with_retry.assert_not_called()
@@ -655,8 +707,11 @@ class TestBusySessionAck:
         assert "10 min" in content  # elapsed
 
     @pytest.mark.asyncio
-    async def test_telegram_omits_status_detail_by_default(self):
+    async def test_telegram_omits_status_detail_by_default(self, monkeypatch):
         """Telegram busy acks stay concise unless busy_ack_detail is enabled."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -17,7 +17,12 @@ import asyncio
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageDispatchDisposition,
+    MessageEvent,
+    MessageType,
+)
 from gateway.session import SessionSource, build_session_key
 
 
@@ -74,6 +79,40 @@ def _session_key(chat_id="12345"):
         platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"
     )
     return build_session_key(source)
+
+
+@pytest.mark.asyncio
+async def test_new_message_reports_background_lifecycle_owner():
+    adapter = _make_adapter()
+    adapter._start_session_processing = lambda _event, _session_key: True
+
+    result = await adapter.handle_message(_make_event("hello"))
+
+    assert result is MessageDispatchDisposition.BACKGROUND_STARTED
+
+
+@pytest.mark.asyncio
+async def test_failed_background_start_is_rejected():
+    adapter = _make_adapter()
+    adapter._start_session_processing = lambda _event, _session_key: False
+    event = _make_event("hello")
+
+    result = await adapter.handle_message(event)
+
+    assert result is MessageDispatchDisposition.REJECTED
+    assert event.metadata["dispatch_reject_reason"] == "dispatch_start_failed"
+
+
+@pytest.mark.asyncio
+async def test_missing_message_handler_reports_transport_unavailable():
+    adapter = _make_adapter()
+    adapter._message_handler = None
+    event = _make_event("hello")
+
+    result = await adapter.handle_message(event)
+
+    assert result is MessageDispatchDisposition.REJECTED
+    assert event.metadata["dispatch_reject_reason"] == "transport_unavailable"
 
 
 # ---------------------------------------------------------------------------
@@ -155,8 +194,9 @@ class TestCommandBypassActiveSession:
         sk = _session_key()
         adapter._active_sessions[sk] = asyncio.Event()
 
-        await adapter.handle_message(_make_event("/status"))
+        result = await adapter.handle_message(_make_event("/status"))
 
+        assert result is MessageDispatchDisposition.SYNC_HANDLED
         assert sk not in adapter._pending_messages
         assert any("handled:status" in r for r in adapter.sent_responses)
 

--- a/tests/gateway/test_dispatch_lifecycle_transfer.py
+++ b/tests/gateway/test_dispatch_lifecycle_transfer.py
@@ -1,0 +1,94 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageDispatchDisposition,
+    MessageEvent,
+    SendResult,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+class LifecycleAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(
+            PlatformConfig(enabled=True, token="test", typing_indicator=False),
+            Platform.TELEGRAM,
+        )
+        self.processing_hooks = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="sent-1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+    async def on_processing_start(self, event):
+        self.processing_hooks.append(("start", event.message_id, None))
+
+    async def on_processing_complete(self, event, outcome):
+        self.processing_hooks.append(("complete", event.message_id, outcome))
+
+
+def _priority_runner(adapter, session_key):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config = SimpleNamespace(
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+    runner._startup_restore_in_progress = False
+    runner._update_prompt_pending = {}
+    runner._running_agents = {session_key: SimpleNamespace(interrupt=lambda _text: None)}
+    runner._running_agents_ts = {}
+    runner._queued_events = {}
+    runner._draining = False
+    runner._busy_input_mode = "queue"
+    runner._restart_requested = False
+    runner._session_db = None
+    runner.session_store = None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_base_priority_queue_transfers_lifecycle_without_early_complete():
+    adapter = LifecycleAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="user-1",
+    )
+    session_key = build_session_key(source)
+    runner = _priority_runner(adapter, session_key)
+    adapter.set_message_handler(runner._handle_message)
+
+    event = MessageEvent(
+        text="second request",
+        source=source,
+        message_id="request-2",
+        internal=True,
+    )
+
+    disposition = await adapter.handle_message(event)
+    task = adapter._session_tasks[session_key]
+    await asyncio.wait_for(task, timeout=1)
+
+    assert disposition is MessageDispatchDisposition.BACKGROUND_STARTED
+    assert event.dispatch_disposition is MessageDispatchDisposition.PENDING_QUEUED
+    assert getattr(event, "_processing_lifecycle_transferred", False) is True
+    assert adapter._pending_messages[session_key] is event
+    assert adapter.processing_hooks == [("start", "request-2", None)]
+    assert session_key not in adapter._active_sessions

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -19,6 +19,34 @@ def _make_config(**extra):
     return PlatformConfig(enabled=True, extra=extra)
 
 
+@pytest.mark.asyncio
+async def test_handle_message_returns_base_dispatch_disposition():
+    from gateway.platforms.base import (
+        BasePlatformAdapter,
+        MessageDispatchDisposition,
+        MessageEvent,
+    )
+    from gateway.platforms.qqbot import QQAdapter
+
+    adapter = object.__new__(QQAdapter)
+    adapter._last_msg_id = {}
+    event = MessageEvent(
+        text="hello",
+        source=mock.MagicMock(chat_id="chat-1"),
+        message_id="message-1",
+    )
+
+    with mock.patch.object(
+        BasePlatformAdapter,
+        "handle_message",
+        mock.AsyncMock(return_value=MessageDispatchDisposition.PENDING_QUEUED),
+    ):
+        result = await QQAdapter.handle_message(adapter, event)
+
+    assert result is MessageDispatchDisposition.PENDING_QUEUED
+    assert adapter._last_msg_id == {"chat-1": "message-1"}
+
+
 # ---------------------------------------------------------------------------
 # check_qq_requirements
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_queue_command.py
+++ b/tests/gateway/test_queue_command.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import MessageDispatchDisposition, MessageEvent, MessageType
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
@@ -97,6 +97,7 @@ async def test_queue_text_only_queues_and_does_not_interrupt():
     result = await runner._handle_message(event)
 
     assert result is not None and "queued" in result.lower()
+    assert event.dispatch_disposition is MessageDispatchDisposition.PENDING_QUEUED
     running_agent.interrupt.assert_not_called()
     assert sk in adapter._pending_messages
     queued = adapter._pending_messages[sk]
@@ -203,6 +204,7 @@ async def test_queue_no_text_no_media_returns_usage():
     result = await runner._handle_message(event)
 
     assert result is not None and "Usage" in result
+    assert event.dispatch_disposition is MessageDispatchDisposition.SYNC_HANDLED
     assert adapter._pending_messages == {}
 
 

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -419,12 +419,16 @@ class TestBusyInputModeQueueFifo:
         session_key = "telegram:user:cap"
 
         cap = GatewayRunner._BUSY_QUEUE_MAX_PENDING
+        accepted = []
         for i in range(cap + 5):
-            runner._queue_or_replace_pending_event(
-                session_key, self._text_event(f"msg-{i:03d}")
+            accepted.append(
+                runner._queue_or_replace_pending_event(
+                    session_key, self._text_event(f"msg-{i:03d}")
+                )
             )
 
         # Exactly ``cap`` follow-ups retained (head + cap-1 in overflow).
+        assert accepted == [True] * cap + [False] * 5
         assert runner._queue_depth(session_key, adapter=adapter) == cap
         assert adapter._pending_messages[session_key].text == "msg-000"
         # The last accepted overflow item is msg-{cap-1}.

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -5,9 +5,16 @@ import types
 from types import SimpleNamespace
 
 import pytest
+from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+)
 from gateway.session import SessionSource
 
 
@@ -21,6 +28,7 @@ class CaptureAdapter(BasePlatformAdapter):
         super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
         self.sent = []
         self.typing = []
+        self.processing_hooks = []
 
     async def connect(self) -> bool:
         return True
@@ -48,6 +56,16 @@ class CaptureAdapter(BasePlatformAdapter):
     async def get_chat_info(self, chat_id: str):
         return {"id": chat_id}
 
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        self.processing_hooks.append(("start", event.message_id, None))
+
+    async def on_processing_complete(
+        self,
+        event: MessageEvent,
+        outcome: ProcessingOutcome,
+    ) -> None:
+        self.processing_hooks.append(("complete", event.message_id, outcome))
+
 
 class CaptureQueuedNativeImageAgent:
     calls = []
@@ -62,6 +80,20 @@ class CaptureQueuedNativeImageAgent:
             "final_response": f"done-{len(type(self).calls)}",
             "messages": [],
             "api_calls": 1,
+        }
+
+
+class SequencedQueuedAgent(CaptureQueuedNativeImageAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls.append(message)
+        call_number = len(type(self).calls)
+        return {
+            "final_response": f"done-{call_number}",
+            "messages": [],
+            "api_calls": 1,
+            "interrupted": call_number == 2,
+            "interrupt_message": "third" if call_number == 2 else None,
+            "history_offset": 0,
         }
 
 
@@ -149,3 +181,122 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
     assert queued_message[0]["type"] == "text"
     assert queued_message[0]["text"].startswith("describe this")
     assert any(part.get("type") == "image_url" for part in queued_message)
+    assert adapter.processing_hooks == [
+        ("start", "queued-1", None),
+        ("complete", "queued-1", ProcessingOutcome.SUCCESS),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_queued_preprocessing_early_return_still_completes_lifecycle(monkeypatch, tmp_path):
+    CaptureQueuedNativeImageAgent.calls = []
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureQueuedNativeImageAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    runner._prepare_inbound_message_text = AsyncMock(return_value=None)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1", chat_type="dm")
+    session_key = "agent:main:telegram:dm:chat-1"
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="@blocked",
+        source=source,
+        message_id="queued-blocked",
+    )
+
+    result = await runner._run_agent(
+        message="first",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done-1"
+    assert adapter.processing_hooks == [
+        ("start", "queued-blocked", None),
+        ("complete", "queued-blocked", ProcessingOutcome.SUCCESS),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_queued_preprocessing_exception_completes_failure(monkeypatch, tmp_path):
+    CaptureQueuedNativeImageAgent.calls = []
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureQueuedNativeImageAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    runner._prepare_inbound_message_text = AsyncMock(side_effect=RuntimeError("prepare failed"))
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1", chat_type="dm")
+    session_key = "agent:main:telegram:dm:chat-1"
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="queued",
+        source=source,
+        message_id="queued-error",
+    )
+
+    with pytest.raises(RuntimeError, match="prepare failed"):
+        await runner._run_agent(
+            message="first",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key=session_key,
+        )
+
+    assert adapter.processing_hooks == [
+        ("start", "queued-error", None),
+        ("complete", "queued-error", ProcessingOutcome.FAILURE),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_nested_queued_turn_uses_its_own_cancelled_outcome(monkeypatch, tmp_path):
+    SequencedQueuedAgent.calls = []
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = SequencedQueuedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    runner._queued_events = {}
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1", chat_type="dm")
+    session_key = "agent:main:telegram:dm:chat-1"
+    second = MessageEvent(text="second", source=source, message_id="queued-2")
+    third = MessageEvent(text="third", source=source, message_id="queued-3")
+    runner._enqueue_fifo(session_key, second, adapter)
+    runner._enqueue_fifo(session_key, third, adapter)
+
+    result = await runner._run_agent(
+        message="first",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done-3"
+    assert adapter.processing_hooks == [
+        ("start", "queued-2", None),
+        ("start", "queued-3", None),
+        ("complete", "queued-3", ProcessingOutcome.SUCCESS),
+        ("complete", "queued-2", ProcessingOutcome.CANCELLED),
+    ]

--- a/tests/gateway/test_steer_command.py
+++ b/tests/gateway/test_steer_command.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageDispatchDisposition, MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
@@ -101,10 +101,12 @@ async def test_steer_calls_agent_steer_and_does_not_interrupt():
     running_agent.steer.return_value = True
     runner._running_agents[sk] = running_agent
 
-    result = await runner._handle_message(_make_event("/steer also check auth.log"))
+    event = _make_event("/steer also check auth.log")
+    result = await runner._handle_message(event)
 
     # The handler replied with a confirmation
     assert result is not None
+    assert event.dispatch_disposition is MessageDispatchDisposition.STEERED
     assert "steer" in result.lower() or "queued" in result.lower()
     # The agent's steer() was called with the payload (prefix stripped)
     running_agent.steer.assert_called_once_with("also check auth.log")
@@ -141,11 +143,14 @@ async def test_steer_with_pending_sentinel_falls_back_to_queue():
     sk = build_session_key(_make_source())
     runner._running_agents[sk] = _AGENT_PENDING_SENTINEL
 
-    result = await runner._handle_message(
-        _make_event("/steer wait up", channel_context="[Thread context]\nAlice: earlier request")
+    event = _make_event(
+        "/steer wait up",
+        channel_context="[Thread context]\nAlice: earlier request",
     )
+    result = await runner._handle_message(event)
 
     assert result is not None
+    assert event.dispatch_disposition is MessageDispatchDisposition.PENDING_QUEUED
     assert "queued" in result.lower() or "starting" in result.lower()
     # The fallback put the full turn payload into the adapter's pending queue.
     assert sk in adapter._pending_messages
@@ -168,11 +173,14 @@ async def test_steer_agent_without_steer_method_falls_back():
     running_agent = MagicMock(spec=[])
     runner._running_agents[sk] = running_agent
 
-    result = await runner._handle_message(
-        _make_event("/steer fallback", channel_context="[Thread context]\nAlice: earlier request")
+    event = _make_event(
+        "/steer fallback",
+        channel_context="[Thread context]\nAlice: earlier request",
     )
+    result = await runner._handle_message(event)
 
     assert result is not None
+    assert event.dispatch_disposition is MessageDispatchDisposition.PENDING_QUEUED
     # Must mention queueing since steer wasn't available
     assert "queued" in result.lower()
     assert sk in adapter._pending_messages
@@ -194,9 +202,11 @@ async def test_steer_rejected_payload_returns_rejection_message():
     running_agent.steer.return_value = False
     runner._running_agents[sk] = running_agent
 
-    result = await runner._handle_message(_make_event("/steer hello"))
+    event = _make_event("/steer hello")
+    result = await runner._handle_message(event)
 
     assert result is not None
+    assert event.dispatch_disposition is MessageDispatchDisposition.SYNC_HANDLED
     assert "rejected" in result.lower() or "empty" in result.lower()
 
 

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -643,6 +643,8 @@ async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegra
         "telegram_dm_topic_reply_fallback": True,
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "463",
+        "gateway_notice_kind": "busy_ack",
+        "busy_input_mode": "interrupt",
     }
 
 

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -65,6 +65,21 @@ When a message arrives from any platform:
    - Otherwise → create `AIAgent` instance and run conversation
 4. **Response** is sent back through the platform adapter
 
+`BasePlatformAdapter.handle_message()` also returns a
+`MessageDispatchDisposition`. `BACKGROUND_STARTED` and `PENDING_QUEUED`
+transfer completion ownership to a background turn; `STEERED` and
+`SYNC_HANDLED` finish synchronously; `REJECTED` means no turn accepted the
+event. Integrations must use this structured result rather than infer
+lifecycle ownership from response text or the presence of an active session.
+`REJECTED` events expose `dispatch_reject_reason` metadata so integrations can
+distinguish `permission_denied`, `transport_unavailable`, `queue_full`, and
+`dispatch_start_failed`. Queued follow-up turns run the normal
+`on_processing_start` / `on_processing_complete` hooks at their recursive turn
+boundary so platform request context follows the queued `MessageEvent`.
+Busy acknowledgments that are actually sent carry
+`gateway_notice_kind=busy_ack` and the effective `busy_input_mode` in send
+metadata.
+
 ### Session Key Format
 
 Session keys encode the full routing context:


### PR DESCRIPTION
## 背景

当 platform adapter 已触发 `on_processing_start`，但 `GatewayRunner` 随后把同一事件转入 queued/steered 路径时，旧实现无法结构化表达 lifecycle ownership。上层 integration 会提前结束或丢失该请求的 processing context，导致实际执行已停止但取消状态无法 terminalize。

## 修复

- 新增 `MessageDispatchDisposition`，让 `handle_message` 明确返回 started、queued、steered、sync handled 或 rejected。
- queued follow-up 接管已经开始的 processing lifecycle，只在真实 turn 完成后发送对应 `on_processing_complete`。
- rejected dispatch 明确返回失败原因，不再把 transport/queue failure 当作正常完成。
- 保留最新主线的 Telegram grace-window 文本合并、`/queue` FIFO 与 media merge 语义。
- pending-sentinel self-bounce 由 adapter 继续 drain，且重派前清理 transfer 标记，保证 lifecycle 恰好 start/complete 一次。
- 更新 gateway lifecycle 文档和行为回归测试。

## 验证

- 受影响 11 个 gateway 测试文件：429 tests passed。
- Ruff 与 `git diff --check`：通过。
- 完整 `tests/gateway/`：11265 passed；发现 2 个与本 patch 相关的最新主线回归并已修复。其余 31 个失败来自本机 macOS `/tmp` 规范化、测试域名被本地网络解析到 `198.18.7.x` 后触发 SSRF 防护，以及可选平台依赖环境；等待 GitHub CI 在标准环境复核。
