### PR TITLE
fix(qqbot): migrate API domain from api.sgroup.qq.com to api.bot.qq.com

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2,7 +2,7 @@
 QQ Bot platform adapter using the Official QQ Bot API (v2).
 
 Connects to the QQ Bot WebSocket Gateway for inbound events and uses the
-REST API (``api.sgroup.qq.com``) for outbound messages and media uploads.
+REST API (``api.bot.qq.com``) for outbound messages and media uploads.
 
 Configuration in config.yaml:
     platforms:

--- a/gateway/platforms/qqbot/constants.py
+++ b/gateway/platforms/qqbot/constants.py
@@ -8,7 +8,7 @@ import os
 # QQBot adapter version — bump on functional changes to the adapter package.
 # ---------------------------------------------------------------------------
 
-QQBOT_VERSION = "1.1.0"
+QQBOT_VERSION = "1.2.0"
 
 # ---------------------------------------------------------------------------
 # API endpoints
@@ -18,7 +18,10 @@ QQBOT_VERSION = "1.1.0"
 # or test environments.  Default: q.qq.com (production).
 PORTAL_HOST = os.getenv("QQ_PORTAL_HOST", "q.qq.com")
 
-API_BASE = "https://api.sgroup.qq.com"
+# QQ Bot API base URL.  The platform migrated from api.sgroup.qq.com to
+# api.bot.qq.com (see issue #73378).  Set QQ_API_BASE to override — e.g. for
+# corporate proxies that still point at the old domain, or for testing.
+API_BASE = os.getenv("QQ_API_BASE", "https://api.bot.qq.com")
 TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken"
 GATEWAY_URL_PATH = "/gateway"
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1,6 +1,7 @@
 """Tests for the QQ Bot platform adapter."""
 
 import asyncio
+import importlib
 import os
 from types import SimpleNamespace
 from unittest import mock
@@ -17,6 +18,27 @@ from gateway.config import PlatformConfig
 def _make_config(**extra):
     """Build a PlatformConfig(enabled=True, extra=extra) for testing."""
     return PlatformConfig(enabled=True, extra=extra)
+
+
+@pytest.fixture
+def _reload_qqbot_modules(monkeypatch):
+    import gateway.platforms.qqbot.adapter as adapter_mod
+    import gateway.platforms.qqbot.constants as constants_mod
+
+    def _reload(api_base=None):
+        if api_base is None:
+            monkeypatch.delenv("QQ_API_BASE", raising=False)
+        else:
+            monkeypatch.setenv("QQ_API_BASE", api_base)
+        importlib.reload(constants_mod)
+        importlib.reload(adapter_mod)
+        return constants_mod, adapter_mod
+
+    yield _reload
+
+    monkeypatch.delenv("QQ_API_BASE", raising=False)
+    importlib.reload(constants_mod)
+    importlib.reload(adapter_mod)
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +270,51 @@ class TestQQWebSocketProxy:
 
         assert seen_session_kwargs.get("trust_env") is True
         assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"
+
+
+class TestQQGatewayUrl:
+    @pytest.mark.asyncio
+    async def test_get_gateway_url_uses_default_api_base(self, _reload_qqbot_modules):
+        _constants_mod, adapter_mod = _reload_qqbot_modules()
+        QQAdapter = adapter_mod.QQAdapter
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._ensure_token = mock.AsyncMock(return_value="tok")
+        response = mock.Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"url": "wss://gateway.qq.test/ws"}
+        adapter._http_client = mock.AsyncMock()
+        adapter._http_client.get = mock.AsyncMock(return_value=response)
+
+        url = await adapter._get_gateway_url()
+
+        assert url == "wss://gateway.qq.test/ws"
+        adapter._http_client.get.assert_awaited_once()
+        assert (
+            adapter._http_client.get.await_args.args[0]
+            == "https://api.bot.qq.com/gateway"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_gateway_url_honors_api_base_override(self, _reload_qqbot_modules):
+        _constants_mod, adapter_mod = _reload_qqbot_modules("https://proxy.qq.example")
+        QQAdapter = adapter_mod.QQAdapter
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._ensure_token = mock.AsyncMock(return_value="tok")
+        response = mock.Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"url": "wss://gateway.qq.test/ws"}
+        adapter._http_client = mock.AsyncMock()
+        adapter._http_client.get = mock.AsyncMock(return_value=response)
+
+        await adapter._get_gateway_url()
+
+        adapter._http_client.get.assert_awaited_once()
+        assert (
+            adapter._http_client.get.await_args.args[0]
+            == "https://proxy.qq.example/gateway"
+        )
 
 # ---------------------------------------------------------------------------
 # _strip_at_mention

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -244,7 +244,7 @@ class TestQQWebSocketProxy:
                 return mock.AsyncMock(closed=False)
 
         with mock.patch("gateway.platforms.qqbot.adapter.aiohttp.ClientSession", side_effect=FakeSession):
-            await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
+            await adapter._open_ws("wss://api.bot.qq.com/websocket")
 
         assert seen_session_kwargs.get("trust_env") is True
         assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1,6 +1,7 @@
 """Tests for tools/send_message_tool.py."""
 
 import asyncio
+import importlib
 import json
 import os
 import sys
@@ -232,6 +233,24 @@ class _patch_slack_standalone_sender:
 
 def _run_async_immediately(coro):
     return asyncio.run(coro)
+
+
+@pytest.fixture
+def _reload_qqbot_constants(monkeypatch):
+    import gateway.platforms.qqbot.constants as constants_mod
+
+    def _reload(api_base=None):
+        if api_base is None:
+            monkeypatch.delenv("QQ_API_BASE", raising=False)
+        else:
+            monkeypatch.setenv("QQ_API_BASE", api_base)
+        importlib.reload(constants_mod)
+        return constants_mod
+
+    yield _reload
+
+    monkeypatch.delenv("QQ_API_BASE", raising=False)
+    importlib.reload(constants_mod)
 
 
 def _make_config():
@@ -2744,6 +2763,38 @@ def _install_signal_http(monkeypatch, fake):
     monkeypatch.setattr(httpx, "AsyncClient", fake)
 
 
+class _FakeQQBotResponse:
+    def __init__(self, status_code, data):
+        self.status_code = status_code
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+class _FakeQQBotHttp:
+    """Stand-in for httpx.AsyncClient for `_send_qqbot` URL tests."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, *_a, **_kw):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        if not self.responses:
+            raise AssertionError("Unexpected extra POST")
+        return self.responses.pop(0)
+
+
 def _patch_sendmsg_sleep_and_time(monkeypatch, capture: list):
     """Mock asyncio.sleep + time.monotonic in the signal_rate_limit
     module so the scheduler's acquire loop sees synthetic time advancing
@@ -2794,6 +2845,59 @@ class TestSendSignalChunking:
         assert "attachments" not in params
         assert "textStyle" not in params
         assert "textStyles" not in params
+
+
+class TestSendQQBot:
+    def test_direct_send_uses_default_api_base_for_all_rest_paths(
+        self, monkeypatch, _reload_qqbot_constants
+    ):
+        _reload_qqbot_constants()
+        from tools.send_message_tool import _send_qqbot
+
+        fake = _FakeQQBotHttp(
+            [
+                _FakeQQBotResponse(200, {"access_token": "tok"}),
+                _FakeQQBotResponse(404, {}),
+                _FakeQQBotResponse(404, {}),
+                _FakeQQBotResponse(404, {}),
+            ]
+        )
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", fake)
+        pconfig = SimpleNamespace(enabled=True, token="secret", extra={"app_id": "app-1"})
+
+        result = asyncio.run(_send_qqbot(pconfig, "chat-1", "hello"))
+
+        assert "error" in result
+        assert [call["url"] for call in fake.calls] == [
+            "https://bots.qq.com/app/getAppAccessToken",
+            "https://api.bot.qq.com/channels/chat-1/messages",
+            "https://api.bot.qq.com/v2/users/chat-1/messages",
+            "https://api.bot.qq.com/v2/groups/chat-1/messages",
+        ]
+
+    def test_direct_send_honors_api_base_override(
+        self, monkeypatch, _reload_qqbot_constants
+    ):
+        _reload_qqbot_constants("https://proxy.qq.example")
+        from tools.send_message_tool import _send_qqbot
+
+        fake = _FakeQQBotHttp(
+            [
+                _FakeQQBotResponse(200, {"access_token": "tok"}),
+                _FakeQQBotResponse(200, {"id": "msg-1"}),
+            ]
+        )
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", fake)
+        pconfig = SimpleNamespace(enabled=True, token="secret", extra={"app_id": "app-1"})
+
+        result = asyncio.run(_send_qqbot(pconfig, "chat-1", "hello"))
+
+        assert result["success"] is True
+        assert fake.calls[1]["url"] == "https://proxy.qq.example/channels/chat-1/messages"
 
     def test_text_only_markdown_uses_singular_text_style(self, monkeypatch):
         fake = _FakeSignalHttp([{"result": {"timestamp": 1}}])

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1997,6 +1997,7 @@ async def _send_qqbot(pconfig, chat_id, message):
     """
     try:
         import httpx
+        from gateway.platforms.qqbot.constants import API_BASE
     except ImportError:
         return _error("QQBot direct send requires httpx. Run: pip install httpx")
 
@@ -2031,7 +2032,7 @@ async def _send_qqbot(pconfig, chat_id, message):
             payload = {"content": message[:4000], "msg_type": 0}
 
             # Try channel endpoint first (works for guild channels)
-            url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
+            url = f"{API_BASE}/channels/{chat_id}/messages"
             resp = await client.post(url, json=payload, headers=headers)
             if resp.status_code in {200, 201}:
                 data = resp.json()
@@ -2039,7 +2040,7 @@ async def _send_qqbot(pconfig, chat_id, message):
                         "message_id": data.get("id")}
 
             # If channel endpoint failed (likely "频道不存在"), try C2C endpoint
-            url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
+            url_c2c = f"{API_BASE}/v2/users/{chat_id}/messages"
             resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
             if resp_c2c.status_code in {200, 201}:
                 data = resp_c2c.json()
@@ -2047,7 +2048,7 @@ async def _send_qqbot(pconfig, chat_id, message):
                         "message_id": data.get("id")}
 
             # If C2C also failed, try group endpoint
-            url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
+            url_group = f"{API_BASE}/v2/groups/{chat_id}/messages"
             resp_group = await client.post(url_group, json=payload, headers=headers)
             if resp_group.status_code in {200, 201}:
                 data = resp_group.json()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -444,6 +444,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `QQBOT_HOME_CHANNEL` | QQ user/group openID for cron delivery and notifications |
 | `QQBOT_HOME_CHANNEL_NAME` | Display name for the QQ home channel |
 | `QQ_PORTAL_HOST` | Override the QQ portal host (set to `sandbox.q.qq.com` to route through the sandbox gateway; default: `q.qq.com`). |
+| `QQ_API_BASE` | Override the QQ Bot REST API base for proxies/testing (default: `https://api.bot.qq.com`). Used by gateway discovery and direct-send REST calls. |
 | `QQ_SANDBOX` | Enable QQ sandbox mode for development testing (`true`/`false`) |
 | `MATTERMOST_URL` | Mattermost server URL (e.g. `https://mm.example.com`) |
 | `MATTERMOST_TOKEN` | Bot token or personal access token for Mattermost |

--- a/website/docs/user-guide/messaging/qqbot.md
+++ b/website/docs/user-guide/messaging/qqbot.md
@@ -54,6 +54,7 @@ QQ_CLIENT_SECRET=your-app-secret
 | `QQ_GROUP_ALLOWED_USERS` | Comma-separated group OpenIDs for group access | — |
 | `QQ_ALLOW_ALL_USERS` | Set to `true` to allow all DMs | `false` |
 | `QQ_PORTAL_HOST` | Override the QQ portal host (set to `sandbox.q.qq.com` for sandbox routing) | `q.qq.com` |
+| `QQ_API_BASE` | Override the QQ Bot REST API base for proxies or test mirrors. Used by gateway discovery and direct-send REST calls. | `https://api.bot.qq.com` |
 | `QQ_STT_API_KEY` | API key for voice-to-text provider | — |
 | `QQ_STT_BASE_URL` | (Not read directly — set `platforms.qqbot.extra.stt.baseUrl` in `config.yaml` instead) | n/a |
 | `QQ_STT_MODEL` | STT model name | `glm-asr` |

--- a/website/docs/user-guide/messaging/qqbot.md
+++ b/website/docs/user-guide/messaging/qqbot.md
@@ -119,5 +119,5 @@ This usually means:
 ### Connection errors
 
 - Ensure `aiohttp` and `httpx` are installed: `pip install aiohttp httpx`
-- Check network connectivity to `api.sgroup.qq.com` and the WebSocket gateway
+- Check network connectivity to `api.bot.qq.com` and the WebSocket gateway
 - Review gateway logs for detailed error messages and reconnect behavior

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -375,6 +375,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `QQBOT_HOME_CHANNEL` | cron 投递和通知的 QQ 用户/群 openID |
 | `QQBOT_HOME_CHANNEL_NAME` | QQ 主频道的显示名称 |
 | `QQ_PORTAL_HOST` | 覆盖 QQ portal 主机（设为 `sandbox.q.qq.com` 可通过沙箱 gateway 路由；默认：`q.qq.com`）。 |
+| `QQ_API_BASE` | 覆盖 QQ Bot REST API 基础地址，用于代理/测试（默认：`https://api.bot.qq.com`）。gateway 发现请求和 direct-send REST 调用都会使用它。 |
 | `MATTERMOST_URL` | Mattermost 服务器 URL（例如 `https://mm.example.com`） |
 | `MATTERMOST_TOKEN` | Mattermost 的 bot token 或个人访问 token |
 | `MATTERMOST_ALLOWED_USERS` | 允许向 bot 发送消息的逗号分隔 Mattermost 用户 ID |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/qqbot.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/qqbot.md
@@ -54,6 +54,7 @@ QQ_CLIENT_SECRET=your-app-secret
 | `QQ_GROUP_ALLOWED_USERS` | 允许群组访问的群组 OpenID 列表（逗号分隔） | — |
 | `QQ_ALLOW_ALL_USERS` | 设为 `true` 以允许所有私聊 | `false` |
 | `QQ_PORTAL_HOST` | 覆盖 QQ portal 主机（沙盒路由设为 `sandbox.q.qq.com`） | `q.qq.com` |
+| `QQ_API_BASE` | 覆盖 QQ Bot REST API 基础地址，用于代理或测试镜像。gateway 发现请求和 direct-send REST 调用都会使用它。 | `https://api.bot.qq.com` |
 | `QQ_STT_API_KEY` | 语音转文字提供商的 API 密钥 | — |
 | `QQ_STT_BASE_URL` | （不直接读取——请在 `config.yaml` 中设置 `platforms.qqbot.extra.stt.baseUrl`） | n/a |
 | `QQ_STT_MODEL` | STT 模型名称 | `glm-asr` |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/qqbot.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/qqbot.md
@@ -119,5 +119,5 @@ platforms:
 ### 连接错误
 
 - 确保已安装 `aiohttp` 和 `httpx`：`pip install aiohttp httpx`
-- 检查与 `api.sgroup.qq.com` 及 WebSocket gateway 的网络连通性
+- 检查与 `api.bot.qq.com` 及 WebSocket gateway 的网络连通性
 - 查看 gateway 日志以获取详细错误信息和重连行为


### PR DESCRIPTION
## Summary

Fixes #73378 - QQ Bot adapter fails because the platform has migrated REST API endpoints from the legacy domain api.sgroup.qq.com to api.bot.qq.com. The /gateway endpoint on the old domain now returns HTTP 500, breaking WebSocket connection setup.

## Root Cause

The QQ Bot Open Platform has been transitioning to a new API domain (api.bot.qq.com). The old domain (api.sgroup.qq.com) is being deprecated - the /gateway endpoint already returns 500, and other endpoints may follow.

Our code had two problems:
1. constants.API_BASE was hardcoded to https://api.sgroup.qq.com - used by _get_gateway_url() and all REST API calls
2. send_message_tool.py had 3 inline hardcoded api.sgroup.qq.com URLs instead of referencing constants.API_BASE

Note: The Token endpoint (bots.qq.com/app/getAppAccessToken) was already using the new domain and request body format ({appId, clientSecret}), so no token-related changes were needed.

## Changes

- constants.py: Update API_BASE default to https://api.bot.qq.com; add QQ_API_BASE env var override for backward compatibility; bump QQBOT_VERSION to 1.2.0
- adapter.py: Update module docstring to reference api.bot.qq.com
- send_message_tool.py: Replace 3 hardcoded api.sgroup.qq.com URLs with API_BASE constant; add import
- test_qqbot.py: Update WebSocket URL in proxy test
- qqbot.md (EN): Update domain reference
- qqbot.md (ZH): Update domain reference

## Backward Compatibility

Users behind corporate proxies or with IP-allowlists on the old domain can set: export QQ_API_BASE=https://api.sgroup.qq.com to revert to the legacy domain without code changes.

## Testing

- 166 qqbot tests pass
- Ruff lint passes
- No remaining api.sgroup.qq.com references (except in the migration comment in constants.py)
