### PR TITLE
fix(dashboard): disable ws ping on wildcard bind to prevent GIL-stall false disconnect

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19817,7 +19817,13 @@ def start_server(
     # (idle timeout ~100s) where half-open IS a real failure mode, so keep the
     # ping at 20/20 to detect it promptly and stay under the tunnel's idle
     # window.
-    _is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    # Wildcard hosts (0.0.0.0, ::) are also treated as "local" for ping
+    # purposes — the user binds to all interfaces for LAN access, but GIL
+    # stalls from agent work still block the event loop and trigger false
+    # disconnects via ws_ping. Disabling the keepalive on wildcard binds
+    # avoids this at the cost of slower half-open detection, which is
+    # acceptable on a trusted LAN.
+    _is_loopback = host in ("127.0.0.1", "localhost", "::1", "0.0.0.0", "::")
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning",
         # proxy_headers defaults to False so _ws_client_is_allowed sees

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -125,7 +125,7 @@ def test_start_server_enables_ws_ping_for_half_open_detection(monkeypatch):
     # without requiring a registered provider (a real public bind would raise
     # SystemExit here). The ping window keys off the host, not the auth flag.
     monkeypatch.setattr(web_server, "should_require_auth", lambda *a, **k: False)
-    web_server.start_server(host="0.0.0.0", port=0, open_browser=False)
+    web_server.start_server(host="198.51.100.1", port=0, open_browser=False)
 
     assert captured["ws_ping_interval"] and captured["ws_ping_interval"] > 0
     assert captured["ws_ping_timeout"] and captured["ws_ping_timeout"] > 0


### PR DESCRIPTION
## Problem

When Dashboard is bound to `0.0.0.0` (all interfaces), uvicorn enables `ws_ping_interval=20s` for half-open connection detection (`_is_loopback = False`). However, GIL-heavy agent tasks (subagent delegation, large tool outputs) can stall the event loop for longer than 20s, preventing timely pong responses. This triggers false WebSocket 1006 disconnects → the frontend shows "gateway exited" after repeated reconnect failures.

## Root Cause

`_is_loopback` only recognized `127.0.0.1`, `localhost`, and `::1`. A wildcard bind (`0.0.0.0` or `::`) was treated as a public bind, enabling uvicorn's transport-level WebSocket keepalive ping. The same GIL-stall argument that justifies disabling ping on loopback (see code comments and #53773, #48445, #50005) applies equally to wildcard binds on trusted LANs: there is no middlebox that would silently drop a healthy connection, so the ping provides no liveness value while actively killing recoverable stalls.

## Fix

Expand `_is_loopback` to also include `"0.0.0.0"` and `"::"`, so wildcard binds also disable the transport-level keepalive ping. Updated the test `test_start_server_enables_ws_ping_for_half_open_detection` to use a real non-loopback address (`198.51.100.1`) instead of `0.0.0.0`.

## Trade-off

Wildcard-bind users behind a Cloudflare Tunnel lose 20s half-open detection; the tunnel's own ~100s idle timeout becomes the detect window. This is acceptable for the primary use case (trusted LAN) and avoids the far more common false-disconnect scenario.

## Related

- `ws_ping_interval=None if _is_loopback else 20.0`
- `ws_ping_timeout=None if _is_loopback else 20.0`
