### PR TITLE
fix(mcp): surface child stderr on failed stdio spawn

### DIFF
--- a/tests/tools/test_mcp_stdio_stderr_expose.py
+++ b/tests/tools/test_mcp_stdio_stderr_expose.py
@@ -1,0 +1,175 @@
+"""Regression tests for surfacing child stderr on failed stdio MCP spawns (#73299).
+
+The Windows stdio-MCP bug reporter's central complaint is that a heavy-import
+Node MCP server (Context7, Playwright) fails the handshake with a generic
+``Connection closed`` while the *real* error lives in the child's stderr —
+``Cannot find module 'express'``, ``SyntaxError: ``, ``EADDRINUSE``, etc. —
+that Hermes silently redirects to ``~/.hermes/logs/mcp-stderr.log``.
+
+These tests verify the contract added in this fix: ``_capture_stderr_since``
+returns whatever the child wrote between the snapshot offset and now, and
+``MCPServerTask._attach_child_stderr`` attaches that tail to the exception
+via ``add_note`` (Python 3.11+) without mutating the exception's args.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools import mcp_tool
+
+
+# ---------------------------------------------------------------------------
+# _capture_stderr_since — pure function on the log file
+# ---------------------------------------------------------------------------
+
+
+def test_capture_returns_empty_when_offset_equals_current_size(tmp_path, monkeypatch):
+    log = tmp_path / "mcp-stderr.log"
+    log.write_text("===== [ts] starting MCP server 'x' =====\nold output\n", encoding="utf-8")
+    monkeypatch.setattr(mcp_tool, "_resolve_log_path_for_test", lambda: log, raising=False)
+
+    # Fall back to monkeypatching the import inside the helper. The helper
+    # imports ``get_hermes_home`` from hermes_constants; we patch the symbol
+    # on that module so the helper sees our tmp log file.
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+
+    offset = log.stat().st_size
+    assert mcp_tool._capture_stderr_since(offset) == ""
+
+
+def test_capture_returns_tail_after_offset(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    log = tmp_path / "logs" / "mcp-stderr.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("===== header =====\n", encoding="utf-8")
+    offset = log.stat().st_size
+    with open(log, "a", encoding="utf-8") as f:
+        f.write("Cannot find module 'express'\n    at /srv/dist/index.js:1\n")
+
+    tail = mcp_tool._capture_stderr_since(offset)
+    assert "Cannot find module 'express'" in tail
+    assert "at /srv/dist/index.js:1" in tail
+
+
+def test_capture_returns_empty_when_log_missing(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    assert mcp_tool._capture_stderr_since(0) == ""
+
+
+def test_capture_returns_empty_when_offset_is_negative(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    log = tmp_path / "logs" / "mcp-stderr.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("anything", encoding="utf-8")
+    assert mcp_tool._capture_stderr_since(-1) == ""
+
+
+def test_capture_truncates_when_tail_exceeds_max_bytes(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    log = tmp_path / "logs" / "mcp-stderr.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("h" * 200, encoding="utf-8")
+    offset = log.stat().st_size
+    log.write_text("x" * 8000, encoding="utf-8")
+
+    tail = mcp_tool._capture_stderr_since(offset, max_bytes=4096)
+    assert len(tail) <= 4096
+    assert tail  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# _attach_child_stderr — MCPServerTask method
+# ---------------------------------------------------------------------------
+
+
+def _make_task_stub():
+    """Minimal stand-in for MCPServerTask — only the method under test is real."""
+
+    class _Stub:
+        _attach_child_stderr = mcp_tool.MCPServerTask._attach_child_stderr
+
+    return _Stub()
+
+
+def test_attach_adds_note_with_child_stderr(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    log = tmp_path / "logs" / "mcp-stderr.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("===== header =====\n", encoding="utf-8")
+    offset = log.stat().st_size
+    with open(log, "a", encoding="utf-8") as f:
+        f.write("Error: Cannot find module 'express'\n")
+
+    task = _make_task_stub()
+    exc = RuntimeError("Connection closed")
+    task._attach_child_stderr(exc, offset)
+
+    assert exc.args == ("Connection closed",)
+    notes = getattr(exc, "__notes__", [])
+    assert any("Cannot find module 'express'" in n for n in notes)
+
+
+def test_attach_noop_when_log_has_no_new_bytes(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    log = tmp_path / "logs" / "mcp-stderr.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("only-this\n", encoding="utf-8")
+    offset = log.stat().st_size
+
+    task = _make_task_stub()
+    exc = RuntimeError("Connection closed")
+    task._attach_child_stderr(exc, offset)
+
+    assert exc.args == ("Connection closed",)
+    assert getattr(exc, "__notes__", []) == []
+
+
+def test_attach_noop_when_log_missing(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    task = _make_task_stub()
+    exc = RuntimeError("Connection closed")
+    task._attach_child_stderr(exc, 0)
+    assert getattr(exc, "__notes__", []) == []
+
+
+def test_attach_preserves_args_so_classifiers_unchanged(tmp_path, monkeypatch):
+    """``str(exc)`` must remain the original to keep auth/permanence classifiers stable."""
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    log = tmp_path / "logs" / "mcp-stderr.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("===== header =====\n", encoding="utf-8")
+    offset = log.stat().st_size
+    with open(log, "a", encoding="utf-8") as f:
+        f.write("child: port already in use\n")
+
+    task = _make_task_stub()
+    exc = ConnectionError("Connection closed")
+    task._attach_child_stderr(exc, offset)
+
+    assert str(exc) == "Connection closed"
+    assert repr(exc).startswith("ConnectionError('Connection closed')")
+    # Notes carry the context; the original ``args`` tuple is untouched.
+    assert any("port already in use" in n for n in getattr(exc, "__notes__", []))

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -195,6 +195,45 @@ def _write_stderr_log_header(server_name: str) -> None:
     except Exception:
         pass
 
+
+def _capture_stderr_since(offset: int, max_bytes: int = 4096) -> str:
+    """Return up to ``max_bytes`` of stderr the child wrote after ``offset``.
+
+    Called from the stdio exception path so a failed MCP spawn surfaces the
+    child's own error message (e.g. ``Cannot find module 'express'``,
+    ``SyntaxError`` at parse, ``EADDRINUSE``) instead of a generic
+    ``Connection closed`` (#73299). Returns ``""`` when the log file is
+    unreadable or no new bytes were written. The return is plain text
+    intended to be appended to an exception's repr by the caller.
+    """
+    if offset < 0:
+        return ""
+    # Resolve the log path via the hermes_constants module object so tests
+    # can ``monkeypatch.setattr(hermes_constants, 'get_hermes_home', ...)``
+    # without us re-binding the name at import time. Function-local imports
+    # still go through the standard import system, so the test patch sticks.
+    import hermes_constants
+
+    log_path = hermes_constants.get_hermes_home() / "logs" / "mcp-stderr.log"
+    try:
+        if not log_path.exists():
+            return ""
+        # ``a``-mode fd from ``_get_mcp_stderr_log`` may still hold the
+        # inode, but reading the file via a fresh handle is portable.
+        size = log_path.stat().st_size
+        if size <= offset:
+            return ""
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            f.seek(offset)
+            data = f.read(max_bytes)
+        if not data.strip():
+            return ""
+        # Trim trailing header line (we wrote one *before* offset was taken,
+        # so the header is part of the new tail — keep it as context).
+        return data.rstrip("\n")
+    except Exception:
+        return ""
+
 # ---------------------------------------------------------------------------
 # Graceful import -- MCP SDK is an optional dependency
 # ---------------------------------------------------------------------------
@@ -1906,6 +1945,30 @@ class MCPServerTask:
         # nor reconnect-loop. Reset on each fresh transport connection.
         self._ping_unsupported: bool = False
 
+    def _attach_child_stderr(self, exc: BaseException, offset: int) -> None:
+        """Append child stderr captured since ``offset`` to ``exc`` as notes.
+
+        Avoids touching the original exception's args (which would change
+        ``repr(exc)`` and break auth/permanence classifiers downstream) by
+        using ``add_note()`` on the exception — Python 3.11+'s standard hook
+        for attaching context. Older Python fallbacks store it on a private
+        attribute so a single defensive ``getattr`` pulls it back for the
+        operator-visible log path (#73299).
+        """
+        tail = _capture_stderr_since(offset)
+        if not tail:
+            return
+        note = f"child stderr (tail, ~/.hermes/logs/mcp-stderr.log):\n{tail}"
+        try:
+            exc.add_note(note)
+        except AttributeError:
+            # Python < 3.11 — stash on a private attribute so the warning
+            # log path can still surface it without rewriting ``str(exc)``.
+            try:
+                exc._hermes_child_stderr = tail  # type: ignore[attr-defined]
+            except Exception:
+                pass
+
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
@@ -2447,6 +2510,18 @@ class MCPServerTask:
         # ~/.hermes/logs/mcp-stderr.log.
         _write_stderr_log_header(self.name)
         _errlog = _get_mcp_stderr_log()
+        # Snapshot the stderr log offset *after* the session header has been
+        # written so the tail captured on failure includes the header as
+        # context but not any unrelated earlier-server output (#73299).
+        _stderr_log_offset = 0
+        try:
+            import hermes_constants
+
+            _stderr_log_offset = (
+                hermes_constants.get_hermes_home() / "logs" / "mcp-stderr.log"
+            ).stat().st_size
+        except Exception:
+            _stderr_log_offset = 0
         try:
             async with stdio_client(server_params, errlog=_errlog) as (
                 read_stream,
@@ -2517,6 +2592,14 @@ class MCPServerTask:
                     # _reconnect_event (e.g. future manual /mcp refresh) for
                     # consistency with _run_http.
                     return await self._wait_for_lifecycle_event()
+        except Exception as exc:
+            # Surface the child's own stderr so a failed stdio spawn stops
+            # being a silent "Connection closed" — operators can see *why*
+            # the server died (missing module, syntax error, EADDRINUSE,
+            # Windows-specific heavy-import handshake timeout, etc.) without
+            # manually tailing ~/.hermes/logs/mcp-stderr.log (#73299).
+            self._attach_child_stderr(exc, _stderr_log_offset)
+            raise
         finally:
             # Runs on clean exit, exceptions, AND asyncio cancellation.
             # If any of the spawned PIDs are still alive, the SDK's


### PR DESCRIPTION
## Summary

Closes #73299

A stdio MCP server whose entrypoint imports a heavy module graph (`@upstash/context7-mcp`, `@playwright/mcp` and similar Node servers that pull in `express`, `StreamableHTTPServerTransport`, the browser stack at top-level) fails the Windows stdio handshake with a generic `Connection closed` after ~11s — while the real error (`Cannot find module 'express'`, `SyntaxError`, `EADDRINUSE`, the heavy-import timeout itself) is silently redirected to `~/.hermes/logs/mcp-stderr.log`. Operators have no way to see why the spawn died without manually tailing that file.

This is especially painful on Windows where the default `ProactorEventLoop` (vs the `SelectorEventLoop` used elsewhere in the CLI) is fragile on the MCP stdio handshake — see #61445. The same failure mode also reproduces when a server's command path is wrong, the entry script has a syntax error, or the server's import graph pulls a credential it doesn't have access to under Hermes's filtered subprocess env.

---

## Fix

- `tools/mcp_tool.py::_run_stdio` snapshots the stderr log offset after the session header has been written, and on any exception before the live event loop attaches the captured tail to the exception via `add_note()` (Python 3.11+ standard hook).
- Original exception args are left intact, so auth/permanence classifiers downstream (`_classify_mcp_failure`, `_is_auth_error`) see the same `repr(exc)` they did before — no behavior change for healthy spawns, only new context on failures.
- `_capture_stderr_since(offset)` reads at most 4 KB from the log, resolves the path via `hermes_constants.get_hermes_home()` (so tests can monkeypatch it), and degrades to `""` on any error — the fix never worsens a spawn failure.
- Uses `add_note()` instead of mutating `exc.args` to keep `str(exc)` stable for downstream `re.match` / classifier code paths.

---

## Tests

Added `tests/tools/test_mcp_stdio_stderr_expose.py` (9 cases, all green):
- Tail captured past offset (the user's actual symptom)
- Empty / negative-offset / missing-log cases no-op (no regression)
- Truncation beyond `max_bytes=4096` (large stderr dumps stay bounded)
- `add_note()` is used, not args mutation (classifiers unchanged)
- `str(exc)` and `repr(exc)` unchanged after attach

---

## Why This Is Safe

- Only touches the failure path. Healthy stdio spawns never enter the new except branch.
- The captured tail is at most 4 KB and is plain text — never executable, never logged at INFO level (it lives in the exception's notes, surfaced only when the operator inspects the failure).
- Stdout (the actual MCP JSON-RPC stream) is untouched — errlog only governs stderr.
- Backward-compatible: Python <3.11 fallback stashes the tail on a private `_hermes_child_stderr` attribute so a future defensive `getattr` can pull it back; no behavior change on those versions.

---

## Out of Scope (Deliberately)

- The Windows `SelectorEventLoop` fix for the handshake timeout itself lives in #61445 — this PR does not touch the event loop. Operators still need that fix for the Context7/Playwright heavy-import case to succeed; this PR just makes the failure mode diagnosable when it doesn't.
- HTTP MCP auto-restart — issue's third suggestion — is its own scope and isn't covered here.
- No telemetry, no new env vars, no config changes. The fix is fully transparent: install the patch and the next failed stdio spawn carries its child's own stderr into the exception.

---

## Checklist

- [x] Tests pass — 9/9 new
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** Only the failure path is touched — healthy stdio spawns never enter the new except branch. The captured tail is bounded to 4 KB, degrades safely to `""` on any read error, and is attached via `add_note()` so `str(exc)` / `repr(exc)` stay unchanged for downstream classifiers.

**Type:** 🐛 Bug fix
**Fixes:** #73299