### PR TITLE
Persist inbound platform reply metadata

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2909,7 +2909,16 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     is present — so orphans from session loading or manual message
     manipulation are always caught.
     """
-    # --- Role allowlist: drop messages with roles the API won't accept ---
+    # --- Role allowlist and internal-metadata stripping ---
+    # Platform correlation fields belong in the durable transcript, not on the
+    # provider wire. Strict OpenAI-compatible backends reject unknown message
+    # properties, and chat/message identifiers are private transport metadata.
+    internal_fields = {
+        "platform_metadata",
+        "platform_message_id",
+        "message_id",
+        "_db_persisted",
+    }
     filtered = []
     for msg in messages:
         role = msg.get("role")
@@ -2919,6 +2928,8 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 role,
             )
             continue
+        if any(field in msg for field in internal_fields):
+            msg = {key: value for key, value in msg.items() if key not in internal_fields}
         filtered.append(msg)
     messages = filtered
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1096,6 +1096,7 @@ def run_conversation(
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    persist_user_platform_metadata: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -1164,6 +1165,7 @@ def run_conversation(
         persist_user_timestamp,
         persist_user_display_kind=persist_user_display_kind,
         persist_user_display_metadata=persist_user_display_metadata,
+        persist_user_platform_metadata=persist_user_platform_metadata,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -338,6 +338,7 @@ def build_turn_context(
     *,
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    persist_user_platform_metadata: Optional[Dict[str, str]] = None,
     restore_or_build_system_prompt,
     install_safe_stdio,
     sanitize_surrogates,
@@ -551,6 +552,11 @@ def build_turn_context(
         user_msg["display_kind"] = persist_user_display_kind
         if persist_user_display_metadata:
             user_msg["display_metadata"] = persist_user_display_metadata
+    if persist_user_platform_metadata:
+        user_msg["platform_metadata"] = dict(persist_user_platform_metadata)
+        platform_message_id = persist_user_platform_metadata.get("message_id")
+        if platform_message_id is not None:
+            user_msg["platform_message_id"] = str(platform_message_id)
 
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1973,6 +1973,22 @@ class MessageEvent:
 
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
+
+    def platform_persistence_metadata(self) -> Dict[str, str]:
+        """Return chat-scoped provenance for durable transcript persistence."""
+        metadata: Dict[str, str] = {}
+        source = self.source
+        platform = getattr(source, "platform", None) if source else None
+        if platform is not None:
+            metadata["platform"] = str(getattr(platform, "value", platform))
+        chat_id = getattr(source, "chat_id", None) if source else None
+        if chat_id is not None:
+            metadata["chat_id"] = str(chat_id)
+        if self.message_id is not None:
+            metadata["message_id"] = str(self.message_id)
+        if self.reply_to_message_id is not None:
+            metadata["reply_to_message_id"] = str(self.reply_to_message_id)
+        return metadata
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14219,6 +14219,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
+                persist_user_platform_metadata=event.platform_persistence_metadata(),
                 channel_prompt=event.channel_prompt,
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
@@ -14666,6 +14667,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
                 if event.message_id:
                     _user_entry["message_id"] = str(event.message_id)
+                _platform_metadata = event.platform_persistence_metadata()
+                if _platform_metadata:
+                    _user_entry["platform_metadata"] = _platform_metadata
                 # Dedupe: skip if this platform message_id is already in the
                 # transcript (prevents duplicate user turns on Telegram retries
                 # after transient failures). #47237
@@ -14708,6 +14712,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     }
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
+                    _platform_metadata = event.platform_persistence_metadata()
+                    if _platform_metadata:
+                        _user_entry["platform_metadata"] = _platform_metadata
                     await self.async_session_store.append_to_transcript(
                         session_entry.session_id,
                         _user_entry,
@@ -20286,6 +20293,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_platform_metadata: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -20304,6 +20312,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_platform_metadata=persist_user_platform_metadata,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -20315,6 +20324,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_platform_metadata=persist_user_platform_metadata,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -20436,6 +20446,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_platform_metadata: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -20451,7 +20462,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
-            return await self._run_agent_via_proxy(
+            proxy_result = await self._run_agent_via_proxy(
                 message=message,
                 context_prompt=context_prompt,
                 history=history,
@@ -20461,6 +20472,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 run_generation=run_generation,
                 event_message_id=event_message_id,
             )
+            # The remote API process cannot persist into this gateway's local
+            # transcript. Mark the result for gateway-side persistence and stamp
+            # the inbound user row with the same provenance as the local runtime.
+            proxy_result["agent_persisted"] = False
+            if persist_user_platform_metadata:
+                for proxy_message in proxy_result.get("messages") or []:
+                    if proxy_message.get("role") == "user":
+                        proxy_message["platform_metadata"] = dict(
+                            persist_user_platform_metadata
+                        )
+                        platform_message_id = persist_user_platform_metadata.get(
+                            "message_id"
+                        )
+                        if platform_message_id is not None:
+                            proxy_message["platform_message_id"] = str(
+                                platform_message_id
+                            )
+                        break
+            return proxy_result
 
         from run_agent import AIAgent
         import queue
@@ -22538,6 +22568,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
+                if persist_user_platform_metadata:
+                    _conversation_kwargs["persist_user_platform_metadata"] = persist_user_platform_metadata
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)
@@ -23608,6 +23640,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     run_generation=run_generation,
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
+                    persist_user_platform_metadata=(
+                        pending_event.platform_persistence_metadata()
+                        if pending_event is not None
+                        else None
+                    ),
                     channel_prompt=next_channel_prompt,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14895,6 +14895,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         }
                         if getattr(event, "message_id", None):
                             _user_entry["message_id"] = str(event.message_id)
+                        _platform_metadata = event.platform_persistence_metadata()
+                        if _platform_metadata:
+                            _user_entry["platform_metadata"] = _platform_metadata
                         await self.async_session_store.append_to_transcript(
                             session_entry.session_id,
                             _user_entry,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3083,6 +3083,7 @@ class SessionStore:
             codex_reasoning_items=message.get("codex_reasoning_items") if message.get("role") == "assistant" else None,
             codex_message_items=message.get("codex_message_items") if message.get("role") == "assistant" else None,
             platform_message_id=(message.get("platform_message_id") or message.get("message_id")),
+            platform_metadata=message.get("platform_metadata"),
             observed=bool(message.get("observed")),
             timestamp=message.get("timestamp"),
             # api_content sidecar: the exact bytes sent to the API for

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1307,6 +1307,7 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_reasoning_items TEXT,
     codex_message_items TEXT,
     platform_message_id TEXT,
+    platform_metadata TEXT,
     observed INTEGER DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
     compacted INTEGER NOT NULL DEFAULT 0,
@@ -6810,6 +6811,41 @@ class SessionDB:
             return None
         return meta
 
+    @staticmethod
+    def _encode_platform_metadata(platform_metadata: Any) -> Optional[str]:
+        """Serialize structured inbound-platform provenance as a JSON object."""
+        if not platform_metadata:
+            return None
+        if isinstance(platform_metadata, str):
+            try:
+                platform_metadata = json.loads(platform_metadata)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Ignoring non-JSON platform metadata on write")
+                return None
+        if not isinstance(platform_metadata, dict):
+            logger.warning("Ignoring non-object platform metadata on write")
+            return None
+        try:
+            return json.dumps(platform_metadata)
+        except (TypeError, ValueError):
+            logger.warning("Ignoring non-serializable platform metadata on write")
+            return None
+
+    @staticmethod
+    def _decode_platform_metadata(raw: Any) -> Optional[Dict[str, Any]]:
+        """Decode a ``platform_metadata`` column without exposing invalid rows."""
+        if raw is None:
+            return None
+        try:
+            metadata = json.loads(raw) if isinstance(raw, str) else raw
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Ignoring invalid platform metadata on message row")
+            return None
+        if not isinstance(metadata, dict):
+            logger.warning("Ignoring non-object platform metadata on message row")
+            return None
+        return metadata
+
     def append_message(
         self,
         session_id: str,
@@ -6825,7 +6861,7 @@ class SessionDB:
         reasoning_details: Any = None,
         codex_reasoning_items: Any = None,
         codex_message_items: Any = None,
-        platform_message_id: str = None,
+        platform_message_id: Optional[str] = None,
         observed: bool = False,
         effect_disposition: Optional[str] = None,
         timestamp: Any = None,
@@ -6833,6 +6869,7 @@ class SessionDB:
         display_kind: Optional[str] = None,
         display_metadata: Optional[Dict[str, Any]] = None,
         compression_lock_holder: Optional[str] = None,
+        platform_metadata: Optional[Dict[str, Any]] = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -6841,10 +6878,15 @@ class SessionDB:
         if role is 'tool' or tool_calls is present).
 
         ``platform_message_id`` is the external messaging platform's own
-        message ID (e.g. Telegram update_id, Yuanbao msg_id).  It is
+        message ID (e.g. Telegram message_id, Yuanbao msg_id).  It is
         independent of the SQLite autoincrement primary key and is used by
         platform-specific flows like yuanbao's recall guard to redact a
         message by its platform-side identifier.
+
+        ``platform_metadata`` stores structured, chat-scoped inbound provenance
+        such as the platform, chat ID, message ID, and reply target. It is
+        available to transcript readers but intentionally excluded from the
+        model conversation projection.
 
         ``api_content`` is the exact content string sent to the API for this
         message when it differs from ``content`` (ephemeral memory/plugin
@@ -6857,6 +6899,7 @@ class SessionDB:
         # Display metadata is presentation-only and never changes the model
         # context role/content replayed to providers.
         display_metadata_json = self._encode_display_metadata(display_metadata)
+        platform_metadata_json = self._encode_platform_metadata(platform_metadata)
         # Serialize structured fields to JSON before entering the write txn
         reasoning_details_json = (
             json.dumps(reasoning_details)
@@ -6925,8 +6968,9 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, platform_metadata, observed,
+                   active, api_content, display_kind, display_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -6944,6 +6988,7 @@ class SessionDB:
                     codex_items_json,
                     codex_message_items_json,
                     platform_message_id,
+                    platform_metadata_json,
                     1 if observed else 0,
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
@@ -7066,8 +7111,9 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, platform_metadata, observed,
+                   active, api_content, display_kind, display_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -7085,6 +7131,7 @@ class SessionDB:
                     codex_items_json,
                     codex_message_items_json,
                     platform_msg_id,
+                    self._encode_platform_metadata(msg.get("platform_metadata")),
                     1 if msg.get("observed") else 0,
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
@@ -7140,6 +7187,40 @@ class SessionDB:
                 and session["end_reason"] == "compression"
             ):
                 raise CompressionSessionClosedError(session_id)
+
+            # Model-safe replay intentionally omits platform_metadata, but it
+            # retains the indexed platform message id under ``message_id``.
+            # Transcript rewrites built from that replay shape must not erase
+            # durable reply-correlation metadata. Carry it forward by stable
+            # platform id without mutating the caller's message dictionaries.
+            existing_platform_metadata: Dict[str, Dict[str, str]] = {}
+            for row in conn.execute(
+                "SELECT platform_message_id, platform_metadata FROM messages "
+                f"WHERE session_id = ?{active_clause} "
+                "AND platform_message_id IS NOT NULL "
+                "AND platform_metadata IS NOT NULL",
+                (session_id,),
+            ).fetchall():
+                decoded = self._decode_platform_metadata(row["platform_metadata"])
+                if decoded is not None:
+                    existing_platform_metadata[str(row["platform_message_id"])] = decoded
+
+            messages_to_insert: List[Dict[str, Any]] = []
+            for message in messages:
+                platform_id = message.get("platform_message_id") or message.get(
+                    "message_id"
+                )
+                preserved = (
+                    existing_platform_metadata.get(str(platform_id))
+                    if platform_id is not None
+                    and message.get("platform_metadata") is None
+                    else None
+                )
+                if preserved is not None:
+                    message = dict(message)
+                    message["platform_metadata"] = preserved
+                messages_to_insert.append(message)
+
             conn.execute(
                 f"DELETE FROM messages WHERE session_id = ?{active_clause}",
                 (session_id,),
@@ -7149,7 +7230,7 @@ class SessionDB:
                 (session_id,),
             )
             total_messages, total_tool_calls = self._insert_message_rows(
-                conn, session_id, messages
+                conn, session_id, messages_to_insert
             )
             conn.execute(
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
@@ -7305,6 +7386,8 @@ class SessionDB:
                     msg["tool_calls"] = []
             if msg.get("display_metadata") is not None:
                 msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
+            if msg.get("platform_metadata") is not None:
+                msg["platform_metadata"] = self._decode_platform_metadata(msg["platform_metadata"])
             result.append(msg)
         return result
 
@@ -7376,6 +7459,8 @@ class SessionDB:
                     msg["tool_calls"] = []
             if msg.get("display_metadata") is not None:
                 msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
+            if msg.get("platform_metadata") is not None:
+                msg["platform_metadata"] = self._decode_platform_metadata(msg["platform_metadata"])
             result.append(msg)
 
         # before_rows includes the anchor itself; subtract 1 for the count of
@@ -7500,6 +7585,8 @@ class SessionDB:
                     msg["tool_calls"] = []
             if msg.get("display_metadata") is not None:
                 msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
+            if msg.get("platform_metadata") is not None:
+                msg["platform_metadata"] = self._decode_platform_metadata(msg["platform_metadata"])
             return msg
 
         return {

--- a/run_agent.py
+++ b/run_agent.py
@@ -2109,6 +2109,10 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    platform_message_id=(
+                        msg.get("platform_message_id") or msg.get("message_id")
+                    ),
+                    platform_metadata=msg.get("platform_metadata"),
                     timestamp=_row_timestamp,
                     api_content=_row_api_content,
                     display_kind=(
@@ -7001,6 +7005,7 @@ class AIAgent:
         persist_user_display_kind: Optional[str] = None,
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        persist_user_platform_metadata: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.aux_accounting import (
@@ -7046,6 +7051,7 @@ class AIAgent:
                     persist_user_timestamp=persist_user_timestamp,
                     persist_user_display_kind=persist_user_display_kind,
                     persist_user_display_metadata=persist_user_display_metadata,
+                    persist_user_platform_metadata=persist_user_platform_metadata,
                     moa_config=moa_config,
                 )
             finally:

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -208,6 +208,21 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.active_system_prompt == "SYSTEM"
 
 
+def test_stamps_inbound_platform_metadata_on_current_user_turn():
+    agent = _FakeAgent()
+    metadata = {
+        "platform": "telegram",
+        "chat_id": "8531920232",
+        "message_id": "4456",
+        "reply_to_message_id": "4455",
+    }
+
+    ctx = _build(agent, persist_user_platform_metadata=metadata)
+
+    assert ctx.messages[-1]["platform_message_id"] == "4456"
+    assert ctx.messages[-1]["platform_metadata"] == metadata
+
+
 def test_turn_start_replaces_stale_parent_history_with_compression_child():
     agent = _FakeAgent()
     stale_history = [{"role": "user", "content": "stale parent"}]

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -91,6 +91,7 @@ def _event():
             user_id="12345",
         ),
         message_id="msg-42",
+        reply_to_message_id="msg-41",
     )
 
 
@@ -181,6 +182,17 @@ async def test_agent_failed_early_no_skip_db_when_no_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, False
     )
+    user_message = next(
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") == "user"
+    )
+    assert user_message["platform_metadata"] == {
+        "platform": "telegram",
+        "chat_id": "-1001",
+        "message_id": "msg-42",
+        "reply_to_message_id": "msg-41",
+    }
 
 
 # ── Test 3: not-new-messages path uses skip_db=True ───────────────────
@@ -210,6 +222,17 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+    user_message = next(
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") == "user"
+    )
+    assert user_message["platform_metadata"] == {
+        "platform": "telegram",
+        "chat_id": "-1001",
+        "message_id": "msg-42",
+        "reply_to_message_id": "msg-41",
+    }
 
 
 # ── Post-stream MEDIA delivery keeps prior-turn deduplication ──────────

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -313,3 +313,28 @@ async def test_normal_path_skip_db_when_agent_has_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+
+
+@pytest.mark.asyncio
+async def test_exception_before_agent_start_persists_platform_metadata(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(side_effect=RuntimeError("provider init failed"))
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    user_message = next(
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") == "user"
+    )
+    assert user_message["message_id"] == "msg-42"
+    assert user_message["platform_metadata"] == {
+        "platform": "telegram",
+        "chat_id": "-1001",
+        "message_id": "msg-42",
+        "reply_to_message_id": "msg-41",
+    }

--- a/tests/gateway/test_message_event_platform_metadata.py
+++ b/tests/gateway/test_message_event_platform_metadata.py
@@ -1,0 +1,22 @@
+from gateway.platforms.base import MessageEvent, Platform, SessionSource
+
+
+def test_message_event_builds_chat_scoped_reply_metadata():
+    event = MessageEvent(
+        text="ack",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="42",
+            chat_id="8531920232",
+            chat_type="dm",
+        ),
+        message_id="4456",
+        reply_to_message_id="4455",
+    )
+
+    assert event.platform_persistence_metadata() == {
+        "platform": "telegram",
+        "chat_id": "8531920232",
+        "message_id": "4456",
+        "reply_to_message_id": "4455",
+    }

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -188,6 +188,12 @@ class TestRunAgentProxyDispatch:
 
         runner._run_agent_via_proxy = AsyncMock(return_value=expected_result)
 
+        metadata = {
+            "platform": "telegram",
+            "chat_id": "chat-1",
+            "message_id": "4456",
+            "reply_to_message_id": "4455",
+        }
         result = await runner._run_agent(
             message="hi",
             context_prompt="",
@@ -196,9 +202,13 @@ class TestRunAgentProxyDispatch:
             session_id="test-session-123",
             session_key="test-key",
             run_generation=7,
+            persist_user_platform_metadata=metadata,
         )
 
         assert result["final_response"] == "Hello from remote!"
+        assert result["agent_persisted"] is False
+        assert result["messages"][0]["platform_message_id"] == "4456"
+        assert result["messages"][0]["platform_metadata"] == metadata
         runner._run_agent_via_proxy.assert_called_once()
         assert runner._run_agent_via_proxy.call_args.kwargs["run_generation"] == 7
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7810,3 +7810,55 @@ class TestDisplayMetadataReadPaths:
         )
         assert db.get_messages_as_conversation("s1")[0]["display_metadata"] == self.META
 
+
+def test_message_platform_metadata_round_trips_without_entering_model_history(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="telegram")
+    metadata = {
+        "platform": "telegram",
+        "chat_id": "8531920232",
+        "message_id": "4456",
+        "reply_to_message_id": "4455",
+    }
+
+    db.append_message(
+        "s1",
+        role="user",
+        content="ack",
+        platform_message_id="4456",
+        platform_metadata=metadata,
+    )
+
+    row = db.get_messages("s1")[0]
+    assert row["platform_message_id"] == "4456"
+    assert row["platform_metadata"] == metadata
+    history = db.get_messages_as_conversation("s1")
+    assert history[0]["message_id"] == "4456"
+    assert "platform_metadata" not in history[0]
+
+
+def test_replace_messages_preserves_platform_metadata(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="telegram")
+    metadata = {
+        "platform": "telegram",
+        "chat_id": "8531920232",
+        "message_id": "4456",
+        "reply_to_message_id": "4455",
+    }
+
+    db.replace_messages(
+        "s1",
+        [
+            {
+                "role": "user",
+                "content": "ack",
+                "platform_message_id": "4456",
+                "platform_metadata": metadata,
+            }
+        ],
+    )
+
+    row = db.get_messages("s1")[0]
+    assert row["platform_message_id"] == "4456"
+    assert row["platform_metadata"] == metadata

--- a/tests/test_platform_metadata_persistence.py
+++ b/tests/test_platform_metadata_persistence.py
@@ -1,0 +1,105 @@
+import inspect
+from unittest.mock import MagicMock
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+from agent.agent_runtime_helpers import sanitize_api_messages
+
+
+def test_flush_persists_inbound_platform_metadata():
+    agent = AIAgent.__new__(AIAgent)
+    session_db = MagicMock()
+    attributes = {
+        "_persist_disabled": False,
+        "_session_db": session_db,
+        "_session_db_created": True,
+        "session_id": "session-1",
+        "_persist_user_message_idx": None,
+        "_persist_user_message_override": None,
+        "_persist_user_message_timestamp": None,
+        "_flushed_db_message_session_id": "session-1",
+        "_flushed_db_message_ids": set(),
+        "_last_flushed_db_idx": 0,
+        "_active_compression_lock_holder": None,
+    }
+    for name, value in attributes.items():
+        setattr(agent, name, value)
+
+    metadata = {
+        "platform": "telegram",
+        "chat_id": "8531920232",
+        "message_id": "4456",
+        "reply_to_message_id": "4455",
+    }
+    message = {
+        "role": "user",
+        "content": "ack",
+        "platform_message_id": "4456",
+        "platform_metadata": metadata,
+    }
+
+    assert agent._flush_messages_to_session_db_unlocked([message], []) is True
+
+    kwargs = session_db.append_message.call_args.kwargs
+    assert kwargs["platform_message_id"] == "4456"
+    assert kwargs["platform_metadata"] == metadata
+
+
+def test_provider_payload_strips_platform_correlation_fields():
+    message = {
+        "role": "user",
+        "content": "ack",
+        "message_id": "4456",
+        "platform_message_id": "4456",
+        "_db_persisted": True,
+        "platform_metadata": {
+            "platform": "telegram",
+            "chat_id": "8531920232",
+            "message_id": "4456",
+            "reply_to_message_id": "4455",
+        },
+    }
+
+    sanitized = sanitize_api_messages([message])
+
+    assert sanitized == [{"role": "user", "content": "ack"}]
+    assert "platform_metadata" in message
+
+
+def test_new_run_argument_does_not_shift_existing_moa_position():
+    parameters = list(inspect.signature(AIAgent.run_conversation).parameters)
+
+    assert parameters.index("persist_user_platform_metadata") == (
+        parameters.index("moa_config") + 1
+    )
+
+
+def test_new_append_argument_does_not_shift_existing_positions():
+    parameters = list(inspect.signature(SessionDB.append_message).parameters)
+
+    assert parameters[-1] == "platform_metadata"
+
+
+def test_replace_from_model_safe_replay_preserves_platform_metadata(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(session_id="session-1", source="telegram")
+    metadata = {
+        "platform": "telegram",
+        "chat_id": "8531920232",
+        "message_id": "4456",
+        "reply_to_message_id": "4455",
+    }
+    db.append_message(
+        "session-1",
+        role="user",
+        content="ack",
+        platform_message_id="4456",
+        platform_metadata=metadata,
+    )
+
+    replay = db.get_messages_as_conversation("session-1")
+    assert "platform_metadata" not in replay[0]
+
+    db.replace_messages("session-1", replay)
+
+    assert db.get_messages("session-1")[0]["platform_metadata"] == metadata


### PR DESCRIPTION
## Summary

Persist inbound platform correlation metadata alongside user transcript rows so gateway features can reliably resolve native replies after a restart.

Each inbound `MessageEvent` can now persist:

- platform
- chat ID
- incoming message ID
- replied-to message ID

`platform_message_id` remains a separate indexed column for deduplication and lookup.

## Implementation

- add an additive `messages.platform_metadata` JSON/TEXT column through the existing declarative schema reconciler
- thread metadata through gateway, turn-context, standard agent, Codex, proxy, queued-follow-up, and early-failure persistence paths
- preserve metadata across append, transcript replacement/compaction, export, and import
- decode structured metadata only on raw transcript reads
- strip platform metadata, message IDs, and the internal DB persistence marker from provider-bound message copies without mutating stored history
- append new optional parameters after existing positional parameters to preserve API compatibility

## Tests

- `tests/test_hermes_state.py`: 470 passed, 1 skipped
- focused gateway/agent/Codex/provider-projection suites: 90 passed
- Ruff and `git diff --check`: passed

A full `scripts/run_tests.sh` run was also attempted locally. It reported 27 failures in unrelated macOS/system-integration suites. The four agent/auth failures inspected separately reproduce unchanged on a clean upstream worktree; none involve the files or behavior changed here.
