### PR TITLE
fix(kanban-dashboard): include profiles without tasks in assignee dropdown (#73235)

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -489,13 +489,9 @@ def get_board(
             )
         ]
         # List of distinct assignees for the lane-by-profile sub-grouping.
-        assignees = [
-            r["assignee"]
-            for r in conn.execute(
-                "SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL "
-                "AND status != 'archived' ORDER BY assignee"
-            )
-        ]
+        # Use known_assignees which unions on-disk profiles with DB profiles
+        # so fresh profiles appear in the picker before they've been assigned.
+        assignees = [a["name"] for a in kanban_db.known_assignees(conn)]
 
         return {
             "columns": [


### PR DESCRIPTION
The ASSIGNEE filter dropdown, bulk-reassign dropdown, and DiagnosticCard reassign picker in the kanban dashboard only showed profiles that already had at least one non-archived task. Profiles that existed on disk but had never been assigned — or whose only tasks were archived — were invisible.

**Root cause:** `get_board()` in `plugin_api.py` built its `assignees` list via a raw SQL DISTINCT query on the `tasks` table, returning only profiles with existing tasks.

**Fix:** Replaced the raw SQL with `kanban_db.known_assignees(conn)`, which already correctly unions on-disk profiles (`list_profiles_on_disk()`) with DB profiles. This is the same helper used by `GET /api/assignees`.

**Existing test** `test_known_assignees_merges_disk_and_board` covers the helper; all 175 kanban core tests pass.

Closes #73235