### PR TITLE
fix(logging): report configured custom provider identity

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -88,6 +88,7 @@ from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
+from hermes_cli.runtime_provider import user_facing_provider_identity
 
 logger = logging.getLogger(__name__)
 
@@ -3148,7 +3149,13 @@ def run_conversation(
                         _cache_pct = f" cache={canonical_usage.cache_read_tokens}/{prompt_tokens} ({100*canonical_usage.cache_read_tokens/prompt_tokens:.0f}%)"
                     logger.info(
                         "API call #%d: model=%s provider=%s in=%d out=%d total=%d latency=%.1fs%s",
-                        agent.session_api_calls, agent.model, agent.provider or "unknown",
+                        agent.session_api_calls, agent.model,
+                        user_facing_provider_identity(
+                            provider=agent.provider,
+                            requested_provider=getattr(agent, "requested_provider", ""),
+                            base_url=getattr(agent, "base_url", "") or None,
+                            model=agent.model,
+                        ),
                         prompt_tokens, completion_tokens, total_tokens,
                         api_duration, _cache_pct,
                     )

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -45,6 +45,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
 )
+from hermes_cli.runtime_provider import user_facing_provider_identity
 
 logger = logging.getLogger(__name__)
 
@@ -489,9 +490,17 @@ def build_turn_context(
     _preview_text = summarize_user_message_for_log(user_message)
     _msg_preview = (_preview_text[:80] + "...") if len(_preview_text) > 80 else _preview_text
     _msg_preview = _msg_preview.replace("\n", " ")
+    from hermes_cli.runtime_provider import user_facing_provider_identity
+
     logger.info(
         "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
-        agent.session_id or "none", agent.model, agent.provider or "unknown",
+        agent.session_id or "none", agent.model,
+        user_facing_provider_identity(
+            provider=agent.provider,
+            requested_provider=getattr(agent, "requested_provider", ""),
+            base_url=getattr(agent, "base_url", "") or None,
+            model=agent.model,
+        ),
         agent.platform or "unknown", len(conversation_history or []),
         _msg_preview,
     )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1008,6 +1008,30 @@ def canonical_custom_identity(
     return None
 
 
+def user_facing_provider_identity(
+    *,
+    provider: Optional[str] = None,
+    requested_provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+    model: Optional[str] = None,
+) -> str:
+    """Return the provider identity humans should see in logs and status."""
+    resolved = str(provider or "").strip().lower()
+    requested = str(requested_provider or "").strip().lower()
+    if resolved != "custom":
+        return resolved or requested or "unknown"
+    if requested not in {"", "auto", "custom", "openrouter"}:
+        return requested
+    identity = canonical_custom_identity(
+        base_url=base_url,
+        config_provider=requested_provider,
+        model=model,
+    )
+    if identity and identity.startswith("custom:"):
+        return identity.split(":", 1)[1]
+    return identity or requested or resolved or "unknown"
+
+
 def _normalize_base_url_for_match(value) -> str:
     return str(value or "").strip().rstrip("/").lower()
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4381,6 +4381,19 @@ class AIAgent:
 
     def _client_log_context(self) -> str:
         provider = getattr(self, "provider", "unknown")
+        requested_provider = getattr(self, "requested_provider", "")
+        if str(provider).strip().lower() == "custom":
+            try:
+                from hermes_cli.runtime_provider import user_facing_provider_identity
+
+                provider = user_facing_provider_identity(
+                    provider=provider,
+                    requested_provider=requested_provider,
+                    base_url=getattr(self, "base_url", "") or None,
+                    model=getattr(self, "model", "") or None,
+                )
+            except Exception:
+                provider = requested_provider or provider
         base_url = getattr(self, "base_url", "unknown")
         model = getattr(self, "model", "unknown")
         return (

--- a/tests/hermes_cli/test_custom_provider_identity.py
+++ b/tests/hermes_cli/test_custom_provider_identity.py
@@ -97,3 +97,18 @@ def test_identity_resolves_back_through_named_lookup(monkeypatch):
     assert entry is not None
     assert entry["base_url"] == "https://api.mimo.example/v1"
     assert entry["api_key"] == "sk-entry"
+
+
+def test_user_facing_identity_uses_named_provider_for_runtime_custom(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "canonical_custom_identity",
+        lambda **_kwargs: "custom:cockpit-local",
+    )
+
+    assert rp.user_facing_provider_identity(
+        provider="custom",
+        requested_provider="cockpit-local",
+        base_url="http://localhost:58730/v1",
+        model="gpt-5.6-luna",
+    ) == "cockpit-local"

--- a/tests/run_agent/test_callable_api_key.py
+++ b/tests/run_agent/test_callable_api_key.py
@@ -82,6 +82,21 @@ class TestCreateOpenAIClientCallable:
         )
         assert client is not None
 
+    def test_client_log_context_uses_requested_custom_provider_identity(self):
+        """Logs should identify a named custom provider, not its wire class."""
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.provider = "custom"
+        agent.requested_provider = "cockpit-local"
+        agent.model = "gpt-5.6-luna"
+        agent.base_url = "http://localhost:58730/v1"
+
+        context = agent._client_log_context()
+
+        assert "provider=cockpit-local" in context
+        assert "provider=custom" not in context
+
 
 # ---------------------------------------------------------------------------
 # Auxiliary runtime preserves the callable


### PR DESCRIPTION
## Summary
- map OpenAI-compatible custom runtime labels back to the configured provider key in user-facing logs
- use the same identity helper for client creation, turn, and API-call log lines
- preserve the internal `custom` transport routing and callable API-key behavior

## Why
Named custom providers currently log as `provider=custom`, which makes Desktop/Gateway diagnostics disagree with the provider users selected. This changes observability only; request routing remains unchanged.

## Tests
- `python -m pytest -o addopts='' tests/hermes_cli/test_custom_provider_identity.py tests/run_agent/test_callable_api_key.py tests/run_agent/test_openai_client_lifecycle.py -q` — 29 passed
- `git diff --check`