### PR TITLE
fix(env_loader): wrap managed .env load in fail-open try/except

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -370,11 +370,17 @@ def _apply_managed_env() -> None:
         return
     if managed_dir is None:
         return
-    managed_env = managed_dir / ".env"
-    if not managed_env.exists():
-        return
-    _sanitize_env_file_if_needed(managed_env)
-    _load_dotenv_with_fallback(managed_env, override=True)
+    try:
+        managed_env = managed_dir / ".env"
+        if not managed_env.exists():
+            return
+        _sanitize_env_file_if_needed(managed_env)
+        _load_dotenv_with_fallback(managed_env, override=True)
+    except Exception:  # noqa: BLE001 — fail-open: PermissionError on
+        # unreadable managed dirs must not crash startup. The outer
+        # try/except above catches get_managed_dir() failures; this
+        # one covers the exists/load boundary.
+        pass
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:

--- a/tests/test_env_loader.py
+++ b/tests/test_env_loader.py
@@ -1,0 +1,74 @@
+"""Tests for hermes_cli.env_loader — fail-open boundary for managed .env.
+
+Regression tests for PR #73408 — _apply_managed_env must never crash
+on filesystem permission errors during startup.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Make the worktree importable without depending on the installed wheel.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class TestManagedEnvFailOpen:
+    """Regression tests for PR #73408 — _apply_managed_env must never crash."""
+
+    def test_permission_error_on_exists_is_swallowed(self, tmp_path, monkeypatch):
+        """When managed_env.exists() raises PermissionError, startup continues.
+
+        This reproduces the Docker s6-setuidgid scenario: /etc/hermes/.env is
+        root-owned mode 0700, process runs as non-root, Path.exists() raises
+        PermissionError instead of returning False.
+        """
+        from hermes_cli.env_loader import _apply_managed_env
+
+        fake_managed_dir = Path("/etc/hermes")
+
+        with mock.patch(
+            "hermes_cli.managed_scope.get_managed_dir", return_value=fake_managed_dir
+        ):
+            with mock.patch.object(Path, "exists", side_effect=PermissionError(
+                "[Errno 13] Permission denied: '/etc/hermes/.env'"
+            )):
+                _apply_managed_env()
+                assert "MANAGED_TEST_VAR" not in os.environ
+
+    def test_os_error_on_exists_is_swallowed(self, tmp_path, monkeypatch):
+        """OSError on exists() must also be swallowed (fail-open)."""
+        from hermes_cli.env_loader import _apply_managed_env
+
+        fake_managed_dir = Path("/etc/hermes")
+
+        with mock.patch(
+            "hermes_cli.managed_scope.get_managed_dir", return_value=fake_managed_dir
+        ):
+            with mock.patch.object(Path, "exists", side_effect=OSError(
+                "[Errno 38] Function not implemented"
+            )):
+                _apply_managed_env()
+                assert "MANAGED_TEST_VAR" not in os.environ
+
+    def test_missing_managed_dir_returns_cleanly(self, tmp_path, monkeypatch):
+        """When get_managed_dir returns None, _apply_managed_env returns early."""
+        from hermes_cli.env_loader import _apply_managed_env
+
+        with mock.patch(
+            "hermes_cli.managed_scope.get_managed_dir", return_value=None
+        ):
+            _apply_managed_env()
+
+    def test_managed_dir_import_failure_returns_cleanly(self, tmp_path, monkeypatch):
+        """When managed_scope module can't be imported, returns early."""
+        from hermes_cli.env_loader import _apply_managed_env
+
+        with mock.patch.dict("sys.modules", {"hermes_cli.managed_scope": None}):
+            _apply_managed_env()


### PR DESCRIPTION
## Problem

`_apply_managed_env()` in `hermes_cli/env_loader.py` has a documented fail-open contract — "any error here is swallowed so managed scope can never block startup." However, the `managed_env.exists()` call at line 374 sits **outside** the function's try/except block (which only wraps `get_managed_dir()`).

On deployments where `/etc/hermes` is root-owned `mode 0700` and the Hermes process runs as a non-root user (the official Docker image's `s6-setuidgid` pattern), `Path.exists()` raises `PermissionError` — not `OSError` — on the unreadable `.env` path. This crashes startup instead of silently continuing.

**Confirmed on Python 3.11.15** — `Path.exists()` does NOT catch `PermissionError` when the parent directory is mode `0700` root-owned but the process runs as a non-root user. `Path.is_dir()` (used in `get_managed_dir()`) is unaffected because it can stat the directory itself.

## Fix

Wrap the `exists()` / `_sanitize_env_file_if_needed()` / `_load_dotenv_with_fallback()` sequence in its own `try: ... except Exception: return`, matching the docstring contract. Any filesystem error (PermissionError, OSError, etc.) is now swallowed.

## Test Plan

- [x] `pytest tests/hermes_cli/test_config.py` — 188 passed
- [x] `pytest tests/ -k "managed"` — 345 passed
- [x] `pytest tests/ -k "env_loader or load_dotenv"` — 52 passed

Closes #73401
