### PR TITLE
fix(acp): unwedge session when final-response send fails

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1955,6 +1955,16 @@ class HermesACPAgent(acp.Agent):
             # particular — used by the interactive sudo password cache scope).
             ctx = contextvars.copy_context()
             result = await loop.run_in_executor(_executor, ctx.run, _run_agent)
+        except asyncio.CancelledError:
+            # Client disconnect/router teardown cancels the prompt coroutine
+            # mid-executor. CancelledError is BaseException, so the handler
+            # below misses it — but the idle-reset invariant is the same one
+            # as the finally around the final-response send below: leaving
+            # is_running stuck True here wedges the session just the same.
+            with state.runtime_lock:
+                state.is_running = False
+                state.current_prompt_text = ""
+            raise
         except Exception:
             logger.exception("Executor error for session %s", session_id)
             with state.runtime_lock:
@@ -2038,25 +2048,42 @@ class HermesACPAgent(acp.Agent):
                 )
             except Exception:
                 logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
-        if (
-            final_response
-            and conn
-            and not suppress_interrupt_response
-            and (not streamed_message or result.get("response_transformed"))
-        ):
-            # Deliver the final response when streaming did not already send it,
-            # or when a plugin hook transformed the response after streaming
-            # finished (e.g. transform_llm_output) — otherwise the appended /
-            # rewritten text never reaches the client.
-            update = acp.update_agent_message_text(final_response)
-            await conn.session_update(session_id, update)
-
-        # Mark this turn idle before draining queued work so recursive prompt()
-        # calls can acquire the session. Queued turns are intentionally run as
-        # normal follow-up user prompts, preserving role alternation and history.
-        with state.runtime_lock:
-            state.is_running = False
-            state.current_prompt_text = ""
+        # The idle reset MUST run on every exit path past this point. An
+        # exception escaping with is_running still True wedges the session:
+        # every later prompt takes the queued branch (:1627) while the drain
+        # loop below is never reached — a dead client that disconnects during
+        # the final-response send used to kill the session silently.
+        try:
+            if (
+                final_response
+                and conn
+                and not suppress_interrupt_response
+                and (not streamed_message or result.get("response_transformed"))
+            ):
+                # Deliver the final response when streaming did not already send
+                # it, or when a plugin hook transformed the response after
+                # streaming finished (e.g. transform_llm_output) — otherwise
+                # the appended / rewritten text never reaches the client.
+                try:
+                    update = acp.update_agent_message_text(final_response)
+                    await conn.session_update(session_id, update)
+                except Exception:
+                    # The turn's result is already durable (save_session ran
+                    # above); a client that disconnected mid-turn must not
+                    # fail the turn or take the session down with it.
+                    logger.warning(
+                        "Failed to deliver final response for ACP session %s",
+                        session_id,
+                        exc_info=True,
+                    )
+        finally:
+            # Mark this turn idle before draining queued work so recursive
+            # prompt() calls can acquire the session. Queued turns are
+            # intentionally run as normal follow-up user prompts, preserving
+            # role alternation and history.
+            with state.runtime_lock:
+                state.is_running = False
+                state.current_prompt_text = ""
 
         while True:
             with state.runtime_lock:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1,6 +1,7 @@
 """Tests for acp_adapter.server — HermesACPAgent ACP server."""
 
 import asyncio
+import logging
 import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
@@ -445,6 +446,112 @@ class TestPrompt:
         )
 
         assert captured.get("child") == resp.session_id
+
+    @pytest.mark.asyncio
+    async def test_prompt_does_not_wedge_when_final_response_send_fails(self, agent, caplog):
+        """A failed final-response delivery must not leave is_running stuck.
+
+        Regression: an exception from the final-response session_update (e.g.
+        the client disconnected mid-turn) escaped prompt() before the idle
+        reset, so every later prompt took the queued branch and the drain
+        loop was never reached — the session silently stopped executing.
+        """
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "first answer",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "first answer"},
+            ],
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock(side_effect=ConnectionError("client gone"))
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hi")]
+        with caplog.at_level(logging.WARNING, logger="acp_adapter.server"):
+            resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        # The turn itself completes normally — the result was already
+        # persisted, so a dead client must not fail the turn...
+        assert resp.stop_reason == "end_turn"
+        # ...the failure is surfaced in the logs, not swallowed silently...
+        assert any(
+            "Failed to deliver final response" in record.getMessage()
+            for record in caplog.records
+        )
+        # ...and the session must be idle again, not wedged.
+        assert state.is_running is False
+        assert state.current_prompt_text == ""
+        assert state.queued_prompts == []
+
+        # The next prompt must execute normally (no phantom queue).
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "second answer",
+            "messages": [],
+        })
+        mock_conn.session_update = AsyncMock()
+        resp2 = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+        assert resp2.stop_reason == "end_turn"
+        state.agent.run_conversation.assert_called_once()
+        assert state.queued_prompts == []
+
+    @pytest.mark.asyncio
+    async def test_prompt_cancelled_final_send_still_resets_running(self, agent):
+        """CancelledError from the final send must still reset is_running.
+
+        The inner guard catches Exception only; cancellation rides the
+        finally. The cancellation must re-propagate (the turn really was
+        cancelled) while leaving the session usable.
+        """
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "answer that never lands",
+            "messages": [],
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock(side_effect=asyncio.CancelledError())
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hi")]
+        with pytest.raises(asyncio.CancelledError):
+            await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert state.is_running is False
+        assert state.current_prompt_text == ""
+
+    @pytest.mark.asyncio
+    async def test_prompt_cancelled_executor_still_resets_running(self, agent):
+        """CancelledError during the executor await must reset + re-raise.
+
+        The executor error handler catches Exception only; without the
+        dedicated CancelledError branch this escaped with is_running stuck
+        True — the same session-wedge class as the final-send path.
+        """
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(
+            side_effect=asyncio.CancelledError()
+        )
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hi")]
+        with pytest.raises(asyncio.CancelledError):
+            await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert state.is_running is False
+        assert state.current_prompt_text == ""
+
 
 
 


### PR DESCRIPTION
## Summary

`HermesACPAgent.prompt()` permanently wedges an ACP session if delivering the
final response raises — the common case being a client (Zed or other ACP
editor) disconnecting mid-turn.

Once `prompt()` marks a session running (`state.is_running = True`,
acp_adapter/server.py:1652), every exit path must reset it. The executor-error
path and the happy path do — but the final-response delivery
(`await conn.session_update(...)`) was unguarded. An exception there escapes
`prompt()` before the reset, and because the queued-prompt drain loop sits
*after* the reset, it is never reached again: every subsequent prompt on that
session takes the queued branch and is appended to `state.queued_prompts`
forever. The user sees "Queued for the next turn. (N queued)" and no prompt
ever executes — silent, unrecoverable message loss until the client restarts
the session.

## Changes

`acp_adapter/server.py`:

1. **Guard the final-response send** with `try/except` + `logger.warning`
   (mirrors the provenance-send and `_send_usage_update` patterns already in
   this file). The turn's result is already durable via
   `session_manager.save_session`, which runs before the send — a client that
   disconnected mid-turn must not fail the turn or take the session down.
2. **Move the idle reset into a `finally`** so the
   `is_running` / `current_prompt_text` invariant is enforced structurally on
   every exit path — including `asyncio.CancelledError` (a `BaseException`
   the inner `except Exception` correctly does not swallow; cancellation
   still re-propagates, the session just no longer wedges).
3. **Same wedge class, one region up:** the executor error handler caught
   only `Exception`, so a `CancelledError` during `run_in_executor` (client
   disconnect / router teardown mid-turn) escaped with `is_running=True`.
   Added a dedicated `except asyncio.CancelledError` branch that resets state
   and re-raises.

`tests/acp/test_server.py` — three regression tests:

- `test_prompt_does_not_wedge_when_final_response_send_fails`: failed final
  send → turn still returns `end_turn`, the failure is logged (caplog), the
  session is idle with an empty queue, and the *next* prompt executes
  normally. Verified to fail against pre-fix code (ConnectionError propagated
  out of `prompt()`).
- `test_prompt_cancelled_final_send_still_resets_running`: `CancelledError`
  from the final send rides the `finally`, re-propagates, session stays usable.
- `test_prompt_cancelled_executor_still_resets_running`: covers the new
  executor-path branch.

## Testing

- `tests/acp/test_server.py`: **95 passed** (incl. the 3 new tests)
- Full `tests/acp` + `tests/acp_adapter`: **345 passed**, 7 failures — all
  pre-existing Windows-environment issues (approval isolation, edit approval,
  ping suppression, image inlining), none in `test_server.py`, none
  attributable to this diff
- `python -m py_compile` and `ruff check` clean on both touched files

## Notes

- Behavior change is intentionally minimal: previously a failed final send
  propagated a JSON-RPC internal error to a (typically already gone) client;
  now the turn completes and the failure is logged with full traceback.
- No protocol, state-shape, or persistence changes.
