### PR TITLE
fix(dashboard): confirm restart and update intent (#25910)

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -243,7 +243,10 @@ so glass and message-bubble transparency do not reveal scrolling text.
   master/detail empties with an icon and action. Don't hand-roll a third
   centered empty.
 - **Confirmation:** `ConfirmDialog` is the only way we ask "are you sure". It
-  opens focused on Confirm, so `Enter` confirms and `Esc` cancels, and it owns
+  opens focused on Confirm, so `Enter` confirms and `Esc` cancels. With
+  `typedConfirmation`, it focuses an input and requires an exact match before
+  click or Enter can confirm; Space remains text input. It clears the input on
+  every opening and owns
   the pending → done → close beat and the inline error — a call site passes an
   async `onConfirm` and nothing else. A third way out (e.g. "Remove from
   sidebar" beside "Delete worktree") goes in the one `secondaryAction` slot.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15903,13 +15903,18 @@ ipcMain.handle('hermes:connections:update-managed', async (_event, rawId) => req
 // app's own update pipeline; Desktop-managed SSH uses the transactional
 // drain/update/restore lifecycle; URL remotes POST their backend updater.
 ipcMain.handle('hermes:connections:update-all', async (_event, payload) => {
+  const mutation = payload?.mutation
+  if (mutation?.confirmation !== 'UPDATE' || typeof mutation.idempotency_key !== 'string' ||
+      !/^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$/.test(mutation.idempotency_key)) {
+    throw new Error('A confirmed update intent is required.')
+  }
   const registry = readDesktopConnectionsRegistry()
 
   // Optional renderer-side exclusions: the everything-update flow dispatches
   // the ACTIVE backend through its own detailed-progress path and chains the
   // local client apply LAST (it relaunches the app), so it excludes those ids
-  // here to avoid double-dispatch. No payload keeps the Settings button's
-  // original all-rows behavior byte-identical.
+  // here to avoid double-dispatch. Settings supplies the same confirmed
+  // intent without exclusions to update all eligible rows.
   const excludeIds = new Set<string>(
     Array.isArray((payload as any)?.excludeIds) ? (payload as any).excludeIds.map((id: unknown) => String(id)) : []
   )
@@ -15952,7 +15957,7 @@ ipcMain.handle('hermes:connections:update-all', async (_event, payload) => {
             ensureRegistryBackend(connection.id, null)
           )
 
-          const body: any = await postJsonForBackend(descriptor, '/api/hermes/update', {}, { timeoutMs: 15_000 })
+          const body: any = await postJsonForBackend(descriptor, '/api/hermes/update', mutation, { timeoutMs: 15_000 })
 
           if (body?.ok === false) {
             // The backend refused (docker/nix/externally-managed installs) —

--- a/apps/desktop/src/api/system.ts
+++ b/apps/desktop/src/api/system.ts
@@ -1,3 +1,5 @@
+import type { ServiceMutationRequest } from '@hermes/shared'
+
 import type {
   ActionResponse,
   ActionStatusResponse,
@@ -135,19 +137,21 @@ export function runCurator(): Promise<ActionResponse> {
   })
 }
 
-export function restartGateway(): Promise<ActionResponse> {
+export function restartGateway(request: ServiceMutationRequest): Promise<ActionResponse> {
   return hermesApi<ActionResponse>({
     ...profileScoped(),
     path: '/api/gateway/restart',
-    method: 'POST'
+    method: 'POST',
+    body: request
   })
 }
 
-export function updateHermes(): Promise<ActionResponse> {
+export function updateHermes(request: ServiceMutationRequest): Promise<ActionResponse> {
   return hermesApi<ActionResponse>({
     ...profileScoped(),
     path: '/api/hermes/update',
-    method: 'POST'
+    method: 'POST',
+    body: request
   })
 }
 

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -30,6 +30,7 @@ import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
+import { confirmServiceMutation } from '@/store/service-mutations'
 import { $sessions, sessionPinId } from '@/store/session'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
@@ -265,10 +266,15 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
 
   const runSystemAction = useCallback(
     async (kind: 'restart' | 'update') => {
+      const request = await confirmServiceMutation(kind)
+
+      if (!request) {
+        return
+      }
       setSystemError('')
 
       try {
-        const started = kind === 'restart' ? await restartGateway() : await updateHermes()
+        const started = kind === 'restart' ? await restartGateway(request) : await updateHermes(request)
         let nextStatus: ActionStatusResponse | null = null
 
         for (let attempt = 0; attempt < 18; attempt += 1) {

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -37,6 +37,7 @@ import { coerceRemoteUrlScheme } from '@/lib/remote-url'
 import { $activeConnectionId, setConnectionsRegistry } from '@/store/connections'
 import { refreshFleetRoster } from '@/store/fleet-roster'
 import { notify, notifyError } from '@/store/notifications'
+import { confirmServiceMutation } from '@/store/service-mutations'
 
 import { EmptyState, ListRow, Pill, SectionHeading, ToggleRow } from './primitives'
 
@@ -575,10 +576,15 @@ export function ConnectionsRegistrySection() {
       return
     }
 
+    const request = await confirmServiceMutation('update', s.updateAll)
+
+    if (!request) {
+      return
+    }
     setUpdatingAll(true)
 
     try {
-      const { results } = await bridge.updateAll()
+      const { results } = await bridge.updateAll({ mutation: request })
 
       for (const row of results) {
         if (row.ok) {
@@ -594,7 +600,7 @@ export function ConnectionsRegistrySection() {
     } finally {
       setUpdatingAll(false)
     }
-  }, [bridge, s.updateAllDone, s.updateAllFailed, s.updateSkippedCloud])
+  }, [bridge, s.updateAll, s.updateAllDone, s.updateAllFailed, s.updateSkippedCloud])
 
   const kindMeta: Record<DesktopConnectionKind, { label: string; desc: string }> = {
     cloud: { desc: s.kindCloudDesc, label: s.kindCloud },

--- a/apps/desktop/src/app/webhooks/index.tsx
+++ b/apps/desktop/src/app/webhooks/index.tsx
@@ -147,21 +147,22 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
   const restartGatewayNow = useCallback(async () => {
     setRestarting(true)
 
-    // runGatewayRestart never rejects (it toasts its own failure); the boolean
-    // is the only signal that the receiver actually came back.
-    const ok = await runGatewayRestart()
+    try {
+      if (!(await runGatewayRestart())) {
+        return
+      }
 
-    if (ok) {
       setRestartNeeded(false)
       setRestartError(null)
       // Give the receiver a moment to bind before re-reading state.
       window.setTimeout(() => void reload(true), 4000)
-    } else {
+    } catch (err) {
       setRestartNeeded(true)
-      setRestartError(w.restartFailed(''))
+      setRestartError(String(err))
+      notifyError(err, w.restartFailed(''))
+    } finally {
+      setRestarting(false)
     }
-
-    setRestarting(false)
   }, [reload, w])
 
   const handleEnable = useCallback(async () => {

--- a/apps/desktop/src/components/confirm-host.test.tsx
+++ b/apps/desktop/src/components/confirm-host.test.tsx
@@ -64,18 +64,24 @@ describe('confirm()', () => {
     expect(read()).toBe(false)
   })
 
-  it('supersedes an open request, answering the one it replaces no', async () => {
+  it('resets typed intent when a new request replaces an open prompt', async () => {
     render(<ConfirmHost />)
-
-    const first = await ask('First?')
-    const second = await act(async () => ask('Second?'))
-
-    await first.pending
-    expect(first.read()).toBe(false)
-    expect(screen.getByText('Second?')).toBeTruthy()
-
+    let first!: Promise<boolean>
+    act(() => {
+      first = confirm({ title: 'First restart', typedConfirmation: 'RESTART' })
+    })
+    fireEvent.change(await screen.findByRole('textbox'), { target: { value: 'RESTART' } })
+    let second!: Promise<boolean>
+    act(() => {
+      second = confirm({ title: 'Second restart', typedConfirmation: 'RESTART' })
+    })
+    expect(await first).toBe(false)
+    await screen.findByText('Second restart')
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('')
     fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
-    await second.pending
-    expect(second.read()).toBe(true)
+    expect($confirmRequest.get()).not.toBeNull()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'RESTART' } })
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
+    expect(await second).toBe(true)
   })
 })

--- a/apps/desktop/src/components/confirm-host.tsx
+++ b/apps/desktop/src/components/confirm-host.tsx
@@ -31,10 +31,12 @@ export function ConfirmHost() {
       // The caller does the work once it has its answer, so there is nothing
       // here to keep the dialog open for.
       dismissOnConfirm
-      onClose={() => settleConfirm(false)}
-      onConfirm={() => settleConfirm(true)}
+      key={shown.id}
+      onClose={() => settleConfirm(false, shown)}
+      onConfirm={() => settleConfirm(true, shown)}
       open={request !== null}
       title={shown.title}
+      typedConfirmation={shown.typedConfirmation}
     />
   )
 }

--- a/apps/desktop/src/components/ui/confirm-dialog.test.tsx
+++ b/apps/desktop/src/components/ui/confirm-dialog.test.tsx
@@ -48,3 +48,49 @@ describe('ConfirmDialog secondary action', () => {
     expect(onSecondary).not.toHaveBeenCalled()
   })
 })
+
+it.each(['wrong', 'correct', 'cancel', 'reopen', 'space', 'duplicate'])(
+  'requires the exact typed intent before confirming: %s',
+  async mode => {
+    const onConfirm = vi.fn()
+    const onClose = vi.fn()
+    const props = { open: true, title: 'Restart', typedConfirmation: 'RESTART', onConfirm, onClose: onClose }
+    const view = render(<ConfirmDialog {...props} />)
+    const input = await screen.findByRole('textbox')
+    const confirm = await screen.findByRole('button', { name: 'Confirm' })
+    await waitFor(() => expect(input.matches(':focus')).toBe(true))
+    fireEvent.click(confirm)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onConfirm).not.toHaveBeenCalled()
+
+    if (mode === 'cancel') {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(onClose).toHaveBeenCalledTimes(1)
+
+      return
+    }
+
+    fireEvent.change(input, { target: { value: mode === 'wrong' ? 'restart' : 'RESTART' } })
+
+    if (mode === 'space') {
+      const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true })
+      input.dispatchEvent(event)
+      expect(event.defaultPrevented).toBe(false)
+      expect(onConfirm).not.toHaveBeenCalled()
+    } else if (mode === 'duplicate') {
+      fireEvent.click(confirm)
+      fireEvent.click(confirm)
+      fireEvent.keyDown(input, { key: 'Enter' })
+      await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1))
+    } else if (mode === 'reopen') {
+      view.rerender(<ConfirmDialog {...props} open={false} />)
+      view.rerender(<ConfirmDialog {...props} />)
+      await waitFor(() => expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(''))
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' })
+      expect(onConfirm).not.toHaveBeenCalled()
+    } else {
+      fireEvent.keyDown(input, { key: 'Enter' })
+      await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(mode === 'correct' ? 1 : 0))
+    }
+  }
+)

--- a/apps/desktop/src/components/ui/confirm-dialog.tsx
+++ b/apps/desktop/src/components/ui/confirm-dialog.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 
 import { ActionStatus } from '@/components/ui/action-status'
 import { Button } from '@/components/ui/button'
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 
@@ -25,6 +26,7 @@ interface ConfirmDialogProps {
   busyLabel?: string
   doneLabel?: string
   cancelLabel?: string
+  typedConfirmation?: string
   destructive?: boolean
   /** Close as soon as onConfirm resolves — for optimistic actions that finish in the background. */
   dismissOnConfirm?: boolean
@@ -54,9 +56,15 @@ export function ConfirmDialog({
   cancelLabel,
   destructive = false,
   dismissOnConfirm = false,
-  secondaryAction
+  secondaryAction,
+  typedConfirmation
 }: ConfirmDialogProps) {
   const { t } = useI18n()
+  const inputId = useId()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const submittingRef = useRef(false)
+  const [confirmation, setConfirmation] = useState('')
+  const ready = typedConfirmation === undefined || confirmation === typedConfirmation
   const confirmRef = useRef<HTMLButtonElement>(null)
   const closeTimerRef = useRef<null | number>(null)
   const [status, setStatus] = useState<'done' | 'idle' | 'saving'>('idle')
@@ -67,12 +75,16 @@ export function ConfirmDialog({
   const resolvedDoneLabel = doneLabel ?? t.common.done
   const resolvedCancelLabel = cancelLabel ?? t.common.cancel
 
+  // Reset the submission latch for a new prompt; no reactive value is mirrored.
+  // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
     if (open) {
+      setConfirmation('')
+      submittingRef.current = false
       setStatus('idle')
       setError(null)
     }
-  }, [open])
+  }, [open, typedConfirmation])
 
   // Cancel the pending close timer on unmount. The timer below holds the
   // "done" beat visible for 600ms, and an unmount inside that window used to
@@ -93,10 +105,12 @@ export function ConfirmDialog({
   }, [])
 
   async function run() {
-    if (busy) {
+    if (busy || submittingRef.current || !ready) {
       return
     }
 
+    submittingRef.current = true
+    setStatus('saving')
     setError(null)
 
     if (dismissOnConfirm) {
@@ -104,6 +118,8 @@ export function ConfirmDialog({
         await onConfirm()
         onClose()
       } catch (err) {
+        submittingRef.current = false
+        setStatus('idle')
         setError(err instanceof Error ? err.message : t.errors.genericFailure)
       }
 
@@ -120,6 +136,7 @@ export function ConfirmDialog({
         onClose()
       }, 600)
     } catch (err) {
+      submittingRef.current = false
       setStatus('idle')
       setError(err instanceof Error ? err.message : t.errors.genericFailure)
     }
@@ -132,7 +149,13 @@ export function ConfirmDialog({
         onKeyDown={event => {
           // Enter/Space confirm regardless of which button holds focus
           // (preventDefault stops a focused Cancel from swallowing it).
-          if ((event.key === 'Enter' || event.key === ' ') && !busy) {
+          const typedInput = event.target === inputRef.current
+
+          if (typedConfirmation !== undefined && event.target !== confirmRef.current && !typedInput) {
+            return
+          }
+
+          if ((event.key === 'Enter' || (event.key === ' ' && !typedInput)) && !event.nativeEvent.isComposing) {
             event.preventDefault()
             void run()
           }
@@ -143,13 +166,28 @@ export function ConfirmDialog({
           // sidebar row) and Enter re-triggers that instead. Radix's default
           // would take the X — confirm is the button Enter maps to.
           event.preventDefault()
-          confirmRef.current?.focus()
+          ;(typedConfirmation === undefined ? confirmRef.current : inputRef.current)?.focus()
         }}
       >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description ? <DialogDescription>{description}</DialogDescription> : null}
         </DialogHeader>
+
+        {typedConfirmation !== undefined && (
+          <div className="flex flex-col gap-2">
+            <label className="text-xs text-muted-foreground" htmlFor={inputId}>
+              {t.common.typedConfirmation(typedConfirmation)}
+            </label>
+            <Input
+              disabled={busy}
+              id={inputId}
+              onChange={event => setConfirmation(event.target.value)}
+              ref={inputRef}
+              value={confirmation}
+            />
+          </div>
+        )}
 
         {error && (
           <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
@@ -176,7 +214,7 @@ export function ConfirmDialog({
             </Button>
           )}
           <Button
-            disabled={busy}
+            disabled={busy || !ready}
             onClick={() => void run()}
             ref={confirmRef}
             variant={destructive ? 'destructive' : 'default'}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1,3 +1,4 @@
+import type { ServiceMutationRequest } from '@hermes/shared'
 import type { GatewayWsUrlResult } from '@hermes/shared'
 import type { TranslucencyState } from '@hermes/shared/translucency'
 
@@ -226,7 +227,8 @@ declare global {
         // cloud entries are skipped (platform-managed), each row independent.
         // excludeIds skips connections the caller updates through another
         // path (the everything-update flow's active backend + local client).
-        updateAll?: (options?: {
+        updateAll?: (options: {
+          mutation: ServiceMutationRequest
           excludeIds?: string[]
         }) => Promise<{ ok: boolean; results: DesktopConnectionUpdateResult[] }>
         // Registry lifecycle push: fired when a connection is removed or

--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -1,3 +1,4 @@
+import { serviceMutationRequest } from '@hermes/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -53,8 +54,8 @@ describe('backend action helpers are profile-scoped', () => {
     setApiRequestProfile('coder')
 
     void getStatus()
-    void restartGateway()
-    void updateHermes()
+    void restartGateway(serviceMutationRequest('RESTART'))
+    void updateHermes(serviceMutationRequest('UPDATE'))
     void checkHermesUpdate()
     void getActionStatus('gateway-restart')
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -68,6 +68,7 @@ export const ar = defineLocale({
     close: 'إغلاق',
     collapse: 'طي',
     confirm: 'تأكيد',
+    typedConfirmation: (value: string) => `اكتب ${value} للتأكيد.`,
     connect: 'اتصال',
     connecting: 'جار الاتصال',
     continue: 'متابعة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -84,6 +84,7 @@ export const en: Translations = {
     close: 'Close',
     collapse: 'Collapse',
     confirm: 'Confirm',
+    typedConfirmation: (value: string) => `Type ${value} to confirm.`,
     connect: 'Connect',
     connecting: 'Connecting',
     continue: 'Continue',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -48,6 +48,7 @@ export const ja = defineLocale({
     close: '閉じる',
     collapse: '折りたたむ',
     confirm: '確認',
+    typedConfirmation: (value: string) => `確認するには ${value} と入力してください。`,
     connect: '接続',
     connecting: '接続中',
     continue: '続ける',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -70,6 +70,7 @@ export const ru = defineLocale({
     close: 'Закрыть',
     collapse: 'Свернуть',
     confirm: 'Подтвердить',
+    typedConfirmation: (value: string) => `Введите ${value} для подтверждения.`,
     connect: 'Подключить',
     connecting: 'Подключение',
     continue: 'Продолжить',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -130,6 +130,7 @@ export interface Translations {
     close: string
     collapse: string
     confirm: string
+    typedConfirmation: (value: string) => string
     connect: string
     connecting: string
     continue: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -48,6 +48,7 @@ export const zhHant = defineLocale({
     close: '關閉',
     collapse: '收合',
     confirm: '確認',
+    typedConfirmation: (value: string) => `輸入 ${value} 以確認。`,
     connect: '連線',
     connecting: '連線中',
     continue: '繼續',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -77,6 +77,7 @@ export const zh = defineLocale({
     close: '关闭',
     collapse: '收起',
     confirm: '确认',
+    typedConfirmation: (value: string) => `输入 ${value} 以确认。`,
     connect: '连接',
     connecting: '连接中',
     continue: '继续',

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1286,7 +1286,9 @@ export const host = {
   onEvent: onGatewayEvent,
 
   /** Restart the backend gateway (progress surfaces in the core statusbar). */
-  restartGateway: async () => runGatewayRestart(),
+  restartGateway: async () => {
+    await runGatewayRestart()
+  },
 
   /** One-shot system status snapshot (platforms, versions, …). */
   status: async () => getStatus(),

--- a/apps/desktop/src/store/confirm.ts
+++ b/apps/desktop/src/store/confirm.ts
@@ -5,12 +5,16 @@ export interface ConfirmRequest {
   description?: string
   confirmLabel?: string
   cancelLabel?: string
+  typedConfirmation?: string
   destructive?: boolean
 }
 
 export interface PendingConfirm extends ConfirmRequest {
+  id: number
   resolve: (confirmed: boolean) => void
 }
+
+let nextRequestId = 0
 
 export const $confirmRequest = atom<null | PendingConfirm>(null)
 
@@ -23,15 +27,15 @@ export function confirm(request: ConfirmRequest): Promise<boolean> {
   settleConfirm(false)
 
   return new Promise<boolean>(resolve => {
-    $confirmRequest.set({ ...request, resolve })
+    $confirmRequest.set({ ...request, id: ++nextRequestId, resolve })
   })
 }
 
 /** Answer the open request, if there still is one. Idempotent. */
-export function settleConfirm(confirmed: boolean): void {
+export function settleConfirm(confirmed: boolean, expected?: PendingConfirm): void {
   const pending = $confirmRequest.get()
 
-  if (!pending) {
+  if (!pending || (expected && pending !== expected)) {
     return
   }
 

--- a/apps/desktop/src/store/service-actions.test.tsx
+++ b/apps/desktop/src/store/service-actions.test.tsx
@@ -1,0 +1,92 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { ConfirmHost } from '@/components/confirm-host'
+import { $confirmRequest, settleConfirm } from '@/store/confirm'
+
+const registry = atom({ connections: [{ id: 'local' }, { id: 'other', kind: 'remote' }] })
+vi.mock('@/store/connections', () => ({
+  $connectionsRegistry: registry,
+  refreshConnectionsRegistry: async () => registry.get()
+}))
+vi.mock('@/store/session', () => ({ $connection: atom({ mode: 'local' }) }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn(), dismissNotification: vi.fn() }))
+const { runGatewayRestart } = await import('./system-actions')
+const { applyBackendUpdate, applyEverythingUpdate } = await import('./updates')
+
+afterEach(() => {
+  settleConfirm(false)
+  cleanup()
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+it.each(['restart', 'update', 'cancel-restart', 'cancel-update', 'all', 'cancel-all'])(
+  'requires a typed prompt before the real action controller dispatches: %s',
+  async mode => {
+    const calls: { path: string; body?: Record<string, unknown> }[] = []
+
+    const updateAll = vi.fn().mockResolvedValue({ ok: true, results: [] })
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = {
+      api: async (request: { path: string; body?: Record<string, unknown> }) => {
+        calls.push(request)
+
+        if (request.path === '/api/gateway/restart') {
+          return { ok: true, name: 'gateway-restart', pid: 123 }
+        }
+
+        if (request.path === '/api/hermes/update') {
+          return { ok: false, name: 'hermes-update', message: 'managed fixture', update_command: 'fixture' }
+        }
+
+        return { running: false, exit_code: 0, lines: [] }
+      },
+      connections: { updateAll },
+      updates: { check: async () => ({ behind: 0, updateAvailable: false }) }
+    }
+    render(<ConfirmHost />)
+    const restart = mode.endsWith('restart')
+    const all = mode.endsWith('all')
+    let pending!: Promise<unknown>
+    act(() => {
+      pending = all ? applyEverythingUpdate() : restart ? runGatewayRestart() : applyBackendUpdate()
+    })
+
+    if (mode === 'restart') {expect(runGatewayRestart()).toBe(pending)}
+
+    try {
+      const input = await screen.findByRole('textbox')
+      expect(calls).toHaveLength(0)
+      expect(updateAll).not.toHaveBeenCalled()
+
+      if (mode.startsWith('cancel')) {
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      } else {
+        fireEvent.change(input, { target: { value: restart ? 'RESTART' : 'UPDATE' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+      }
+
+      let result: unknown
+      await act(async () => {
+        result = await pending
+      })
+
+      if (restart) {expect(result).toBe(!mode.startsWith('cancel'))}
+
+      if (mode.startsWith('cancel')) {
+        expect(calls).toHaveLength(0)
+        expect(updateAll).not.toHaveBeenCalled()
+      } else {
+        const body = all ? updateAll.mock.calls[0][0].mutation : calls[0].body
+        expect(body).toMatchObject({ confirmation: restart ? 'RESTART' : 'UPDATE' })
+        expect(body.idempotency_key).toMatch(/^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$/)
+      }
+
+      await waitFor(() => expect($confirmRequest.get()).toBeNull())
+    } finally {
+      settleConfirm(false)
+      await pending
+    }
+  }
+)

--- a/apps/desktop/src/store/service-mutations.ts
+++ b/apps/desktop/src/store/service-mutations.ts
@@ -1,0 +1,18 @@
+import { serviceMutationRequest, type ServiceMutationRequest } from '@hermes/shared'
+
+import { translateNow } from '@/i18n'
+import { confirm } from '@/store/confirm'
+
+export async function confirmServiceMutation(
+  action: 'restart' | 'update',
+  title?: string
+): Promise<ServiceMutationRequest | null> {
+  const confirmation = action === 'restart' ? 'RESTART' : 'UPDATE'
+
+  const accepted = await confirm({
+    title: title ?? translateNow(action === 'restart' ? 'commandCenter.restartGateway' : 'commandCenter.updateHermes'),
+    typedConfirmation: confirmation
+  })
+
+  return accepted ? serviceMutationRequest(confirmation) : null
+}

--- a/apps/desktop/src/store/system-actions.ts
+++ b/apps/desktop/src/store/system-actions.ts
@@ -3,6 +3,7 @@ import { atom } from 'nanostores'
 import { getActionStatus, restartGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { notifyError } from '@/store/notifications'
+import { confirmServiceMutation } from '@/store/service-mutations'
 import type { ActionResponse } from '@/types/hermes'
 
 const POLL_ATTEMPTS = 18
@@ -38,13 +39,27 @@ async function awaitAction(name: string): Promise<void> {
 // indicator. Self-contained and never rejects, so every trigger — Cmd+K, the
 // messaging save/toggle toasts — gets identical feedback from a plain
 // `void runGatewayRestart()`, and a failure is the only thing that toasts.
-// Resolves `true` when the restart child completed cleanly (callers that keep
-// a "restart needed" banner clear it on that signal only).
-export async function runGatewayRestart(): Promise<boolean> {
+let restartInFlight: Promise<boolean> | null = null
+
+export function runGatewayRestart(): Promise<boolean> {
+  restartInFlight ??= confirmAndRestart().finally(() => {
+    restartInFlight = null
+  })
+
+  return restartInFlight
+}
+
+async function confirmAndRestart(): Promise<boolean> {
+  const request = await confirmServiceMutation('restart')
+
+  if (!request) {
+    return false
+  }
+
   $gatewayRestarting.set(true)
 
   try {
-    const started: ActionResponse = await restartGateway()
+    const started: ActionResponse = await restartGateway(request)
     await awaitAction(started.name)
 
     return true

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DesktopUpdateStatus } from '@/global'
 
+vi.mock('@/store/service-mutations', () => ({
+  confirmServiceMutation: async () => ({ confirmation: 'UPDATE', idempotency_key: 'confirmed-update-test-123' })
+}))
+
 const storage = new Map<string, string>()
 
 vi.mock('@/lib/storage', () => ({

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -1,9 +1,9 @@
+import type { ServiceMutationRequest } from '@hermes/shared'
+import { atom } from 'nanostores'
 /**
  * Desktop self-update store. Tracks distance from the configured branch,
  * surfaces it as an ambient pill, and orchestrates the apply flow.
  */
-
-import { atom } from 'nanostores'
 
 import type {
   DesktopUpdateApplyOptions,
@@ -21,6 +21,7 @@ import { $connectionsRegistry, refreshConnectionsRegistry } from '@/store/connec
 import { reconnectGateway } from '@/store/gateway-reconnect'
 import { dismissNotification, notify } from '@/store/notifications'
 import { onboardingSurfaceActive } from '@/store/onboarding-presence'
+import { confirmServiceMutation } from '@/store/service-mutations'
 import { $connection } from '@/store/session'
 import type { BackendUpdateCheckResponse } from '@/types/hermes'
 
@@ -678,7 +679,12 @@ function legacyBackendReachedTarget(
 
 let backendUpdateInFlight: Promise<DesktopUpdateApplyResult> | null = null
 
-async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
+async function runBackendUpdate(confirmedRequest?: ServiceMutationRequest): Promise<DesktopUpdateApplyResult> {
+  const request = confirmedRequest ?? (await confirmServiceMutation('update'))
+
+  if (!request) {
+    return { ok: false, error: 'cancelled' }
+  }
   dismissNotification(UPDATE_TOAST_ID)
   $backendUpdateApply.set({
     ...IDLE,
@@ -695,7 +701,7 @@ async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
       ? previousStatus.targetSha.slice('backend:'.length)
       : undefined
 
-    const started = await updateHermes()
+    const started = await updateHermes(request)
     const applyStartedAtMs = Date.now()
 
     if (!started.ok) {
@@ -808,12 +814,12 @@ async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   }
 }
 
-export function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
+export function applyBackendUpdate(confirmedRequest?: ServiceMutationRequest): Promise<DesktopUpdateApplyResult> {
   if (backendUpdateInFlight) {
     return backendUpdateInFlight
   }
 
-  backendUpdateInFlight = runBackendUpdate().finally(() => {
+  backendUpdateInFlight = runBackendUpdate(confirmedRequest).finally(() => {
     backendUpdateInFlight = null
   })
 
@@ -896,6 +902,11 @@ export function applyEverythingUpdate(): Promise<void> {
 }
 
 async function runEverythingUpdate(): Promise<void> {
+  const request = await confirmServiceMutation('update', translateNow('settings.connections.updateAll'))
+
+  if (!request) {
+    return
+  }
   $updateEverything.set({ running: true })
 
   // Snapshot the client status before any leg runs: the backend leg's own
@@ -912,7 +923,7 @@ async function runEverythingUpdate(): Promise<void> {
     if (isRemoteMode()) {
       $updateOverlayTarget.set('backend')
 
-      await applyBackendUpdate().catch(() => null)
+      await applyBackendUpdate(request).catch(() => null)
     }
 
     // 2. Fan out to every OTHER eligible registered connection. The active
@@ -931,7 +942,7 @@ async function runEverythingUpdate(): Promise<void> {
 
     if (bridge?.updateAll && remaining.length > 0) {
       try {
-        const { results } = await bridge.updateAll({ excludeIds })
+        const { results } = await bridge.updateAll({ excludeIds, mutation: request })
 
         for (const row of results) {
           if (row.ok) {

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -59,6 +59,7 @@ export {
   JsonRpcGatewayError,
   type WebSocketLike
 } from './json-rpc-gateway'
+export { serviceMutationRequest, type ServiceMutationRequest } from './service-mutation'
 export { skillInvocationText } from './skill-scaffold'
 export {
   type HermesSkin,
@@ -101,6 +102,7 @@ export {
   WINDOWS_GLASS_MIN_BUILD,
   type WindowsBackgroundMaterial
 } from './translucency'
+
 export {
   buildHermesWebSocketUrl,
   type GatewayAuthMode,

--- a/apps/shared/src/service-mutation.ts
+++ b/apps/shared/src/service-mutation.ts
@@ -1,0 +1,28 @@
+export type ServiceMutationConfirmation = 'RESTART' | 'UPDATE'
+
+export interface ServiceMutationRequest {
+  confirmation: ServiceMutationConfirmation
+  idempotency_key: string
+}
+
+function randomUuid(): string {
+  const cryptoObj = globalThis.crypto
+
+  if (typeof cryptoObj?.randomUUID === 'function') {
+    return cryptoObj.randomUUID()
+  }
+
+  const bytes = cryptoObj.getRandomValues(new Uint8Array(16))
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+export function serviceMutationRequest(confirmation: ServiceMutationConfirmation): ServiceMutationRequest {
+  return {
+    confirmation,
+    idempotency_key: randomUuid()
+  }
+}

--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -23,6 +23,7 @@ _REDACTED_FIELDS: frozenset = frozenset({
 
 class AuditEvent(enum.Enum):
     """Event types; values are the literal ``event`` field on the JSON line."""
+    DASHBOARD_MUTATION = "dashboard_mutation"
     LOGIN_START = "login_start"
     LOGIN_SUCCESS = "login_success"
     LOGIN_FAILURE = "login_failure"

--- a/hermes_cli/dashboard_mutations.py
+++ b/hermes_cli/dashboard_mutations.py
@@ -1,0 +1,34 @@
+"""Confirmed intents for the dashboard's service-interrupting actions.
+
+Other dashboard mutation classes are outside this contract.
+"""
+
+from dataclasses import dataclass
+import re
+from typing import Any
+
+
+SERVICE_MUTATION_CONFIRMATIONS = {
+    "gateway-restart": "RESTART",
+    "hermes-update": "UPDATE",
+}
+_IDEMPOTENCY_KEY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{15,127}")
+
+
+@dataclass(frozen=True)
+class ServiceMutation:
+    action: str
+    idempotency_key: str
+
+
+def validate_service_mutation(action: str, body: Any) -> ServiceMutation:
+    """Require exact intent and a bounded key before any process is started."""
+    if not isinstance(body, dict):
+        raise ValueError("body must be an object")
+    confirmation = SERVICE_MUTATION_CONFIRMATIONS[action]
+    if body.get("confirmation") != confirmation:
+        raise ValueError(f"confirmation must exactly match {confirmation!r}")
+    key = body.get("idempotency_key")
+    if not isinstance(key, str) or not _IDEMPOTENCY_KEY_RE.fullmatch(key):
+        raise ValueError("idempotency_key must contain 16-128 letters, digits, or ._:-")
+    return ServiceMutation(action, key)

--- a/hermes_cli/web_routers/actions.py
+++ b/hermes_cli/web_routers/actions.py
@@ -10,12 +10,14 @@ import logging
 import re
 import secrets
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Request
 
+from hermes_cli.dashboard_mutations import SERVICE_MUTATION_CONFIRMATIONS, ServiceMutation, validate_service_mutation
 from hermes_cli import __version__
 from hermes_cli.config import format_docker_update_message, recommended_update_command_for_method
 from hermes_cli.web_deps import LateState, late
@@ -36,6 +38,59 @@ _ACTION_COMMANDS = LateState("_ACTION_COMMANDS", "hermes_cli.web_server_gateway"
 _ACTION_IDS = LateState("_ACTION_IDS", "hermes_cli.web_server_gateway")
 _ACTION_PROCS = LateState("_ACTION_PROCS", "hermes_cli.web_server_gateway")
 _ACTION_RESULTS = LateState("_ACTION_RESULTS", "hermes_cli.web_server_gateway")
+
+# Only live actions retain a key; this is process-local retry coalescing, not
+# a durable receipt store. The existing restart cooldown also applies after exit.
+_SERVICE_MUTATION_INTENTS: dict[str, tuple[str, str]] = {}
+_SERVICE_MUTATION_LOCK = threading.RLock()
+
+
+def _audit_service_mutation(request: Request, action: str, target: str, result: str) -> None:
+    from hermes_cli.dashboard_auth.audit import AuditEvent, audit_log
+
+    session = getattr(request.state, "session", None)
+    principal = getattr(request.state, "token_principal", None)
+    actor = "local-dashboard"
+    if session is not None:
+        actor = str(getattr(session, "user_id", None) or getattr(session, "email", "user"))
+    elif principal is not None:
+        actor = str(getattr(principal, "principal", "service"))
+    audit_log(AuditEvent.DASHBOARD_MUTATION, actor=actor, action=action, target=target, result=result)
+
+
+async def _service_mutation_request(request: Request, action: str, target: str) -> ServiceMutation:
+    try:
+        body = await request.json()
+        return validate_service_mutation(action, body)
+    except ValueError as exc:
+        _audit_service_mutation(request, action, target, "rejected")
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@contextlib.contextmanager
+def _guard_service_mutation(request: Request, mutation: ServiceMutation, target: str):
+    # Check and spawn without yielding, including when called from worker threads.
+    with _SERVICE_MUTATION_LOCK:
+        try:
+            for action in SERVICE_MUTATION_CONFIRMATIONS:
+                proc = _ACTION_PROCS.get(action)
+                if proc is None or proc.poll() is not None:
+                    _SERVICE_MUTATION_INTENTS.pop(action, None)
+                    continue
+                if action != mutation.action or _SERVICE_MUTATION_INTENTS.get(action) != (target, mutation.idempotency_key):
+                    raise HTTPException(status_code=409, detail=f"{action} is already in progress")
+            yield
+        except Exception as exc:
+            result = "conflict" if isinstance(exc, HTTPException) and exc.status_code == 409 else "failed"
+            _audit_service_mutation(request, mutation.action, target, result)
+            raise
+
+
+def _service_mutation_result(request: Request, mutation: ServiceMutation, target: str, result: str, response: dict):
+    if result in {"started", "reused"}:
+        _SERVICE_MUTATION_INTENTS[mutation.action] = (target, mutation.idempotency_key)
+    _audit_service_mutation(request, mutation.action, target, result)
+    return response
 
 
 def _server_path(name: str) -> Path:
@@ -64,6 +119,7 @@ _UPDATE_REFUSAL_ERROR_CODES = {
 
 def _finish_action(name: str, exit_code: Optional[int], pid: Optional[int]) -> None:
     """Record a terminal result and drop the live-process registries for ``name``."""
+    _SERVICE_MUTATION_INTENTS.pop(name, None)
     _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": pid}
     for registry in (_ACTION_PROCS, _ACTION_COMMANDS, _ACTION_IDS):
         registry.pop(name, None)
@@ -136,11 +192,17 @@ def _durable_completed_update_action_id(lines: List[str]) -> Optional[str]:
 
 
 @router.post("/api/gateway/restart")
-async def restart_gateway(profile: Optional[str] = None):
-    """Kick off a ``hermes gateway restart`` in the background."""
-    with http_failure("Failed to spawn gateway restart", 500, "Failed to restart gateway"):
-        proc, _reused = _spawn_gateway_restart(profile)
-    return {"ok": True, "pid": proc.pid, "name": "gateway-restart"}
+async def restart_gateway(request: Request, profile: Optional[str] = None):
+    """Start a restart with exact RESTART confirmation and an idempotency key."""
+    target = profile or "default"
+    mutation = await _service_mutation_request(request, "gateway-restart", target)
+    with _guard_service_mutation(request, mutation, target):
+        with http_failure("Failed to spawn gateway restart", 500, "Failed to restart gateway"):
+            proc, reused = _spawn_gateway_restart(profile)
+        return _service_mutation_result(
+            request, mutation, target, "reused" if reused else "started",
+            {"ok": True, "pid": proc.pid, "name": "gateway-restart", "already_running": reused},
+        )
 
 
 @router.get("/api/gateway/migrate/plan")
@@ -216,37 +278,42 @@ def _update_refused(error: str, message: str, update_command: str) -> Dict[str, 
 
 
 @router.post("/api/hermes/update")
-async def update_hermes():
-    """Kick off ``hermes update`` in the background."""
-    if _dashboard_local_update_managed_externally():
-        message = _MANAGED_EXTERNALLY_MESSAGE + " The built-in local updater is disabled here."
-        return _update_refused("dashboard_update_managed_externally", message, "managed outside dashboard")
+async def update_hermes(request: Request):
+    """Start an update with exact UPDATE confirmation and an idempotency key."""
+    target = "installation"
+    mutation = await _service_mutation_request(request, "hermes-update", target)
+    with _guard_service_mutation(request, mutation, target):
+        existing = _ACTION_PROCS.get("hermes-update")
+        if existing is not None and existing.poll() is None:
+            response = {"ok": True, "pid": existing.pid, "name": "hermes-update", "already_running": True}
+            action_id = _ACTION_IDS.get("hermes-update")
+            if action_id:
+                response["action_id"] = action_id
+            return _service_mutation_result(request, mutation, target, "reused", response)
 
-    # Shared admission gate: marker-first, then the docker/nix/apt heuristics —
-    # one decision with the CLI paths.
-    from hermes_cli.update_contract import evaluate_update_admission, record_refusal_receipt
+        if _dashboard_local_update_managed_externally():
+            message = _MANAGED_EXTERNALLY_MESSAGE + " The built-in local updater is disabled here."
+            response = _update_refused("dashboard_update_managed_externally", message, "managed outside dashboard")
+            return _service_mutation_result(request, mutation, target, "unsupported", response)
 
-    refusal = evaluate_update_admission(_server_path("PROJECT_ROOT"))
-    if refusal is not None:
-        response = _update_refused(
-            _UPDATE_REFUSAL_ERROR_CODES.get(refusal.code, "update_not_in_place"), refusal.message, refusal.update_command,
+        # Keep the same marker-first admission policy as the CLI updater.
+        from hermes_cli.update_contract import evaluate_update_admission, record_refusal_receipt
+
+        refusal = evaluate_update_admission(_server_path("PROJECT_ROOT"))
+        if refusal is not None:
+            response = _update_refused(
+                _UPDATE_REFUSAL_ERROR_CODES.get(refusal.code, "update_not_in_place"), refusal.message, refusal.update_command,
+            )
+            record_refusal_receipt(refusal)
+            return _service_mutation_result(request, mutation, target, "unsupported", response)
+
+        action_id = secrets.token_hex(16)
+        with http_failure("Failed to spawn hermes update", 500, "Failed to start update"):
+            proc = _spawn_hermes_action(["update"], "hermes-update", env_overrides={"HERMES_ACTION_ID": action_id})
+        return _service_mutation_result(
+            request, mutation, target, "started",
+            {"ok": True, "pid": proc.pid, "name": "hermes-update", "action_id": action_id},
         )
-        record_refusal_receipt(refusal)
-        return response
-
-    existing = _ACTION_PROCS.get("hermes-update")
-    if existing is not None and existing.poll() is None:
-        response = {"ok": True, "pid": existing.pid, "name": "hermes-update", "already_running": True}
-        action_id = _ACTION_IDS.get("hermes-update")
-        if action_id:
-            response["action_id"] = action_id
-        return response
-
-    action_id = secrets.token_hex(16)
-    with http_failure("Failed to spawn hermes update", 500, "Failed to start update"):
-        proc = _spawn_hermes_action(["update"], "hermes-update", env_overrides={"HERMES_ACTION_ID": action_id})
-    return {"ok": True, "pid": proc.pid, "name": "hermes-update", "action_id": action_id}
-
 
 _NON_APPLYABLE_MESSAGES = {
     "docker": format_docker_update_message,

--- a/hermes_cli/web_routers/actions.py
+++ b/hermes_cli/web_routers/actions.py
@@ -117,12 +117,17 @@ _UPDATE_REFUSAL_ERROR_CODES = {
 }
 
 
-def _finish_action(name: str, exit_code: Optional[int], pid: Optional[int]) -> None:
-    """Record a terminal result and drop the live-process registries for ``name``."""
-    _SERVICE_MUTATION_INTENTS.pop(name, None)
-    _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": pid}
-    for registry in (_ACTION_PROCS, _ACTION_COMMANDS, _ACTION_IDS):
-        registry.pop(name, None)
+def _finish_action(
+    name: str, exit_code: Optional[int], pid: Optional[int], *, expected_proc: Optional[subprocess.Popen] = None,
+) -> None:
+    """Retire the observed process without deleting a newer service action."""
+    with _SERVICE_MUTATION_LOCK:
+        if expected_proc is not None and _ACTION_PROCS.get(name) is not expected_proc:
+            return
+        _SERVICE_MUTATION_INTENTS.pop(name, None)
+        _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": pid}
+        for registry in (_ACTION_PROCS, _ACTION_COMMANDS, _ACTION_IDS):
+            registry.pop(name, None)
 
 
 def _record_completed_action(name: str, message: str, exit_code: int = 1) -> None:
@@ -431,7 +436,7 @@ async def get_action_status(name: str, lines: int = 200):
         if exit_code is not None:
             with contextlib.suppress(Exception):
                 proc.wait(timeout=1)
-            _finish_action(name, exit_code, pid)
+            _finish_action(name, exit_code, pid, expected_proc=proc)
 
     response = {"name": name, "running": running, "exit_code": exit_code, "pid": pid, "lines": tail}
     if durable_update_action_id:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19595,6 +19595,8 @@
       "devDependencies": {
         "@babel/core": "8.0.1",
         "@rolldown/plugin-babel": "0.2.3",
+        "@testing-library/dom": "10.4.1",
+        "@testing-library/react": "16.3.2",
         "@types/babel__core": "7.20.5",
         "@types/node": "22.20.1",
         "@types/qrcode": "1.5.6",
@@ -19603,6 +19605,7 @@
         "@vitejs/plugin-react": "6.0.3",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint-plugin-react-refresh": "0.5.3",
+        "jsdom": "29.1.1",
         "three": "0.180.0",
         "typescript": "6.0.3",
         "vite": "8.2.0",

--- a/tests/hermes_cli/test_service_mutations.py
+++ b/tests/hermes_cli/test_service_mutations.py
@@ -73,10 +73,43 @@ def test_service_actions_reject_incomplete_intent_before_spawning(service_client
 
 
 @pytest.mark.parametrize("action", ["gateway-restart", "hermes-update"])
-@pytest.mark.parametrize("scenario", ["retry", "different-key", "other-action", "profile", "completed", "spawn-failure", "unsupported", "concurrent-same", "concurrent-other"])
+@pytest.mark.parametrize("scenario", ["retry", "different-key", "other-action", "profile", "completed", "spawn-failure", "unsupported", "concurrent-same", "concurrent-other", "status-respawn"])
 def test_service_intents_bind_retries_and_conflicts_to_the_running_action(service_client, monkeypatch, action, scenario):
     ctx = service_client
     url = endpoint(action)
+    if scenario == "status-respawn":
+        first = ctx.client.post(url, json=intent(action))
+        assert first.status_code == 200
+        old = ctx.spawned[0]
+        old.returncode = 0
+        entered = threading.Event()
+        resume = threading.Event()
+
+        def wait_old(*_args, **_kwargs):
+            entered.set()
+            assert resume.wait(5)
+            return 0
+
+        old.wait = wait_old
+        if action == "gateway-restart":
+            started_at, proc, command = ctx.server._LAST_GATEWAY_RESTART
+            monkeypatch.setattr(ctx.server, "_LAST_GATEWAY_RESTART", (started_at - 11, proc, command))
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            status = pool.submit(ctx.client.get, f"/api/actions/{action}/status")
+            try:
+                assert entered.wait(5)
+                second = ctx.client.post(url, json=intent(action, "replacement-request-12345"))
+                assert second.status_code == 200
+                assert len(ctx.spawned) == 2
+            finally:
+                resume.set()
+            assert status.result(timeout=5).status_code == 200
+        retry = ctx.client.post(url, json=intent(action, "replacement-request-12345"))
+        assert retry.status_code == 200
+        assert retry.json()["pid"] == second.json()["pid"]
+        assert len(ctx.spawned) == 2
+        assert ctx.gateway._ACTION_PROCS[action] is ctx.spawned[-1]
+        return
     if scenario.startswith("concurrent"):
         original_spawn = ctx.gateway.subprocess.Popen
         start = threading.Barrier(2)

--- a/tests/hermes_cli/test_service_mutations.py
+++ b/tests/hermes_cli/test_service_mutations.py
@@ -1,0 +1,150 @@
+"""Authenticated service intents must guard process creation, including retries."""
+
+import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def service_client(monkeypatch, _isolate_hermes_home, tmp_path):
+    import hermes_state
+    import hermes_cli.web_server as server
+    import hermes_cli.web_server_gateway as gateway
+    import hermes_cli.web_routers.actions as actions
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", home / "state.db")
+    for name in ("_ACTION_PROCS", "_ACTION_COMMANDS", "_ACTION_IDS", "_ACTION_RESULTS"):
+        monkeypatch.setattr(gateway, name, {})
+    monkeypatch.setattr(gateway, "_ACTION_LOG_DIR", tmp_path / "actions")
+    monkeypatch.setattr(server, "_LAST_GATEWAY_RESTART", None)
+    monkeypatch.setattr(actions, "_SERVICE_MUTATION_INTENTS", {}, raising=False)
+    monkeypatch.setattr("hermes_cli.gateway._reap_unsupervised_gateway_orphans", lambda: None)
+    monkeypatch.setattr("hermes_cli.web_server_files._dashboard_local_update_managed_externally", lambda: False)
+    monkeypatch.setattr("hermes_cli.update_contract.evaluate_update_admission", lambda *_: None)
+    (home / "profiles" / "coder").mkdir(parents=True, exist_ok=True)
+    (home / "profiles" / "coder" / "config.yaml").write_text("{}\n", encoding="utf-8")
+    spawned = []
+
+    def spawn(argv, **kwargs):
+        proc = SimpleNamespace(pid=1000 + len(spawned), returncode=None, argv=argv, kwargs=kwargs)
+        proc.poll = lambda: proc.returncode
+        spawned.append(proc)
+        return proc
+
+    monkeypatch.setattr(gateway.subprocess, "Popen", spawn)
+    client = TestClient(server.app)
+    client.headers[server._SESSION_HEADER_NAME] = server._SESSION_TOKEN
+
+    def audit():
+        path = home / "logs" / "dashboard-auth.log"
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()] if path.exists() else []
+
+    yield SimpleNamespace(client=client, spawned=spawned, gateway=gateway, server=server, audit=audit)
+    client.close()
+
+
+def intent(action, key="confirmed-request-123456"):
+    return {"confirmation": "RESTART" if action == "gateway-restart" else "UPDATE", "idempotency_key": key}
+
+
+def endpoint(action):
+    return "/api/gateway/restart" if action == "gateway-restart" else "/api/hermes/update"
+
+
+@pytest.mark.parametrize("action", ["gateway-restart", "hermes-update"])
+@pytest.mark.parametrize("payload", [None, [], "RESTART", {}, {"confirmation": "wrong"}, {"confirmation": "RESTART", "idempotency_key": "short"}])
+def test_service_actions_reject_incomplete_intent_before_spawning(service_client, action, payload):
+    ctx = service_client
+    response = ctx.client.post(endpoint(action), json=payload)
+    assert response.status_code == 400
+    assert ctx.spawned == []
+    event = ctx.audit()[-1]
+    assert event["event"] == "dashboard_mutation"
+    assert event["action"] == action
+    assert event["result"] == "rejected"
+    assert event["actor"] == "local-dashboard"
+
+
+@pytest.mark.parametrize("action", ["gateway-restart", "hermes-update"])
+@pytest.mark.parametrize("scenario", ["retry", "different-key", "other-action", "profile", "completed", "spawn-failure", "unsupported", "concurrent-same", "concurrent-other"])
+def test_service_intents_bind_retries_and_conflicts_to_the_running_action(service_client, monkeypatch, action, scenario):
+    ctx = service_client
+    url = endpoint(action)
+    if scenario.startswith("concurrent"):
+        original_spawn = ctx.gateway.subprocess.Popen
+        start = threading.Barrier(2)
+
+        def delayed_spawn(*args, **kwargs):
+            time.sleep(0.05)  # leave a real overlap between request threads
+            return original_spawn(*args, **kwargs)
+
+        def request(key):
+            start.wait(timeout=5)
+            return ctx.client.post(url, json=intent(action, key))
+
+        monkeypatch.setattr(ctx.gateway.subprocess, "Popen", delayed_spawn)
+        second_key = "another-confirmed-request-123" if scenario == "concurrent-other" else "confirmed-request-123456"
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(request, "confirmed-request-123456")
+            second = pool.submit(request, second_key)
+            responses = [first.result(timeout=5), second.result(timeout=5)]
+        assert sorted(response.status_code for response in responses) == ([200, 409] if scenario == "concurrent-other" else [200, 200])
+        assert len(ctx.spawned) == 1
+        return
+    if scenario == "spawn-failure":
+        def fail_spawn(*_args, **_kwargs):
+            raise OSError("fixture spawn failure")
+        monkeypatch.setattr(ctx.gateway.subprocess, "Popen", fail_spawn)
+        response = ctx.client.post(url, json=intent(action))
+        assert response.status_code == 500
+        assert ctx.audit()[-1]["result"] == "failed"
+        return
+    if scenario == "unsupported":
+        if action == "gateway-restart":
+            pytest.skip("Update admission applies only to the updater")
+        monkeypatch.setattr("hermes_cli.web_server_files._dashboard_local_update_managed_externally", lambda: True)
+        response = ctx.client.post(url, json=intent(action))
+        assert response.status_code == 200 and response.json()["ok"] is False
+        assert ctx.spawned == []
+        assert ctx.audit()[-1]["result"] == "unsupported"
+        return
+
+    first = ctx.client.post(url, json={**intent(action), "secret": "do-not-audit-this-value"})
+    assert first.status_code == 200
+    assert len(ctx.spawned) == 1
+    other_action = "hermes-update" if action == "gateway-restart" else "gateway-restart"
+    next_url = endpoint(other_action) if scenario == "other-action" else url
+    next_body = intent(other_action) if scenario == "other-action" else intent(action)
+    if scenario == "different-key":
+        next_body = intent(action, "another-confirmed-request-123")
+    if scenario == "profile":
+        if action == "hermes-update":
+            next_url = endpoint(other_action) + "?profile=coder"
+            next_body = intent(other_action)
+        else:
+            next_url += "?profile=coder"
+    if scenario == "completed":
+        ctx.spawned[0].returncode = 0
+        # The restart cooldown remains authoritative after the child exits.
+        next_body = intent(action, "another-confirmed-request-123")
+
+    second = ctx.client.post(next_url, json=next_body)
+    conflict = scenario in {"different-key", "other-action", "profile"}
+    assert second.status_code == (409 if conflict else 200)
+    assert len(ctx.spawned) == (2 if scenario == "completed" and action == "hermes-update" else 1)
+    if scenario == "retry" or (scenario == "completed" and action == "gateway-restart"):
+        assert second.json()["pid"] == first.json()["pid"]
+    if scenario == "retry" and action == "hermes-update":
+        assert second.json()["action_id"] == first.json()["action_id"]
+    events = ctx.audit()
+    assert events[0]["result"] == "started"
+    assert events[-1]["result"] == ("conflict" if conflict else "started" if len(ctx.spawned) == 2 else "reused")
+    assert "do-not-audit-this-value" not in json.dumps(events)
+    assert "confirmed-request-123456" not in json.dumps(events)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1279,7 +1279,7 @@ class TestWebServerEndpoints:
         _web_server_gateway._ACTION_PROCS.pop("hermes-update", None)
         _web_server_gateway._ACTION_RESULTS.pop("hermes-update", None)
 
-        resp = self.client.post("/api/hermes/update")
+        resp = self.client.post("/api/hermes/update", json={"confirmation": "UPDATE", "idempotency_key": "confirmed-update-test-123"})
 
         assert resp.status_code == 200
         data = resp.json()
@@ -1320,7 +1320,7 @@ class TestWebServerEndpoints:
         _web_server_gateway._ACTION_PROCS.pop("hermes-update", None)
         _web_server_gateway._ACTION_RESULTS.pop("hermes-update", None)
 
-        resp = self.client.post("/api/hermes/update")
+        resp = self.client.post("/api/hermes/update", json={"confirmation": "UPDATE", "idempotency_key": "confirmed-update-test-123"})
 
         assert resp.status_code == 200
         data = resp.json()
@@ -1387,7 +1387,7 @@ class TestWebServerEndpoints:
         _web_server_gateway._ACTION_PROCS.pop("hermes-update", None)
         _web_server_gateway._ACTION_RESULTS.pop("hermes-update", None)
 
-        resp = self.client.post("/api/hermes/update")
+        resp = self.client.post("/api/hermes/update", json={"confirmation": "UPDATE", "idempotency_key": "confirmed-update-test-123"})
 
         assert resp.status_code == 200
         assert resp.json() == {
@@ -1420,7 +1420,7 @@ class TestWebServerEndpoints:
         _web_server_gateway._ACTION_IDS["hermes-update"] = "b" * 32
 
         try:
-            resp = self.client.post("/api/hermes/update")
+            resp = self.client.post("/api/hermes/update", json={"confirmation": "UPDATE", "idempotency_key": "confirmed-update-test-123"})
         finally:
             _web_server_gateway._ACTION_PROCS.pop("hermes-update", None)
             _web_server_gateway._ACTION_IDS.pop("hermes-update", None)

--- a/web/package.json
+++ b/web/package.json
@@ -42,6 +42,8 @@
   "devDependencies": {
     "@babel/core": "8.0.1",
     "@rolldown/plugin-babel": "0.2.3",
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/react": "16.3.2",
     "@types/babel__core": "7.20.5",
     "@types/node": "22.20.1",
     "@types/qrcode": "1.5.6",
@@ -50,6 +52,7 @@
     "@vitejs/plugin-react": "6.0.3",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint-plugin-react-refresh": "0.5.3",
+    "jsdom": "29.1.1",
     "three": "0.180.0",
     "typescript": "6.0.3",
     "vite": "8.2.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { serviceMutationRequest } from "@hermes/shared";
 import {
   lazy,
   Suspense,
@@ -60,7 +61,7 @@ import { Button } from "@nous-research/ui/ui/components/button";
 import { SelectionSwitcher } from "@nous-research/ui/ui/components/selection-switcher";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
-import { ConfirmDialog } from "@nous-research/ui/ui/components/confirm-dialog";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import { SidebarFooter } from "@/components/SidebarFooter";
 import { SidebarStatusStrip, gatewayLine } from "@/components/SidebarStatusStrip";
@@ -1012,21 +1013,18 @@ function SidebarSystemActions({
       setUpdateConfirmOpen(true);
       return;
     }
-    void runAction(action);
-    navigate("/sessions");
-    onNavigate();
   };
 
   const confirmRestart = () => {
     setRestartConfirmOpen(false);
-    void runAction("restart");
+    void runAction("restart", serviceMutationRequest("RESTART"));
     navigate("/sessions");
     onNavigate();
   };
 
   const confirmUpdate = () => {
     setUpdateConfirmOpen(false);
-    void runAction("update");
+    void runAction("update", serviceMutationRequest("UPDATE"));
     navigate("/sessions");
     onNavigate();
   };
@@ -1082,6 +1080,7 @@ function SidebarSystemActions({
       loading={pendingAction === "restart"}
       onCancel={() => setRestartConfirmOpen(false)}
       onConfirm={confirmRestart}
+      typedConfirmation="RESTART"
       open={restartConfirmOpen}
       title={
         t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`
@@ -1097,6 +1096,7 @@ function SidebarSystemActions({
       loading={pendingAction === "update" || updateConfirmChecking}
       onCancel={() => setUpdateConfirmOpen(false)}
       onConfirm={confirmUpdate}
+      typedConfirmation="UPDATE"
       open={updateConfirmOpen}
       title={t.status.updateHermesConfirmTitle ?? `${t.status.updateHermes}?`}
     />

--- a/web/src/components/ConfirmDialog.test.tsx
+++ b/web/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+afterEach(cleanup);
+
+
+it.each(['wrong', 'correct', 'cancel', 'reopen', 'space', 'duplicate', 'retry'])(
+  'requires the exact typed intent before confirming: %s', async (mode) => {
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+    const props = { open: true, title: 'Restart', typedConfirmation: 'RESTART', onConfirm, onCancel: onClose };
+    const view = render(<ConfirmDialog {...props} />);
+    const input = await screen.findByRole('textbox');
+    const confirm = await screen.findByRole('button', { name: 'Confirm' });
+    await waitFor(() => expect(input.matches(':focus')).toBe(true));
+    fireEvent.click(confirm);
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onConfirm).not.toHaveBeenCalled();
+    if (mode === 'cancel') {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+      return;
+    }
+    fireEvent.change(input, { target: { value: mode === 'wrong' ? 'restart' : 'RESTART' } });
+    if (mode === 'space') {
+      const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+      input.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(false);
+      expect(onConfirm).not.toHaveBeenCalled();
+    } else if (mode === 'retry') {
+      let rejectAttempt!: (error: Error) => void;
+      onConfirm.mockImplementationOnce(() => new Promise<void>((_resolve, reject) => {
+        rejectAttempt = reject;
+      }).catch(() => {})); // The consumer reports the error and keeps the prompt open.
+      fireEvent.click(confirm);
+      fireEvent.click(confirm);
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+      await act(async () => { rejectAttempt(new Error('fixture failure')); });
+      fireEvent.click(confirm);
+      await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(2));
+    } else if (mode === 'duplicate') {
+      fireEvent.click(confirm);
+      fireEvent.click(confirm);
+      fireEvent.keyDown(input, { key: 'Enter' });
+      await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    } else if (mode === 'reopen') {
+      view.rerender(<ConfirmDialog {...props} open={false} />);
+      view.rerender(<ConfirmDialog {...props} />);
+      await waitFor(() => expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(''));
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+      expect(onConfirm).not.toHaveBeenCalled();
+    } else {
+      fireEvent.keyDown(input, { key: 'Enter' });
+      await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(mode === 'correct' ? 1 : 0));
+    }
+  }
+);

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@nous-research/ui/ui/components/button";
+import { Input } from "@nous-research/ui/ui/components/input";
+import { useI18n } from "@/i18n";
 import { AlertTriangle } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn, themedBody } from "@/lib/utils";
 
@@ -11,12 +13,17 @@ interface ConfirmDialogProps {
   destructive?: boolean;
   loading?: boolean;
   onCancel: () => void;
-  onConfirm: () => void;
+  onConfirm: () => Promise<void> | void;
   open: boolean;
   title: string;
+  typedConfirmation?: string;
 }
 
-export function ConfirmDialog({
+export function ConfirmDialog(props: ConfirmDialogProps) {
+  return props.open ? <OpenConfirmDialog key={props.typedConfirmation} {...props} /> : null;
+}
+
+function OpenConfirmDialog({
   cancelLabel = "Cancel",
   confirmLabel = "Confirm",
   description,
@@ -26,7 +33,13 @@ export function ConfirmDialog({
   onConfirm,
   open,
   title,
+  typedConfirmation,
 }: ConfirmDialogProps) {
+  const { t } = useI18n();
+  const submittingRef = useRef(false);
+  const inputId = useId();
+  const [confirmation, setConfirmation] = useState("");
+  const ready = typedConfirmation === undefined || confirmation === typedConfirmation;
   const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -34,11 +47,11 @@ export function ConfirmDialog({
 
     const prevActive = document.activeElement as HTMLElement | null;
     dialogRef.current
-      ?.querySelector<HTMLButtonElement>("[data-confirm]")
+      ?.querySelector<HTMLElement>(typedConfirmation !== undefined ? "input" : "[data-confirm]")
       ?.focus();
 
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+      if (e.key === "Escape" && !loading) {
         e.preventDefault();
         onCancel();
       }
@@ -53,7 +66,17 @@ export function ConfirmDialog({
       document.body.style.overflow = prevOverflow;
       prevActive?.focus?.();
     };
-  }, [open, onCancel]);
+  }, [open, onCancel, typedConfirmation, loading]);
+
+  const run = async () => {
+    if (!ready || loading || submittingRef.current) return;
+    submittingRef.current = true;
+    try {
+      await onConfirm();
+    } finally {
+      submittingRef.current = false;
+    }
+  };
 
   if (!open) return null;
 
@@ -64,7 +87,7 @@ export function ConfirmDialog({
       aria-labelledby="confirm-dialog-title"
       aria-describedby={description ? "confirm-dialog-desc" : undefined}
       onClick={(e) => {
-        if (e.target === e.currentTarget) onCancel();
+        if (e.target === e.currentTarget && !loading) onCancel();
       }}
       className="fixed inset-0 z-[200] flex items-center justify-center bg-background/85 p-4"
     >
@@ -101,6 +124,27 @@ export function ConfirmDialog({
           </div>
         </div>
 
+        {typedConfirmation !== undefined && (
+          <div className="flex flex-col gap-2 px-4 pt-4">
+            <label className="text-xs text-muted-foreground" htmlFor={inputId}>
+              {t.common.typedConfirmation(typedConfirmation)}
+            </label>
+            <Input
+              autoComplete="off"
+              disabled={loading}
+              id={inputId}
+              onChange={(event) => setConfirmation(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+                  event.preventDefault();
+                  void run();
+                }
+              }}
+              spellCheck={false}
+              value={confirmation}
+            />
+          </div>
+        )}
         <div className="flex items-center justify-end gap-2 p-3">
           <Button type="button" outlined onClick={onCancel} disabled={loading}>
             {cancelLabel}
@@ -109,8 +153,8 @@ export function ConfirmDialog({
             data-confirm
             type="button"
             destructive={destructive}
-            onClick={onConfirm}
-            disabled={loading}
+            onClick={() => void run()}
+            disabled={loading || !ready}
           >
             {loading ? "…" : confirmLabel}
           </Button>

--- a/web/src/contexts/SystemActions.tsx
+++ b/web/src/contexts/SystemActions.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { serviceMutationRequest, type ServiceMutationRequest } from "@hermes/shared";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import type { ActionStatusResponse } from "@/lib/api";
 import { Toast } from "@nous-research/ui/ui/components/toast";
@@ -7,6 +9,12 @@ import {
   SystemActionsContext,
   type SystemAction,
 } from "./system-actions-context";
+
+interface MutationPrompt {
+  action: SystemAction;
+  id: number;
+  resolve: (request: ServiceMutationRequest | null) => void;
+}
 
 const ACTION_NAMES: Record<SystemAction, string> = {
   restart: "gateway-restart",
@@ -18,6 +26,24 @@ export function SystemActionsProvider({
 }: {
   children: React.ReactNode;
 }) {
+  const [prompt, setPrompt] = useState<MutationPrompt | null>(null);
+  const promptRef = useRef<MutationPrompt | null>(null);
+  const promptIdRef = useRef(0);
+  const confirmMutation = useCallback((action: SystemAction) => {
+    promptRef.current?.resolve(null);
+    return new Promise<ServiceMutationRequest | null>((resolve) => {
+      const next = { action, id: ++promptIdRef.current, resolve };
+      promptRef.current = next;
+      setPrompt(next);
+    });
+  }, []);
+  const settlePrompt = useCallback((current: MutationPrompt, accepted: boolean) => {
+    if (promptRef.current !== current) return;
+    promptRef.current = null;
+    setPrompt(null);
+    current.resolve(accepted ? serviceMutationRequest(current.action === "restart" ? "RESTART" : "UPDATE") : null);
+  }, []);
+  useEffect(() => () => { promptRef.current?.resolve(null); promptRef.current = null; }, []);
   const [pendingAction, setPendingAction] = useState<SystemAction | null>(null);
   const [activeAction, setActiveAction] = useState<SystemAction | null>(null);
   const [actionStatus, setActionStatus] = useState<ActionStatusResponse | null>(
@@ -65,15 +91,15 @@ export function SystemActionsProvider({
   }, [activeAction, t.status.actionFinished, t.status.actionFailed]);
 
   const runAction = useCallback(
-    async (action: SystemAction) => {
+    async (action: SystemAction, request: ServiceMutationRequest) => {
       setPendingAction(action);
       setActionStatus(null);
       try {
         if (action === "restart") {
-          await api.restartGateway();
+          await api.restartGateway(request);
           setActiveAction(action);
         } else {
-          const resp = await api.updateHermes();
+          const resp = await api.updateHermes(request);
           // Some installs cannot apply updates from inside the dashboard. The
           // endpoint returns a structured {ok:false, message, update_command}
           // envelope instead of spawning the action; surface that guidance
@@ -122,9 +148,21 @@ export function SystemActionsProvider({
         isRunning,
         pendingAction,
         runAction,
+        confirmMutation,
       }}
     >
       {children}
+      {prompt && <ConfirmDialog
+        key={prompt.id}
+        open
+        typedConfirmation={prompt.action === "restart" ? "RESTART" : "UPDATE"}
+        title={prompt.action === "restart" ? t.status.restartGateway : t.status.updateHermes}
+        description={prompt.action === "restart" ? t.status.restartGatewayConfirmMessage : t.status.updateHermesConfirmMessage}
+        cancelLabel={t.common.cancel}
+        confirmLabel={t.common.confirm}
+        onCancel={() => settlePrompt(prompt, false)}
+        onConfirm={() => settlePrompt(prompt, true)}
+      />}
       <Toast toast={toast} />
     </SystemActionsContext.Provider>
   );

--- a/web/src/contexts/system-actions-context.ts
+++ b/web/src/contexts/system-actions-context.ts
@@ -1,3 +1,4 @@
+import type { ServiceMutationRequest } from "@hermes/shared";
 import { createContext } from "react";
 import type { ActionStatusResponse } from "@/lib/api";
 
@@ -14,5 +15,6 @@ export interface SystemActionsState {
   isBusy: boolean;
   isRunning: boolean;
   pendingAction: SystemAction | null;
-  runAction: (action: SystemAction) => Promise<void>;
+  confirmMutation: (action: SystemAction) => Promise<ServiceMutationRequest | null>;
+  runAction: (action: SystemAction, request: ServiceMutationRequest) => Promise<void>;
 }

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -7,6 +7,7 @@ export const af: Translations = {
     cancel: "Kanselleer",
     close: "Maak toe",
     confirm: "Bevestig",
+    typedConfirmation: (value: string) => `Tik ${value} om te bevestig.`,
     delete: "Skrap",
     refresh: "Herlaai",
     retry: "Probeer weer",

--- a/web/src/i18n/ar.ts
+++ b/web/src/i18n/ar.ts
@@ -7,6 +7,7 @@ export const ar = defineLocale({
     cancel: "إلغاء",
     close: "إغلاق",
     confirm: "تأكيد",
+    typedConfirmation: (value: string) => `اكتب ${value} للتأكيد.`,
     delete: "حذف",
     refresh: "تحديث",
     retry: "إعادة المحاولة",

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -7,6 +7,7 @@ export const de: Translations = {
     cancel: "Abbrechen",
     close: "Schließen",
     confirm: "Bestätigen",
+    typedConfirmation: (value: string) => `Gib ${value} zur Bestätigung ein.`,
     delete: "Löschen",
     refresh: "Aktualisieren",
     retry: "Erneut versuchen",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -7,6 +7,7 @@ export const en: Translations = {
     cancel: "Cancel",
     close: "Close",
     confirm: "Confirm",
+    typedConfirmation: (value: string) => `Type ${value} to confirm.`,
     delete: "Delete",
     refresh: "Refresh",
     retry: "Retry",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -7,6 +7,7 @@ export const es: Translations = {
     cancel: "Cancelar",
     close: "Cerrar",
     confirm: "Confirmar",
+    typedConfirmation: (value: string) => `Escribe ${value} para confirmar.`,
     delete: "Eliminar",
     refresh: "Actualizar",
     retry: "Reintentar",

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -7,6 +7,7 @@ export const fr: Translations = {
     cancel: "Annuler",
     close: "Fermer",
     confirm: "Confirmer",
+    typedConfirmation: (value: string) => `Saisissez ${value} pour confirmer.`,
     delete: "Supprimer",
     refresh: "Actualiser",
     retry: "Réessayer",

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -7,6 +7,7 @@ export const ga: Translations = {
     cancel: "Cealaigh",
     close: "Dún",
     confirm: "Deimhnigh",
+    typedConfirmation: (value: string) => `Clóscríobh ${value} chun deimhniú.`,
     delete: "Scrios",
     refresh: "Athnuaigh",
     retry: "Bain triail eile as",

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -7,6 +7,7 @@ export const hu: Translations = {
     cancel: "Mégse",
     close: "Bezárás",
     confirm: "Megerősítés",
+    typedConfirmation: (value: string) => `A megerősítéshez írd be: ${value}.`,
     delete: "Törlés",
     refresh: "Frissítés",
     retry: "Újra",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -7,6 +7,7 @@ export const it: Translations = {
     cancel: "Annulla",
     close: "Chiudi",
     confirm: "Conferma",
+    typedConfirmation: (value: string) => `Digita ${value} per confermare.`,
     delete: "Elimina",
     refresh: "Aggiorna",
     retry: "Riprova",

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -7,6 +7,7 @@ export const ja: Translations = {
     cancel: "キャンセル",
     close: "閉じる",
     confirm: "確認",
+    typedConfirmation: (value: string) => `確認するには ${value} と入力してください。`,
     delete: "削除",
     refresh: "更新",
     retry: "再試行",

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -7,6 +7,7 @@ export const ko: Translations = {
     cancel: "취소",
     close: "닫기",
     confirm: "확인",
+    typedConfirmation: (value: string) => `확인하려면 ${value}을(를) 입력하세요.`,
     delete: "삭제",
     refresh: "새로고침",
     retry: "다시 시도",

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -7,6 +7,7 @@ export const pt: Translations = {
     cancel: "Cancelar",
     close: "Fechar",
     confirm: "Confirmar",
+    typedConfirmation: (value: string) => `Digite ${value} para confirmar.`,
     delete: "Eliminar",
     refresh: "Atualizar",
     retry: "Tentar novamente",

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -7,6 +7,7 @@ export const ru: Translations = {
     cancel: "Отмена",
     close: "Закрыть",
     confirm: "Подтвердить",
+    typedConfirmation: (value: string) => `Введите ${value} для подтверждения.`,
     delete: "Удалить",
     refresh: "Обновить",
     retry: "Повторить",

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -7,6 +7,7 @@ export const tr: Translations = {
     cancel: "İptal",
     close: "Kapat",
     confirm: "Onayla",
+    typedConfirmation: (value: string) => `Onaylamak için ${value} yazın.`,
     delete: "Sil",
     refresh: "Yenile",
     retry: "Yeniden dene",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -25,6 +25,7 @@ export interface Translations {
     cancel: string;
     close: string;
     confirm: string;
+    typedConfirmation: (value: string) => string;
     delete: string;
     refresh: string;
     retry: string;

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -7,6 +7,7 @@ export const uk: Translations = {
     cancel: "Скасувати",
     close: "Закрити",
     confirm: "Підтвердити",
+    typedConfirmation: (value: string) => `Введіть ${value}, щоб підтвердити.`,
     delete: "Видалити",
     refresh: "Оновити",
     retry: "Повторити",

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -7,6 +7,7 @@ export const zhHant: Translations = {
     cancel: "取消",
     close: "關閉",
     confirm: "確認",
+    typedConfirmation: (value: string) => `輸入 ${value} 以確認。`,
     delete: "刪除",
     refresh: "重新整理",
     retry: "重試",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -7,6 +7,7 @@ export const zh: Translations = {
     cancel: "取消",
     close: "关闭",
     confirm: "确认",
+    typedConfirmation: (value: string) => `输入 ${value} 以确认。`,
     delete: "删除",
     refresh: "刷新",
     retry: "重试",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,4 @@
+import type { ServiceMutationRequest } from "@hermes/shared";
 import { buildHermesWebSocketUrl } from "@hermes/shared";
 
 // The dashboard can be served either at the root of its host (e.g.
@@ -954,14 +955,22 @@ export const api = {
     ),
 
   // Gateway / update actions
-  restartGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/restart", { method: "POST" }),
+  restartGateway: (request: ServiceMutationRequest) =>
+    fetchJSON<ActionResponse>("/api/gateway/restart", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    }),
   getGatewayMigratePlan: () =>
     fetchJSON<GatewayMigratePlan>("/api/gateway/migrate/plan"),
   migrateGatewayToMultiplex: () =>
     fetchJSON<ActionResponse>("/api/gateway/migrate", { method: "POST" }),
-  updateHermes: () =>
-    fetchJSON<ActionResponse>("/api/hermes/update", { method: "POST" }),
+  updateHermes: (request: ServiceMutationRequest) =>
+    fetchJSON<ActionResponse>("/api/hermes/update", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    }),
   checkHermesUpdate: (force = false) =>
     fetchJSON<UpdateCheckResponse>(
       `/api/hermes/update/check${force ? "?force=true" : ""}`,

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -1,3 +1,4 @@
+import { useSystemActions } from "@/contexts/useSystemActions";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import {
   AlertTriangle,
@@ -130,6 +131,7 @@ function normalizeWhatsAppMode(mode: unknown): "bot" | "self-chat" | null {
 }
 
 export default function ChannelsPage() {
+  const { confirmMutation } = useSystemActions();
   const [platforms, setPlatforms] = useState<MessagingPlatform[]>([]);
   const [envPath, setEnvPath] = useState("~/.hermes/.env");
   const [gatewayStartCommand, setGatewayStartCommand] = useState(
@@ -260,9 +262,11 @@ export default function ChannelsPage() {
   };
 
   const handleRestart = async () => {
+    const request = await confirmMutation("restart");
+    if (!request) return;
     setRestarting(true);
     try {
-      await api.restartGateway();
+      await api.restartGateway(request);
       showToast("Gateway restarting…", "success");
       setRestartNeeded(false);
       // Give the gateway a moment to come up, then refresh status.
@@ -1065,6 +1069,7 @@ function TelegramOnboardingPanel({
   setRestartNeeded: (needed: boolean) => void;
   showToast: (message: string, type: "success" | "error") => void;
 }) {
+  const { confirmMutation } = useSystemActions();
   const [setup, setSetup] = useState<TelegramOnboardingStartResponse | null>(
     null,
   );
@@ -1237,7 +1242,13 @@ function TelegramOnboardingPanel({
         void watchRestartOutcome();
       } else if (result.restart_started === undefined && result.needs_restart) {
         try {
-          await api.restartGateway();
+          const request = await confirmMutation("restart");
+          if (!request) {
+            onRestartNeeded();
+            await onChanged();
+            return;
+          }
+          await api.restartGateway(request);
           showToast("Telegram saved; gateway restarting…", "success");
           setRestartNeeded(false);
           setTimeout(() => void onChanged(), 4000);

--- a/web/src/pages/SystemPage.tsx
+++ b/web/src/pages/SystemPage.tsx
@@ -1,3 +1,5 @@
+import { serviceMutationRequest } from "@hermes/shared";
+import { useSystemActions } from "@/contexts/useSystemActions";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 import {
@@ -39,7 +41,7 @@ import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
-import { ConfirmDialog } from "@nous-research/ui/ui/components/confirm-dialog";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { HermesConsoleModal } from "@/components/HermesConsoleModal";
@@ -192,6 +194,7 @@ const MEMORY_STATUS_TONE: Record<
 };
 
 export default function SystemPage() {
+  const { confirmMutation } = useSystemActions();
   const { toast, showToast } = useToast();
 
   const [status, setStatus] = useState<StatusResponse | null>(null);
@@ -299,7 +302,9 @@ export default function SystemPage() {
         await api.stopGateway();
         setActiveAction("gateway-stop");
       } else {
-        await api.restartGateway();
+        const request = await confirmMutation("restart");
+        if (!request) return;
+        await api.restartGateway(request);
         setActiveAction("gateway-restart");
       }
       showToast(`Gateway ${verb} started`, "success");
@@ -567,7 +572,7 @@ export default function SystemPage() {
       return;
     }
     try {
-      const resp = await api.updateHermes();
+      const resp = await api.updateHermes(serviceMutationRequest("UPDATE"));
       if (!resp.ok) {
         showToast(
           resp.message ??
@@ -674,6 +679,7 @@ export default function SystemPage() {
       />
 
       <ConfirmDialog
+        typedConfirmation="UPDATE"
         open={canUpdateHermes && updateConfirmOpen}
         onCancel={() => setUpdateConfirmOpen(false)}
         onConfirm={() => void applyUpdate()}

--- a/web/src/pages/WebhooksPage.tsx
+++ b/web/src/pages/WebhooksPage.tsx
@@ -1,3 +1,4 @@
+import { useSystemActions } from "@/contexts/useSystemActions";
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import {
   AlertTriangle,
@@ -57,6 +58,7 @@ function CopyButton({ value }: { value: string }) {
 }
 
 export default function WebhooksPage() {
+  const { confirmMutation } = useSystemActions();
   const [data, setData] = useState<WebhooksResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [enabling, setEnabling] = useState(false);
@@ -130,9 +132,11 @@ export default function WebhooksPage() {
   }, [showToast]);
 
   const handleRestart = useCallback(async () => {
+    const request = await confirmMutation("restart");
+    if (!request) return;
     setRestarting(true);
     try {
-      await api.restartGateway();
+      await api.restartGateway(request);
       setRestartNeeded(false);
       setRestartError(null);
       setRestartMessage("Gateway restarting…");
@@ -146,7 +150,7 @@ export default function WebhooksPage() {
     } finally {
       setRestarting(false);
     }
-  }, [loadWebhooks, showToast, watchRestartOutcome]);
+  }, [confirmMutation, loadWebhooks, showToast, watchRestartOutcome]);
 
   const handleEnableWebhooks = useCallback(async () => {
     setEnabling(true);

--- a/web/src/pages/service-actions.test.tsx
+++ b/web/src/pages/service-actions.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { useState, type ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, expect, it, vi } from "vitest";
+import { SystemActionsProvider } from "@/contexts/SystemActions";
+import { PageHeaderContext } from "@/contexts/page-header-context";
+import { setManagementProfile } from "@/lib/api";
+import ChannelsPage from "./ChannelsPage";
+import WebhooksPage from "./WebhooksPage";
+import SystemPage from "./SystemPage";
+
+function Shell({ children }: { children: ReactNode }) {
+  const [end, setEnd] = useState<ReactNode>(null);
+  return <MemoryRouter><PageHeaderContext.Provider value={{ setEnd, setAfterTitle: () => {}, setTitle: () => {} }}>
+    <SystemActionsProvider>{end}{children}</SystemActionsProvider>
+  </PageHeaderContext.Provider></MemoryRouter>;
+}
+
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); setManagementProfile(""); });
+
+it.each(["channels", "cancel", "webhooks", "system-restart", "system-update"])(
+  "requires typed intent at the live page before sending a service action: %s", async (mode) => {
+    const requests: { url: string; body: Record<string, unknown> }[] = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const path = String(url).split("?")[0];
+      let data: unknown = null;
+      if (path === "/api/gateway/restart" || path === "/api/hermes/update") {
+        requests.push({ url: String(url), body: JSON.parse(String(init?.body ?? "{}")) });
+        data = { ok: true, name: path.includes("restart") ? "gateway-restart" : "hermes-update", pid: 123 };
+      } else if (path.includes("/actions/")) data = { running: false, exit_code: 0, lines: [] };
+      else if (path === "/api/messaging/platforms") data = { platforms: [], env_path: "fixture.env" };
+      else if (path === "/api/webhooks") data = { enabled: false, subscriptions: [] };
+      else if (path === "/api/webhooks/enable") data = { ok: true, restart_started: false };
+      else if (path === "/api/status") data = { gateway_running: true, can_update_hermes: true, active_sessions: 0 };
+      else if (path === "/api/hermes/update/check") data = { can_apply: true, update_available: true, behind: 1, update_command: "hermes update", commits: [] };
+      else if (path.includes("credential")) data = { providers: [] };
+      else if (path.includes("checkpoints")) data = { sessions: [], total_bytes: 0 };
+      else if (path.includes("hooks")) data = { hooks: [] };
+      return new Response(JSON.stringify(data), { status: 200, headers: { "Content-Type": "application/json" } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    setManagementProfile("coder");
+    render(<Shell>{mode.startsWith("system") ? <SystemPage /> : mode === "webhooks" ? <WebhooksPage /> : <ChannelsPage />}</Shell>);
+    if (mode === "webhooks") fireEvent.click(await screen.findByRole("button", { name: "Enable webhooks" }));
+    const action = mode === "system-update" ? "UPDATE" : "RESTART";
+    const name = mode === "system-update" ? /Update now/i : mode === "system-restart" ? /^Restart$/i : /^Restart gateway$/i;
+    fireEvent.click(await screen.findByRole("button", { name }));
+    const input = await screen.findByRole("textbox", { name: `Type ${action} to confirm.` });
+    expect(requests).toHaveLength(0);
+    if (mode === "cancel") {
+      fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
+      await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+      expect(requests).toHaveLength(0);
+      return;
+    }
+    fireEvent.change(input, { target: { value: action.toLowerCase() } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(requests).toHaveLength(0);
+    fireEvent.change(input, { target: { value: action } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(requests).toHaveLength(1));
+    expect(requests[0].body.confirmation).toBe(action);
+    expect(requests[0].body.idempotency_key).toMatch(/^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$/);
+    if (action === "RESTART") expect(requests[0].url).toContain("profile=coder");
+  }
+);

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -580,7 +580,9 @@ same auth gate as the rest of `/api/`.
 | `GET /api/memory` | Active provider + available providers + built-in file sizes |
 | `PUT /api/memory/provider` | Select a provider (empty = built-in only) |
 | `POST /api/memory/reset` | Reset built-in memory. Body: `{target: all\|memory\|user}` |
-| `POST /api/gateway/start` · `/stop` · `/restart` | Gateway lifecycle (backgrounded) |
+| `POST /api/gateway/start` · `/stop` | Gateway lifecycle (backgrounded) |
+| `POST /api/gateway/restart` | Restart the gateway. Body: `{confirmation: "RESTART", idempotency_key: string}` |
+| `POST /api/hermes/update` | Update Hermes. Body: `{confirmation: "UPDATE", idempotency_key: string}` |
 | `POST /api/ops/doctor` · `/security-audit` · `/backup` · `/import` | Diagnostics & maintenance (backgrounded; tail via `/api/actions/{name}/status`) |
 | `GET /api/ops/hooks` | Configured shell hooks + allowlist status |
 | `GET /api/ops/checkpoints` · `POST .../prune` | Inspect / prune the `/rollback` store |
@@ -598,6 +600,8 @@ same auth gate as the rest of `/api/`.
 | `GET /api/sessions/{id}/export` | Export a session (metadata + messages) as JSON |
 | `POST /api/sessions/prune` | Delete ended sessions older than N days |
 | `PUT /api/cron/jobs/{id}` | Edit a cron job's prompt / schedule / name / deliver |
+
+Restart and update controls require typing the exact confirmation shown in the dialog. API clients must also send that confirmation and an `idempotency_key` of 16–128 characters, starting with a letter or digit and using only letters, digits, `.`, `_`, `:`, or `-`. Generate one key for each confirmed operation and reuse it when retrying that request. Missing or invalid fields return HTTP 400; conflicting restart/update work returns HTTP 409. An identical request reuses its running process. Keys are held only while the action is running in this dashboard process; they are not durable across dashboard restarts. The existing restart cooldown still coalesces nearby restarts after a child exits.
 
 ## Authentication (gated mode)
 


### PR DESCRIPTION
Restart and update controls now require the exact typed intent before dispatching a service request. Web and desktop callers carry that intent and one idempotency key through their APIs, including the desktop connection-update fan-out. Cancellation keeps pending-restart state intact. Existing update previews, progress handling and profile routing remain available.

The backend requires confirmation and a bounded key, reuses a running action only for the same key and target, and returns HTTP 409 for conflicting restart/update work. It records actor, target and immediate outcome without request bodies or keys. The existing restart cooldown, orphan cleanup, update-admission guidance and durable update action IDs are preserved.

This is the restart/update slice of #25910. Keys are process-local and live-action scoped; other mutation classes and durable idempotency remain outside this change. Current clients are migrated before backend enforcement in compatible prefixes: dialog support, caller migration, then enforcement. A separate fourth commit fixes stale threaded status cleanup so it cannot erase a replacement action. Older API clients must supply the documented request fields. The caller migration incorporates Teknium's review of the earlier proposal.

Validation:
- Reproduced missing typed prompts in both primitives and all 11 exercised caller cases before fixing them.
- 237 Python tests passed, with one inapplicable parameter case skipped. Coverage includes actual authenticated HTTP handlers, concurrent requests, spawn bookkeeping, cooldown, audit records and update admission.
- 100 frontend tests passed, including actual Channels, Webhooks and System pages and desktop action controllers. The production web build and desktop renderer, Electron and end-to-end type checks passed for each client prefix.
- Ruff and diff checks passed. The Windows scanner reports five unchanged encoding findings in untouched test_web_server.py lines; exact-base comparison found zero introduced findings.

Not checked:
- Native Windows/macOS and packaged Electron execution.
- Live gateway restart or installation update; tests replace process creation.
- CodeRabbit: skipped for this self-authored P3 PR.

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.
