### PR TITLE
fix: skip supervisor wrappers in dashboard scan and respawn (#73379)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6819,6 +6819,12 @@ def _scan_dashboard_processes(
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
+    # Shell loop keywords that indicate a supervisor/respawn wrapper rather
+    # than a direct ``hermes dashboard`` invocation.  Wrappers like
+    # ``bash -lc "while true; do hermes dashboard …; sleep 3; done"``
+    # contain the substring "hermes dashboard" but should NOT be killed —
+    # killing the wrapper destroys the supervisor itself (#73379).
+    _LOOP_INDICATORS = ("while true", "while :", "until ", "; do ")
     patterns = [
         "hermes dashboard",
         "hermes_cli.main dashboard",
@@ -6867,6 +6873,7 @@ def _scan_dashboard_processes(
                     pid_str = line[len("ProcessId=") :]
                     if (
                         any(p in current_cmd for p in patterns)
+                        and not any(kw in current_cmd.lower() for kw in _LOOP_INDICATORS)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -6900,6 +6907,10 @@ def _scan_dashboard_processes(
                         continue
                     command = parts[1]
                     if any(p in command for p in patterns) and pid != self_pid:
+                        # Skip supervisor/respawn wrappers (#73379).
+                        cmd_lower = command.lower()
+                        if any(kw in cmd_lower for kw in _LOOP_INDICATORS):
+                            continue
                         dashboard_processes.append((pid, command))
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
@@ -7579,14 +7590,33 @@ def _kill_stale_dashboard_processes(
     pid_cgroup: dict[int, str | None] = {}
     pid_service: dict[int, str | None] = {}
     pid_cmdline: dict[int, list[str]] = {}
+    pid_ppid: dict[int, int] = {}
     if restart_managed and sys.platform != "win32":
         for pid in pids:
             cg_path = _get_pid_cgroup_path(pid)
             pid_cgroup[pid] = cg_path
             pid_service[pid] = _get_systemd_service_for_pid(pid)
+            # Snapshot the parent PID so we can skip respawning processes
+            # that are supervised by something other than systemd (tmux,
+            # supervisord, runit, etc.).  If PPID != 1 the supervisor will
+            # handle the restart; respawning with start_new_session=True
+            # would detach the child from its supervisor (#73379).
+            try:
+                with open(f"/proc/{pid}/status") as _f:
+                    for _line in _f:
+                        if _line.startswith("PPid:"):
+                            pid_ppid[pid] = int(_line.split()[1])
+                            break
+            except (OSError, IndexError, ValueError):
+                pass
             if not pid_service[pid]:
                 # Manually-started process: preserve its exact argv so we
                 # can respawn it after the update (#40449, #68934).
+                # But skip if the process has a living parent (PPID != 1) —
+                # the supervisor will restart it, and detaching would orphan
+                # it outside its original supervision scope (#73379).
+                if pid_ppid.get(pid, 1) != 1:
+                    continue
                 cmdline = _dashboard_cmdline_for_pid(pid)
                 if cmdline:
                     pid_cmdline[pid] = cmdline

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7602,7 +7602,7 @@ def _kill_stale_dashboard_processes(
             # handle the restart; respawning with start_new_session=True
             # would detach the child from its supervisor (#73379).
             try:
-                with open(f"/proc/{pid}/status") as _f:
+                with open(f"/proc/{pid}/status", encoding="utf-8") as _f:
                     for _line in _f:
                         if _line.startswith("PPid:"):
                             pid_ppid[pid] = int(_line.split()[1])

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -14,6 +14,7 @@ History:
 from __future__ import annotations
 
 import importlib
+import io
 import os
 import sys
 from unittest.mock import patch, MagicMock
@@ -232,6 +233,93 @@ class TestFindStaleDashboardPids:
             )
             pids = _find_stale_dashboard_pids(exclude_pids={12345})
         assert pids == []
+
+
+    def test_supervisor_wrapper_while_true_skipped(self):
+        """A shell loop wrapper containing 'hermes dashboard' should not be
+        matched — killing it would destroy the supervisor itself (#73379).
+        """
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(
+                        10000,
+                        'bash -lc "while true; do hermes dashboard '
+                        "--host 127.0.0.1 --port 9119 --no-open "
+                        '--skip-build; sleep 3; done"',
+                    ),
+                    _ps_line(
+                        20000,
+                        "python3 /path/to/venv/bin/hermes dashboard "
+                        "--host 127.0.0.1 --port 9119 --no-open",
+                    ),
+                ])
+                + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        # The wrapper (PID 10000) should be skipped; only the actual
+        # dashboard process (PID 20000) should be returned.
+        assert 10000 not in pids
+        assert 20000 in pids
+
+    def test_supervisor_wrapper_while_colon_skipped(self):
+        """'while :' is a POSIX idiom for infinite loops."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_ps_line(
+                    10001,
+                    "sh -c 'while :; do hermes dashboard --port 9119; sleep 1; done'",
+                )
+                + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert pids == []
+
+    def test_supervisor_wrapper_until_skipped(self):
+        """'until' loop wrappers should also be skipped."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_ps_line(
+                    10002,
+                    "bash -c 'until false; do hermes serve --port 8300; sleep 2; done'",
+                )
+                + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert pids == []
+
+    def test_supervisor_wrapper_semicolon_do_skipped(self):
+        "'; do ' in the command indicates a loop body."
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_ps_line(
+                    10003,
+                    "bash -lc 'for i in 1 2 3; do hermes dashboard --port 9119; done'",
+                )
+                + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert pids == []
+
+    def test_direct_hermes_dashboard_still_matched(self):
+        """Direct ``hermes dashboard`` without loop constructs must still match."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_ps_line(12345, "hermes dashboard --port 9119 --no-open")
+                + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert pids == [12345]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill semantics")
@@ -792,6 +880,43 @@ class TestManualBackendRespawn:
         assert failed == [["hermes", "serve"]]
         out = capsys.readouterr().out
         assert "✗ failed to restart" in out
+
+    def test_supervised_non_systemd_pid_not_respawned(self, capsys):
+        """Processes with PPID != 1 are supervised by something other than
+        systemd (tmux, supervisord, etc.).  They should be killed but NOT
+        respawned — the supervisor will handle the restart (#73379).
+        """
+        live = self._live()
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        proc_status = io.BytesIO(b"Name:\thermes\ntest\nPPid:\t42\nState:\tS\n")
+
+        real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if isinstance(path, str) and path.startswith("/proc/"):
+                return io.TextIOWrapper(proc_status, encoding="utf-8")
+            return real_open(path, *args, **kwargs)
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[5555]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid") as capture, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("builtins.open", side_effect=fake_open), \
+             patch("time.sleep"):
+            _kill_stale_dashboard_processes(restart_managed=True)
+
+        # PPID 42 ≠ 1 → supervised → cmdline capture and respawn both skipped.
+        capture.assert_not_called()
+        respawn.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Restart anything not auto-restarted" in out
 
 
 class TestCmdlineCapture:


### PR DESCRIPTION
## Summary

`hermes update` permanently orphans non-systemd-supervised dashboard processes by:

1. **Killing supervisor wrappers** — `_scan_dashboard_processes()` uses substring matching, so a wrapper like `bash -lc "while true; do hermes dashboard ...; sleep 3; done"` matches the pattern "hermes dashboard". Both the wrapper AND the actual dashboard process are killed, destroying the supervisor itself.

2. **Respawning detached** — after killing, both processes are respawned with `start_new_session=True`, which detaches them from the original supervision scope (tmux, supervisord, etc.). The respawned process holds port 9119 with PPID 1, while the supervisor crash-loops on `address already in use`.

## Changes

### `hermes_cli/main.py`

**Fix 1 — Filter supervisor wrappers from scan**: Added loop-indicator detection (`while true`, `while :`, `until `, `; do `) in `_scan_dashboard_processes()`. Shell loop wrappers are now skipped — only the actual dashboard/serve process is matched.

**Fix 2 — Don't respawn supervised processes**: `_kill_stale_dashboard_processes()` now snapshots each PID's PPID (from `/proc/{pid}/status`) before killing. Processes with PPID != 1 are supervised by something other than systemd (tmux, supervisord, runit, etc.). These are killed but NOT respawned — the supervisor will handle the restart. This prevents the orphan scenario where `start_new_session=True` detaches the child from its supervisor.

### `tests/hermes_cli/test_update_stale_dashboard.py`

Added 6 new tests:
- `test_supervisor_wrapper_while_true_skipped` — "while true" wrapper skipped, actual process matched
- `test_supervisor_wrapper_while_colon_skipped` — "while :" POSIX idiom skipped
- `test_supervisor_wrapper_until_skipped` — "until" loop wrapper skipped
- `test_supervisor_wrapper_semicolon_do_skipped` — "for ...; do ..." wrapper skipped
- `test_direct_hermes_dashboard_still_matched` — direct invocations still match
- `test_supervised_non_systemd_pid_not_respawned` — PPID != 1 → kill but don't respawn

## Test Plan

- [x] All 46 tests pass (40 existing + 6 new)
- [x] Existing `TestFindStaleDashboardPids` tests unchanged — direct dashboard invocations still matched
- [x] Existing `TestManualBackendRespawn` tests unchanged — PID 1 processes still respawned
- [x] New tests verify supervisor wrappers are filtered and supervised processes aren't respawned

Fixes #73379
