### PR TITLE
fix(cli): catch PermissionError in _apply_managed_env() (#73401)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -371,7 +371,10 @@ def _apply_managed_env() -> None:
     if managed_dir is None:
         return
     managed_env = managed_dir / ".env"
-    if not managed_env.exists():
+    try:
+        if not managed_env.exists():
+            return
+    except PermissionError:  # noqa: BLE001 — fail-open per docstring
         return
     _sanitize_env_file_if_needed(managed_env)
     _load_dotenv_with_fallback(managed_env, override=True)


### PR DESCRIPTION
## Summary

Fixes #73401.

`_apply_managed_env()` has a documented fail-open contract: "any error here is swallowed so managed scope can never block startup." However, `managed_env.exists()` (a `Path.stat()` call) can raise `PermissionError` when the managed directory is root-owned with mode 0700 and the process runs as a non-root user (e.g. via `s6-setuidgid` in Docker). This uncaught exception crashes startup.

## Fix

Wrap the `managed_env.exists()` check in a `try/except PermissionError` block that returns early, matching the fail-open behavior of the existing `get_managed_dir()` guard above it.

## Changes

- `hermes_cli/env_loader.py`: Add `try/except PermissionError` around `managed_env.exists()`

## Testing

- Syntax check: PASS
- Lint: PASS
- The fix is a single-line guard addition; no behavior change when the path is readable.
