### PR TITLE
fix(browser): check for .cmd shim on Windows in _has_agent_browser() (#73395)

### DIFF
--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -158,17 +158,23 @@ def _toolset_enabled(config: Dict[str, object], toolset_key: str) -> bool:
 
 def _has_agent_browser() -> bool:
     import shutil
+    import sys
 
     from hermes_constants import agent_browser_runnable
 
     # Validate the resolved binary actually runs — a dangling global symlink
-    # (issue #48521) is reported by ``which`` but fails at exec. Fall through to
-    # the local node_modules copy, which the validator also checks.
+    # (issue #48521) is reported by ``which`` but fails at exec. Fall through
+    # to the local node_modules copy, which the validator also checks.
     if agent_browser_runnable(shutil.which("agent-browser")):
         return True
-    local_bin = (
-        Path(__file__).parent.parent / "node_modules" / ".bin" / "agent-browser"
-    )
+    bin_dir = Path(__file__).parent.parent / "node_modules" / ".bin"
+    # On Windows npm creates .cmd shims; the bare ``agent-browser`` is a
+    # POSIX shell script that cannot be executed directly (#73395).
+    if sys.platform == "win32":
+        cmd_shim = bin_dir / "agent-browser.cmd"
+        if cmd_shim.exists():
+            return agent_browser_runnable(str(cmd_shim))
+    local_bin = bin_dir / "agent-browser"
     return agent_browser_runnable(str(local_bin)) if local_bin.exists() else False
 
 


### PR DESCRIPTION
## Summary

Fixes #73395.

On Windows, npm creates `.cmd` shims (e.g. `agent-browser.cmd`) in `node_modules/.bin/`. The bare `agent-browser` file is a POSIX shell script (`#!/bin/sh`) that cannot be executed by Python `subprocess.run` on Windows, causing `_has_agent_browser()` to return `False` even when the CLI is properly installed.

This makes the desktop tool settings panel show "needs_setup" and the "Run setup" button keeps showing after successful installation.

## Fix

Check for `agent-browser.cmd` first on Windows before falling back to the bare `agent-browser` path. This matches the pattern used by `shutil.which()` which already checks for `.cmd` on Windows.

## Changes

- `hermes_cli/nous_subscription.py`: Add Windows `.cmd` shim check in `_has_agent_browser()`

## Testing

- Syntax check: PASS
- Lint: PASS
- The fix only activates on `sys.platform == "win32"`; no behavior change on Unix.
