### PR TITLE
feat(hindsight): offer a starter memory template during setup

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -957,7 +957,8 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # Step 5: Optional starter template. Only for cloud / local_external —
         # the API is reachable now; local_embedded's daemon isn't up during setup.
-        if mode in ("cloud", "local_external"):
+        from . import templates as _hs_templates
+        if _hs_templates.supported_for_mode(mode):
             self._offer_starter_template(mode, provider_config, env_writes)
 
         if mode == "local_embedded":

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -955,6 +955,11 @@ class HindsightMemoryProvider(MemoryProvider):
                     new_lines.append(f"{k}={v}")
             env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
 
+        # Step 5: Optional starter template. Only for cloud / local_external —
+        # the API is reachable now; local_embedded's daemon isn't up during setup.
+        if mode in ("cloud", "local_external"):
+            self._offer_starter_template(mode, provider_config, env_writes)
+
         if mode == "local_embedded":
             materialized_config = dict(provider_config)
             config_path = Path(hermes_home) / "hindsight" / "config.json"
@@ -981,6 +986,24 @@ class HindsightMemoryProvider(MemoryProvider):
         if env_writes:
             print("  API keys saved to .env")
         print("\n  Start a new session to activate.\n")
+
+    def _offer_starter_template(self, mode: str, provider_config: dict, env_writes: dict) -> None:
+        """Offer to seed the bank with a Hermes starter template (best-effort)."""
+        from hermes_cli.memory_setup import _CANCELLED, _curses_select
+
+        from . import templates as _hs_templates
+
+        default_url = _DEFAULT_LOCAL_URL if mode == "local_external" else _DEFAULT_API_URL
+        api_url = provider_config.get("api_url") or default_url
+        bank_id = provider_config.get("bank_id", "hermes")
+        api_key = env_writes.get("HINDSIGHT_API_KEY") or os.environ.get("HINDSIGHT_API_KEY", "") or None
+        _hs_templates.run_template_step(
+            api_url=api_url,
+            bank_id=bank_id,
+            api_key=api_key,
+            select=_curses_select,
+            cancelled=_CANCELLED,
+        )
 
     def get_config_schema(self):
         return [

--- a/plugins/memory/hindsight/templates.py
+++ b/plugins/memory/hindsight/templates.py
@@ -1,0 +1,106 @@
+"""Starter bank templates for the Hindsight memory-provider setup wizard.
+
+Fetches the Hindsight Bank Templates catalog, filters to templates tagged for
+the ``hermes`` integration, and applies a chosen manifest to the user's bank
+via the import API (``POST /v1/default/banks/{bank}/import``, which creates the
+bank if it doesn't exist).
+
+Kept out of ``__init__`` so the wizard logic stays small and testable. The
+catalog source is overridable with ``HINDSIGHT_TEMPLATES_URL`` (e.g. to pin a
+version or point at a mirror).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+from urllib.parse import urljoin
+
+logger = logging.getLogger(__name__)
+
+# The Bank Templates catalog lives in the Hindsight docs repo and is the same
+# file that powers hindsight.vectorize.io/templates.
+_DEFAULT_CATALOG_URL = (
+    "https://raw.githubusercontent.com/vectorize-io/hindsight/main/"
+    "hindsight-docs/src/data/templates.json"
+)
+_HTTP_TIMEOUT = 15
+
+
+def catalog_url() -> str:
+    return os.environ.get("HINDSIGHT_TEMPLATES_URL", _DEFAULT_CATALOG_URL)
+
+
+def _get_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:  # noqa: S310 - fixed https catalog
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def fetch_hermes_templates(url: str | None = None) -> list[dict]:
+    """Return catalog entries tagged for the ``hermes`` integration."""
+    catalog = _get_json(url or catalog_url())
+    entries = catalog.get("templates", []) if isinstance(catalog, dict) else []
+    return [e for e in entries if "hermes" in (e.get("integrations") or [])]
+
+
+def fetch_manifest(entry: dict, url: str | None = None) -> dict:
+    """Fetch the BankTemplateManifest JSON for a catalog entry."""
+    # manifest_file is relative to the catalog (e.g. "templates/foo.json").
+    manifest_url = urljoin(url or catalog_url(), entry["manifest_file"])
+    return _get_json(manifest_url)
+
+
+def apply_template(api_url: str, bank_id: str, api_key: str | None, manifest: dict) -> None:
+    """Apply a manifest to a bank via the import endpoint. Raises on failure."""
+    endpoint = f"{api_url.rstrip('/')}/v1/default/banks/{bank_id}/import"
+    data = json.dumps(manifest).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(endpoint, data=data, headers=headers, method="POST")  # noqa: S310
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:  # noqa: S310
+        resp.read()  # drain; urlopen raises HTTPError on non-2xx
+
+
+def run_template_step(
+    *,
+    api_url: str,
+    bank_id: str,
+    api_key: str | None,
+    select,
+    cancelled,
+    log=print,
+) -> str | None:
+    """Drive the wizard's starter-template step.
+
+    ``select(title, items, default, cancel_returns)`` is the picker (injected so
+    this is testable without curses). Returns the applied template id, or None
+    if skipped/blank/failed. Never raises — the template is a nice-to-have.
+    """
+    try:
+        entries = fetch_hermes_templates()
+    except Exception as e:  # network/parse — non-fatal
+        logger.debug("Hindsight: could not fetch templates: %s", e)
+        return None
+    if not entries:
+        return None
+
+    items = [(e.get("name", e["id"]), (e.get("description") or "")[:72]) for e in entries]
+    items.append(("Blank", "Start with an empty memory bank"))
+    idx = select("  Starter memory template", items, default=0, cancel_returns=cancelled)
+    if idx == cancelled or idx >= len(entries):
+        return None  # blank or cancelled
+
+    entry = entries[idx]
+    try:
+        manifest = fetch_manifest(entry)
+        apply_template(api_url, bank_id, api_key, manifest)
+        log(f"  ✓ Applied '{entry.get('name', entry['id'])}' template to bank '{bank_id}'")
+        return entry["id"]
+    except Exception as e:
+        log(f"  ⚠ Could not apply template ({e}). You can apply one later from "
+            f"hindsight.vectorize.io/templates.")
+        return None

--- a/plugins/memory/hindsight/templates.py
+++ b/plugins/memory/hindsight/templates.py
@@ -28,6 +28,14 @@ _DEFAULT_CATALOG_URL = (
 )
 _HTTP_TIMEOUT = 15
 
+# The starter-template step needs the API reachable during setup. A
+# local_embedded daemon isn't running yet at that point, so it's skipped there.
+SUPPORTED_MODES = ("cloud", "local_external")
+
+
+def supported_for_mode(mode: str) -> bool:
+    return mode in SUPPORTED_MODES
+
 
 def catalog_url() -> str:
     return os.environ.get("HINDSIGHT_TEMPLATES_URL", _DEFAULT_CATALOG_URL)
@@ -65,6 +73,27 @@ def apply_template(api_url: str, bank_id: str, api_key: str | None, manifest: di
         resp.read()  # drain; urlopen raises HTTPError on non-2xx
 
 
+def probe_existing_customization(api_url: str, bank_id: str, api_key: str | None) -> bool:
+    """Best-effort: True if the bank already has template-level config, mental
+    models, or directives — i.e. applying a template would overwrite settings.
+
+    A missing bank, or any error, is treated as "not customized": the step must
+    never block on this probe.
+    """
+    endpoint = f"{api_url.rstrip('/')}/v1/default/banks/{bank_id}/export"
+    headers = {"Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(endpoint, headers=headers)  # noqa: S310
+    try:
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:  # noqa: S310
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as e:  # missing bank / network — treat as not customized
+        logger.debug("Hindsight: bank customization probe skipped: %s", e)
+        return False
+    return bool(data.get("bank") or data.get("mental_models") or data.get("directives"))
+
+
 def run_template_step(
     *,
     api_url: str,
@@ -95,6 +124,22 @@ def run_template_step(
         return None  # blank or cancelled
 
     entry = entries[idx]
+
+    # If the bank is already configured (re-running setup on an existing bank),
+    # applying a template overwrites its config and upserts its models/directives.
+    # Confirm before clobbering.
+    if probe_existing_customization(api_url, bank_id, api_key):
+        confirm = select(
+            f"  Bank '{bank_id}' already has memory settings — apply this template on top?",
+            [("Apply", "Overwrite config; add/update mental models & directives"),
+             ("Keep existing", "Leave the bank as-is")],
+            default=1,
+            cancel_returns=cancelled,
+        )
+        if confirm != 0:
+            log(f"  Kept existing settings for bank '{bank_id}'.")
+            return None
+
     try:
         manifest = fetch_manifest(entry)
         apply_template(api_url, bank_id, api_key, manifest)

--- a/tests/plugins/memory/test_hindsight_templates.py
+++ b/tests/plugins/memory/test_hindsight_templates.py
@@ -1,0 +1,144 @@
+"""Tests for the Hindsight setup-wizard starter-template step."""
+
+import json
+from contextlib import contextmanager
+
+import pytest
+
+from plugins.memory.hindsight import templates as tpl
+
+
+_CATALOG = {
+    "templates": [
+        {"id": "conversation", "name": "Conversation", "integrations": ["litellm", "hermes"],
+         "manifest_file": "templates/conversation.json"},
+        {"id": "coding-agent", "name": "Coding Agent", "integrations": ["claude-code"],
+         "manifest_file": "templates/coding-agent.json"},
+        {"id": "hermes-gateway-bot", "name": "Gateway Bot", "integrations": ["hermes"],
+         "manifest_file": "templates/hermes-gateway-bot.json"},
+    ]
+}
+
+
+def test_fetch_hermes_templates_filters_to_hermes(monkeypatch):
+    monkeypatch.setattr(tpl, "_get_json", lambda url: _CATALOG)
+    entries = tpl.fetch_hermes_templates("https://example/templates.json")
+    ids = [e["id"] for e in entries]
+    assert ids == ["conversation", "hermes-gateway-bot"]  # coding-agent excluded
+
+
+def test_fetch_manifest_resolves_relative_url(monkeypatch):
+    seen = {}
+
+    def _fake(url):
+        seen["url"] = url
+        return {"version": "1"}
+
+    monkeypatch.setattr(tpl, "_get_json", _fake)
+    tpl.fetch_manifest(
+        {"manifest_file": "templates/hermes-gateway-bot.json"},
+        "https://raw.example/data/templates.json",
+    )
+    assert seen["url"] == "https://raw.example/data/templates/hermes-gateway-bot.json"
+
+
+def test_apply_template_posts_to_import_endpoint(monkeypatch):
+    captured = {}
+
+    @contextmanager
+    def _fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["auth"] = req.get_header("Authorization")
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+
+        class _Resp:
+            def read(self):
+                return b""
+
+        yield _Resp()
+
+    monkeypatch.setattr(tpl.urllib.request, "urlopen", _fake_urlopen)
+    tpl.apply_template("https://api.hindsight.vectorize.io/", "hermes", "hsk_abc", {"version": "1"})
+
+    assert captured["url"] == "https://api.hindsight.vectorize.io/v1/default/banks/hermes/import"
+    assert captured["method"] == "POST"
+    assert captured["auth"] == "Bearer hsk_abc"
+    assert captured["body"] == {"version": "1"}
+
+
+def test_apply_template_omits_auth_when_no_key(monkeypatch):
+    captured = {}
+
+    @contextmanager
+    def _fake_urlopen(req, timeout=None):
+        captured["auth"] = req.get_header("Authorization")
+
+        class _Resp:
+            def read(self):
+                return b""
+
+        yield _Resp()
+
+    monkeypatch.setattr(tpl.urllib.request, "urlopen", _fake_urlopen)
+    tpl.apply_template("http://localhost:8888", "hermes", None, {"version": "1"})
+    assert captured["auth"] is None
+
+
+def _select_returning(idx):
+    def _select(title, items, default=0, cancel_returns=None):
+        return idx
+    return _select
+
+
+def test_run_template_step_applies_selected(monkeypatch):
+    monkeypatch.setattr(tpl, "fetch_hermes_templates", lambda url=None: [
+        {"id": "hermes-gateway-bot", "name": "Gateway Bot", "manifest_file": "templates/x.json"},
+    ])
+    monkeypatch.setattr(tpl, "fetch_manifest", lambda entry, url=None: {"version": "1"})
+    applied = {}
+    monkeypatch.setattr(tpl, "apply_template",
+                        lambda api_url, bank_id, api_key, manifest: applied.update(bank=bank_id))
+
+    result = tpl.run_template_step(
+        api_url="https://api", bank_id="hermes", api_key="k",
+        select=_select_returning(0), cancelled=-1, log=lambda *_: None,
+    )
+    assert result == "hermes-gateway-bot"
+    assert applied["bank"] == "hermes"
+
+
+def test_run_template_step_blank_selection_skips(monkeypatch):
+    entries = [{"id": "hermes-gateway-bot", "name": "Gateway Bot", "manifest_file": "templates/x.json"}]
+    monkeypatch.setattr(tpl, "fetch_hermes_templates", lambda url=None: entries)
+    called = {"applied": False}
+    monkeypatch.setattr(tpl, "apply_template",
+                        lambda *a, **k: called.update(applied=True))
+    # index len(entries) == the "Blank" row
+    result = tpl.run_template_step(
+        api_url="https://api", bank_id="hermes", api_key="k",
+        select=_select_returning(len(entries)), cancelled=-1, log=lambda *_: None,
+    )
+    assert result is None
+    assert called["applied"] is False
+
+
+def test_run_template_step_no_templates_is_noop(monkeypatch):
+    monkeypatch.setattr(tpl, "fetch_hermes_templates", lambda url=None: [])
+    result = tpl.run_template_step(
+        api_url="https://api", bank_id="hermes", api_key="k",
+        select=_select_returning(0), cancelled=-1, log=lambda *_: None,
+    )
+    assert result is None
+
+
+def test_run_template_step_swallows_fetch_errors(monkeypatch):
+    def _boom(url=None):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(tpl, "fetch_hermes_templates", _boom)
+    # must not raise
+    assert tpl.run_template_step(
+        api_url="https://api", bank_id="hermes", api_key="k",
+        select=_select_returning(0), cancelled=-1, log=lambda *_: None,
+    ) is None

--- a/tests/plugins/memory/test_hindsight_templates.py
+++ b/tests/plugins/memory/test_hindsight_templates.py
@@ -91,11 +91,28 @@ def _select_returning(idx):
     return _select
 
 
+def _select_seq(*returns):
+    it = iter(returns)
+
+    def _select(title, items, default=0, cancel_returns=None):
+        return next(it)
+
+    return _select
+
+
+def test_supported_for_mode():
+    assert tpl.supported_for_mode("cloud") is True
+    assert tpl.supported_for_mode("local_external") is True
+    assert tpl.supported_for_mode("local_embedded") is False
+    assert tpl.supported_for_mode("local") is False
+
+
 def test_run_template_step_applies_selected(monkeypatch):
     monkeypatch.setattr(tpl, "fetch_hermes_templates", lambda url=None: [
         {"id": "hermes-gateway-bot", "name": "Gateway Bot", "manifest_file": "templates/x.json"},
     ])
     monkeypatch.setattr(tpl, "fetch_manifest", lambda entry, url=None: {"version": "1"})
+    monkeypatch.setattr(tpl, "probe_existing_customization", lambda *a: False)
     applied = {}
     monkeypatch.setattr(tpl, "apply_template",
                         lambda api_url, bank_id, api_key, manifest: applied.update(bank=bank_id))
@@ -142,3 +159,102 @@ def test_run_template_step_swallows_fetch_errors(monkeypatch):
         api_url="https://api", bank_id="hermes", api_key="k",
         select=_select_returning(0), cancelled=-1, log=lambda *_: None,
     ) is None
+
+
+def test_run_template_step_swallows_apply_errors(monkeypatch):
+    # gap 1: a failed apply (e.g. 401 for an OAuth-only user) must not crash setup.
+    import urllib.error
+
+    monkeypatch.setattr(tpl, "fetch_hermes_templates", lambda url=None: [
+        {"id": "hermes-gateway-bot", "name": "Gateway Bot", "manifest_file": "templates/x.json"},
+    ])
+    monkeypatch.setattr(tpl, "fetch_manifest", lambda entry, url=None: {"version": "1"})
+    monkeypatch.setattr(tpl, "probe_existing_customization", lambda *a: False)
+
+    def _raise(*a, **k):
+        raise urllib.error.HTTPError("u", 401, "Unauthorized", {}, None)
+
+    monkeypatch.setattr(tpl, "apply_template", _raise)
+    logs = []
+    result = tpl.run_template_step(
+        api_url="https://api", bank_id="hermes", api_key=None,
+        select=_select_returning(0), cancelled=-1, log=logs.append,
+    )
+    assert result is None
+    assert any("Could not apply" in line for line in logs)
+
+
+def _fake_urlopen(payload):
+    @contextmanager
+    def _cm(req, timeout=None):
+        class _Resp:
+            def read(self):
+                return json.dumps(payload).encode("utf-8")
+
+        yield _Resp()
+
+    return _cm
+
+
+def test_probe_existing_customization_true_when_bank_has_config(monkeypatch):
+    monkeypatch.setattr(tpl.urllib.request, "urlopen",
+                        _fake_urlopen({"version": "1", "bank": {"reflect_mission": "x"}}))
+    assert tpl.probe_existing_customization("https://api", "hermes", "k") is True
+
+
+def test_probe_existing_customization_false_when_empty(monkeypatch):
+    monkeypatch.setattr(tpl.urllib.request, "urlopen",
+                        _fake_urlopen({"version": "1"}))
+    assert tpl.probe_existing_customization("https://api", "hermes", "k") is False
+
+
+def test_probe_existing_customization_false_on_error(monkeypatch):
+    def _boom(req, timeout=None):
+        raise OSError("no bank")
+
+    monkeypatch.setattr(tpl.urllib.request, "urlopen", _boom)
+    assert tpl.probe_existing_customization("https://api", "missing", None) is False
+
+
+def _wire_apply(monkeypatch, customized):
+    monkeypatch.setattr(tpl, "fetch_hermes_templates", lambda url=None: [
+        {"id": "hermes-gateway-bot", "name": "Gateway Bot", "manifest_file": "templates/x.json"},
+    ])
+    monkeypatch.setattr(tpl, "fetch_manifest", lambda entry, url=None: {"version": "1"})
+    monkeypatch.setattr(tpl, "probe_existing_customization", lambda *a: customized)
+    called = {"applied": False}
+    monkeypatch.setattr(tpl, "apply_template", lambda *a, **k: called.update(applied=True))
+    return called
+
+
+def test_warns_and_keeps_existing_when_declined(monkeypatch):
+    called = _wire_apply(monkeypatch, customized=True)
+    # first select = pick template (0); second select = confirm -> "Keep existing" (1)
+    result = tpl.run_template_step(
+        api_url="https://api", bank_id="hermes", api_key="k",
+        select=_select_seq(0, 1), cancelled=-1, log=lambda *_: None,
+    )
+    assert result is None
+    assert called["applied"] is False
+
+
+def test_warns_then_applies_when_confirmed(monkeypatch):
+    called = _wire_apply(monkeypatch, customized=True)
+    # pick template (0), confirm "Apply" (0)
+    result = tpl.run_template_step(
+        api_url="https://api", bank_id="hermes", api_key="k",
+        select=_select_seq(0, 0), cancelled=-1, log=lambda *_: None,
+    )
+    assert result == "hermes-gateway-bot"
+    assert called["applied"] is True
+
+
+def test_fresh_bank_skips_the_warning(monkeypatch):
+    called = _wire_apply(monkeypatch, customized=False)
+    # only ONE select call (no confirm) — _select_seq with a single value proves it
+    result = tpl.run_template_step(
+        api_url="https://api", bank_id="hermes", api_key="k",
+        select=_select_seq(0), cancelled=-1, log=lambda *_: None,
+    )
+    assert result == "hermes-gateway-bot"
+    assert called["applied"] is True


### PR DESCRIPTION
## Summary

`hermes memory setup` currently leaves the user with a **blank** Hindsight bank — the "day-one empty brain." This adds an optional step that seeds the bank with a **starter template** so the agent's memory arrives already configured (mission, dispositions, mental models, directives) for its use case.

It reuses Hindsight's existing **Bank Templates** feature (the catalog behind [hindsight.vectorize.io/templates](https://hindsight.vectorize.io/templates)) and its import API — nothing new server-side.

## Flow

After config is saved (cloud / local_external), the wizard:
1. Fetches the templates catalog and filters to entries tagged for the **`hermes`** integration.
2. Shows a picker (with **Blank** always available).
3. On selection, fetches the manifest and `POST`s it to `/v1/default/banks/{bank}/import` (which creates the bank if needed and applies config + mental models + directives).

It's **best-effort and non-fatal** — any network/apply failure just prints a hint and continues. Skipped for `local_embedded` (its daemon isn't running during setup).

## Details
- New `plugins/memory/hindsight/templates.py` keeps the logic out of the provider module and testable.
- Catalog source defaults to the Hindsight docs repo and is overridable via **`HINDSIGHT_TEMPLATES_URL`** (pin a version / point at a mirror).
- Auth uses the API key from `.env`/environment; OAuth-only users (no `hsk_` key) will see the graceful "apply one later" hint.

## Tests
`tests/plugins/memory/test_hindsight_templates.py` (8, all passing):
- hermes-only filtering of the catalog
- manifest URL resolution (relative → absolute)
- the import `POST` (correct endpoint + `Authorization` header + body; and omitted auth when no key)
- picker orchestration: applies the selection, skips on Blank, no-ops with no templates, swallows fetch errors

```
scripts/run_tests.sh tests/plugins/memory/test_hindsight_templates.py   # 8 passed
```
(The 2 pre-existing `test_hindsight_provider.py::TestConfig`/`TestAvailability` failures reproduce on clean `main` and are unrelated.)

## Depends on
The Hermes starter templates land in **vectorize-io/hindsight#2996** (adds the `hermes`-tagged templates to the catalog). Until that merges, the picker filters an empty set and the step no-ops cleanly.