### PR TITLE
fix(telegram): disambiguate colliding model picker labels

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -38,6 +38,26 @@ def _redact_telegram_error_text(error: object) -> str:
         return "<telegram error redacted>"
 
 
+def _model_picker_labels(model_ids: list[str]) -> list[str]:
+    """Build readable, unambiguous labels for model-picker buttons.
+
+    Provider-qualified IDs such as ``cc/claude-opus-5`` and
+    ``kr/claude-opus-5`` have the same short suffix. Keep the compact suffix
+    for unambiguous models, but retain the full ID when shortening would make
+    two buttons indistinguishable. The returned labels are display-only; the
+    original IDs remain in the picker state for callbacks.
+    """
+    short_ids = [model_id.rsplit("/", 1)[-1] for model_id in model_ids]
+    counts: dict[str, int] = {}
+    for short_id in short_ids:
+        counts[short_id] = counts.get(short_id, 0) + 1
+
+    return [
+        model_id if counts[short_id] > 1 else short_id
+        for model_id, short_id in zip(model_ids, short_ids)
+    ]
+
+
 def _consume_abandoned_task(task: asyncio.Task) -> None:
     """Observe a detached task's terminal exception to avoid noisy loop logs."""
     try:
@@ -5795,13 +5815,18 @@ class TelegramAdapter(BasePlatformAdapter):
         page_models = models[start:end]
 
         buttons: list = []
+        labels = _model_picker_labels(models)
+        displayed_labels: set[str] = set()
         for i, model_id in enumerate(page_models):
             abs_idx = start + i
-            short = model_id.split("/")[-1] if "/" in model_id else model_id
-            if len(short) > 38:
-                short = short[:35] + "..."
+            label = labels[abs_idx]
+            if len(label) > 38:
+                label = label[:35] + "..."
+            if label in displayed_labels:
+                label = f"{label[:32]}...[{abs_idx}]"
+            displayed_labels.add(label)
             buttons.append(
-                InlineKeyboardButton(short, callback_data=f"mm:{abs_idx}")
+                InlineKeyboardButton(label, callback_data=f"mm:{abs_idx}")
             )
 
         rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -84,6 +84,35 @@ class TestTelegramModelPicker:
             ("gpt-5.6-sol", "mm:2"),
         ]
 
+    def test_model_keyboard_disambiguates_colliding_truncated_labels(self, monkeypatch):
+        import plugins.platforms.telegram.adapter as tg
+
+        built = []
+
+        class _RecordingButton:
+            def __init__(self, text, callback_data=None, **kwargs):
+                built.append((text, callback_data))
+
+        class _RecordingMarkup:
+            def __init__(self, rows):
+                self.inline_keyboard = rows
+
+        monkeypatch.setattr(tg, "InlineKeyboardButton", _RecordingButton)
+        monkeypatch.setattr(tg, "InlineKeyboardMarkup", _RecordingMarkup)
+
+        model_ids = [
+            "provider-" + "x" * 28 + "a/claude-opus-5-" + "y" * 40,
+            "provider-" + "x" * 28 + "b/claude-opus-5-" + "y" * 40,
+        ]
+
+        _make_adapter()._build_model_keyboard(model_ids, 0)
+
+        assert built[:2] == [
+            (model_ids[0][:35] + "...", "mm:0"),
+            (model_ids[1][:32] + "...[1]", "mm:1"),
+        ]
+        assert built[0][0] != built[1][0]
+
     def test_model_picker_callback_receives_original_colliding_id(self):
         import asyncio
 

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -32,7 +32,7 @@ def _ensure_telegram_mock():
 _ensure_telegram_mock()
 
 from gateway.config import PlatformConfig
-from plugins.platforms.telegram.adapter import TelegramAdapter
+from plugins.platforms.telegram.adapter import TelegramAdapter, _model_picker_labels
 
 
 def _make_adapter():
@@ -43,6 +43,77 @@ def _make_adapter():
 
 
 class TestTelegramModelPicker:
+    def test_model_labels_preserve_provider_prefix_only_for_collisions(self):
+        model_ids = [
+            "cc/claude-opus-5",
+            "kr/claude-opus-5",
+            "gpt-5.6-sol",
+        ]
+
+        assert _model_picker_labels(model_ids) == [
+            "cc/claude-opus-5",
+            "kr/claude-opus-5",
+            "gpt-5.6-sol",
+        ]
+
+    def test_model_keyboard_uses_full_labels_for_collisions(self, monkeypatch):
+        import plugins.platforms.telegram.adapter as tg
+
+        built = []
+
+        class _RecordingButton:
+            def __init__(self, text, callback_data=None, **kwargs):
+                built.append((text, callback_data))
+
+        class _RecordingMarkup:
+            def __init__(self, rows):
+                self.inline_keyboard = rows
+
+        monkeypatch.setattr(tg, "InlineKeyboardButton", _RecordingButton)
+        monkeypatch.setattr(tg, "InlineKeyboardMarkup", _RecordingMarkup)
+
+        adapter = _make_adapter()
+        adapter._build_model_keyboard(
+            ["cc/claude-opus-5", "kr/claude-opus-5", "gpt-5.6-sol"],
+            0,
+        )
+
+        assert built[:3] == [
+            ("cc/claude-opus-5", "mm:0"),
+            ("kr/claude-opus-5", "mm:1"),
+            ("gpt-5.6-sol", "mm:2"),
+        ]
+
+    def test_model_picker_callback_receives_original_colliding_id(self):
+        import asyncio
+
+        callback_args = []
+
+        async def on_model_selected(*args):
+            callback_args.append(args)
+            return "switched"
+
+        adapter = _make_adapter()
+        adapter._model_picker_state["12345"] = {
+            "providers": [],
+            "current_model": "old",
+            "current_provider": "provider",
+            "session_key": "s",
+            "on_model_selected": on_model_selected,
+            "selected_provider": "custom:api",
+            "model_list": ["cc/claude-opus-5", "kr/claude-opus-5"],
+            "msg_id": 42,
+        }
+        query = AsyncMock()
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        asyncio.run(adapter._handle_model_picker_callback(query, "mm:1", "12345"))
+
+        assert callback_args == [("12345", "kr/claude-opus-5", "custom:api")]
+
     @pytest.mark.asyncio
     async def test_send_model_picker_escapes_dynamic_provider_label(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- preserve provider-qualified model IDs in Telegram button labels when their shortened suffixes collide
- keep compact suffix-only labels for models that remain unambiguous
- keep callback routing index-based so the original full model ID is sent unchanged
- disambiguate labels that would collide again after Telegram button truncation

## Problem
A custom provider can expose distinct model IDs such as `cc/claude-opus-5` and `kr/claude-opus-5`. The Telegram picker shortened both with `split("/")[-1]`, rendering two identical `claude-opus-5` buttons even though they route to different backends.

## Test plan
- `pytest tests/gateway/test_telegram_model_picker.py -q` — 10 passed
- `python -m compileall -q plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_model_picker.py`
- `git diff --check origin/main...HEAD`

The change is display-only; picker state and callbacks continue to use the original full model IDs.