### PR TITLE
fix(env): keep managed scope permission errors fail-open

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -366,15 +366,15 @@ def _apply_managed_env() -> None:
         from hermes_cli import managed_scope
 
         managed_dir = managed_scope.get_managed_dir()
+        if managed_dir is None:
+            return
+        managed_env = managed_dir / ".env"
+        if not managed_env.exists():
+            return
+        _sanitize_env_file_if_needed(managed_env)
+        _load_dotenv_with_fallback(managed_env, override=True)
     except Exception:  # noqa: BLE001 — managed scope must never block startup
         return
-    if managed_dir is None:
-        return
-    managed_env = managed_dir / ".env"
-    if not managed_env.exists():
-        return
-    _sanitize_env_file_if_needed(managed_env)
-    _load_dotenv_with_fallback(managed_env, override=True)
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:

--- a/tests/hermes_cli/test_managed_scope_env.py
+++ b/tests/hermes_cli/test_managed_scope_env.py
@@ -56,3 +56,25 @@ def test_no_managed_env_is_noop(env_homes, monkeypatch):
     (home / ".env").write_text("SOME_VALUE=from_user\n", encoding="utf-8")
     load_hermes_dotenv(hermes_home=str(home))
     assert os.environ["SOME_VALUE"] == "from_user"
+
+
+def test_managed_env_permission_error_does_not_block_startup(env_homes, monkeypatch):
+    from hermes_cli import managed_scope
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    class UnreadableManagedEnv:
+        def exists(self):
+            raise PermissionError("managed .env is not readable")
+
+    class ManagedDir:
+        def __truediv__(self, name):
+            assert name == ".env"
+            return UnreadableManagedEnv()
+
+    home, _managed = env_homes
+    (home / ".env").write_text("USER_ONLY=keepme\n", encoding="utf-8")
+    monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: ManagedDir())
+
+    load_hermes_dotenv(hermes_home=str(home))
+
+    assert os.environ["USER_ONLY"] == "keepme"


### PR DESCRIPTION
## What does this PR do?

Keeps managed-scope environment loading fail-open when the managed directory or `.env` cannot be accessed.

`_apply_managed_env()` documented that any managed-scope error must not block startup, but only `get_managed_dir()` was inside its exception boundary. A `PermissionError` from `managed_env.exists()` therefore propagated through `load_hermes_dotenv()` and aborted CLI or gateway startup.

This moves the complete managed `.env` path check, sanitization, and load into the existing fail-open boundary. Normal precedence is unchanged: a readable managed `.env` is still applied last with `override=True`.

## Related Issue

Fixes #73401

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extend the existing fail-open boundary in `hermes_cli/env_loader.py` across all managed `.env` operations.
- Add a regression test in `tests/hermes_cli/test_managed_scope_env.py` that makes the managed `.env` existence check raise `PermissionError` and verifies startup continues with the user `.env` value intact.

## How to Test

1. Run `uv run pytest tests/hermes_cli/test_managed_scope_env.py tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_managed_scope.py tests/hermes_cli/test_managed_scope_regression.py -q`.
2. Confirm all 39 related tests pass, including the managed `.env` permission regression.
3. Run `.venv/bin/ruff check --no-cache hermes_cli/env_loader.py tests/hermes_cli/test_managed_scope_env.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, behavior now matches the existing docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses the existing platform-independent exception boundary
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
.......................................                                  [100%]
39 passed in 0.65s

All checks passed!
```
