### PR TITLE
fix(cli): don't orphan dashboard under non-systemd supervisors during update (#73379)

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -13,6 +13,7 @@ patches on ``hermes_cli.main`` resolve unchanged.
 """
 
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -23,6 +24,103 @@ def _m():
     from hermes_cli import main
 
     return main
+
+
+# Shells that supervisors (tmux/respawn loops, supervisord-style wrappers) use
+# to run a respawn script via ``-c``. The dashboard leaf is always
+# ``python``/``hermes`` itself, never one of these.
+_SHELL_INTERPRETERS = frozenset(
+    {"bash", "sh", "zsh", "dash", "ksh", "ash", "fish", "tcsh", "csh", "mksh"}
+)
+
+
+def _is_shell_supervisor_command(command: str) -> bool:
+    """Return ``True`` when *command* is a shell interpreter running a respawn loop.
+
+    Supervisor wrappers — e.g.
+    ``bash -lc 'while true; do hermes dashboard …; sleep 3; done'`` running
+    inside a tmux pane — contain the dashboard invocation only as text inside
+    a ``-c`` script string. They are *not* the dashboard process itself.
+    Matching them makes ``hermes update`` kill the supervisor and then
+    detached-respawn the backend, orphaning it on the dashboard port while the
+    supervisor crash-loops on "address already in use" (#73379).
+
+    A real dashboard leaf (``python …/hermes dashboard``) is never a shell
+    ``-c`` invocation, so it is still detected normally. A one-shot
+    ``bash -c "hermes dashboard …"`` with no loop is intentionally still
+    matched — it is a rare but legitimate direct invocation.
+    """
+    tokens = command.split()
+    if len(tokens) < 2:
+        return False
+    if os.path.basename(tokens[0]).lower() not in _SHELL_INTERPRETERS:
+        return False
+    # The script lives in a -c / --command argument (also combined short flags
+    # such as ``-lc`` / ``-ic``).
+    has_command_flag = any(
+        tok in ("-c", "--command")
+        or (
+            tok.startswith("-")
+            and not tok.startswith("--")
+            and len(tok) <= 4
+            and "c" in tok
+        )
+        for tok in tokens[1:]
+    )
+    if not has_command_flag:
+        return False
+    lowered = command.lower()
+    # Only treat as a supervisor when the wrapper actually runs a respawn loop
+    # — the marker of the orphan-on-restart bug class.
+    return any(kw in lowered for kw in ("while", "until", "for ", ";do", "; do"))
+
+
+def _parent_pid_for_pid(pid: int) -> int | None:
+    """Best-effort parent-PID lookup for *pid* (Linux ``/proc`` / macOS ``ps``).
+
+    Used to decide whether a killed dashboard leaf was supervised: a live
+    respawn-loop parent will restart it in-session, so we must not also
+    detached-respawn it (#73379).
+    """
+    try:
+        status_path = f"/proc/{pid}/status"
+        if os.path.exists(status_path):
+            with open(status_path, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    if line.startswith("PPid:"):
+                        try:
+                            return int(line.split(":")[1].strip())
+                        except (ValueError, IndexError):
+                            return None
+            return None
+        # macOS (no /proc): best-effort via ps.
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "ppid="],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        ppid = (result.stdout or "").strip()
+        return int(ppid) if ppid.isdigit() else None
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        return None
+
+
+def _parent_is_supervisor(ppid: int) -> bool:
+    """Return ``True`` if *ppid* is a live respawn-loop supervisor process.
+
+    Reads the parent's argv; if it is a shell ``-c`` respawn loop, the killed
+    dashboard child will be restarted by that supervisor, so detachedly
+    respawning it here would orphan the backend on the dashboard port
+    (#73379). A missing/unreadable parent (already reaped) returns ``False``
+    so the caller falls back to the existing detached-respawn path.
+    """
+    parent_argv = _m()._dashboard_cmdline_for_pid(ppid)
+    if not parent_argv:
+        return False
+    return _is_shell_supervisor_command(shlex.join(parent_argv))
 
 
 def _scan_dashboard_processes(
@@ -102,6 +200,7 @@ def _scan_dashboard_processes(
                     if (
                         any(p in current_cmd for p in patterns)
                         and int(pid_str) != self_pid
+                        and not _is_shell_supervisor_command(current_cmd)
                     ):
                         try:
                             dashboard_processes.append((int(pid_str), current_cmd))
@@ -133,7 +232,11 @@ def _scan_dashboard_processes(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if (
+                        any(p in command for p in patterns)
+                        and pid != self_pid
+                        and not _is_shell_supervisor_command(command)
+                    ):
                         dashboard_processes.append((pid, command))
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
@@ -210,6 +313,7 @@ def _kill_stale_dashboard_processes(
     pid_cgroup: dict[int, str | None] = {}
     pid_service: dict[int, str | None] = {}
     pid_cmdline: dict[int, list[str]] = {}
+    pid_ppid: dict[int, int | None] = {}
     if restart_managed and sys.platform != "win32":
         for pid in pids:
             cg_path = _m()._get_pid_cgroup_path(pid)
@@ -217,10 +321,13 @@ def _kill_stale_dashboard_processes(
             pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
             if not pid_service[pid]:
                 # Manually-started process: preserve its exact argv so we
-                # can respawn it after the update (#40449, #68934).
+                # can respawn it after the update (#40449, #68934).  Also
+                # remember its parent PID so the respawn step can tell a
+                # supervised leaf from a genuine orphan (#73379).
                 cmdline = _m()._dashboard_cmdline_for_pid(pid)
                 if cmdline:
                     pid_cmdline[pid] = cmdline
+                    pid_ppid[pid] = _m()._parent_pid_for_pid(pid)
 
     killed: list[int] = []
     failed: list[tuple[int, str]] = []
@@ -300,6 +407,7 @@ def _kill_stale_dashboard_processes(
         failed_restarts: list[tuple[str, str]] = []
         seen_services: set[str] = set()
         respawn_cmds: list[list[str]] = []
+        supervised_restart: list[tuple[int, int]] = []
         for pid in killed:
             svc_name = pid_service.get(pid)
             if svc_name:
@@ -312,7 +420,18 @@ def _kill_stale_dashboard_processes(
                     failed_restarts.append((svc_name, "systemctl restart returned non-zero"))
                     unrecovered.append(pid)
             elif pid in pid_cmdline:
-                respawn_cmds.append(pid_cmdline[pid])
+                # Before detached-respawning a manually-started leaf, check
+                # whether its parent is a live respawn-loop supervisor. If so,
+                # the supervisor will restart the leaf in-session; respawning
+                # detached here would orphan the backend on the dashboard port
+                # while the supervisor crash-loops on "address already in use"
+                # (#73379). Genuine orphans (PPID 1 / nohup) and interactive
+                # shells keep the existing detached-respawn behaviour.
+                parent = pid_ppid.get(pid)
+                if parent and parent != 1 and _parent_is_supervisor(parent):
+                    supervised_restart.append((pid, parent))
+                else:
+                    respawn_cmds.append(pid_cmdline[pid])
             else:
                 unrecovered.append(pid)
 
@@ -320,6 +439,11 @@ def _kill_stale_dashboard_processes(
             print(f"    ✓ restarted systemd service {svc}")
         for svc, err in failed_restarts:
             print(f"    ⚠ {svc}: {err}")
+        for pid, parent in supervised_restart:
+            print(
+                f"    ↻ leaving PID {pid} to its supervisor (PID {parent}) — "
+                f"it will restart the dashboard"
+            )
 
         if respawn_cmds:
             failed_cmds = _m()._respawn_dashboard_processes(respawn_cmds)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7226,7 +7226,10 @@ def cmd_gui(args: argparse.Namespace):
 # monkeypatches on hermes_cli.main.<name> keep resolving unchanged.
 from hermes_cli.dashboard_procs import (  # noqa: F401
     _detect_concurrent_hermes_instances,
+    _is_shell_supervisor_command,
     _kill_stale_dashboard_processes,
+    _parent_is_supervisor,
+    _parent_pid_for_pid,
     _scan_dashboard_processes,
 )
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -425,3 +425,206 @@ class TestCmdlineCapture:
         live = self._live()
         monkeypatch.setattr(live.sys, "platform", "win32")
         assert live._dashboard_cmdline_for_pid(123) is None
+
+
+class TestShellSupervisorDetection:
+    """``_is_shell_supervisor_command`` recognises respawn-loop wrappers.
+
+    A supervisor such as ``bash -lc 'while true; do hermes dashboard …'``
+    contains the dashboard invocation only as text inside a ``-c`` script.
+    The dashboard process itself is never a shell ``-c`` invocation, so it is
+    still matched by the scan (#73379).
+    """
+
+    def _fn(self):
+        import importlib
+
+        live = sys.modules.get("hermes_cli.main") or importlib.import_module("hermes_cli.main")
+        return live._is_shell_supervisor_command
+
+    def test_bash_lc_while_loop_is_supervisor(self):
+        is_sup = self._fn()
+        assert is_sup(
+            "bash -lc 'while true; do hermes dashboard --host 127.0.0.1 "
+            "--port 9119 --no-open --skip-build; echo restarting; sleep 3; done'"
+        )
+
+    def test_sh_c_until_loop_is_supervisor(self):
+        is_sup = self._fn()
+        assert is_sup("sh -c 'until false; do hermes serve --port 9000; sleep 5; done'")
+
+    def test_zsh_for_loop_is_supervisor(self):
+        is_sup = self._fn()
+        assert is_sup("zsh -c 'for i in {1..100}; do hermes dashboard; sleep 2; done'")
+
+    def test_direct_python_dashboard_not_supervisor(self):
+        is_sup = self._fn()
+        assert not is_sup("python3 -m hermes_cli.main dashboard --port 9119")
+
+    def test_direct_hermes_serve_not_supervisor(self):
+        is_sup = self._fn()
+        assert not is_sup("/opt/hermes/bin/hermes serve --port 9119")
+
+    def test_interactive_shell_not_supervisor(self):
+        is_sup = self._fn()
+        assert not is_sup("/bin/bash")
+
+    def test_one_shot_bash_c_without_loop_not_supervisor(self):
+        """A one-shot ``bash -c "hermes dashboard …"`` (no loop) is a rare but
+        legitimate direct invocation — it must still be detected."""
+        is_sup = self._fn()
+        assert not is_sup("bash -c 'hermes dashboard --port 9119'")
+
+    def test_shell_running_script_file_not_supervisor(self):
+        """``bash some-script.sh`` runs a file, not a ``-c`` script string."""
+        is_sup = self._fn()
+        assert not is_sup("bash /home/user/run-dashboard.sh")
+
+
+class TestScanExcludesSupervisorWrappers:
+    """The ps/wmic scan must not return respawn-loop supervisor wrappers,
+    only the real dashboard leaf (#73379 Layer 1)."""
+
+    def test_wrapper_and_leaf_only_leaf_returned(self):
+        wrapper = (
+            "bash -lc 'while true; do hermes dashboard --host 127.0.0.1 "
+            "--port 9119 --no-open --skip-build; sleep 3; done'"
+        )
+        leaf = "python3 -m hermes_cli.main dashboard --host 127.0.0.1 --port 9119 --no-open --skip-build"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(4241, wrapper),
+                    _ps_line(4242, leaf),
+                ]) + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        # Only the leaf (4242) — the supervisor wrapper (4241) is excluded.
+        assert pids == [4242]
+
+    def test_serve_wrapper_excluded(self):
+        wrapper = "sh -c 'while true; do hermes serve --port 9000; sleep 2; done'"
+        leaf = "hermes serve --port 9000 --no-open"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([_ps_line(5001, wrapper), _ps_line(5002, leaf)]) + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert pids == [5002]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill semantics")
+class TestSupervisedLeafRespawnGuard:
+    """A dashboard leaf whose parent is a live respawn-loop supervisor must
+    NOT be detached-respawned — the supervisor restarts it in-session
+    (#73379 Layer 3). Without this guard, a detached orphan reclaims the
+    dashboard port and the supervisor crash-loops on "address already in use".
+    """
+
+    def test_supervised_leaf_left_to_supervisor_not_respawned(self, capsys):
+        LEAF = 4242
+        SUP = 4241
+        leaf_cmd = ["python3", "-m", "hermes_cli.main", "dashboard",
+                    "--host", "127.0.0.1", "--port", "9119", "--no-open"]
+        sup_cmd = ["bash", "-lc",
+                   "while true; do hermes dashboard --host 127.0.0.1 "
+                   "--port 9119 --no-open; sleep 3; done"]
+
+        def cmdline_side(pid):
+            return {LEAF: leaf_cmd, SUP: sup_cmd}.get(pid)
+
+        respawned: list[list[str]] = []
+
+        def fake_kill(pid, sig):
+            # Leaf is already gone after SIGTERM → counted as killed, no poll.
+            raise ProcessLookupError
+
+        with patch("hermes_cli.main._restart_managed_dashboard_service",
+                   return_value=False), \
+             patch("hermes_cli.main._find_stale_dashboard_pids",
+                   return_value=[LEAF]), \
+             patch("hermes_cli.main._get_pid_cgroup_path", return_value=None), \
+             patch("hermes_cli.main._get_systemd_service_for_pid",
+                   return_value=None), \
+             patch("hermes_cli.main._dashboard_cmdline_for_pid",
+                   side_effect=cmdline_side), \
+             patch("hermes_cli.main._parent_pid_for_pid", return_value=SUP), \
+             patch("hermes_cli.main._respawn_dashboard_processes",
+                   side_effect=lambda cmds: (respawned.extend(cmds) or [])), \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            _kill_stale_dashboard_processes(restart_managed=True)
+
+        # The supervised leaf must not be detached-respawned.
+        assert respawned == []
+        out = capsys.readouterr().out
+        assert "supervisor" in out.lower()
+
+    def test_orphaned_leaf_still_respawned(self, capsys):
+        """A genuinely orphaned leaf (PPID 1 / no supervisor) keeps the
+        existing detached-respawn behaviour — the fix must not regress the
+        common manual-restart path (#40449)."""
+        LEAF = 4242
+        leaf_cmd = ["python3", "-m", "hermes_cli.main", "dashboard", "--port", "9119"]
+
+        respawned: list[list[str]] = []
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        with patch("hermes_cli.main._restart_managed_dashboard_service",
+                   return_value=False), \
+             patch("hermes_cli.main._find_stale_dashboard_pids",
+                   return_value=[LEAF]), \
+             patch("hermes_cli.main._get_pid_cgroup_path", return_value=None), \
+             patch("hermes_cli.main._get_systemd_service_for_pid",
+                   return_value=None), \
+             patch("hermes_cli.main._dashboard_cmdline_for_pid",
+                   return_value=leaf_cmd), \
+             patch("hermes_cli.main._parent_pid_for_pid", return_value=1), \
+             patch("hermes_cli.main._respawn_dashboard_processes",
+                   side_effect=lambda cmds: (respawned.extend(cmds) or [])), \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert respawned == [leaf_cmd]
+
+    def test_terminal_parent_not_treated_as_supervisor(self, capsys):
+        """A leaf whose parent is an ordinary interactive shell (not a respawn
+        loop) is still detached-respawned — the guard only fires for actual
+        supervisor loops."""
+        LEAF = 4242
+        SHELL = 4241
+        leaf_cmd = ["python3", "-m", "hermes_cli.main", "dashboard", "--port", "9119"]
+        shell_cmd = ["/bin/bash"]  # interactive shell, no -c loop
+
+        def cmdline_side(pid):
+            return {LEAF: leaf_cmd, SHELL: shell_cmd}.get(pid)
+
+        respawned: list[list[str]] = []
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        with patch("hermes_cli.main._restart_managed_dashboard_service",
+                   return_value=False), \
+             patch("hermes_cli.main._find_stale_dashboard_pids",
+                   return_value=[LEAF]), \
+             patch("hermes_cli.main._get_pid_cgroup_path", return_value=None), \
+             patch("hermes_cli.main._get_systemd_service_for_pid",
+                   return_value=None), \
+             patch("hermes_cli.main._dashboard_cmdline_for_pid",
+                   side_effect=cmdline_side), \
+             patch("hermes_cli.main._parent_pid_for_pid", return_value=SHELL), \
+             patch("hermes_cli.main._respawn_dashboard_processes",
+                   side_effect=lambda cmds: (respawned.extend(cmds) or [])), \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert respawned == [leaf_cmd]


### PR DESCRIPTION
## What

On a host where the dashboard runs under a non-systemd supervisor (tmux + a shell respawn loop), `hermes update` permanently **orphans** the backend: an unsupervised process holds port 9119 while the supervisor crash-loops forever on `address already in use`. The port keeps answering HTTP 200 from a stale backend, silently, for hours.

Two interacting root causes in `hermes_cli/main.py`:

1. **Matcher over-matches supervisor wrappers.** `_scan_dashboard_processes` classifies any process whose cmdline contains `"hermes dashboard"` as a dashboard — including the supervisor loop wrapper. So the supervisor itself is killed (the log says "Stopping 2 dashboard process(es)" when only one dashboard runs).
2. **Respawn detaches from whatever supervisor existed.** The killed leaf is respawned with `start_new_session=True`, reparented to init and pushed *outside* the supervisor's session. It grabs the port; the supervisor's own restart then fails to bind → identical crash-loop.

The third behaviour the reporter notes (supervisor detection is systemd-only) is **made moot** by fix #1: once the supervisor wrapper is no longer in the kill list, it is never (mis)classified by the systemd check.

## How it's fixed

- **Layer 1 — don't classify supervisors as dashboards.** New `_is_shell_supervisor_command()` detects a shell interpreter running a `-c` respawn loop (interpreter basename in a known set + a `-c`/`--command` flag + a loop keyword `while`/`until`/`for`). `_scan_dashboard_processes` excludes such wrappers in **both** the POSIX (`ps`) and Windows (`wmic`) scan branches, so only the real dashboard leaf is matched (and killed). A one-shot shell invocation with no loop is intentionally still detected (rare but legitimate direct invocation).
- **Layer 3 — don't detach-respawn a supervised leaf.** Before detached-respawning a manually-started leaf, check whether its parent is a *live respawn-loop supervisor* (`_parent_pid_for_pid` + `_parent_is_supervisor`). If so, leave the restart to the supervisor (it restarts its child in-session) instead of spawning a detached orphan. Genuine orphans (PPID 1 / nohup), interactive shells, and systemd units keep the existing detached-respawn behaviour — no regression of #40449's manual-restart path. PPID lookup works on Linux (`/proc`) **and** macOS (`ps -o ppid=`).

## Verification

- `python3 -m pytest tests/hermes_cli/test_update_stale_dashboard.py -o addopts= --tb=short` → **53 passed** (40 existing + 13 new).
- **RED proof on upstream/main:** 2 scan tests assert the actual bug (the wrapper PID *is* returned by the scan before the fix — `[4241, 4242]` instead of `[4242]`) before proving green; not merely a missing-attribute error.
- **No-regression cases:** orphaned leaf (PPID 1) still detached-respawned; leaf whose parent is an ordinary interactive shell (not a loop) still respawned.
- One focused commit, `git rev-list --left-right --count upstream/main...HEAD` == `0 1`, rebased clean, `git diff --check` clean.

## Test breakdown (13 new)

- `TestShellSupervisorDetection` (8): bash/sh/zsh loops → True; python/hermes direct, interactive shell, one-shot (no loop), shell+script-file → False.
- `TestScanExcludesSupervisorWrappers` (2): wrapper+leaf → only leaf; serve wrapper → only leaf.
- `TestSupervisedLeafRespawnGuard` (3): supervised leaf not respawned; orphaned leaf still respawned; terminal-parent leaf still respawned.

Closes #73379.

Auto-published by Moonsong via Path B automated pipeline.
