### PR TITLE
fix(desktop): stop Windows Desktop from misopening forward-slash WSL UNC cwd

### DIFF
--- a/apps/desktop/electron/wsl-path-bridge.test.ts
+++ b/apps/desktop/electron/wsl-path-bridge.test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { parseDefaultDistro, resolvePickerDefaultPath, wslPosixToWindowsAccessible } from './wsl-path-bridge'
+import {
+  parseDefaultDistro,
+  resolveLocalReadPath,
+  resolvePickerDefaultPath,
+  wslPosixToWindowsAccessible
+} from './wsl-path-bridge'
 
 test('parseDefaultDistro reads the first distro from clean utf-8 output', () => {
   assert.equal(parseDefaultDistro('Ubuntu\nDebian\n'), 'Ubuntu')
@@ -32,10 +37,34 @@ test('wslPosixToWindowsAccessible maps an in-distro POSIX path to a UNC share', 
 test('wslPosixToWindowsAccessible leaves non-absolute / already-Windows paths alone', () => {
   assert.equal(wslPosixToWindowsAccessible('C:\\Users\\alex', 'Ubuntu'), 'C:\\Users\\alex')
   assert.equal(wslPosixToWindowsAccessible('relative/dir', 'Ubuntu'), 'relative/dir')
+  assert.equal(
+    wslPosixToWindowsAccessible('\\\\wsl.localhost\\Ubuntu\\home\\alex', 'Ubuntu'),
+    '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+  )
+  assert.equal(
+    wslPosixToWindowsAccessible('//wsl.localhost/Ubuntu/home/alex', 'Debian'),
+    '//wsl.localhost/Ubuntu/home/alex'
+  )
+  assert.equal(wslPosixToWindowsAccessible('//wsl$/Debian/tmp', 'Ubuntu'), '//wsl$/Debian/tmp')
 })
 
 test('resolvePickerDefaultPath bridges a WSL cwd but passes Windows paths and empties through', () => {
   assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu'), '\\\\wsl.localhost\\Ubuntu\\home\\alex')
   assert.equal(resolvePickerDefaultPath('C:\\proj', 'Ubuntu'), 'C:\\proj')
   assert.equal(resolvePickerDefaultPath(undefined, 'Ubuntu'), undefined)
+  assert.equal(
+    resolvePickerDefaultPath('//wsl.localhost/Ubuntu/home/alex', 'Ubuntu'),
+    '//wsl.localhost/Ubuntu/home/alex'
+  )
+  assert.equal(resolvePickerDefaultPath('//wsl$/Debian/tmp', 'Ubuntu'), '//wsl$/Debian/tmp')
+})
+
+test('resolveLocalReadPath passes forward-slash WSL UNC through', () => {
+  // UNC must not be mistaken for POSIX; on non-Windows the bridge is skipped
+  // entirely, so either path still leaves the value unchanged.
+  assert.equal(
+    resolveLocalReadPath('//wsl.localhost/Ubuntu/home/alex', 'Ubuntu'),
+    '//wsl.localhost/Ubuntu/home/alex'
+  )
+  assert.equal(resolveLocalReadPath('//wsl$/Debian/tmp', 'Ubuntu'), '//wsl$/Debian/tmp')
 })

--- a/apps/desktop/electron/wsl-path-bridge.ts
+++ b/apps/desktop/electron/wsl-path-bridge.ts
@@ -17,6 +17,16 @@ let cachedDistro: null | string = null
 let cachedUncBase: null | string = null
 
 /**
+ * Already a Windows-host path the picker/fs can open without bridging.
+ * Mirrors renderer `isWindowsPath` (drive, `\\…` UNC, or `//…` UNC).
+ * Forward-slash UNC must be detected before any `\`→`/` normalize, or
+ * `//wsl.localhost/…` is mistaken for POSIX and nested under another UNC.
+ */
+function isWindowsHostPath(path: string): boolean {
+  return WIN_DRIVE_RE.test(path) || path.startsWith('\\') || path.startsWith('//')
+}
+
+/**
  * Pick the default distro from `wsl.exe -l -q` output.
  *
  * `wsl.exe` emits UTF-16LE without a BOM unless `WSL_UTF8=1` (WSL >= 0.64), so
@@ -94,6 +104,11 @@ function wslUncBase(distro: string): string {
  */
 export function wslPosixToWindowsAccessible(posixPath: string, distro: string = resolveDefaultWslDistro()): string {
   const value = String(posixPath || '').trim()
+
+  if (isWindowsHostPath(value)) {
+    return value
+  }
+
   const normalized = value.replace(/\\/g, '/')
 
   if (!normalized.startsWith('/')) {
@@ -124,14 +139,16 @@ export function resolvePickerDefaultPath(
 
   const value = String(defaultPath).trim()
 
-  return value.startsWith('/') && !WIN_DRIVE_RE.test(value) ? wslPosixToWindowsAccessible(value, distro) : defaultPath
+  return value.startsWith('/') && !isWindowsHostPath(value)
+    ? wslPosixToWindowsAccessible(value, distro)
+    : defaultPath
 }
 
 /** fs read path: on Windows, make a WSL cwd readable via its UNC / drive form. */
 export function resolveLocalReadPath(dirPath: string, distro: string = resolveDefaultWslDistro()): string {
   const value = String(dirPath || '').trim()
 
-  return IS_WINDOWS && value.startsWith('/') && !WIN_DRIVE_RE.test(value)
+  return IS_WINDOWS && value.startsWith('/') && !isWindowsHostPath(value)
     ? wslPosixToWindowsAccessible(value, distro)
     : value
 }


### PR DESCRIPTION
## What does this PR do?

Stops Windows Desktop from misopening a forward-slash WSL UNC cwd (for example `//wsl.localhost/...`) when opening the native file/folder picker or reading a local directory. Those paths are already Windows-accessible; the path bridge was treating the leading `/` as POSIX and nesting another UNC prefix.

### Bug Cause

`resolvePickerDefaultPath` / `resolveLocalReadPath` gated bridging on `value.startsWith('/')` without recognizing forward-slash UNC (`//server/...`). The renderer already treats `//` as a Windows path via `isWindowsPath` in `workspace-groups.ts`, so the bridge disagreed with the rest of Desktop.

### Reproduction Steps

1. On Windows Desktop, use a session/project cwd of the form `//wsl.localhost/<distro>/home/<user>/...`.
2. Open a native picker that uses that cwd as `defaultPath`, or local-read that path.
3. Observe the resolved path.

Expected: unchanged or a valid UNC such as `\\wsl.localhost\<distro>\home\...`.
Before fix: nested UNC such as `\\wsl.localhost\<distro>\wsl.localhost\<distro>\home\...`.

### Fix

Add `isWindowsHostPath` (drive, `\\...`, or `//...`) aligned with the renderer, and pass those paths through in `wslPosixToWindowsAccessible`, `resolvePickerDefaultPath`, and `resolveLocalReadPath` before any `\` to `/` normalize. Vitest covers both `//wsl.localhost/...` and `//wsl$/...`.

## Related Issue

Fixes #73421

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/wsl-path-bridge.ts` - recognize already-Windows UNC/drive paths and skip bridging
- `apps/desktop/electron/wsl-path-bridge.test.ts` - regression coverage for forward-slash and backslash WSL UNC

## How to Test

1. Manual (Windows Desktop + WSL cwd as `//wsl.localhost/...`): open picker / local read; confirm the dialog targets the real share, not a nested UNC.
2. Automated (already run locally, 8 passed):

```bash
cd apps/desktop
npx vitest run electron/wsl-path-bridge.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run relevant automated tests and all tests pass (`npx vitest run electron/wsl-path-bridge.test.ts` - 8 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A
