### PR TITLE
fix(tools): recover eager calls sent through bridge

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -333,6 +333,32 @@ def _tool_search_scoped_names(agent) -> frozenset:
     return names
 
 
+def _tool_search_scoped_direct_names(agent) -> frozenset:
+    """Return eager tool names visible in this session."""
+    try:
+        import model_tools
+        from tools import tool_search as _ts
+    except Exception:
+        return frozenset()
+
+    try:
+        scoped_defs = model_tools.get_tool_definitions(
+            enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+            disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        ) or []
+        return frozenset(
+            name
+            for td in scoped_defs
+            if (name := (td.get("function") or {}).get("name", ""))
+            and name not in _ts.BRIDGE_TOOL_NAMES
+            and not _ts.is_deferrable_tool_name(name)
+        )
+    except Exception:
+        return frozenset()
+
+
 @dataclass
 class _ManagedToolResult:
     result: Any
@@ -745,7 +771,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
-                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
+                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(
+                    function_args,
+                    allow_eager=True,
+                )
                 if not _err and _underlying:
                     if _underlying in _tool_search_scoped_names(agent):
                         # Probe-validate before unwrapping (ironclaw#5149):
@@ -757,6 +786,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         else:
                             function_name = _underlying
                             function_args = _underlying_args
+                    elif _underlying in _tool_search_scoped_direct_names(agent):
+                        function_name = _underlying
+                        function_args = _underlying_args
                     else:
                         _ts_scope_block = (
                             f"'{_underlying}' is not available in this session. "
@@ -1436,7 +1468,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         try:
             from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
-                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
+                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(
+                    function_args,
+                    allow_eager=True,
+                )
                 if not _err and _underlying:
                     if _underlying in _tool_search_scoped_names(agent):
                         # Probe-validate before unwrapping (ironclaw#5149):
@@ -1458,6 +1493,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         else:
                             function_name = _underlying
                             function_args = _underlying_args
+                    elif _underlying in _tool_search_scoped_direct_names(agent):
+                        function_name = _underlying
+                        function_args = _underlying_args
                     else:
                         _ts_scope_block = (
                             f"'{_underlying}' is not available in this session. "

--- a/model_tools.py
+++ b/model_tools.py
@@ -1180,7 +1180,10 @@ def handle_function_call(
             return _ts_mod.dispatch_tool_describe(function_args or {},
                                                   current_tool_defs=current_defs)
         if function_name == _ts_mod.TOOL_CALL_NAME:
-            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(function_args or {})
+            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(
+                function_args or {},
+                allow_eager=True,
+            )
             if err or not underlying_name:
                 return tool_error(err or "tool_call could not be resolved")
             # Defense in depth: the underlying tool MUST be in the session's
@@ -1190,7 +1193,15 @@ def handle_function_call(
             # restricted session can never invoke an out-of-scope tool through
             # the bridge even if the catalog scoping above regressed.
             _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
-            if underlying_name not in _scoped_deferrable:
+            _scoped_direct = {
+                (td.get("function") or {}).get("name", "")
+                for td in current_defs
+                if (td.get("function") or {}).get("name", "") not in _ts_mod.BRIDGE_TOOL_NAMES
+                and not _ts_mod.is_deferrable_tool_name(
+                    (td.get("function") or {}).get("name", "")
+                )
+            }
+            if underlying_name not in _scoped_deferrable and underlying_name not in _scoped_direct:
                 return tool_error(
                     f"'{underlying_name}' is not available in this session. "
                     "Use tool_search to find tools you can call."
@@ -1198,9 +1209,10 @@ def handle_function_call(
             # Probe-validate against the deferred tool's schema (ironclaw#5149):
             # a blind call missing required arguments returns the parameter
             # schema instead of dispatching into an opaque downstream failure.
-            _probe_err = _ts_mod.validate_deferred_call_args(underlying_name, underlying_args)
-            if _probe_err is not None:
-                return _probe_err
+            if underlying_name in _scoped_deferrable:
+                _probe_err = _ts_mod.validate_deferred_call_args(underlying_name, underlying_args)
+                if _probe_err is not None:
+                    return _probe_err
             # Recurse with the underlying tool. All hooks fire against the
             # real tool name. The bridge is invisible to hooks by design.
             return handle_function_call(

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -5,6 +5,8 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from run_agent import AIAgent
 
 
@@ -218,6 +220,95 @@ def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_
     assert started_events == [("tool.started", "web_search", allowed_args, {})]
     assert len(completed_events) == 1
     assert completed_events[0][1] == "web_search"
+
+
+@pytest.mark.parametrize(
+    ("executor_name", "direct_name", "args"),
+    [
+        (
+            "_execute_tool_calls_sequential",
+            "terminal",
+            {"command": "echo recovered"},
+        ),
+        (
+            "_execute_tool_calls_concurrent",
+            "terminal",
+            {"command": "echo recovered"},
+        ),
+        (
+            "_execute_tool_calls_sequential",
+            "mcp__notes__command_execute",
+            {"command": "open_daily_note"},
+        ),
+        (
+            "_execute_tool_calls_concurrent",
+            "mcp__notes__command_execute",
+            {"command": "open_daily_note"},
+        ),
+    ],
+)
+def test_executor_unwraps_visible_eager_tool_call(
+    executor_name, direct_name, args
+):
+    agent = _make_agent("tool_call", direct_name)
+    tc = _mock_tool_call(
+        "tool_call",
+        json.dumps({"name": direct_name, "arguments": args}),
+        f"c-{executor_name}",
+    )
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with (
+        patch(
+            "model_tools.get_tool_definitions",
+            return_value=_make_tool_defs(direct_name),
+        ),
+        patch(
+            "run_agent.handle_function_call",
+            return_value=json.dumps({"ok": True}),
+        ) as dispatch,
+    ):
+        getattr(agent, executor_name)(msg, messages, "task-1")
+
+    dispatch.assert_called_once()
+    assert dispatch.call_args.args[:2] == (direct_name, args)
+    assert json.loads(messages[0]["content"]) == {"ok": True}
+
+
+@pytest.mark.parametrize(
+    "executor_name",
+    ["_execute_tool_calls_sequential", "_execute_tool_calls_concurrent"],
+)
+def test_executor_rejects_out_of_scope_eager_tool_call(executor_name):
+    agent = _make_agent("tool_call", "web_search")
+    tc = _mock_tool_call(
+        "tool_call",
+        json.dumps(
+            {
+                "name": "mcp__notes__command_execute",
+                "arguments": {"command": "should_not_run"},
+            }
+        ),
+        f"c-{executor_name}",
+    )
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with (
+        patch(
+            "model_tools.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch(
+            "run_agent.handle_function_call",
+            return_value="SHOULD_NOT_RUN",
+        ) as dispatch,
+    ):
+        getattr(agent, executor_name)(msg, messages, "task-1")
+
+    dispatch.assert_not_called()
+    assert "not available in this session" in messages[0]["content"]
 
 
 def test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispatch():

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -257,6 +257,37 @@ class TestBridgeDispatch:
         assert "remain available" in result["hint"]
         assert "before concluding" in result["hint"]
 
+    @pytest.mark.parametrize(
+        "name",
+        ["terminal", "mcp__notes__command_execute"],
+    )
+    def test_tool_describe_recovers_visible_eager_tool(self, name):
+        from tools.tool_search import (
+            dispatch_tool_describe,
+            is_deferrable_tool_name,
+        )
+
+        result = dispatch_tool_describe(
+            {"name": name},
+            current_tool_defs=[_td(name, "Visible session tool")],
+        )
+
+        assert not is_deferrable_tool_name(name)
+        payload = json.loads(result)
+        assert payload["name"] == name
+        assert payload["invocation"] == "direct"
+        assert f"Call '{name}' directly" in payload["hint"]
+
+    def test_tool_describe_rejects_unavailable_eager_tool(self):
+        from tools.tool_search import dispatch_tool_describe
+
+        result = dispatch_tool_describe(
+            {"name": "terminal"},
+            current_tool_defs=[_td("web_search", "Search the web")],
+        )
+
+        assert "error" in json.loads(result)
+
 
     def test_resolve_underlying_call_parses_object_args(self):
         from tools.tool_search import resolve_underlying_call
@@ -296,6 +327,66 @@ class TestHandleFunctionCallIntegration:
         # Without a real registry, the matches will be empty, but the
         # dispatch path completed without error.
         assert "matches" in parsed or "error" in parsed
+
+    @pytest.mark.parametrize(
+        ("name", "arguments"),
+        [
+            ("terminal", {"command": "echo recovered"}),
+            ("mcp__notes__command_execute", {"command": "open_daily_note"}),
+        ],
+    )
+    def test_tool_call_dispatches_visible_eager_tool(
+        self, monkeypatch, name, arguments
+    ):
+        import model_tools
+        from tools.tool_search import is_deferrable_tool_name
+
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda **_kw: [_td(name, "Visible session tool")],
+        )
+        seen = {}
+
+        def dispatch(name, args, **_kw):
+            seen.update(name=name, args=args)
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(model_tools.registry, "dispatch", dispatch)
+
+        result = model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={
+                "name": name,
+                "arguments": arguments,
+            },
+        )
+
+        assert not is_deferrable_tool_name(name)
+        assert json.loads(result) == {"ok": True}
+        assert seen == {
+            "name": name,
+            "args": arguments,
+        }
+
+    def test_tool_call_rejects_out_of_scope_eager_tool(self, monkeypatch):
+        import model_tools
+
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda **_kw: [_td("web_search", "Search the web")],
+        )
+
+        result = model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={
+                "name": "mcp__notes__command_execute",
+                "arguments": {"command": "should_not_run"},
+            },
+        )
+
+        assert "not available in this session" in json.loads(result)["error"]
 
 
 class TestRegression_OpenClawCron84141:

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -925,6 +925,19 @@ def dispatch_tool_describe(args: Dict[str, Any],
     if not name:
         return tool_error("name is required")
     if not is_deferrable_tool_name(name):
+        for td in current_tool_defs:
+            fn = td.get("function") or {}
+            if fn.get("name") == name and name not in BRIDGE_TOOL_NAMES:
+                return json.dumps(
+                    {
+                        "name": name,
+                        "description": fn.get("description", ""),
+                        "parameters": fn.get("parameters", {}),
+                        "invocation": "direct",
+                        "hint": f"Call '{name}' directly; do not use tool_call.",
+                    },
+                    ensure_ascii=False,
+                )
         return tool_error(
             f"'{name}' is not a deferrable tool. If you see it in the tools list "
             "already, call it directly; otherwise check the spelling against tool_search."
@@ -1016,7 +1029,11 @@ def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str
         return None
 
 
-def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
+def resolve_underlying_call(
+    args: Dict[str, Any],
+    *,
+    allow_eager: bool = False,
+) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
     """Parse a ``tool_call`` invocation into (underlying_name, args, error_msg).
 
     Used by:
@@ -1041,7 +1058,7 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
             return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
-    if not is_deferrable_tool_name(name):
+    if not allow_eager and not is_deferrable_tool_name(name):
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."


### PR DESCRIPTION
## What does this PR do?

Stops eager MCP/core tools from entering a repeated `tool_describe` / `tool_call` rejection loop when a model mistakenly routes an already-visible tool through the progressive-disclosure bridge.

- `tool_describe` now returns the visible eager tool's schema with `invocation: "direct"` and an explicit direct-call hint.
- `tool_call` transparently unwraps an eager tool that is visible in the current session, in both the model-tools dispatcher and the agent's sequential/concurrent executors.
- The recovery path is gated by the same session-scoped tool definitions as normal dispatch, so it cannot invoke an out-of-scope tool.
- Deferred calls retain required-argument probe validation; eager calls proceed through the normal hooks, middleware, approvals, and guardrails under the real tool name.

Fixes #73388.

## Why runtime recovery?

Prompt wording alone cannot guarantee that every model follows the eager/deferred distinction, and the reported failure can exhaust a run. Treating a bridge-wrapped visible tool as a compatibility form makes the intended action deterministic while preserving the session permission boundary.

## Tests

- `pytest tests/tools/test_tool_search.py tests/tools/test_tool_search_context_provider.py tests/agent/test_tool_executor_checkpoint_paths.py tests/run_agent/test_tool_executor_contextvar_propagation.py -q` — 67 passed
- Ruff on all four changed files — passed
- `py_compile` for runtime files — passed
- `git diff --check` — passed
